### PR TITLE
feat: close DG3 category resolver and intake parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,6 +535,10 @@ scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
 scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+
+# Named chunk presets for slow verification targets; still delegates to scripts/run_tests.sh.
+scripts/run_test_chunks.sh broad
+scripts/run_test_chunks.sh run-agent-file -- -q --durations=20
 ```
 
 ### Why the wrapper (and why the old "just call pytest" doesn't work)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ hermes chat -q "Hello"
 ### Run tests
 
 ```bash
-pytest tests/ -v
+scripts/run_tests.sh
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
-python -m pytest tests/ -q
+scripts/run_tests.sh
 ```
 
 > **RL Training (optional):** To work on the RL/Tinker-Atropos integration:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -691,6 +691,81 @@ class HermesACPAgent(acp.Agent):
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
         return f"Model switched to: {new_model}\nProvider: {provider_label}"
 
+    @staticmethod
+    def _truncate_tool_description(description: str, limit: int = 80) -> str:
+        rendered = str(description or "").strip()
+        if len(rendered) <= limit:
+            return rendered
+        return rendered[: limit - 3] + "..."
+
+    @classmethod
+    def _format_surface_line(cls, contract: dict[str, Any], description: str) -> str:
+        canonical_name = contract.get("canonical_name") or contract.get("name") or "?"
+        if contract.get("is_canonical_knowledge_surface"):
+            label = "built-in/canonical"
+        elif contract.get("is_additive"):
+            label = f"additive/{contract.get('source', 'registry')}"
+        else:
+            label = f"built-in/{contract.get('source', 'toolset')}"
+        tools = contract.get("tools") or []
+        suffix = f" [{label}; {len(tools)} raw tools]"
+        summary = cls._truncate_tool_description(description, limit=100)
+        return f"  {canonical_name}{suffix}: {summary}" if summary else f"  {canonical_name}{suffix}"
+
+    @classmethod
+    def _collect_visible_surface_sections(
+        cls,
+        visible_tool_names: set[str],
+        enabled_toolsets: list[str],
+    ) -> list[str]:
+        from toolsets import get_all_toolsets, get_toolset_contract
+
+        lines: list[str] = []
+        all_toolsets = get_all_toolsets()
+
+        canonical_lines: list[str] = []
+        seen_canonical: set[str] = set()
+        for toolset_name, toolset_info in all_toolsets.items():
+            contract = get_toolset_contract(toolset_name)
+            if not contract or not contract.get("is_canonical_knowledge_surface"):
+                continue
+            contract_tools = set(contract.get("tools") or [])
+            if not contract_tools or not contract_tools.issubset(visible_tool_names):
+                continue
+            canonical_name = contract.get("canonical_name") or toolset_name
+            if canonical_name in seen_canonical:
+                continue
+            seen_canonical.add(canonical_name)
+            canonical_lines.append(cls._format_surface_line(contract, toolset_info.get("description", "")))
+
+        if canonical_lines:
+            lines.append("Canonical built-in knowledge surfaces visible from current tool membership:")
+            lines.extend(canonical_lines)
+
+        additive_lines: list[str] = []
+        seen_additive: set[str] = set()
+        for toolset_name in enabled_toolsets:
+            contract = get_toolset_contract(toolset_name)
+            if not contract or not contract.get("is_additive"):
+                continue
+            contract_tools = set(contract.get("tools") or [])
+            if contract_tools and not contract_tools.issubset(visible_tool_names):
+                continue
+            canonical_name = contract.get("canonical_name") or toolset_name
+            if canonical_name in seen_additive:
+                continue
+            seen_additive.add(canonical_name)
+            toolset_info = all_toolsets.get(toolset_name) or all_toolsets.get(canonical_name) or {}
+            additive_lines.append(cls._format_surface_line(contract, toolset_info.get("description", "")))
+
+        if additive_lines:
+            if lines:
+                lines.append("")
+            lines.append("Additive tool surfaces visible from current tool membership:")
+            lines.extend(additive_lines)
+
+        return lines
+
     def _cmd_tools(self, args: str, state: SessionState) -> str:
         try:
             from model_tools import get_tool_definitions
@@ -698,13 +773,21 @@ class HermesACPAgent(acp.Agent):
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             if not tools:
                 return "No tools available."
+            visible_tool_names = {
+                t.get("function", {}).get("name", "?")
+                for t in tools
+                if t.get("function", {}).get("name")
+            }
             lines = [f"Available tools ({len(tools)}):"]
+            surface_lines = self._collect_visible_surface_sections(visible_tool_names, list(toolsets))
+            if surface_lines:
+                lines.append("")
+                lines.extend(surface_lines)
+                lines.append("")
+            lines.append(f"Raw tools ({len(tools)}):")
             for t in tools:
                 name = t.get("function", {}).get("name", "?")
-                desc = t.get("function", {}).get("description", "")
-                # Truncate long descriptions
-                if len(desc) > 80:
-                    desc = desc[:77] + "..."
+                desc = self._truncate_tool_description(t.get("function", {}).get("description", ""))
                 lines.append(f"  {name}: {desc}")
             return "\n".join(lines)
         except Exception as e:

--- a/agent/archetypes.py
+++ b/agent/archetypes.py
@@ -1,0 +1,443 @@
+"""Wave 1 archetype presets and canonical resolution helpers."""
+
+from __future__ import annotations
+
+from dataclasses import MISSING, dataclass, fields
+from types import MappingProxyType
+from typing import Any, Final, Mapping
+
+from agent.route_categories import BUILTIN_ROUTE_CATEGORIES, DEFAULT_ROUTE_CATEGORY
+from agent.runtime_modes import RUNTIME_MODES_BY_NAME
+
+
+@dataclass(frozen=True)
+class Archetype:
+    """Reusable Wave 1 task blueprint."""
+
+    name: str
+    summary: str
+    default_route_category: str
+    default_delegation_profile: str
+    default_skills: tuple[str, ...]
+    default_required_tools: tuple[str, ...]
+    permission_preset: str
+    fallback_policy: str
+    kind: str = "archetype"
+
+
+@dataclass(frozen=True)
+class SpecialistMapping:
+    """Compatibility-safe specialist overlay resolved onto a base archetype."""
+
+    name: str
+    archetype_name: str
+    default_route_category: str | None = None
+    default_delegation_profile: str | None = None
+    kind: str = "specialist"
+
+
+@dataclass(frozen=True)
+class NamedWorkflow:
+    """Canonical named-workflow taxonomy entry."""
+
+    name: str
+    mode: str
+    summary: str
+    plan: tuple[str, ...]
+    acceptance: tuple[str, ...]
+    consumption: Mapping[str, Any] | None = None
+    default_task_contract: Mapping[str, Any] | None = None
+    kind: str = "named_workflow"
+
+
+DEFAULT_ARCHETYPE_NAME: Final[str] = "generalist"
+_SPECIALIST_ALIASES: Final[Mapping[str, str]] = MappingProxyType({"reviewer": "code_reviewer"})
+
+
+def _normalize_name(value: str | None) -> str:
+    return str(value or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _normalize_names(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = tuple(dict.fromkeys(value.strip() for value in values if value and value.strip()))
+    if not normalized:
+        raise ValueError("Archetype defaults must include at least one normalized value")
+    return normalized
+
+
+def _required_archetype_fields() -> tuple[str, ...]:
+    return tuple(
+        field.name
+        for field in fields(Archetype)
+        if field.name not in {"name", "summary", "kind"}
+        and field.default is MISSING
+        and field.default_factory is MISSING
+    )
+
+
+def _make_named_workflow(
+    *,
+    name: str,
+    mode: str,
+    summary: str,
+    plan: tuple[str, ...],
+    acceptance: tuple[str, ...],
+    consumption: Mapping[str, Any] | None = None,
+    default_task_contract: Mapping[str, Any] | None = None,
+) -> NamedWorkflow:
+    normalized_name = _require_non_empty_normalized_string(name, "name")
+    normalized_mode = _require_non_empty_normalized_string(mode, "mode")
+    return NamedWorkflow(
+        name=normalized_name,
+        mode=normalized_mode,
+        summary=summary.strip(),
+        plan=_normalize_names(plan),
+        acceptance=_normalize_names(acceptance),
+        consumption=MappingProxyType(dict(consumption)) if consumption is not None else None,
+        default_task_contract=MappingProxyType(dict(default_task_contract)) if default_task_contract is not None else None,
+    )
+
+
+def _require_non_empty_normalized_string(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(f"{field_name} must be non-empty")
+    if normalized_value != value:
+        raise ValueError(f"{field_name} must use canonical normalized form")
+    return normalized_value
+
+
+def _make_archetype(
+    *,
+    name: str,
+    summary: str,
+    default_route_category: str,
+    default_delegation_profile: str,
+    default_skills: tuple[str, ...],
+    default_required_tools: tuple[str, ...],
+    permission_preset: str,
+    fallback_policy: str,
+) -> Archetype:
+    if default_route_category not in BUILTIN_ROUTE_CATEGORIES:
+        raise ValueError(f"Unknown default route category for archetype {name}: {default_route_category}")
+    if not default_delegation_profile.strip():
+        raise ValueError(f"Archetype {name} requires a default delegation profile")
+    return Archetype(
+        name=name,
+        summary=summary.strip(),
+        default_route_category=default_route_category,
+        default_delegation_profile=default_delegation_profile.strip(),
+        default_skills=_normalize_names(default_skills),
+        default_required_tools=_normalize_names(default_required_tools),
+        permission_preset=permission_preset.strip(),
+        fallback_policy=fallback_policy.strip(),
+    )
+
+
+BUILTIN_ARCHETYPES: Final[tuple[Archetype, ...]] = (
+    _make_archetype(
+        name="generalist",
+        summary="Balanced starter preset for legacy-compatible delegated work without specialist bias.",
+        default_route_category=DEFAULT_ROUTE_CATEGORY,
+        default_delegation_profile="general",
+        default_skills=("general_reasoning", "task_execution"),
+        default_required_tools=("read_file", "search_files"),
+        permission_preset="inherit",
+        fallback_policy="legacy_default_mapping",
+    ),
+    _make_archetype(
+        name="researcher",
+        summary="Research-oriented preset for evidence gathering and synthesis without changing route semantics.",
+        default_route_category="deep",
+        default_delegation_profile="research",
+        default_skills=("research", "analysis", "synthesis"),
+        default_required_tools=("read_file", "search_files", "web_search", "web_extract"),
+        permission_preset="inherit",
+        fallback_policy="degrade_to_generalist",
+    ),
+    _make_archetype(
+        name="implementer",
+        summary="Implementation-oriented preset for repository changes and local verification.",
+        default_route_category="deep",
+        default_delegation_profile="implementation",
+        default_skills=("implementation", "python", "testing"),
+        default_required_tools=("read_file", "search_files", "patch", "terminal"),
+        permission_preset="workspace_write",
+        fallback_policy="degrade_to_generalist",
+    ),
+    _make_archetype(
+        name="verifier",
+        summary="Verification-oriented preset for targeted test runs, review, and evidence capture.",
+        default_route_category="quick",
+        default_delegation_profile="verification",
+        default_skills=("verification", "testing", "review"),
+        default_required_tools=("read_file", "search_files", "terminal"),
+        permission_preset="workspace_write",
+        fallback_policy="degrade_to_generalist",
+    ),
+)
+
+ARCHETYPES_BY_NAME: Final[Mapping[str, Archetype]] = MappingProxyType(
+    {archetype.name: archetype for archetype in BUILTIN_ARCHETYPES}
+)
+
+ARCHETYPE_SCHEMA_FIELDS: Final[tuple[str, ...]] = tuple(field.name for field in fields(Archetype))
+REQUIRED_ARCHETYPE_FIELDS: Final[tuple[str, ...]] = _required_archetype_fields()
+
+def validate_specialist_mapping(mapping: SpecialistMapping) -> SpecialistMapping:
+    if not isinstance(mapping, SpecialistMapping):
+        raise ValueError("specialist mapping must be a SpecialistMapping instance")
+
+    _require_non_empty_normalized_string(mapping.name, "name")
+    _require_non_empty_normalized_string(mapping.archetype_name, "archetype_name")
+
+    if mapping.kind != "specialist":
+        raise ValueError("kind must equal specialist")
+    if mapping.name in ARCHETYPES_BY_NAME:
+        raise ValueError(f"specialist name collides with archetype: {mapping.name}")
+    if mapping.name in BUILTIN_ROUTE_CATEGORIES:
+        raise ValueError(f"specialist name collides with route category: {mapping.name}")
+    if mapping.name in RUNTIME_MODES_BY_NAME:
+        raise ValueError(f"specialist name collides with runtime mode: {mapping.name}")
+    if mapping.archetype_name not in ARCHETYPES_BY_NAME:
+        raise ValueError(f"Unknown archetype for specialist {mapping.name}: {mapping.archetype_name}")
+    if mapping.default_route_category is not None and mapping.default_route_category not in BUILTIN_ROUTE_CATEGORIES:
+        raise ValueError(
+            f"Unknown default route category for specialist {mapping.name}: {mapping.default_route_category}"
+        )
+    if mapping.default_delegation_profile is not None and not mapping.default_delegation_profile.strip():
+        raise ValueError(f"Specialist {mapping.name} requires a non-empty default delegation profile")
+    return mapping
+
+
+def validate_specialist_mappings(
+    mappings: Mapping[str, SpecialistMapping],
+) -> Mapping[str, SpecialistMapping]:
+    seen_names: set[str] = set()
+    for mapping_name, mapping in mappings.items():
+        normalized_mapping_name = _require_non_empty_normalized_string(mapping_name, "mapping_name")
+        validate_specialist_mapping(mapping)
+        if normalized_mapping_name != mapping.name:
+            raise ValueError(
+                f"specialist mapping registry key must match canonical name: {mapping_name} != {mapping.name}"
+            )
+        if mapping.name in seen_names:
+            raise ValueError(f"duplicate specialist mapping name: {mapping.name}")
+        seen_names.add(mapping.name)
+    return mappings
+
+
+SPECIALIST_MAPPINGS_BY_NAME: Final[Mapping[str, SpecialistMapping]] = MappingProxyType(
+    validate_specialist_mappings(
+        {
+            "analyst": SpecialistMapping(
+                name="analyst",
+                archetype_name="researcher",
+                default_route_category="deep",
+                default_delegation_profile="research",
+            ),
+            "investigator": SpecialistMapping(
+                name="investigator",
+                archetype_name="researcher",
+                default_route_category="deep",
+                default_delegation_profile="research",
+            ),
+            "builder": SpecialistMapping(
+                name="builder",
+                archetype_name="implementer",
+                default_route_category="deep",
+                default_delegation_profile="implementation",
+            ),
+            "code_reviewer": SpecialistMapping(
+                name="code_reviewer",
+                archetype_name="verifier",
+                default_route_category="quick",
+                default_delegation_profile="verification",
+            ),
+            "qa_guard": SpecialistMapping(
+                name="qa_guard",
+                archetype_name="verifier",
+                default_route_category="quick",
+                default_delegation_profile="verification",
+            ),
+            "bug_hunter": SpecialistMapping(
+                name="bug_hunter",
+                archetype_name="implementer",
+                default_route_category="deep",
+                default_delegation_profile="implementation",
+            ),
+            "planner": SpecialistMapping(
+                name="planner",
+                archetype_name="generalist",
+                default_route_category="deep",
+                default_delegation_profile="general",
+            ),
+        }
+    )
+)
+
+BUILTIN_NAMED_WORKFLOWS: Final[tuple[NamedWorkflow, ...]] = (
+    _make_named_workflow(
+        name="planner",
+        mode="plan",
+        summary="Structured planning workflow that emits an execution-ready handoff.",
+        plan=(
+            "capture objective, constraints, and success criteria before execution",
+            "decompose work into ordered executable steps with dependencies",
+            "emit a structured handoff contract that a deep worker can execute",
+        ),
+        acceptance=(
+            "structured workflow artifact is present",
+            "execution handoff remains machine-readable",
+        ),
+        consumption={
+            "downstream_role": "deep_worker",
+            "consumes": "execution_task_contract",
+        },
+        default_task_contract={
+            "expected_outcome": "Execution-ready handoff produced from planner workflow activation.",
+            "required_skills": ["general_reasoning", "task_execution"],
+            "required_tools": ["read_file", "search_files"],
+            "must_do": [
+                "decompose the work into ordered steps",
+                "preserve constraints and verification requirements in structured form",
+            ],
+            "must_not_do": [
+                "do not collapse the workflow into prose-only instructions",
+                "do not treat planner as an execution-only label",
+            ],
+        },
+    ),
+    _make_named_workflow(
+        name="deep_worker",
+        mode="execute",
+        summary="Execution workflow that consumes a structured handoff contract.",
+        plan=(
+            "read the structured handoff before acting",
+            "execute the contracted work in order",
+            "report verification evidence against the contract",
+        ),
+        acceptance=(
+            "structured handoff contract is consumed before execution",
+            "execution result reports contract-driven verification evidence",
+        ),
+        consumption={
+            "consumes": "execution_task_contract",
+            "task_contract_present": True,
+        },
+    ),
+)
+
+NAMED_WORKFLOWS_BY_NAME: Final[Mapping[str, NamedWorkflow]] = MappingProxyType(
+    {workflow.name: workflow for workflow in BUILTIN_NAMED_WORKFLOWS}
+)
+
+
+def list_archetypes() -> tuple[Archetype, ...]:
+    """Return built-in archetypes in declaration order."""
+
+    return BUILTIN_ARCHETYPES
+
+
+def get_default_archetype() -> Archetype:
+    """Return the canonical compatibility-safe default archetype."""
+
+    return ARCHETYPES_BY_NAME[DEFAULT_ARCHETYPE_NAME]
+
+
+def resolve_archetype(name: str | None) -> Archetype:
+    """Resolve a canonical archetype name, falling back to the default archetype."""
+
+    normalized_name = _normalize_name(name)
+    if not normalized_name:
+        return get_default_archetype()
+    return ARCHETYPES_BY_NAME.get(normalized_name, get_default_archetype())
+
+
+def resolve_archetype_defaults(
+    archetype_name: str | None,
+    *,
+    overrides: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve an archetype into the supported default-bearing fields."""
+
+    archetype = resolve_archetype(archetype_name)
+    resolved: dict[str, Any] = {
+        field_name: list(getattr(archetype, field_name))
+        if field_name in {"default_skills", "default_required_tools"}
+        else getattr(archetype, field_name)
+        for field_name in REQUIRED_ARCHETYPE_FIELDS
+    }
+    if not overrides:
+        return resolved
+
+    for field_name in REQUIRED_ARCHETYPE_FIELDS:
+        if field_name not in overrides or overrides[field_name] is None:
+            continue
+        value = overrides[field_name]
+        if field_name in {"default_skills", "default_required_tools"}:
+            if not isinstance(value, (list, tuple)):
+                raise TypeError(f"{field_name} overrides must be a list or tuple")
+            resolved[field_name] = [str(item).strip() for item in value if str(item).strip()]
+            continue
+        resolved[field_name] = str(value).strip()
+    return resolved
+
+
+def resolve_specialist_mapping(name: str | None) -> SpecialistMapping | None:
+    """Resolve a canonical specialist overlay name."""
+
+    normalized_name = _normalize_name(name)
+    if not normalized_name:
+        return None
+    canonical_name = _SPECIALIST_ALIASES.get(normalized_name, normalized_name)
+    return SPECIALIST_MAPPINGS_BY_NAME.get(canonical_name)
+
+
+def resolve_specialist_defaults(name: str | None) -> dict[str, Any]:
+    """Return the default-bearing overlay fields for a specialist."""
+
+    specialist = resolve_specialist_mapping(name)
+    if specialist is None:
+        return {}
+    resolved: dict[str, Any] = {}
+    if specialist.default_route_category:
+        resolved["default_route_category"] = specialist.default_route_category
+    if specialist.default_delegation_profile:
+        resolved["default_delegation_profile"] = specialist.default_delegation_profile
+    return resolved
+
+
+def resolve_named_workflow(name: str | None) -> NamedWorkflow | None:
+    """Resolve a canonical named-workflow taxonomy entry."""
+
+    normalized_name = _normalize_name(name)
+    if not normalized_name:
+        return None
+    return NAMED_WORKFLOWS_BY_NAME.get(normalized_name)
+
+
+__all__ = [
+    "ARCHETYPES_BY_NAME",
+    "ARCHETYPE_SCHEMA_FIELDS",
+    "BUILTIN_ARCHETYPES",
+    "BUILTIN_NAMED_WORKFLOWS",
+    "DEFAULT_ARCHETYPE_NAME",
+    "NAMED_WORKFLOWS_BY_NAME",
+    "NamedWorkflow",
+    "REQUIRED_ARCHETYPE_FIELDS",
+    "SPECIALIST_MAPPINGS_BY_NAME",
+    "Archetype",
+    "SpecialistMapping",
+    "get_default_archetype",
+    "list_archetypes",
+    "resolve_archetype",
+    "resolve_archetype_defaults",
+    "resolve_named_workflow",
+    "resolve_specialist_defaults",
+    "resolve_specialist_mapping",
+    "validate_specialist_mapping",
+    "validate_specialist_mappings",
+]

--- a/agent/compaction_checkpoint.py
+++ b/agent/compaction_checkpoint.py
@@ -1,0 +1,219 @@
+"""Canonical compaction checkpoint artifacts for Book/JSONL memory.
+
+This module writes a structured continuation artifact every time Hermes
+compacts context. The artifact is canonical/local-first and intentionally
+separate from derived recall systems like Rasputin.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from hermes_constants import get_hermes_home
+
+
+def write_compaction_checkpoint(
+    *,
+    session_id: str,
+    messages: List[Dict[str, Any]],
+    preservation_notes: str,
+    approx_tokens: int | None,
+    context_length: int,
+    threshold_tokens: int,
+) -> Dict[str, str]:
+    """Write canonical continuation artifacts for an imminent compaction.
+
+    Returns a dict of artifact paths for logging/testing. All writes are local,
+    profile-scoped, and safe to call repeatedly.
+    """
+    timestamp = datetime.now(timezone.utc)
+    timestamp_iso = timestamp.isoformat().replace("+00:00", "Z")
+    timestamp_slug = timestamp.strftime("%Y%m%d-%H%M%S")
+    safe_session_id = (session_id or "unknown-session").strip() or "unknown-session"
+
+    hermes_home = get_hermes_home()
+    workspace_dir = hermes_home / "workspace"
+    memory_root = _resolve_memory_root(workspace_dir)
+    handoffs_dir = memory_root / "handoffs"
+    daily_dir = memory_root / "daily"
+    events_dir = memory_root / "events"
+    checkpoints_dir = memory_root / "context-checkpoints" / "completed"
+    for directory in (handoffs_dir, daily_dir, events_dir, checkpoints_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    profile = _infer_profile_name(hermes_home)
+    fleet = _infer_fleet(profile)
+    context_percent = _compute_context_percent(approx_tokens, context_length)
+
+    recent_user_messages = _recent_messages(messages, roles={"user"}, limit=3)
+    recent_assistant_messages = _recent_messages(messages, roles={"assistant", "tool"}, limit=4)
+    last_user_message = recent_user_messages[-1] if recent_user_messages else ""
+
+    handoff_md = _render_handoff_markdown(
+        session_id=safe_session_id,
+        profile=profile,
+        fleet=fleet,
+        saved_at=timestamp_iso,
+        approx_tokens=approx_tokens,
+        context_length=context_length,
+        threshold_tokens=threshold_tokens,
+        context_percent=context_percent,
+        preservation_notes=preservation_notes,
+        recent_user_messages=recent_user_messages,
+        recent_assistant_messages=recent_assistant_messages,
+    )
+
+    handoff_path = handoffs_dir / f"{safe_session_id}-compaction-{timestamp_slug}.md"
+    handoff_path.write_text(handoff_md, encoding="utf-8")
+
+    latest_handoff_path = handoffs_dir / "latest.md"
+    latest_handoff_path.write_text(handoff_md, encoding="utf-8")
+
+    checkpoint_payload = {
+        "session_id": safe_session_id,
+        "saved_at": timestamp_iso,
+        "status": "pending_compaction",
+        "profile": profile,
+        "fleet": fleet,
+        "context_tokens": approx_tokens,
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "context_percent": context_percent,
+        "last_user_message": last_user_message,
+        "recent_user_messages": recent_user_messages,
+        "recent_assistant_messages": recent_assistant_messages,
+        "preservation_notes": preservation_notes,
+        "handoff_path": str(handoff_path),
+    }
+    checkpoint_json_path = checkpoints_dir / f"{safe_session_id}-{timestamp_slug}.json"
+    checkpoint_json_path.write_text(json.dumps(checkpoint_payload, indent=2), encoding="utf-8")
+
+    event_payload = {
+        "kind": "compaction_checkpoint",
+        "session_id": safe_session_id,
+        "saved_at": timestamp_iso,
+        "profile": profile,
+        "fleet": fleet,
+        "context_tokens": approx_tokens,
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "context_percent": context_percent,
+        "handoff_path": str(handoff_path),
+        "checkpoint_json_path": str(checkpoint_json_path),
+    }
+    event_path = events_dir / f"{timestamp.strftime('%Y-%m-%d')}.jsonl"
+    with event_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event_payload, ensure_ascii=False) + "\n")
+
+    daily_path = daily_dir / f"{timestamp.strftime('%Y-%m-%d')}.md"
+    with daily_path.open("a", encoding="utf-8") as f:
+        f.write(
+            "\n## Compaction Checkpoint\n"
+            f"- Timestamp: {timestamp_iso}\n"
+            f"- Session: {safe_session_id}\n"
+            f"- Profile/Fleet: {profile} / {fleet}\n"
+            f"- Context: {approx_tokens if approx_tokens is not None else 'unknown'} / {context_length}"
+            f" (threshold {threshold_tokens}, {context_percent}%)\n"
+            f"- Handoff: `{handoff_path}`\n"
+            f"- Note: {preservation_notes.strip() or 'No preservation notes.'}\n"
+        )
+
+    return {
+        "handoff_path": str(handoff_path),
+        "latest_handoff_path": str(latest_handoff_path),
+        "checkpoint_json_path": str(checkpoint_json_path),
+        "event_path": str(event_path),
+        "daily_path": str(daily_path),
+    }
+
+
+def _infer_profile_name(hermes_home: Path) -> str:
+    if hermes_home.parent.name == "profiles":
+        return hermes_home.name
+    return "default"
+
+
+def _resolve_memory_root(workspace_dir: Path) -> Path:
+    candidates = [
+        workspace_dir / "memory",
+        workspace_dir / "pantheon-migrated" / "workspace-generic" / "memory",
+        workspace_dir / "workspace-generic" / "memory",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _infer_fleet(profile: str) -> str:
+    name = (profile or "").strip().lower()
+    if any(token in name for token in ("bharat", "fitlife", "bd")):
+        return "bd"
+    if any(token in name for token in ("swivo", "rani", "rs")):
+        return "rs"
+    return "generic"
+
+
+def _compute_context_percent(approx_tokens: int | None, context_length: int) -> float:
+    if not approx_tokens or context_length <= 0:
+        return 0.0
+    return round((approx_tokens / context_length) * 100, 1)
+
+
+def _recent_messages(
+    messages: Iterable[Dict[str, Any]], *, roles: set[str], limit: int
+) -> List[str]:
+    collected: List[str] = []
+    for msg in messages:
+        if msg.get("role") not in roles:
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                str(item.get("text", "")) if isinstance(item, dict) else str(item)
+                for item in content
+            )
+        text = " ".join(str(content).split()).strip()
+        if text:
+            collected.append(text[:600])
+    return collected[-limit:]
+
+
+def _render_handoff_markdown(
+    *,
+    session_id: str,
+    profile: str,
+    fleet: str,
+    saved_at: str,
+    approx_tokens: int | None,
+    context_length: int,
+    threshold_tokens: int,
+    context_percent: float,
+    preservation_notes: str,
+    recent_user_messages: List[str],
+    recent_assistant_messages: List[str],
+) -> str:
+    user_block = "\n".join(f"- {item}" for item in recent_user_messages) or "- None captured."
+    assistant_block = "\n".join(f"- {item}" for item in recent_assistant_messages) or "- None captured."
+    return (
+        f"# Compaction Checkpoint — {saved_at}\n\n"
+        f"- Session ID: `{session_id}`\n"
+        f"- Profile: `{profile}`\n"
+        f"- Fleet: `{fleet}`\n"
+        f"- Status: pending compaction\n"
+        f"- Context usage: `{approx_tokens if approx_tokens is not None else 'unknown'}` / `{context_length}`"
+        f" (threshold `{threshold_tokens}`, `{context_percent}%`)\n\n"
+        "## Preserve Exactly\n"
+        f"{preservation_notes.strip() or 'No explicit preservation notes.'}\n\n"
+        "## Recent User Asks\n"
+        f"{user_block}\n\n"
+        "## Recent Assistant / Tool State\n"
+        f"{assistant_block}\n\n"
+        "## Continuation Guidance\n"
+        "- Resume from the latest user ask and the recent assistant/tool state above.\n"
+        "- Treat this file as a canonical pre-compaction handoff artifact.\n"
+        "- Cross-check with the session tail and current workspace state before repeating work.\n"
+    )

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -209,6 +209,35 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
 
+    def _resolve_threshold_tokens(self, context_length: int) -> int:
+        percentage_threshold = max(
+            int(context_length * self.threshold_percent),
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        explicit = getattr(self, "explicit_threshold_tokens", None)
+        if explicit is None:
+            return percentage_threshold
+        if explicit >= context_length:
+            if not self.quiet_mode:
+                logger.warning(
+                    "Explicit compression threshold_tokens=%d is >= context_length=%d for model=%s; "
+                    "falling back to percentage threshold=%d",
+                    explicit,
+                    context_length,
+                    self.model,
+                    percentage_threshold,
+                )
+            return percentage_threshold
+        return explicit
+
+    def _refresh_token_budgets(self) -> None:
+        self.threshold_tokens = self._resolve_threshold_tokens(self.context_length)
+        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
+        self.tail_token_budget = target_tokens
+        self.max_summary_tokens = min(
+            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
+
     def update_model(
         self,
         model: str,
@@ -217,6 +246,7 @@ class ContextCompressor(ContextEngine):
         api_key: str = "",
         provider: str = "",
         api_mode: str = "",
+        explicit_threshold_tokens: int | None = None,
     ) -> None:
         """Update model info after a model switch or fallback activation."""
         self.model = model
@@ -225,10 +255,9 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        if explicit_threshold_tokens is not None:
+            self.explicit_threshold_tokens = explicit_threshold_tokens
+        self._refresh_token_budgets()
 
     def __init__(
         self,
@@ -244,6 +273,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        explicit_threshold_tokens: int | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -255,6 +285,11 @@ class ContextCompressor(ContextEngine):
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
+        self.explicit_threshold_tokens = (
+            int(explicit_threshold_tokens)
+            if explicit_threshold_tokens is not None and int(explicit_threshold_tokens) > 0
+            else None
+        )
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -262,29 +297,30 @@ class ContextCompressor(ContextEngine):
             provider=provider,
         )
         # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        # the percentage would suggest a lower value.  When an explicit
+        # threshold_tokens override is configured, it takes precedence so long
+        # as it still fits inside the active model context window.
+        self._refresh_token_budgets()
         self.compression_count = 0
 
-        # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
-
         if not quiet_mode:
+            effective_threshold_pct = (
+                (self.threshold_tokens / self.context_length) * 100
+                if self.context_length else 0
+            )
+            threshold_source = (
+                "explicit_threshold_tokens"
+                if self.explicit_threshold_tokens is not None
+                and self.threshold_tokens == self.explicit_threshold_tokens
+                else "threshold_percent"
+            )
             logger.info(
                 "Context compressor initialized: model=%s context_length=%d "
-                "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
+                "threshold=%d (%.0f%%, %s) target_ratio=%.0f%% tail_budget=%d "
                 "provider=%s base_url=%s",
                 model, self.context_length, self.threshold_tokens,
-                threshold_percent * 100, self.summary_target_ratio * 100,
+                effective_threshold_pct, threshold_source,
+                self.summary_target_ratio * 100,
                 self.tail_token_budget,
                 provider or "none", base_url or "none",
             )

--- a/agent/continuation_enforcer.py
+++ b/agent/continuation_enforcer.py
@@ -1,0 +1,457 @@
+"""Continuation queue + delegation loop guard for Hermes orchestration.
+
+Phase 2 builds on the lightweight orchestration state added in Phase 1.
+This module keeps a small durable queue of sessions that ended with open work,
+and exposes a simple circuit breaker for repeated delegated-child failures.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.orchestration_state import get_session_state
+from hermes_constants import get_hermes_dir
+
+_QUEUE_LOCK = threading.RLock()
+_ACTIVE_TODO_STATUSES = {"pending", "in_progress"}
+_DELEGATION_FAILURE_STATUSES = {"failed", "error", "interrupted", "blocked"}
+_MAX_CONSECUTIVE_DELEGATION_FAILURES = 3
+_MAX_PREVIEW_CHARS = 500
+_DEFAULT_RETRY_LEASE_SECONDS = 300
+_DEFAULT_MAX_RETRY_AGE_SECONDS = 6 * 60 * 60
+_DEFAULT_MAX_AUTO_RESUME_ATTEMPTS = 3
+_MAX_CONTINUATION_EVENTS = 25
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _iso_from_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _clear_retry_runtime_fields(item: Dict[str, Any]) -> None:
+    for key in ("leaseOwner", "leaseClaimedAt", "leaseExpiresAt"):
+        item.pop(key, None)
+
+
+def _append_event(
+    item: Dict[str, Any],
+    event_type: str,
+    message: Optional[str],
+    *,
+    timestamp: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    events = item.get("events")
+    if not isinstance(events, list):
+        events = []
+        item["events"] = events
+    entry: Dict[str, Any] = {
+        "type": str(event_type or "event").strip() or "event",
+        "timestamp": timestamp or _now_iso(),
+        "message": _truncate_preview(message) or "Continuation updated.",
+    }
+    if metadata:
+        clean_metadata = {
+            str(key): value
+            for key, value in metadata.items()
+            if value is not None
+        }
+        if clean_metadata:
+            entry["metadata"] = clean_metadata
+    events.append(entry)
+    if len(events) > _MAX_CONTINUATION_EVENTS:
+        item["events"] = events[-_MAX_CONTINUATION_EVENTS:]
+
+
+def _truncate_preview(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) <= _MAX_PREVIEW_CHARS:
+        return text
+    return text[:_MAX_PREVIEW_CHARS].rstrip() + "…"
+
+
+def _queue_dir() -> Path:
+    directory = get_hermes_dir("runtime/orchestration", "orchestration_state")
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _queue_path() -> Path:
+    return _queue_dir() / "continuations.json"
+
+
+def _normalize_todo(item: Dict[str, Any]) -> Dict[str, str]:
+    status = str(item.get("status", "pending")).strip().lower()
+    return {
+        "id": str(item.get("id", "")).strip() or "?",
+        "content": str(item.get("content", "")).strip() or "(no description)",
+        "status": status or "pending",
+    }
+
+
+def _active_todos(todos: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    return [
+        _normalize_todo(item)
+        for item in todos or []
+        if str(item.get("status", "")).strip().lower() in _ACTIVE_TODO_STATUSES
+    ]
+
+
+def _read_queue() -> Dict[str, Any]:
+    path = _queue_path()
+    if not path.exists():
+        return {"items": []}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            items = payload.get("items")
+            payload["items"] = items if isinstance(items, list) else []
+            return payload
+    except Exception:
+        pass
+    return {"items": []}
+
+
+def _write_queue(payload: Dict[str, Any]) -> Dict[str, Any]:
+    path = _queue_path()
+    tmp_path = path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+    return payload
+
+
+def get_pending_continuations() -> List[Dict[str, Any]]:
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = [item for item in payload.get("items", []) if isinstance(item, dict) and item.get("status") == "pending"]
+        items.sort(key=lambda item: str(item.get("updatedAt") or item.get("createdAt") or ""), reverse=True)
+        return items
+
+
+def get_continuation_record(session_id: str) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        return None
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        for item in payload.get("items", []):
+            if isinstance(item, dict) and item.get("sessionId") == normalized_session_id:
+                return dict(item)
+    return None
+
+
+def append_continuation_event(
+    session_id: str,
+    event_type: str,
+    message: Optional[str],
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None:
+            return None
+        _append_event(existing, event_type, message, timestamp=now, metadata=metadata)
+        existing["updatedAt"] = now
+        _write_queue(payload)
+        return dict(existing)
+
+
+def request_continuation_retry(
+    session_id: str,
+    *,
+    requested_by: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None or not (existing.get("openTodos") or []):
+            return None
+
+        existing["status"] = "retry_requested"
+        existing["retryRequestedAt"] = now
+        existing["updatedAt"] = now
+        existing["requestedBy"] = str(requested_by or "").strip() or existing.get("requestedBy")
+        existing["retryRequestCount"] = int(existing.get("retryRequestCount") or 0) + 1
+        existing.pop("resolution", None)
+        _clear_retry_runtime_fields(existing)
+        _append_event(
+            existing,
+            "retry_requested",
+            f"Retry requested by {existing.get('requestedBy') or 'operator'}.",
+            timestamp=now,
+            metadata={"requested_by": existing.get("requestedBy")},
+        )
+        _write_queue(payload)
+        return dict(existing)
+
+
+def block_continuation(
+    session_id: str,
+    *,
+    resolution: str,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None:
+            return None
+
+        existing["status"] = "blocked"
+        existing["resolution"] = str(resolution or "blocked").strip() or "blocked"
+        existing["updatedAt"] = now
+        _clear_retry_runtime_fields(existing)
+        _append_event(existing, "blocked", str(existing.get("resolution") or "blocked"), timestamp=now)
+        _write_queue(payload)
+        return dict(existing)
+
+
+def release_continuation_claim(
+    session_id: str,
+    worker_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    normalized_worker_id = str(worker_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+    if not normalized_worker_id:
+        raise ValueError("worker_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None:
+            return None
+        if str(existing.get("leaseOwner") or "").strip() not in ("", normalized_worker_id):
+            return None
+
+        existing["status"] = "retry_requested"
+        existing["updatedAt"] = now
+        if reason:
+            existing["lastReleaseReason"] = str(reason).strip()
+        _clear_retry_runtime_fields(existing)
+        _append_event(existing, "retry_released", str(reason or "released"), timestamp=now, metadata={"worker_id": normalized_worker_id})
+        _write_queue(payload)
+        return dict(existing)
+
+
+def claim_retry_requested_continuation(
+    worker_id: str,
+    *,
+    lease_seconds: int = _DEFAULT_RETRY_LEASE_SECONDS,
+    max_retry_age_seconds: int = _DEFAULT_MAX_RETRY_AGE_SECONDS,
+    max_auto_resume_attempts: int = _DEFAULT_MAX_AUTO_RESUME_ATTEMPTS,
+) -> Optional[Dict[str, Any]]:
+    normalized_worker_id = str(worker_id or "").strip()
+    if not normalized_worker_id:
+        raise ValueError("worker_id is required")
+
+    now = _now_iso()
+    now_dt = _parse_iso(now) or datetime.now(timezone.utc)
+
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        dirty = False
+        candidates: List[Dict[str, Any]] = []
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            status = str(item.get("status") or "").strip().lower()
+            if status == "running":
+                lease_expires_at = _parse_iso(item.get("leaseExpiresAt"))
+                if lease_expires_at and lease_expires_at > now_dt:
+                    continue
+                item["status"] = "retry_requested"
+                item["updatedAt"] = now
+                _clear_retry_runtime_fields(item)
+                dirty = True
+                status = "retry_requested"
+
+            if status != "retry_requested":
+                continue
+
+            retry_requested_at = _parse_iso(item.get("retryRequestedAt") or item.get("updatedAt") or item.get("createdAt"))
+            if (
+                max_retry_age_seconds >= 0
+                and retry_requested_at is not None
+                and (now_dt - retry_requested_at).total_seconds() > max_retry_age_seconds
+            ):
+                item["status"] = "blocked"
+                item["resolution"] = "retry_request_expired"
+                item["updatedAt"] = now
+                _clear_retry_runtime_fields(item)
+                _append_event(item, "blocked", "retry_request_expired", timestamp=now)
+                dirty = True
+                continue
+
+            if max_auto_resume_attempts >= 0 and int(item.get("resumeCount") or 0) >= max_auto_resume_attempts:
+                item["status"] = "blocked"
+                item["resolution"] = "max_auto_resume_attempts_exceeded"
+                item["updatedAt"] = now
+                _clear_retry_runtime_fields(item)
+                _append_event(item, "blocked", "max_auto_resume_attempts_exceeded", timestamp=now)
+                dirty = True
+                continue
+
+            candidates.append(item)
+
+        candidates.sort(key=lambda item: str(item.get("retryRequestedAt") or item.get("updatedAt") or item.get("createdAt") or ""))
+        if not candidates:
+            if dirty:
+                _write_queue(payload)
+            return None
+
+        claimed = candidates[0]
+        claimed["status"] = "running"
+        claimed["leaseOwner"] = normalized_worker_id
+        claimed["leaseClaimedAt"] = now
+        claimed["leaseExpiresAt"] = _iso_from_datetime(now_dt + timedelta(seconds=max(int(lease_seconds or 0), 1)))
+        claimed["resumeCount"] = int(claimed.get("resumeCount") or 0) + 1
+        claimed["lastResumedAt"] = now
+        claimed["updatedAt"] = now
+        claimed.pop("resolution", None)
+        _append_event(claimed, "auto_resume_claimed", f"Claimed by {normalized_worker_id}.", timestamp=now, metadata={"worker_id": normalized_worker_id})
+        _write_queue(payload)
+        return dict(claimed)
+
+
+def reconcile_session_continuation(
+    session_id: str,
+    *,
+    outcome_status: str,
+    todos: List[Dict[str, Any]] | None,
+    response_preview: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create/update/remove pending continuation state for a finished session.
+
+    Returns the pending record when one exists after reconciliation, otherwise None.
+    """
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    active_todos = _active_todos(todos or [])
+    normalized_status = str(outcome_status or "failed").strip().lower() or "failed"
+    now = _now_iso()
+
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+
+        if normalized_status == "completed" or not active_todos:
+            if existing is not None:
+                existing["status"] = "resolved"
+                existing["resolution"] = normalized_status if normalized_status == "completed" else "cleared"
+                existing["openTodos"] = active_todos
+                existing["responsePreview"] = _truncate_preview(response_preview)
+                existing["updatedAt"] = now
+                _clear_retry_runtime_fields(existing)
+                _append_event(existing, "resolved", str(existing.get("resolution") or "resolved"), timestamp=now)
+                _write_queue(payload)
+            return None
+
+        if existing is None:
+            existing = {
+                "sessionId": normalized_session_id,
+                "status": "pending",
+                "reason": normalized_status,
+                "responsePreview": _truncate_preview(response_preview),
+                "openTodos": active_todos,
+                "createdAt": now,
+                "updatedAt": now,
+                "attemptCount": 1,
+            }
+            _append_event(existing, "pending_created", f"Continuation created from {normalized_status} outcome.", timestamp=now)
+            items.append(existing)
+        else:
+            existing["status"] = "pending"
+            existing["reason"] = normalized_status
+            existing["responsePreview"] = _truncate_preview(response_preview)
+            existing["openTodos"] = active_todos
+            existing["updatedAt"] = now
+            existing["attemptCount"] = int(existing.get("attemptCount") or 0) + 1
+            existing.setdefault("createdAt", now)
+            existing.pop("resolution", None)
+            _clear_retry_runtime_fields(existing)
+            _append_event(existing, "pending_updated", f"Continuation updated from {normalized_status} outcome.", timestamp=now)
+
+        _write_queue(payload)
+        return dict(existing)
+
+
+def should_block_delegation(session_id: str, goal: str) -> Optional[str]:
+    normalized_session_id = str(session_id or "").strip()
+    normalized_goal = " ".join(str(goal or "").split()).strip().casefold()
+    if not normalized_session_id or not normalized_goal:
+        return None
+
+    state = get_session_state(normalized_session_id)
+    if not state:
+        return None
+
+    matching = [
+        entry
+        for entry in (state.get("delegations") or [])
+        if isinstance(entry, dict)
+        and " ".join(str(entry.get("goal") or "").split()).strip().casefold() == normalized_goal
+    ]
+    if len(matching) < _MAX_CONSECUTIVE_DELEGATION_FAILURES:
+        return None
+
+    recent = matching[-_MAX_CONSECUTIVE_DELEGATION_FAILURES:]
+    if all(str(entry.get("status") or "").strip().lower() in _DELEGATION_FAILURE_STATUSES for entry in recent):
+        display_goal = str(goal).strip()
+        return (
+            f"Blocked delegated retry loop for '{display_goal}': the last "
+            f"{_MAX_CONSECUTIVE_DELEGATION_FAILURES} attempts all ended without completion. "
+            "Surface the unfinished work through the continuation queue instead of retrying automatically."
+        )
+    return None

--- a/agent/continuation_engine.py
+++ b/agent/continuation_engine.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+
+DEFAULT_MAX_RUNTIME_RESUMES = 2
+_ACTIVE_TODO_STATUSES = {"pending", "in_progress"}
+_STOP_OUTCOME_STATUSES = {"completed", "stopped", "cancelled", "canceled"}
+
+
+def _normalize_runtime_mode(runtime_mode: Optional[str]) -> str:
+    mode = str(runtime_mode or "").strip().lower().replace("-", "_")
+    if mode == "ralph_loop":
+        return "ralph"
+    if mode in {"ulw", "ulw_loop"}:
+        return "ultrawork"
+    return mode
+
+
+def _normalize_todos(items: Any) -> list[dict[str, str]]:
+    if not isinstance(items, list):
+        return []
+    normalized: list[dict[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        normalized.append(
+            {
+                "id": str(item.get("id") or "?").strip() or "?",
+                "content": str(item.get("content") or item.get("id") or "pending work").strip() or "pending work",
+                "status": str(item.get("status") or "pending").strip().lower() or "pending",
+            }
+        )
+    return normalized
+
+
+def build_continuation_snapshot(agent: Any, result: Optional[dict[str, Any]]) -> dict[str, Any]:
+    payload = result if isinstance(result, dict) else {}
+    getter = getattr(agent, "get_orchestration_continuation_snapshot", None)
+    if callable(getter):
+        try:
+            snapshot = getter(payload)
+            if isinstance(snapshot, dict):
+                todos = _normalize_todos(snapshot.get("todoItems") or [])
+                active = _normalize_todos(snapshot.get("activeTodos") or [])
+                return {
+                    "sessionId": str(snapshot.get("sessionId") or getattr(agent, "session_id", "") or ""),
+                    "outcomeStatus": str(snapshot.get("outcomeStatus") or "incomplete").strip().lower() or "incomplete",
+                    "todoItems": todos,
+                    "activeTodos": active,
+                    "responsePreview": str(snapshot.get("responsePreview") or payload.get("final_response") or payload.get("error") or "").strip(),
+                    "apiCalls": int(snapshot.get("apiCalls") or payload.get("api_calls") or 0),
+                    "stopRequested": bool(snapshot.get("stopRequested") or payload.get("stopRequested") or payload.get("stop_requested")),
+                    "retryRequested": bool(snapshot.get("retryRequested") or payload.get("retryRequested") or payload.get("retry_requested")),
+                }
+        except Exception:
+            pass
+
+    todos = _normalize_todos(payload.get("todoItems") or payload.get("todos") or [])
+    active = [item for item in todos if item["status"] in _ACTIVE_TODO_STATUSES]
+    if payload.get("interrupted"):
+        outcome = "interrupted"
+    elif payload.get("failed"):
+        outcome = "failed"
+    elif payload.get("completed") and not active:
+        outcome = "completed"
+    elif active:
+        outcome = "incomplete"
+    else:
+        outcome = "completed"
+    return {
+        "sessionId": str(getattr(agent, "session_id", "") or ""),
+        "outcomeStatus": outcome,
+        "todoItems": todos,
+        "activeTodos": active,
+        "responsePreview": str(payload.get("final_response") or payload.get("error") or "").strip(),
+        "apiCalls": int(payload.get("api_calls") or 0),
+        "stopRequested": bool(payload.get("stopRequested") or payload.get("stop_requested")),
+        "retryRequested": bool(payload.get("retryRequested") or payload.get("retry_requested")),
+    }
+
+
+def should_use_continuation_engine(runtime_mode: Optional[str], snapshot: dict[str, Any]) -> bool:
+    mode = _normalize_runtime_mode(runtime_mode)
+    if mode not in {"ultrawork", "ralph"}:
+        return False
+    if bool(snapshot.get("stopRequested")):
+        return False
+
+    outcome = str(snapshot.get("outcomeStatus") or "").strip().lower()
+    active_todos = bool(snapshot.get("activeTodos"))
+    retry_requested = bool(snapshot.get("retryRequested"))
+
+    if outcome in _STOP_OUTCOME_STATUSES:
+        return False
+    if mode == "ultrawork":
+        return active_todos
+    return retry_requested or outcome in {"failed", "interrupted", "incomplete"} or active_todos
+
+
+def build_runtime_resume_message(
+    snapshot: dict[str, Any], *, runtime_mode: Optional[str], attempt: int, max_attempts: int
+) -> str:
+    todos = snapshot.get("activeTodos") or []
+    todo_lines = "\n".join(
+        f"- [{item.get('status') or 'pending'}] {item.get('content') or item.get('id') or 'pending work'}"
+        for item in todos
+    ) or "- Continue the unfinished task"
+    reason = str(snapshot.get("outcomeStatus") or "interrupted")
+    mode = _normalize_runtime_mode(runtime_mode)
+    if mode == "ralph":
+        return (
+            f"[System note: Ralph-loop continuation engine retry. "
+            f"Attempt {attempt}/{max_attempts}. Previous outcome: {reason}. "
+            "Retry the unfinished or failed work now. Stop cleanly if the loop should end, otherwise keep going until the objective is complete.]\n\n"
+            "Open work or retry target:\n"
+            f"{todo_lines}"
+        )
+    return (
+        f"[System note: Ultrawork continuation engine resume. "
+        f"Attempt {attempt}/{max_attempts}. Previous outcome: {reason}. "
+        "Finish the remaining open work before declaring completion. Do not stop at a status update.]\n\n"
+        "Open work:\n"
+        f"{todo_lines}"
+    )
+
+
+def apply_bounded_continuation_engine(
+    child: Any,
+    initial_result: dict[str, Any],
+    *,
+    runtime_mode: Optional[str],
+    max_resumes: int = DEFAULT_MAX_RUNTIME_RESUMES,
+    on_snapshot: Optional[Callable[[dict[str, Any], int], None]] = None,
+) -> dict[str, Any]:
+    result = dict(initial_result or {})
+    snapshot = build_continuation_snapshot(child, result)
+    snapshots = [snapshot]
+    if callable(on_snapshot):
+        on_snapshot(snapshot, 0)
+
+    resume_count = 0
+    while resume_count < max(int(max_resumes or 0), 0) and should_use_continuation_engine(runtime_mode, snapshot):
+        resume_count += 1
+        continuation_message = build_runtime_resume_message(
+            snapshot,
+            runtime_mode=runtime_mode,
+            attempt=resume_count,
+            max_attempts=max(int(max_resumes or 0), 0),
+        )
+        next_result = child.run_conversation(user_message=continuation_message)
+        if isinstance(next_result, dict):
+            result = next_result
+        else:
+            result = {"final_response": str(next_result)}
+        snapshot = build_continuation_snapshot(child, result)
+        snapshots.append(snapshot)
+        if callable(on_snapshot):
+            on_snapshot(snapshot, resume_count)
+
+    return {
+        "result": result,
+        "snapshot": snapshot,
+        "resume_count": resume_count,
+        "attempt_count": len(snapshots),
+        "snapshots": snapshots,
+        "exhausted": should_use_continuation_engine(runtime_mode, snapshot),
+        "mode": str(runtime_mode or "").strip().lower() or None,
+    }

--- a/agent/intent_preclassifier.py
+++ b/agent/intent_preclassifier.py
@@ -1,0 +1,541 @@
+"""Wave 2 intent preclassifier for top-level runtime/specialist activation.
+
+This module is intentionally additive on top of the Wave 1 schema and overlay
+work. It does not mutate prompt assembly or delegation plumbing. Instead it
+provides a deterministic, compatibility-safe preclassification step that can be
+consumed by higher-level runtime activation code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from agent.archetypes import resolve_archetype, resolve_specialist_defaults, resolve_specialist_mapping
+from agent.route_categories import (
+    DEFAULT_ROUTE_CATEGORY,
+    BUILTIN_ROUTE_CATEGORIES,
+    resolve_literal_category,
+    resolve_literal_category_from_route_category,
+    resolve_literal_category_to_route_category,
+)
+from agent.runtime_modes import get_default_runtime_mode, resolve_runtime_mode
+from agent.task_contracts import TaskContract, validate_task_contract
+
+_DEFAULT_ARCHETYPE = resolve_archetype(None)
+_DEFAULT_RUNTIME_MODE = get_default_runtime_mode()
+
+
+@dataclass(frozen=True)
+class IntentPreclassification:
+    inferred_archetype: str
+    inferred_specialist: str | None
+    inferred_category: str
+    inferred_route_category: str
+    inferred_runtime_mode: str
+    inferred_delegation_profile: str | None
+    activation_reason: str
+    task_contract: TaskContract | None = None
+    inference_source: str = "wave2_intent_preclassifier"
+
+
+@dataclass(frozen=True)
+class _KeywordRule:
+    label: str
+    keywords: tuple[str, ...]
+    score: int
+
+
+def _normalize_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _extract_text_and_contract(
+    payload: str | Mapping[str, Any] | None,
+    *,
+    task_contract: dict[str, Any] | TaskContract | None = None,
+) -> tuple[str, TaskContract | None]:
+    resolved_contract = validate_task_contract(task_contract) if task_contract is not None else None
+    if payload is None:
+        return "", resolved_contract
+    if isinstance(payload, str):
+        return _normalize_text(payload), resolved_contract
+    if not isinstance(payload, Mapping):
+        return _normalize_text(payload), resolved_contract
+
+    contract_payload = payload.get("task_contract")
+    if resolved_contract is None and contract_payload is not None:
+        resolved_contract = validate_task_contract(contract_payload)
+
+    text_parts: list[str] = []
+    for key in ("message", "user_message", "prompt", "task", "summary", "content"):
+        value = payload.get(key)
+        if value:
+            text_parts.append(str(value))
+
+    if resolved_contract is not None:
+        text_parts.extend(
+            [
+                resolved_contract.task,
+                resolved_contract.expected_outcome,
+                " ".join(resolved_contract.required_skills),
+                " ".join(resolved_contract.required_tools),
+            ]
+        )
+
+    return _normalize_text(" ".join(text_parts)), resolved_contract
+
+
+_SPECIALIST_RULES: tuple[_KeywordRule, ...] = (
+    _KeywordRule(
+        label="multimodal_specialist",
+        keywords=(
+            "image",
+            "images",
+            "screenshot",
+            "screenshots",
+            "diagram",
+            "diagrams",
+            "chart",
+            "charts",
+            "figure",
+            "figures",
+            "pdf",
+            "slide deck",
+            "slides",
+            "visual",
+        ),
+        score=9,
+    ),
+    _KeywordRule(
+        label="code_reviewer",
+        keywords=(
+            "code review",
+            "review this patch",
+            "review the patch",
+            "review this diff",
+            "review the diff",
+            "review the code",
+            "pr review",
+            "pull request",
+            "audit the patch",
+        ),
+        score=8,
+    ),
+    _KeywordRule(
+        label="qa_guard",
+        keywords=(
+            "qa",
+            "regression",
+            "acceptance",
+            "smoke test",
+            "release confidence",
+            "validate the fix",
+        ),
+        score=7,
+    ),
+    _KeywordRule(
+        label="bug_hunter",
+        keywords=(
+            "debug",
+            "bug",
+            "reproduce",
+            "root cause",
+            "trace the failure",
+        ),
+        score=7,
+    ),
+    _KeywordRule(
+        label="builder",
+        keywords=(
+            "implement",
+            "implementation",
+            "code",
+            "patch",
+            "refactor",
+            "build the feature",
+        ),
+        score=6,
+    ),
+    _KeywordRule(
+        label="investigator",
+        keywords=(
+            "research",
+            "investigate",
+            "investigation",
+            "triage",
+            "gather evidence",
+            "trace the issue",
+        ),
+        score=6,
+    ),
+    _KeywordRule(
+        label="analyst",
+        keywords=(
+            "analyze",
+            "analysis",
+            "compare",
+            "synthesize",
+            "findings",
+        ),
+        score=5,
+    ),
+    _KeywordRule(
+        label="writer",
+        keywords=(
+            "write",
+            "draft",
+            "edit",
+            "revise",
+            "rewrite",
+        ),
+        score=5,
+    ),
+    _KeywordRule(
+        label="planner",
+        keywords=(
+            "plan",
+            "planning",
+            "decompose",
+            "sequence the work",
+            "execution plan",
+        ),
+        score=5,
+    ),
+)
+
+
+_ARCHETYPE_RULES: tuple[_KeywordRule, ...] = (
+    _KeywordRule(
+        label="implementer",
+        keywords=(
+            "implement",
+            "implementation",
+            "code",
+            "patch",
+            "fix",
+            "refactor",
+            "bug",
+            "repo",
+            "repository",
+            "pytest",
+            "test",
+            "tests",
+        ),
+        score=3,
+    ),
+    _KeywordRule(
+        label="researcher",
+        keywords=(
+            "research",
+            "investigate",
+            "analyze",
+            "analysis",
+            "compare",
+            "sources",
+            "findings",
+            "synthesize",
+            "synthesis",
+        ),
+        score=3,
+    ),
+    _KeywordRule(
+        label="verifier",
+        keywords=(
+            "verify",
+            "verification",
+            "validate",
+            "review",
+            "audit",
+            "confirm",
+            "check",
+            "smoke test",
+        ),
+        score=2,
+    ),
+)
+
+_ROUTE_RULES: tuple[_KeywordRule, ...] = (
+    _KeywordRule(
+        "visual",
+        (
+            "image",
+            "images",
+            "screenshot",
+            "screenshots",
+            "visual",
+            "diagram",
+            "diagrams",
+            "chart",
+            "charts",
+            "figure",
+            "figures",
+            "pdf",
+            "slides",
+            "slide deck",
+        ),
+        5,
+    ),
+    _KeywordRule("writing", ("write", "draft", "edit", "copy", "email", "blog", "documentation"), 4),
+    _KeywordRule(
+        "ultrabrain",
+        ("ultrabrain", "deep reasoning", "hardest", "prove", "proof", "formal", "rigorous"),
+        6,
+    ),
+    _KeywordRule(
+        "deep",
+        (
+            "research",
+            "investigate",
+            "analyze",
+            "analysis",
+            "implement",
+            "implementation",
+            "architecture",
+            "multi-step",
+            "complex",
+            "careful",
+            "deep lane",
+        ),
+        3,
+    ),
+    _KeywordRule("quick", ("quick", "fast", "brief", "simple", "small", "lightweight"), 2),
+)
+
+_RUNTIME_RULES: tuple[_KeywordRule, ...] = (
+    _KeywordRule("ultrawork", ("ultrawork", "ulw"), 8),
+    _KeywordRule("ralph", ("ralph", "ralph-loop"), 7),
+    _KeywordRule(
+        "interview_planning",
+        ("interview", "interview prep", "interview preparation", "mock interview"),
+        6,
+    ),
+    _KeywordRule(
+        "execution_supervisor",
+        ("supervise", "supervisor", "oversee", "oversight", "coordinate", "orchestrate"),
+        5,
+    ),
+)
+
+
+def _score_rules(text: str, rules: tuple[_KeywordRule, ...]) -> dict[str, int]:
+    scores: dict[str, int] = {rule.label: 0 for rule in rules}
+    for rule in rules:
+        for keyword in rule.keywords:
+            if keyword in text:
+                scores[rule.label] += rule.score
+    return scores
+
+
+def _pick_label(text: str, rules: tuple[_KeywordRule, ...], default: str) -> str:
+    scores = _score_rules(text, rules)
+    best_label = default
+    best_score = 0
+    for rule in rules:
+        score = scores[rule.label]
+        if score > best_score:
+            best_label = rule.label
+            best_score = score
+    return best_label if best_score > 0 else default
+
+
+def _infer_specialist(text: str) -> str | None:
+    specialist = _pick_label(text, _SPECIALIST_RULES, "")
+    if not specialist:
+        return None
+    resolved_specialist = resolve_specialist_mapping(specialist)
+    return resolved_specialist.name if resolved_specialist is not None else None
+
+
+def _infer_archetype(text: str, inferred_specialist: str | None = None) -> str:
+    if inferred_specialist:
+        specialist_mapping = resolve_specialist_mapping(inferred_specialist)
+        if specialist_mapping is not None:
+            return specialist_mapping.archetype_name
+    return _pick_label(text, _ARCHETYPE_RULES, _DEFAULT_ARCHETYPE.name)
+
+
+def _infer_route_category(text: str, inferred_archetype: str) -> str:
+    route = _pick_label(text, _ROUTE_RULES, "")
+    if route:
+        return route
+    if inferred_archetype in {"implementer", "researcher"}:
+        return "deep"
+    if inferred_archetype == "verifier":
+        return "quick"
+    return DEFAULT_ROUTE_CATEGORY
+
+
+def _infer_category(
+    *,
+    inferred_route_category: str,
+    explicit_category: str | None = None,
+) -> str:
+    if explicit_category:
+        resolved_literal_category = resolve_literal_category(explicit_category)
+        resolved_route_from_category = resolve_literal_category_to_route_category(resolved_literal_category.name)
+        if resolved_route_from_category.name == inferred_route_category:
+            return resolved_literal_category.name
+    return resolve_literal_category_from_route_category(inferred_route_category).name
+
+
+def _apply_specialist_overlay_defaults(
+    inferred_specialist: str | None,
+    *,
+    inferred_route_category: str,
+    inferred_delegation_profile: str | None,
+) -> tuple[str, str | None]:
+    if not inferred_specialist:
+        return inferred_route_category, inferred_delegation_profile
+
+    specialist_defaults = resolve_specialist_defaults(inferred_specialist)
+    if not specialist_defaults:
+        return inferred_route_category, inferred_delegation_profile
+
+    route_category = inferred_route_category
+    if route_category == DEFAULT_ROUTE_CATEGORY:
+        overlay_route_category = str(specialist_defaults.get("default_route_category") or "").strip()
+        if overlay_route_category:
+            route_category = overlay_route_category
+
+    delegation_profile = inferred_delegation_profile
+    if not delegation_profile:
+        overlay_profile = str(specialist_defaults.get("default_delegation_profile") or "").strip()
+        if overlay_profile:
+            delegation_profile = overlay_profile
+
+    return route_category, delegation_profile
+
+
+def _infer_runtime_mode(text: str, task_contract: TaskContract | None = None) -> str:
+    if task_contract is not None and isinstance(task_contract.context, Mapping):
+        command_runtime = task_contract.context.get("command_runtime")
+        if isinstance(command_runtime, Mapping):
+            runtime_mode = resolve_runtime_mode(command_runtime.get("runtime_mode")).name
+            if runtime_mode != _DEFAULT_RUNTIME_MODE.name:
+                return runtime_mode
+
+        command_name = _normalize_text(task_contract.context.get("command"))
+        if command_name == "ralph-loop":
+            return "ralph"
+        if command_name == "ulw-loop":
+            return "ultrawork"
+
+    explicit = _pick_label(text, _RUNTIME_RULES, "")
+    if explicit:
+        return resolve_runtime_mode(explicit).name
+    return _DEFAULT_RUNTIME_MODE.name
+
+
+def _infer_delegation_profile(inferred_archetype: str) -> str | None:
+    archetype = resolve_archetype(inferred_archetype)
+    return archetype.default_delegation_profile or None
+
+
+def _build_activation_reason(
+    *,
+    raw_text: str,
+    inferred_archetype: str,
+    inferred_specialist: str | None,
+    inferred_category: str,
+    inferred_route_category: str,
+    inferred_runtime_mode: str,
+    inferred_delegation_profile: str | None,
+) -> str:
+    reasons: list[str] = []
+    if not raw_text.strip() or raw_text.strip() in {"help", "hi", "hello"}:
+        reasons.append("fallback: underspecified top-level intent")
+    if "ultrawork" in raw_text:
+        reasons.append("explicit runtime keyword: ultrawork")
+    elif "ulw" in raw_text:
+        reasons.append("explicit runtime keyword: ulw -> ultrawork")
+    if "ralph-loop" in raw_text or "ralph" in raw_text:
+        reasons.append("explicit runtime keyword: ralph -> ralph")
+    if inferred_runtime_mode == "interview_planning" and "interview" in raw_text:
+        reasons.append("explicit runtime keyword: interview")
+    if inferred_runtime_mode == "execution_supervisor" and any(
+        marker in raw_text for marker in ("supervise", "supervisor", "oversee", "oversight", "coordinate", "orchestrate")
+    ):
+        reasons.append("explicit runtime keyword: supervision/orchestration")
+    if not reasons and inferred_specialist is not None:
+        reasons.append(f"keyword-derived specialist: {inferred_specialist}")
+    if not reasons and inferred_archetype != _DEFAULT_ARCHETYPE.name:
+        reasons.append(f"keyword-derived archetype: {inferred_archetype}")
+    if not reasons and inferred_route_category != DEFAULT_ROUTE_CATEGORY:
+        reasons.append(f"keyword-derived route_category: {inferred_route_category}")
+    if not reasons:
+        reasons.append("fallback: compatibility-safe default activation")
+
+    reasons.append(
+        "resolved outputs: "
+        f"archetype={inferred_archetype}, "
+        f"specialist={inferred_specialist or 'none'}, "
+        f"category={inferred_category}, "
+        f"route_category={inferred_route_category}, "
+        f"delegation_profile={inferred_delegation_profile or 'none'}, "
+        f"runtime_mode={inferred_runtime_mode}"
+    )
+    return "; ".join(reasons)
+
+
+def preclassify_intent(
+    payload: str | Mapping[str, Any] | None,
+    *,
+    task_contract: dict[str, Any] | TaskContract | None = None,
+) -> IntentPreclassification:
+    """Deterministically classify top-level work into Wave 2 activation outputs.
+
+    The classifier is intentionally lightweight and compatibility-safe:
+    - unknown or underspecified input falls back to Wave 1-compatible defaults
+    - runtime mode, route category, delegation profile, and archetype remain
+      distinct output layers
+    - any provided task contract is preserved in structured form
+    """
+
+    text, resolved_task_contract = _extract_text_and_contract(payload, task_contract=task_contract)
+    explicit_category = None
+    if isinstance(payload, Mapping):
+        explicit_category = str(payload.get("category") or "").strip() or None
+
+    inferred_specialist = _infer_specialist(text)
+    inferred_archetype = _infer_archetype(text, inferred_specialist)
+    inferred_route_category = _infer_route_category(text, inferred_archetype)
+    inferred_runtime_mode = _infer_runtime_mode(text, resolved_task_contract)
+    inferred_delegation_profile = _infer_delegation_profile(inferred_archetype)
+    inferred_route_category, inferred_delegation_profile = _apply_specialist_overlay_defaults(
+        inferred_specialist,
+        inferred_route_category=inferred_route_category,
+        inferred_delegation_profile=inferred_delegation_profile,
+    )
+    inferred_category = _infer_category(
+        inferred_route_category=inferred_route_category,
+        explicit_category=explicit_category,
+    )
+
+    if inferred_route_category not in BUILTIN_ROUTE_CATEGORIES:
+        inferred_route_category = DEFAULT_ROUTE_CATEGORY
+    inferred_runtime_mode = resolve_runtime_mode(inferred_runtime_mode).name
+
+    activation_reason = _build_activation_reason(
+        raw_text=text,
+        inferred_archetype=inferred_archetype,
+        inferred_specialist=inferred_specialist,
+        inferred_category=inferred_category,
+        inferred_route_category=inferred_route_category,
+        inferred_runtime_mode=inferred_runtime_mode,
+        inferred_delegation_profile=inferred_delegation_profile,
+    )
+
+    return IntentPreclassification(
+        inferred_archetype=inferred_archetype,
+        inferred_specialist=inferred_specialist,
+        inferred_category=inferred_category,
+        inferred_route_category=inferred_route_category,
+        inferred_runtime_mode=inferred_runtime_mode,
+        inferred_delegation_profile=inferred_delegation_profile,
+        activation_reason=activation_reason,
+        task_contract=resolved_task_contract,
+    )
+
+
+__all__ = ["IntentPreclassification", "preclassify_intent"]

--- a/agent/orchestration_state.py
+++ b/agent/orchestration_state.py
@@ -1,0 +1,216 @@
+"""Durable orchestration state for active Hermes sessions.
+
+Stores small per-session JSON snapshots under HERMES_HOME so Pan and future
+continuation logic can inspect what the agent is currently doing, including
+child delegations. This is intentionally lightweight and profile-scoped.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_dir
+
+_STATE_LOCK = threading.RLock()
+_MAX_PREVIEW_CHARS = 500
+_MAX_DELEGATIONS = 20
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _truncate_preview(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) <= _MAX_PREVIEW_CHARS:
+        return text
+    return text[:_MAX_PREVIEW_CHARS].rstrip() + "…"
+
+
+def _state_dir() -> Path:
+    directory = get_hermes_dir("runtime/orchestration", "orchestration_state")
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _state_path(session_id: str) -> Path:
+    safe_session_id = str(session_id or "").strip()
+    if not safe_session_id:
+        raise ValueError("session_id is required")
+    return _state_dir() / f"{safe_session_id}.json"
+
+
+def _read_state(session_id: str) -> Dict[str, Any]:
+    path = _state_path(session_id)
+    if not path.exists():
+        return {
+            "sessionId": session_id,
+            "status": "running",
+            "platform": None,
+            "userId": None,
+            "messagePreview": None,
+            "responsePreview": None,
+            "startedAt": None,
+            "updatedAt": None,
+            "endedAt": None,
+            "sessionLifecycle": "active",
+            "delegations": [],
+        }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload.setdefault("sessionId", session_id)
+            payload.setdefault("delegations", [])
+            payload.setdefault("sessionLifecycle", "active")
+            return payload
+    except Exception:
+        pass
+    return {
+        "sessionId": session_id,
+        "status": "running",
+        "platform": None,
+        "userId": None,
+        "messagePreview": None,
+        "responsePreview": None,
+        "startedAt": None,
+        "updatedAt": None,
+        "endedAt": None,
+        "sessionLifecycle": "active",
+        "delegations": [],
+    }
+
+
+def _write_state(session_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    path = _state_path(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+    return payload
+
+
+def get_session_state(session_id: str) -> Optional[Dict[str, Any]]:
+    with _STATE_LOCK:
+        path = _state_path(session_id)
+        if not path.exists():
+            return None
+        return _read_state(session_id)
+
+
+def record_agent_start(
+    session_id: str,
+    *,
+    platform: Optional[str] = None,
+    user_id: Optional[str] = None,
+    message: Optional[str] = None,
+) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        payload["status"] = "running"
+        payload["platform"] = platform or payload.get("platform")
+        payload["userId"] = user_id or payload.get("userId")
+        payload["messagePreview"] = _truncate_preview(message) or payload.get("messagePreview")
+        payload["startedAt"] = payload.get("startedAt") or now
+        payload["updatedAt"] = now
+        payload["endedAt"] = None
+        payload["sessionLifecycle"] = "active"
+        return _write_state(session_id, payload)
+
+
+def record_agent_end(
+    session_id: str,
+    *,
+    status: str = "completed",
+    response: Optional[str] = None,
+) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        payload["status"] = status
+        payload["responsePreview"] = _truncate_preview(response) if response is not None else payload.get("responsePreview")
+        payload["updatedAt"] = now
+        if status and status != "running":
+            payload["endedAt"] = now
+        return _write_state(session_id, payload)
+
+
+def record_session_lifecycle(session_id: str, lifecycle: str) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        payload["sessionLifecycle"] = lifecycle
+        payload["updatedAt"] = now
+        if lifecycle in {"ended", "reset"}:
+            payload["endedAt"] = now
+        return _write_state(session_id, payload)
+
+
+def record_delegation_start(
+    session_id: str,
+    *,
+    goal: str,
+    task_index: Optional[int] = None,
+    toolsets: Optional[list[str]] = None,
+) -> str:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        delegations = payload.setdefault("delegations", [])
+        delegation_id = f"dlg_{len(delegations) + 1}_{int(datetime.now(timezone.utc).timestamp() * 1000)}"
+        delegations.append(
+            {
+                "id": delegation_id,
+                "taskIndex": task_index,
+                "goal": _truncate_preview(goal),
+                "status": "running",
+                "summary": None,
+                "apiCalls": None,
+                "durationSeconds": None,
+                "model": None,
+                "toolsets": toolsets or [],
+                "startedAt": now,
+                "updatedAt": now,
+            }
+        )
+        if len(delegations) > _MAX_DELEGATIONS:
+            payload["delegations"] = delegations[-_MAX_DELEGATIONS:]
+        payload["updatedAt"] = now
+        _write_state(session_id, payload)
+        return delegation_id
+
+
+def record_delegation_end(
+    session_id: str,
+    delegation_id: str,
+    *,
+    status: str,
+    summary: Optional[str] = None,
+    api_calls: Optional[int] = None,
+    duration_seconds: Optional[float] = None,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        delegations = payload.setdefault("delegations", [])
+        for entry in delegations:
+            if entry.get("id") != delegation_id:
+                continue
+            entry["status"] = status
+            entry["summary"] = _truncate_preview(summary) if summary is not None else entry.get("summary")
+            entry["apiCalls"] = api_calls if api_calls is not None else entry.get("apiCalls")
+            entry["durationSeconds"] = duration_seconds if duration_seconds is not None else entry.get("durationSeconds")
+            entry["model"] = model if model is not None else entry.get("model")
+            entry["updatedAt"] = now
+            break
+        payload["updatedAt"] = now
+        return _write_state(session_id, payload)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -10,11 +10,26 @@ import os
 import re
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Optional
+from typing import Any, Optional
 
+from agent.archetypes import Archetype, resolve_archetype
+from agent.context_rules import (
+    MAX_HERMES_CONTEXT_LAYERS,
+    apply_bounded_hierarchical_context,
+    discover_hermes_context_layers,
+)
+from agent.route_categories import (
+    LiteralCategory,
+    RouteCategory,
+    get_route_category,
+    resolve_literal_category,
+    resolve_literal_category_from_route_category,
+)
+from agent.runtime_modes import RuntimeMode, resolve_runtime_mode
 from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
@@ -24,9 +39,427 @@ from agent.skill_utils import (
     parse_frontmatter,
     skill_matches_platform,
 )
+from agent.task_contracts import TaskContract, validate_task_contract
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PromptOverlaySection:
+    """Structured prompt section used for deterministic overlay assembly."""
+
+    key: str
+    title: str
+    content: str
+
+
+WAVE1_OVERLAY_ORDER = (
+    "archetype",
+    "category",
+    "route_category",
+    "delegation_profile",
+    "runtime_mode",
+    "skills",
+    "task_contract",
+    "orchestration_hints",
+)
+
+_WAVE1_OVERLAY_TITLES = {
+    "archetype": "Archetype",
+    "category": "Category",
+    "route_category": "Route Category",
+    "delegation_profile": "Delegation Profile",
+    "runtime_mode": "Runtime Mode",
+    "skills": "Skills",
+    "task_contract": "Task Contract",
+    "orchestration_hints": "Orchestration Hints",
+}
+
+
+def _normalize_overlay_list(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, (list, tuple, set)):
+        raise TypeError("Overlay list values must be a string or list-like collection")
+    return list(dict.fromkeys(str(value).strip() for value in values if str(value).strip()))
+
+
+def _format_json_block(payload: Any) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def _format_archetype_overlay(archetype: Archetype) -> str:
+    return "\n".join(
+        [
+            f"name: {archetype.name}",
+            f"summary: {archetype.summary}",
+            f"default_route_category: {archetype.default_route_category}",
+            f"default_delegation_profile: {archetype.default_delegation_profile}",
+            "default_skills:",
+            *[f"- {skill}" for skill in archetype.default_skills],
+            "default_required_tools:",
+            *[f"- {tool_name}" for tool_name in archetype.default_required_tools],
+            f"permission_preset: {archetype.permission_preset}",
+            f"fallback_policy: {archetype.fallback_policy}",
+        ]
+    )
+
+
+def _coerce_literal_category_overlay(
+    category: Any,
+    *,
+    route_category_name: str,
+) -> LiteralCategory | dict[str, str]:
+    if isinstance(category, LiteralCategory):
+        payload = {
+            "name": category.name,
+            "summary": category.summary,
+            "mapped_route_category": category.route_category,
+            "default_runtime_mode": category.default_runtime_mode or "inherit",
+        }
+    elif isinstance(category, dict):
+        name = str(category.get("name") or "").strip()
+        if not name:
+            raise ValueError("category overlay dict requires a non-empty name")
+        payload = {
+            "name": name,
+            "summary": str(category.get("summary") or "").strip(),
+            "mapped_route_category": str(category.get("mapped_route_category") or route_category_name).strip() or route_category_name,
+            "default_runtime_mode": str(category.get("default_runtime_mode") or "inherit").strip() or "inherit",
+        }
+    else:
+        resolved = resolve_literal_category(category)
+        payload = {
+            "name": resolved.name,
+            "summary": resolved.summary,
+            "mapped_route_category": resolved.route_category,
+            "default_runtime_mode": resolved.default_runtime_mode or "inherit",
+        }
+
+    mapped_route = get_route_category(payload["mapped_route_category"])
+    payload["fallback_semantics"] = "inherits_mapped_route_category"
+    payload["mapped_route_fallbacks"] = ", ".join(mapped_route.fallback_models) if mapped_route.fallback_models else "(none)"
+    return payload
+
+
+def _format_literal_category_overlay(category: LiteralCategory | dict[str, str]) -> str:
+    if isinstance(category, LiteralCategory):
+        mapped_route = get_route_category(category.route_category)
+        payload = {
+            "name": category.name,
+            "summary": category.summary,
+            "mapped_route_category": category.route_category,
+            "default_runtime_mode": category.default_runtime_mode or "inherit",
+            "fallback_semantics": "inherits_mapped_route_category",
+            "mapped_route_fallbacks": ", ".join(mapped_route.fallback_models) if mapped_route.fallback_models else "(none)",
+        }
+    else:
+        payload = category
+    return "\n".join(
+        [
+            f"name: {payload['name']}",
+            f"summary: {payload['summary']}",
+            f"mapped_route_category: {payload['mapped_route_category']}",
+            f"default_runtime_mode: {payload['default_runtime_mode']}",
+            f"fallback_semantics: {payload['fallback_semantics']}",
+            f"mapped_route_fallbacks: {payload['mapped_route_fallbacks']}",
+        ]
+    )
+
+
+def _coerce_route_category_overlay(route_category: Any) -> RouteCategory | dict[str, str]:
+    if isinstance(route_category, RouteCategory):
+        return route_category
+    if isinstance(route_category, dict):
+        name = str(route_category.get("name") or "").strip()
+        if not name:
+            raise ValueError("route_category overlay dict requires a non-empty name")
+        return {
+            "name": name,
+            "summary": str(route_category.get("summary") or "").strip(),
+            "intensity": str(route_category.get("intensity") or "").strip(),
+        }
+    return get_route_category(str(route_category).strip())
+
+
+def _format_route_category_overlay(route_category: RouteCategory | dict[str, str]) -> str:
+    if isinstance(route_category, RouteCategory):
+        payload = {
+            "name": route_category.name,
+            "summary": route_category.summary,
+            "intensity": route_category.intensity,
+        }
+    else:
+        payload = route_category
+    return "\n".join(
+        [
+            f"name: {payload['name']}",
+            f"summary: {payload['summary']}",
+            f"intensity: {payload['intensity']}",
+        ]
+    )
+
+
+def _coerce_runtime_mode_overlay(runtime_mode: Any) -> RuntimeMode | dict[str, str]:
+    if isinstance(runtime_mode, RuntimeMode):
+        return runtime_mode
+    if isinstance(runtime_mode, dict):
+        name = str(runtime_mode.get("name") or "").strip()
+        if not name:
+            raise ValueError("runtime_mode overlay dict requires a non-empty name")
+        return {
+            "name": name,
+            "description": str(runtime_mode.get("description") or "").strip(),
+            "operating_posture": str(runtime_mode.get("operating_posture") or "").strip(),
+            "kind": str(runtime_mode.get("kind") or "runtime_mode").strip() or "runtime_mode",
+        }
+    return resolve_runtime_mode(str(runtime_mode).strip())
+
+
+def _format_runtime_mode_overlay(runtime_mode: RuntimeMode | dict[str, str]) -> str:
+    if isinstance(runtime_mode, RuntimeMode):
+        payload = {
+            "name": runtime_mode.name,
+            "description": runtime_mode.description,
+            "operating_posture": runtime_mode.operating_posture,
+            "kind": runtime_mode.kind,
+        }
+    else:
+        payload = runtime_mode
+    return "\n".join(
+        [
+            f"name: {payload['name']}",
+            f"description: {payload['description']}",
+            f"operating_posture: {payload['operating_posture']}",
+            f"kind: {payload['kind']}",
+        ]
+    )
+
+
+def _format_delegation_profile_overlay(delegation_profile: str) -> str:
+    return f"name: {delegation_profile}"
+
+
+def _format_skills_overlay(skills: list[str]) -> str:
+    return "\n".join(f"- {skill_name}" for skill_name in skills)
+
+
+def _format_orchestration_hints_overlay(orchestration_hints: Any) -> str:
+    if isinstance(orchestration_hints, str):
+        return orchestration_hints.strip()
+    if isinstance(orchestration_hints, (list, tuple, dict)):
+        return _format_json_block(orchestration_hints)
+    raise TypeError("orchestration_hints must be a string, list, tuple, or dict")
+
+
+def normalize_wave1_overlay_inputs(
+    *,
+    archetype_name: str | None = None,
+    category: Any = None,
+    route_category: Any = None,
+    delegation_profile: str | None = None,
+    runtime_mode: Any = None,
+    skills: Any = None,
+    task_contract: dict[str, Any] | TaskContract | None = None,
+    orchestration_hints: Any = None,
+) -> dict[str, Any]:
+    """Canonicalize Wave 1 overlay inputs before any rendering occurs."""
+
+    archetype = resolve_archetype(archetype_name)
+    resolved_route_category = _coerce_route_category_overlay(
+        route_category if route_category not in (None, "") else archetype.default_route_category
+    )
+    route_category_name = getattr(resolved_route_category, "name", None)
+    if route_category_name is None:
+        route_category_name = resolved_route_category["name"]
+    resolved_category = _coerce_literal_category_overlay(
+        category if category not in (None, "") else resolve_literal_category_from_route_category(route_category_name),
+        route_category_name=route_category_name,
+    )
+    resolved_delegation_profile = (
+        str(delegation_profile).strip()
+        if delegation_profile and str(delegation_profile).strip()
+        else archetype.default_delegation_profile
+    )
+    resolved_runtime_mode = _coerce_runtime_mode_overlay(runtime_mode or None)
+    explicit_skills = _normalize_overlay_list(skills)
+    resolved_skills = list(archetype.default_skills)
+    resolved_skills.extend(explicit_skills)
+    resolved_skills = list(dict.fromkeys(resolved_skills))
+
+    validated_contract = None
+    if task_contract is not None:
+        validated_contract = validate_task_contract(task_contract).model_dump()
+
+    rendered_orchestration_hints = None
+    if orchestration_hints is not None:
+        rendered_orchestration_hints = _format_orchestration_hints_overlay(orchestration_hints)
+        if not rendered_orchestration_hints:
+            rendered_orchestration_hints = None
+
+    category_name = getattr(resolved_category, "name", None)
+    if category_name is None:
+        category_name = resolved_category["name"]
+
+    runtime_mode_name = getattr(resolved_runtime_mode, "name", None)
+    if runtime_mode_name is None:
+        runtime_mode_name = resolved_runtime_mode["name"]
+
+    return {
+        "archetype": archetype.name,
+        "archetype_definition": archetype,
+        "category": category_name,
+        "category_definition": resolved_category,
+        "route_category": route_category_name,
+        "route_category_definition": resolved_route_category,
+        "delegation_profile": resolved_delegation_profile,
+        "runtime_mode": runtime_mode_name,
+        "runtime_mode_definition": resolved_runtime_mode,
+        "skills": resolved_skills,
+        "skills_explicit": bool(explicit_skills),
+        "task_contract": validated_contract,
+        "orchestration_hints": orchestration_hints,
+        "orchestration_hints_rendered": rendered_orchestration_hints,
+    }
+
+
+def build_wave1_overlay_sections_from_normalized(normalized_inputs: dict[str, Any]) -> list[PromptOverlaySection]:
+    """Render Wave 1 overlay sections from canonical normalized inputs."""
+
+    sections: list[PromptOverlaySection] = [
+        PromptOverlaySection(
+            key="archetype",
+            title=_WAVE1_OVERLAY_TITLES["archetype"],
+            content=_format_archetype_overlay(normalized_inputs["archetype_definition"]),
+        ),
+        PromptOverlaySection(
+            key="category",
+            title=_WAVE1_OVERLAY_TITLES["category"],
+            content=_format_literal_category_overlay(normalized_inputs["category_definition"]),
+        ),
+        PromptOverlaySection(
+            key="route_category",
+            title=_WAVE1_OVERLAY_TITLES["route_category"],
+            content=_format_route_category_overlay(normalized_inputs["route_category_definition"]),
+        ),
+        PromptOverlaySection(
+            key="delegation_profile",
+            title=_WAVE1_OVERLAY_TITLES["delegation_profile"],
+            content=_format_delegation_profile_overlay(normalized_inputs["delegation_profile"]),
+        ),
+        PromptOverlaySection(
+            key="runtime_mode",
+            title=_WAVE1_OVERLAY_TITLES["runtime_mode"],
+            content=_format_runtime_mode_overlay(normalized_inputs["runtime_mode_definition"]),
+        ),
+    ]
+
+    if normalized_inputs.get("skills_explicit"):
+        sections.append(
+            PromptOverlaySection(
+                key="skills",
+                title=_WAVE1_OVERLAY_TITLES["skills"],
+                content=_format_skills_overlay(normalized_inputs["skills"]),
+            )
+        )
+
+    if normalized_inputs.get("task_contract") is not None:
+        sections.append(
+            PromptOverlaySection(
+                key="task_contract",
+                title=_WAVE1_OVERLAY_TITLES["task_contract"],
+                content=_format_json_block(normalized_inputs["task_contract"]),
+            )
+        )
+
+    if normalized_inputs.get("orchestration_hints_rendered"):
+        sections.append(
+            PromptOverlaySection(
+                key="orchestration_hints",
+                title=_WAVE1_OVERLAY_TITLES["orchestration_hints"],
+                content=normalized_inputs["orchestration_hints_rendered"],
+            )
+        )
+
+    section_order = tuple(section.key for section in sections)
+    expected_prefix = tuple(key for key in WAVE1_OVERLAY_ORDER if key in section_order)
+    if section_order != expected_prefix:
+        raise AssertionError(
+            f"Wave 1 overlay order violation: expected {expected_prefix}, got {section_order}"
+        )
+
+    return sections
+
+
+def build_wave1_overlay_prompt_from_normalized(normalized_inputs: dict[str, Any]) -> str:
+    sections = build_wave1_overlay_sections_from_normalized(normalized_inputs)
+    if not sections:
+        return ""
+    rendered_sections = [f"## {section.title}\n{section.content}" for section in sections]
+    return "# Wave 1 Prompt Overlays\n\n" + "\n\n".join(rendered_sections)
+
+
+def build_wave1_overlay_sections(
+    *,
+    archetype_name: str | None = None,
+    category: Any = None,
+    route_category: Any = None,
+    delegation_profile: str | None = None,
+    runtime_mode: Any = None,
+    skills: Any = None,
+    task_contract: dict[str, Any] | TaskContract | None = None,
+    orchestration_hints: Any = None,
+) -> list[PromptOverlaySection]:
+    """Build the Wave 1 prompt overlays in the exact locked order.
+
+    Ordering is structural and deterministic so downstream delegation code can
+    rely on this helper instead of hand-assembling prompt fragments.
+    """
+
+    normalized_inputs = normalize_wave1_overlay_inputs(
+        archetype_name=archetype_name,
+        category=category,
+        route_category=route_category,
+        delegation_profile=delegation_profile,
+        runtime_mode=runtime_mode,
+        skills=skills,
+        task_contract=task_contract,
+        orchestration_hints=orchestration_hints,
+    )
+    return build_wave1_overlay_sections_from_normalized(normalized_inputs)
+
+
+def build_wave1_overlay_prompt(
+    *,
+    archetype_name: str | None = None,
+    category: Any = None,
+    route_category: Any = None,
+    delegation_profile: str | None = None,
+    runtime_mode: Any = None,
+    skills: Any = None,
+    task_contract: dict[str, Any] | TaskContract | None = None,
+    orchestration_hints: Any = None,
+) -> str:
+    """Render the exact Wave 1 overlays as a prompt block.
+
+    `task_contract` is preserved as canonical structured JSON inside its own
+    section rather than flattened into prose.
+    """
+
+    normalized_inputs = normalize_wave1_overlay_inputs(
+        archetype_name=archetype_name,
+        category=category,
+        route_category=route_category,
+        delegation_profile=delegation_profile,
+        runtime_mode=runtime_mode,
+        skills=skills,
+        task_contract=task_contract,
+        orchestration_hints=orchestration_hints,
+    )
+    return build_wave1_overlay_prompt_from_normalized(normalized_inputs)
 
 # ---------------------------------------------------------------------------
 # Context file scanning — detect prompt injection in AGENTS.md, .cursorrules,
@@ -919,11 +1352,8 @@ def load_soul_md() -> Optional[str]:
         return None
 
 
-def _load_hermes_md(cwd_path: Path) -> str:
-    """.hermes.md / HERMES.md — walk to git root."""
-    hermes_md_path = _find_hermes_md(cwd_path)
-    if not hermes_md_path:
-        return ""
+def _load_hermes_md_file(cwd_path: Path, hermes_md_path: Path) -> str:
+    """Load one .hermes.md/HERMES.md file with stable relative path rendering."""
     try:
         content = hermes_md_path.read_text(encoding="utf-8").strip()
         if not content:
@@ -933,13 +1363,24 @@ def _load_hermes_md(cwd_path: Path) -> str:
         try:
             rel = str(hermes_md_path.relative_to(cwd_path))
         except ValueError:
-            pass
+            try:
+                rel = str(hermes_md_path.relative_to(_find_git_root(cwd_path) or cwd_path.parent))
+            except ValueError:
+                rel = hermes_md_path.name
         content = _scan_context_content(content, rel)
         result = f"## {rel}\n\n{content}"
-        return _truncate_content(result, ".hermes.md")
+        return _truncate_content(result, hermes_md_path.name)
     except Exception as e:
         logger.debug("Could not read %s: %s", hermes_md_path, e)
         return ""
+
+
+def _load_hermes_md(cwd_path: Path) -> str:
+    """Backward-compatible single-file .hermes.md / HERMES.md loader."""
+    hermes_md_path = _find_hermes_md(cwd_path)
+    if not hermes_md_path:
+        return ""
+    return _load_hermes_md_file(cwd_path, hermes_md_path)
 
 
 def _load_agents_md(cwd_path: Path) -> str:
@@ -1004,36 +1445,57 @@ def _load_cursorrules(cwd_path: Path) -> str:
     return _truncate_content(cursorrules_content, ".cursorrules")
 
 
-def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
-    """Discover and load context files for the system prompt.
+def build_context_files_prompt(
+    cwd: Optional[str] = None,
+    skip_soul: bool = False,
+    task_contract: dict[str, Any] | TaskContract | None = None,
+    max_hermes_hierarchy_layers: int = MAX_HERMES_CONTEXT_LAYERS,
+) -> str:
+    """Discover and load bounded project context for the system prompt.
 
-    Priority (first found wins — only ONE project context type is loaded):
-      1. .hermes.md / HERMES.md  (walk to git root)
-      2. AGENTS.md / agents.md   (cwd only)
-      3. CLAUDE.md / claude.md   (cwd only)
-      4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
+    Hierarchical behavior:
+      1. Load up to ``max_hermes_hierarchy_layers`` .hermes.md/HERMES.md files
+         along the git-root→cwd lineage, in deterministic root→leaf order.
+      2. If no Hermes lineage exists, fall back to exactly one cwd-only context
+         source by the historical priority order: AGENTS.md → CLAUDE.md → cursor rules.
+      3. SOUL.md from HERMES_HOME remains independent and optional.
 
-    SOUL.md from HERMES_HOME is independent and always included when present.
-    Each context source is capped at 20,000 chars.
-
-    When *skip_soul* is True, SOUL.md is not included here (it was already
-    loaded via ``load_soul_md()`` for the identity slot).
+    When ``task_contract`` is provided, bounded context precedence metadata is
+    rendered additively without mutating the canonical contract fields.
     """
     if cwd is None:
         cwd = os.getcwd()
 
     cwd_path = Path(cwd).resolve()
-    sections = []
+    sections: list[str] = []
+    layer_descriptors = []
 
-    # Priority-based project context: first match wins
-    project_context = (
-        _load_hermes_md(cwd_path)
-        or _load_agents_md(cwd_path)
-        or _load_claude_md(cwd_path)
-        or _load_cursorrules(cwd_path)
+    hermes_layers = discover_hermes_context_layers(
+        cwd_path,
+        max_layers=max_hermes_hierarchy_layers,
     )
-    if project_context:
-        sections.append(project_context)
+    if hermes_layers:
+        for layer in hermes_layers:
+            project_context = _load_hermes_md_file(cwd_path, layer.path)
+            if project_context:
+                sections.append(project_context)
+                layer_descriptors.append(layer)
+    else:
+        project_context = (
+            _load_agents_md(cwd_path)
+            or _load_claude_md(cwd_path)
+            or _load_cursorrules(cwd_path)
+        )
+        if project_context:
+            sections.append(project_context)
+
+    if task_contract is not None and layer_descriptors:
+        bounded = apply_bounded_hierarchical_context(task_contract, layer_descriptors)
+        sections.append(
+            "## Context Precedence\n\n"
+            "Task-contract fields remain authoritative. Bounded hierarchical context is additive only.\n\n"
+            + "precedence: " + " > ".join(bounded.precedence)
+        )
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/agent/route_categories.py
+++ b/agent/route_categories.py
@@ -1,0 +1,273 @@
+"""Wave 1 route-category schema.
+
+Route categories are routing labels, not delegation profiles.
+They intentionally use a distinct data model so later config and resolution work
+can map route categories onto delegation behavior without collapsing the two.
+
+DG2 adds a bounded literal-category product facade on top of the existing
+route-category substrate. Literal categories expose upstream-facing names while
+truthfully delegating route/fallback behavior to mapped internal route
+categories.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Mapping
+
+
+@dataclass(frozen=True)
+class RouteCategory:
+    """First-class routing concept used to classify delegation lanes."""
+
+    name: str
+    summary: str
+    intensity: str
+    fallback_models: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LiteralCategory:
+    """Bounded upstream-facing category facade mapped onto route categories."""
+
+    name: str
+    summary: str
+    route_category: str
+    default_runtime_mode: str | None = None
+
+
+def _require_non_empty_normalized_string(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if not value:
+        raise ValueError(f"{field_name} must be non-empty")
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(f"{field_name} must be non-empty")
+    if normalized_value != value:
+        raise ValueError(f"{field_name} must use canonical normalized form")
+    return normalized_value
+
+
+def _normalize_literal_lookup_name(value: str | None) -> str:
+    token = str(value or "").strip().lower()
+    if not token:
+        return ""
+    return token.replace("_", "-").replace(" ", "-")
+
+
+def validate_route_category(category: RouteCategory) -> RouteCategory:
+    if not isinstance(category, RouteCategory):
+        raise ValueError("route category must be a RouteCategory instance")
+
+    _require_non_empty_normalized_string(category.name, "name")
+    _require_non_empty_normalized_string(category.summary, "summary")
+    _require_non_empty_normalized_string(category.intensity, "intensity")
+    if not isinstance(category.fallback_models, tuple):
+        raise ValueError("fallback_models must be a tuple")
+    for fallback_model in category.fallback_models:
+        _require_non_empty_normalized_string(fallback_model, "fallback_models")
+    return category
+
+
+def validate_literal_category(category: LiteralCategory) -> LiteralCategory:
+    if not isinstance(category, LiteralCategory):
+        raise ValueError("literal category must be a LiteralCategory instance")
+
+    _require_non_empty_normalized_string(category.name, "name")
+    _require_non_empty_normalized_string(category.summary, "summary")
+    _require_non_empty_normalized_string(category.route_category, "route_category")
+    if category.default_runtime_mode is not None:
+        _require_non_empty_normalized_string(category.default_runtime_mode, "default_runtime_mode")
+    return category
+
+
+def validate_route_categories(
+    categories: tuple[RouteCategory, ...],
+) -> tuple[RouteCategory, ...]:
+    seen_names: set[str] = set()
+
+    for category in categories:
+        validate_route_category(category)
+        if category.name in seen_names:
+            raise ValueError(f"duplicate route category name: {category.name}")
+        seen_names.add(category.name)
+
+    return categories
+
+
+def validate_literal_categories(
+    categories: tuple[LiteralCategory, ...],
+) -> tuple[LiteralCategory, ...]:
+    seen_names: set[str] = set()
+
+    for category in categories:
+        validate_literal_category(category)
+        if category.name in seen_names:
+            raise ValueError(f"duplicate literal category name: {category.name}")
+        seen_names.add(category.name)
+
+    return categories
+
+
+_ROUTE_CATEGORY_SPECS: Final[tuple[tuple[str, str, str, tuple[str, ...]], ...]] = (
+    ("ultrabrain", "Highest-depth routing lane for especially demanding reasoning.", "highest", ("deep",)),
+    ("deep", "High-depth routing lane for careful multi-step work.", "high", ("quick",)),
+    ("quick", "Fast-path routing lane for lighter-weight execution.", "low", ("default",)),
+    ("visual", "Routing lane for image- or screenshot-centered work.", "medium", ("quick",)),
+    ("writing", "Routing lane for drafting, editing, and communication-heavy work.", "medium", ("quick",)),
+    ("artistry", "Routing lane for creative generation, aesthetic exploration, and design-led work.", "medium", ("visual",)),
+    ("unspecified_low", "Fallback routing lane when intent is underspecified but appears lightweight.", "low", ("default",)),
+    ("unspecified_high", "Fallback routing lane when intent is underspecified and appears demanding.", "high", ("deep",)),
+)
+
+
+_LITERAL_CATEGORY_SPECS: Final[tuple[tuple[str, str, str, str | None], ...]] = (
+    ("ultrabrain", "Highest-depth upstream category for especially demanding reasoning.", "ultrabrain", None),
+    ("deep", "High-depth upstream category for careful multi-step work.", "deep", None),
+    ("quick", "Fast-path upstream category for lighter-weight execution.", "quick", None),
+    ("visual-engineering", "Upstream category for image-, screenshot-, and visual-engineering-centered work.", "visual", None),
+    ("writing", "Upstream category for drafting, editing, and communication-heavy work.", "writing", None),
+    ("artistry", "Upstream category for creative generation, aesthetic exploration, and design-led work.", "artistry", None),
+    ("unspecified-low", "Fallback upstream category when intent is underspecified but appears lightweight.", "unspecified_low", None),
+    ("unspecified-high", "Fallback upstream category when intent is underspecified and appears demanding.", "unspecified_high", None),
+)
+
+
+_BUILTIN_ROUTE_CATEGORY_LIST: Final[tuple[RouteCategory, ...]] = validate_route_categories(
+    tuple(
+        RouteCategory(name=name, summary=summary, intensity=intensity, fallback_models=fallback_models)
+        for name, summary, intensity, fallback_models in _ROUTE_CATEGORY_SPECS
+    )
+)
+
+_BUILTIN_LITERAL_CATEGORY_LIST: Final[tuple[LiteralCategory, ...]] = validate_literal_categories(
+    tuple(
+        LiteralCategory(
+            name=name,
+            summary=summary,
+            route_category=route_category,
+            default_runtime_mode=default_runtime_mode,
+        )
+        for name, summary, route_category, default_runtime_mode in _LITERAL_CATEGORY_SPECS
+    )
+)
+
+BUILTIN_ROUTE_CATEGORIES: Final[Mapping[str, RouteCategory]] = MappingProxyType(
+    {category.name: category for category in _BUILTIN_ROUTE_CATEGORY_LIST}
+)
+
+BUILTIN_LITERAL_CATEGORIES: Final[Mapping[str, LiteralCategory]] = MappingProxyType(
+    {category.name: category for category in _BUILTIN_LITERAL_CATEGORY_LIST}
+)
+
+DEFAULT_ROUTE_CATEGORY: Final[str] = "unspecified_low"
+DEFAULT_LITERAL_CATEGORY: Final[str] = "unspecified-low"
+
+_LITERAL_CATEGORY_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        name: name
+        for name in BUILTIN_LITERAL_CATEGORIES
+    }
+    | {
+        "visual": "visual-engineering",
+        "unspecified-low": "unspecified-low",
+        "unspecified-high": "unspecified-high",
+        "unspecified_low": "unspecified-low",
+        "unspecified_high": "unspecified-high",
+    }
+)
+
+
+def get_route_categories() -> Mapping[str, RouteCategory]:
+    """Return the built-in route-category registry."""
+
+    return BUILTIN_ROUTE_CATEGORIES
+
+
+def get_literal_categories() -> Mapping[str, LiteralCategory]:
+    """Return the built-in literal-category registry."""
+
+    return BUILTIN_LITERAL_CATEGORIES
+
+
+def get_route_category(name: str) -> RouteCategory:
+    """Resolve a built-in route category by name."""
+
+    try:
+        return BUILTIN_ROUTE_CATEGORIES[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown route category: {name}") from exc
+
+
+def get_literal_category(name: str) -> LiteralCategory:
+    """Resolve a built-in literal category by exact canonical name."""
+
+    try:
+        return BUILTIN_LITERAL_CATEGORIES[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown literal category: {name}") from exc
+
+
+def resolve_route_category(name: str | None) -> RouteCategory:
+    """Resolve a route category, falling back to the canonical Wave 1 default.
+
+    Route categories remain first-class routing labels. Unknown, empty, or
+    whitespace-padded values should degrade to the compatibility-safe default
+    instead of silently reusing delegation-profile semantics.
+    """
+
+    normalized_name = str(name or "").strip()
+    if not normalized_name:
+        return BUILTIN_ROUTE_CATEGORIES[DEFAULT_ROUTE_CATEGORY]
+    return BUILTIN_ROUTE_CATEGORIES.get(normalized_name, BUILTIN_ROUTE_CATEGORIES[DEFAULT_ROUTE_CATEGORY])
+
+
+def resolve_literal_category(name: str | None) -> LiteralCategory:
+    """Resolve a literal product category with deterministic compatibility aliases."""
+
+    normalized_name = _normalize_literal_lookup_name(name)
+    if not normalized_name:
+        return BUILTIN_LITERAL_CATEGORIES[DEFAULT_LITERAL_CATEGORY]
+    canonical_name = _LITERAL_CATEGORY_ALIASES.get(normalized_name, DEFAULT_LITERAL_CATEGORY)
+    return BUILTIN_LITERAL_CATEGORIES[canonical_name]
+
+
+def resolve_literal_category_from_route_category(route_category_name: str | None) -> LiteralCategory:
+    """Translate a route category into the bounded literal category facade."""
+
+    resolved_route_category = resolve_route_category(route_category_name)
+    for literal_category in BUILTIN_LITERAL_CATEGORIES.values():
+        if literal_category.route_category == resolved_route_category.name:
+            return literal_category
+    return BUILTIN_LITERAL_CATEGORIES[DEFAULT_LITERAL_CATEGORY]
+
+
+def resolve_literal_category_to_route_category(name: str | None) -> RouteCategory:
+    """Resolve literal category fallback/runtime behavior via the mapped route category."""
+
+    literal_category = resolve_literal_category(name)
+    return BUILTIN_ROUTE_CATEGORIES[literal_category.route_category]
+
+
+__all__ = [
+    "BUILTIN_LITERAL_CATEGORIES",
+    "BUILTIN_ROUTE_CATEGORIES",
+    "DEFAULT_LITERAL_CATEGORY",
+    "DEFAULT_ROUTE_CATEGORY",
+    "LiteralCategory",
+    "RouteCategory",
+    "get_literal_categories",
+    "get_literal_category",
+    "get_route_categories",
+    "get_route_category",
+    "resolve_literal_category",
+    "resolve_literal_category_from_route_category",
+    "resolve_literal_category_to_route_category",
+    "resolve_route_category",
+    "validate_literal_categories",
+    "validate_literal_category",
+    "validate_route_categories",
+    "validate_route_category",
+]

--- a/agent/runtime_modes.py
+++ b/agent/runtime_modes.py
@@ -1,0 +1,153 @@
+"""Wave 1 runtime-mode schema and built-in defaults.
+
+Runtime modes are a top-level operating-mode concept. They must remain distinct
+from route categories, delegation profiles, skills, task contracts, and
+archetypes. This module is intentionally schema-only for Wave 1 and does not
+implement activation or intent-classification behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Mapping
+
+
+@dataclass(frozen=True)
+class RuntimeMode:
+    """Canonical Wave 1 runtime-mode definition.
+
+    The schema intentionally models runtime modes as their own concept rather
+    than reusing route-category or archetype structures.
+    """
+
+    name: str
+    description: str
+    operating_posture: str
+    kind: str = "runtime_mode"
+
+
+def _require_non_empty_normalized_string(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if not value:
+        raise ValueError(f"{field_name} must be non-empty")
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(f"{field_name} must be non-empty")
+    if normalized_value != value:
+        raise ValueError(f"{field_name} must use canonical normalized form")
+    return normalized_value
+
+
+def validate_runtime_mode(mode: RuntimeMode) -> RuntimeMode:
+    if not isinstance(mode, RuntimeMode):
+        raise ValueError("runtime mode must be a RuntimeMode instance")
+
+    _require_non_empty_normalized_string(mode.name, "name")
+    _require_non_empty_normalized_string(mode.description, "description")
+    _require_non_empty_normalized_string(mode.operating_posture, "operating_posture")
+
+    if mode.kind != "runtime_mode":
+        raise ValueError("kind must equal runtime_mode")
+
+    return mode
+
+
+def validate_runtime_modes(
+    modes: tuple[RuntimeMode, ...], *, default_name: str
+) -> tuple[RuntimeMode, ...]:
+    normalized_default_name = _require_non_empty_normalized_string(default_name, "default_name")
+    seen_names: set[str] = set()
+
+    for mode in modes:
+        validate_runtime_mode(mode)
+        if mode.name in seen_names:
+            raise ValueError(f"duplicate runtime mode name: {mode.name}")
+        seen_names.add(mode.name)
+
+    if normalized_default_name not in seen_names:
+        raise ValueError(f"default runtime mode is not registered: {normalized_default_name}")
+
+    return modes
+
+
+DEFAULT_RUNTIME_MODE_NAME: Final[str] = "default"
+
+BUILTIN_RUNTIME_MODES: Final[tuple[RuntimeMode, ...]] = validate_runtime_modes(
+    (
+        RuntimeMode(
+            name="default",
+            description="Standard Hermes operating posture with no specialized runtime bias.",
+            operating_posture="balanced_general_operation",
+        ),
+        RuntimeMode(
+            name="ultrawork",
+            description="High-focus execution posture reserved as a runtime-mode schema default.",
+            operating_posture="high_intensity_execution",
+        ),
+        RuntimeMode(
+            name="ralph",
+            description="Bounded Ralph-loop operating posture for structured run-until-complete execution.",
+            operating_posture="bounded_progress_execution",
+        ),
+        RuntimeMode(
+            name="interview_planning",
+            description="Interview-planning operating posture for structured preparation workflows.",
+            operating_posture="structured_preparation",
+        ),
+        RuntimeMode(
+            name="execution_supervisor",
+            description="Execution-supervisor operating posture for oversight-oriented sessions.",
+            operating_posture="oversight_and_coordination",
+        ),
+    ),
+    default_name=DEFAULT_RUNTIME_MODE_NAME,
+)
+
+RUNTIME_MODES_BY_NAME: Final[Mapping[str, RuntimeMode]] = MappingProxyType(
+    {mode.name: mode for mode in BUILTIN_RUNTIME_MODES}
+)
+
+
+def list_runtime_modes() -> tuple[RuntimeMode, ...]:
+    """Return the built-in Wave 1 runtime modes in declaration order."""
+
+    return BUILTIN_RUNTIME_MODES
+
+
+def get_default_runtime_mode() -> RuntimeMode:
+    """Return the canonical default runtime mode."""
+
+    return RUNTIME_MODES_BY_NAME[DEFAULT_RUNTIME_MODE_NAME]
+
+
+def resolve_runtime_mode(mode_name: str | None) -> RuntimeMode:
+    """Resolve a runtime mode name, falling back to the Wave 1 default.
+
+    Runtime-mode resolution accepts compatibility-safe case/spacing variants so
+    runtime posture remains deterministic even when the input arrives from a
+    loosely-normalized prompt overlay or delegated child payload.
+    """
+
+    if not mode_name:
+        return get_default_runtime_mode()
+
+    normalized_name = str(mode_name).strip().lower().replace(" ", "_").replace("-", "_")
+    if not normalized_name:
+        return get_default_runtime_mode()
+
+    return RUNTIME_MODES_BY_NAME.get(normalized_name, get_default_runtime_mode())
+
+
+__all__ = [
+    "BUILTIN_RUNTIME_MODES",
+    "DEFAULT_RUNTIME_MODE_NAME",
+    "RUNTIME_MODES_BY_NAME",
+    "RuntimeMode",
+    "get_default_runtime_mode",
+    "list_runtime_modes",
+    "resolve_runtime_mode",
+    "validate_runtime_mode",
+    "validate_runtime_modes",
+]

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -59,6 +59,101 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
+def _build_result(model: Any, runtime: Dict[str, Any], label: Optional[str]) -> Dict[str, Any]:
+    return {
+        "model": model,
+        "runtime": {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
+        },
+        "label": label,
+        "signature": (
+            model,
+            runtime.get("provider"),
+            runtime.get("base_url"),
+            runtime.get("api_mode"),
+            runtime.get("command"),
+            tuple(runtime.get("args") or ()),
+        ),
+    }
+
+
+def _build_primary_result(primary: Dict[str, Any]) -> Dict[str, Any]:
+    return _build_result(
+        primary.get("model"),
+        {
+            "api_key": primary.get("api_key"),
+            "base_url": primary.get("base_url"),
+            "provider": primary.get("provider"),
+            "api_mode": primary.get("api_mode"),
+            "command": primary.get("command"),
+            "args": list(primary.get("args") or []),
+            "credential_pool": primary.get("credential_pool"),
+        },
+        None,
+    )
+
+
+def _normalize_route_entry(route: Any, *, reason: str) -> Optional[Dict[str, Any]]:
+    if not isinstance(route, dict):
+        return None
+
+    provider = str(route.get("provider") or "").strip().lower()
+    model = str(route.get("model") or "").strip()
+    if not provider or not model:
+        return None
+
+    normalized = dict(route)
+    normalized["provider"] = provider
+    normalized["model"] = model
+    normalized["routing_reason"] = reason
+    return normalized
+
+
+def _resolve_configured_route(route: Optional[Dict[str, Any]], *, label_prefix: str) -> Optional[Dict[str, Any]]:
+    if not route:
+        return None
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    explicit_api_key = None
+    api_key_env = str(route.get("api_key_env") or "").strip()
+    if api_key_env:
+        explicit_api_key = os.getenv(api_key_env) or None
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=route.get("provider"),
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=route.get("base_url"),
+        )
+    except Exception:
+        return None
+
+    return _build_result(
+        route.get("model"),
+        runtime,
+        f"{label_prefix} {route.get('model')} ({runtime.get('provider')})",
+    )
+
+
+def choose_primary_agent_route(routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return the configured strong/primary route when smart routing is enabled."""
+    cfg = routing_config or {}
+    if not _coerce_bool(cfg.get("enabled"), False):
+        return None
+
+    return _normalize_route_entry(
+        cfg.get("primary_agent"),
+        reason="primary_agent",
+    )
+
+
 def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Return the configured cheap-model route when a message looks simple.
 
@@ -69,12 +164,11 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     if not _coerce_bool(cfg.get("enabled"), False):
         return None
 
-    cheap_model = cfg.get("cheap_model") or {}
-    if not isinstance(cheap_model, dict):
-        return None
-    provider = str(cheap_model.get("provider") or "").strip().lower()
-    model = str(cheap_model.get("model") or "").strip()
-    if not provider or not model:
+    cheap_model = _normalize_route_entry(
+        cfg.get("cheap_model") or {},
+        reason="simple_turn",
+    )
+    if not cheap_model:
         return None
 
     text = (user_message or "").strip()
@@ -100,11 +194,7 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     if words & _COMPLEX_KEYWORDS:
         return None
 
-    route = dict(cheap_model)
-    route["provider"] = provider
-    route["model"] = model
-    route["routing_reason"] = "simple_turn"
-    return route
+    return cheap_model
 
 
 def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any]], primary: Dict[str, Any]) -> Dict[str, Any]:
@@ -112,84 +202,19 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
 
     Returns a dict with model/runtime/signature/label fields.
     """
+    default_primary = _build_primary_result(primary)
+    primary_route = choose_primary_agent_route(routing_config)
+
+    def _resolve_effective_primary() -> Dict[str, Any]:
+        configured_primary = _resolve_configured_route(
+            primary_route,
+            label_prefix="smart route → primary",
+        )
+        return configured_primary or default_primary
+
     route = choose_cheap_model_route(user_message, routing_config)
     if not route:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-                "credential_pool": primary.get("credential_pool"),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
+        return _resolve_effective_primary()
 
-    from hermes_cli.runtime_provider import resolve_runtime_provider
-
-    explicit_api_key = None
-    api_key_env = str(route.get("api_key_env") or "").strip()
-    if api_key_env:
-        explicit_api_key = os.getenv(api_key_env) or None
-
-    try:
-        runtime = resolve_runtime_provider(
-            requested=route.get("provider"),
-            explicit_api_key=explicit_api_key,
-            explicit_base_url=route.get("base_url"),
-        )
-    except Exception:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-                "credential_pool": primary.get("credential_pool"),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
-
-    return {
-        "model": route.get("model"),
-        "runtime": {
-            "api_key": runtime.get("api_key"),
-            "base_url": runtime.get("base_url"),
-            "provider": runtime.get("provider"),
-            "api_mode": runtime.get("api_mode"),
-            "command": runtime.get("command"),
-            "args": list(runtime.get("args") or []),
-            "credential_pool": runtime.get("credential_pool"),
-        },
-        "label": f"smart route → {route.get('model')} ({runtime.get('provider')})",
-        "signature": (
-            route.get("model"),
-            runtime.get("provider"),
-            runtime.get("base_url"),
-            runtime.get("api_mode"),
-            runtime.get("command"),
-            tuple(runtime.get("args") or ()),
-        ),
-    }
+    cheap_result = _resolve_configured_route(route, label_prefix="smart route →")
+    return cheap_result or _resolve_effective_primary()

--- a/cli.py
+++ b/cli.py
@@ -4598,9 +4598,28 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        user_provs=None,
+        custom_provs=None,
+        trigger_command: str | None = None,
+    ) -> None:
         """Open prompt_toolkit-native /model picker modal."""
-        self._capture_modal_input_snapshot()
+        consumed_trigger = False
+        if trigger_command and getattr(self, "_app", None):
+            try:
+                buf = self._app.current_buffer
+                if (buf.text or "").strip() == trigger_command.strip():
+                    buf.reset()
+                    self._modal_input_snapshot = None
+                    consumed_trigger = True
+            except Exception:
+                consumed_trigger = False
+        if not consumed_trigger:
+            self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
         self._model_picker_state = {
             "stage": "provider",
@@ -4848,6 +4867,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                trigger_command=cmd_original,
             )
             return
 

--- a/gateway/authority_snapshot.py
+++ b/gateway/authority_snapshot.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from hermes_state import SessionDB
+from hermes_cli.profiles import get_active_profile_name, get_profile_dir, list_profiles
+
+
+_ACTIONABLE_CONTINUATION_STATUSES = {"pending", "retry_requested", "running"}
+
+
+def _to_iso(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    try:
+        return datetime.fromtimestamp(float(value)).isoformat()
+    except Exception:
+        return None
+
+
+def _profile_root(profile_id: Optional[str]) -> Path:
+    normalized = str(profile_id or "").strip() or get_active_profile_name()
+    return get_profile_dir(normalized)
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+            return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _load_soul(profile_root: Path) -> Optional[str]:
+    soul_path = profile_root / "SOUL.md"
+    if not soul_path.exists():
+        return None
+    try:
+        return soul_path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def _count_sessions(profile_root: Path) -> int:
+    db_path = profile_root / "state.db"
+    if not db_path.exists():
+        return 0
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cursor = conn.execute("SELECT COUNT(*) FROM sessions")
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+        finally:
+            conn.close()
+    except Exception:
+        return 0
+
+
+def _count_skills(profile_root: Path) -> int:
+    skills_dir = profile_root / "skills"
+    if not skills_dir.is_dir():
+        return 0
+    count = 0
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        skill_path = str(skill_md)
+        if "/.hub/" in skill_path or "/.git/" in skill_path:
+            continue
+        count += 1
+    return count
+
+
+def _read_profile_config_subset(profile_id: str) -> Optional[Dict[str, Any]]:
+    profile_root = _profile_root(profile_id)
+    if not profile_root.exists():
+        return None
+
+    raw = _load_yaml(profile_root / "config.yaml")
+    model_cfg = raw.get("model") if isinstance(raw.get("model"), dict) else {}
+    agent_cfg = raw.get("agent") if isinstance(raw.get("agent"), dict) else {}
+    terminal_cfg = raw.get("terminal") if isinstance(raw.get("terminal"), dict) else {}
+    display_cfg = raw.get("display") if isinstance(raw.get("display"), dict) else {}
+    memory_cfg = raw.get("memory") if isinstance(raw.get("memory"), dict) else {}
+    approvals_cfg = raw.get("approvals") if isinstance(raw.get("approvals"), dict) else {}
+    compression_cfg = raw.get("compression") if isinstance(raw.get("compression"), dict) else {}
+
+    return {
+        "modelDefault": model_cfg.get("default"),
+        "modelProvider": model_cfg.get("provider"),
+        "modelBaseUrl": model_cfg.get("base_url"),
+        "maxTurns": agent_cfg.get("max_turns"),
+        "reasoningEffort": agent_cfg.get("reasoning_effort"),
+        "toolUseEnforcement": agent_cfg.get("tool_use_enforcement"),
+        "policyPreset": raw.get("ui_policy_preset"),
+        "toolsets": raw.get("toolsets"),
+        "terminalBackend": terminal_cfg.get("backend"),
+        "terminalTimeout": terminal_cfg.get("timeout"),
+        "displayCompact": display_cfg.get("compact"),
+        "displayStreaming": display_cfg.get("streaming"),
+        "displayShowCost": display_cfg.get("show_cost"),
+        "displayPersonality": display_cfg.get("personality"),
+        "memoryEnabled": memory_cfg.get("memory_enabled"),
+        "userProfileEnabled": memory_cfg.get("user_profile_enabled"),
+        "approvalsMode": approvals_cfg.get("mode"),
+        "compressionEnabled": compression_cfg.get("enabled"),
+        "compressionThreshold": compression_cfg.get("threshold"),
+        "soul": _load_soul(profile_root),
+    }
+
+
+def _list_authority_profiles(active_profile: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for profile in list_profiles():
+        config = _load_yaml(profile.path / "config.yaml")
+        model_cfg = config.get("model") if isinstance(config.get("model"), dict) else {}
+        model_default = model_cfg.get("default")
+        policy_preset = config.get("ui_policy_preset") or "safe-chat"
+        session_count = _count_sessions(profile.path)
+        skill_count = _count_skills(profile.path)
+        rows.append(
+            {
+                "id": profile.name,
+                "name": profile.name,
+                "modelDefault": model_default,
+                "policyPreset": policy_preset,
+                "sessionCount": session_count,
+                "skillCount": skill_count,
+                "extensionCount": 0,
+                "integrationsCount": 0,
+                "runtimeProvider": "real-hermes" if model_default else "unconfigured",
+                "runtimeSummary": f"{model_default or 'No default model'} · {session_count} sessions · {skill_count} skills",
+                "trustMode": policy_preset,
+                "runtimeHealth": "healthy" if model_default else "degraded",
+                "profileContextLabel": (
+                    f"{profile.name} · active runtime profile"
+                    if profile.name == active_profile
+                    else f"{profile.name} · authority api profile"
+                ),
+                "workspacePath": ((config.get("terminal") or {}).get("cwd") if isinstance(config.get("terminal"), dict) else None),
+                "active": profile.name == active_profile,
+            }
+        )
+    return rows
+
+
+def _open_session_db(profile_id: str) -> Optional[SessionDB]:
+    profile_root = _profile_root(profile_id)
+    db_path = profile_root / "state.db"
+    if not db_path.exists():
+        return None
+    try:
+        return SessionDB(db_path)
+    except Exception:
+        return None
+
+
+def _list_sessions(profile_id: str, search: Optional[str] = None) -> List[Dict[str, Any]]:
+    db = _open_session_db(profile_id)
+    if db is None:
+        return []
+    try:
+        rows = db.list_sessions_rich(limit=100, include_children=True)
+    finally:
+        db.close()
+
+    query = str(search or "").strip().lower()
+    sessions: List[Dict[str, Any]] = []
+    for row in rows:
+        preview = str(row.get("preview") or "") or None
+        title = str(row.get("title") or "").strip() or ((preview or "")[:40] if preview else "Untitled session")
+        hay = f"{title} {preview or ''}".lower()
+        if query and query not in hay:
+            continue
+        archived = bool(row.get("ended_at"))
+        model_config: Dict[str, Any] = {}
+        raw_model_config = row.get("model_config")
+        if raw_model_config:
+            try:
+                model_config = json.loads(raw_model_config) or {}
+            except Exception:
+                model_config = {}
+        sessions.append(
+            {
+                "id": row.get("id"),
+                "title": title,
+                "updatedAt": _to_iso(row.get("last_active") or row.get("started_at")),
+                "preview": preview,
+                "workspaceLabel": "Archived" if archived else ("Forks" if row.get("parent_session_id") else "Active workspace"),
+                "pinned": bool(model_config.get("pinned", False)),
+                "archived": archived,
+                "parentSessionId": row.get("parent_session_id"),
+                "source": str(row.get("source") or "unknown").lower(),
+                "profileId": profile_id,
+                "model": row.get("model") or "unknown",
+                "provider": model_config.get("provider", "real-hermes"),
+            }
+        )
+    return sessions
+
+
+def _get_session(profile_id: str, session_id: str) -> Optional[Dict[str, Any]]:
+    db = _open_session_db(profile_id)
+    if db is None:
+        return None
+    try:
+        row = db.get_session(session_id)
+        if not row:
+            return None
+        messages = db.get_messages(session_id)
+    finally:
+        db.close()
+
+    model_config: Dict[str, Any] = {}
+    raw_model_config = row.get("model_config")
+    if raw_model_config:
+        try:
+            model_config = json.loads(raw_model_config) or {}
+        except Exception:
+            model_config = {}
+
+    normalized_messages = []
+    preview = None
+    for index, message in enumerate(messages, start=1):
+        content = message.get("content") or ""
+        if preview is None and message.get("role") == "user" and content:
+            preview = str(content)[:160]
+        normalized_messages.append(
+            {
+                "id": f"{session_id}-{index}",
+                "role": message.get("role"),
+                "content": content,
+                "createdAt": _to_iso(message.get("timestamp")),
+            }
+        )
+
+    title = str(row.get("title") or "").strip() or ((preview or "")[:40] if preview else "Untitled session")
+    archived = bool(row.get("ended_at"))
+    return {
+        "id": row.get("id"),
+        "title": title,
+        "updatedAt": _to_iso(row.get("started_at")),
+        "preview": preview,
+        "messages": normalized_messages,
+        "parentSessionId": row.get("parent_session_id"),
+        "loadedSkillIds": model_config.get("loadedSkillIds", []),
+        "archived": archived,
+        "pinned": bool(model_config.get("pinned", False)),
+        "source": str(row.get("source") or "unknown").lower(),
+        "profileId": profile_id,
+        "settings": {
+            "model": row.get("model") or "unknown",
+            "provider": model_config.get("provider", "real-hermes"),
+            "policyPreset": model_config.get("policyPreset", "safe-chat"),
+            "memoryMode": model_config.get("memoryMode", "standard"),
+        },
+    }
+
+
+def _read_runs(profile_id: str) -> List[Dict[str, Any]]:
+    runs_path = _profile_root(profile_id) / "runtime" / "runs" / "index.json"
+    if not runs_path.exists():
+        return []
+    try:
+        payload = json.loads(runs_path.read_text(encoding="utf-8")) or {}
+        runs = payload.get("runs") if isinstance(payload, dict) else []
+        return runs if isinstance(runs, list) else []
+    except Exception:
+        return []
+
+
+def _read_continuations(profile_id: str) -> Dict[str, List[Dict[str, Any]]]:
+    queue_path = _profile_root(profile_id) / "runtime" / "orchestration" / "continuations.json"
+    if not queue_path.exists():
+        return {"continuations": [], "history": []}
+    try:
+        payload = json.loads(queue_path.read_text(encoding="utf-8")) or {}
+        items = payload.get("items") if isinstance(payload, dict) else []
+        if not isinstance(items, list):
+            items = []
+    except Exception:
+        items = []
+
+    actionable: List[Dict[str, Any]] = []
+    history: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "unknown").strip().lower()
+        if status in _ACTIONABLE_CONTINUATION_STATUSES:
+            actionable.append(item)
+        else:
+            history.append(item)
+
+    actionable.sort(key=lambda item: str(item.get("updatedAt") or item.get("createdAt") or ""), reverse=True)
+    history.sort(key=lambda item: str(item.get("updatedAt") or item.get("createdAt") or ""), reverse=True)
+    return {"continuations": actionable, "history": history}
+
+
+def _get_workspaces(profile_id: str) -> Dict[str, Any]:
+    profile_root = _profile_root(profile_id)
+    config = _load_yaml(profile_root / "config.yaml")
+    terminal_cfg = config.get("terminal") if isinstance(config.get("terminal"), dict) else {}
+    known: List[Dict[str, Any]] = []
+    configured_cwd = str(terminal_cfg.get("cwd") or "").strip() or None
+    if configured_cwd:
+        known.append(
+            {
+                "id": "terminal-cwd",
+                "label": "Configured workspace",
+                "path": configured_cwd,
+                "source": "terminal.cwd",
+            }
+        )
+    workspace_root = profile_root / "workspace"
+    if workspace_root.exists():
+        known.append(
+            {
+                "id": "profile-workspace",
+                "label": "Profile workspace",
+                "path": str(workspace_root),
+                "source": "profile-workspace",
+            }
+        )
+    current = known[0] if known else None
+    return {"current": current, "known": known}
+
+
+def get_authority_snapshot(
+    *,
+    profile_id: Optional[str] = None,
+    search: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    selected_profile = str(profile_id or "").strip() or get_active_profile_name()
+    active_profile = get_active_profile_name()
+    continuations = _read_continuations(selected_profile)
+    return {
+        "profileId": selected_profile,
+        "profiles": _list_authority_profiles(active_profile),
+        "config": _read_profile_config_subset(selected_profile),
+        "sessions": _list_sessions(selected_profile, search),
+        "session": _get_session(selected_profile, str(session_id or "").strip()) if session_id else None,
+        "runs": _read_runs(selected_profile),
+        "continuations": continuations["continuations"],
+        "history": continuations["history"],
+        "workspaces": _get_workspaces(selected_profile),
+    }

--- a/gateway/builtin_hooks/orchestration_state.py
+++ b/gateway/builtin_hooks/orchestration_state.py
@@ -1,0 +1,44 @@
+"""Built-in orchestration-state hook.
+
+Persists lightweight lifecycle state for gateway sessions so Pan can show the
+current session status and delegated-child progress without parsing transcripts.
+"""
+
+from __future__ import annotations
+
+from agent.orchestration_state import record_agent_end, record_agent_start, record_session_lifecycle
+
+
+async def handle(event_type: str, context: dict) -> None:
+    session_id = str((context or {}).get("session_id") or "").strip()
+    if not session_id:
+        return
+
+    if event_type == "agent:start":
+        record_agent_start(
+            session_id,
+            platform=(context or {}).get("platform"),
+            user_id=(context or {}).get("user_id"),
+            message=(context or {}).get("message"),
+        )
+        return
+
+    if event_type == "agent:end":
+        status = str((context or {}).get("status") or "").strip() or ""
+        if not status:
+            orchestration = (context or {}).get("orchestration") or {}
+            if isinstance(orchestration, dict):
+                status = str(orchestration.get("outcomeStatus") or "").strip()
+        record_agent_end(
+            session_id,
+            status=status or "completed",
+            response=(context or {}).get("response"),
+        )
+        return
+
+    if event_type == "session:end":
+        record_session_lifecycle(session_id, "ended")
+        return
+
+    if event_type == "session:reset":
+        record_session_lifecycle(session_id, "reset")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,6 +40,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from gateway.authority_snapshot import get_authority_snapshot
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -486,6 +487,23 @@ class APIServerAdapter(BasePlatformAdapter):
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
             status=401,
         )
+
+    async def _handle_authority_snapshot(self, request: "web.Request") -> "web.Response":
+        """GET /api/authority/snapshot — return a profile-scoped authority snapshot."""
+        auth_err = self._check_auth(request)
+        if auth_err is not None:
+            return auth_err
+
+        try:
+            snapshot = get_authority_snapshot(
+                profile_id=request.query.get("profile_id"),
+                search=request.query.get("search"),
+                session_id=request.query.get("session_id"),
+            )
+            return web.json_response(snapshot)
+        except Exception as e:
+            logger.exception("Authority snapshot request failed")
+            return web.json_response({"error": str(e)}, status=500)
 
     # ------------------------------------------------------------------
     # Session DB helper
@@ -2315,6 +2333,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
+            self._app.router.add_get("/api/authority/snapshot", self._handle_authority_snapshot)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -104,9 +104,11 @@ if _config_path.exists():
         import yaml as _yaml
         with open(_config_path, encoding="utf-8") as _f:
             _cfg = _yaml.safe_load(_f) or {}
-        # Expand ${ENV_VAR} references before bridging to env vars.
-        from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        # Expand ${ENV_VAR} references and normalize known profile-local paths
+        # before bridging values into env vars. This repairs legacy in-container
+        # paths like /root/.hermes/profiles/<name>/workspace on host installs.
+        from hermes_cli.config import _expand_env_vars, _normalize_profile_path_settings
+        _cfg = _normalize_profile_path_settings(_expand_env_vars(_cfg))
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4127,6 +4127,51 @@ class GatewayRunner:
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
 
+            orchestration = agent_result.get("orchestration")
+            if not isinstance(orchestration, dict):
+                orchestration = {}
+            active_todos = orchestration.get("activeTodos") or orchestration.get("todoItems") or []
+            if not isinstance(active_todos, list):
+                active_todos = []
+            status = str(orchestration.get("outcomeStatus") or "").strip().lower()
+            if not status:
+                if agent_result.get("interrupted"):
+                    status = "interrupted"
+                elif agent_result.get("failed"):
+                    status = "failed"
+                elif agent_result.get("completed", True):
+                    status = "completed"
+                else:
+                    status = "interrupted" if active_todos else "completed"
+            response_preview = (
+                orchestration.get("responsePreview")
+                or response
+                or agent_result.get("final_response")
+                or agent_result.get("error")
+                or ""
+            )
+            if not orchestration:
+                orchestration = {
+                    "sessionId": session_entry.session_id,
+                    "outcomeStatus": status,
+                    "activeTodos": active_todos,
+                    "responsePreview": str(response_preview or "").strip(),
+                }
+                agent_result["orchestration"] = orchestration
+            try:
+                from agent.continuation_enforcer import reconcile_session_continuation
+
+                continuation = reconcile_session_continuation(
+                    str(session_entry.session_id or orchestration.get("sessionId") or "").strip(),
+                    outcome_status=status,
+                    todos=active_todos,
+                    response_preview=str(response_preview or "").strip(),
+                )
+                if continuation is not None:
+                    agent_result["continuation"] = continuation
+            except Exception as exc:
+                logger.debug("Failed to reconcile continuation state: %s", exc)
+
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:
                 from gateway.display_config import resolve_display_setting as _rds
@@ -4154,6 +4199,8 @@ class GatewayRunner:
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "status": status,
+                "orchestration": orchestration,
             })
             
             # Check for pending process watchers (check_interval on background processes)
@@ -4382,6 +4429,104 @@ class GatewayRunner:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
     
+    def _build_auto_resume_message(self, continuation: Dict[str, Any]) -> str:
+        reason = str(continuation.get("reason") or "interrupted").strip() or "interrupted"
+        todos = continuation.get("openTodos") or continuation.get("activeTodos") or []
+        todo_lines = []
+        for item in todos:
+            if isinstance(item, dict):
+                content = str(item.get("content") or item.get("id") or "pending work").strip()
+                status = str(item.get("status") or "pending").strip()
+                todo_lines.append(f"- [{status}] {content}")
+        todo_block = "\n".join(todo_lines) if todo_lines else "- Continue the interrupted task"
+        return (
+            "[System note: Auto-resume the previously interrupted task. "
+            f"Previous outcome: {reason}. Finish the remaining work before anything else.]\n\n"
+            "Open work:\n"
+            f"{todo_block}"
+        )
+
+    async def _process_retry_requested_continuations_once(self) -> int:
+        from agent.continuation_enforcer import (
+            append_continuation_event,
+            claim_retry_requested_continuation,
+            reconcile_session_continuation,
+            release_continuation_claim,
+        )
+
+        worker_id = getattr(self, "_auto_resume_worker_id", None) or f"gateway-auto-resume:{os.getpid()}"
+        self._auto_resume_worker_id = worker_id
+        continuation = claim_retry_requested_continuation(worker_id)
+        if not continuation:
+            return 0
+
+        session_id = str(continuation.get("sessionId") or "").strip()
+        session_entry = next(
+            (
+                entry
+                for entry in self.session_store.list_sessions()
+                if getattr(entry, "session_id", None) == session_id
+            ),
+            None,
+        )
+        if session_entry is None or session_entry.origin is None:
+            release_continuation_claim(session_id, worker_id, reason="session_missing")
+            return 0
+
+        if self._running_agents.get(session_entry.session_key):
+            release_continuation_claim(session_id, worker_id, reason="session_busy")
+            return 0
+
+        result = await self._run_agent(
+            message=self._build_auto_resume_message(continuation),
+            context_prompt="",
+            history=self.session_store.load_transcript(session_entry.session_id),
+            source=session_entry.origin,
+            session_id=session_entry.session_id,
+            session_key=session_entry.session_key,
+        )
+
+        orchestration = result.get("orchestration") if isinstance(result, dict) else {}
+        if not isinstance(orchestration, dict):
+            orchestration = {}
+        status = str(orchestration.get("outcomeStatus") or "").strip().lower()
+        if not status:
+            if result.get("interrupted"):
+                status = "interrupted"
+            elif result.get("failed"):
+                status = "failed"
+            elif result.get("completed", True):
+                status = "completed"
+            else:
+                status = "interrupted"
+        active_todos = orchestration.get("activeTodos") or orchestration.get("todoItems") or []
+        if not isinstance(active_todos, list):
+            active_todos = []
+        response_preview = (
+            orchestration.get("responsePreview")
+            or result.get("final_response")
+            or result.get("error")
+            or ""
+        )
+        reconcile_session_continuation(
+            session_entry.session_id,
+            outcome_status=status,
+            todos=active_todos,
+            response_preview=str(response_preview or "").strip(),
+        )
+
+        adapter = self.adapters.get(session_entry.origin.platform)
+        if adapter is not None and result.get("final_response"):
+            metadata = {"thread_id": session_entry.origin.thread_id} if session_entry.origin.thread_id else None
+            await adapter.send(session_entry.origin.chat_id, result.get("final_response"), metadata=metadata)
+            append_continuation_event(
+                session_entry.session_id,
+                "auto_resume_delivered",
+                result.get("final_response"),
+                metadata={"worker_id": worker_id},
+            )
+        return 1
+
     def _format_session_info(self) -> str:
         """Resolve current model config and return a formatted info block.
 
@@ -9294,6 +9439,12 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+            _orchestration = result.get("orchestration") if isinstance(result, dict) else None
+            if not isinstance(_orchestration, dict) and agent is not None and hasattr(agent, "get_orchestration_continuation_snapshot"):
+                try:
+                    _orchestration = agent.get_orchestration_continuation_snapshot(result)
+                except Exception:
+                    _orchestration = None
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
@@ -9319,6 +9470,8 @@ class GatewayRunner:
                     "final_response": error_msg,
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
+                    "completed": result.get("completed", False),
+                    "interrupted": result.get("interrupted", False),
                     "failed": result.get("failed", False),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
@@ -9327,6 +9480,8 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "session_id": getattr(_agent, "session_id", session_id) if _agent else session_id,
+                    "orchestration": _orchestration,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -9410,6 +9565,9 @@ class GatewayRunner:
                 "last_reasoning": result.get("last_reasoning"),
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
+                "completed": result.get("completed", False),
+                "interrupted": result.get("interrupted", False),
+                "failed": result.get("failed", False),
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "last_prompt_tokens": _last_prompt_toks,
@@ -9418,6 +9576,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "orchestration": _orchestration,
             }
         
         # Start progress message sender if enabled
@@ -9805,7 +9964,24 @@ class GatewayRunner:
                         merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
-                    return result_holder[0] or {"final_response": response, "messages": history}
+                    payload = result_holder[0] or {"final_response": response, "messages": history}
+                    if not isinstance(payload, dict):
+                        payload = {"final_response": response, "messages": history}
+                    orchestration = payload.get("orchestration")
+                    _agent_for_orchestration = agent_holder[0]
+                    if not isinstance(orchestration, dict) and _agent_for_orchestration is not None and hasattr(_agent_for_orchestration, "get_orchestration_continuation_snapshot"):
+                        try:
+                            orchestration = _agent_for_orchestration.get_orchestration_continuation_snapshot(payload)
+                        except Exception:
+                            orchestration = None
+                    if not isinstance(orchestration, dict):
+                        orchestration = {}
+                    if not orchestration.get("outcomeStatus"):
+                        orchestration["outcomeStatus"] = "interrupted"
+                    payload["interrupted"] = True
+                    payload["completed"] = False
+                    payload["orchestration"] = orchestration
+                    return payload
 
                 was_interrupted = result.get("interrupted")
                 if not was_interrupted:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -995,6 +995,20 @@ class SessionStore:
         entries.sort(key=lambda e: e.updated_at, reverse=True)
 
         return entries
+
+    def get_runtime_activation_snapshot(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Load the persisted runtime activation snapshot for a session."""
+        if not self._db:
+            return None
+        try:
+            session = self._db.get_session(session_id)
+        except Exception as e:
+            logger.debug("Could not load runtime activation snapshot for %s: %s", session_id, e)
+            return None
+        if not session:
+            return None
+        snapshot = session.get("runtime_activation_snapshot")
+        return dict(snapshot) if isinstance(snapshot, dict) else None
     
     def get_transcript_path(self, session_id: str) -> Path:
         """Get the path to a session's legacy transcript file."""

--- a/hermes_cli/command_templates.py
+++ b/hermes_cli/command_templates.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from agent.task_contracts import (
+    ORCHESTRATION_HINTS_SCHEMA,
+    ORCHESTRATION_HINTS_VERSION,
+    TaskContract,
+    build_named_workflow_artifact,
+    validate_orchestration_hints,
+    validate_task_contract,
+)
+
+
+WORK_STARTING_COMMANDS: frozenset[str] = frozenset(
+    {
+        "handoff",
+        "init-deep",
+        "start-work",
+        "ralph-loop",
+        "ulw-loop",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CommandInvocation:
+    command_name: str
+    raw_args: str
+    task_contract: dict[str, Any]
+    named_workflow: dict[str, Any] | None
+    orchestration_hints: dict[str, Any]
+    prompt_text: str
+
+
+@dataclass(frozen=True)
+class CommandTemplate:
+    name: str
+    summary: str
+    default_request: str
+    contract_builder: Callable[..., dict[str, Any]]
+    hints_builder: Callable[..., dict[str, Any]]
+
+
+_GENERIC_SKILLS = ["repo-navigation", "implementation", "verification"]
+_GENERIC_TOOLS = ["read_file", "search_files", "patch", "terminal"]
+
+
+def _normalize_request(raw_args: str, default_request: str) -> str:
+    text = str(raw_args or "").strip()
+    return text or default_request
+
+
+def _parse_explicit_task_contract(raw_args: str) -> dict[str, Any] | None:
+    text = str(raw_args or "").strip()
+    if not text or text[0] not in "[{":
+        return None
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise TypeError("expected a JSON object")
+    return payload
+
+
+def _request_text_for_contract(
+    raw_args: str,
+    default_request: str,
+    *,
+    explicit_contract: dict[str, Any] | None = None,
+) -> str:
+    if explicit_contract is not None:
+        return str(explicit_contract.get("task") or "").strip() or default_request
+    return _normalize_request(raw_args, default_request)
+
+
+def _validated_explicit_contract(explicit_contract: dict[str, Any]) -> dict[str, Any]:
+    return validate_task_contract(explicit_contract).model_dump()
+
+
+def _attach_explicit_contract_metadata(
+    hints: dict[str, Any],
+    *,
+    command_name: str,
+    session_id: str | None,
+    cwd: str | None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata = {
+        "command": command_name,
+        "session_id": session_id,
+        "cwd": cwd,
+        "input_mode": "explicit_json_contract",
+        "preserve_exact_task_contract": True,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    hints["invocation_metadata"] = metadata
+    return validate_orchestration_hints(hints).model_dump()
+
+
+def _base_contract(
+    *,
+    command_name: str,
+    request_text: str,
+    session_id: str | None,
+    cwd: str | None,
+    expected_outcome: str,
+    must_do: list[Any],
+    must_not_do: list[Any],
+    required_skills: list[str] | None = None,
+    required_tools: list[str] | None = None,
+    extra_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    context = {
+        "command": command_name,
+        "request": request_text,
+        "session_id": session_id,
+        "cwd": cwd,
+    }
+    if extra_context:
+        context.update(extra_context)
+    return validate_task_contract(
+        {
+            "task": request_text,
+            "expected_outcome": expected_outcome,
+            "required_skills": list(required_skills or _GENERIC_SKILLS),
+            "required_tools": list(required_tools or _GENERIC_TOOLS),
+            "must_do": must_do,
+            "must_not_do": must_not_do,
+            "context": context,
+        }
+    ).model_dump()
+
+
+def _base_hints(*, command_name: str, request_text: str, loop_style: str = "single_pass") -> dict[str, Any]:
+    return validate_orchestration_hints(
+        {
+            "schema": ORCHESTRATION_HINTS_SCHEMA,
+            "schema_version": ORCHESTRATION_HINTS_VERSION,
+            "command": command_name,
+            "loop_style": loop_style,
+            "request": request_text,
+            "bounded_context": {
+                "enabled": True,
+                "max_hermes_hierarchy_files": 3,
+                "task_contract_precedence": "preserve_existing_fields",
+            },
+        }
+    ).model_dump()
+
+
+def _handoff_contract(*, raw_args: str, session_id: str | None, cwd: str | None) -> dict[str, Any]:
+    raw_args = str(raw_args or "").strip()
+    explicit_contract = _parse_explicit_task_contract(raw_args)
+    request_text = _request_text_for_contract(
+        raw_args,
+        "Continue the handed-off work from the current session state.",
+        explicit_contract=explicit_contract,
+    )
+    if explicit_contract is not None:
+        return _validated_explicit_contract(explicit_contract)
+    return _base_contract(
+        command_name="handoff",
+        request_text=request_text,
+        session_id=session_id,
+        cwd=cwd,
+        expected_outcome="A concise takeover that continues the active task without dropping the prior contract.",
+        must_do=[
+            "inspect the current conversation and workspace before acting",
+            {"handoff": ["preserve active scope", "report what was resumed"]},
+        ],
+        must_not_do=[
+            "do not discard or rewrite an explicit structured task contract",
+            "do not widen scope beyond the handed-off task",
+        ],
+        extra_context={"handoff_mode": "resume_or_consume_contract"},
+    )
+
+
+def _handoff_hints(*, raw_args: str, session_id: str | None, cwd: str | None) -> dict[str, Any]:
+    explicit_contract = _parse_explicit_task_contract(raw_args)
+    request_text = _request_text_for_contract(
+        raw_args,
+        "Continue the handed-off work from the current session state.",
+        explicit_contract=explicit_contract,
+    )
+    hints = _base_hints(command_name="handoff", request_text=request_text)
+    hints["handoff"] = {"consume_existing_contract": True, "announce_resumption": True}
+    if explicit_contract is not None:
+        return _attach_explicit_contract_metadata(
+            hints,
+            command_name="handoff",
+            session_id=session_id,
+            cwd=cwd,
+            extra_metadata={"handoff_mode": "resume_or_consume_contract"},
+        )
+    return hints
+
+
+def _start_work_contract(*, raw_args: str, session_id: str | None, cwd: str | None) -> dict[str, Any]:
+    explicit_contract = _parse_explicit_task_contract(raw_args)
+    request_text = _request_text_for_contract(
+        raw_args,
+        "Start the requested work from the current session context.",
+        explicit_contract=explicit_contract,
+    )
+    if explicit_contract is not None:
+        return _validated_explicit_contract(explicit_contract)
+    return _base_contract(
+        command_name="start-work",
+        request_text=request_text,
+        session_id=session_id,
+        cwd=cwd,
+        expected_outcome="A concrete work start with scoped execution and fresh verification evidence.",
+        must_do=[
+            "identify the exact target before editing",
+            {"verification": ["run focused checks", "report exact outputs"]},
+        ],
+        must_not_do=[
+            "do not skip prerequisite inspection",
+            "do not mutate canonical Wave 1 fields through prose-only instructions",
+        ],
+    )
+
+
+def _start_work_hints(*, raw_args: str, session_id: str | None, cwd: str | None) -> dict[str, Any]:
+    explicit_contract = _parse_explicit_task_contract(raw_args)
+    request_text = _request_text_for_contract(
+        raw_args,
+        "Start the requested work from the current session context.",
+        explicit_contract=explicit_contract,
+    )
+    hints = _base_hints(command_name="start-work", request_text=request_text)
+    hints["work_start"] = {"emit_contract_ack": True}
+    if explicit_contract is not None:
+        return _attach_explicit_contract_metadata(
+            hints,
+            command_name="start-work",
+            session_id=session_id,
+            cwd=cwd,
+        )
+    return hints
+
+
+def _loop_contract(*, command_name: str, raw_args: str, session_id: str | None, cwd: str | None) -> dict[str, Any]:
+    explicit_contract = _parse_explicit_task_contract(raw_args)
+    request_text = _request_text_for_contract(
+        raw_args,
+        f"Run the {command_name} workflow for the current objective.",
+        explicit_contract=explicit_contract,
+    )
+    if explicit_contract is not None:
+        return _validated_explicit_contract(explicit_contract)
+    return _base_contract(
+        command_name=command_name,
+        request_text=request_text,
+        session_id=session_id,
+        cwd=cwd,
+        expected_outcome=f"A bounded {command_name} execution loop with explicit progress and completion criteria.",
+        must_do=[
+            "keep the loop bounded and deterministic",
+            {"progress": ["state what remains", "stop when completion criteria are met"]},
+        ],
+        must_not_do=[
+            "do not recurse indefinitely",
+            "do not overwrite preserved task-contract context fields",
+        ],
+        extra_context={
+            "loop_family": command_name,
+            "command_runtime": {
+                "command_name": command_name,
+                "runtime_mode": "ralph" if command_name == "ralph-loop" else "ultrawork",
+                "continuation_semantics": (
+                    {
+                        "retry_on_failed_or_interrupted": True,
+                        "stop_requires_explicit_exit": True,
+                    }
+                    if command_name == "ralph-loop"
+                    else {
+                        "completion_gate": "open_todos_block_done",
+                        "require_open_work_closure": True,
+                    }
+                ),
+            },
+        },
+    )
+
+
+def _loop_hints(*, command_name: str, raw_args: str, session_id: str | None, cwd: str | None) -> dict[str, Any]:
+    explicit_contract = _parse_explicit_task_contract(raw_args)
+    request_text = _request_text_for_contract(
+        raw_args,
+        f"Run the {command_name} workflow for the current objective.",
+        explicit_contract=explicit_contract,
+    )
+    hints = _base_hints(command_name=command_name, request_text=request_text, loop_style=command_name.replace("-", "_"))
+    hints["loop"] = {
+        "family": command_name,
+        "bounded": True,
+        "continuation_semantics": (
+            {
+                "retry_on_failed_or_interrupted": True,
+                "stop_requires_explicit_exit": True,
+            }
+            if command_name == "ralph-loop"
+            else {
+                "completion_gate": "open_todos_block_done",
+                "require_open_work_closure": True,
+            }
+        ),
+    }
+    if explicit_contract is not None:
+        return _attach_explicit_contract_metadata(
+            hints,
+            command_name=command_name,
+            session_id=session_id,
+            cwd=cwd,
+            extra_metadata={"loop_family": command_name},
+        )
+    return hints
+
+
+def render_command_prompt(invocation: CommandInvocation) -> str:
+    lines = [
+        f"[OMO command {invocation.command_name}]",
+        "Use the following structured external input as authoritative command context.",
+        "TASK_CONTRACT_JSON:",
+        json.dumps(invocation.task_contract, indent=2, ensure_ascii=False),
+        "ORCHESTRATION_HINTS_JSON:",
+        json.dumps(invocation.orchestration_hints, indent=2, ensure_ascii=False),
+    ]
+    if invocation.named_workflow:
+        lines.extend(
+            [
+                "NAMED_WORKFLOW_JSON:",
+                json.dumps(invocation.named_workflow, indent=2, ensure_ascii=False),
+            ]
+        )
+    lines.append(
+        f"USER_REQUEST: {invocation.orchestration_hints.get('request') or invocation.task_contract.get('task', '')}"
+    )
+    return "\n".join(lines)
+
+
+def _build_invocation(template: CommandTemplate, *, raw_args: str, session_id: str | None, cwd: str | None) -> CommandInvocation:
+    task_contract = template.contract_builder(raw_args=raw_args, session_id=session_id, cwd=cwd)
+    orchestration_hints = template.hints_builder(raw_args=raw_args, session_id=session_id, cwd=cwd)
+    named_workflow = None
+    invocation_metadata = orchestration_hints.get("invocation_metadata") if isinstance(orchestration_hints, dict) else None
+    explicit_contract_supplied = (
+        isinstance(invocation_metadata, dict)
+        and invocation_metadata.get("input_mode") == "explicit_json_contract"
+    )
+    if template.name == "start-work" and not explicit_contract_supplied:
+        named_workflow = build_named_workflow_artifact(
+            objective=str(task_contract.get("task") or orchestration_hints.get("request") or "").strip(),
+            specialist=None,
+            archetype="generalist",
+            route_category="deep",
+            runtime_mode="default",
+            delegation_profile="implementation",
+            task_contract=task_contract,
+        )
+    invocation = CommandInvocation(
+        command_name=template.name,
+        raw_args=str(raw_args or "").strip(),
+        task_contract=task_contract,
+        named_workflow=named_workflow,
+        orchestration_hints=orchestration_hints,
+        prompt_text="",
+    )
+    return CommandInvocation(
+        command_name=invocation.command_name,
+        raw_args=invocation.raw_args,
+        task_contract=invocation.task_contract,
+        named_workflow=invocation.named_workflow,
+        orchestration_hints=invocation.orchestration_hints,
+        prompt_text=render_command_prompt(invocation),
+    )
+
+
+def _template_registry() -> dict[str, CommandTemplate]:
+    from agent.init_deep import build_init_deep_task_contract, build_init_deep_hints
+
+    return {
+        "handoff": CommandTemplate(
+            name="handoff",
+            summary="Resume handed-off work using a structured task contract.",
+            default_request="Continue the handed-off work from the current session state.",
+            contract_builder=_handoff_contract,
+            hints_builder=_handoff_hints,
+        ),
+        "init-deep": CommandTemplate(
+            name="init-deep",
+            summary="Start a deep initialization pass with repo and task triage.",
+            default_request="Perform deep initialization for the current task.",
+            contract_builder=build_init_deep_task_contract,
+            hints_builder=build_init_deep_hints,
+        ),
+        "start-work": CommandTemplate(
+            name="start-work",
+            summary="Start execution using a structured work contract.",
+            default_request="Start the requested work from the current session context.",
+            contract_builder=_start_work_contract,
+            hints_builder=_start_work_hints,
+        ),
+        "ralph-loop": CommandTemplate(
+            name="ralph-loop",
+            summary="Run the Ralph loop with bounded progress state.",
+            default_request="Run the ralph-loop workflow for the current objective.",
+            contract_builder=lambda **kwargs: _loop_contract(command_name="ralph-loop", **kwargs),
+            hints_builder=lambda **kwargs: _loop_hints(command_name="ralph-loop", **kwargs),
+        ),
+        "ulw-loop": CommandTemplate(
+            name="ulw-loop",
+            summary="Run the ULW loop with bounded progress state.",
+            default_request="Run the ulw-loop workflow for the current objective.",
+            contract_builder=lambda **kwargs: _loop_contract(command_name="ulw-loop", **kwargs),
+            hints_builder=lambda **kwargs: _loop_hints(command_name="ulw-loop", **kwargs),
+        ),
+    }
+
+
+COMMAND_TEMPLATES = _template_registry()
+
+
+def resolve_work_command_template(command_name: str | None) -> CommandTemplate | None:
+    name = str(command_name or "").strip().lower().lstrip("/")
+    return COMMAND_TEMPLATES.get(name)
+
+
+def build_command_invocation(
+    command_name: str,
+    *,
+    raw_args: str = "",
+    session_id: str | None = None,
+    cwd: str | None = None,
+) -> CommandInvocation:
+    template = resolve_work_command_template(command_name)
+    if template is None:
+        raise KeyError(f"Unknown OMO work command: {command_name}")
+    normalized_cwd = str(Path(cwd).resolve()) if cwd else None
+    return _build_invocation(template, raw_args=raw_args, session_id=session_id, cwd=normalized_cwd)
+
+
+__all__ = [
+    "COMMAND_TEMPLATES",
+    "CommandInvocation",
+    "CommandTemplate",
+    "WORK_STARTING_COMMANDS",
+    "build_command_invocation",
+    "render_command_prompt",
+    "resolve_work_command_template",
+]

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -95,8 +95,22 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
-    CommandDef("resume", "Resume a previously-named session", "Session",
-               args_hint="[name]"),
+    CommandDef("resume", "Resume or attach to a previous session by name or session ID", "Session",
+               args_hint="[name|session-id]"),
+    CommandDef("attach", "Show attachable handoff targets or attach this chat to a session", "Session",
+               gateway_only=True, args_hint="[name|session-id]"),
+    CommandDef("handoff", "Create or consume a structured task-contract handoff (not chat attach)", "Session",
+               args_hint="[request|<task-contract-json>]"),
+    CommandDef("stop-continuation", "Block the current continuation retry queue entry", "Session",
+               args_hint="[session-id]"),
+    CommandDef("init-deep", "Start a deep initialization pass with a structured task contract", "Session",
+               args_hint="[objective]"),
+    CommandDef("start-work", "Start scoped work using a structured task contract", "Session",
+               args_hint="[objective]"),
+    CommandDef("ralph-loop", "Run the Ralph loop with bounded retry/stop semantics and a structured task contract", "Session",
+              args_hint="[objective]"),
+    CommandDef("ulw-loop", "Run the ULW loop with open-work completion gating and a structured task contract", "Session",
+              args_hint="[objective]"),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
@@ -190,12 +204,33 @@ def _build_command_lookup() -> dict[str, CommandDef]:
 _COMMAND_LOOKUP: dict[str, CommandDef] = _build_command_lookup()
 
 
+def normalize_command_name(name: str) -> str:
+    """Normalize a slash-command token without changing non-Telegram aliases.
+
+    Accepts names with or without a leading slash. If *name* already matches a
+    canonical command or explicit alias, it is preserved as-is (lowercased).
+    Otherwise, an underscore variant is translated back to the registered
+    hyphenated spelling when that lookup exists. This lets Telegram menu
+    commands like ``/start_work`` resolve to ``start-work`` without affecting
+    existing aliases like ``reload_mcp`` or ``reset``.
+    """
+    normalized = name.lower().lstrip("/")
+    if not normalized:
+        return normalized
+    if normalized in _COMMAND_LOOKUP:
+        return normalized
+    hyphenated = normalized.replace("_", "-")
+    if hyphenated in _COMMAND_LOOKUP:
+        return hyphenated
+    return normalized
+
+
 def resolve_command(name: str) -> CommandDef | None:
     """Resolve a command name or alias to its CommandDef.
 
     Accepts names with or without the leading slash.
     """
-    return _COMMAND_LOOKUP.get(name.lower().lstrip("/"))
+    return _COMMAND_LOOKUP.get(normalize_command_name(name))
 
 
 def _build_description(cmd: CommandDef) -> str:
@@ -276,6 +311,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "restart",
         "status",
         "stop",
+        "stop-continuation",
         "update",
     }
 )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -203,7 +203,7 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_default_hermes_root, get_hermes_home  # noqa: F811,E402
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -216,6 +216,57 @@ def get_env_path() -> Path:
 def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
+
+
+def _normalize_profile_local_path(value: Any) -> Any:
+    """Map legacy in-container profile paths onto the local Hermes root when safe.
+
+    Older profile files sometimes persisted paths like
+    ``/root/.hermes/profiles/<name>/workspace``. On a host install, the same
+    profile lives under the local Hermes root (for example
+    ``/Users/alice/.hermes/profiles/<name>/workspace``). Only rewrite when the
+    equivalent local target already exists, so we don't silently point users at
+    a guessed path.
+    """
+    if not isinstance(value, str):
+        return value
+
+    raw = value.strip()
+    if not raw.startswith("/root/.hermes/"):
+        return raw
+
+    try:
+        relative = Path(raw).relative_to(Path("/root/.hermes"))
+    except ValueError:
+        return raw
+
+    candidate = get_default_hermes_root() / relative
+    if candidate.exists() or candidate.parent.exists():
+        return str(candidate)
+    return raw
+
+
+def _normalize_profile_path_settings(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize known profile-local path settings without touching unrelated keys."""
+    normalized = dict(config)
+
+    terminal_cfg = normalized.get("terminal")
+    if isinstance(terminal_cfg, dict) and "cwd" in terminal_cfg:
+        updated_terminal = dict(terminal_cfg)
+        updated_terminal["cwd"] = _normalize_profile_local_path(updated_terminal.get("cwd"))
+        normalized["terminal"] = updated_terminal
+
+    skills_cfg = normalized.get("skills")
+    if isinstance(skills_cfg, dict):
+        external_dirs = skills_cfg.get("external_dirs")
+        if isinstance(external_dirs, list):
+            updated_skills = dict(skills_cfg)
+            updated_skills["external_dirs"] = [
+                _normalize_profile_local_path(item) for item in external_dirs
+            ]
+            normalized["skills"] = updated_skills
+
+    return normalized
 
 def _secure_dir(path):
     """Set directory to owner-only access (0700 by default). No-op on Windows.
@@ -346,6 +397,10 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "agents": {},
+    "categories": {},
+    "runtime_fallback": {"enabled": False},
+    "model_capabilities": {},
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
@@ -668,6 +723,10 @@ DEFAULT_CONFIG = {
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
+    # Category profiles also serve as Hermes-native routing hints for the
+    # primary agent: the delegate_task schema and orchestration notes surface
+    # their names and routing_description values so the parent can choose the
+    # right category before spawning subagents.
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
@@ -675,8 +734,52 @@ DEFAULT_CONFIG = {
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
+        "max_concurrent_children": 3,
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "auto_decompose_large_tasks": True,  # prompt the primary agent to make a todo list on large requests
+        "auto_fanout_batch_mode": True,      # prefer one batched delegate_task call over many single-task calls
+        "auto_fanout_max_tasks": 3,          # soft cap for one delegated batch after routing/truncation logic
+        "default_category": "general",     # fallback routing label when the primary agent omits category
+        "categories": {
+            "general": {
+                "routing_description": "Default fallback for uncategorized delegated work.",
+                "max_concurrent_children": 3,
+            },
+            "research": {
+                "routing_description": "Audits, comparisons, investigation, and read-heavy research.",
+                "max_concurrent_children": 3,
+                "max_iterations": 25,
+                "enabled_tools": [
+                    "read_file",
+                    "search_files",
+                    "session_search",
+                    "skills_list",
+                    "skill_view",
+                    "web_search",
+                    "web_extract",
+                    "browser_navigate",
+                    "browser_snapshot",
+                    "browser_console",
+                    "browser_scroll",
+                    "browser_get_images",
+                    "vision_analyze",
+                    "browser_vision",
+                ],
+            },
+            "implementation": {
+                "routing_description": "Code changes, patches, refactors, and other write-heavy implementation work.",
+                "max_concurrent_children": 2,
+                "max_iterations": 35,
+                "toolsets": ["terminal", "file"],
+            },
+            "verification": {
+                "routing_description": "Tests, validation, regression checks, and review passes.",
+                "max_concurrent_children": 3,
+                "max_iterations": 20,
+                "toolsets": ["terminal", "file", "web"],
+            },
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
@@ -788,7 +891,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 18,
+    "_config_version": 19,
 }
 
 # =============================================================================
@@ -1952,7 +2055,8 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "credential_pool_strategies", "agents",
+    "categories", "runtime_fallback", "model_capabilities", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
 }
@@ -1991,6 +2095,38 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
 
     issues: List[ConfigIssue] = []
+
+    agents_cfg = config.get("agents")
+    if agents_cfg is not None and not isinstance(agents_cfg, dict):
+        issues.append(ConfigIssue(
+            "warning",
+            f"agents should be a mapping of named agent configs, got {type(agents_cfg).__name__}",
+            "Change to:\n  agents:\n    oracle:\n      model: openai/gpt-5.4",
+        ))
+
+    categories_cfg = config.get("categories")
+    if categories_cfg is not None and not isinstance(categories_cfg, dict):
+        issues.append(ConfigIssue(
+            "warning",
+            f"categories should be a mapping of named category configs, got {type(categories_cfg).__name__}",
+            "Change to:\n  categories:\n    research:\n      model: anthropic/claude-haiku-4-5",
+        ))
+
+    runtime_fallback_cfg = config.get("runtime_fallback")
+    if runtime_fallback_cfg is not None and not isinstance(runtime_fallback_cfg, (bool, dict)):
+        issues.append(ConfigIssue(
+            "warning",
+            f"runtime_fallback should be either a boolean or a config dict, got {type(runtime_fallback_cfg).__name__}",
+            "Use either 'runtime_fallback: true' or a mapping like runtime_fallback:\n  enabled: true",
+        ))
+
+    model_capabilities_cfg = config.get("model_capabilities")
+    if model_capabilities_cfg is not None and not isinstance(model_capabilities_cfg, dict):
+        issues.append(ConfigIssue(
+            "warning",
+            f"model_capabilities should be a config dict, got {type(model_capabilities_cfg).__name__}",
+            "Change to:\n  model_capabilities:\n    enabled: true",
+        ))
 
     # ── custom_providers must be a list, not a dict ──────────────────────
     cp = config.get("custom_providers")
@@ -2083,6 +2219,40 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    default: your-model-name\n"
             "    base_url: https://...",
         ))
+
+    delegation_cfg = config.get("delegation")
+    if delegation_cfg is not None:
+        if not isinstance(delegation_cfg, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"delegation should be a dict, got {type(delegation_cfg).__name__}",
+                "Change to:\n  delegation:\n    max_iterations: 50\n    max_concurrent_children: 3",
+            ))
+        else:
+            categories = delegation_cfg.get("categories")
+            if categories is not None and not isinstance(categories, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.categories should be a dict of category profiles, got {type(categories).__name__}",
+                    "Change to:\n  delegation:\n    categories:\n      research:\n        enabled_tools:\n          - read_file",
+                ))
+            elif isinstance(categories, dict):
+                for name, entry in categories.items():
+                    if not isinstance(entry, dict):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"delegation.categories.{name} should be a dict, got {type(entry).__name__}",
+                            "Each category should define keys like toolsets, enabled_tools, max_iterations, or max_concurrent_children",
+                        ))
+                        continue
+
+                    routing_description = entry.get("routing_description")
+                    if routing_description is not None and not isinstance(routing_description, str):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"delegation.categories.{name}.routing_description should be a string, got {type(routing_description).__name__}",
+                            "Use a short sentence describing when the primary agent should route work into this category.",
+                        ))
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
@@ -2762,6 +2932,56 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _normalize_openagent_named_bucket(bucket: Any) -> Dict[str, Dict[str, Any]]:
+    """Normalize OpenAgent-style named agent/category mappings."""
+    if not isinstance(bucket, dict):
+        return {}
+
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for raw_name, entry in bucket.items():
+        name = str(raw_name or "").strip()
+        if not name:
+            continue
+        if isinstance(entry, str):
+            model = entry.strip()
+            if model:
+                normalized[name] = {"model": model}
+        elif isinstance(entry, dict):
+            normalized[name] = dict(entry)
+    return normalized
+
+
+def _normalize_runtime_fallback_config(config: Any) -> Dict[str, Any]:
+    """Normalize runtime_fallback from bool-or-dict into dict form."""
+    if isinstance(config, bool):
+        return {"enabled": config}
+    if isinstance(config, dict):
+        return dict(config)
+    return {"enabled": False}
+
+
+def _normalize_model_capabilities_config(config: Any) -> Dict[str, Any]:
+    """Normalize model_capabilities to a mapping or empty dict."""
+    return dict(config) if isinstance(config, dict) else {}
+
+
+def _normalize_openagent_config_buckets(
+    config: Dict[str, Any], *, include_defaults: bool = True,
+) -> Dict[str, Any]:
+    """Normalize OpenAgent-style config buckets while preserving shorthand."""
+    config = dict(config)
+
+    if include_defaults or "agents" in config:
+        config["agents"] = _normalize_openagent_named_bucket(config.get("agents"))
+    if include_defaults or "categories" in config:
+        config["categories"] = _normalize_openagent_named_bucket(config.get("categories"))
+    if include_defaults or "runtime_fallback" in config:
+        config["runtime_fallback"] = _normalize_runtime_fallback_config(config.get("runtime_fallback"))
+    if include_defaults or "model_capabilities" in config:
+        config["model_capabilities"] = _normalize_model_capabilities_config(config.get("model_capabilities"))
+
+    return config
+
 
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
@@ -2804,10 +3024,15 @@ def load_config() -> Dict[str, Any]:
         except Exception as e:
             print(f"Warning: Failed to load config: {e}")
 
-    normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-    expanded = _expand_env_vars(normalized)
-    _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(expanded)
-    return expanded
+    normalized = _normalize_profile_path_settings(
+        _expand_env_vars(
+            _normalize_openagent_config_buckets(
+                _normalize_root_model_keys(_normalize_max_turns_config(config))
+            )
+        )
+    )
+    _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(normalized)
+    return normalized
 
 
 _SECURITY_COMMENT = """
@@ -2916,9 +3141,19 @@ def save_config(config: Dict[str, Any]):
 
     ensure_hermes_home()
     config_path = get_config_path()
-    current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+    current_normalized = _normalize_profile_path_settings(
+        _normalize_openagent_config_buckets(
+            _normalize_root_model_keys(_normalize_max_turns_config(config)),
+            include_defaults=False,
+        )
+    )
     normalized = current_normalized
-    raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+    raw_existing = _normalize_profile_path_settings(
+        _normalize_openagent_config_buckets(
+            _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config())),
+            include_defaults=False,
+        )
+    )
     if raw_existing:
         normalized = _preserve_env_ref_templates(
             normalized,
@@ -2969,7 +3204,11 @@ def load_env() -> Dict[str, str]:
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
                 key, _, value = line.partition('=')
-                env_vars[key.strip()] = value.strip().strip('"\'')
+                parsed_key = key.strip()
+                parsed_value = value.strip().strip('"\'')
+                if parsed_key in {"MESSAGING_CWD", "TERMINAL_CWD"}:
+                    parsed_value = _normalize_profile_local_path(parsed_value)
+                env_vars[parsed_key] = parsed_value
     
     return env_vars
 
@@ -3119,6 +3358,8 @@ def save_env_value(key: str, value: str):
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     value = value.replace("\n", "").replace("\r", "")
+    if key in {"MESSAGING_CWD", "TERMINAL_CWD"}:
+        value = _normalize_profile_local_path(value)
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
     ensure_hermes_home()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -13,6 +13,7 @@ This module provides:
 """
 
 import copy
+import difflib
 import os
 import platform
 import re
@@ -59,8 +60,107 @@ _EXTRA_ENV_KEYS = frozenset({
 })
 import yaml
 
+from agent.archetypes import (
+    DEFAULT_ARCHETYPE_NAME,
+    REQUIRED_ARCHETYPE_FIELDS,
+    get_tool_restrictions,
+    resolve_archetype,
+    resolve_archetype_defaults,
+    resolve_specialist_mapping,
+)
+from agent.route_categories import (
+    BUILTIN_LITERAL_CATEGORIES,
+    BUILTIN_ROUTE_CATEGORIES,
+    DEFAULT_LITERAL_CATEGORY,
+    DEFAULT_ROUTE_CATEGORY,
+    resolve_literal_category,
+)
+from agent.runtime_modes import (
+    BUILTIN_RUNTIME_MODES,
+    DEFAULT_RUNTIME_MODE_NAME,
+    resolve_runtime_mode,
+)
+from agent.task_contracts import REQUIRED_TASK_CONTRACT_FIELDS, validate_task_contract
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+
+DEFAULT_OMO_AGENTS = {
+    "sisyphus": {
+        "archetype": "generalist",
+        "specialist": "builder",
+        "mode": "primary",
+        "color": "blue",
+        "aliases": ["orchestrator"],
+    },
+    "hephaestus": {
+        "archetype": "implementer",
+        "route_category": "deep",
+        "mode": "subagent",
+        "color": "red",
+        "aliases": ["deep_worker"],
+    },
+    "oracle": {
+        "archetype": "researcher",
+        "blocked_tools": ["write_file", "patch", "terminal", "execute_code", "delegate_task", "task"],
+        "mode": "subagent",
+    },
+    "librarian": {
+        "archetype": "researcher",
+        "mode": "subagent",
+        "blocked_tools": ["write_file", "patch", "terminal", "execute_code", "delegate_task", "task"],
+    },
+    "explore": {
+        "archetype": "researcher",
+        "specialist": "investigator",
+        "mode": "subagent",
+        "blocked_tools": ["write_file", "patch", "execute_code", "delegate_task"],
+        "aliases": ["explorer"],
+    },
+    "multimodal-looker": {
+        "archetype": "generalist",
+        "specialist": "multimodal_specialist",
+        "allowed_tools": [
+            "read_file",
+            "search_files",
+            "vision_analyze",
+            "browser_vision",
+            "browser_snapshot",
+            "browser_get_images",
+        ],
+        "mode": "subagent",
+        "aliases": ["looker"],
+    },
+    "prometheus": {
+        "archetype": "generalist",
+        "specialist": "planner",
+        "mode": "subagent",
+        "color": "green",
+        "aliases": ["planner"],
+    },
+    "metis": {
+        "archetype": "verifier",
+        "mode": "subagent",
+        "aliases": ["gap_analyzer"],
+    },
+    "momus": {
+        "archetype": "verifier",
+        "mode": "subagent",
+        "blocked_tools": ["write_file", "patch", "terminal", "execute_code", "delegate_task", "task"],
+        "aliases": ["critic"],
+    },
+    "atlas": {
+        "archetype": "generalist",
+        "specialist": "planner",
+        "mode": "subagent",
+        "blocked_tools": ["delegate_task", "task"],
+    },
+    "sisyphus-junior": {
+        "archetype": "implementer",
+        "mode": "subagent",
+        "aliases": ["executor"],
+    },
+}
 
 
 # =============================================================================
@@ -397,7 +497,7 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
-    "agents": {},
+    "agents": copy.deepcopy(DEFAULT_OMO_AGENTS),
     "categories": {},
     "runtime_fallback": {"enabled": False},
     "model_capabilities": {},
@@ -502,6 +602,15 @@ DEFAULT_CONFIG = {
         "threshold": 0.50,            # compress when context usage exceeds this ratio
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "protected_tools": [
+            "task",
+            "todoread",
+            "todowrite",
+            "lsp_rename",
+            "session_search",
+            "session_read",
+            "session_write",
+        ],
 
     },
 
@@ -723,10 +832,11 @@ DEFAULT_CONFIG = {
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
-    # Category profiles also serve as Hermes-native routing hints for the
-    # primary agent: the delegate_task schema and orchestration notes surface
-    # their names and routing_description values so the parent can choose the
-    # right category before spawning subagents.
+    # delegation_profiles is the primary Wave 1 config surface for delegation
+    # policy. DG2 adds category as a bounded literal upstream product surface.
+    # Route categories and runtime modes stay separate internal registries:
+    # their metadata is still rendered into prompts and runtime state, while
+    # literal category names map onto that substrate truthfully.
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
@@ -740,8 +850,47 @@ DEFAULT_CONFIG = {
         "auto_decompose_large_tasks": True,  # prompt the primary agent to make a todo list on large requests
         "auto_fanout_batch_mode": True,      # prefer one batched delegate_task call over many single-task calls
         "auto_fanout_max_tasks": 3,          # soft cap for one delegated batch after routing/truncation logic
-        "default_category": "general",     # fallback routing label when the primary agent omits category
-        "categories": {
+        "default_category": DEFAULT_LITERAL_CATEGORY,
+        # Wave 1 schema/default surfaces. These remain structurally distinct:
+        # category is the literal upstream-facing product surface, route_category
+        # is the mapped internal routing label, delegation_profile selects a child
+        # policy profile, runtime_mode is an operating-mode concept, and
+        # task_contract stays canonical structured data.
+        "category": DEFAULT_LITERAL_CATEGORY,
+        "archetype": DEFAULT_ARCHETYPE_NAME,
+        "runtime_mode": DEFAULT_RUNTIME_MODE_NAME,
+        "route_category": DEFAULT_ROUTE_CATEGORY,
+        "default_route_category": DEFAULT_ROUTE_CATEGORY,
+        "default_delegation_profile": "general",
+        "default_skills": ["general_reasoning", "task_execution"],
+        "default_required_tools": ["read_file", "search_files"],
+        "permission_preset": "inherit",
+        "fallback_policy": "legacy_default_mapping",
+        "task_contract": None,
+        "literal_categories": {
+            name: {
+                "summary": category.summary,
+                "route_category": category.route_category,
+                "default_runtime_mode": category.default_runtime_mode,
+            }
+            for name, category in BUILTIN_LITERAL_CATEGORIES.items()
+        },  # built-in literal-category mapping metadata
+        "route_categories": {
+            name: {
+                "summary": category.summary,
+                "intensity": category.intensity,
+            }
+            for name, category in BUILTIN_ROUTE_CATEGORIES.items()
+        },  # built-in route-category metadata overrides only
+        "runtime_modes": {
+            mode.name: {
+                "description": mode.description,
+                "operating_posture": mode.operating_posture,
+                "kind": mode.kind,
+            }
+            for mode in BUILTIN_RUNTIME_MODES
+        },  # built-in runtime-mode metadata overrides only
+        "delegation_profiles": {
             "general": {
                 "routing_description": "Default fallback for uncategorized delegated work.",
                 "max_concurrent_children": 3,
@@ -891,7 +1040,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 19,
+    "_config_version": 20,
 }
 
 # =============================================================================
@@ -2086,11 +2235,15 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     Catches common YAML formatting mistakes that produce confusing runtime
     errors (like "Unknown provider") instead of clear diagnostics.
 
-    Can be called with a pre-loaded config dict, or will load from disk.
+    Can be called with a pre-loaded config dict, or will load the raw config
+    from disk so warnings can still see ignored/unknown keys before
+    normalization drops them.
     """
+    raw_config = config
     if config is None:
         try:
-            config = load_config()
+            config = read_raw_config()
+            raw_config = config
         except Exception:
             return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
 
@@ -2199,6 +2352,36 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                     "Add: model: anthropic/claude-sonnet-4 (or another model)",
                 ))
 
+    fallback_providers = config.get("fallback_providers")
+    if fallback_providers is not None:
+        if not isinstance(fallback_providers, list):
+            issues.append(ConfigIssue(
+                "error",
+                f"fallback_providers should be a list of provider/model dicts, got {type(fallback_providers).__name__}",
+                "Change to:\n  fallback_providers:\n    - provider: openrouter\n      model: anthropic/claude-sonnet-4",
+            ))
+        else:
+            for i, entry in enumerate(fallback_providers):
+                if not isinstance(entry, dict):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"fallback_providers[{i}] should be a dict, got {type(entry).__name__}",
+                        "Each fallback_providers entry should include provider and model fields.",
+                    ))
+                    continue
+                if not entry.get("provider"):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"fallback_providers[{i}] is missing 'provider' field",
+                        "Add: provider: openrouter (or another provider)",
+                    ))
+                if not entry.get("model"):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"fallback_providers[{i}] is missing 'model' field",
+                        "Add: model: anthropic/claude-sonnet-4 (or another model)",
+                    ))
+
     # ── Check for fallback_model accidentally nested inside custom_providers ──
     if isinstance(cp, dict) and "fallback_model" not in config and "fallback_model" in (cp or {}):
         issues.append(ConfigIssue(
@@ -2229,20 +2412,29 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "Change to:\n  delegation:\n    max_iterations: 50\n    max_concurrent_children: 3",
             ))
         else:
+            profile_buckets = []
+            delegation_profiles = delegation_cfg.get("delegation_profiles")
+            if delegation_profiles is not None:
+                profile_buckets.append(("delegation_profiles", delegation_profiles, "primary Wave 1 delegation-profile config"))
             categories = delegation_cfg.get("categories")
-            if categories is not None and not isinstance(categories, dict):
-                issues.append(ConfigIssue(
-                    "error",
-                    f"delegation.categories should be a dict of category profiles, got {type(categories).__name__}",
-                    "Change to:\n  delegation:\n    categories:\n      research:\n        enabled_tools:\n          - read_file",
-                ))
-            elif isinstance(categories, dict):
-                for name, entry in categories.items():
+            if categories is not None:
+                profile_buckets.append(("categories", categories, "legacy alias for delegation_profiles"))
+
+            for bucket_name, bucket_value, bucket_note in profile_buckets:
+                if not isinstance(bucket_value, dict):
+                    issues.append(ConfigIssue(
+                        "error",
+                        f"delegation.{bucket_name} should be a dict of delegation profiles, got {type(bucket_value).__name__}",
+                        f"Change to:\n  delegation:\n    {bucket_name}:\n      research:\n        enabled_tools:\n          - read_file",
+                    ))
+                    continue
+
+                for name, entry in bucket_value.items():
                     if not isinstance(entry, dict):
                         issues.append(ConfigIssue(
                             "warning",
-                            f"delegation.categories.{name} should be a dict, got {type(entry).__name__}",
-                            "Each category should define keys like toolsets, enabled_tools, max_iterations, or max_concurrent_children",
+                            f"delegation.{bucket_name}.{name} should be a dict, got {type(entry).__name__}",
+                            f"Each {bucket_note} entry should define keys like toolsets, enabled_tools, runtime_mode, max_iterations, or max_concurrent_children",
                         ))
                         continue
 
@@ -2250,9 +2442,71 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                     if routing_description is not None and not isinstance(routing_description, str):
                         issues.append(ConfigIssue(
                             "warning",
-                            f"delegation.categories.{name}.routing_description should be a string, got {type(routing_description).__name__}",
-                            "Use a short sentence describing when the primary agent should route work into this category.",
+                            f"delegation.{bucket_name}.{name}.routing_description should be a string, got {type(routing_description).__name__}",
+                            "Use a short sentence describing when the primary agent should route work into this delegation profile.",
                         ))
+
+            route_categories = delegation_cfg.get("route_categories")
+            if route_categories is not None and not isinstance(route_categories, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.route_categories should be a dict of built-in route-category metadata overrides, got {type(route_categories).__name__}",
+                    "Change to:\n  delegation:\n    route_categories:\n      quick:\n        summary: Fast-path routing lane\n        intensity: low",
+                ))
+
+            runtime_modes = delegation_cfg.get("runtime_modes")
+            if runtime_modes is not None and not isinstance(runtime_modes, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.runtime_modes should be a dict of built-in runtime-mode metadata overrides, got {type(runtime_modes).__name__}",
+                    "Change to:\n  delegation:\n    runtime_modes:\n      default:\n        description: Standard Hermes operating posture\n        operating_posture: balanced_general_operation",
+                ))
+
+            delegation_metadata = inspect_wave1_delegation_metadata(
+                _normalize_wave1_delegation_config({"delegation": delegation_cfg}, include_defaults=False),
+                raw_config if isinstance(raw_config, dict) else {"delegation": delegation_cfg},
+            )
+            ignored_route_category_names = delegation_metadata["ignored_route_category_names"]
+            if ignored_route_category_names:
+                issues.append(ConfigIssue(
+                    "warning",
+                    "delegation.route_categories contains unknown names that stay inactive metadata only: "
+                    + ", ".join(ignored_route_category_names),
+                    "Wave 1 only applies built-in route-category metadata overrides. Unknown names are ignored for routing semantics; use delegation_profiles/categories for active delegation profiles.",
+                ))
+
+            ignored_runtime_mode_names = delegation_metadata["ignored_runtime_mode_names"]
+            if ignored_runtime_mode_names:
+                issues.append(ConfigIssue(
+                    "warning",
+                    "delegation.runtime_modes contains unknown names that stay inactive metadata only: "
+                    + ", ".join(ignored_runtime_mode_names),
+                    "Wave 1 only applies built-in runtime-mode metadata overrides. Unknown names are ignored for runtime semantics.",
+                ))
+
+            task_contract = delegation_cfg.get("task_contract")
+            if task_contract not in (None, "", {}) and not isinstance(task_contract, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.task_contract should be a dict matching the Wave 1 task-contract schema, got {type(task_contract).__name__}",
+                    "Remove delegation.task_contract to preserve legacy delegation behavior, or add all required fields under delegation.task_contract.",
+                ))
+
+            permission_preset = delegation_cfg.get("permission_preset")
+            if permission_preset is not None and not isinstance(permission_preset, str):
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"delegation.permission_preset should be a string, got {type(permission_preset).__name__}",
+                    "Use values like 'inherit' or 'workspace_write' to preserve Wave 1 permission semantics.",
+                ))
+
+            fallback_policy = delegation_cfg.get("fallback_policy")
+            if fallback_policy is not None and not isinstance(fallback_policy, str):
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"delegation.fallback_policy should be a string, got {type(fallback_policy).__name__}",
+                    "Use values like 'legacy_default_mapping' or 'degrade_to_generalist' to preserve Wave 1 fallback semantics.",
+                ))
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
@@ -2934,21 +3188,497 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
 
 def _normalize_openagent_named_bucket(bucket: Any) -> Dict[str, Dict[str, Any]]:
     """Normalize OpenAgent-style named agent/category mappings."""
+    return _normalize_openagent_named_bucket_with_defaults(bucket)
+
+
+def _normalize_openagent_named_bucket_with_defaults(
+    bucket: Any,
+    defaults: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, Dict[str, Any]]:
     if not isinstance(bucket, dict):
-        return {}
+        bucket = {}
 
     normalized: Dict[str, Dict[str, Any]] = {}
+    if isinstance(defaults, dict):
+        for raw_name, entry in defaults.items():
+            name = str(raw_name or "").strip()
+            if not name:
+                continue
+            normalized[name] = _normalize_openagent_named_entry(entry)
+
+    alias_map = _build_named_agent_alias_map(normalized)
     for raw_name, entry in bucket.items():
         name = str(raw_name or "").strip()
         if not name:
             continue
+        name = alias_map.get(name, name)
+        base = dict(normalized.get(name, {}))
+        normalized[name] = _normalize_openagent_named_entry(entry, defaults=base)
+    return normalized
+
+
+def _build_named_agent_alias_map(registry: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
+    """Map every explicit secondary alias to its canonical agent name."""
+    alias_map: Dict[str, str] = {}
+    for canonical_name, entry in registry.items():
+        for alias in _normalize_named_string_list(entry.get("aliases")):
+            alias_map.setdefault(alias, canonical_name)
+    return alias_map
+
+
+def _canonicalize_named_agent_lookup_key(value: Any) -> str:
+    """Normalize named-agent invocation tokens for stable lookup."""
+    token = str(value or "").strip().lower()
+    if not token:
+        return ""
+    token = re.sub(r"[\s_]+", "-", token)
+    token = re.sub(r"-+", "-", token)
+    return token.strip("-")
+
+
+def _build_named_agent_lookup_map(registry: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
+    """Map canonical/alias invocation variants onto canonical names."""
+    lookup: Dict[str, str] = {}
+    for canonical_name, entry in registry.items():
+        lookup.setdefault(_canonicalize_named_agent_lookup_key(canonical_name), canonical_name)
+        for alias in _normalize_named_string_list(entry.get("aliases")):
+            lookup.setdefault(_canonicalize_named_agent_lookup_key(alias), canonical_name)
+    return lookup
+
+
+def _resolve_named_agent_disabled_state(
+    canonical_name: str,
+    *,
+    registry: Dict[str, Dict[str, Any]],
+    config: Optional[Dict[str, Any]],
+) -> Tuple[bool, Optional[str]]:
+    """Return whether an agent is disabled and which canonical surface disabled it."""
+    source = config if isinstance(config, dict) else {}
+    lookup_map = _build_named_agent_lookup_map(registry)
+
+    for entry in source.get("disabled_agents") or []:
+        disabled_name = lookup_map.get(_canonicalize_named_agent_lookup_key(entry))
+        if disabled_name == canonical_name:
+            return True, "disabled_agents"
+
+    raw_agents = source.get("agents")
+    if isinstance(raw_agents, dict):
+        for raw_name, raw_entry in raw_agents.items():
+            if not isinstance(raw_entry, dict) or not raw_entry.get("disable"):
+                continue
+            disabled_name = lookup_map.get(_canonicalize_named_agent_lookup_key(raw_name))
+            if disabled_name == canonical_name:
+                return True, f"agents.{canonical_name}.disable"
+
+    return False, None
+
+
+_NAMED_AGENT_PERMISSION_KEYS = (
+    "edit",
+    "bash",
+    "webfetch",
+    "doom_loop",
+    "external_directory",
+)
+_NAMED_AGENT_PERMISSION_VALUES = {"ask", "allow", "deny"}
+_NAMED_AGENT_FALLBACK_MODEL_KEYS = (
+    "model",
+    "variant",
+    "reasoningEffort",
+    "temperature",
+    "top_p",
+    "maxTokens",
+    "thinking",
+)
+
+
+def _normalize_named_agent_permission_surface(value: Any) -> Optional[Dict[str, Any]]:
+    """Normalize the bounded upstream-style named-agent permission surface."""
+    if not isinstance(value, dict):
+        return None
+
+    normalized: Dict[str, Any] = {}
+    for key in _NAMED_AGENT_PERMISSION_KEYS:
+        if key not in value:
+            continue
+        raw = value.get(key)
+        if isinstance(raw, str):
+            permission_value = raw.strip().lower()
+            if permission_value in _NAMED_AGENT_PERMISSION_VALUES:
+                normalized[key] = permission_value
+            continue
+        if key == "bash" and isinstance(raw, dict):
+            per_command: Dict[str, str] = {}
+            for raw_command, raw_permission in raw.items():
+                command = str(raw_command or "").strip()
+                permission_value = str(raw_permission or "").strip().lower()
+                if command and permission_value in _NAMED_AGENT_PERMISSION_VALUES:
+                    per_command[command] = permission_value
+            if per_command:
+                normalized[key] = per_command
+    return normalized or None
+
+
+def _normalize_named_agent_fallback_models(value: Any) -> List[Dict[str, Any]]:
+    """Normalize fallback_models into a bounded list of model entries."""
+    entries = value if isinstance(value, list) else [value]
+    normalized: List[Dict[str, Any]] = []
+    for entry in entries:
         if isinstance(entry, str):
             model = entry.strip()
             if model:
-                normalized[name] = {"model": model}
-        elif isinstance(entry, dict):
-            normalized[name] = dict(entry)
+                normalized.append({"model": model})
+            continue
+        if not isinstance(entry, dict):
+            continue
+        model = str(entry.get("model") or "").strip()
+        if not model:
+            continue
+        normalized_entry: Dict[str, Any] = {"model": model}
+        for key in _NAMED_AGENT_FALLBACK_MODEL_KEYS:
+            if key == "model" or key not in entry:
+                continue
+            raw = entry.get(key)
+            if raw in (None, ""):
+                continue
+            if key == "thinking":
+                if isinstance(raw, dict) and raw:
+                    normalized_entry[key] = copy.deepcopy(raw)
+                continue
+            if isinstance(raw, str):
+                stripped = raw.strip()
+                if stripped:
+                    normalized_entry[key] = stripped
+                continue
+            if isinstance(raw, (int, float)):
+                normalized_entry[key] = raw
+        normalized.append(normalized_entry)
     return normalized
+
+
+def _normalize_named_agent_disable_flag(value: Any) -> bool:
+    """Normalize a named-agent disable flag to a strict boolean."""
+    return value is True
+
+
+
+def _resolve_disabled_named_agents(
+    registry: Dict[str, Dict[str, Any]],
+    config: Optional[Dict[str, Any]] = None,
+) -> Tuple[set, Dict[str, str]]:
+    """Resolve disabled named agents from per-agent and global config surfaces."""
+    lookup_map = _build_named_agent_lookup_map(registry)
+    disabled_names = set()
+    disabled_via: Dict[str, str] = {}
+
+    for canonical_name, entry in registry.items():
+        if _normalize_named_agent_disable_flag(entry.get("disable")):
+            disabled_names.add(canonical_name)
+            disabled_via.setdefault(canonical_name, f"agents.{canonical_name}.disable")
+
+    raw_disabled_agents = []
+    if isinstance(config, dict):
+        raw_disabled_agents = _normalize_named_string_list(config.get("disabled_agents"))
+    for raw_name in raw_disabled_agents:
+        canonical_name = lookup_map.get(_canonicalize_named_agent_lookup_key(raw_name), raw_name)
+        if canonical_name in registry:
+            disabled_names.add(canonical_name)
+            disabled_via[canonical_name] = "disabled_agents"
+
+    return disabled_names, disabled_via
+
+
+def _format_named_agent_permission_surface(permission_surface: Optional[Dict[str, Any]]) -> str:
+    """Render the bounded named-agent permission surface for detail views."""
+    if not permission_surface:
+        return "-"
+
+    parts: List[str] = []
+    for key in _NAMED_AGENT_PERMISSION_KEYS:
+        if key not in permission_surface:
+            continue
+        value = permission_surface[key]
+        if isinstance(value, dict):
+            command_summary = ",".join(
+                f"{command}:{value[command]}"
+                for command in sorted(value)
+            )
+            parts.append(f"{key}={command_summary}")
+        else:
+            parts.append(f"{key}={value}")
+    return "; ".join(parts) if parts else "-"
+
+
+def _format_named_agent_fallback_models(fallback_models: List[Dict[str, Any]]) -> str:
+    """Render bounded fallback-model truth for detail views."""
+    if not fallback_models:
+        return "-"
+
+    rendered_models: List[str] = []
+    for entry in fallback_models:
+        label = entry.get("model", "")
+        extras: List[str] = []
+        for key in _NAMED_AGENT_FALLBACK_MODEL_KEYS:
+            if key == "model" or key not in entry:
+                continue
+            value = entry[key]
+            if isinstance(value, dict):
+                extras.append(f"{key}={value}")
+            else:
+                extras.append(f"{key}={value}")
+        if extras:
+            label = f"{label} [{' '.join(extras)}]"
+        rendered_models.append(label)
+    return " -> ".join(rendered_models)
+
+
+def _normalize_openagent_named_entry(
+    entry: Any,
+    *,
+    defaults: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = copy.deepcopy(defaults or {})
+
+    if isinstance(entry, str):
+        model = entry.strip()
+        if model:
+            normalized["model"] = model
+        return normalized
+
+    if not isinstance(entry, dict):
+        return normalized
+
+    for key, value in entry.items():
+        normalized[key] = copy.deepcopy(value)
+
+    for key in (
+        "model",
+        "provider",
+        "archetype",
+        "specialist",
+        "route_category",
+        "runtime_mode",
+        "color",
+        "description",
+        "base_url",
+        "api_key",
+        "reasoning_effort",
+        "routing_description",
+        "acp_command",
+    ):
+        if key in entry:
+            value = str(entry.get(key) or "").strip()
+            if value:
+                normalized[key] = value
+            else:
+                normalized.pop(key, None)
+
+    for key in ("blocked_tools", "allowed_tools", "toolsets", "enabled_tools", "acp_args", "aliases"):
+        if key in entry:
+            value = _normalize_named_string_list(entry.get(key))
+            if value:
+                normalized[key] = value
+            else:
+                normalized.pop(key, None)
+
+    if "provider_options" in entry:
+        provider_options = entry.get("provider_options")
+        if isinstance(provider_options, dict):
+            normalized["provider_options"] = copy.deepcopy(provider_options)
+        else:
+            normalized.pop("provider_options", None)
+
+    if "permission" in entry:
+        permission_surface = _normalize_named_agent_permission_surface(entry.get("permission"))
+        if permission_surface:
+            normalized["permission"] = permission_surface
+        else:
+            normalized.pop("permission", None)
+
+    if "fallback_models" in entry:
+        fallback_models = _normalize_named_agent_fallback_models(entry.get("fallback_models"))
+        if fallback_models:
+            normalized["fallback_models"] = fallback_models
+        else:
+            normalized.pop("fallback_models", None)
+
+    if "disable" in entry:
+        if _normalize_named_agent_disable_flag(entry.get("disable")):
+            normalized["disable"] = True
+        else:
+            normalized.pop("disable", None)
+
+    if "ultrawork" in entry:
+        ultrawork = entry.get("ultrawork")
+        if isinstance(ultrawork, dict):
+            normalized_ultrawork = {
+                key: str(ultrawork.get(key) or "").strip()
+                for key in ("model", "variant")
+                if str(ultrawork.get(key) or "").strip()
+            }
+            if normalized_ultrawork:
+                normalized["ultrawork"] = normalized_ultrawork
+            else:
+                normalized.pop("ultrawork", None)
+        else:
+            normalized.pop("ultrawork", None)
+
+    if "mode" in entry:
+        mode = str(entry.get("mode") or "").strip().lower()
+        if mode in {"primary", "subagent", "disabled"}:
+            normalized["mode"] = mode
+        else:
+            normalized.pop("mode", None)
+
+    return normalized
+
+
+def _normalize_named_agent_registry(bucket: Any) -> Dict[str, Dict[str, Any]]:
+    """Normalize named agents, merging user config onto built-in OMO defaults."""
+    return _normalize_openagent_named_bucket_with_defaults(bucket, DEFAULT_OMO_AGENTS)
+
+
+def get_named_agent_registry(config: Optional[Dict[str, Any]] = None) -> Dict[str, Dict[str, Any]]:
+    """Return the normalized named-agent registry from config."""
+    source = load_config() if config is None else config
+    return _normalize_named_agent_registry(source.get("agents"))
+
+
+def describe_named_agent(name: str, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return a resolved, user-facing description of a named agent."""
+    source = config if isinstance(config, dict) else load_config()
+    registry = get_named_agent_registry(source)
+    requested_name = str(name or "").strip()
+    alias_map = _build_named_agent_alias_map(registry)
+    disabled_names, disabled_via = _resolve_disabled_named_agents(registry, source)
+    canonical_name = alias_map.get(requested_name, requested_name)
+    if canonical_name == requested_name:
+        lookup_map = _build_named_agent_lookup_map(registry)
+        canonical_name = lookup_map.get(_canonicalize_named_agent_lookup_key(requested_name), requested_name)
+    entry = registry.get(canonical_name)
+    if not entry:
+        available = sorted({*registry, *alias_map})
+        hint = ""
+        matches = difflib.get_close_matches(requested_name, available, n=3, cutoff=0.5)
+        if matches:
+            hint = f" Did you mean: {', '.join(matches)}?"
+        raise KeyError(f"Unknown named agent '{requested_name}'.{hint}")
+
+    specialist = str(entry.get("specialist") or "").strip() or None
+    specialist_mapping = resolve_specialist_mapping(specialist)
+    resolved_archetype = str(entry.get("archetype") or "").strip() or (
+        specialist_mapping.archetype_name if specialist_mapping is not None else DEFAULT_ARCHETYPE_NAME
+    )
+    archetype_defaults = resolve_archetype_defaults(resolved_archetype)
+    blocked_tools, allowed_tools = get_tool_restrictions(resolved_archetype, specialist)
+
+    named_blocked = set(_normalize_named_string_list(entry.get("blocked_tools")))
+    named_allowed = set(_normalize_named_string_list(entry.get("allowed_tools")))
+    effective_blocked = set(blocked_tools) | named_blocked
+    effective_allowed = set(allowed_tools)
+    if named_allowed:
+        effective_allowed = effective_allowed.intersection(named_allowed) if effective_allowed else set(named_allowed)
+    effective_allowed.difference_update(effective_blocked)
+    reviewer_like = bool((specialist or "").strip().lower() in {"code_reviewer", "qa_guard"} or resolved_archetype == "verifier")
+    configured_permission_surface = _normalize_named_agent_permission_surface(entry.get("permission"))
+    configured_fallback_models = _normalize_named_agent_fallback_models(entry.get("fallback_models"))
+
+    return {
+        "name": canonical_name,
+        "requested_name": requested_name or canonical_name,
+        "aliases": _normalize_named_string_list(entry.get("aliases")),
+        "description": str(entry.get("description") or "").strip(),
+        "mode": str(entry.get("mode") or "subagent").strip() or "subagent",
+        "provider": str(entry.get("provider") or "").strip(),
+        "model": str(entry.get("model") or "").strip(),
+        "resolved_archetype": resolved_archetype,
+        "resolved_specialist": specialist,
+        "resolved_route_category": str(entry.get("route_category") or archetype_defaults.get("default_route_category") or DEFAULT_ROUTE_CATEGORY).strip(),
+        "resolved_runtime_mode": str(entry.get("runtime_mode") or DEFAULT_RUNTIME_MODE_NAME).strip(),
+        "toolsets": _normalize_named_string_list(entry.get("toolsets")),
+        "enabled_tools": _normalize_named_string_list(entry.get("enabled_tools")),
+        "named_allowed_tools": sorted(named_allowed),
+        "named_blocked_tools": sorted(named_blocked),
+        "effective_allowed_tools": sorted(effective_allowed),
+        "effective_blocked_tools": sorted(effective_blocked),
+        "configured_permission_surface": configured_permission_surface,
+        "configured_fallback_models": configured_fallback_models,
+        "permission_truth_surface": "configured_named_agent_surface" if configured_permission_surface else None,
+        "fallback_truth_surface": "configured_named_agent_surface" if configured_fallback_models else None,
+        "completion_gate": "verification_evidence_required" if reviewer_like else None,
+        "behavior_boundary": "reviewer_read_only" if reviewer_like else None,
+        "is_disabled": canonical_name in disabled_names,
+        "disabled_via": disabled_via.get(canonical_name),
+    }
+
+
+def render_named_agents_text(name: Optional[str] = None, config: Optional[Dict[str, Any]] = None) -> str:
+    """Render a CLI/gateway-friendly named-agent overview or detail view."""
+    source = config if isinstance(config, dict) else load_config()
+    registry = get_named_agent_registry(source)
+    requested_name = str(name or "").strip()
+    if requested_name:
+        desc = describe_named_agent(requested_name, config=source)
+        lines = [f"Named agent: {desc['name']}"]
+        if desc["requested_name"] != desc["name"]:
+            lines.append(f"Requested as: {desc['requested_name']}")
+        if desc["aliases"]:
+            lines.append(f"Aliases: {', '.join(desc['aliases'])}")
+        if desc["description"]:
+            lines.append(f"Description: {desc['description']}")
+        lines.append(f"Status: {'disabled' if desc['is_disabled'] else 'enabled'}")
+        if desc["disabled_via"]:
+            lines.append(f"Disabled via: {desc['disabled_via']}")
+        lines.extend(
+            [
+                f"Mode: {desc['mode']}",
+                f"Invocation: @{desc['name']} <prompt> (leading mention only)",
+                f"Archetype: {desc['resolved_archetype']}",
+                f"Specialist: {desc['resolved_specialist'] or '-'}",
+                f"Route category: {desc['resolved_route_category']}",
+                f"Runtime mode: {desc['resolved_runtime_mode']}",
+                f"Provider: {desc['provider'] or '-'}",
+                f"Model: {desc['model'] or '-'}",
+                f"Toolsets: {', '.join(desc['toolsets']) if desc['toolsets'] else '-'}",
+                f"Enabled tools: {', '.join(desc['enabled_tools']) if desc['enabled_tools'] else '-'}",
+                f"Named allowed tools: {', '.join(desc['named_allowed_tools']) if desc['named_allowed_tools'] else '-'}",
+                f"Named blocked tools: {', '.join(desc['named_blocked_tools']) if desc['named_blocked_tools'] else '-'}",
+                f"Effective allowed tools: {', '.join(desc['effective_allowed_tools']) if desc['effective_allowed_tools'] else '-'}",
+                f"Effective blocked tools: {', '.join(desc['effective_blocked_tools']) if desc['effective_blocked_tools'] else '-'}",
+                f"Configured permission surface: {_format_named_agent_permission_surface(desc['configured_permission_surface'])}",
+                f"Permission truth surface: {desc['permission_truth_surface'] or '-'}",
+                f"Configured fallback models: {_format_named_agent_fallback_models(desc['configured_fallback_models'])}",
+                f"Fallback truth surface: {desc['fallback_truth_surface'] or '-'}",
+                f"Behavior boundary: {desc['behavior_boundary'] or '-'}",
+                f"Completion gate: {desc['completion_gate'] or '-'}",
+            ]
+        )
+        return "\n".join(lines)
+
+    visible_agent_names = [
+        agent_name for agent_name in registry
+        if not describe_named_agent(agent_name, config=source)["is_disabled"]
+    ]
+    lines = [f"Named agents ({len(visible_agent_names)}):"]
+    for agent_name in visible_agent_names:
+        desc = describe_named_agent(agent_name, config=source)
+        label = agent_name
+        if desc["aliases"]:
+            label = f"{label} (aliases: {', '.join(desc['aliases'])})"
+        summary = [desc["resolved_archetype"]]
+        if desc["resolved_specialist"]:
+            summary.append(desc["resolved_specialist"])
+        summary.append(desc["mode"])
+        if desc["model"]:
+            summary.append(desc["model"])
+        restriction = ""
+        if desc["effective_allowed_tools"]:
+            restriction = f" · allow={len(desc['effective_allowed_tools'])}"
+        elif desc["effective_blocked_tools"]:
+            restriction = f" · block={len(desc['effective_blocked_tools'])}"
+        lines.append(f"- {label} · {' · '.join(summary)}{restriction}")
+    lines.append("Use /named-agents <name> to inspect one agent.")
+    return "\n".join(lines)
 
 
 def _normalize_runtime_fallback_config(config: Any) -> Dict[str, Any]:
@@ -2965,6 +3695,285 @@ def _normalize_model_capabilities_config(config: Any) -> Dict[str, Any]:
     return dict(config) if isinstance(config, dict) else {}
 
 
+def _normalize_named_string_list(value: Any) -> List[str]:
+    """Normalize a list/tuple of names into trimmed unique strings."""
+    if not isinstance(value, (list, tuple)):
+        return []
+    normalized: List[str] = []
+    seen = set()
+    for item in value:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        normalized.append(text)
+        seen.add(text)
+    return normalized
+
+
+def _normalize_wave1_route_categories(route_categories: Any) -> Dict[str, Dict[str, Any]]:
+    """Normalize built-in route-category metadata overrides while preserving built-ins."""
+    normalized: Dict[str, Dict[str, Any]] = {
+        name: {
+            "summary": category.summary,
+            "intensity": category.intensity,
+        }
+        for name, category in BUILTIN_ROUTE_CATEGORIES.items()
+    }
+    if not isinstance(route_categories, dict):
+        return normalized
+
+    for raw_name, entry in route_categories.items():
+        name = str(raw_name or "").strip()
+        if not name or name not in normalized:
+            continue
+        if isinstance(entry, str):
+            normalized[name] = {
+                "summary": entry.strip(),
+                "intensity": normalized.get(name, {}).get("intensity", ""),
+            }
+            continue
+        if not isinstance(entry, dict):
+            continue
+        merged = dict(normalized.get(name, {}))
+        if "summary" in entry and entry["summary"] is not None:
+            merged["summary"] = str(entry["summary"]).strip()
+        if "intensity" in entry and entry["intensity"] is not None:
+            merged["intensity"] = str(entry["intensity"]).strip()
+        normalized[name] = merged
+    return normalized
+
+
+def _normalize_wave1_runtime_modes(runtime_modes: Any) -> Dict[str, Dict[str, Any]]:
+    """Normalize built-in runtime-mode metadata overrides while preserving built-ins."""
+    normalized: Dict[str, Dict[str, Any]] = {
+        mode.name: {
+            "description": mode.description,
+            "operating_posture": mode.operating_posture,
+            "kind": mode.kind,
+        }
+        for mode in BUILTIN_RUNTIME_MODES
+    }
+    if not isinstance(runtime_modes, dict):
+        return normalized
+
+    for raw_name, entry in runtime_modes.items():
+        name = str(raw_name or "").strip()
+        if not name or name not in normalized:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        merged = dict(normalized.get(name, {}))
+        for field_name in ("description", "operating_posture", "kind"):
+            if field_name in entry and entry[field_name] is not None:
+                merged[field_name] = str(entry[field_name]).strip()
+        if not merged.get("kind"):
+            merged["kind"] = "runtime_mode"
+        normalized[name] = merged
+    return normalized
+
+
+def _collect_unknown_wave1_metadata_names(entries: Any, known_names: List[str]) -> List[str]:
+    """Return trimmed unknown metadata-override names in stable order."""
+    if not isinstance(entries, dict):
+        return []
+
+    known_name_set = {name.strip() for name in known_names if str(name).strip()}
+    unknown_names: List[str] = []
+    seen_names = set()
+    for raw_name in entries:
+        name = str(raw_name or "").strip()
+        if not name or name in known_name_set or name in seen_names:
+            continue
+        seen_names.add(name)
+        unknown_names.append(name)
+    return unknown_names
+
+
+def _wave1_effective_metadata_override_names(
+    defaults: Dict[str, Dict[str, Any]],
+    normalized: Any,
+) -> List[str]:
+    """Return built-in metadata names whose effective values differ from defaults."""
+    if not isinstance(normalized, dict):
+        return []
+
+    override_names: List[str] = []
+    for name, default_entry in defaults.items():
+        if normalized.get(name) != default_entry:
+            override_names.append(name)
+    return override_names
+
+
+def inspect_wave1_delegation_metadata(
+    config: Optional[Dict[str, Any]] = None,
+    raw_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, List[str]]:
+    """Inspect effective and ignored Wave 1 delegation metadata overrides."""
+    if config is None:
+        config = load_config()
+    if raw_config is None:
+        raw_config = read_raw_config()
+
+    normalized_delegation = config.get("delegation") if isinstance(config, dict) else {}
+    if not isinstance(normalized_delegation, dict):
+        normalized_delegation = {}
+
+    raw_delegation = raw_config.get("delegation") if isinstance(raw_config, dict) else {}
+    if not isinstance(raw_delegation, dict):
+        raw_delegation = {}
+
+    default_route_categories = {
+        name: {
+            "summary": category.summary,
+            "intensity": category.intensity,
+        }
+        for name, category in BUILTIN_ROUTE_CATEGORIES.items()
+    }
+    default_runtime_modes = {
+        mode.name: {
+            "description": mode.description,
+            "operating_posture": mode.operating_posture,
+            "kind": mode.kind,
+        }
+        for mode in BUILTIN_RUNTIME_MODES
+    }
+
+    return {
+        "effective_route_category_override_names": _wave1_effective_metadata_override_names(
+            default_route_categories,
+            normalized_delegation.get("route_categories"),
+        ),
+        "ignored_route_category_names": _collect_unknown_wave1_metadata_names(
+            raw_delegation.get("route_categories"),
+            list(default_route_categories.keys()),
+        ),
+        "effective_runtime_mode_override_names": _wave1_effective_metadata_override_names(
+            default_runtime_modes,
+            normalized_delegation.get("runtime_modes"),
+        ),
+        "ignored_runtime_mode_names": _collect_unknown_wave1_metadata_names(
+            raw_delegation.get("runtime_modes"),
+            list(default_runtime_modes.keys()),
+        ),
+    }
+
+
+def _normalize_wave1_task_contract(task_contract: Any) -> Optional[Dict[str, Any]]:
+    """Normalize a configured task contract or raise with migration guidance."""
+    if task_contract in (None, "", {}):
+        return None
+    if not isinstance(task_contract, dict):
+        raise ValueError(
+            "delegation.task_contract must be a dict matching the Wave 1 task-contract schema. "
+            "Migration guidance: either remove delegation.task_contract to keep the legacy default-mapping path, "
+            f"or provide all required fields: {', '.join(REQUIRED_TASK_CONTRACT_FIELDS)}"
+        )
+    try:
+        return validate_task_contract(task_contract).model_dump()
+    except Exception as exc:
+        raise ValueError(
+            "Invalid delegation.task_contract in config. Migration guidance: remove delegation.task_contract "
+            "to preserve legacy delegation behavior, or update it to include the required structured fields "
+            f"({', '.join(REQUIRED_TASK_CONTRACT_FIELDS)}). Original error: {exc}"
+        ) from exc
+
+
+def _normalize_wave1_delegation_config(
+    config: Dict[str, Any], *, include_defaults: bool = True,
+) -> Dict[str, Any]:
+    """Resolve Wave 1 delegation surfaces into compatibility-safe defaults."""
+    config = dict(config)
+    if not include_defaults and "delegation" not in config:
+        return config
+
+    delegation = config.get("delegation")
+    if not isinstance(delegation, dict):
+        delegation = {}
+    else:
+        delegation = dict(delegation)
+
+    requested_archetype = delegation.get("archetype")
+    resolved_archetype = resolve_archetype(requested_archetype)
+    delegation["archetype"] = resolved_archetype.name
+
+    archetype_overrides = {}
+    for field_name in REQUIRED_ARCHETYPE_FIELDS:
+        if field_name not in delegation or delegation[field_name] is None:
+            continue
+        value = delegation[field_name]
+        if field_name in {"default_skills", "default_required_tools"}:
+            archetype_overrides[field_name] = _normalize_named_string_list(value)
+        else:
+            archetype_overrides[field_name] = value
+    archetype_defaults = resolve_archetype_defaults(
+        resolved_archetype.name,
+        overrides=archetype_overrides,
+    )
+
+    explicit_category_input = str(
+        delegation.get("category")
+        or delegation.get("default_category")
+        or ""
+    ).strip()
+    resolved_literal_category = resolve_literal_category(explicit_category_input)
+
+    explicit_route_category = str(
+        delegation.get("route_category")
+        or delegation.get("default_route_category")
+        or ""
+    ).strip()
+    resolved_route_category = (
+        explicit_route_category
+        if explicit_route_category in BUILTIN_ROUTE_CATEGORIES
+        else resolved_literal_category.route_category
+        or str(archetype_defaults["default_route_category"]).strip()
+        or DEFAULT_ROUTE_CATEGORY
+    )
+
+    runtime_mode = resolve_runtime_mode(delegation.get("runtime_mode"))
+    delegation["category"] = resolved_literal_category.name
+    delegation["runtime_mode"] = runtime_mode.name
+    delegation["route_category"] = resolved_route_category
+    delegation["default_route_category"] = resolved_route_category
+    delegation["default_category"] = resolved_literal_category.name
+    resolved_default_profile = str(
+        delegation.get("default_delegation_profile")
+        or archetype_defaults["default_delegation_profile"]
+    ).strip()
+    delegation["default_delegation_profile"] = resolved_default_profile
+    delegation["default_skills"] = _normalize_named_string_list(
+        delegation.get("default_skills") or archetype_defaults["default_skills"]
+    )
+    delegation["default_required_tools"] = _normalize_named_string_list(
+        delegation.get("default_required_tools") or archetype_defaults["default_required_tools"]
+    )
+    delegation["permission_preset"] = str(
+        delegation.get("permission_preset") or archetype_defaults["permission_preset"]
+    ).strip()
+    delegation["fallback_policy"] = str(
+        delegation.get("fallback_policy") or archetype_defaults["fallback_policy"]
+    ).strip()
+    delegation["task_contract"] = _normalize_wave1_task_contract(delegation.get("task_contract"))
+    delegation["route_categories"] = _normalize_wave1_route_categories(delegation.get("route_categories"))
+    delegation["runtime_modes"] = _normalize_wave1_runtime_modes(delegation.get("runtime_modes"))
+    normalized_profiles: Dict[str, Dict[str, Any]] = {}
+    for bucket_name in ("delegation_profiles", "categories"):
+        bucket = delegation.get(bucket_name)
+        if not isinstance(bucket, dict):
+            continue
+        for raw_name, entry in _normalize_openagent_named_bucket(bucket).items():
+            merged = dict(normalized_profiles.get(raw_name, {}))
+            if isinstance(entry, dict):
+                merged.update(entry)
+            normalized_profiles[raw_name] = merged
+    delegation["delegation_profiles"] = normalized_profiles
+    delegation["categories"] = copy.deepcopy(normalized_profiles)
+    delegation["archetype_defaults"] = dict(archetype_defaults)
+
+    config["delegation"] = delegation
+    return config
+
+
 def _normalize_openagent_config_buckets(
     config: Dict[str, Any], *, include_defaults: bool = True,
 ) -> Dict[str, Any]:
@@ -2972,7 +3981,7 @@ def _normalize_openagent_config_buckets(
     config = dict(config)
 
     if include_defaults or "agents" in config:
-        config["agents"] = _normalize_openagent_named_bucket(config.get("agents"))
+        config["agents"] = _normalize_named_agent_registry(config.get("agents"))
     if include_defaults or "categories" in config:
         config["categories"] = _normalize_openagent_named_bucket(config.get("categories"))
     if include_defaults or "runtime_fallback" in config:
@@ -3026,8 +4035,10 @@ def load_config() -> Dict[str, Any]:
 
     normalized = _normalize_profile_path_settings(
         _expand_env_vars(
-            _normalize_openagent_config_buckets(
-                _normalize_root_model_keys(_normalize_max_turns_config(config))
+            _normalize_wave1_delegation_config(
+                _normalize_openagent_config_buckets(
+                    _normalize_root_model_keys(_normalize_max_turns_config(config))
+                )
             )
         )
     )
@@ -3142,15 +4153,21 @@ def save_config(config: Dict[str, Any]):
     ensure_hermes_home()
     config_path = get_config_path()
     current_normalized = _normalize_profile_path_settings(
-        _normalize_openagent_config_buckets(
-            _normalize_root_model_keys(_normalize_max_turns_config(config)),
+        _normalize_wave1_delegation_config(
+            _normalize_openagent_config_buckets(
+                _normalize_root_model_keys(_normalize_max_turns_config(config)),
+                include_defaults=False,
+            ),
             include_defaults=False,
         )
     )
     normalized = current_normalized
     raw_existing = _normalize_profile_path_settings(
-        _normalize_openagent_config_buckets(
-            _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config())),
+        _normalize_wave1_delegation_config(
+            _normalize_openagent_config_buckets(
+                _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config())),
+                include_defaults=False,
+            ),
             include_defaults=False,
         )
     )
@@ -3599,7 +4616,29 @@ def show_config():
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
     print(f"  Model:        {config.get('model', 'not set')}")
     print(f"  Max turns:    {config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])}")
-    
+
+    # Delegation
+    print()
+    print(color("◆ Delegation", Colors.CYAN, Colors.BOLD))
+    delegation = config.get('delegation', {}) if isinstance(config.get('delegation'), dict) else {}
+    raw_config = read_raw_config()
+    delegation_metadata = inspect_wave1_delegation_metadata(config, raw_config)
+    print(f"  Default profile: {delegation.get('default_delegation_profile', 'general')}")
+    print(f"  Category:        {delegation.get('category', DEFAULT_LITERAL_CATEGORY)}")
+    print(f"  Route category:  {delegation.get('route_category', DEFAULT_ROUTE_CATEGORY)}")
+    print(f"  Runtime mode:    {delegation.get('runtime_mode', DEFAULT_RUNTIME_MODE_NAME)}")
+
+    effective_route_overrides = delegation_metadata['effective_route_category_override_names']
+    effective_runtime_overrides = delegation_metadata['effective_runtime_mode_override_names']
+    ignored_route_names = delegation_metadata['ignored_route_category_names']
+    ignored_runtime_names = delegation_metadata['ignored_runtime_mode_names']
+    print(f"  Route metadata overrides:   {', '.join(effective_route_overrides) if effective_route_overrides else color('(none)', Colors.DIM)}")
+    print(f"  Runtime metadata overrides: {', '.join(effective_runtime_overrides) if effective_runtime_overrides else color('(none)', Colors.DIM)}")
+    if ignored_route_names:
+        print(f"  Ignored route metadata:     {', '.join(ignored_route_names)}")
+    if ignored_runtime_names:
+        print(f"  Ignored runtime metadata:   {', '.join(ignored_runtime_names)}")
+
     # Display
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7540,6 +7540,16 @@ Examples:
         help="Environment variables for stdio servers (KEY=VALUE)",
     )
 
+    mcp_sub.add_parser("catalog", help="Browse built-in MCP presets and bundles")
+
+    mcp_install_p = mcp_sub.add_parser(
+        "install",
+        help="Install a built-in MCP preset or bundle into config.yaml",
+    )
+    mcp_install_p.add_argument("catalog_name", help="Built-in MCP preset or bundle name")
+    mcp_install_p.add_argument("--as", dest="as_name", help="Custom server name when installing a single preset")
+    mcp_install_p.add_argument("--yes", "-y", action="store_true", help="Skip overwrite confirmation")
+
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4042,6 +4042,12 @@ def cmd_auth(args):
     auth_command(args)
 
 
+def cmd_project(args):
+    """Project OS management."""
+    from hermes_cli.projects import project_command
+    project_command(args)
+
+
 def cmd_status(args):
     """Show status of all components."""
     from hermes_cli.status import show_status
@@ -6648,6 +6654,35 @@ For more help on a command:
     )
     auth_reset.add_argument("provider", help="Provider id")
     auth_parser.set_defaults(func=cmd_auth)
+
+    # =========================================================================
+    # project command
+    # =========================================================================
+    project_parser = subparsers.add_parser(
+        "project",
+        help="Manage local project cells",
+        description="List, initialize, inspect, and refresh Hermes Project OS cells",
+    )
+    project_subparsers = project_parser.add_subparsers(dest="project_action")
+
+    project_subparsers.add_parser("list", help="List known projects")
+
+    project_init = project_subparsers.add_parser("init", help="Initialize a new project cell")
+    project_init.add_argument("project_id", help="Project id (lowercase, alphanumeric, '_' and '-')")
+    project_init.add_argument("name", help="Human-readable project name")
+    project_init.add_argument("summary", help="Short project summary")
+    project_init.add_argument("--repo-path", default=None, help="Optional git repository path to associate")
+
+    project_show = project_subparsers.add_parser("show", help="Show project metadata")
+    project_show.add_argument("project_id", help="Project id")
+
+    project_digest = project_subparsers.add_parser("digest", help="Generate a status digest report")
+    project_digest.add_argument("project_id", help="Project id")
+
+    project_status = project_subparsers.add_parser("status", help="Alias for generating a status digest")
+    project_status.add_argument("project_id", help="Project id")
+
+    project_parser.set_defaults(func=cmd_project, project_action="list")
 
     # =========================================================================
     # status command

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import time
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import (
@@ -30,7 +31,167 @@ logger = logging.getLogger(__name__)
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-_MCP_PRESETS: Dict[str, Dict[str, Any]] = {}
+_MCP_PRESET_CONFIG_KEYS = frozenset({
+    "url",
+    "command",
+    "args",
+    "env",
+    "headers",
+    "auth",
+    "timeout",
+    "connect_timeout",
+    "sampling",
+    "tools",
+})
+
+_MCP_PRESETS: Dict[str, Dict[str, Any]] = {
+    "fetch": {
+        "display_name": "Fetch",
+        "description": "Fetch and convert remote web content to agent-friendly text.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-fetch"],
+    },
+    "github": {
+        "display_name": "GitHub",
+        "description": "Read and mutate GitHub issues, PRs, repos, and code search.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {
+            "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}",
+        },
+    },
+    "ink": {
+        "display_name": "Ink",
+        "description": "Hosted remote MCP endpoint for Ink deployment workflows.",
+        "url": "https://mcp.ml.ink/mcp",
+    },
+    "memory": {
+        "display_name": "Memory",
+        "description": "Lightweight knowledge graph + memory primitives.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-memory"],
+    },
+    "sequential-thinking": {
+        "display_name": "Sequential Thinking",
+        "description": "Stepwise planning and reasoning helper tools.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+    },
+    "time": {
+        "display_name": "Time",
+        "description": "Time and timezone helper tools.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-time"],
+    },
+}
+
+_MCP_BUNDLES: Dict[str, Dict[str, Any]] = {
+    "developer": {
+        "display_name": "Developer Essentials",
+        "description": "Common coding and repo helpers for day-to-day development work.",
+        "servers": [
+            {"name": "github", "preset": "github"},
+            {"name": "fetch", "preset": "fetch"},
+            {"name": "sequential-thinking", "preset": "sequential-thinking"},
+        ],
+    },
+    "research": {
+        "display_name": "Research Starter",
+        "description": "Web retrieval plus structured reasoning helpers.",
+        "servers": [
+            {"name": "fetch", "preset": "fetch"},
+            {"name": "sequential-thinking", "preset": "sequential-thinking"},
+            {"name": "time", "preset": "time"},
+        ],
+    },
+}
+
+_ENV_VAR_INTERPOLATION_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _canonical_catalog_name(name: Optional[str]) -> str:
+    return str(name or "").strip().lower().replace("_", "-")
+
+
+def _resolve_mcp_preset(preset_name: str) -> Dict[str, Any]:
+    preset = _MCP_PRESETS.get(_canonical_catalog_name(preset_name))
+    if not preset:
+        raise ValueError(f"Unknown MCP preset: {preset_name}")
+    return preset
+
+
+def _resolve_mcp_bundle(bundle_name: str) -> Dict[str, Any]:
+    bundle = _MCP_BUNDLES.get(_canonical_catalog_name(bundle_name))
+    if not bundle:
+        raise ValueError(f"Unknown MCP bundle: {bundle_name}")
+    return bundle
+
+
+def _iter_required_env_vars(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, str):
+        found.update(_ENV_VAR_INTERPOLATION_RE.findall(value))
+    elif isinstance(value, dict):
+        for item in value.values():
+            found.update(_iter_required_env_vars(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(_iter_required_env_vars(item))
+    return found
+
+
+def _materialize_mcp_preset(
+    preset_name: str,
+    *,
+    overrides: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    preset = _resolve_mcp_preset(preset_name)
+    config: Dict[str, Any] = {}
+    for key in _MCP_PRESET_CONFIG_KEYS:
+        if key in preset:
+            config[key] = deepcopy(preset[key])
+
+    for key, value in (overrides or {}).items():
+        if key not in _MCP_PRESET_CONFIG_KEYS:
+            continue
+        if key in {"env", "headers"} and isinstance(value, dict):
+            merged = dict(config.get(key) or {})
+            merged.update(deepcopy(value))
+            if merged:
+                config[key] = merged
+        else:
+            config[key] = deepcopy(value)
+    return config
+
+
+def _expand_mcp_bundle(bundle_name: str) -> Dict[str, Dict[str, Any]]:
+    bundle = _resolve_mcp_bundle(bundle_name)
+    entries: Dict[str, Dict[str, Any]] = {}
+    for entry in bundle.get("servers") or []:
+        if not isinstance(entry, dict):
+            raise ValueError(f"Invalid MCP bundle entry in '{bundle_name}'")
+        server_name = str(entry.get("name") or "").strip()
+        preset_name = str(entry.get("preset") or "").strip()
+        if not server_name or not preset_name:
+            raise ValueError(f"Invalid MCP bundle entry in '{bundle_name}'")
+        overrides = {
+            key: entry[key]
+            for key in _MCP_PRESET_CONFIG_KEYS
+            if key in entry
+        }
+        entries[server_name] = _materialize_mcp_preset(preset_name, overrides=overrides)
+        entries[server_name].setdefault("enabled", True)
+    return entries
+
+
+def _preset_transport_summary(config: Dict[str, Any]) -> str:
+    if config.get("url"):
+        return f"http {config['url']}"
+    if config.get("command"):
+        args = config.get("args") or []
+        preview = " ".join(str(arg) for arg in args[:2])
+        return f"stdio {config['command']} {preview}".strip()
+    return "custom"
 
 
 # ─── UI Helpers ───────────────────────────────────────────────────────────────
@@ -134,25 +295,111 @@ def _apply_mcp_preset(
     if not preset_name:
         return url, command, cmd_args, False
 
-    preset = _MCP_PRESETS.get(preset_name)
-    if not preset:
-        raise ValueError(f"Unknown MCP preset: {preset_name}")
-
     if url or command:
         return url, command, cmd_args, False
 
-    url = preset.get("url")
-    command = preset.get("command")
-    cmd_args = list(preset.get("args") or [])
+    preset_config = _materialize_mcp_preset(preset_name)
+    url = preset_config.get("url")
+    command = preset_config.get("command")
+    cmd_args = list(preset_config.get("args") or [])
 
-    if url:
-        server_config["url"] = url
-    if command:
-        server_config["command"] = command
-    if cmd_args:
-        server_config["args"] = cmd_args
+    for key, value in preset_config.items():
+        if key == "args":
+            if cmd_args:
+                server_config["args"] = cmd_args
+            continue
+        server_config[key] = value
 
     return url, command, cmd_args, True
+
+
+def cmd_mcp_catalog(args=None):
+    """List the built-in MCP preset and bundle catalog."""
+    print()
+    print(color("  Built-in MCP Presets:", Colors.CYAN + Colors.BOLD))
+    print()
+    for preset_name in sorted(_MCP_PRESETS):
+        preset = _MCP_PRESETS[preset_name]
+        display_name = preset.get("display_name") or preset_name
+        transport = _preset_transport_summary(preset)
+        required_env = sorted(_iter_required_env_vars(_materialize_mcp_preset(preset_name)))
+        env_suffix = f" [env: {', '.join(required_env)}]" if required_env else ""
+        print(f"  {preset_name:<22} {display_name}")
+        print(f"    {preset.get('description', '').strip()}")
+        print(f"    {transport}{env_suffix}")
+    if _MCP_BUNDLES:
+        print()
+        print(color("  Built-in MCP Bundles:", Colors.CYAN + Colors.BOLD))
+        print()
+        for bundle_name in sorted(_MCP_BUNDLES):
+            bundle = _MCP_BUNDLES[bundle_name]
+            display_name = bundle.get("display_name") or bundle_name
+            members = ", ".join(entry.get("name", "?") for entry in (bundle.get("servers") or []))
+            print(f"  {bundle_name:<22} {display_name}")
+            print(f"    {bundle.get('description', '').strip()}")
+            print(f"    installs: {members}")
+    print()
+    _info("Install one with: hermes mcp install <preset-or-bundle>")
+    _info("Or discovery-install a single server with: hermes mcp add <name> --preset <preset>")
+
+
+def cmd_mcp_install(args):
+    """Install a built-in MCP preset or bundle into plain mcp_servers config."""
+    catalog_name = getattr(args, "catalog_name", None) or getattr(args, "name", None)
+    alias = str(getattr(args, "as_name", None) or "").strip() or None
+    yes = bool(getattr(args, "yes", False))
+
+    if not catalog_name:
+        _error("Missing MCP preset or bundle name")
+        return
+
+    catalog_key = _canonical_catalog_name(catalog_name)
+
+    try:
+        if catalog_key in _MCP_PRESETS:
+            server_name = alias or catalog_key
+            installs = {
+                server_name: _materialize_mcp_preset(catalog_key)
+            }
+            installs[server_name].setdefault("enabled", True)
+            installed_kind = "preset"
+        elif catalog_key in _MCP_BUNDLES:
+            if alias:
+                _error("--as is only supported when installing a single MCP preset")
+                return
+            installs = _expand_mcp_bundle(catalog_key)
+            installed_kind = "bundle"
+        else:
+            _error(f"Unknown MCP preset or bundle: {catalog_name}")
+            return
+    except ValueError as exc:
+        _error(str(exc))
+        return
+
+    existing = _get_mcp_servers()
+    conflicts = sorted(name for name in installs if name in existing)
+    if conflicts and not yes:
+        if not _confirm(
+            f"Overwrite existing MCP server(s): {', '.join(conflicts)}?",
+            default=False,
+        ):
+            _info("Cancelled.")
+            return
+
+    config = load_config()
+    config.setdefault("mcp_servers", {}).update(installs)
+    save_config(config)
+
+    print()
+    _success(
+        f"Installed MCP {installed_kind} '{catalog_key}' to {display_hermes_home()}/config.yaml"
+    )
+    for server_name, server_config in installs.items():
+        required_env = sorted(_iter_required_env_vars(server_config))
+        env_suffix = f" [env: {', '.join(required_env)}]" if required_env else ""
+        _info(f"{server_name}: {_preset_transport_summary(server_config)}{env_suffix}")
+    _info("These entries were expanded into normal mcp_servers config entries.")
+    _info("Run `hermes mcp test <name>` to verify each server, or `hermes mcp list` to review them.")
 
 
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
@@ -237,6 +484,7 @@ def cmd_mcp_add(args):
             cmd_args=list(cmd_args),
             server_config=server_config,
         )
+        auth_type = auth_type or server_config.get("auth")
     except ValueError as exc:
         _error(str(exc))
         return
@@ -269,7 +517,13 @@ def cmd_mcp_add(args):
         if cmd_args:
             server_config["args"] = cmd_args
         if explicit_env:
-            server_config["env"] = explicit_env
+            merged_env = dict(server_config.get("env") or {})
+            merged_env.update(explicit_env)
+            server_config["env"] = merged_env
+
+    required_env = sorted(_iter_required_env_vars(server_config))
+    if required_env:
+        _info(f"Required environment variables: {', '.join(required_env)}")
 
 
     # ── Authentication ────────────────────────────────────────────────
@@ -748,6 +1002,8 @@ def mcp_command(args):
 
     handlers = {
         "add": cmd_mcp_add,
+        "catalog": cmd_mcp_catalog,
+        "install": cmd_mcp_install,
         "remove": cmd_mcp_remove,
         "rm": cmd_mcp_remove,
         "list": cmd_mcp_list,
@@ -766,6 +1022,8 @@ def mcp_command(args):
         cmd_mcp_list()
         print(color("  Commands:", Colors.CYAN))
         _info("hermes mcp serve                              Run as MCP server")
+        _info("hermes mcp catalog                            Browse built-in presets and bundles")
+        _info("hermes mcp install <preset-or-bundle>         Install built-in catalog entries")
         _info("hermes mcp add <name> --url <endpoint>        Add an MCP server")
         _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
         _info("hermes mcp add <name> --preset <preset>       Add from a known preset")

--- a/hermes_cli/projects.py
+++ b/hermes_cli/projects.py
@@ -1,0 +1,524 @@
+"""Project OS CLI helpers for Hermes.
+
+Implements a small local-first project operating system on top of the current
+profile-scoped HERMES_HOME. Projects live under:
+
+    <HERMES_HOME>/project-os-v1/projects/<project_id>/
+
+The registry lives at:
+
+    <HERMES_HOME>/project-os-v1/projects/registry.json
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.colors import Colors, color
+from hermes_constants import get_hermes_home
+
+_PROJECT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{1,63}$")
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _project_os_root() -> Path:
+    return get_hermes_home() / "project-os-v1"
+
+
+def _projects_root() -> Path:
+    return _project_os_root() / "projects"
+
+
+def _registry_path() -> Path:
+    return _projects_root() / "registry.json"
+
+
+def _detect_owner_profile() -> str:
+    home = get_hermes_home().resolve()
+    if home.parent.name == "profiles":
+        return home.name
+    return "default"
+
+
+def _validate_project_id(project_id: str) -> None:
+    if not _PROJECT_ID_RE.match(project_id):
+        raise ValueError(
+            f"Invalid project id {project_id!r}. Must match [a-z0-9][a-z0-9_-]{{1,63}}"
+        )
+
+
+def _read_registry() -> Dict[str, Any]:
+    path = _registry_path()
+    if not path.exists():
+        return {
+            "schema_version": "1",
+            "generated_at": _iso_now(),
+            "projects": [],
+        }
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_registry(payload: Dict[str, Any]) -> None:
+    path = _registry_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload["generated_at"] = _iso_now()
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _default_pairing_status(now: str) -> Dict[str, Any]:
+    return {
+        "state": "unpaired",
+        "issued_at": None,
+        "approved_at": None,
+        "revoked_at": None,
+        "expires_at": None,
+        "device_label": None,
+        "code_hint": None,
+        "updated_at": now,
+    }
+
+
+def _git_metadata(repo_path: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not repo_path:
+        return None
+    repo = Path(repo_path)
+    if not repo.exists():
+        raise FileNotFoundError(f"Repo path does not exist: {repo_path}")
+
+    def _run(*args: str) -> str:
+        return subprocess.run(args, cwd=repo, capture_output=True, text=True, check=True).stdout.strip()
+
+    commit = _run("/usr/bin/git", "rev-parse", "HEAD")
+    short_commit = _run("/usr/bin/git", "rev-parse", "--short", "HEAD")
+    branch = _run("/usr/bin/git", "rev-parse", "--abbrev-ref", "HEAD")
+    if branch == "HEAD":
+        branch = "detached-head"
+    dirty = bool(_run("/usr/bin/git", "status", "--short"))
+
+    return {
+        "path": str(repo),
+        "url": None,
+        "branch": branch,
+        "commit": commit,
+        "short_commit": short_commit,
+        "dirty": dirty,
+    }
+
+
+def _project_dir(project_id: str) -> Path:
+    return _projects_root() / project_id
+
+
+def _manifest_path(project_id: str) -> Path:
+    return _project_dir(project_id) / "reports" / "manifest.json"
+
+
+def _status_digest_path(project_id: str) -> Path:
+    return _project_dir(project_id) / "reports" / "01-status-digest.md"
+
+
+def _load_project_from_registry(project_id: str) -> Optional[Dict[str, Any]]:
+    payload = _read_registry()
+    for project in payload.get("projects", []):
+        if project.get("id") == project_id:
+            return project
+    return None
+
+
+def _load_manifest(project_id: str) -> Dict[str, Any]:
+    path = _manifest_path(project_id)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_project_yaml(project_id: str) -> Dict[str, Any]:
+    path = _project_dir(project_id) / "project.yaml"
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _display_value(value: Any, default: str = "n/a") -> str:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return str(value).lower()
+    text = str(value).strip()
+    return text or default
+
+
+def get_project_details(project_id: str) -> Dict[str, Any]:
+    project = _load_project_from_registry(project_id)
+    if not project:
+        raise FileNotFoundError(f"Project '{project_id}' not found")
+
+    project_dir = _project_dir(project_id)
+    project_yaml = _load_project_yaml(project_id)
+    manifest = _load_manifest(project_id)
+    digest_path = _status_digest_path(project_id)
+
+    pairing_state = "unknown"
+    pairing_path = project_dir / "pairing" / "status.json"
+    if pairing_path.exists():
+        try:
+            pairing_payload = json.loads(pairing_path.read_text(encoding="utf-8"))
+            pairing_state = pairing_payload.get("state") or "unknown"
+        except json.JSONDecodeError:
+            pairing_state = "invalid"
+
+    repo_cfg = project_yaml.get("repo") if isinstance(project_yaml.get("repo"), dict) else {}
+    repo_path = project.get("repo_path") or repo_cfg.get("path")
+    repo_state: Dict[str, Any] = {
+        "path": repo_path,
+        "branch": repo_cfg.get("branch") if repo_path else None,
+        "commit": repo_cfg.get("commit") if repo_path else None,
+        "short_commit": None,
+        "dirty": repo_cfg.get("dirty") if repo_path else None,
+    }
+    if repo_state.get("commit"):
+        repo_state["short_commit"] = str(repo_state["commit"])[:7]
+
+    repo_error = None
+    if repo_path:
+        try:
+            repo_state = _git_metadata(repo_path)
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            repo_error = str(exc)
+
+    return {
+        "project": project,
+        "project_dir": project_dir,
+        "project_yaml": project_yaml,
+        "manifest": manifest,
+        "digest_path": digest_path,
+        "pairing_state": pairing_state,
+        "repo": repo_state,
+        "repo_error": repo_error,
+    }
+
+
+def print_project_details(project_id: str) -> None:
+    details = get_project_details(project_id)
+    project = details["project"]
+    project_dir = details["project_dir"]
+    manifest = details["manifest"]
+    repo = details["repo"]
+    digest_path = details["digest_path"]
+
+    print()
+    print(color(f"Project: {project['id']}", Colors.BOLD, Colors.CYAN))
+    print(f"Name:          {project['name']}")
+    print(f"Summary:       {project['summary']}")
+    print(f"Status:        {project['status']}")
+    print(f"Owner profile: {project['owner_profile']}")
+    print(f"Cell path:     {project_dir}")
+    print(f"Created:       {_display_value(details['project_yaml'].get('created_at'))}")
+    print(f"Updated:       {_display_value(details['project_yaml'].get('updated_at'))}")
+
+    print()
+    print(color("Artifacts", Colors.BOLD))
+    print(f"Project config:     {project_dir / 'project.yaml'}")
+    print(f"Brief:              {project_dir / 'brief.md'}")
+    print(f"Executive summary:  {project_dir / 'reports' / '00-executive-summary.md'}")
+    if digest_path.exists():
+        digest_label = str(digest_path)
+    else:
+        digest_label = f"{digest_path} (not generated yet)"
+    print(f"Status digest:      {digest_label}")
+    print(f"Manifest:           {_manifest_path(project['id'])}")
+    print(f"Manifest artifacts: {len(manifest.get('artifacts', []))}")
+    print(f"Latest workflow:    {_display_value(manifest.get('workflow'))}")
+    print(f"Pairing state:      {_display_value(details['pairing_state'], default='unknown')}")
+
+    print()
+    print(color("Repository", Colors.BOLD))
+    print(f"Path:   {_display_value(repo.get('path'))}")
+    print(f"Branch: {_display_value(repo.get('branch'))}")
+    print(f"Commit: {_display_value(repo.get('short_commit') or repo.get('commit'))}")
+    print(f"Dirty:  {_display_value(repo.get('dirty'))}")
+    if details["repo_error"]:
+        print(f"Repo check: {details['repo_error']}")
+    print()
+
+
+def init_project(project_id: str, name: str, summary: str, repo_path: Optional[str] = None) -> Path:
+    _validate_project_id(project_id)
+    if not name.strip():
+        raise ValueError("Project name is required")
+    if not summary.strip():
+        raise ValueError("Project summary is required")
+
+    project_dir = _project_dir(project_id)
+    if project_dir.exists():
+        raise FileExistsError(f"Project '{project_id}' already exists at {project_dir}")
+
+    repo = _git_metadata(repo_path)
+    now = _iso_now()
+    owner_profile = _detect_owner_profile()
+    config_dir = _project_os_root() / "config"
+
+    project_yaml_lines = [
+        'schema_version: "1"',
+        f'id: {project_id}',
+        f'name: {name}',
+        f'summary: {summary}',
+        'status: active',
+        'priority: medium',
+        f'owner_profile: {owner_profile}',
+        f'project_root: {project_dir}',
+        'workspace_contracts:',
+        f'  path_policies: {config_dir / "path-policies.yaml"}',
+        f'  modules: {config_dir / "modules.yaml"}',
+        f'  modules_lock: {config_dir / "modules.lock.yaml"}',
+        'repo:',
+    ]
+    if repo:
+        project_yaml_lines.extend([
+            f"  path: {repo['path']}",
+            '  url: null',
+            f"  branch: {repo['branch']}",
+            f"  commit: {repo['commit']}",
+            f"  dirty: {'true' if repo['dirty'] else 'false'}",
+        ])
+    else:
+        project_yaml_lines.extend([
+            '  path: null',
+            '  url: null',
+            '  branch: null',
+            '  commit: null',
+            '  dirty: false',
+        ])
+    project_yaml_lines.extend([
+        'artifacts:',
+        '  reports_dir: reports',
+        '  tasks_dir: tasks',
+        '  checkpoints_dir: checkpoints',
+        '  logs_dir: logs',
+        '  assets_dir: assets',
+        '  approvals_file: approvals.jsonl',
+        '  sync_dir: sync',
+        '  pairing_dir: pairing',
+        'sync:',
+        '  mode: local-only',
+        '  path_policies:',
+        '    - path: repo',
+        '      policy: git-owned',
+        '    - path: reports',
+        '      policy: mirror',
+        '    - path: checkpoints',
+        '      policy: mirror',
+        '    - path: project.yaml',
+        '      policy: merge',
+        '    - path: memories.jsonl',
+        '      policy: append-only',
+        'cloudflare:',
+        '  enabled: false',
+        '  workspace_id: null',
+        '  remote_mode: null',
+        f'created_at: {now}',
+        f'updated_at: {now}',
+    ])
+    _write(project_dir / "project.yaml", "\n".join(project_yaml_lines) + "\n")
+    _write(project_dir / "brief.md", f"# {name}\n\n{summary}\n")
+    _write(project_dir / "tasks" / "README.md", "# Tasks\n\nTrack next actions and operator-owned work here.\n")
+    _write(project_dir / "tasks" / "next-actions.md", "# Next Actions\n\n- Review latest project digest\n- Decide whether any lightweight report artifacts should be approved\n- Refresh sync projection before mobile/operator review\n")
+    _write(project_dir / "checkpoints" / "README.md", "# Checkpoints\n\nStore resumable state snapshots here.\n")
+    _write(project_dir / "logs" / "README.md", "# Logs\n\nStore operator logs, run notes, and workflow outputs here.\n")
+    _write(project_dir / "assets" / "README.md", "# Assets\n\nStore diagrams, screenshots, and auxiliary artifacts here.\n")
+    _write(project_dir / "sync" / "README.md", "# Sync\n\nGenerated project-aware sync manifests live here.\n")
+    _write(project_dir / "approvals.jsonl", "")
+    _write(project_dir / "pairing" / "status.json", json.dumps(_default_pairing_status(now), indent=2) + "\n")
+
+    short_commit = repo.get("short_commit") if repo else None
+    summary_body = (
+        f"# Executive Summary\n\n"
+        f"Project: {name}\n"
+        f"Status: active\n"
+        f"Updated: {now}\n\n"
+        f"## What this project is\n{summary}\n\n"
+        f"## Current state\n"
+        f"- Phase: kickoff\n"
+        f"- Primary objective: establish a canonical Hermes Project OS cell\n"
+        f"- Biggest risk: artifact drift before UI integration exists\n"
+        f"- Next operator action: connect this project to Pan project views\n\n"
+        f"## Evidence\n"
+        f"- Repo path: {repo['path'] if repo else 'n/a'}\n"
+        f"- Commit: {short_commit or 'n/a'}\n"
+        f"- Generated from: hermes project init\n"
+    )
+    _write(project_dir / "reports" / "00-executive-summary.md", summary_body)
+
+    manifest = {
+        "project_id": project_id,
+        "generated_at": now,
+        "workflow": "project-kickoff",
+        "artifacts": [
+            "project.yaml",
+            "brief.md",
+            "tasks/README.md",
+            "tasks/next-actions.md",
+            "reports/00-executive-summary.md",
+            "reports/manifest.json",
+            "checkpoints/README.md",
+            "logs/README.md",
+            "assets/README.md",
+            "approvals.jsonl",
+            "pairing/status.json",
+        ],
+    }
+    _write(_manifest_path(project_id), json.dumps(manifest, indent=2) + "\n")
+
+    payload = _read_registry()
+    payload.setdefault("projects", []).append({
+        "id": project_id,
+        "name": name,
+        "status": "active",
+        "owner_profile": owner_profile,
+        "path": str(project_dir),
+        "repo_path": repo.get("path") if repo else None,
+        "summary": summary,
+    })
+    _write_registry(payload)
+    return project_dir
+
+
+def list_projects() -> List[Dict[str, Any]]:
+    return list(_read_registry().get("projects", []))
+
+
+def generate_status_digest(project_id: str) -> Path:
+    project = _load_project_from_registry(project_id)
+    if not project:
+        raise FileNotFoundError(f"Project '{project_id}' not found")
+
+    project_yaml_path = _project_dir(project_id) / "project.yaml"
+    if not project_yaml_path.exists():
+        raise FileNotFoundError(f"Missing project.yaml for '{project_id}'")
+    project_yaml = project_yaml_path.read_text(encoding="utf-8")
+
+    repo_path = project.get("repo_path")
+    repo_state = {"path": repo_path or "n/a", "branch": "n/a", "commit": "n/a", "dirty": "n/a"}
+    if repo_path:
+        repo = _git_metadata(repo_path)
+        if repo:
+            repo_state = {
+                "path": repo["path"],
+                "branch": repo["branch"],
+                "commit": repo["commit"],
+                "dirty": str(repo["dirty"]).lower(),
+            }
+
+    now = _iso_now()
+    body = (
+        f"# Status Digest\n\n"
+        f"Updated: {now}\n\n"
+        f"## Current status\n"
+        f"- Project: {project['name']}\n"
+        f"- Status: {project['status']}\n"
+        f"- Owner profile: {project['owner_profile']}\n\n"
+        f"## Repo state\n"
+        f"- Path: {repo_state['path']}\n"
+        f"- Branch: {repo_state['branch']}\n"
+        f"- Commit: {repo_state['commit']}\n"
+        f"- Dirty: {repo_state['dirty']}\n\n"
+        f"## Open work\n"
+        f"- Connect project cell to Pan UI project routes\n"
+        f"- Promote owner workflows into installed skills after prototype review\n\n"
+        f"## Risks / blockers\n"
+        f"- UI integration may still be incomplete for this profile\n"
+        f"- Cloud sync intentionally not enabled\n\n"
+        f"## Recommended next actions\n"
+        f"1. Build or verify Pan project routes\n"
+        f"2. Review project.yaml for completeness\n"
+        f"3. Generate richer project docs if the repo is ready\n"
+    )
+    digest_path = _status_digest_path(project_id)
+    _write(digest_path, body)
+
+    manifest_path = _manifest_path(project_id)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if "reports/01-status-digest.md" not in manifest.get("artifacts", []):
+        manifest["artifacts"].append("reports/01-status-digest.md")
+    manifest["generated_at"] = now
+    _write(manifest_path, json.dumps(manifest, indent=2) + "\n")
+    return digest_path
+
+
+def project_command(args) -> int:
+    action = getattr(args, "project_action", None)
+
+    if action is None or action == "list":
+        projects = list_projects()
+        if not projects:
+            print(color("No projects found. Create one with 'hermes project init ...'", Colors.DIM))
+            return 0
+
+        print()
+        print(f" {'Project':<18} {'Status':<10} {'Profile':<16} Summary")
+        print(f" {'─'*17}  {'─'*9}  {'─'*15}  {'─'*40}")
+        for project in projects:
+            print(
+                f" {project['id']:<18} {project['status']:<10} {project['owner_profile']:<16} "
+                f"{project['summary'][:80]}"
+            )
+        print()
+        return 0
+
+    if action == "init":
+        try:
+            project_dir = init_project(
+                project_id=args.project_id,
+                name=args.name,
+                summary=args.summary,
+                repo_path=getattr(args, "repo_path", None),
+            )
+        except (ValueError, FileExistsError, FileNotFoundError, subprocess.CalledProcessError) as exc:
+            print(color(f"Error: {exc}", Colors.RED))
+            return 1
+        print(color(f"Created project cell: {project_dir}", Colors.GREEN))
+        return 0
+
+    if action == "show":
+        try:
+            print_project_details(args.project_id)
+        except FileNotFoundError as exc:
+            print(color(f"Error: {exc}", Colors.RED))
+            return 1
+        return 0
+
+    if action in {"digest", "status"}:
+        try:
+            digest_path = generate_status_digest(args.project_id)
+            project = _load_project_from_registry(args.project_id)
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            print(color(f"Error: {exc}", Colors.RED))
+            return 1
+        print(color(f"Updated status digest: {digest_path}", Colors.GREEN))
+        if project:
+            print(f"Project: {project['name']}")
+            print(f"Profile: {project['owner_profile']}")
+            print(f"Path:    {project['path']}")
+        return 0
+
+    print(color(f"Unknown project action: {action}", Colors.RED))
+    return 1

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -51,6 +51,7 @@ CONFIGURABLE_TOOLSETS = [
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
+    ("code_intel",      "🧩 Code Intelligence",         "AST structure, definitions, diagnostics"),
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),

--- a/hermes_cli/work_command_adapter.py
+++ b/hermes_cli/work_command_adapter.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from hermes_cli.command_templates import CommandInvocation, build_command_invocation
+from hermes_cli.commands import resolve_command
+
+WORK_COMMAND_ADAPTER_SCHEMA = "hermes/work-command-intake"
+WORK_COMMAND_ADAPTER_VERSION = "2.0"
+
+
+class WorkCommandContractError(ValueError):
+    """User-facing failure for malformed work-command payloads."""
+
+    def __init__(self, message: str, *, command_name: str, raw_args: str = "", cause: Exception | None = None):
+        super().__init__(message)
+        self.command_name = command_name
+        self.raw_args = raw_args
+        self.cause = cause
+
+
+@dataclass(frozen=True)
+class PreparedWorkCommand:
+    invocation: CommandInvocation
+    adapter_schema: str = WORK_COMMAND_ADAPTER_SCHEMA
+    adapter_version: str = WORK_COMMAND_ADAPTER_VERSION
+
+    @property
+    def command_name(self) -> str:
+        return self.invocation.command_name
+
+    @property
+    def raw_args(self) -> str:
+        return self.invocation.raw_args
+
+    @property
+    def task_contract(self) -> dict[str, Any]:
+        return self.invocation.task_contract
+
+    @property
+    def orchestration_hints(self) -> dict[str, Any]:
+        return self.invocation.orchestration_hints
+
+    @property
+    def agent_message(self) -> str:
+        return self.invocation.prompt_text
+
+    @property
+    def display_text(self) -> str:
+        suffix = f" {self.raw_args}" if self.raw_args else ""
+        return f"/{self.command_name}{suffix}"
+
+
+def is_prepared_work_command(value: Any) -> bool:
+    return isinstance(value, PreparedWorkCommand)
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    parts: list[str] = []
+    for error in exc.errors(include_url=False):
+        loc = ".".join(str(part) for part in error.get("loc") or ()) or "payload"
+        msg = str(error.get("msg") or "invalid value")
+        parts.append(f"{loc}: {msg}")
+    return "; ".join(parts) or str(exc)
+
+
+def _normalize_cwd(cwd: str | None) -> str | None:
+    return str(Path(cwd).resolve()) if cwd else None
+
+
+def _normalize_work_command_name(command_name: str) -> str:
+    normalized_command = str(command_name or "").strip().lower().lstrip("/")
+    resolved = resolve_command(normalized_command)
+    if resolved is None:
+        return normalized_command
+    return resolved.name
+
+
+def prepare_work_command(
+    command_name: str,
+    *,
+    raw_args: str = "",
+    session_id: str | None = None,
+    cwd: str | None = None,
+) -> PreparedWorkCommand:
+    normalized_command = _normalize_work_command_name(command_name)
+    normalized_args = str(raw_args or "").strip()
+    try:
+        invocation = build_command_invocation(
+            normalized_command,
+            raw_args=normalized_args,
+            session_id=session_id,
+            cwd=_normalize_cwd(cwd),
+        )
+    except json.JSONDecodeError as exc:
+        raise WorkCommandContractError(
+            f"Malformed /{normalized_command} work command JSON: expected a valid JSON object.",
+            command_name=normalized_command,
+            raw_args=normalized_args,
+            cause=exc,
+        ) from exc
+    except ValidationError as exc:
+        raise WorkCommandContractError(
+            f"Invalid /{normalized_command} task contract: {_format_validation_error(exc)}",
+            command_name=normalized_command,
+            raw_args=normalized_args,
+            cause=exc,
+        ) from exc
+    except (TypeError, ValueError) as exc:
+        raise WorkCommandContractError(
+            f"Invalid /{normalized_command} work command payload: {exc}",
+            command_name=normalized_command,
+            raw_args=normalized_args,
+            cause=exc,
+        ) from exc
+    except KeyError as exc:
+        raise WorkCommandContractError(
+            f"Unknown work command: /{normalized_command}",
+            command_name=normalized_command,
+            raw_args=normalized_args,
+            cause=exc,
+        ) from exc
+    return PreparedWorkCommand(invocation=invocation)
+
+
+__all__ = [
+    "PreparedWorkCommand",
+    "WORK_COMMAND_ADAPTER_SCHEMA",
+    "WORK_COMMAND_ADAPTER_VERSION",
+    "WorkCommandContractError",
+    "is_prepared_work_command",
+    "prepare_work_command",
+]

--- a/model_tools.py
+++ b/model_tools.py
@@ -188,7 +188,44 @@ _LEGACY_TOOLSET_MAP = {
     "tts_tools": ["text_to_speech"],
 }
 
-_LSP_TOOL_NAMES = {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+_LSP_TOOL_NAMES = {
+    "lsp_document_symbols",
+    "lsp_definition",
+    "lsp_diagnostics",
+    "lsp_prepare_rename",
+    "lsp_references",
+    "lsp_rename",
+}
+
+
+def filter_tool_definitions_by_name(
+    tool_definitions: Optional[List[Dict[str, Any]]],
+    enabled_tools: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Return tool definitions filtered to the enabled tool-name set.
+
+    Preserves declaration order and ignores unknown names so caller-side runtime
+    overlays can narrow an already-resolved tool surface without mutating the
+    registry or re-running discovery.
+    """
+    if not tool_definitions:
+        return []
+    if enabled_tools is None:
+        return list(tool_definitions)
+
+    allowed = {
+        str(name).strip()
+        for name in enabled_tools
+        if isinstance(name, str) and str(name).strip()
+    }
+    if not allowed:
+        return []
+
+    return [
+        tool_def
+        for tool_def in tool_definitions
+        if str(tool_def.get("function", {}).get("name") or "").strip() in allowed
+    ]
 
 
 def _append_description_suffix(description: str, suffix: str) -> str:
@@ -519,11 +556,11 @@ def handle_function_call(
             # Still fire the hook for observers — just don't check for blocking
             # (the caller already did that).
             try:
-                from hermes_cli.plugins import invoke_hook
-                invoke_hook(
+                from hermes_cli.plugins import invoke_legacy_tool_hook
+                invoke_legacy_tool_hook(
                     "pre_tool_call",
-                    tool_name=function_name,
-                    args=function_args,
+                    function_name,
+                    function_args,
                     task_id=task_id or "",
                     session_id=session_id or "",
                     tool_call_id=tool_call_id or "",
@@ -557,11 +594,11 @@ def handle_function_call(
             )
 
         try:
-            from hermes_cli.plugins import invoke_hook
-            invoke_hook(
+            from hermes_cli.plugins import invoke_legacy_tool_hook
+            invoke_legacy_tool_hook(
                 "post_tool_call",
-                tool_name=function_name,
-                args=function_args,
+                function_name,
+                function_args,
                 result=result,
                 task_id=task_id or "",
                 session_id=session_id or "",
@@ -594,7 +631,42 @@ def get_toolset_for_tool(tool_name: str) -> Optional[str]:
 
 def get_available_toolsets() -> Dict[str, dict]:
     """Return toolset availability info for UI display."""
-    return registry.get_available_toolsets()
+    from toolsets import get_all_toolsets, resolve_toolset
+
+    registry_toolsets = registry.get_available_toolsets()
+    availability_by_toolset = registry.check_toolset_requirements()
+    combined: Dict[str, dict] = {}
+
+    for name, metadata in get_all_toolsets().items():
+        resolved_tools = resolve_toolset(name)
+        requirements = []
+        available = True
+        for tool_name in resolved_tools:
+            owning_toolset = registry.get_toolset_for_tool(tool_name)
+            if owning_toolset is None:
+                continue
+            available = available and availability_by_toolset.get(owning_toolset, True)
+            registry_meta = registry_toolsets.get(owning_toolset, {})
+            for requirement in registry_meta.get("requirements", []):
+                if requirement not in requirements:
+                    requirements.append(requirement)
+        combined[name] = {
+            "available": available,
+            "tools": resolved_tools,
+            "description": metadata.get("description", ""),
+            "requirements": requirements,
+            "canonical_name": metadata.get("canonical_name", name),
+            "source": metadata.get("source"),
+            "is_builtin": metadata.get("is_builtin", False),
+            "is_additive": metadata.get("is_additive", False),
+            "is_alias": metadata.get("is_alias", False),
+            "is_canonical_knowledge_surface": metadata.get(
+                "is_canonical_knowledge_surface", False
+            ),
+            "boundary_note": metadata.get("boundary_note"),
+        }
+
+    return combined
 
 
 def check_toolset_requirements() -> Dict[str, bool]:

--- a/model_tools.py
+++ b/model_tools.py
@@ -209,6 +209,7 @@ def _append_description_suffix(description: str, suffix: str) -> str:
 
 def get_tool_definitions(
     enabled_toolsets: List[str] = None,
+    enabled_tools: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
 ) -> List[Dict[str, Any]]:
@@ -219,6 +220,7 @@ def get_tool_definitions(
 
     Args:
         enabled_toolsets: Only include tools from these toolsets.
+        enabled_tools: Only include these exact tool names (intersected after toolset filtering).
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
 
@@ -267,6 +269,19 @@ def get_tool_definitions(
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
+
+    if enabled_tools is not None:
+        explicit_tools = {
+            str(name).strip()
+            for name in enabled_tools
+            if isinstance(name, str) and str(name).strip()
+        }
+        tools_to_include &= explicit_tools
+        if not quiet_mode:
+            if explicit_tools:
+                print(f"🎯 Explicit tool filter: {', '.join(sorted(explicit_tools))}")
+            else:
+                print("🎯 Explicit tool filter provided, but it resolved to no valid tool names")
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/model_tools.py
+++ b/model_tools.py
@@ -188,6 +188,20 @@ _LEGACY_TOOLSET_MAP = {
     "tts_tools": ["text_to_speech"],
 }
 
+_LSP_TOOL_NAMES = {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+
+
+def _append_description_suffix(description: str, suffix: str) -> str:
+    description = (description or "").rstrip()
+    suffix = (suffix or "").strip()
+    if not suffix or suffix in description:
+        return description
+    if not description:
+        return suffix
+    if description.endswith("."):
+        return f"{description} {suffix}"
+    return f"{description}. {suffix}"
+
 
 # =============================================================================
 # get_tool_definitions  (the main schema provider)
@@ -301,6 +315,22 @@ def get_tool_definitions(
                         "function": {**td["function"], "description": desc},
                     }
                     break
+
+    if _LSP_TOOL_NAMES & available_tool_names:
+        from tools.lsp_tools import get_lsp_host_capability_description
+
+        capability_suffix = get_lsp_host_capability_description()
+        for i, td in enumerate(filtered_tools):
+            if td.get("function", {}).get("name") not in _LSP_TOOL_NAMES:
+                continue
+            desc = td["function"].get("description", "")
+            filtered_tools[i] = {
+                "type": "function",
+                "function": {
+                    **td["function"],
+                    "description": _append_description_suffix(desc, capability_suffix),
+                },
+            }
 
     if not quiet_mode:
         if filtered_tools:

--- a/plugins/memory/rasputin/README.md
+++ b/plugins/memory/rasputin/README.md
@@ -1,0 +1,23 @@
+# Rasputin memory provider
+
+Rasputin is a bundled Hermes memory provider that treats Rasputin as a derived retrieval sidecar rather than the canonical memory store.
+
+Behavior in this V1 implementation:
+- best-effort `/health` check during initialize
+- best-effort `/search` recall for prompt injection
+- best-effort background `/commit` mirroring for completed turns
+- mirrored commits for built-in memory writes
+- pre-compaction checkpoint commits before old turns are summarized away
+- fail-open behavior throughout so Hermes continues normally when Rasputin is unavailable
+
+Canonical memory remains Hermes built-ins plus Ryan Book/JSONL. No model-facing Rasputin tools are exposed in V1.
+
+Environment variables:
+- `RASPUTIN_ENABLED` (default: `true`)
+- `RASPUTIN_BASE_URL` (default: `http://127.0.0.1:7777`)
+- `RASPUTIN_TIMEOUT_SECONDS` (default: `8.0`)
+- `RASPUTIN_COMMIT_TIMEOUT_SECONDS` (default: `20.0`)
+- `RASPUTIN_SOURCE_NAMESPACE` (default: `hermes`)
+- `RASPUTIN_PREFETCH_LIMIT` (default: `8`)
+- `RASPUTIN_COMMIT_IMPORTANCE_DEFAULT` (default: `60`)
+- `RASPUTIN_FAIL_OPEN` (default: `true`)

--- a/plugins/memory/rasputin/__init__.py
+++ b/plugins/memory/rasputin/__init__.py
@@ -1,0 +1,310 @@
+"""Rasputin memory provider for Hermes.
+
+V1 scope from the planning docs:
+- Rasputin is a derived retrieval and enrichment sidecar
+- built-in Hermes memory plus Ryan Book/JSONL remain canonical
+- no model-facing Rasputin tools in v1
+- all failures must fail open so turns continue normally
+
+The provider implements Hermes' memory lifecycle with best-effort recall,
+mirrored writes, and pre-compaction checkpoint syncing while keeping the
+canonical memory path authoritative.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+from .client import RasputinClient, RasputinClientConfig
+from .formatter import format_recall_block
+from .mappers import (
+    build_compaction_checkpoint_commit,
+    build_memory_write_commit,
+    build_turn_commit,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class RasputinProviderConfig:
+    """Environment-backed provider config for the Rasputin integration."""
+
+    enabled: bool = True
+    base_url: str = "http://127.0.0.1:7777"
+    timeout_seconds: float = 8.0
+    commit_timeout_seconds: float = 20.0
+    source_namespace: str = "hermes"
+    prefetch_limit: int = 8
+    commit_importance_default: int = 60
+    fail_open: bool = True
+
+    @classmethod
+    def from_env(cls) -> "RasputinProviderConfig":
+        return cls(
+            enabled=_env_bool("RASPUTIN_ENABLED", True),
+            base_url=os.getenv("RASPUTIN_BASE_URL", cls.base_url).strip() or cls.base_url,
+            timeout_seconds=_env_float("RASPUTIN_TIMEOUT_SECONDS", cls.timeout_seconds),
+            commit_timeout_seconds=_env_float(
+                "RASPUTIN_COMMIT_TIMEOUT_SECONDS",
+                cls.commit_timeout_seconds,
+            ),
+            source_namespace=os.getenv("RASPUTIN_SOURCE_NAMESPACE", cls.source_namespace).strip() or cls.source_namespace,
+            prefetch_limit=max(1, _env_int("RASPUTIN_PREFETCH_LIMIT", cls.prefetch_limit)),
+            commit_importance_default=max(
+                1,
+                min(100, _env_int("RASPUTIN_COMMIT_IMPORTANCE_DEFAULT", cls.commit_importance_default)),
+            ),
+            fail_open=_env_bool("RASPUTIN_FAIL_OPEN", True),
+        )
+
+
+class RasputinMemoryProvider(MemoryProvider):
+    """Derived-memory Rasputin provider.
+
+    The implementation stays intentionally conservative: it wires up Hermes'
+    provider lifecycle, performs best-effort search and commit calls, and keeps
+    every path safe when Rasputin is unavailable.
+    """
+
+    def __init__(self) -> None:
+        self._config = RasputinProviderConfig.from_env()
+        self._client: Optional[RasputinClient] = None
+        self._session_id = ""
+        self._platform = "cli"
+        self._agent_context = "primary"
+        self._user_id = ""
+        self._healthy = False
+        self._prefetch_cache: Dict[str, List[Dict[str, Any]]] = {}
+        self._prefetch_lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "rasputin"
+
+    def is_available(self) -> bool:
+        """Return True when the provider is enabled by config.
+
+        Per the MemoryProvider contract, this does not make network calls.
+        Actual server reachability is checked in initialize().
+        """
+        self._config = RasputinProviderConfig.from_env()
+        return self._config.enabled and bool(self._config.base_url)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize the provider for a session and run a best-effort health check."""
+        self._config = RasputinProviderConfig.from_env()
+        self._session_id = session_id
+        self._platform = str(kwargs.get("platform") or "cli")
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        self._user_id = str(kwargs.get("user_id") or "")
+        self._client = RasputinClient(
+            RasputinClientConfig(
+                base_url=self._config.base_url,
+                timeout_seconds=self._config.timeout_seconds,
+                commit_timeout_seconds=self._config.commit_timeout_seconds,
+                fail_open=self._config.fail_open,
+            )
+        )
+
+        # Fail-open by design: provider readiness should never break canonical memory.
+        self._healthy = self._client.healthcheck()
+        if self._healthy:
+            logger.info("Rasputin provider initialized against %s", self._config.base_url)
+        else:
+            logger.warning(
+                "Rasputin health check failed for %s; continuing in fail-open mode",
+                self._config.base_url,
+            )
+
+    def system_prompt_block(self) -> str:
+        if not self._config.enabled:
+            return ""
+        return (
+            "# Rasputin Memory\n"
+            "Derived retrieval sidecar only. Canonical memory remains Hermes built-ins "
+            "plus Ryan Book/JSONL.\n"
+            "V1 exposes no Rasputin tools to the model; recall and mirrored writes are "
+            "best-effort and may be absent when Rasputin is unavailable."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return formatted recall, using cached results when available."""
+        query = (query or "").strip()
+        if not query or not self._client:
+            return ""
+
+        cache_key = session_id or self._session_id
+        with self._prefetch_lock:
+            cached = self._prefetch_cache.pop(cache_key, None)
+        if cached is not None:
+            return format_recall_block(cached, limit=self._config.prefetch_limit)
+
+        results = self._client.search(query, limit=self._config.prefetch_limit)
+        return format_recall_block(results, limit=self._config.prefetch_limit)
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Start a best-effort background search for the next turn."""
+        query = (query or "").strip()
+        if not query or not self._client:
+            return
+
+        cache_key = session_id or self._session_id
+
+        def _run() -> None:
+            try:
+                results = self._client.search(query, limit=self._config.prefetch_limit)
+                with self._prefetch_lock:
+                    self._prefetch_cache[cache_key] = results
+            except Exception:
+                logger.debug("Rasputin queue_prefetch failed", exc_info=True)
+
+        threading.Thread(target=_run, daemon=True, name="rasputin-prefetch").start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Mirror a completed turn into Rasputin without blocking the response path."""
+        if not self._client or self._agent_context != "primary":
+            return
+        if not (user_content or "").strip() and not (assistant_content or "").strip():
+            return
+
+        payload = build_turn_commit(
+            user_content,
+            assistant_content,
+            session_id=session_id or self._session_id,
+            platform=self._platform,
+            agent_context=self._agent_context,
+            user_id=self._user_id,
+            namespace=self._config.source_namespace,
+        )
+        self._commit_best_effort(payload, label="turn")
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in memory writes while preserving canonical ownership."""
+        if not self._client:
+            return
+        if action not in {"add", "replace"}:
+            return
+        if not (content or "").strip():
+            return
+
+        payload = build_memory_write_commit(
+            action,
+            target,
+            content,
+            namespace=self._config.source_namespace,
+            session_id=self._session_id,
+        )
+        self._commit_best_effort(payload, label="memory-write")
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Mirror a structured checkpoint before compaction discards turns."""
+        if not self._client or self._agent_context != "primary" or not messages:
+            return ""
+
+        excerpt_lines: List[str] = []
+        for msg in messages[-8:]:
+            role = str(msg.get("role") or "").strip().lower()
+            if role not in {"user", "assistant", "tool"}:
+                continue
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = " ".join(
+                    str(item.get("text", "")) if isinstance(item, dict) else str(item)
+                    for item in content
+                )
+            text = " ".join(str(content).split()).strip()
+            if not text:
+                continue
+            excerpt_lines.append(f"{role.upper()}: {text[:500]}")
+
+        if not excerpt_lines:
+            return ""
+
+        excerpt = "\n".join(excerpt_lines)
+        notes = (
+            "Preserve the latest unresolved user asks, exact errors, ports, IDs, file paths, and active decisions from this pre-compaction checkpoint.\n"
+            f"Recent excerpt:\n{excerpt}"
+        )
+        payload = build_compaction_checkpoint_commit(
+            notes,
+            session_id=self._session_id,
+            platform=self._platform,
+            agent_context=self._agent_context,
+            user_id=self._user_id,
+            namespace=self._config.source_namespace,
+        )
+        self._commit_best_effort(payload, label="compaction-checkpoint")
+        return notes
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """V1 is context-only; no model-facing Rasputin tools are exposed."""
+        return []
+
+    def _commit_best_effort(self, payload: Dict[str, Any], *, label: str) -> None:
+        """Fire a background commit and swallow failures.
+
+        TODO:
+        - add a bounded queue and flush on shutdown if reliability needs increase
+        - consider retries once real traffic patterns are known
+        """
+        if not self._client:
+            return
+
+        def _run() -> None:
+            try:
+                ok = self._client.commit(payload)
+                if not ok:
+                    logger.debug("Rasputin %s commit skipped/failed (fail-open)", label)
+            except Exception:
+                logger.debug("Rasputin %s commit failed", label, exc_info=True)
+
+        threading.Thread(target=_run, daemon=True, name=f"rasputin-{label}").start()
+
+
+def register(ctx) -> None:
+    """Register Rasputin as a Hermes memory provider plugin."""
+    ctx.register_memory_provider(RasputinMemoryProvider())
+
+
+__all__ = [
+    "RasputinClient",
+    "RasputinClientConfig",
+    "RasputinMemoryProvider",
+    "RasputinProviderConfig",
+    "format_recall_block",
+    "register",
+]

--- a/plugins/memory/rasputin/client.py
+++ b/plugins/memory/rasputin/client.py
@@ -1,0 +1,106 @@
+"""HTTP client for the bundled Rasputin memory provider."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping
+from urllib import request
+
+logger = logging.getLogger(__name__)
+
+_MAX_COMMIT_TEXT_CHARS = 12_000
+
+
+@dataclass(frozen=True)
+class RasputinClientConfig:
+    base_url: str
+    timeout_seconds: float = 8.0
+    commit_timeout_seconds: float = 20.0
+    fail_open: bool = True
+
+
+class RasputinClient:
+    def __init__(self, config: RasputinClientConfig):
+        self.config = config
+        self.base_url = (config.base_url or "").rstrip("/")
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    def _post_json(self, path: str, payload: Mapping[str, Any], *, timeout: float) -> Dict[str, Any] | None:
+        body = json.dumps(dict(payload)).encode("utf-8")
+        req = request.Request(
+            self._url(path),
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with request.urlopen(req, timeout=timeout) as response:
+                raw = response.read().decode("utf-8", errors="replace")
+        except Exception:
+            if self.config.fail_open:
+                logger.debug("Rasputin POST %s failed", path, exc_info=True)
+                return None
+            raise
+
+        if not raw.strip():
+            return {}
+        try:
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {"results": data}
+        except Exception:
+            if self.config.fail_open:
+                logger.debug("Rasputin POST %s returned non-JSON payload", path, exc_info=True)
+                return None
+            raise
+
+    def healthcheck(self) -> bool:
+        req = request.Request(self._url("/health"))
+        try:
+            with request.urlopen(req, timeout=self.config.timeout_seconds) as response:
+                response.read()
+            return True
+        except Exception:
+            if self.config.fail_open:
+                logger.debug("Rasputin healthcheck failed", exc_info=True)
+                return False
+            raise
+
+    def search(self, query: str, *, limit: int = 8) -> List[Dict[str, Any]]:
+        clean_query = (query or "").strip()
+        if not clean_query:
+            return []
+        payload = {
+            "query": clean_query,
+            "limit": max(int(limit or 1), 1),
+        }
+        data = self._post_json("/search", payload, timeout=self.config.timeout_seconds)
+        if not isinstance(data, Mapping):
+            return []
+        results = data.get("results") or data.get("matches") or data.get("items") or []
+        return [dict(item) for item in results if isinstance(item, Mapping)]
+
+    @staticmethod
+    def _prepare_commit_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
+        prepared = dict(payload)
+        metadata = prepared.get("metadata")
+        prepared["metadata"] = dict(metadata) if isinstance(metadata, Mapping) else {}
+
+        text = str(prepared.get("text") or "")
+        if len(text) > _MAX_COMMIT_TEXT_CHARS:
+            prepared["text"] = text[:_MAX_COMMIT_TEXT_CHARS]
+            prepared["metadata"]["rasputin_truncated"] = True
+            prepared["metadata"]["rasputin_original_text_length"] = len(text)
+        else:
+            prepared["text"] = text
+        return prepared
+
+    def commit(self, payload: Mapping[str, Any]) -> bool:
+        prepared = self._prepare_commit_payload(payload)
+        data = self._post_json("/commit", prepared, timeout=self.config.commit_timeout_seconds)
+        if data is None:
+            return False
+        ok = data.get("ok")
+        return True if ok is None else bool(ok)

--- a/plugins/memory/rasputin/formatter.py
+++ b/plugins/memory/rasputin/formatter.py
@@ -1,0 +1,151 @@
+"""Formatting helpers for Rasputin recall blocks.
+
+The provider is context-only in V1, so the formatter's job is simply to turn
+raw search hits into a compact injected block with provenance. Canonical memory
+stays in Hermes built-ins and JSONL; Rasputin output is advisory context.
+
+TODO:
+- tighten formatting against the final Rasputin hit schema
+- add richer grouping for daily-log windows if they become noisy
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+import textwrap
+
+
+def format_recall_block(results: Iterable[Mapping[str, Any]], *, limit: int = 8) -> str:
+    """Render a compact recall block for prompt injection."""
+    hits = [dict(hit) for hit in list(results or [])[: max(int(limit or 1), 1)]]
+    if not hits:
+        return ""
+
+    facts: List[Dict[str, Any]] = []
+    windows: List[Dict[str, Any]] = []
+    other: List[Dict[str, Any]] = []
+
+    for hit in hits:
+        bucket = _bucket_for_hit(hit)
+        if bucket == "facts":
+            facts.append(hit)
+        elif bucket == "windows":
+            windows.append(hit)
+        else:
+            other.append(hit)
+
+    lines = ["# Rasputin Recall"]
+    mixed = sum(bool(group) for group in (facts, windows, other)) > 1
+
+    if facts:
+        if mixed:
+            lines.append("## Facts")
+        lines.extend(_format_group(facts))
+    if windows:
+        if mixed:
+            lines.append("## Windows")
+        lines.extend(_format_group(windows))
+    if other:
+        if mixed:
+            lines.append("## Other")
+        lines.extend(_format_group(other))
+
+    return "\n".join(lines)
+
+
+def _format_group(hits: Iterable[Mapping[str, Any]]) -> List[str]:
+    lines: List[str] = []
+    for hit in hits:
+        metadata = _metadata(hit)
+        identifier = (
+            str(metadata.get("canonical_id") or "").strip()
+            or str(hit.get("id") or "").strip()
+            or str(hit.get("source") or "").strip()
+            or "rasputin-hit"
+        )
+        score = _score_text(hit)
+        provenance = _provenance_text(hit, metadata)
+        text = _truncate(_extract_text(hit), width=220)
+
+        lines.append(f"- [score {score}] {identifier}")
+        if provenance:
+            lines.append(f"  {provenance}")
+        if text:
+            lines.append(f"  text: {text}")
+        lines.append("")
+    if lines:
+        lines.pop()
+    return lines
+
+
+def _bucket_for_hit(hit: Mapping[str, Any]) -> str:
+    metadata = _metadata(hit)
+    kind = str(metadata.get("kind") or "").lower()
+    source = str(hit.get("source") or metadata.get("source") or "").lower()
+    if kind in {"typed_memory", "memory_write"}:
+        return "facts"
+    if kind in {"conversation_window", "session_window", "daily_log_window"}:
+        return "windows"
+    if "window" in kind or "window" in source:
+        return "windows"
+    if metadata.get("canonical_id") or metadata.get("memory_type"):
+        return "facts"
+    return "other"
+
+
+def _metadata(hit: Mapping[str, Any]) -> Dict[str, Any]:
+    metadata = hit.get("metadata")
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _score_text(hit: Mapping[str, Any]) -> str:
+    value = hit.get("score")
+    if value is None:
+        value = hit.get("similarity")
+    if value is None:
+        return "n/a"
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _provenance_text(hit: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    parts: List[str] = []
+
+    source = str(hit.get("source") or metadata.get("source") or "").strip()
+    if source:
+        parts.append(f"source: {source}")
+
+    fleet = str(metadata.get("fleet") or "").strip()
+    if fleet:
+        parts.append(f"fleet: {fleet}")
+
+    memory_type = str(metadata.get("memory_type") or metadata.get("type") or "").strip()
+    if memory_type:
+        parts.append(f"type: {memory_type}")
+
+    session_id = str(metadata.get("session_id") or "").strip()
+    if session_id:
+        parts.append(f"session: {session_id}")
+
+    kind = str(metadata.get("kind") or "").strip()
+    if kind and kind not in {"typed_memory", "conversation_window", "session_window", "daily_log_window", "memory_write"}:
+        parts.append(f"kind: {kind}")
+
+    return " | ".join(parts)
+
+
+def _extract_text(hit: Mapping[str, Any]) -> str:
+    for key in ("text", "content", "snippet", "summary"):
+        value = hit.get(key)
+        if isinstance(value, str) and value.strip():
+            return " ".join(value.split())
+    return ""
+
+
+def _truncate(text: str, *, width: int) -> str:
+    text = " ".join((text or "").split())
+    if not text:
+        return ""
+    return textwrap.shorten(text, width=width, placeholder=" …")

--- a/plugins/memory/rasputin/mappers.py
+++ b/plugins/memory/rasputin/mappers.py
@@ -1,0 +1,198 @@
+"""Payload mappers for Rasputin commit bodies.
+
+These helpers preserve the architectural rule from the planning docs:
+Rasputin is a derived retrieval plane, not the canonical memory store.
+Mappings therefore keep provenance metadata so Rasputin commits remain
+rebuildable from Hermes-native sources.
+
+TODO:
+- wire build_jsonl_fact_commit() into the separate backfill/import scripts
+- refine text rendering once real canonical JSONL samples are exercised
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+
+_TYPE_IMPORTANCE = {
+    "fact": 80,
+    "decision": 90,
+    "pattern": 70,
+    "gotcha": 85,
+    "incident": 90,
+    "preference": 85,
+}
+
+
+def build_turn_commit(
+    user_content: str,
+    assistant_content: str,
+    *,
+    session_id: str = "",
+    platform: str = "cli",
+    agent_context: str = "primary",
+    user_id: str = "",
+    namespace: str = "hermes",
+) -> Dict[str, Any]:
+    """Map one completed Hermes turn into a Rasputin window commit."""
+    return {
+        "text": _strip_join(
+            f"USER: {(user_content or '').strip()}",
+            f"ASSISTANT: {(assistant_content or '').strip()}",
+        ),
+        "source": "hermes-turn",
+        "importance": 55,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "conversation_window",
+            "session_id": session_id,
+            "platform": platform,
+            "agent_context": agent_context,
+            "user_id": user_id or None,
+        },
+    }
+
+
+def build_memory_write_commit(
+    action: str,
+    target: str,
+    content: str,
+    *,
+    namespace: str = "hermes",
+    session_id: str = "",
+) -> Dict[str, Any]:
+    """Map a built-in Hermes memory write into a Rasputin mirror commit."""
+    clean_action = (action or "").strip() or "add"
+    clean_target = (target or "").strip() or "memory"
+    clean_content = (content or "").strip()
+    return {
+        "text": f"MEMORY WRITE [target={clean_target} action={clean_action}]: {clean_content}",
+        "source": "hermes-memory-write",
+        "importance": 75,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "memory_write",
+            "session_id": session_id or None,
+            "target": clean_target,
+            "action": clean_action,
+        },
+    }
+
+
+def build_compaction_checkpoint_commit(
+    checkpoint_text: str,
+    *,
+    session_id: str = "",
+    platform: str = "cli",
+    agent_context: str = "primary",
+    user_id: str = "",
+    namespace: str = "hermes",
+) -> Dict[str, Any]:
+    """Map a pre-compaction checkpoint into a Rasputin mirror commit."""
+    clean_text = (checkpoint_text or "").strip()
+    return {
+        "text": f"COMPACTION CHECKPOINT:\n{clean_text}",
+        "source": "hermes-compaction-checkpoint",
+        "importance": 82,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "compaction_checkpoint",
+            "session_id": session_id or None,
+            "platform": platform,
+            "agent_context": agent_context,
+            "user_id": user_id or None,
+        },
+    }
+
+
+def build_jsonl_fact_commit(
+    record: Mapping[str, Any],
+    *,
+    namespace: str = "ryan-book",
+    source_path: str = "",
+) -> Dict[str, Any]:
+    """Scaffold mapper for canonical JSONL typed memory backfill.
+
+    This is intentionally not wired into the live provider yet. It exists so the
+    backfill/import phase can reuse a single mapping definition later.
+    """
+    memory_type = str(record.get("type") or "fact").strip() or "fact"
+    pinned = bool(record.get("pinned"))
+    trust = _coerce_float(record.get("trust"))
+    importance = _importance_for_record(memory_type, pinned=pinned, trust=trust)
+    metadata = {
+        "namespace": namespace,
+        "kind": "typed_memory",
+        "canonical_id": record.get("id"),
+        "memory_type": memory_type,
+        "fleet": record.get("fleet"),
+        "tags": list(record.get("tags") or []),
+        "trust": trust,
+        "pinned": pinned,
+        "source_path": source_path or None,
+        "source_created_at": record.get("created_at"),
+    }
+    return {
+        "text": _render_typed_memory_text(record, memory_type),
+        "source": f"jsonl-{memory_type}",
+        "importance": importance,
+        "metadata": metadata,
+    }
+
+
+def _render_typed_memory_text(record: Mapping[str, Any], memory_type: str) -> str:
+    content = record.get("content")
+    pieces = [f"[{memory_type}]"]
+    if isinstance(content, Mapping):
+        for key, value in content.items():
+            rendered = _render_value(value)
+            if rendered:
+                pieces.append(f"{key}: {rendered}")
+    else:
+        rendered = _render_value(content)
+        if rendered:
+            pieces.append(rendered)
+    return "\n".join(pieces)
+
+
+def _importance_for_record(memory_type: str, *, pinned: bool, trust: float | None) -> int:
+    importance = _TYPE_IMPORTANCE.get(memory_type, 80)
+    if pinned:
+        importance = min(100, importance + 5)
+    if trust is not None and trust < 0.6:
+        importance = max(40, importance - 10)
+    return importance
+
+
+def _render_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        parts = [part for part in (_render_value(item) for item in value) if part]
+        return ", ".join(parts)
+    if isinstance(value, Mapping):
+        parts = []
+        for key, item in value.items():
+            rendered = _render_value(item)
+            if rendered:
+                parts.append(f"{key}={rendered}")
+        return ", ".join(parts)
+    return str(value).strip()
+
+
+def _strip_join(*parts: str) -> str:
+    return "\n".join(part for part in parts if part and part.strip())
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/plugins/memory/rasputin/plugin.yaml
+++ b/plugins/memory/rasputin/plugin.yaml
@@ -1,0 +1,6 @@
+name: rasputin
+version: 0.1.0
+description: "Rasputin derived-memory sidecar — best-effort recall, mirrored writes, and pre-compaction checkpoint syncing with fail-open behavior."
+hooks:
+  - on_pre_compress
+  - on_memory_write

--- a/run_agent.py
+++ b/run_agent.py
@@ -61,6 +61,7 @@ else:
 
 # Import our tool system
 from model_tools import (
+    filter_tool_definitions_by_name,
     get_tool_definitions,
     get_toolset_for_tool,
     handle_function_call,
@@ -92,10 +93,21 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.context_compressor import ContextCompressor
+from agent.continuation_engine import (
+    DEFAULT_MAX_RUNTIME_RESUMES,
+    build_continuation_snapshot,
+    build_runtime_resume_message,
+    should_use_continuation_engine,
+)
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, build_wave1_overlay_prompt_from_normalized, normalize_wave1_overlay_inputs
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.archetypes import resolve_archetype, resolve_specialist_mapping
+from agent.intent_preclassifier import preclassify_intent
+from agent.route_categories import BUILTIN_ROUTE_CATEGORIES, DEFAULT_ROUTE_CATEGORY, resolve_route_category
+from agent.runtime_modes import get_default_runtime_mode, resolve_runtime_mode
+from agent.task_contracts import build_named_workflow_artifact, validate_named_workflow_artifact, validate_task_contract
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
@@ -251,6 +263,30 @@ _DESTRUCTIVE_PATTERNS = re.compile(
 )
 # Output redirects that overwrite files (> but not >>)
 _REDIRECT_OVERWRITE = re.compile(r'[^>]>[^>]|^>[^>]')
+_REVIEWER_ARCHETYPES = frozenset({"verifier"})
+_REVIEWER_SPECIALISTS = frozenset({"code_reviewer", "qa_guard"})
+_REVIEWER_DELEGATION_PROFILES = frozenset({"verification"})
+_REVIEWER_BLOCKED_TOOLS = frozenset({"write_file", "patch", "memory", "send_message"})
+_REVIEWER_EVIDENCE_TOOLS = frozenset({
+    "browser_console",
+    "browser_get_images",
+    "browser_navigate",
+    "browser_scroll",
+    "browser_snapshot",
+    "browser_vision",
+    "ha_get_state",
+    "ha_list_entities",
+    "ha_list_services",
+    "process",
+    "read_file",
+    "search_files",
+    "session_search",
+    "task",
+    "terminal",
+    "vision_analyze",
+    "web_extract",
+    "web_search",
+})
 
 
 def _is_destructive_command(cmd: str) -> bool:
@@ -808,7 +844,8 @@ class AIAgent:
                 daemon=True,
             ).start()
 
-        self.tool_progress_callback = tool_progress_callback
+        self._external_tool_progress_callback = tool_progress_callback
+        self.tool_progress_callback = self._wrap_tool_progress_callback(tool_progress_callback)
         self.tool_start_callback = tool_start_callback
         self.tool_complete_callback = tool_complete_callback
         self.suppress_status_output = False
@@ -1214,7 +1251,16 @@ class AIAgent:
         
         # Cached system prompt -- built once per session, only rebuilt on compression
         self._cached_system_prompt: Optional[str] = None
-        
+
+        # Wave 2 parent-runtime activation state. This is refreshed at the start
+        # of each top-level turn before any delegation/tool orchestration can run.
+        self._runtime_activation_state: Dict[str, Any] = self._build_default_runtime_activation_state()
+        self.runtime_activation_state: Dict[str, Any] = copy.deepcopy(self._runtime_activation_state)
+        self._runtime_activation_snapshot: Dict[str, Any] = {"current": None, "last": None}
+        self._current_turn_runtime_activation_note: str = ""
+        self._supervisor_task_snapshot: List[Dict[str, Any]] = []
+        self._current_turn_swarm: Dict[str, Dict[str, Any]] = {}
+
         # Filesystem checkpoint manager (transparent — not a tool)
         from tools.checkpoint_manager import CheckpointManager
         self._checkpoint_mgr = CheckpointManager(
@@ -1240,6 +1286,12 @@ class AIAgent:
                     user_id=None,
                     parent_session_id=self._parent_session_id,
                 )
+                session_row = self._session_db.get_session(self.session_id)
+                if session_row:
+                    self._runtime_activation_snapshot = dict(
+                        session_row.get("runtime_activation_snapshot")
+                        or {"current": None, "last": None}
+                    )
             except Exception as e:
                 # Transient SQLite lock contention (e.g. CLI and gateway writing
                 # concurrently) must NOT permanently disable session_search for
@@ -2638,6 +2690,7 @@ class AIAgent:
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    metadata=msg.get("metadata") if role == "assistant" else None,
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
@@ -3328,7 +3381,88 @@ class AIAgent:
             "todoItems": todo_items,
             "activeTodos": active_todos,
             "responsePreview": response_preview,
+            "stopRequested": bool(payload.get("stopRequested") or payload.get("stop_requested")),
+            "retryRequested": bool(payload.get("retryRequested") or payload.get("retry_requested")),
         }
+
+    @staticmethod
+    def _runtime_continuation_message_flag(message: Any, *keys: str) -> Any:
+        if isinstance(message, dict):
+            for key in keys:
+                if key in message:
+                    return message.get(key)
+            return None
+        for key in keys:
+            if hasattr(message, key):
+                return getattr(message, key)
+        return None
+
+    def _build_runtime_continuation_turn_outcome(
+        self,
+        *,
+        assistant_message: Any,
+        final_response: str,
+        interrupted: bool = False,
+    ) -> dict[str, Any]:
+        outcome_status = str(
+            self._runtime_continuation_message_flag(assistant_message, "outcomeStatus", "outcome_status") or ""
+        ).strip().lower()
+        completed = bool(self._runtime_continuation_message_flag(assistant_message, "completed"))
+        failed = bool(self._runtime_continuation_message_flag(assistant_message, "failed"))
+        interrupted_flag = bool(interrupted or self._runtime_continuation_message_flag(assistant_message, "interrupted"))
+        if outcome_status == "completed":
+            completed = True
+        elif outcome_status == "failed":
+            failed = True
+        elif outcome_status == "interrupted":
+            interrupted_flag = True
+        return {
+            "final_response": final_response,
+            "completed": completed,
+            "failed": failed,
+            "interrupted": interrupted_flag,
+            "stopRequested": bool(
+                self._runtime_continuation_message_flag(assistant_message, "stopRequested", "stop_requested")
+            ),
+            "retryRequested": bool(
+                self._runtime_continuation_message_flag(assistant_message, "retryRequested", "retry_requested")
+            ),
+        }
+
+    def _maybe_enqueue_runtime_continuation(
+        self,
+        *,
+        messages: list,
+        assistant_message: Any,
+        finish_reason: str,
+        final_response: str,
+        runtime_resume_count: int,
+        turn_outcome: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        runtime_state = self.get_runtime_activation_state() if hasattr(self, "get_runtime_activation_state") else {}
+        runtime_mode = runtime_state.get("runtime_mode") if isinstance(runtime_state, dict) else None
+        snapshot = build_continuation_snapshot(
+            self,
+            dict(turn_outcome or {"final_response": final_response, "completed": False, "failed": False, "interrupted": False}),
+        )
+        if not should_use_continuation_engine(runtime_mode, snapshot):
+            return False
+        if runtime_resume_count >= DEFAULT_MAX_RUNTIME_RESUMES:
+            return False
+
+        continuation_prompt = build_runtime_resume_message(
+            snapshot,
+            runtime_mode=runtime_mode,
+            attempt=runtime_resume_count + 1,
+            max_attempts=DEFAULT_MAX_RUNTIME_RESUMES,
+        )
+        continuation_msg = self._build_assistant_message(assistant_message, finish_reason or "incomplete")
+        messages.append(continuation_msg)
+        messages.append({"role": "user", "content": continuation_prompt})
+        self._emit_status(
+            f"↻ Runtime continuation queued ({runtime_mode or 'default'} {runtime_resume_count + 1}/{DEFAULT_MAX_RUNTIME_RESUMES})"
+        )
+        return True
 
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider and context engine — call at actual session boundaries.
@@ -3520,6 +3654,416 @@ class AIAgent:
 
 
 
+    @staticmethod
+    def _build_default_runtime_activation_state() -> Dict[str, Any]:
+        default_archetype = resolve_archetype(None)
+        default_runtime_mode = get_default_runtime_mode()
+        default_route_category = resolve_route_category(default_archetype.default_route_category).name
+        default_delegation_profile = default_archetype.default_delegation_profile
+        return {
+            "archetype": default_archetype.name,
+            "specialist": None,
+            "route_category": default_route_category,
+            "runtime_mode": default_runtime_mode.name,
+            "delegation_profile": default_delegation_profile,
+            "activation_reason": "fallback: compatibility-safe default activation",
+            "task_contract": None,
+            "named_workflow": None,
+            "wave1_overlay_prompt": "",
+            "activation_note": "",
+            "activation_applied": False,
+            "inference_source": "wave2_intent_preclassifier",
+        }
+
+    def get_runtime_activation_state(self) -> Dict[str, Any]:
+        return copy.deepcopy(self.runtime_activation_state)
+
+    def get_runtime_activation_snapshot(self) -> Dict[str, Any]:
+        return copy.deepcopy(getattr(self, "_runtime_activation_snapshot", {"current": None, "last": None}))
+
+    @staticmethod
+    def _summarize_task_contract_for_snapshot(task_contract: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(task_contract, dict) or not task_contract:
+            return None
+
+        parts: list[str] = []
+        task = str(task_contract.get("task") or "").strip()
+        if task:
+            parts.append(task)
+
+        required_tools = task_contract.get("required_tools")
+        if isinstance(required_tools, list) and required_tools:
+            tools_preview = ", ".join(str(item) for item in required_tools[:3])
+            if len(required_tools) > 3:
+                tools_preview = f"{tools_preview}, +{len(required_tools) - 3} more"
+            parts.append(f"tools: {tools_preview}")
+
+        expected_outcome = str(task_contract.get("expected_outcome") or "").strip()
+        if expected_outcome:
+            parts.append(f"outcome: {expected_outcome}")
+
+        if not parts:
+            return "structured task contract present"
+        return " | ".join(parts)[:500]
+
+    @staticmethod
+    def _summarize_named_workflow_for_snapshot(named_workflow: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(named_workflow, dict) or not named_workflow:
+            return None
+        workflow_name = str(named_workflow.get("workflow_name") or "").strip()
+        mode = str(named_workflow.get("mode") or "").strip()
+        objective = str(named_workflow.get("objective") or "").strip()
+        parts = [part for part in (workflow_name, mode, objective) if part]
+        return " | ".join(parts)[:500] if parts else "named workflow artifact present"
+
+    def _build_runtime_activation_snapshot_entry(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        task_contract = state.get("task_contract") if isinstance(state, dict) else None
+        named_workflow = state.get("named_workflow") if isinstance(state, dict) else None
+        return {
+            "specialist": state.get("specialist"),
+            "archetype": state.get("archetype"),
+            "route_category": state.get("route_category"),
+            "delegation_profile": state.get("delegation_profile"),
+            "runtime_mode": state.get("runtime_mode"),
+            "task_contract_present": bool(task_contract),
+            "task_contract_summary": self._summarize_task_contract_for_snapshot(task_contract),
+            "named_workflow_present": bool(named_workflow),
+            "named_workflow_summary": self._summarize_named_workflow_for_snapshot(named_workflow),
+            "activation_source": state.get("inference_source") or "wave2_intent_preclassifier",
+            "activation_reason": state.get("activation_reason") or "fallback: compatibility-safe default activation",
+            "activation_applied": bool(state.get("activation_applied")),
+        }
+
+    def _persist_runtime_activation_snapshot(self) -> None:
+        if not self._session_db or not getattr(self, "session_id", None):
+            return
+        try:
+            self._session_db.update_runtime_activation_snapshot(
+                self.session_id,
+                copy.deepcopy(self._runtime_activation_snapshot),
+            )
+        except Exception as exc:
+            logger.debug("Session DB update_runtime_activation_snapshot failed: %s", exc)
+
+    def _update_runtime_activation_snapshot(self, state: Dict[str, Any]) -> None:
+        previous_current = copy.deepcopy(
+            (getattr(self, "_runtime_activation_snapshot", {}) or {}).get("current")
+        )
+        self._runtime_activation_snapshot = {
+            "current": self._build_runtime_activation_snapshot_entry(state),
+            "last": previous_current,
+        }
+        self._persist_runtime_activation_snapshot()
+
+    @staticmethod
+    def _should_apply_runtime_activation_state(state: Dict[str, Any]) -> bool:
+        if state.get("specialist"):
+            return True
+        if state.get("task_contract"):
+            return True
+        if state.get("named_workflow"):
+            return True
+        if state.get("archetype") != "generalist":
+            return True
+        if state.get("route_category") != DEFAULT_ROUTE_CATEGORY:
+            return True
+        if state.get("runtime_mode") != get_default_runtime_mode().name:
+            return True
+        return bool(state.get("delegation_profile") and state.get("delegation_profile") != "general")
+
+    def _get_named_role_policy(self) -> Dict[str, Any]:
+        state = getattr(self, "runtime_activation_state", None)
+        if not isinstance(state, dict):
+            state = getattr(self, "_runtime_activation_state", None)
+        if not isinstance(state, dict):
+            state = {}
+
+        raw_specialist = str(state.get("specialist") or "").strip().lower()
+        specialist_mapping = resolve_specialist_mapping(raw_specialist)
+        specialist = specialist_mapping.name if specialist_mapping is not None else raw_specialist
+        archetype = str(state.get("archetype") or "").strip().lower()
+        delegation_profile = str(state.get("delegation_profile") or "").strip().lower()
+        reviewer_like = bool(specialist in _REVIEWER_SPECIALISTS)
+        allowed_tool_names = set(getattr(self, "valid_tool_names", set()) or [])
+        if reviewer_like:
+            allowed_tool_names.difference_update(_REVIEWER_BLOCKED_TOOLS)
+        return {
+            "reviewer_like": reviewer_like,
+            "specialist": specialist or None,
+            "archetype": archetype or None,
+            "delegation_profile": delegation_profile or None,
+            "allowed_tool_names": allowed_tool_names,
+        }
+
+    def _get_runtime_scoped_tool_names(self) -> set[str]:
+        policy = self._get_named_role_policy()
+        allowed_tool_names = policy.get("allowed_tool_names")
+        if not isinstance(allowed_tool_names, set):
+            return set(getattr(self, "valid_tool_names", set()) or [])
+        return set(allowed_tool_names)
+
+    def _get_runtime_scoped_tools(self) -> List[Dict[str, Any]]:
+        return filter_tool_definitions_by_name(
+            getattr(self, "tools", None),
+            sorted(self._get_runtime_scoped_tool_names()),
+        )
+
+    def _maybe_block_named_role_tool_call(self, function_name: str, function_args: Optional[Dict[str, Any]]) -> Optional[str]:
+        policy = self._get_named_role_policy()
+        if not policy.get("reviewer_like"):
+            return None
+        if function_name in _REVIEWER_BLOCKED_TOOLS:
+            return (
+                "Reviewer/verifier runtime boundary: this role is read-only and cannot call "
+                f"'{function_name}'. Use read-only inspection, testing, or delegation instead."
+            )
+        if function_name == "terminal" and _is_destructive_command(str((function_args or {}).get("command") or "")):
+            return (
+                "Reviewer/verifier runtime boundary: destructive terminal commands are blocked in "
+                "read-only verification sessions."
+            )
+        return None
+
+    def _evaluate_named_role_completion_gate(self, messages: List[Dict[str, Any]]) -> Optional[str]:
+        policy = self._get_named_role_policy()
+        if not policy.get("reviewer_like"):
+            return None
+
+        tool_names: set[str] = set()
+        blocked_violation_seen = False
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    if not isinstance(tc, dict):
+                        continue
+                    tool_name = str(tc.get("function", {}).get("name") or "").strip()
+                    if tool_name:
+                        tool_names.add(tool_name)
+            elif msg.get("role") == "tool":
+                content = str(msg.get("content") or "")
+                if "Reviewer/verifier runtime boundary:" in content:
+                    blocked_violation_seen = True
+
+        if blocked_violation_seen:
+            return "Reviewer/verifier completion gate blocked success after a read-only policy violation."
+        if not tool_names.intersection(_REVIEWER_EVIDENCE_TOOLS):
+            return (
+                "Reviewer/verifier completion gate blocked success: no verification evidence tool "
+                "was used in this run."
+            )
+        return None
+
+    def _build_runtime_activation_note(self, state: Dict[str, Any]) -> str:
+        if not self._should_apply_runtime_activation_state(state):
+            return ""
+
+        lines = [
+            "<wave2-runtime-activation>",
+            "Wave 2 Runtime Activation",
+            f"specialist: {state.get('specialist') or 'none'}",
+            f"activation_reason: {state.get('activation_reason') or 'fallback: compatibility-safe default activation'}",
+            f"inference_source: {state.get('inference_source') or 'wave2_intent_preclassifier'}",
+        ]
+        overlay_prompt = str(state.get("wave1_overlay_prompt") or "").strip()
+        if overlay_prompt:
+            lines.extend(["", overlay_prompt])
+        named_workflow = state.get("named_workflow")
+        if isinstance(named_workflow, dict) and named_workflow:
+            lines.extend(["", "<named-workflow>", json.dumps(named_workflow, indent=2, ensure_ascii=False), "</named-workflow>"])
+        lines.append("</wave2-runtime-activation>")
+        return "\n".join(lines)
+
+    def _reconcile_supervisor_tasks(self) -> list[dict[str, Any]]:
+        if getattr(self, "session_id", None) in (None, ""):
+            return []
+        try:
+            from agent.task_store import TaskStore
+
+            store = TaskStore()
+            records = store.reconcile_tasks(owner_session_id=self.session_id)
+        except Exception as exc:
+            logger.debug("Execution supervisor task reconciliation failed: %s", exc, exc_info=True)
+            return []
+
+        snapshots = [
+            {
+                "task_id": record.id,
+                "status": record.execution.status.value,
+                "archetype": record.archetype,
+                "route_category": record.route_category,
+                "delegation_profile": record.delegation_profile,
+                "runtime_mode": record.runtime_mode,
+                "summary": record.summary,
+            }
+            for record in records
+        ]
+        self._supervisor_task_snapshot = snapshots
+        return snapshots
+
+    def _build_execution_supervisor_note(self) -> str:
+        state = getattr(self, "runtime_activation_state", {}) or {}
+        if state.get("runtime_mode") != "execution_supervisor":
+            self._supervisor_task_snapshot = []
+            return ""
+
+        snapshots = self._reconcile_supervisor_tasks()
+        if not snapshots:
+            return ""
+
+        lines = [
+            "<execution-supervisor-state>",
+            "Persistent task state snapshot",
+        ]
+        for item in snapshots:
+            lines.append(
+                "- task_id={task_id} status={status} archetype={archetype} route_category={route_category} delegation_profile={delegation_profile} runtime_mode={runtime_mode}".format(
+                    task_id=item.get("task_id"),
+                    status=item.get("status"),
+                    archetype=item.get("archetype") or "none",
+                    route_category=item.get("route_category") or "none",
+                    delegation_profile=item.get("delegation_profile") or "none",
+                    runtime_mode=item.get("runtime_mode") or "none",
+                )
+            )
+            if item.get("summary"):
+                lines.append(f"  summary: {item['summary']}")
+        lines.append("</execution-supervisor-state>")
+        return "\n".join(lines)
+
+    def _resolve_runtime_activation_state(self, user_message: str) -> Dict[str, Any]:
+        if getattr(self, "_delegate_depth", 0) != 0:
+            state = self._build_default_runtime_activation_state()
+            delegate_resolution = dict(getattr(self, "_delegate_resolution", {}) or {})
+            specialist_mapping = resolve_specialist_mapping(delegate_resolution.get("specialist"))
+            resolved_specialist = specialist_mapping.name if specialist_mapping is not None else None
+            delegate_archetype = delegate_resolution.get("archetype") or state["archetype"]
+            if specialist_mapping is not None:
+                delegate_archetype = specialist_mapping.archetype_name
+            delegate_route_category = (
+                delegate_resolution.get("route_category_definition")
+                or delegate_resolution.get("route_category")
+                or (specialist_mapping.default_route_category if specialist_mapping is not None else None)
+                or state["route_category"]
+            )
+            delegate_delegation_profile = (
+                delegate_resolution.get("delegation_profile")
+                or (specialist_mapping.default_delegation_profile if specialist_mapping is not None else None)
+                or state["delegation_profile"]
+            )
+            normalized_inputs = normalize_wave1_overlay_inputs(
+                archetype_name=delegate_archetype,
+                route_category=delegate_route_category,
+                delegation_profile=delegate_delegation_profile,
+                runtime_mode=delegate_resolution.get("runtime_mode_definition") or delegate_resolution.get("runtime_mode") or state["runtime_mode"],
+                skills=delegate_resolution.get("skills"),
+                task_contract=delegate_resolution.get("task_contract"),
+                orchestration_hints=delegate_resolution.get("orchestration_hints"),
+            )
+            resolved_named_workflow = None
+            raw_named_workflow = delegate_resolution.get("named_workflow")
+            if isinstance(raw_named_workflow, dict) and raw_named_workflow:
+                try:
+                    resolved_named_workflow = validate_named_workflow_artifact(raw_named_workflow).model_dump(by_alias=True)
+                except Exception as exc:
+                    logger.debug("Ignoring invalid delegate named_workflow during runtime activation passthrough: %s", exc)
+            state.update({
+                "specialist": resolved_specialist,
+                "archetype": normalized_inputs["archetype"],
+                "route_category": normalized_inputs["route_category"],
+                "runtime_mode": normalized_inputs["runtime_mode"],
+                "delegation_profile": normalized_inputs["delegation_profile"],
+                "task_contract": normalized_inputs["task_contract"],
+                "named_workflow": resolved_named_workflow,
+                "wave1_overlay_prompt": build_wave1_overlay_prompt_from_normalized(normalized_inputs),
+            })
+            state["inference_source"] = "delegate_passthrough"
+            state["activation_note"] = self._build_runtime_activation_note(state)
+            state["activation_applied"] = bool(state["activation_note"])
+            return state
+
+        try:
+            preclassification = preclassify_intent(user_message)
+        except Exception as exc:
+            logger.debug("Wave 2 runtime activation preclassification failed: %s", exc, exc_info=True)
+            preclassification = preclassify_intent(None)
+
+        default_state = self._build_default_runtime_activation_state()
+        raw_specialist = getattr(preclassification, "inferred_specialist", None)
+        specialist_mapping = resolve_specialist_mapping(raw_specialist)
+        resolved_specialist = specialist_mapping.name if specialist_mapping is not None else None
+
+        inferred_archetype = specialist_mapping.archetype_name if specialist_mapping is not None else getattr(preclassification, "inferred_archetype", None)
+        resolved_archetype = resolve_archetype(inferred_archetype)
+        raw_route_category = str(getattr(preclassification, "inferred_route_category", "") or "").strip()
+        if raw_route_category and raw_route_category in BUILTIN_ROUTE_CATEGORIES:
+            route_category = resolve_route_category(raw_route_category).name
+        elif specialist_mapping is not None and specialist_mapping.default_route_category:
+            route_category = resolve_route_category(specialist_mapping.default_route_category).name
+        else:
+            route_category = resolve_route_category(resolved_archetype.default_route_category).name
+        runtime_mode = resolve_runtime_mode(getattr(preclassification, "inferred_runtime_mode", None)).name
+        delegation_profile = str(getattr(preclassification, "inferred_delegation_profile", "") or "").strip()
+        if not delegation_profile and specialist_mapping is not None and specialist_mapping.default_delegation_profile:
+            delegation_profile = specialist_mapping.default_delegation_profile
+        if not delegation_profile:
+            delegation_profile = resolved_archetype.default_delegation_profile or default_state["delegation_profile"]
+
+        task_contract_payload = None
+        raw_task_contract = getattr(preclassification, "task_contract", None)
+        if raw_task_contract not in (None, "", {}):
+            try:
+                task_contract_payload = validate_task_contract(raw_task_contract).model_dump()
+            except Exception as exc:
+                logger.debug("Ignoring invalid task_contract from runtime activation preclassifier: %s", exc)
+
+        normalized_inputs = normalize_wave1_overlay_inputs(
+            archetype_name=resolved_archetype.name,
+            route_category=route_category,
+            delegation_profile=delegation_profile,
+            runtime_mode=runtime_mode,
+            task_contract=task_contract_payload,
+        )
+
+        state = {
+            "archetype": normalized_inputs["archetype"],
+            "specialist": resolved_specialist,
+            "route_category": normalized_inputs["route_category"],
+            "runtime_mode": normalized_inputs["runtime_mode"],
+            "delegation_profile": normalized_inputs["delegation_profile"],
+            "activation_reason": str(
+                getattr(preclassification, "activation_reason", "")
+                or default_state["activation_reason"]
+            ).strip(),
+            "task_contract": normalized_inputs["task_contract"],
+            "inference_source": str(
+                getattr(preclassification, "inference_source", "")
+                or default_state["inference_source"]
+            ).strip(),
+        }
+        state["named_workflow"] = build_named_workflow_artifact(
+            objective=user_message,
+            specialist=resolved_specialist,
+            archetype=state["archetype"],
+            route_category=state["route_category"],
+            runtime_mode=state["runtime_mode"],
+            delegation_profile=state["delegation_profile"],
+            task_contract=state["task_contract"],
+        )
+        state["wave1_overlay_prompt"] = build_wave1_overlay_prompt_from_normalized(normalized_inputs)
+        state["activation_note"] = self._build_runtime_activation_note(state)
+        state["activation_applied"] = bool(state["activation_note"])
+        return state
+
+    def _activate_runtime_for_turn(self, user_message: str) -> Dict[str, Any]:
+        state = self._resolve_runtime_activation_state(user_message)
+        self._runtime_activation_state = copy.deepcopy(state)
+        self.runtime_activation_state = copy.deepcopy(state)
+        self._update_runtime_activation_snapshot(state)
+        self._current_turn_runtime_activation_note = state.get("activation_note") or ""
+        return self.runtime_activation_state
+
     def _build_system_prompt(self, system_message: str = None) -> str:
         """
         Assemble the full system prompt from all layers.
@@ -3648,7 +4192,10 @@ class AIAgent:
             # other dev files — inflating token usage by ~10k for no benefit.
             _context_cwd = os.getenv("TERMINAL_CWD") or None
             context_files_prompt = build_context_files_prompt(
-                cwd=_context_cwd, skip_soul=_soul_loaded)
+                cwd=_context_cwd,
+                skip_soul=_soul_loaded,
+                task_contract=(self.get_runtime_activation_state() or {}).get("task_contract"),
+            )
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
@@ -4027,7 +4574,7 @@ class AIAgent:
 
     def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
-        source_tools = tools if tools is not None else self.tools
+        source_tools = tools if tools is not None else self._get_runtime_scoped_tools()
         if not source_tools:
             return None
 
@@ -6855,7 +7402,7 @@ class AIAgent:
             return build_anthropic_kwargs(
                 model=self.model,
                 messages=anthropic_messages,
-                tools=self.tools,
+                tools=self._get_runtime_scoped_tools(),
                 max_tokens=ephemeral_out if ephemeral_out is not None else self.max_tokens,
                 reasoning_config=self.reasoning_config,
                 is_oauth=self._is_anthropic_oauth,
@@ -6877,7 +7424,7 @@ class AIAgent:
                 **build_converse_kwargs(
                     model=self.model,
                     messages=api_messages,
-                    tools=self.tools,
+                    tools=self._get_runtime_scoped_tools(),
                     max_tokens=self.max_tokens or 4096,
                     temperature=None,  # Let the model use its default
                     guardrail_config=guardrail,
@@ -7052,8 +7599,9 @@ class AIAgent:
                 "sessionId": self.session_id or "hermes",
                 "promptId": str(uuid.uuid4()),
             }
-        if self.tools:
-            api_kwargs["tools"] = self.tools
+        active_tools = self._get_runtime_scoped_tools()
+        if active_tools:
+            api_kwargs["tools"] = active_tools
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
@@ -7221,6 +7769,155 @@ class AIAgent:
 
         return {"effort": requested_effort}
 
+    def _subagent_swarm_id(self, goal: str, task_index: Any) -> str:
+        return f"sa:{int(task_index or 0)}:{goal or 'subagent'}"
+
+    def _record_subagent_swarm_event(self, event_type: str, tool_name: str = None, preview: str = None, **kwargs) -> None:
+        if not isinstance(event_type, str) or not event_type.startswith("subagent."):
+            return
+        goal = str(kwargs.get("goal") or "")
+        task_index = int(kwargs.get("task_index") or 0)
+        task_count = int(kwargs.get("task_count") or 1)
+        item_id = self._subagent_swarm_id(goal, task_index)
+        entry = self._current_turn_swarm.get(item_id) or {
+            "durationSeconds": None,
+            "goal": goal,
+            "id": item_id,
+            "index": task_index,
+            "notes": [],
+            "status": "running",
+            "summary": None,
+            "taskCount": task_count,
+            "thinking": [],
+            "tools": [],
+        }
+        entry["goal"] = goal or entry.get("goal") or "subagent"
+        entry["taskCount"] = task_count or entry.get("taskCount") or 1
+        text = str(preview or "").strip()
+        if event_type == "subagent.start":
+            entry["status"] = "running"
+        elif event_type == "subagent.thinking":
+            if text and text not in entry["thinking"]:
+                entry["thinking"] = [*entry["thinking"], text][-6:]
+            if entry.get("status") != "completed":
+                entry["status"] = "running"
+        elif event_type == "subagent.tool":
+            tool_line = f"{tool_name}: {text}".strip(": ") if tool_name else text
+            if tool_line and tool_line not in entry["tools"]:
+                entry["tools"] = [*entry["tools"], tool_line][-8:]
+            if entry.get("status") != "completed":
+                entry["status"] = "running"
+        elif event_type == "subagent.progress":
+            if text and text not in entry["notes"]:
+                entry["notes"] = [*entry["notes"], text][-8:]
+            if entry.get("status") != "completed":
+                entry["status"] = "running"
+        elif event_type == "subagent.complete":
+            entry["status"] = str(kwargs.get("status") or "completed")
+            if kwargs.get("duration_seconds") is not None:
+                try:
+                    entry["durationSeconds"] = float(kwargs.get("duration_seconds"))
+                except (TypeError, ValueError):
+                    pass
+            summary = str(kwargs.get("summary") or text or "").strip()
+            if summary:
+                entry["summary"] = summary
+        self._current_turn_swarm[item_id] = entry
+
+    def _build_current_turn_swarm_snapshot(self) -> Optional[Dict[str, Any]]:
+        if not self._current_turn_swarm:
+            return None
+        subagents = sorted(
+            ({
+                "durationSeconds": item.get("durationSeconds"),
+                "goal": item.get("goal") or "subagent",
+                "id": item.get("id"),
+                "index": int(item.get("index") or 0),
+                "notes": list(item.get("notes") or []),
+                "status": str(item.get("status") or "running"),
+                "summary": item.get("summary"),
+                "taskCount": int(item.get("taskCount") or 1),
+                "thinking": list(item.get("thinking") or []),
+                "tools": list(item.get("tools") or []),
+            } for item in self._current_turn_swarm.values()),
+            key=lambda item: (item["index"], item["goal"]),
+        )
+        if not subagents:
+            return None
+        return {"swarm": {"subagents": subagents, "turnStatus": "persisted"}}
+
+    def _wrap_tool_progress_callback(self, callback):
+        if callback is None:
+            return None
+
+        def _wrapped(event_type, tool_name=None, preview=None, args=None, **kwargs):
+            try:
+                self._record_subagent_swarm_event(event_type, tool_name=tool_name, preview=preview, **kwargs)
+            except Exception:
+                pass
+            return callback(event_type, tool_name, preview, args, **kwargs)
+
+        return _wrapped
+
+    def _subagent_swarm_key(self, payload: Dict[str, Any]) -> Optional[str]:
+        goal = str(payload.get("goal") or "").strip()
+        index = payload.get("task_index", 0)
+        if not goal and index is None:
+            return None
+        return f"sa:{index}:{goal}"
+
+    def _record_subagent_swarm_event(self, event_type: str, tool_name=None, preview=None, **payload) -> None:
+        if not isinstance(event_type, str) or not event_type.startswith("subagent."):
+            return
+        key = self._subagent_swarm_key(payload)
+        if not key:
+            return
+        current = self._current_turn_swarm.get(key) or {
+            "goal": str(payload.get("goal") or "").strip(),
+            "id": key,
+            "index": int(payload.get("task_index", 0) or 0),
+            "notes": [],
+            "status": "running",
+            "summary": "",
+            "taskCount": payload.get("task_count"),
+            "thinking": [],
+            "tools": [],
+        }
+        current["goal"] = str(payload.get("goal") or current.get("goal") or "").strip()
+        current["index"] = int(payload.get("task_index", current.get("index", 0)) or 0)
+        if payload.get("task_count") is not None:
+            current["taskCount"] = payload.get("task_count")
+        if event_type == "subagent.thinking" and payload.get("text"):
+            current.setdefault("thinking", []).append(str(payload.get("text")))
+        elif event_type == "subagent.progress" and payload.get("text"):
+            current.setdefault("notes", []).append(str(payload.get("text")))
+        elif event_type == "subagent.tool":
+            label = preview or tool_name or payload.get("tool_name")
+            if label:
+                current.setdefault("tools", []).append(str(label))
+        elif event_type in {"subagent.complete", "subagent.error"}:
+            status = payload.get("status")
+            if isinstance(status, str) and status.strip():
+                current["status"] = status.strip()
+            elif event_type == "subagent.error":
+                current["status"] = "failed"
+            else:
+                current["status"] = "completed"
+            if payload.get("summary"):
+                current["summary"] = str(payload.get("summary"))
+            if payload.get("duration_seconds") is not None:
+                current["durationSeconds"] = payload.get("duration_seconds")
+        self._current_turn_swarm[key] = current
+
+    def _build_current_turn_swarm_snapshot(self) -> Optional[Dict[str, Any]]:
+        if not self._current_turn_swarm:
+            return None
+        subagents = sorted(
+            (copy.deepcopy(item) for item in self._current_turn_swarm.values()),
+            key=lambda item: (int(item.get("index", 0)), str(item.get("goal", ""))),
+        )
+        return {"swarm": {"subagents": subagents, "turnStatus": "persisted"}}
+
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
         """Build a normalized assistant message dict from an API response message.
 
@@ -7271,6 +7968,11 @@ class AIAgent:
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }
+
+        if finish_reason != "tool_calls":
+            swarm_snapshot = self._build_current_turn_swarm_snapshot()
+            if swarm_snapshot:
+                msg["metadata"] = swarm_snapshot
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
@@ -7610,6 +8312,12 @@ class AIAgent:
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
+                    runtime_activation_snapshot=copy.deepcopy(self._runtime_activation_snapshot),
+                )
+                self._emit_status(
+                    "🧵 Context compacted — continuing the same conversation under a new "
+                    f"session id ({self.session_id}, was {old_session_id}). "
+                    "Work/state are preserved; this is not a reset."
                 )
                 # Auto-number the title for the continuation session
                 if old_title:
@@ -7701,6 +8409,10 @@ class AIAgent:
         if block_message is not None:
             return json.dumps({"error": block_message}, ensure_ascii=False)
 
+        named_role_block = self._maybe_block_named_role_tool_call(function_name, function_args)
+        if named_role_block is not None:
+            return json.dumps({"error": named_role_block}, ensure_ascii=False)
+
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             return _todo_tool(
@@ -7757,7 +8469,15 @@ class AIAgent:
                 toolsets=function_args.get("toolsets"),
                 tasks=function_args.get("tasks"),
                 category=function_args.get("category"),
+                archetype=function_args.get("archetype"),
+                route_category=function_args.get("route_category"),
+                delegation_profile=function_args.get("delegation_profile"),
+                runtime_mode=function_args.get("runtime_mode"),
+                skills=function_args.get("skills"),
+                task_contract=function_args.get("task_contract"),
                 max_iterations=function_args.get("max_iterations"),
+                persistent=bool(function_args.get("persistent", False)),
+                background=bool(function_args.get("background", False)),
                 acp_command=function_args.get("acp_command"),
                 acp_args=function_args.get("acp_args"),
                 parent_agent=self,
@@ -7767,7 +8487,7 @@ class AIAgent:
                 function_name, function_args, effective_task_id,
                 tool_call_id=tool_call_id,
                 session_id=self.session_id or "",
-                enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                enabled_tools=sorted(self._get_runtime_scoped_tool_names()),
                 skip_pre_tool_call_hook=True,
             )
 
@@ -8259,7 +8979,18 @@ class AIAgent:
                         context=function_args.get("context"),
                         toolsets=function_args.get("toolsets"),
                         tasks=tasks_arg,
+                        category=function_args.get("category"),
+                        archetype=function_args.get("archetype"),
+                        route_category=function_args.get("route_category"),
+                        delegation_profile=function_args.get("delegation_profile"),
+                        runtime_mode=function_args.get("runtime_mode"),
+                        skills=function_args.get("skills"),
+                        task_contract=function_args.get("task_contract"),
                         max_iterations=function_args.get("max_iterations"),
+                        persistent=bool(function_args.get("persistent", False)),
+                        background=bool(function_args.get("background", False)),
+                        acp_command=function_args.get("acp_command"),
+                        acp_args=function_args.get("acp_args"),
                         parent_agent=self,
                     )
                     _delegate_result = function_result
@@ -8332,7 +9063,7 @@ class AIAgent:
                         function_name, function_args, effective_task_id,
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        enabled_tools=sorted(self._get_runtime_scoped_tool_names()),
                         skip_pre_tool_call_hook=True,
                     )
                     _spinner_result = function_result
@@ -8352,7 +9083,7 @@ class AIAgent:
                         function_name, function_args, effective_task_id,
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        enabled_tools=sorted(self._get_runtime_scoped_tool_names()),
                         skip_pre_tool_call_hook=True,
                     )
                 except Exception as tool_error:
@@ -8672,6 +9403,7 @@ class AIAgent:
         self._stream_callback = stream_callback
         self._persist_user_message_idx = None
         self._persist_user_message_override = persist_user_message
+        self._current_turn_swarm = {}
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
         
@@ -8742,6 +9474,7 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+        self._activate_runtime_for_turn(original_user_message)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -8833,7 +9566,7 @@ class AIAgent:
             _preflight_tokens = estimate_request_tokens_rough(
                 messages,
                 system_prompt=active_system_prompt or "",
-                tools=self.tools or None,
+                tools=self._get_runtime_scoped_tools() or None,
             )
 
             if _preflight_tokens >= self.context_compressor.threshold_tokens:
@@ -8879,7 +9612,7 @@ class AIAgent:
                     _preflight_tokens = estimate_request_tokens_rough(
                         messages,
                         system_prompt=active_system_prompt or "",
-                        tools=self.tools or None,
+                        tools=self._get_runtime_scoped_tools() or None,
                     )
                     if _preflight_tokens < self.context_compressor.threshold_tokens:
                         break  # Under threshold
@@ -8925,6 +9658,7 @@ class AIAgent:
         final_response = None
         interrupted = False
         codex_ack_continuations = 0
+        runtime_resume_count = 0
         length_continue_retries = 0
         truncated_tool_call_retries = 0
         truncated_response_prefix = ""
@@ -9047,6 +9781,11 @@ class AIAgent:
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
                     _injections = []
+                    if self._current_turn_runtime_activation_note:
+                        _injections.append(self._current_turn_runtime_activation_note)
+                    _execution_supervisor_note = self._build_execution_supervisor_note()
+                    if _execution_supervisor_note:
+                        _injections.append(_execution_supervisor_note)
                     if self._should_inject_orchestration_note(original_user_message, api_call_count):
                         _injections.append(self._build_orchestration_user_note())
                     if _ext_prefetch_cache:
@@ -11543,6 +12282,23 @@ class AIAgent:
                     ):
                         messages.pop()
 
+                    if self._maybe_enqueue_runtime_continuation(
+                        messages=messages,
+                        assistant_message=assistant_message,
+                        finish_reason=finish_reason,
+                        final_response=final_response,
+                        runtime_resume_count=runtime_resume_count,
+                        turn_outcome=self._build_runtime_continuation_turn_outcome(
+                            assistant_message=assistant_message,
+                            final_response=final_response,
+                            interrupted=interrupted,
+                        ),
+                    ):
+                        runtime_resume_count += 1
+                        self._session_messages = messages
+                        self._save_session_log(messages)
+                        continue
+
                     messages.append(final_msg)
                     
                     _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
@@ -11675,6 +12431,12 @@ class AIAgent:
         else:
             logger.info(_diag_msg, *_diag_args)
 
+        if final_response and not interrupted:
+            named_role_completion_error = self._evaluate_named_role_completion_gate(messages)
+            if named_role_completion_error:
+                final_response = named_role_completion_error
+                completed = False
+
         # Plugin hook: post_llm_call
         # Fired once per turn after the tool-calling loop completes.
         # Plugins can use this to persist conversation data (e.g. sync
@@ -11714,6 +12476,7 @@ class AIAgent:
             "model": self.model,
             "provider": self.provider,
             "base_url": self.base_url,
+            "runtime_activation": self.get_runtime_activation_state(),
             "input_tokens": self.session_input_tokens,
             "output_tokens": self.session_output_tokens,
             "cache_read_tokens": self.session_cache_read_tokens,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1035,46 +1035,51 @@ class AIAgent:
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
             else:
-                # No explicit creds — use the centralized provider router
-                from agent.auxiliary_client import resolve_provider_client
-                _routed_client, _ = resolve_provider_client(
-                    self.provider or "auto", model=self.model, raw_codex=True)
-                if _routed_client is not None:
-                    client_kwargs = {
-                        "api_key": _routed_client.api_key,
-                        "base_url": str(_routed_client.base_url),
-                    }
-                    # Preserve any default_headers the router set
-                    if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-                        client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                if api_key:
+                    client_kwargs = {"api_key": api_key}
+                    if base_url:
+                        client_kwargs["base_url"] = base_url
                 else:
-                    # When the user explicitly chose a non-OpenRouter provider
-                    # but no credentials were found, fail fast with a clear
-                    # message instead of silently routing through OpenRouter.
-                    _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
-                        # Look up the actual env var name from the provider
-                        # config — some providers use non-standard names
-                        # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
-                        _env_hint = f"{_explicit.upper()}_API_KEY"
-                        try:
-                            from hermes_cli.auth import PROVIDER_REGISTRY
-                            _pcfg = PROVIDER_REGISTRY.get(_explicit)
-                            if _pcfg and _pcfg.api_key_env_vars:
-                                _env_hint = _pcfg.api_key_env_vars[0]
-                        except Exception:
-                            pass
+                    # No explicit creds — use the centralized provider router
+                    from agent.auxiliary_client import resolve_provider_client
+                    _routed_client, _ = resolve_provider_client(
+                        self.provider or "auto", model=self.model, raw_codex=True)
+                    if _routed_client is not None:
+                        client_kwargs = {
+                            "api_key": _routed_client.api_key,
+                            "base_url": str(_routed_client.base_url),
+                        }
+                        # Preserve any default_headers the router set
+                        if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
+                            client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    else:
+                        # When the user explicitly chose a non-OpenRouter provider
+                        # but no credentials were found, fail fast with a clear
+                        # message instead of silently routing through OpenRouter.
+                        _explicit = (self.provider or "").strip().lower()
+                        if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                            # Look up the actual env var name from the provider
+                            # config — some providers use non-standard names
+                            # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
+                            _env_hint = f"{_explicit.upper()}_API_KEY"
+                            try:
+                                from hermes_cli.auth import PROVIDER_REGISTRY
+                                _pcfg = PROVIDER_REGISTRY.get(_explicit)
+                                if _pcfg and _pcfg.api_key_env_vars:
+                                    _env_hint = _pcfg.api_key_env_vars[0]
+                            except Exception:
+                                pass
+                            raise RuntimeError(
+                                f"Provider '{_explicit}' is set in config.yaml but no API key "
+                                f"was found. Set the {_env_hint} environment "
+                                f"variable, or switch to a different provider with `hermes model`."
+                            )
+                        # No provider configured — reject with a clear message.
                         raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_env_hint} environment "
-                            f"variable, or switch to a different provider with `hermes model`."
+                            "No LLM provider configured. Run `hermes model` to "
+                            "select a provider, or run `hermes setup` for first-time "
+                            "configuration."
                         )
-                    # No provider configured — reject with a clear message.
-                    raise RuntimeError(
-                        "No LLM provider configured. Run `hermes model` to "
-                        "select a provider, or run `hermes setup` for first-time "
-                        "configuration."
-                    )
             
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
@@ -1141,6 +1146,7 @@ class AIAgent:
         # Get available tools with filtering
         self.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
+            enabled_tools=self.enabled_tools,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
@@ -1156,6 +1162,8 @@ class AIAgent:
                 # Show filtering info if applied
                 if enabled_toolsets:
                     print(f"   ✅ Enabled toolsets: {', '.join(enabled_toolsets)}")
+                if self.enabled_tools:
+                    print(f"   🎯 Enabled tools: {', '.join(self.enabled_tools)}")
                 if disabled_toolsets:
                     print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
         elif not self.quiet_mode:
@@ -1251,6 +1259,7 @@ class AIAgent:
             _agent_cfg = _load_agent_config()
         except Exception:
             _agent_cfg = {}
+        self._delegation_cfg = _agent_cfg.get("delegation", {}) if isinstance(_agent_cfg.get("delegation", {}), dict) else {}
 
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -1414,6 +1414,19 @@ class AIAgent:
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        compression_threshold_tokens = _compression_cfg.get("threshold_tokens")
+        if compression_threshold_tokens is not None:
+            try:
+                compression_threshold_tokens = int(compression_threshold_tokens)
+                if compression_threshold_tokens <= 0:
+                    raise ValueError("threshold_tokens must be positive")
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid compression.threshold_tokens in config.yaml: %r — must be a positive integer. "
+                    "Falling back to percentage threshold.",
+                    compression_threshold_tokens,
+                )
+                compression_threshold_tokens = None
 
         # Read explicit context_length override from model config
         _model_cfg = _agent_cfg.get("model", {})
@@ -1554,6 +1567,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                explicit_threshold_tokens=compression_threshold_tokens,
             )
         self.compression_enabled = compression_enabled
 
@@ -1642,7 +1656,20 @@ class AIAgent:
 
         if not self.quiet_mode:
             if compression_enabled:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                _threshold_pct = int(
+                    (self.context_compressor.threshold_tokens / max(self.context_compressor.context_length, 1)) * 100
+                )
+                _explicit_threshold = getattr(self.context_compressor, "explicit_threshold_tokens", None)
+                if _explicit_threshold is not None and self.context_compressor.threshold_tokens == _explicit_threshold:
+                    print(
+                        f"📊 Context limit: {self.context_compressor.context_length:,} tokens "
+                        f"(compress at explicit threshold_tokens = {self.context_compressor.threshold_tokens:,} ≈ {_threshold_pct}%)"
+                    )
+                else:
+                    print(
+                        f"📊 Context limit: {self.context_compressor.context_length:,} tokens "
+                        f"(compress at {_threshold_pct}% = {self.context_compressor.threshold_tokens:,})"
+                    )
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -37,7 +37,7 @@ import time
 import threading
 from types import SimpleNamespace
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Mapping
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -103,9 +103,16 @@ from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, build_wave1_overlay_prompt_from_normalized, normalize_wave1_overlay_inputs
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
-from agent.archetypes import resolve_archetype, resolve_specialist_mapping
+from agent.archetypes import get_tool_restrictions, resolve_archetype, resolve_specialist_mapping
 from agent.intent_preclassifier import preclassify_intent
-from agent.route_categories import BUILTIN_ROUTE_CATEGORIES, DEFAULT_ROUTE_CATEGORY, resolve_route_category
+from agent.route_categories import (
+    BUILTIN_ROUTE_CATEGORIES,
+    DEFAULT_ROUTE_CATEGORY,
+    resolve_literal_category,
+    resolve_literal_category_from_route_category,
+    resolve_literal_category_to_route_category,
+    resolve_route_category,
+)
 from agent.runtime_modes import get_default_runtime_mode, resolve_runtime_mode
 from agent.task_contracts import build_named_workflow_artifact, validate_named_workflow_artifact, validate_task_contract
 from agent.display import (
@@ -267,6 +274,11 @@ _REVIEWER_ARCHETYPES = frozenset({"verifier"})
 _REVIEWER_SPECIALISTS = frozenset({"code_reviewer", "qa_guard"})
 _REVIEWER_DELEGATION_PROFILES = frozenset({"verification"})
 _REVIEWER_BLOCKED_TOOLS = frozenset({"write_file", "patch", "memory", "send_message"})
+_MULTIMODAL_SPECIALIST = "multimodal_specialist"
+_MULTIMODAL_CAPABILITY_TOOLS = frozenset({
+    "vision_analyze",
+    "browser_vision",
+})
 _REVIEWER_EVIDENCE_TOOLS = frozenset({
     "browser_console",
     "browser_get_images",
@@ -287,6 +299,7 @@ _REVIEWER_EVIDENCE_TOOLS = frozenset({
     "web_extract",
     "web_search",
 })
+_LEADING_NAMED_AGENT_INVOKE_RE = re.compile(r"^\s*@(?P<agent>[^\s:]+)\s+(?P<message>.+?)\s*$", re.DOTALL)
 
 
 def _is_destructive_command(cmd: str) -> bool:
@@ -298,6 +311,59 @@ def _is_destructive_command(cmd: str) -> bool:
     if _REDIRECT_OVERWRITE.search(cmd):
         return True
     return False
+
+
+def _extract_leading_named_agent_invocation_payload(user_message: Any) -> Optional[Dict[str, Any]]:
+    """Resolve a leading ``@agent`` invocation into runtime-activation inputs.
+
+    Bound intentionally to the smallest honest DG1 surface:
+    only a leading mention followed by a non-empty prompt is recognized.
+    Inline mentions and bare ``@agent`` prompts are left untouched.
+    """
+    if not isinstance(user_message, str):
+        return None
+    match = _LEADING_NAMED_AGENT_INVOKE_RE.match(user_message)
+    if not match:
+        return None
+
+    requested_name = str(match.group("agent") or "").strip()
+    stripped_message = str(match.group("message") or "").strip()
+    if not requested_name or not stripped_message:
+        return None
+
+    try:
+        from hermes_cli.config import describe_named_agent
+
+        desc = describe_named_agent(requested_name)
+    except Exception:
+        return None
+
+    specialist_hint = str(desc.get("resolved_specialist") or desc.get("name") or "").strip() or None
+    specialist_mapping = resolve_specialist_mapping(specialist_hint)
+    resolved_archetype = (
+        specialist_mapping.archetype_name
+        if specialist_mapping is not None
+        else str(desc.get("resolved_archetype") or "").strip() or resolve_archetype(None).name
+    )
+    resolved_route_category = str(desc.get("resolved_route_category") or "").strip() or (
+        specialist_mapping.default_route_category if specialist_mapping is not None else resolve_archetype(resolved_archetype).default_route_category
+    )
+    resolved_delegation_profile = (
+        str(getattr(specialist_mapping, "default_delegation_profile", "") or "").strip()
+        or resolve_archetype(resolved_archetype).default_delegation_profile
+        or "general"
+    )
+
+    return {
+        "message": stripped_message,
+        "named_agent": desc["name"],
+        "specialist": specialist_hint,
+        "archetype": resolved_archetype,
+        "route_category": resolved_route_category,
+        "runtime_mode": str(desc.get("resolved_runtime_mode") or "default").strip() or "default",
+        "delegation_profile": resolved_delegation_profile,
+        "activation_reason": f"named-agent invocation: {desc['name']}",
+    }
 
 
 def _should_parallelize_tool_batch(tool_calls) -> bool:
@@ -1468,6 +1534,21 @@ class AIAgent:
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        compression_protected_tools = _compression_cfg.get("protected_tools")
+        if compression_protected_tools is not None:
+            if isinstance(compression_protected_tools, (list, tuple, set, frozenset)):
+                compression_protected_tools = [
+                    str(tool_name)
+                    for tool_name in compression_protected_tools
+                    if str(tool_name)
+                ]
+            else:
+                logger.warning(
+                    "Invalid compression.protected_tools in config.yaml: %r — must be a list of tool names. "
+                    "Falling back to built-in defaults.",
+                    compression_protected_tools,
+                )
+                compression_protected_tools = None
         compression_threshold_tokens = _compression_cfg.get("threshold_tokens")
         if compression_threshold_tokens is not None:
             try:
@@ -1622,6 +1703,7 @@ class AIAgent:
                 provider=self.provider,
                 api_mode=self.api_mode,
                 explicit_threshold_tokens=compression_threshold_tokens,
+                protected_tools=compression_protected_tools,
             )
         self.compression_enabled = compression_enabled
 
@@ -3365,11 +3447,14 @@ class AIAgent:
             if str(item.get("status") or "").strip().lower() in {"pending", "in_progress"}
         ]
 
-        if payload.get("interrupted"):
+        explicit_outcome_status = str(payload.get("outcomeStatus") or payload.get("outcome_status") or "").strip().lower()
+        if explicit_outcome_status in {"stopped", "cancelled", "canceled"}:
+            outcome_status = explicit_outcome_status
+        elif payload.get("interrupted"):
             outcome_status = "interrupted"
         elif payload.get("failed"):
             outcome_status = "failed"
-        elif payload.get("completed") or not active_todos:
+        elif payload.get("completed") or explicit_outcome_status == "completed" or not active_todos:
             outcome_status = "completed"
         else:
             outcome_status = "incomplete"
@@ -3416,14 +3501,16 @@ class AIAgent:
             failed = True
         elif outcome_status == "interrupted":
             interrupted_flag = True
+        stop_requested = bool(
+            self._runtime_continuation_message_flag(assistant_message, "stopRequested", "stop_requested")
+        ) or outcome_status in {"stopped", "cancelled", "canceled"}
         return {
             "final_response": final_response,
             "completed": completed,
             "failed": failed,
             "interrupted": interrupted_flag,
-            "stopRequested": bool(
-                self._runtime_continuation_message_flag(assistant_message, "stopRequested", "stop_requested")
-            ),
+            "outcomeStatus": outcome_status or None,
+            "stopRequested": stop_requested,
             "retryRequested": bool(
                 self._runtime_continuation_message_flag(assistant_message, "retryRequested", "retry_requested")
             ),
@@ -3662,6 +3749,8 @@ class AIAgent:
         default_delegation_profile = default_archetype.default_delegation_profile
         return {
             "archetype": default_archetype.name,
+            "category": resolve_literal_category_from_route_category(default_route_category).name,
+            "named_agent": None,
             "specialist": None,
             "route_category": default_route_category,
             "runtime_mode": default_runtime_mode.name,
@@ -3674,6 +3763,40 @@ class AIAgent:
             "activation_applied": False,
             "inference_source": "wave2_intent_preclassifier",
         }
+
+    @staticmethod
+    def _finalize_runtime_activation_reason(
+        activation_reason: Any,
+        *,
+        named_agent: Optional[str],
+        specialist: Optional[str],
+        archetype: str,
+        category: str,
+        route_category: str,
+        delegation_profile: str,
+        runtime_mode: str,
+    ) -> str:
+        base_reason = str(activation_reason or "").strip() or "fallback: compatibility-safe default activation"
+        resolved_segments = [
+            ("named_agent", str(named_agent or "").strip()),
+            ("specialist", str(specialist or "").strip()),
+            ("archetype", str(archetype or "").strip()),
+            ("category", str(category or "").strip()),
+            ("route_category", str(route_category or "").strip()),
+            ("delegation_profile", str(delegation_profile or "").strip()),
+            ("runtime_mode", str(runtime_mode or "").strip()),
+        ]
+        missing_segments: list[str] = []
+        rewritten_reason = base_reason
+        for key, value in resolved_segments:
+            if not value:
+                continue
+            rewritten_reason, replacements = re.subn(rf"{re.escape(key)}=[^,;\s]+", f"{key}={value}", rewritten_reason)
+            if replacements == 0 and f"{key}={value}" not in rewritten_reason:
+                missing_segments.append(f"{key}={value}")
+        if not missing_segments:
+            return rewritten_reason
+        return f"{rewritten_reason}; final_state: {' '.join(missing_segments)}"
 
     def get_runtime_activation_state(self) -> Dict[str, Any]:
         return copy.deepcopy(self.runtime_activation_state)
@@ -3719,12 +3842,20 @@ class AIAgent:
     def _build_runtime_activation_snapshot_entry(self, state: Dict[str, Any]) -> Dict[str, Any]:
         task_contract = state.get("task_contract") if isinstance(state, dict) else None
         named_workflow = state.get("named_workflow") if isinstance(state, dict) else None
+        activation_identity = (
+            state.get("named_agent")
+            or state.get("specialist")
+            or state.get("archetype")
+        )
         return {
+            "named_agent": state.get("named_agent"),
             "specialist": state.get("specialist"),
             "archetype": state.get("archetype"),
+            "category": state.get("category"),
             "route_category": state.get("route_category"),
             "delegation_profile": state.get("delegation_profile"),
             "runtime_mode": state.get("runtime_mode"),
+            "activation_identity": activation_identity,
             "task_contract_present": bool(task_contract),
             "task_contract_summary": self._summarize_task_contract_for_snapshot(task_contract),
             "named_workflow_present": bool(named_workflow),
@@ -3745,6 +3876,70 @@ class AIAgent:
         except Exception as exc:
             logger.debug("Session DB update_runtime_activation_snapshot failed: %s", exc)
 
+    @staticmethod
+    def _resolve_machine_readable_task_contract(
+        task_contract_payload: Any,
+        *,
+        named_workflow_payload: Any = None,
+        log_context: str,
+    ) -> Optional[Dict[str, Any]]:
+        resolved_task_contract = None
+        if task_contract_payload not in (None, "", {}):
+            try:
+                resolved_task_contract = validate_task_contract(task_contract_payload).model_dump()
+            except Exception as exc:
+                logger.debug("Ignoring invalid task_contract from %s: %s", log_context, exc)
+
+        resolved_named_workflow = None
+        if isinstance(named_workflow_payload, dict) and named_workflow_payload:
+            try:
+                resolved_named_workflow = validate_named_workflow_artifact(named_workflow_payload).model_dump(by_alias=True)
+            except Exception as exc:
+                logger.debug("Ignoring invalid named_workflow from %s: %s", log_context, exc)
+
+        if resolved_task_contract is not None:
+            return resolved_task_contract
+
+        workflow_task_contract = (
+            resolved_named_workflow.get("execution_task_contract")
+            if isinstance(resolved_named_workflow, dict)
+            else None
+        )
+        if workflow_task_contract not in (None, "", {}):
+            try:
+                return validate_task_contract(workflow_task_contract).model_dump()
+            except Exception as exc:
+                logger.debug(
+                    "Ignoring invalid named_workflow.execution_task_contract from %s: %s",
+                    log_context,
+                    exc,
+                )
+        return None
+
+    @staticmethod
+    def _resolve_delegate_runtime_mode_payload(delegate_resolution: Mapping[str, Any], default_runtime_mode: str) -> Any:
+        runtime_mode_definition = delegate_resolution.get("runtime_mode_definition")
+        if isinstance(runtime_mode_definition, Mapping):
+            runtime_mode_name = str(runtime_mode_definition.get("name") or "").strip()
+            description = str(runtime_mode_definition.get("description") or "").strip()
+            operating_posture = str(runtime_mode_definition.get("operating_posture") or "").strip()
+            kind = str(runtime_mode_definition.get("kind") or "").strip()
+            resolved_runtime_mode = resolve_runtime_mode(runtime_mode_name)
+            if (
+                runtime_mode_name
+                and resolved_runtime_mode.name == runtime_mode_name
+                and description
+                and operating_posture
+                and kind == "runtime_mode"
+            ):
+                return runtime_mode_definition
+            logger.debug(
+                "Ignoring invalid delegate runtime_mode_definition during runtime activation passthrough: %s",
+                runtime_mode_definition,
+            )
+        runtime_mode_name = delegate_resolution.get("runtime_mode")
+        return resolve_runtime_mode(runtime_mode_name or default_runtime_mode).name
+
     def _update_runtime_activation_snapshot(self, state: Dict[str, Any]) -> None:
         previous_current = copy.deepcopy(
             (getattr(self, "_runtime_activation_snapshot", {}) or {}).get("current")
@@ -3757,6 +3952,8 @@ class AIAgent:
 
     @staticmethod
     def _should_apply_runtime_activation_state(state: Dict[str, Any]) -> bool:
+        if state.get("named_agent"):
+            return True
         if state.get("specialist"):
             return True
         if state.get("task_contract"):
@@ -3778,21 +3975,55 @@ class AIAgent:
         if not isinstance(state, dict):
             state = {}
 
+        named_agent = str(state.get("named_agent") or "").strip() or None
         raw_specialist = str(state.get("specialist") or "").strip().lower()
         specialist_mapping = resolve_specialist_mapping(raw_specialist)
         specialist = specialist_mapping.name if specialist_mapping is not None else raw_specialist
         archetype = str(state.get("archetype") or "").strip().lower()
         delegation_profile = str(state.get("delegation_profile") or "").strip().lower()
         reviewer_like = bool(specialist in _REVIEWER_SPECIALISTS)
-        allowed_tool_names = set(getattr(self, "valid_tool_names", set()) or [])
+        valid_tool_names = set(getattr(self, "valid_tool_names", set()) or [])
+
+        blocked_tool_names: set[str] = set()
+        allowed_tool_names = set(valid_tool_names)
+        restriction_source = None
+        allowed_tool_boundary_active = False
+        if archetype or specialist:
+            try:
+                restricted_archetype = archetype or resolve_archetype(None).name
+                resolved_blocked, resolved_allowed = get_tool_restrictions(restricted_archetype, specialist or None)
+            except Exception:
+                resolved_blocked, resolved_allowed = frozenset(), frozenset()
+            else:
+                blocked_tool_names.update(resolved_blocked)
+                if resolved_allowed:
+                    allowed_tool_boundary_active = True
+                    allowed_tool_names.intersection_update(resolved_allowed)
+                    if not valid_tool_names:
+                        allowed_tool_names = set(resolved_allowed)
+                    restriction_source = "allowed_tools"
+                if resolved_blocked:
+                    restriction_source = restriction_source or "blocked_tools"
+
         if reviewer_like:
-            allowed_tool_names.difference_update(_REVIEWER_BLOCKED_TOOLS)
+            blocked_tool_names.update(_REVIEWER_BLOCKED_TOOLS)
+            restriction_source = restriction_source or "reviewer_read_only"
+
+        allowed_tool_names.difference_update(blocked_tool_names)
+        runtime_boundary_active = reviewer_like or bool(blocked_tool_names) or allowed_tool_boundary_active
+
         return {
             "reviewer_like": reviewer_like,
+            "named_agent": named_agent,
+            "identity_name": named_agent or specialist or archetype or None,
             "specialist": specialist or None,
             "archetype": archetype or None,
             "delegation_profile": delegation_profile or None,
             "allowed_tool_names": allowed_tool_names,
+            "allowed_tool_boundary_active": allowed_tool_boundary_active,
+            "blocked_tool_names": blocked_tool_names,
+            "runtime_boundary_active": runtime_boundary_active,
+            "restriction_source": restriction_source,
         }
 
     def _get_runtime_scoped_tool_names(self) -> set[str]:
@@ -3808,19 +4039,41 @@ class AIAgent:
             sorted(self._get_runtime_scoped_tool_names()),
         )
 
+    def _has_multimodal_capability_tools(self) -> bool:
+        available_tool_names = set(getattr(self, "valid_tool_names", set()) or [])
+        return bool(available_tool_names.intersection(_MULTIMODAL_CAPABILITY_TOOLS))
+
     def _maybe_block_named_role_tool_call(self, function_name: str, function_args: Optional[Dict[str, Any]]) -> Optional[str]:
         policy = self._get_named_role_policy()
-        if not policy.get("reviewer_like"):
+
+        if policy.get("reviewer_like"):
+            if function_name in _REVIEWER_BLOCKED_TOOLS:
+                return (
+                    "Reviewer/verifier runtime boundary: this role is read-only and cannot call "
+                    f"'{function_name}'. Use read-only inspection, testing, or delegation instead."
+                )
+            if function_name == "terminal" and _is_destructive_command(str((function_args or {}).get("command") or "")):
+                return (
+                    "Reviewer/verifier runtime boundary: destructive terminal commands are blocked in "
+                    "read-only verification sessions."
+                )
+
+        if not policy.get("runtime_boundary_active"):
             return None
-        if function_name in _REVIEWER_BLOCKED_TOOLS:
+
+        blocked_tool_names = set(policy.get("blocked_tool_names") or [])
+        allowed_tool_names = set(policy.get("allowed_tool_names") or [])
+        specialist = str(policy.get("identity_name") or policy.get("specialist") or policy.get("archetype") or "named role")
+
+        if function_name in blocked_tool_names:
             return (
-                "Reviewer/verifier runtime boundary: this role is read-only and cannot call "
-                f"'{function_name}'. Use read-only inspection, testing, or delegation instead."
+                f"Named role runtime boundary ({specialist}): tool '{function_name}' is blocked for this role. "
+                "Use the role's permitted tools instead."
             )
-        if function_name == "terminal" and _is_destructive_command(str((function_args or {}).get("command") or "")):
+        if policy.get("allowed_tool_boundary_active") and function_name not in allowed_tool_names:
             return (
-                "Reviewer/verifier runtime boundary: destructive terminal commands are blocked in "
-                "read-only verification sessions."
+                f"Named role runtime boundary ({specialist}): tool '{function_name}' is outside this role's "
+                "allowed tool set."
             )
         return None
 
@@ -3829,31 +4082,158 @@ class AIAgent:
         if not policy.get("reviewer_like"):
             return None
 
-        tool_names: set[str] = set()
+        tool_names = self._collect_tool_names_used_in_messages(messages)
+        _, successful_tool_names, tool_result_seen = self._collect_tool_execution_outcomes(messages)
         blocked_violation_seen = False
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if msg.get("role") == "assistant":
-                for tc in msg.get("tool_calls") or []:
-                    if not isinstance(tc, dict):
-                        continue
-                    tool_name = str(tc.get("function", {}).get("name") or "").strip()
-                    if tool_name:
-                        tool_names.add(tool_name)
-            elif msg.get("role") == "tool":
+            if msg.get("role") == "tool":
                 content = str(msg.get("content") or "")
                 if "Reviewer/verifier runtime boundary:" in content:
                     blocked_violation_seen = True
 
         if blocked_violation_seen:
             return "Reviewer/verifier completion gate blocked success after a read-only policy violation."
-        if not tool_names.intersection(_REVIEWER_EVIDENCE_TOOLS):
+        evidence_tool_names = tool_names.intersection(_REVIEWER_EVIDENCE_TOOLS)
+        if not evidence_tool_names:
             return (
                 "Reviewer/verifier completion gate blocked success: no verification evidence tool "
                 "was used in this run."
             )
+        if tool_result_seen and not successful_tool_names.intersection(_REVIEWER_EVIDENCE_TOOLS):
+            return (
+                "Reviewer/verifier completion gate blocked success: no successful verification evidence tool "
+                "result was produced in this run."
+            )
         return None
+
+    @staticmethod
+    def _collect_tool_names_used_in_messages(messages: List[Dict[str, Any]]) -> set[str]:
+        tool_names: set[str] = set()
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            for tc in msg.get("tool_calls") or []:
+                if not isinstance(tc, dict):
+                    continue
+                tool_name = str(tc.get("function", {}).get("name") or "").strip()
+                if tool_name:
+                    tool_names.add(tool_name)
+        return tool_names
+
+    @staticmethod
+    def _collect_tool_execution_outcomes(messages: List[Dict[str, Any]]) -> tuple[set[str], set[str], bool]:
+        requested_tool_names: set[str] = set()
+        successful_tool_names: set[str] = set()
+        call_name_by_id: dict[str, str] = {}
+        tool_result_seen = False
+
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            for tc in msg.get("tool_calls") or []:
+                if not isinstance(tc, dict):
+                    continue
+                tool_name = str(tc.get("function", {}).get("name") or "").strip()
+                if not tool_name:
+                    continue
+                requested_tool_names.add(tool_name)
+                tool_call_id = str(tc.get("id") or tc.get("call_id") or "").strip()
+                if tool_call_id:
+                    call_name_by_id[tool_call_id] = tool_name
+
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "tool":
+                continue
+            tool_call_id = str(msg.get("tool_call_id") or "").strip()
+            tool_name = call_name_by_id.get(tool_call_id)
+            if not tool_name:
+                tool_name = str(msg.get("tool_name") or msg.get("name") or "").strip()
+            if not tool_name:
+                continue
+            tool_result_seen = True
+            is_failure, _ = _detect_tool_failure(tool_name, str(msg.get("content") or ""))
+            if not is_failure:
+                successful_tool_names.add(tool_name)
+
+        return requested_tool_names, successful_tool_names, tool_result_seen
+
+    def _evaluate_task_contract_completion_gate(self, messages: List[Dict[str, Any]]) -> Optional[str]:
+        state = getattr(self, "runtime_activation_state", None)
+        if not isinstance(state, dict):
+            state = getattr(self, "_runtime_activation_state", None)
+        if not isinstance(state, dict):
+            state = {}
+
+        task_contract = state.get("task_contract")
+        if not isinstance(task_contract, dict) or not task_contract:
+            return None
+
+        required_tools = task_contract.get("required_tools")
+        if not isinstance(required_tools, list) or not required_tools:
+            return None
+
+        normalized_required_tools = [
+            str(tool_name).strip()
+            for tool_name in required_tools
+            if str(tool_name).strip()
+        ]
+        if not normalized_required_tools:
+            return None
+
+        available_tool_names = self._get_runtime_scoped_tool_names()
+        missing_tools = sorted(
+            tool_name for tool_name in normalized_required_tools if tool_name not in available_tool_names
+        )
+        if missing_tools:
+            return (
+                "Task contract completion gate blocked success: required tool(s) unavailable in this "
+                f"runtime: {', '.join(missing_tools)}."
+            )
+
+        used_tool_names = self._collect_tool_names_used_in_messages(messages)
+        unused_required_tools = sorted(
+            tool_name for tool_name in normalized_required_tools if tool_name not in used_tool_names
+        )
+        if unused_required_tools:
+            return (
+                "Task contract completion gate blocked success: required tool(s) were not used in this "
+                f"run: {', '.join(unused_required_tools)}."
+            )
+
+        _, successful_tool_names, tool_result_seen = self._collect_tool_execution_outcomes(messages)
+        if tool_result_seen:
+            unsuccessful_required_tools = sorted(
+                tool_name for tool_name in normalized_required_tools if tool_name not in successful_tool_names
+            )
+            if unsuccessful_required_tools:
+                return (
+                    "Task contract completion gate blocked success: required tool(s) did not produce "
+                    f"successful results in this run: {', '.join(unsuccessful_required_tools)}."
+                )
+
+        return None
+
+    def _get_active_iteration_limit(self) -> int:
+        configured_limit = max(1, int(getattr(self, "max_iterations", 1) or 1))
+        if getattr(self, "_delegate_depth", 0) != 0:
+            return configured_limit
+
+        runtime_state = getattr(self, "runtime_activation_state", None)
+        if not isinstance(runtime_state, dict):
+            runtime_state = getattr(self, "_runtime_activation_state", None)
+        runtime_mode_name = runtime_state.get("runtime_mode") if isinstance(runtime_state, dict) else None
+
+        try:
+            runtime_mode = resolve_runtime_mode(runtime_mode_name)
+        except Exception:
+            runtime_mode = get_default_runtime_mode()
+
+        runtime_cap = getattr(runtime_mode, "iteration_cap", configured_limit)
+        if not isinstance(runtime_cap, int) or runtime_cap < 1:
+            runtime_cap = configured_limit
+        return min(configured_limit, runtime_cap)
 
     def _build_runtime_activation_note(self, state: Dict[str, Any]) -> str:
         if not self._should_apply_runtime_activation_state(state):
@@ -3863,6 +4243,12 @@ class AIAgent:
             "<wave2-runtime-activation>",
             "Wave 2 Runtime Activation",
             f"specialist: {state.get('specialist') or 'none'}",
+            f"named_agent: {state.get('named_agent') or 'none'}",
+            f"archetype: {state.get('archetype') or 'generalist'}",
+            f"category: {state.get('category') or resolve_literal_category_from_route_category(state.get('route_category')).name}",
+            f"route_category: {state.get('route_category') or DEFAULT_ROUTE_CATEGORY}",
+            f"delegation_profile: {state.get('delegation_profile') or 'general'}",
+            f"runtime_mode: {state.get('runtime_mode') or get_default_runtime_mode().name}",
             f"activation_reason: {state.get('activation_reason') or 'fallback: compatibility-safe default activation'}",
             f"inference_source: {state.get('inference_source') or 'wave2_intent_preclassifier'}",
         ]
@@ -3932,7 +4318,7 @@ class AIAgent:
         lines.append("</execution-supervisor-state>")
         return "\n".join(lines)
 
-    def _resolve_runtime_activation_state(self, user_message: str) -> Dict[str, Any]:
+    def _resolve_runtime_activation_state(self, user_message: Any) -> Dict[str, Any]:
         if getattr(self, "_delegate_depth", 0) != 0:
             state = self._build_default_runtime_activation_state()
             delegate_resolution = dict(getattr(self, "_delegate_resolution", {}) or {})
@@ -3952,105 +4338,235 @@ class AIAgent:
                 or (specialist_mapping.default_delegation_profile if specialist_mapping is not None else None)
                 or state["delegation_profile"]
             )
-            normalized_inputs = normalize_wave1_overlay_inputs(
-                archetype_name=delegate_archetype,
-                route_category=delegate_route_category,
-                delegation_profile=delegate_delegation_profile,
-                runtime_mode=delegate_resolution.get("runtime_mode_definition") or delegate_resolution.get("runtime_mode") or state["runtime_mode"],
-                skills=delegate_resolution.get("skills"),
-                task_contract=delegate_resolution.get("task_contract"),
-                orchestration_hints=delegate_resolution.get("orchestration_hints"),
-            )
-            resolved_named_workflow = None
             raw_named_workflow = delegate_resolution.get("named_workflow")
+            resolved_named_workflow = None
             if isinstance(raw_named_workflow, dict) and raw_named_workflow:
                 try:
                     resolved_named_workflow = validate_named_workflow_artifact(raw_named_workflow).model_dump(by_alias=True)
                 except Exception as exc:
                     logger.debug("Ignoring invalid delegate named_workflow during runtime activation passthrough: %s", exc)
+            effective_task_contract = self._resolve_machine_readable_task_contract(
+                delegate_resolution.get("task_contract"),
+                named_workflow_payload=resolved_named_workflow,
+                log_context="delegate runtime activation passthrough",
+            )
+            delegate_category = (
+                delegate_resolution.get("category_definition")
+                or delegate_resolution.get("category")
+                or resolve_literal_category_from_route_category(delegate_route_category)
+            )
+            normalized_inputs = normalize_wave1_overlay_inputs(
+                archetype_name=delegate_archetype,
+                category=delegate_category,
+                route_category=delegate_route_category,
+                delegation_profile=delegate_delegation_profile,
+                runtime_mode=self._resolve_delegate_runtime_mode_payload(delegate_resolution, state["runtime_mode"]),
+                skills=delegate_resolution.get("skills"),
+                task_contract=effective_task_contract,
+                orchestration_hints=delegate_resolution.get("orchestration_hints"),
+            )
             state.update({
+                "named_agent": str(delegate_resolution.get("named_agent") or delegate_resolution.get("agent") or "").strip() or None,
                 "specialist": resolved_specialist,
                 "archetype": normalized_inputs["archetype"],
+                "category": normalized_inputs["category"],
                 "route_category": normalized_inputs["route_category"],
                 "runtime_mode": normalized_inputs["runtime_mode"],
                 "delegation_profile": normalized_inputs["delegation_profile"],
-                "task_contract": normalized_inputs["task_contract"],
+                "task_contract": effective_task_contract,
                 "named_workflow": resolved_named_workflow,
                 "wave1_overlay_prompt": build_wave1_overlay_prompt_from_normalized(normalized_inputs),
             })
+            state["activation_reason"] = self._finalize_runtime_activation_reason(
+                delegate_resolution.get("activation_reason") or state.get("activation_reason"),
+                named_agent=state.get("named_agent"),
+                specialist=state.get("specialist"),
+                archetype=state["archetype"],
+                category=state["category"],
+                route_category=state["route_category"],
+                delegation_profile=state["delegation_profile"],
+                runtime_mode=state["runtime_mode"],
+            )
             state["inference_source"] = "delegate_passthrough"
             state["activation_note"] = self._build_runtime_activation_note(state)
             state["activation_applied"] = bool(state["activation_note"])
             return state
 
+        preclassification_input = user_message
+        if isinstance(user_message, str):
+            try:
+                from hermes_cli.command_templates import extract_structured_command_prompt_payload
+
+                structured_payload = extract_structured_command_prompt_payload(user_message)
+                if structured_payload is not None:
+                    preclassification_input = {
+                        "message": user_message,
+                        **structured_payload,
+                    }
+            except Exception as exc:
+                logger.debug("Failed to extract structured command payload for runtime activation: %s", exc)
+
+        explicit_named_agent = None
+        explicit_specialist = None
+        explicit_archetype = None
+        explicit_route_category = None
+        explicit_category = None
+        explicit_runtime_mode = None
+        explicit_delegation_profile = None
+        explicit_activation_reason = ""
+        if isinstance(preclassification_input, Mapping):
+            explicit_named_agent = str(preclassification_input.get("named_agent") or preclassification_input.get("agent") or "").strip() or None
+            explicit_specialist = str(preclassification_input.get("specialist") or "").strip() or None
+            explicit_archetype = str(preclassification_input.get("archetype") or "").strip() or None
+            explicit_route_category = str(preclassification_input.get("route_category") or "").strip() or None
+            explicit_category = str(preclassification_input.get("category") or "").strip() or None
+            explicit_runtime_mode = str(preclassification_input.get("runtime_mode") or "").strip() or None
+            explicit_delegation_profile = str(preclassification_input.get("delegation_profile") or "").strip() or None
+            explicit_activation_reason = str(preclassification_input.get("activation_reason") or "").strip()
+
         try:
-            preclassification = preclassify_intent(user_message)
+            preclassification = preclassify_intent(preclassification_input)
         except Exception as exc:
             logger.debug("Wave 2 runtime activation preclassification failed: %s", exc, exc_info=True)
             preclassification = preclassify_intent(None)
 
         default_state = self._build_default_runtime_activation_state()
-        raw_specialist = getattr(preclassification, "inferred_specialist", None)
+        raw_specialist = explicit_specialist or getattr(preclassification, "inferred_specialist", None)
         specialist_mapping = resolve_specialist_mapping(raw_specialist)
         resolved_specialist = specialist_mapping.name if specialist_mapping is not None else None
+        activation_reason = str(
+            explicit_activation_reason
+            or getattr(preclassification, "activation_reason", "")
+            or default_state["activation_reason"]
+        ).strip()
 
-        inferred_archetype = specialist_mapping.archetype_name if specialist_mapping is not None else getattr(preclassification, "inferred_archetype", None)
-        resolved_archetype = resolve_archetype(inferred_archetype)
-        raw_route_category = str(getattr(preclassification, "inferred_route_category", "") or "").strip()
-        if raw_route_category and raw_route_category in BUILTIN_ROUTE_CATEGORIES:
+        if resolved_specialist == _MULTIMODAL_SPECIALIST and not self._has_multimodal_capability_tools():
+            available_multimodal_tools = sorted(
+                set(getattr(self, "valid_tool_names", set()) or []).intersection(_MULTIMODAL_CAPABILITY_TOOLS)
+            )
+            resolved_specialist = None
+            specialist_mapping = None
+            inferred_archetype = None
+            inferred_category = ""
+            raw_route_category = ""
+            delegation_profile = ""
+            activation_reason = (
+                f"{activation_reason}; fallback: multimodal tools unavailable "
+                f"(requires one of {sorted(_MULTIMODAL_CAPABILITY_TOOLS)}, available={available_multimodal_tools})"
+            )
+        else:
+            inferred_archetype = (
+                specialist_mapping.archetype_name
+                if specialist_mapping is not None
+                else (explicit_archetype or getattr(preclassification, "inferred_archetype", None))
+            )
+            inferred_category = str(explicit_category or getattr(preclassification, "inferred_category", "") or "").strip()
+            raw_route_category = str(explicit_route_category or getattr(preclassification, "inferred_route_category", "") or "").strip()
+            delegation_profile = str(explicit_delegation_profile or getattr(preclassification, "inferred_delegation_profile", "") or "").strip()
+
+        resolved_archetype = resolve_archetype(explicit_archetype or inferred_archetype)
+        if explicit_route_category and explicit_route_category in BUILTIN_ROUTE_CATEGORIES:
+            route_category = resolve_route_category(explicit_route_category).name
+        elif raw_route_category and raw_route_category in BUILTIN_ROUTE_CATEGORIES:
             route_category = resolve_route_category(raw_route_category).name
+        elif inferred_category:
+            route_category = resolve_literal_category_to_route_category(inferred_category).name
         elif specialist_mapping is not None and specialist_mapping.default_route_category:
             route_category = resolve_route_category(specialist_mapping.default_route_category).name
         else:
             route_category = resolve_route_category(resolved_archetype.default_route_category).name
-        runtime_mode = resolve_runtime_mode(getattr(preclassification, "inferred_runtime_mode", None)).name
-        delegation_profile = str(getattr(preclassification, "inferred_delegation_profile", "") or "").strip()
+        if inferred_category:
+            category = resolve_literal_category(inferred_category).name
+        else:
+            category = resolve_literal_category_from_route_category(route_category).name
+        runtime_mode = resolve_runtime_mode(explicit_runtime_mode or getattr(preclassification, "inferred_runtime_mode", None)).name
         if not delegation_profile and specialist_mapping is not None and specialist_mapping.default_delegation_profile:
             delegation_profile = specialist_mapping.default_delegation_profile
         if not delegation_profile:
             delegation_profile = resolved_archetype.default_delegation_profile or default_state["delegation_profile"]
 
-        task_contract_payload = None
-        raw_task_contract = getattr(preclassification, "task_contract", None)
-        if raw_task_contract not in (None, "", {}):
-            try:
-                task_contract_payload = validate_task_contract(raw_task_contract).model_dump()
-            except Exception as exc:
-                logger.debug("Ignoring invalid task_contract from runtime activation preclassifier: %s", exc)
+        structured_named_workflow = None
+        structured_payload_present = False
+        if isinstance(preclassification_input, Mapping):
+            structured_payload_present = any(
+                preclassification_input.get(key) not in (None, "", {})
+                for key in ("task_contract", "named_workflow", "orchestration_hints")
+            )
+            raw_named_workflow = preclassification_input.get("named_workflow")
+            if isinstance(raw_named_workflow, dict) and raw_named_workflow:
+                try:
+                    structured_named_workflow = validate_named_workflow_artifact(raw_named_workflow).model_dump(by_alias=True)
+                except Exception as exc:
+                    logger.debug("Ignoring invalid named_workflow from runtime activation payload: %s", exc)
+
+        task_contract_payload = self._resolve_machine_readable_task_contract(
+            getattr(preclassification, "task_contract", None),
+            named_workflow_payload=structured_named_workflow,
+            log_context="runtime activation preclassifier/payload",
+        )
 
         normalized_inputs = normalize_wave1_overlay_inputs(
             archetype_name=resolved_archetype.name,
+            category=category,
             route_category=route_category,
             delegation_profile=delegation_profile,
             runtime_mode=runtime_mode,
+            skills=resolved_archetype.default_skills,
             task_contract=task_contract_payload,
         )
 
+        resolved_named_agent = (
+            str(preclassification_input.get("named_agent") or preclassification_input.get("agent") or "").strip() or None
+            if isinstance(preclassification_input, Mapping)
+            else None
+        )
+        activation_reason = self._finalize_runtime_activation_reason(
+            activation_reason,
+            named_agent=resolved_named_agent,
+            specialist=resolved_specialist,
+            archetype=normalized_inputs["archetype"],
+            category=normalized_inputs["category"],
+            route_category=normalized_inputs["route_category"],
+            delegation_profile=normalized_inputs["delegation_profile"],
+            runtime_mode=normalized_inputs["runtime_mode"],
+        )
         state = {
+            "named_agent": resolved_named_agent,
             "archetype": normalized_inputs["archetype"],
+            "category": normalized_inputs["category"],
             "specialist": resolved_specialist,
             "route_category": normalized_inputs["route_category"],
             "runtime_mode": normalized_inputs["runtime_mode"],
             "delegation_profile": normalized_inputs["delegation_profile"],
-            "activation_reason": str(
-                getattr(preclassification, "activation_reason", "")
-                or default_state["activation_reason"]
-            ).strip(),
+            "activation_reason": activation_reason,
             "task_contract": normalized_inputs["task_contract"],
             "inference_source": str(
                 getattr(preclassification, "inference_source", "")
                 or default_state["inference_source"]
             ).strip(),
         }
-        state["named_workflow"] = build_named_workflow_artifact(
-            objective=user_message,
-            specialist=resolved_specialist,
-            archetype=state["archetype"],
-            route_category=state["route_category"],
-            runtime_mode=state["runtime_mode"],
-            delegation_profile=state["delegation_profile"],
-            task_contract=state["task_contract"],
-        )
+        if structured_named_workflow is not None:
+            state["named_workflow"] = structured_named_workflow
+        elif structured_payload_present:
+            state["named_workflow"] = None
+        else:
+            workflow_objective = user_message
+            if isinstance(preclassification_input, Mapping):
+                workflow_objective = (
+                    preclassification_input.get("message")
+                    or preclassification_input.get("user_message")
+                    or preclassification_input.get("task")
+                    or user_message
+                )
+            state["named_workflow"] = build_named_workflow_artifact(
+                objective=workflow_objective,
+                specialist=resolved_specialist,
+                archetype=state["archetype"],
+                route_category=state["route_category"],
+                runtime_mode=state["runtime_mode"],
+                delegation_profile=state["delegation_profile"],
+                task_contract=state["task_contract"],
+            )
         state["wave1_overlay_prompt"] = build_wave1_overlay_prompt_from_normalized(normalized_inputs)
         state["activation_note"] = self._build_runtime_activation_note(state)
         state["activation_applied"] = bool(state["activation_note"])
@@ -6898,7 +7414,7 @@ class AIAgent:
             # when no explicit key is in the fallback config.
             if fb_base_url_hint and "ollama.com" in fb_base_url_hint.lower() and not fb_api_key_hint:
                 fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
-            fb_client, _resolved_fb_model = resolve_provider_client(
+            fb_client, resolved_fb_model = resolve_provider_client(
                 fb_provider, model=fb_model, raw_codex=True,
                 explicit_base_url=fb_base_url_hint,
                 explicit_api_key=fb_api_key_hint)
@@ -6910,9 +7426,9 @@ class AIAgent:
             try:
                 from hermes_cli.model_normalize import normalize_model_for_provider
 
-                fb_model = normalize_model_for_provider(fb_model, fb_provider)
+                fb_model = resolved_fb_model or normalize_model_for_provider(fb_model, fb_provider)
             except Exception:
-                pass
+                fb_model = resolved_fb_model or fb_model
 
             # Determine api_mode from provider / base URL / model
             fb_api_mode = "chat_completions"
@@ -9384,6 +9900,29 @@ class AIAgent:
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates
         # that are invalid UTF-8 and crash JSON serialization in the OpenAI SDK.
+        runtime_activation_input = user_message
+        try:
+            from hermes_cli.work_command_adapter import is_prepared_work_command
+        except Exception:
+            is_prepared_work_command = None
+
+        if callable(is_prepared_work_command) and is_prepared_work_command(user_message):
+            prepared_work_command = user_message
+            runtime_activation_input = {
+                "message": prepared_work_command.agent_message,
+                "task_contract": prepared_work_command.task_contract,
+                "named_workflow": prepared_work_command.invocation.named_workflow,
+                "orchestration_hints": prepared_work_command.orchestration_hints,
+            }
+            user_message = prepared_work_command.agent_message
+            if persist_user_message is None:
+                persist_user_message = prepared_work_command.display_text
+        else:
+            named_agent_invocation = _extract_leading_named_agent_invocation_payload(user_message)
+            if named_agent_invocation is not None:
+                runtime_activation_input = dict(named_agent_invocation)
+                user_message = str(named_agent_invocation.get("message") or user_message)
+
         if isinstance(user_message, str):
             user_message = _sanitize_surrogates(user_message)
         if isinstance(persist_user_message, str):
@@ -9443,8 +9982,6 @@ class AIAgent:
         # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
-        self.iteration_budget = IterationBudget(self.max_iterations)
-
         # Log conversation turn start for debugging/observability
         _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
         _msg_preview = _msg_preview.replace("\n", " ")
@@ -9473,8 +10010,10 @@ class AIAgent:
         self._user_turn_count += 1
 
         # Preserve the original user message (no nudge injection).
-        original_user_message = persist_user_message if persist_user_message is not None else user_message
-        self._activate_runtime_for_turn(original_user_message)
+        original_user_message = persist_user_message if isinstance(persist_user_message, str) else user_message
+        self._activate_runtime_for_turn(runtime_activation_input)
+        active_iteration_limit = self._get_active_iteration_limit()
+        self.iteration_budget = IterationBudget(active_iteration_limit)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -9704,7 +10243,7 @@ class AIAgent:
             except Exception:
                 pass
 
-        while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
+        while (api_call_count < active_iteration_limit and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
 
@@ -9904,7 +10443,7 @@ class AIAgent:
             thinking_spinner = None
             
             if not self.quiet_mode:
-                self._vprint(f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{self.max_iterations}...")
+                self._vprint(f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{active_iteration_limit}...")
                 self._vprint(f"{self.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
                 self._vprint(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
             else:
@@ -12357,26 +12896,26 @@ class AIAgent:
                     break
         
         if final_response is None and (
-            api_call_count >= self.max_iterations
+            api_call_count >= active_iteration_limit
             or self.iteration_budget.remaining <= 0
         ):
             # Budget exhausted — ask the model for a summary via one extra
             # API call with tools stripped.  _handle_max_iterations injects a
             # user message and makes a single toolless request.
-            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{self.max_iterations})"
+            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{active_iteration_limit})"
             self._emit_status(
-                f"⚠️ Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
+                f"⚠️ Iteration budget exhausted ({api_call_count}/{active_iteration_limit}) "
                 "— asking model to summarise"
             )
             if not self.quiet_mode:
                 self._safe_print(
-                    f"\n⚠️  Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
+                    f"\n⚠️  Iteration budget exhausted ({api_call_count}/{active_iteration_limit}) "
                     "— requesting summary..."
                 )
             final_response = self._handle_max_iterations(messages, api_call_count)
-        
+
         # Determine if conversation completed successfully
-        completed = final_response is not None and api_call_count < self.max_iterations
+        completed = final_response is not None and api_call_count < active_iteration_limit
 
         # Save trajectory if enabled
         self._save_trajectory(messages, user_message, completed)
@@ -12415,7 +12954,7 @@ class AIAgent:
             "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
         )
         _diag_args = (
-            _turn_exit_reason, self.model, api_call_count, self.max_iterations,
+            _turn_exit_reason, self.model, api_call_count, active_iteration_limit,
             _budget_used, _budget_max,
             _turn_tool_count, _last_msg_role, _resp_len,
             self.session_id or "none",
@@ -12436,6 +12975,11 @@ class AIAgent:
             if named_role_completion_error:
                 final_response = named_role_completion_error
                 completed = False
+            else:
+                task_contract_completion_error = self._evaluate_task_contract_completion_gate(messages)
+                if task_contract_completion_error:
+                    final_response = task_contract_completion_error
+                    completed = False
 
         # Plugin hook: post_llm_call
         # Fired once per turn after the tool-calling loop completes.

--- a/run_agent.py
+++ b/run_agent.py
@@ -616,6 +616,7 @@ class AIAgent:
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = 1.0,
         enabled_toolsets: List[str] = None,
+        enabled_tools: List[str] = None,
         disabled_toolsets: List[str] = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
@@ -847,6 +848,7 @@ class AIAgent:
 
         # Store toolset filtering options
         self.enabled_toolsets = enabled_toolsets
+        self.enabled_tools = list(enabled_tools) if enabled_tools is not None else None
         self.disabled_toolsets = disabled_toolsets
         
         # Model response configuration
@@ -3292,6 +3294,42 @@ class AIAgent:
             "budget_max": self.iteration_budget.max_total,
         }
 
+    def get_orchestration_continuation_snapshot(self, result: Optional[dict]) -> dict:
+        """Summarize resumable work for gateway continuation handling."""
+        payload = result if isinstance(result, dict) else {}
+        todo_items = []
+        try:
+            if getattr(self, "_todo_store", None) is not None:
+                raw_items = self._todo_store.read() or []
+                if isinstance(raw_items, list):
+                    todo_items = [dict(item) for item in raw_items if isinstance(item, dict)]
+        except Exception:
+            todo_items = []
+
+        active_todos = [
+            dict(item)
+            for item in todo_items
+            if str(item.get("status") or "").strip().lower() in {"pending", "in_progress"}
+        ]
+
+        if payload.get("interrupted"):
+            outcome_status = "interrupted"
+        elif payload.get("failed"):
+            outcome_status = "failed"
+        elif payload.get("completed") or not active_todos:
+            outcome_status = "completed"
+        else:
+            outcome_status = "incomplete"
+
+        response_preview = str(payload.get("final_response") or payload.get("error") or "").strip()
+        return {
+            "sessionId": str(getattr(self, "session_id", "") or ""),
+            "outcomeStatus": outcome_status,
+            "todoItems": todo_items,
+            "activeTodos": active_todos,
+            "responsePreview": response_preview,
+        }
+
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider and context engine — call at actual session boundaries.
 
@@ -3732,6 +3770,73 @@ class AIAgent:
             )
         return messages
 
+    def _todo_has_active_items(self) -> bool:
+        try:
+            items = self._todo_store.read()
+        except Exception:
+            return False
+        return any(item.get("status") in ("pending", "in_progress") for item in items)
+
+    def _should_inject_orchestration_note(self, user_message: str, api_call_count: int) -> bool:
+        cfg = self._delegation_cfg if isinstance(self._delegation_cfg, dict) else {}
+        if getattr(self, "_delegate_depth", 0) != 0:
+            return False
+        if api_call_count != 1:
+            return False
+        if not cfg.get("auto_decompose_large_tasks", True):
+            return False
+        if not isinstance(user_message, str) or not user_message.strip():
+            return False
+        if "todo" not in self.valid_tool_names:
+            return False
+        if self._todo_has_active_items():
+            return False
+        text = user_message.lower()
+        score = 0
+        if len(user_message) >= 220:
+            score += 2
+        if len(re.findall(r"\b(and|also|then|after|before|while)\b", text)) >= 2:
+            score += 2
+        if any(token in text for token in ("across the board", "all profiles", "across all profiles", "end-to-end", "hardening pass", "make sure", "implement", "verify", "fix regressions", "audit")):
+            score += 2
+        if len(re.findall(r"\b(test|verify|implement|update|check|ensure|review|compare|patch|refactor)\b", text)) >= 3:
+            score += 2
+        if text.count("\n-") >= 2 or text.count("\n1.") >= 1 or text.count("; ") >= 2:
+            score += 2
+        return score >= 4
+
+    def _build_orchestration_user_note(self) -> str:
+        cfg = self._delegation_cfg if isinstance(self._delegation_cfg, dict) else {}
+        max_children = cfg.get("max_concurrent_children", 3)
+        try:
+            max_children = max(1, int(max_children))
+        except (TypeError, ValueError):
+            max_children = 3
+        auto_fanout_max = self._resolve_auto_fanout_max_tasks(cfg, max_children)
+        lines = [
+            "<runtime-orchestration-policy>",
+            "This request appears large or multi-step.",
+            "Before substantive execution, create a concise todo list with 2-7 items and mark exactly one item in_progress.",
+            "After planning, continue execution immediately instead of stopping after the plan.",
+        ]
+        if cfg.get("auto_fanout_batch_mode", True) and "delegate_task" in self.valid_tool_names:
+            lines.append(
+                f"When independent subtasks exist, prefer ONE delegate_task batch call with tasks=[...] (up to {auto_fanout_max} tasks) instead of many separate delegate_task calls."
+            )
+            lines.append(
+                "Use delegation categories when they fit: research for audits/comparison, implementation for code changes, verification for tests/review."
+            )
+        lines.append("</runtime-orchestration-policy>")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _resolve_auto_fanout_max_tasks(cfg: dict, max_children: int) -> int:
+        auto_fanout_max = cfg.get("auto_fanout_max_tasks", max_children)
+        try:
+            return max(1, min(max_children, int(auto_fanout_max)))
+        except (TypeError, ValueError):
+            return min(max_children, 3)
+
     @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:
         """Truncate excess delegate_task calls to max_concurrent_children.
@@ -3762,6 +3867,106 @@ class AIAgent:
             delegate_count - max_children, max_children,
         )
         return truncated
+
+    @staticmethod
+    def _coalesce_delegate_task_calls(tool_calls: list) -> list:
+        if not tool_calls:
+            return tool_calls
+        try:
+            from tools.delegate_tool import _load_config, _resolve_batch_concurrency_limit
+            cfg = _load_config()
+        except Exception:
+            cfg = {}
+            from tools.delegate_tool import _resolve_batch_concurrency_limit
+        if not cfg.get("auto_fanout_batch_mode", True):
+            return tool_calls
+
+        merged_tasks = []
+        first_delegate = None
+        max_iterations = None
+        delegate_count = 0
+
+        for tc in tool_calls:
+            if tc.function.name != "delegate_task":
+                continue
+            delegate_count += 1
+            first_delegate = first_delegate or tc
+            try:
+                args = json.loads(tc.function.arguments or "{}")
+            except Exception:
+                return tool_calls
+            if not isinstance(args, dict):
+                return tool_calls
+            current_max_iterations = args.get("max_iterations")
+            if current_max_iterations is not None:
+                try:
+                    max_iterations = max(int(current_max_iterations), max_iterations or 0)
+                except (TypeError, ValueError):
+                    return tool_calls
+            top_level_defaults = {
+                key: args.get(key)
+                for key in ("category", "acp_command", "acp_args")
+                if args.get(key) is not None
+            }
+            if isinstance(args.get("tasks"), list):
+                for task in args["tasks"]:
+                    if not isinstance(task, dict) or not str(task.get("goal", "")).strip():
+                        return tool_calls
+                    normalized = dict(task)
+                    for key, value in top_level_defaults.items():
+                        normalized.setdefault(key, value)
+                    merged_tasks.append(normalized)
+            else:
+                goal = str(args.get("goal") or "").strip()
+                if not goal:
+                    return tool_calls
+                task = {"goal": goal}
+                for key in ("context", "toolsets", "category", "acp_command", "acp_args"):
+                    if args.get(key) is not None:
+                        task[key] = args.get(key)
+                merged_tasks.append(task)
+
+        if delegate_count == 0:
+            return tool_calls
+
+        batch_limit, _limit_category = _resolve_batch_concurrency_limit(merged_tasks, None, cfg)
+        auto_fanout_max = AIAgent._resolve_auto_fanout_max_tasks(cfg, batch_limit)
+        needs_rewrite = delegate_count > 1
+
+        if len(merged_tasks) > auto_fanout_max:
+            merged_tasks = merged_tasks[:auto_fanout_max]
+            needs_rewrite = True
+            logger.warning(
+                "Coalesced delegate_task fanout exceeded auto_fanout_max_tasks=%d; truncating merged batch",
+                auto_fanout_max,
+            )
+
+        if not needs_rewrite:
+            return tool_calls
+
+        merged_args = {"tasks": merged_tasks}
+        if max_iterations is not None:
+            merged_args["max_iterations"] = max_iterations
+        merged_call = SimpleNamespace(
+            id=getattr(first_delegate, "id", None),
+            type=getattr(first_delegate, "type", "function"),
+            function=SimpleNamespace(
+                name="delegate_task",
+                arguments=json.dumps(merged_args, ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+            ),
+        )
+
+        output = []
+        inserted = False
+        for tc in tool_calls:
+            if tc.function.name == "delegate_task":
+                if not inserted:
+                    output.append(merged_call)
+                    inserted = True
+                continue
+            output.append(tc)
+        logger.info("Coalesced %d delegate_task calls into one batch with %d task(s)", delegate_count, len(merged_tasks))
+        return output
 
     @staticmethod
     def _deduplicate_tool_calls(tool_calls: list) -> list:
@@ -7551,7 +7756,10 @@ class AIAgent:
                 context=function_args.get("context"),
                 toolsets=function_args.get("toolsets"),
                 tasks=function_args.get("tasks"),
+                category=function_args.get("category"),
                 max_iterations=function_args.get("max_iterations"),
+                acp_command=function_args.get("acp_command"),
+                acp_args=function_args.get("acp_args"),
                 parent_agent=self,
             )
         else:
@@ -8839,6 +9047,8 @@ class AIAgent:
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
                     _injections = []
+                    if self._should_inject_orchestration_note(original_user_message, api_call_count):
+                        _injections.append(self._build_orchestration_user_note())
                     if _ext_prefetch_cache:
                         _fenced = build_memory_context_block(_ext_prefetch_cache)
                         if _fenced:
@@ -10885,6 +11095,9 @@ class AIAgent:
                     self._invalid_json_retries = 0
 
                     # ── Post-call guardrails ──────────────────────────
+                    assistant_message.tool_calls = self._coalesce_delegate_task_calls(
+                        assistant_message.tool_calls
+                    )
                     assistant_message.tool_calls = self._cap_delegate_task_calls(
                         assistant_message.tool_calls
                     )

--- a/scripts/run_test_chunks.sh
+++ b/scripts/run_test_chunks.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Named chunk runner for hermes-agent verification suites.
+# Delegates every chunk to scripts/run_tests.sh so CI-parity policy stays in one place.
+#
+# Usage:
+#   scripts/run_test_chunks.sh list
+#   scripts/run_test_chunks.sh list broad
+#   scripts/run_test_chunks.sh broad
+#   scripts/run_test_chunks.sh broad run-agent-a run-agent-b
+#   scripts/run_test_chunks.sh run-agent-file -- -q --durations=20
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_TESTS="$SCRIPT_DIR/run_tests.sh"
+
+if [ ! -x "$RUN_TESTS" ]; then
+  echo "error: expected executable runner at $RUN_TESTS" >&2
+  exit 1
+fi
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/run_test_chunks.sh list [suite]
+  scripts/run_test_chunks.sh <suite> [chunk ...] [-- <extra pytest args>]
+
+Suites:
+  broad              Broad verification suite for current orchestration hardening targets.
+  native-orchestration-broad
+  run-agent-file     Chunked runner for tests/run_agent/test_run_agent.py.
+
+Examples:
+  scripts/run_test_chunks.sh broad
+  scripts/run_test_chunks.sh broad run-agent-a run-agent-b
+  scripts/run_test_chunks.sh run-agent-file -- -q --durations=20
+EOF
+}
+
+suite_alias() {
+  case "$1" in
+    broad) echo "native-orchestration-broad" ;;
+    run-agent) echo "run-agent-file" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+suite_chunks() {
+  case "$1" in
+    native-orchestration-broad)
+      printf '%s\n' \
+        config-validation \
+        delegate \
+        delegate-toolset-scope \
+        run-agent-a \
+        run-agent-b \
+        run-agent-c \
+        run-agent-d \
+        run-agent-e \
+        run-agent-f
+      ;;
+    run-agent-file)
+      printf '%s\n' \
+        run-agent-a \
+        run-agent-b \
+        run-agent-c \
+        run-agent-d \
+        run-agent-e \
+        run-agent-f
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+chunk_nodes() {
+  case "$1" in
+    config-validation)
+      printf '%s\n' tests/hermes_cli/test_config_validation.py
+      ;;
+    delegate)
+      printf '%s\n' tests/tools/test_delegate.py
+      ;;
+    delegate-toolset-scope)
+      printf '%s\n' tests/tools/test_delegate_toolset_scope.py
+      ;;
+    run-agent-a)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::test_aiagent_reuses_existing_errors_log_handler \
+        tests/run_agent/test_run_agent.py::TestProviderModelNormalization \
+        tests/run_agent/test_run_agent.py::TestHasContentAfterThinkBlock \
+        tests/run_agent/test_run_agent.py::TestStripThinkBlocks \
+        tests/run_agent/test_run_agent.py::TestExtractReasoning \
+        tests/run_agent/test_run_agent.py::TestCleanSessionContent \
+        tests/run_agent/test_run_agent.py::TestGetMessagesUpToLastAssistant \
+        tests/run_agent/test_run_agent.py::TestMaskApiKey \
+        tests/run_agent/test_run_agent.py::TestInit \
+        tests/run_agent/test_run_agent.py::TestInterrupt \
+        tests/run_agent/test_run_agent.py::TestHydrateTodoStore \
+        tests/run_agent/test_run_agent.py::TestBuildSystemPrompt \
+        tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig \
+        tests/run_agent/test_run_agent.py::TestInvalidateSystemPrompt \
+        tests/run_agent/test_run_agent.py::TestBuildApiKwargs \
+        tests/run_agent/test_run_agent.py::TestBuildAssistantMessage
+      ;;
+    run-agent-b)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestFormatToolsForSystemMessage \
+        tests/run_agent/test_run_agent.py::TestExecuteToolCalls \
+        tests/run_agent/test_run_agent.py::TestConcurrentToolExecution \
+        tests/run_agent/test_run_agent.py::TestPathsOverlap \
+        tests/run_agent/test_run_agent.py::TestParallelScopePathNormalization \
+        tests/run_agent/test_run_agent.py::TestHandleMaxIterations \
+        tests/run_agent/test_run_agent.py::TestRunConversation
+      ;;
+    run-agent-c)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestRetryExhaustion \
+        tests/run_agent/test_run_agent.py::TestFlushSentinelNotLeaked \
+        tests/run_agent/test_run_agent.py::TestConversationHistoryNotMutated \
+        tests/run_agent/test_run_agent.py::TestNousCredentialRefresh \
+        tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery \
+        tests/run_agent/test_run_agent.py::TestMaxTokensParam \
+        tests/run_agent/test_run_agent.py::TestSystemPromptStability \
+        tests/run_agent/test_run_agent.py::TestBudgetPressure \
+        tests/run_agent/test_run_agent.py::TestSafeWriter \
+        tests/run_agent/test_run_agent.py::TestSaveSessionLogAtomicWrite
+      ;;
+    run-agent-d)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestBuildApiKwargsAnthropicMaxTokens \
+        tests/run_agent/test_run_agent.py::TestAnthropicImageFallback \
+        tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider \
+        tests/run_agent/test_run_agent.py::test_aiagent_uses_copilot_acp_client \
+        tests/run_agent/test_run_agent.py::test_quiet_spinner_allowed_with_explicit_print_fn \
+        tests/run_agent/test_run_agent.py::test_quiet_spinner_allowed_on_real_tty \
+        tests/run_agent/test_run_agent.py::test_quiet_spinner_suppressed_on_non_tty_without_print_fn \
+        tests/run_agent/test_run_agent.py::test_is_openai_client_closed_honors_custom_client_flag \
+        tests/run_agent/test_run_agent.py::test_is_openai_client_closed_handles_method_form \
+        tests/run_agent/test_run_agent.py::test_is_openai_client_closed_falls_back_to_http_client \
+        tests/run_agent/test_run_agent.py::TestAnthropicBaseUrlPassthrough \
+        tests/run_agent/test_run_agent.py::TestAnthropicCredentialRefresh
+      ;;
+    run-agent-e)
+      printf '%s\n' tests/run_agent/test_run_agent.py::TestStreamingApiCall
+      ;;
+    run-agent-f)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestInterruptVprintForceTrue \
+        tests/run_agent/test_run_agent.py::TestAnthropicInterruptHandler \
+        tests/run_agent/test_run_agent.py::TestStreamCallbackNonStreamingProvider \
+        tests/run_agent/test_run_agent.py::TestPersistUserMessageOverride \
+        tests/run_agent/test_run_agent.py::TestVprintForceOnErrors \
+        tests/run_agent/test_run_agent.py::TestNormalizeCodexDictArguments \
+        tests/run_agent/test_run_agent.py::TestOAuthFlagAfterCredentialRefresh \
+        tests/run_agent/test_run_agent.py::TestFallbackSetsOAuthFlag \
+        tests/run_agent/test_run_agent.py::TestMemoryNudgeCounterPersistence \
+        tests/run_agent/test_run_agent.py::TestDeadRetryCode \
+        tests/run_agent/test_run_agent.py::TestMemoryContextSanitization \
+        tests/run_agent/test_run_agent.py::TestMemoryProviderTurnStart \
+        tests/run_agent/test_run_agent.py::TestNativeOrchestrationHardening
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+if [ "$1" = "list" ]; then
+  if [ "$#" -eq 1 ]; then
+    echo "native-orchestration-broad"
+    echo "run-agent-file"
+    exit 0
+  fi
+  SUITE="$(suite_alias "$2")"
+  suite_chunks "$SUITE"
+  exit 0
+fi
+
+SUITE="$(suite_alias "$1")"
+shift
+
+DEFAULT_CHUNKS=()
+while IFS= read -r chunk_name; do
+  DEFAULT_CHUNKS+=("$chunk_name")
+done < <(suite_chunks "$SUITE")
+if [ "${#DEFAULT_CHUNKS[@]}" -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+SELECTED_CHUNKS=()
+PASSTHROUGH_ARGS=()
+PARSING_CHUNKS=1
+for arg in "$@"; do
+  if [ "$arg" = "--" ]; then
+    PARSING_CHUNKS=0
+    continue
+  fi
+  if [ "$PARSING_CHUNKS" -eq 1 ]; then
+    SELECTED_CHUNKS+=("$arg")
+  else
+    PASSTHROUGH_ARGS+=("$arg")
+  fi
+done
+
+if [ "${#SELECTED_CHUNKS[@]}" -eq 0 ]; then
+  SELECTED_CHUNKS=("${DEFAULT_CHUNKS[@]}")
+fi
+
+for chunk in "${SELECTED_CHUNKS[@]}"; do
+  if ! chunk_nodes "$chunk" >/dev/null; then
+    echo "error: unknown chunk '$chunk' for suite '$SUITE'" >&2
+    echo "available chunks:" >&2
+    suite_chunks "$SUITE" >&2
+    exit 1
+  fi
+done
+
+echo "▶ suite: $SUITE"
+echo "▶ chunks: ${SELECTED_CHUNKS[*]}"
+if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+  echo "▶ pass-through pytest args: ${PASSTHROUGH_ARGS[*]}"
+fi
+
+for chunk in "${SELECTED_CHUNKS[@]}"; do
+  nodes=()
+  while IFS= read -r node; do
+    nodes+=("$node")
+  done < <(chunk_nodes "$chunk")
+  echo
+  echo "== chunk: $chunk =="
+  if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+    "$RUN_TESTS" "${PASSTHROUGH_ARGS[@]}" "${nodes[@]}"
+  else
+    "$RUN_TESTS" "${nodes[@]}"
+  fi
+done

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -24,19 +24,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Activate venv ───────────────────────────────────────────────────────────
-# Prefer a .venv in the current tree, fall back to the main checkout's venv
-# (useful for worktrees where we don't always duplicate the venv).
+# Prefer the first working env in the current tree, then fall back to the main
+# checkout's venv (useful for worktrees where we don't always duplicate the
+# virtualenv). A stale `.venv` without pytest should not block a healthy `venv`.
 VENV=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+CANDIDATES=("$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv")
+SKIPPED_VENVS=()
+for candidate in "${CANDIDATES[@]}"; do
+  PYTHON_CANDIDATE="$candidate/bin/python"
+  if [ ! -x "$PYTHON_CANDIDATE" ]; then
+    continue
+  fi
+  if "$PYTHON_CANDIDATE" -c "import pytest" >/dev/null 2>&1; then
     VENV="$candidate"
     break
   fi
+  SKIPPED_VENVS+=("$candidate")
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  if [ "${#SKIPPED_VENVS[@]}" -gt 0 ]; then
+    echo "warning: skipped unusable virtualenv(s) without pytest: ${SKIPPED_VENVS[*]}" >&2
+  fi
+  echo "error: no working virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
   exit 1
+fi
+
+if [ "${#SKIPPED_VENVS[@]}" -gt 0 ]; then
+  echo "warning: skipped unusable virtualenv(s) without pytest: ${SKIPPED_VENVS[*]}" >&2
 fi
 
 PYTHON="$VENV/bin/python"

--- a/tests/agent/test_archetypes.py
+++ b/tests/agent/test_archetypes.py
@@ -1,0 +1,207 @@
+from dataclasses import MISSING, fields
+
+from agent import archetypes
+from agent.route_categories import DEFAULT_ROUTE_CATEGORY
+
+
+_EXPECTED_BUILTIN_ARCHETYPES = {
+    "generalist": {
+        "summary": "Balanced starter preset for legacy-compatible delegated work without specialist bias.",
+        "default_route_category": DEFAULT_ROUTE_CATEGORY,
+        "default_delegation_profile": "general",
+        "default_skills": ("general_reasoning", "task_execution"),
+        "default_required_tools": ("read_file", "search_files"),
+        "permission_preset": "inherit",
+        "fallback_policy": "legacy_default_mapping",
+    },
+    "researcher": {
+        "summary": "Research-oriented preset for evidence gathering and synthesis without changing route semantics.",
+        "default_route_category": "deep",
+        "default_delegation_profile": "research",
+        "default_skills": ("research", "analysis", "synthesis"),
+        "default_required_tools": ("read_file", "search_files", "web_search", "web_extract"),
+        "permission_preset": "inherit",
+        "fallback_policy": "degrade_to_generalist",
+    },
+    "implementer": {
+        "summary": "Implementation-oriented preset for repository changes and local verification.",
+        "default_route_category": "deep",
+        "default_delegation_profile": "implementation",
+        "default_skills": ("implementation", "python", "testing"),
+        "default_required_tools": ("read_file", "search_files", "patch", "terminal"),
+        "permission_preset": "workspace_write",
+        "fallback_policy": "degrade_to_generalist",
+    },
+    "verifier": {
+        "summary": "Verification-oriented preset for targeted test runs, review, and evidence capture.",
+        "default_route_category": "quick",
+        "default_delegation_profile": "verification",
+        "default_skills": ("verification", "testing", "review"),
+        "default_required_tools": ("read_file", "search_files", "terminal"),
+        "permission_preset": "workspace_write",
+        "fallback_policy": "degrade_to_generalist",
+    },
+}
+
+
+def test_builtin_archetypes_are_wave_1_canonical_only():
+    builtins = archetypes.list_archetypes()
+
+    assert tuple(item.name for item in builtins) == (
+        "generalist",
+        "researcher",
+        "implementer",
+        "verifier",
+    )
+    assert archetypes.DEFAULT_ARCHETYPE_NAME == "generalist"
+    assert set(archetypes.ARCHETYPES_BY_NAME) == set(_EXPECTED_BUILTIN_ARCHETYPES)
+
+    for item in builtins:
+        expected = _EXPECTED_BUILTIN_ARCHETYPES[item.name]
+        assert item.summary == expected["summary"]
+        assert item.default_route_category == expected["default_route_category"]
+        assert item.default_delegation_profile == expected["default_delegation_profile"]
+        assert item.default_skills == expected["default_skills"]
+        assert item.default_required_tools == expected["default_required_tools"]
+        assert item.permission_preset == expected["permission_preset"]
+        assert item.fallback_policy == expected["fallback_policy"]
+        assert item.kind == "archetype"
+
+
+def test_resolve_archetype_normalizes_case_space_and_hyphen_only():
+    assert archetypes.resolve_archetype("Researcher").name == "researcher"
+    assert archetypes.resolve_archetype("researcher").name == "researcher"
+    assert archetypes.resolve_archetype("  IMPLEMENTER  ").name == "implementer"
+    assert archetypes.resolve_archetype("imple menter").name == "generalist"
+    assert archetypes.resolve_archetype("imple-menter").name == "generalist"
+    assert archetypes.resolve_archetype("Generalist").name == "generalist"
+    assert archetypes.resolve_archetype("generalist").name == "generalist"
+    assert archetypes.resolve_archetype("generalist ").name == "generalist"
+    assert archetypes.resolve_archetype("re-searcher").name == "generalist"
+    assert archetypes.resolve_archetype("re searcher").name == "generalist"
+
+
+def test_resolve_archetype_falls_back_to_default_for_missing_or_unknown_names():
+    default = archetypes.get_default_archetype()
+
+    assert archetypes.resolve_archetype(None) is default
+    assert archetypes.resolve_archetype("") is default
+    assert archetypes.resolve_archetype("unknown") is default
+    assert archetypes.resolve_archetype("planner") is default
+
+
+def test_resolve_archetype_defaults_returns_required_fields_and_applies_overrides():
+    defaults = archetypes.resolve_archetype_defaults("Implementer")
+
+    assert defaults == {
+        "default_route_category": "deep",
+        "default_delegation_profile": "implementation",
+        "default_skills": ["implementation", "python", "testing"],
+        "default_required_tools": ["read_file", "search_files", "patch", "terminal"],
+        "permission_preset": "workspace_write",
+        "fallback_policy": "degrade_to_generalist",
+    }
+
+    overridden = archetypes.resolve_archetype_defaults(
+        "implementer",
+        overrides={
+            "default_route_category": "quick",
+            "default_skills": [" refactor ", "", "python"],
+            "default_required_tools": ("terminal", "read_file"),
+            "permission_preset": " inherit ",
+            "fallback_policy": " custom ",
+        },
+    )
+
+    assert overridden == {
+        "default_route_category": "quick",
+        "default_delegation_profile": "implementation",
+        "default_skills": ["refactor", "python"],
+        "default_required_tools": ["terminal", "read_file"],
+        "permission_preset": "inherit",
+        "fallback_policy": "custom",
+    }
+
+
+def test_schema_fields_and_required_fields_align_with_dataclass_shape():
+    dataclass_fields = tuple(field.name for field in fields(archetypes.Archetype))
+    required_default_fields = tuple(
+        field.name
+        for field in fields(archetypes.Archetype)
+        if field.name not in {"name", "summary", "kind"}
+        and field.default is MISSING
+        and field.default_factory is MISSING
+    )
+
+    assert archetypes.ARCHETYPE_SCHEMA_FIELDS == dataclass_fields
+    assert archetypes.REQUIRED_ARCHETYPE_FIELDS == required_default_fields
+    assert archetypes.REQUIRED_ARCHETYPE_FIELDS == (
+        "default_route_category",
+        "default_delegation_profile",
+        "default_skills",
+        "default_required_tools",
+        "permission_preset",
+        "fallback_policy",
+    )
+
+
+def test_wave_1_module_exports_include_compatibility_specialist_surface():
+    assert archetypes.__all__ == [
+        "ARCHETYPES_BY_NAME",
+        "ARCHETYPE_SCHEMA_FIELDS",
+        "BUILTIN_ARCHETYPES",
+        "BUILTIN_NAMED_WORKFLOWS",
+        "DEFAULT_ARCHETYPE_NAME",
+        "NAMED_WORKFLOWS_BY_NAME",
+        "NamedWorkflow",
+        "REQUIRED_ARCHETYPE_FIELDS",
+        "SPECIALIST_MAPPINGS_BY_NAME",
+        "Archetype",
+        "SpecialistMapping",
+        "get_default_archetype",
+        "list_archetypes",
+        "resolve_archetype",
+        "resolve_archetype_defaults",
+        "resolve_named_workflow",
+        "resolve_specialist_defaults",
+        "resolve_specialist_mapping",
+        "validate_specialist_mapping",
+        "validate_specialist_mappings",
+    ]
+
+    for exported_name in (
+        "SpecialistMapping",
+        "SPECIALIST_MAPPINGS_BY_NAME",
+        "resolve_specialist_mapping",
+        "resolve_specialist_defaults",
+        "NamedWorkflow",
+        "NAMED_WORKFLOWS_BY_NAME",
+        "resolve_named_workflow",
+    ):
+        assert hasattr(archetypes, exported_name)
+
+    for removed_name in (
+        "SPECIALIST_ALIASES",
+        "SPECIALIST_MAPPING_SCHEMA_FIELDS",
+        "BUILTIN_SPECIALIST_MAPPINGS",
+        "list_specialist_mappings",
+    ):
+        assert not hasattr(archetypes, removed_name)
+
+
+def test_named_workflow_registry_exposes_canonical_members_and_resolution():
+    assert set(archetypes.NAMED_WORKFLOWS_BY_NAME) == {"planner", "deep_worker"}
+
+    planner = archetypes.resolve_named_workflow("planner")
+    assert planner is archetypes.NAMED_WORKFLOWS_BY_NAME["planner"]
+    assert planner.name == "planner"
+    assert planner.mode == "plan"
+    assert planner.kind == "named_workflow"
+
+    deep_worker = archetypes.resolve_named_workflow("deep worker")
+    assert deep_worker is archetypes.NAMED_WORKFLOWS_BY_NAME["deep_worker"]
+    assert deep_worker.name == "deep_worker"
+    assert deep_worker.mode == "execute"
+    assert deep_worker.kind == "named_workflow"
+
+    assert archetypes.resolve_named_workflow("unknown") is None

--- a/tests/agent/test_compaction_checkpoint.py
+++ b/tests/agent/test_compaction_checkpoint.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+from agent.compaction_checkpoint import write_compaction_checkpoint
+
+
+def _sample_messages():
+    return [
+        {"role": "user", "content": "Build the Thindi SEO architecture plan."},
+        {"role": "assistant", "content": "I gathered the current constraints and architecture options."},
+        {"role": "tool", "content": "{\"status\": \"success\", \"output\": \"Council review loaded\"}"},
+        {"role": "user", "content": "Continue from the council review and produce final blind spots."},
+        {"role": "assistant", "content": "Working through the final synthesis now."},
+    ]
+
+
+def test_write_compaction_checkpoint_creates_canonical_artifacts(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "thindi"
+    workspace = hermes_home / "workspace"
+    workspace.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = write_compaction_checkpoint(
+        session_id="session-123",
+        messages=_sample_messages(),
+        preservation_notes="Preserve exact port 8642 and the unresolved backlink strategy gap.",
+        approx_tokens=185000,
+        context_length=200000,
+        threshold_tokens=185000,
+    )
+
+    handoff_path = Path(result["handoff_path"])
+    checkpoint_json_path = Path(result["checkpoint_json_path"])
+    event_path = Path(result["event_path"])
+    daily_path = Path(result["daily_path"])
+    latest_path = Path(result["latest_handoff_path"])
+
+    assert handoff_path.exists()
+    assert checkpoint_json_path.exists()
+    assert event_path.exists()
+    assert daily_path.exists()
+    assert latest_path.exists()
+
+    checkpoint_payload = json.loads(checkpoint_json_path.read_text())
+    assert checkpoint_payload["session_id"] == "session-123"
+    assert checkpoint_payload["profile"] == "thindi"
+    assert checkpoint_payload["fleet"] == "generic"
+    assert checkpoint_payload["context_length"] == 200000
+    assert checkpoint_payload["threshold_tokens"] == 185000
+    assert checkpoint_payload["context_percent"] == 92.5
+    assert "8642" in checkpoint_payload["preservation_notes"]
+
+    event_lines = [line for line in event_path.read_text().splitlines() if line.strip()]
+    assert len(event_lines) == 1
+    event_payload = json.loads(event_lines[0])
+    assert event_payload["kind"] == "compaction_checkpoint"
+    assert event_payload["session_id"] == "session-123"
+    assert event_payload["profile"] == "thindi"
+
+    daily_text = daily_path.read_text()
+    assert "Compaction Checkpoint" in daily_text
+    assert "session-123" in daily_text
+    assert "185000" in daily_text
+
+    latest_text = latest_path.read_text()
+    assert "session-123" in latest_text
+
+
+def test_write_compaction_checkpoint_appends_event_jsonl(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    workspace = hermes_home / "workspace"
+    workspace.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_compaction_checkpoint(
+        session_id="session-a",
+        messages=_sample_messages(),
+        preservation_notes="first",
+        approx_tokens=90000,
+        context_length=100000,
+        threshold_tokens=85000,
+    )
+    second = write_compaction_checkpoint(
+        session_id="session-b",
+        messages=_sample_messages(),
+        preservation_notes="second",
+        approx_tokens=91000,
+        context_length=100000,
+        threshold_tokens=85000,
+    )
+
+    event_path = Path(second["event_path"])
+    lines = [json.loads(line) for line in event_path.read_text().splitlines() if line.strip()]
+    assert [line["session_id"] for line in lines] == ["session-a", "session-b"]
+
+
+def test_write_compaction_checkpoint_prefers_existing_legacy_book_memory_root(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "generic-core"
+    legacy_memory_root = hermes_home / "workspace" / "pantheon-migrated" / "workspace-generic" / "memory"
+    legacy_memory_root.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = write_compaction_checkpoint(
+        session_id="legacy-session",
+        messages=_sample_messages(),
+        preservation_notes="legacy",
+        approx_tokens=120000,
+        context_length=200000,
+        threshold_tokens=185000,
+    )
+
+    assert str(legacy_memory_root) in result["handoff_path"]
+    assert str(legacy_memory_root) in result["event_path"]

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -621,6 +621,19 @@ class TestSummaryTargetRatio:
         # 50% of 200K = 100K, which is above the 64K floor
         assert c.threshold_tokens == 100_000
 
+    def test_explicit_threshold_tokens_override_percentage(self):
+        """An explicit token threshold should take precedence over threshold_percent."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                threshold_percent=0.50,
+                explicit_threshold_tokens=185_000,
+            )
+        assert c.threshold_percent == 0.50
+        assert c.threshold_tokens == 185_000
+        assert c.tail_token_budget == 37_000
+
     def test_default_protect_last_n_is_20(self):
         """Default protect_last_n should be 20."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):

--- a/tests/agent/test_continuation_enforcer.py
+++ b/tests/agent/test_continuation_enforcer.py
@@ -1,0 +1,137 @@
+import agent.continuation_enforcer as continuation_enforcer
+from agent.continuation_enforcer import (
+    claim_retry_requested_continuation,
+    get_continuation_record,
+    get_pending_continuations,
+    reconcile_session_continuation,
+    request_continuation_retry,
+    should_block_delegation,
+)
+from agent.orchestration_state import (
+    record_agent_start,
+    record_delegation_end,
+    record_delegation_start,
+)
+
+
+class TestContinuationEnforcer:
+    def test_reconcile_creates_pending_continuation_for_open_todos(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        record = reconcile_session_continuation(
+            "session-1",
+            outcome_status="interrupted",
+            todos=[
+                {"id": "t1", "content": "Inspect failing logs", "status": "in_progress"},
+                {"id": "t2", "content": "Write final summary", "status": "completed"},
+            ],
+            response_preview="Interrupted while collecting the remaining evidence.",
+        )
+
+        assert record is not None
+        assert record["sessionId"] == "session-1"
+        assert record["status"] == "pending"
+        assert record["reason"] == "interrupted"
+        assert [item["id"] for item in record["openTodos"]] == ["t1"]
+        assert record["attemptCount"] == 1
+
+        queue = get_pending_continuations()
+        assert len(queue) == 1
+        assert queue[0]["sessionId"] == "session-1"
+
+    def test_reconcile_resolves_existing_continuation_after_completion(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        reconcile_session_continuation(
+            "session-2",
+            outcome_status="failed",
+            todos=[{"id": "t1", "content": "Recover partial output", "status": "pending"}],
+            response_preview="Provider call failed before the wrap-up.",
+        )
+
+        resolved = reconcile_session_continuation(
+            "session-2",
+            outcome_status="completed",
+            todos=[{"id": "t1", "content": "Recover partial output", "status": "completed"}],
+            response_preview="Recovered and completed successfully.",
+        )
+
+        assert resolved is None
+        assert get_pending_continuations() == []
+
+    def test_retry_requested_claim_sets_running_lease_and_blocks_second_claim(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        reconcile_session_continuation(
+            "session-retry",
+            outcome_status="interrupted",
+            todos=[{"id": "t1", "content": "Inspect failing logs", "status": "pending"}],
+            response_preview="Need another pass.",
+        )
+
+        requested = request_continuation_retry("session-retry", requested_by="pan")
+        assert requested is not None
+        assert requested["status"] == "retry_requested"
+        assert requested["requestedBy"] == "pan"
+
+        claimed = claim_retry_requested_continuation("gateway-worker-1", lease_seconds=90)
+        assert claimed is not None
+        assert claimed["sessionId"] == "session-retry"
+        assert claimed["status"] == "running"
+        assert claimed["leaseOwner"] == "gateway-worker-1"
+        assert claimed["resumeCount"] == 1
+
+        assert claim_retry_requested_continuation("gateway-worker-2", lease_seconds=90) is None
+
+        persisted = get_continuation_record("session-retry")
+        assert persisted is not None
+        assert persisted["status"] == "running"
+        assert persisted["leaseOwner"] == "gateway-worker-1"
+        assert [event["type"] for event in persisted["events"]][-2:] == ["retry_requested", "auto_resume_claimed"]
+
+    def test_retry_requested_claim_blocks_stale_request(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(continuation_enforcer, "_now_iso", lambda: "2026-04-16T20:00:00Z")
+
+        reconcile_session_continuation(
+            "session-stale",
+            outcome_status="failed",
+            todos=[{"id": "t1", "content": "Recover partial output", "status": "pending"}],
+            response_preview="Worker crashed mid-flight.",
+        )
+        request_continuation_retry("session-stale", requested_by="pan")
+
+        monkeypatch.setattr(continuation_enforcer, "_now_iso", lambda: "2026-04-16T20:05:00Z")
+
+        claimed = claim_retry_requested_continuation(
+            "gateway-worker-1",
+            max_retry_age_seconds=60,
+        )
+
+        assert claimed is None
+        blocked = get_continuation_record("session-stale")
+        assert blocked is not None
+        assert blocked["status"] == "blocked"
+        assert blocked["resolution"] == "retry_request_expired"
+
+    def test_delegation_guard_blocks_after_three_recent_failures_for_same_goal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_agent_start("session-guard", message="Parent task")
+
+        for status in ("failed", "error", "interrupted"):
+            delegation_id = record_delegation_start("session-guard", goal="Inspect auth middleware", task_index=0)
+            record_delegation_end(
+                "session-guard",
+                delegation_id,
+                status=status,
+                summary=f"Attempt ended with {status}.",
+                api_calls=2,
+                duration_seconds=1.5,
+                model="gpt-5.4",
+            )
+
+        guard_reason = should_block_delegation("session-guard", "Inspect auth middleware")
+        assert guard_reason is not None
+        assert "Inspect auth middleware" in guard_reason
+
+        assert should_block_delegation("session-guard", "Different task") is None

--- a/tests/agent/test_orchestration_state.py
+++ b/tests/agent/test_orchestration_state.py
@@ -1,0 +1,76 @@
+from agent.orchestration_state import (
+    get_session_state,
+    record_agent_end,
+    record_agent_start,
+    record_delegation_end,
+    record_delegation_start,
+    record_session_lifecycle,
+)
+
+
+class TestOrchestrationState:
+    def test_agent_start_creates_running_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state = record_agent_start(
+            "session-1",
+            platform="telegram",
+            user_id="user-123",
+            message="Investigate why the task stalled and summarize the fix.",
+        )
+
+        assert state["sessionId"] == "session-1"
+        assert state["status"] == "running"
+        assert state["platform"] == "telegram"
+        assert state["userId"] == "user-123"
+        assert state["messagePreview"].startswith("Investigate why the task stalled")
+        assert state["startedAt"] is not None
+        assert state["updatedAt"] is not None
+
+    def test_delegation_start_and_end_update_same_session_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_agent_start("session-2", message="Parent task")
+
+        delegation_id = record_delegation_start(
+            "session-2",
+            goal="Search the repo for all auth middleware implementations.",
+            task_index=1,
+            toolsets=["terminal", "file"],
+        )
+        state = get_session_state("session-2")
+        assert state is not None
+        assert len(state["delegations"]) == 1
+        assert state["delegations"][0]["id"] == delegation_id
+        assert state["delegations"][0]["status"] == "running"
+        assert state["delegations"][0]["taskIndex"] == 1
+        assert state["delegations"][0]["toolsets"] == ["terminal", "file"]
+
+        record_delegation_end(
+            "session-2",
+            delegation_id,
+            status="completed",
+            summary="Found three auth middleware entrypoints and one shared helper.",
+            api_calls=4,
+            duration_seconds=12.5,
+            model="gpt-5.4",
+        )
+        updated = get_session_state("session-2")
+        assert updated is not None
+        assert updated["delegations"][0]["status"] == "completed"
+        assert updated["delegations"][0]["summary"].startswith("Found three auth middleware")
+        assert updated["delegations"][0]["apiCalls"] == 4
+        assert updated["delegations"][0]["durationSeconds"] == 12.5
+        assert updated["delegations"][0]["model"] == "gpt-5.4"
+
+    def test_agent_end_and_session_lifecycle_mark_completion(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_agent_start("session-3", message="Parent task")
+        record_agent_end("session-3", status="completed", response="Implemented the requested fix and verified it.")
+        record_session_lifecycle("session-3", "ended")
+
+        state = get_session_state("session-3")
+        assert state is not None
+        assert state["status"] == "completed"
+        assert state["responsePreview"] == "Implemented the requested fix and verified it."
+        assert state["sessionLifecycle"] == "ended"
+        assert state["endedAt"] is not None

--- a/tests/agent/test_route_categories.py
+++ b/tests/agent/test_route_categories.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from agent.route_categories import (
+    BUILTIN_LITERAL_CATEGORIES,
+    BUILTIN_ROUTE_CATEGORIES,
+    DEFAULT_LITERAL_CATEGORY,
+    DEFAULT_ROUTE_CATEGORY,
+    LiteralCategory,
+    RouteCategory,
+    get_literal_categories,
+    get_literal_category,
+    get_route_categories,
+    get_route_category,
+    resolve_literal_category,
+    resolve_literal_category_to_route_category,
+    resolve_route_category,
+    validate_literal_categories,
+    validate_literal_category,
+    validate_route_categories,
+    validate_route_category,
+)
+
+
+EXPECTED_NAMES = (
+    "ultrabrain",
+    "deep",
+    "quick",
+    "visual",
+    "writing",
+    "artistry",
+    "unspecified_low",
+    "unspecified_high",
+)
+
+EXPECTED_LITERAL_NAMES = (
+    "ultrabrain",
+    "deep",
+    "quick",
+    "visual-engineering",
+    "writing",
+    "artistry",
+    "unspecified-low",
+    "unspecified-high",
+)
+
+
+def test_builtin_route_categories_are_preserved_exactly() -> None:
+    assert tuple(BUILTIN_ROUTE_CATEGORIES) == EXPECTED_NAMES
+    assert DEFAULT_ROUTE_CATEGORY == "unspecified_low"
+
+
+def test_builtin_literal_categories_expose_upstream_product_names_exactly() -> None:
+    assert tuple(BUILTIN_LITERAL_CATEGORIES) == EXPECTED_LITERAL_NAMES
+    assert DEFAULT_LITERAL_CATEGORY == "unspecified-low"
+    assert BUILTIN_LITERAL_CATEGORIES["visual-engineering"].route_category == "visual"
+    assert BUILTIN_LITERAL_CATEGORIES["unspecified-low"].route_category == "unspecified_low"
+    assert BUILTIN_LITERAL_CATEGORIES["unspecified-high"].route_category == "unspecified_high"
+
+
+@pytest.mark.parametrize(
+    ("category", "message"),
+    [
+        (LiteralCategory(name="", summary="summary", route_category="deep"), "name"),
+        (LiteralCategory(name="deep", summary="", route_category="deep"), "summary"),
+        (LiteralCategory(name="deep", summary="summary", route_category=""), "route_category"),
+        (LiteralCategory(name=" deep ", summary="summary", route_category="deep"), "normalized"),
+        (LiteralCategory(name="deep", summary=" summary ", route_category="deep"), "normalized"),
+        (LiteralCategory(name="deep", summary="summary", route_category=" deep "), "normalized"),
+    ],
+)
+def test_validate_literal_category_rejects_invalid_values(category: LiteralCategory, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_literal_category(category)
+
+
+def test_validate_literal_categories_rejects_duplicate_names() -> None:
+    categories = (
+        LiteralCategory(name="deep", summary="summary", route_category="deep"),
+        LiteralCategory(name="deep", summary="another", route_category="quick"),
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        validate_literal_categories(categories)
+
+
+def test_get_literal_category_is_strict_on_unknown_name() -> None:
+    with pytest.raises(KeyError, match="Unknown literal category"):
+        get_literal_category("unknown")
+
+
+def test_get_literal_categories_returns_immutable_registry_view() -> None:
+    registry = get_literal_categories()
+
+    assert isinstance(registry, MappingProxyType)
+    with pytest.raises(TypeError):
+        registry["new"] = LiteralCategory(name="new", summary="summary", route_category="deep")
+
+
+def test_resolve_literal_category_normalizes_compatibility_aliases_to_canonical_upstream_names() -> None:
+    assert resolve_literal_category(None) is BUILTIN_LITERAL_CATEGORIES[DEFAULT_LITERAL_CATEGORY]
+    assert resolve_literal_category("visual") is BUILTIN_LITERAL_CATEGORIES["visual-engineering"]
+    assert resolve_literal_category("unspecified_low") is BUILTIN_LITERAL_CATEGORIES["unspecified-low"]
+    assert resolve_literal_category("unspecified-high") is BUILTIN_LITERAL_CATEGORIES["unspecified-high"]
+    assert resolve_literal_category("unknown-literal-category") is BUILTIN_LITERAL_CATEGORIES[DEFAULT_LITERAL_CATEGORY]
+
+
+def test_literal_category_resolution_truthfully_delegates_fallbacks_to_mapped_route_categories() -> None:
+    assert resolve_literal_category_to_route_category("visual-engineering") is BUILTIN_ROUTE_CATEGORIES["visual"]
+    assert resolve_literal_category_to_route_category("visual").fallback_models == ("quick",)
+    assert resolve_literal_category_to_route_category("unspecified-low").fallback_models == ("default",)
+
+
+@pytest.mark.parametrize(
+    ("category", "message"),
+    [
+        (RouteCategory(name="", summary="summary", intensity="high"), "name"),
+        (RouteCategory(name="deep", summary="", intensity="high"), "summary"),
+        (RouteCategory(name="deep", summary="summary", intensity=""), "intensity"),
+        (RouteCategory(name="deep", summary="summary", intensity="high", fallback_models=(" default ",)), "normalized"),
+        (RouteCategory(name=" deep ", summary="summary", intensity="high"), "normalized"),
+        (RouteCategory(name="deep", summary=" summary ", intensity="high"), "normalized"),
+        (RouteCategory(name="deep", summary="summary", intensity=" high "), "normalized"),
+    ],
+)
+def test_validate_route_category_rejects_invalid_values(category: RouteCategory, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_route_category(category)
+
+
+def test_validate_route_categories_rejects_duplicate_names() -> None:
+    categories = (
+        RouteCategory(name="deep", summary="summary", intensity="high"),
+        RouteCategory(name="deep", summary="another", intensity="low"),
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        validate_route_categories(categories)
+
+
+def test_get_route_category_is_strict_on_unknown_name() -> None:
+    with pytest.raises(KeyError, match="Unknown route category"):
+        get_route_category("unknown")
+
+
+def test_get_route_categories_returns_immutable_registry_view() -> None:
+    registry = get_route_categories()
+
+    assert isinstance(registry, MappingProxyType)
+    with pytest.raises(TypeError):
+        registry["new"] = RouteCategory(name="new", summary="summary", intensity="low")
+
+
+def test_resolve_route_category_falls_back_to_default_without_reusing_other_taxonomy() -> None:
+    assert resolve_route_category(None) is BUILTIN_ROUTE_CATEGORIES[DEFAULT_ROUTE_CATEGORY]
+    assert resolve_route_category("") is BUILTIN_ROUTE_CATEGORIES[DEFAULT_ROUTE_CATEGORY]
+    assert resolve_route_category("  deep  ") is BUILTIN_ROUTE_CATEGORIES["deep"]
+    assert resolve_route_category("unknown-route-category") is BUILTIN_ROUTE_CATEGORIES[DEFAULT_ROUTE_CATEGORY]
+
+
+def test_builtin_route_categories_include_default_fallback_chains() -> None:
+    assert BUILTIN_ROUTE_CATEGORIES["ultrabrain"].fallback_models == ("deep",)
+    assert BUILTIN_ROUTE_CATEGORIES["deep"].fallback_models == ("quick",)
+    assert BUILTIN_ROUTE_CATEGORIES["quick"].fallback_models == ("default",)
+    assert BUILTIN_ROUTE_CATEGORIES["visual"].fallback_models == ("quick",)
+    assert BUILTIN_ROUTE_CATEGORIES["writing"].fallback_models == ("quick",)
+    assert BUILTIN_ROUTE_CATEGORIES["artistry"].fallback_models == ("visual",)
+    assert BUILTIN_ROUTE_CATEGORIES["unspecified_low"].fallback_models == ("default",)
+    assert BUILTIN_ROUTE_CATEGORIES["unspecified_high"].fallback_models == ("deep",)

--- a/tests/agent/test_runtime_activation.py
+++ b/tests/agent/test_runtime_activation.py
@@ -1,0 +1,528 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.intent_preclassifier import IntentPreclassification, preclassify_intent
+from hermes_cli.command_templates import build_command_invocation
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _sample_task_contract() -> dict:
+    return {
+        "task": "Implement the delegated change",
+        "expected_outcome": "A passing implementation with verification evidence",
+        "required_skills": ["python", "testing"],
+        "required_tools": ["read_file", "patch", "terminal"],
+        "must_do": [
+            "inspect repo patterns before editing",
+            {"verification": ["run targeted pytest", "report exact command output"]},
+        ],
+        "must_not_do": {
+            "forbidden_files": ["tools/delegate_tool.py"],
+            "notes": ["do not flatten structured contract sections into prose"],
+        },
+        "context": {
+            "ticket": "W2-2 / PR-W2-2",
+            "paths": {"repo": "/root/.hermes/hermes-agent"},
+        },
+    }
+
+
+class TestRuntimeActivationPreclassifier:
+    def test_ultrawork_and_ulw_alias_to_same_runtime_target(self):
+        ultrawork = preclassify_intent("Use ultrawork mode to implement the patch and run tests.")
+        ulw = preclassify_intent("Use ulw mode to implement the patch and run tests.")
+
+        assert ultrawork.inferred_runtime_mode == "ultrawork"
+        assert ulw.inferred_runtime_mode == "ultrawork"
+        assert ultrawork.inferred_specialist == ulw.inferred_specialist == "builder"
+        assert ultrawork.inferred_archetype == ulw.inferred_archetype == "implementer"
+        assert ultrawork.inferred_route_category == ulw.inferred_route_category == "deep"
+        assert "ultrawork" in ultrawork.activation_reason
+        assert "ulw" in ulw.activation_reason
+
+    def test_ralph_keyword_resolves_to_distinct_runtime_target(self):
+        result = preclassify_intent("Use ralph mode to implement the patch and keep working until the task is closed.")
+
+        assert result.inferred_runtime_mode == "ralph"
+        assert result.inferred_specialist == "builder"
+        assert result.inferred_archetype == "implementer"
+        assert result.inferred_route_category == "deep"
+        assert "ralph" in result.activation_reason
+
+    def test_loop_commands_preserve_distinct_runtime_modes_via_structured_contracts(self):
+        ralph = build_command_invocation(
+            "ralph-loop",
+            raw_args="Implement the requested change",
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+        ulw = build_command_invocation(
+            "ulw-loop",
+            raw_args="Implement the requested change",
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+
+        ralph_result = preclassify_intent({"message": "Implement the requested change", "task_contract": ralph.task_contract})
+        ulw_result = preclassify_intent({"message": "Implement the requested change", "task_contract": ulw.task_contract})
+
+        ralph_runtime = ralph.task_contract["context"]["command_runtime"]
+        ulw_runtime = ulw.task_contract["context"]["command_runtime"]
+
+        assert ralph_runtime["command_name"] == "ralph-loop"
+        assert ralph_runtime["runtime_mode"] == "ralph"
+        assert ralph_runtime["continuation_semantics"] == {
+            "retry_on_failed_or_interrupted": True,
+            "stop_requires_explicit_exit": True,
+        }
+        assert ulw_runtime["command_name"] == "ulw-loop"
+        assert ulw_runtime["runtime_mode"] == "ultrawork"
+        assert ulw_runtime["continuation_semantics"] == {
+            "completion_gate": "open_todos_block_done",
+            "require_open_work_closure": True,
+        }
+        assert ralph_result.inferred_runtime_mode == "ralph"
+        assert ulw_result.inferred_runtime_mode == "ultrawork"
+        assert ralph_result.task_contract is not None
+        assert ulw_result.task_contract is not None
+        assert ralph_result.task_contract.model_dump() == ralph.task_contract
+        assert ulw_result.task_contract.model_dump() == ulw.task_contract
+
+    def test_preclassifier_is_deterministic_for_same_input(self):
+        message = "Research the API behavior, compare sources, and summarize the findings."
+
+        first = preclassify_intent(message)
+        second = preclassify_intent(message)
+
+        assert first == second
+        assert first.inferred_specialist == "analyst"
+        assert first.inferred_archetype == "researcher"
+        assert first.inferred_route_category == "deep"
+        assert first.inferred_runtime_mode == "default"
+        assert first.inferred_delegation_profile == "research"
+
+    def test_unknown_or_underspecified_input_falls_back_safely(self):
+        result = preclassify_intent("help")
+
+        assert result.inferred_specialist is None
+        assert result.inferred_archetype == "generalist"
+        assert result.inferred_route_category == "unspecified_low"
+        assert result.inferred_runtime_mode == "default"
+        assert result.inferred_delegation_profile == "general"
+        assert "fallback" in result.activation_reason.lower()
+
+    def test_specialist_runtime_route_and_delegation_layers_remain_distinct(self):
+        result = preclassify_intent(
+            "Research the architecture, but activate ultrawork while keeping the work in the deep lane."
+        )
+
+        assert result.inferred_specialist == "investigator"
+        assert result.inferred_archetype == "researcher"
+        assert result.inferred_delegation_profile == "research"
+        assert result.inferred_route_category == "deep"
+        assert result.inferred_runtime_mode == "ultrawork"
+        assert result.inferred_specialist != result.inferred_archetype
+        assert result.inferred_specialist != result.inferred_route_category
+        assert result.inferred_specialist != result.inferred_runtime_mode
+        assert result.inferred_archetype != result.inferred_route_category
+        assert result.inferred_archetype != result.inferred_runtime_mode
+        assert result.inferred_delegation_profile != result.inferred_route_category
+
+    def test_task_contract_remains_structured_and_is_not_collapsed_into_prose(self):
+        task_contract = _sample_task_contract()
+
+        result = preclassify_intent(
+            {"message": "Implement the change in ultrawork mode.", "task_contract": task_contract}
+        )
+
+        assert isinstance(result, IntentPreclassification)
+        assert result.inferred_specialist == "builder"
+        assert result.task_contract is not None
+        assert result.task_contract.model_dump() == task_contract
+        assert isinstance(result.task_contract.must_do, list)
+        assert isinstance(result.task_contract.must_not_do, dict)
+        assert isinstance(result.task_contract.context, dict)
+
+    def test_ambiguous_review_prompt_exposes_specialist_without_overloading_archetype(self):
+        result = preclassify_intent("Review this patch, verify the risky changes, and call out regressions.")
+
+        assert result.inferred_specialist == "code_reviewer"
+        assert result.inferred_archetype == "verifier"
+        assert result.inferred_delegation_profile == "verification"
+        assert result.inferred_route_category == "quick"
+        assert "specialist=code_reviewer" in result.activation_reason
+        assert "archetype=verifier" in result.activation_reason
+
+    def test_planner_specialist_applies_overlay_defaults_without_collapsing_into_archetype(self):
+        result = preclassify_intent("Plan the rollout, decompose the work, and sequence the execution plan.")
+
+        assert result.inferred_specialist == "planner"
+        assert result.inferred_archetype == "generalist"
+        assert result.inferred_route_category == "deep"
+        assert result.inferred_delegation_profile == "general"
+        assert result.inferred_specialist != result.inferred_archetype
+        assert "specialist=planner" in result.activation_reason
+
+    @pytest.mark.parametrize(
+        ("prompt", "specialist", "archetype", "route_category", "delegation_profile"),
+        [
+            (
+                "implement the delegated change",
+                "builder",
+                "implementer",
+                "deep",
+                "implementation",
+            ),
+            (
+                "Review this patch, verify the risky changes, and call out regressions.",
+                "code_reviewer",
+                "verifier",
+                "quick",
+                "verification",
+            ),
+            (
+                "qa regression validate the fix",
+                "qa_guard",
+                "verifier",
+                "quick",
+                "verification",
+            ),
+            (
+                "Plan the rollout, decompose the work, and sequence the execution plan.",
+                "planner",
+                "generalist",
+                "deep",
+                "general",
+            ),
+            (
+                "Reproduce the bug, trace the failure, and identify the root cause.",
+                "bug_hunter",
+                "implementer",
+                "deep",
+                "implementation",
+            ),
+            (
+                "Analyze the API behavior, compare sources, and synthesize the findings.",
+                "analyst",
+                "researcher",
+                "deep",
+                "research",
+            ),
+            (
+                "Investigate the architecture, gather evidence, and triage the issue.",
+                "investigator",
+                "researcher",
+                "deep",
+                "research",
+            ),
+        ],
+        ids=["builder", "code_reviewer", "qa_guard", "planner", "bug_hunter", "analyst", "investigator"],
+    )
+    def test_preclassifier_specialist_matrix_keeps_taxonomy_layers_explicit(
+        self,
+        prompt: str,
+        specialist: str,
+        archetype: str,
+        route_category: str,
+        delegation_profile: str,
+    ):
+        result = preclassify_intent(prompt)
+
+        assert result.inferred_specialist == specialist
+        assert result.inferred_archetype == archetype
+        assert result.inferred_route_category == route_category
+        assert result.inferred_delegation_profile == delegation_profile
+        assert result.inferred_runtime_mode == "default"
+        assert f"specialist={specialist}" in result.activation_reason
+        assert f"archetype={archetype}" in result.activation_reason
+        assert f"route_category={route_category}" in result.activation_reason
+        assert f"delegation_profile={delegation_profile}" in result.activation_reason
+        assert "runtime_mode=default" in result.activation_reason
+
+        if specialist != archetype:
+            assert result.inferred_specialist != result.inferred_archetype
+        assert result.inferred_specialist != result.inferred_route_category
+        assert result.inferred_specialist != result.inferred_runtime_mode
+        assert result.inferred_archetype != result.inferred_route_category
+        assert result.inferred_archetype != result.inferred_runtime_mode
+        assert result.inferred_delegation_profile != result.inferred_route_category
+
+    def test_runtime_activation_normalizes_legacy_reviewer_alias_to_canonical_specialist(self):
+        agent = _make_agent()
+        legacy_alias = SimpleNamespace(
+            inferred_specialist="reviewer",
+            inferred_archetype="verifier",
+            inferred_route_category="quick",
+            inferred_runtime_mode="default",
+            inferred_delegation_profile="verification",
+            activation_reason="legacy specialist alias",
+            task_contract=None,
+            inference_source="test_preclassifier",
+        )
+
+        with patch("run_agent.preclassify_intent", return_value=legacy_alias):
+            state = agent._resolve_runtime_activation_state("Review this patch.")
+
+        assert state["specialist"] == "code_reviewer"
+        assert state["archetype"] == "verifier"
+        assert state["route_category"] == "quick"
+        assert state["delegation_profile"] == "verification"
+        assert state["runtime_mode"] == "default"
+        assert state["inference_source"] == "test_preclassifier"
+        assert "specialist: code_reviewer" in state["activation_note"]
+        assert "## Archetype\nname: verifier" in state["wave1_overlay_prompt"]
+        assert "## Delegation Profile\nname: verification" in state["wave1_overlay_prompt"]
+
+    def test_preclassifier_mixed_review_and_bug_prompt_keeps_keyword_collision_behavior_explicit(self):
+        result = preclassify_intent(
+            "Review this patch, reproduce the bug, and call out regressions with verification evidence."
+        )
+
+        assert result.inferred_specialist == "bug_hunter"
+        assert result.inferred_archetype == "implementer"
+        assert result.inferred_route_category == "deep"
+        assert result.inferred_delegation_profile == "implementation"
+        assert result.inferred_runtime_mode == "default"
+        assert "specialist=bug_hunter" in result.activation_reason
+        assert "specialist=code_reviewer" not in result.activation_reason
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+class _FakeClient(MagicMock):
+    pass
+
+
+def _make_agent(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-12345678",
+            base_url="https://example.test/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = _FakeClient()
+    return agent
+
+
+class TestRuntimeActivationRunAgentIntegration:
+    def test_run_conversation_stores_and_applies_top_level_runtime_activation(self):
+        agent = _make_agent("delegate_task")
+        captured_api_kwargs = {}
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Done.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            result = agent.run_conversation("Use ultrawork mode to implement the patch and run tests.")
+
+        assert result["final_response"] == "Done."
+        state = agent.get_runtime_activation_state()
+        assert state["specialist"] == "builder"
+        assert state["archetype"] == "implementer"
+        assert state["route_category"] == "deep"
+        assert state["delegation_profile"] == "implementation"
+        assert state["runtime_mode"] == "ultrawork"
+        assert state["activation_applied"] is True
+        assert state["task_contract"] is None
+        assert "specialist: builder" in state["activation_note"]
+        assert "# Wave 1 Prompt Overlays" in state["wave1_overlay_prompt"]
+
+        injected_user_message = captured_api_kwargs["messages"][-1]["content"]
+        assert injected_user_message.startswith("Use ultrawork mode to implement the patch and run tests.")
+        assert "<wave2-runtime-activation>" in injected_user_message
+        assert "specialist: builder" in injected_user_message
+        assert "## Archetype" in injected_user_message
+        assert "## Route Category" in injected_user_message
+        assert "## Delegation Profile" in injected_user_message
+        assert "## Runtime Mode" in injected_user_message
+
+    def test_runtime_activation_snapshot_is_persisted_without_polluting_transcript(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-12345678",
+                base_url="https://example.test/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=db,
+                session_id="snapshot-session",
+            )
+        agent.client = _FakeClient()
+
+        def fake_api_call(_api_kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Done.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        classification = preclassify_intent(
+            {
+                "message": "Implement the delegated change in ultrawork mode.",
+                "task_contract": _sample_task_contract(),
+            }
+        )
+
+        with (
+            patch("run_agent.preclassify_intent", return_value=classification),
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+        ):
+            result = agent.run_conversation("Implement the delegated change in ultrawork mode.")
+
+        assert result["final_response"] == "Done."
+        snapshot = agent.get_runtime_activation_snapshot()
+        assert snapshot["current"]["archetype"] == "implementer"
+        assert snapshot["current"]["runtime_mode"] == "ultrawork"
+        assert snapshot["current"]["task_contract_present"] is True
+        assert "Implement the delegated change" in (snapshot["current"]["task_contract_summary"] or "")
+        assert snapshot["last"] is None
+
+        session_row = db.get_session("snapshot-session")
+        assert session_row["runtime_activation_snapshot"] == snapshot
+
+        transcript = db.get_messages_as_conversation("snapshot-session")
+        assert transcript[0]["role"] == "user"
+        assert "<wave2-runtime-activation>" not in (transcript[0]["content"] or "")
+        db.close()
+
+    def test_runtime_activation_snapshot_tracks_current_and_last_across_session_reload(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-12345678",
+                base_url="https://example.test/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=db,
+                session_id="reload-session",
+            )
+        agent.client = _FakeClient()
+
+        def fake_api_call(_api_kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Done.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            agent.run_conversation("Use ultrawork mode to implement the patch and run tests.")
+            agent.run_conversation("hello", conversation_history=db.get_messages_as_conversation("reload-session"))
+
+        snapshot = db.get_session("reload-session")["runtime_activation_snapshot"]
+        assert snapshot["current"]["runtime_mode"] == "default"
+        assert snapshot["last"]["runtime_mode"] == "ultrawork"
+        assert snapshot["last"]["archetype"] == "implementer"
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            reloaded = AIAgent(
+                api_key="test-key-12345678",
+                base_url="https://example.test/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=db,
+                session_id="reload-session",
+            )
+
+        assert reloaded.get_runtime_activation_snapshot() == snapshot
+        db.close()
+
+    def test_unknown_preclassifier_outputs_degrade_safely_without_activation_overlay(self):
+        agent = _make_agent()
+        captured_api_kwargs = {}
+
+        bogus = SimpleNamespace(
+            inferred_specialist="ghost_specialist",
+            inferred_archetype="ghost_archetype",
+            inferred_route_category="ghost_lane",
+            inferred_runtime_mode="ghost_runtime",
+            inferred_delegation_profile="",
+            activation_reason="classifier returned unknown values",
+            task_contract=None,
+            inference_source="test_preclassifier",
+        )
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Safe fallback.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with (
+            patch("run_agent.preclassify_intent", return_value=bogus),
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Safe fallback."
+        state = agent.get_runtime_activation_state()
+        assert state["specialist"] is None
+        assert state["archetype"] == "generalist"
+        assert state["route_category"] == "unspecified_low"
+        assert state["delegation_profile"] == "general"
+        assert state["runtime_mode"] == "default"
+        assert state["activation_applied"] is False
+        assert captured_api_kwargs["messages"][-1]["content"] == "hello"

--- a/tests/agent/test_runtime_activation.py
+++ b/tests/agent/test_runtime_activation.py
@@ -5,6 +5,7 @@ import pytest
 
 from agent.intent_preclassifier import IntentPreclassification, preclassify_intent
 from hermes_cli.command_templates import build_command_invocation
+from hermes_cli.work_command_adapter import prepare_work_command
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -218,8 +219,15 @@ class TestRuntimeActivationPreclassifier:
                 "deep",
                 "research",
             ),
+            (
+                "Inspect this PDF diagram and explain the visual flow.",
+                "multimodal_specialist",
+                "researcher",
+                "visual",
+                "research",
+            ),
         ],
-        ids=["builder", "code_reviewer", "qa_guard", "planner", "bug_hunter", "analyst", "investigator"],
+        ids=["builder", "code_reviewer", "qa_guard", "planner", "bug_hunter", "analyst", "investigator", "multimodal_specialist"],
     )
     def test_preclassifier_specialist_matrix_keeps_taxonomy_layers_explicit(
         self,
@@ -276,6 +284,24 @@ class TestRuntimeActivationPreclassifier:
         assert "## Archetype\nname: verifier" in state["wave1_overlay_prompt"]
         assert "## Delegation Profile\nname: verification" in state["wave1_overlay_prompt"]
 
+    def test_runtime_activation_extracts_structured_contract_from_rendered_handoff_prompt(self):
+        agent = _make_agent()
+        invocation = build_command_invocation(
+            "handoff",
+            raw_args='{"task":"Resume the delegated task","expected_outcome":"Done","required_skills":["python"],"required_tools":["terminal"],"must_do":["inspect state"],"must_not_do":["discard context"],"context":{"ticket":"p1"}}',
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+
+        state = agent._resolve_runtime_activation_state(invocation.prompt_text)
+
+        assert state["task_contract"] == invocation.task_contract
+        assert state["runtime_mode"] == "default"
+        assert state["delegation_profile"] == "general"
+        assert state["named_workflow"] is None
+        assert state["activation_applied"] is True
+        assert "Resume the delegated task" in (state["activation_note"] or "")
+
     def test_preclassifier_mixed_review_and_bug_prompt_keeps_keyword_collision_behavior_explicit(self):
         result = preclassify_intent(
             "Review this patch, reproduce the bug, and call out regressions with verification evidence."
@@ -288,6 +314,17 @@ class TestRuntimeActivationPreclassifier:
         assert result.inferred_runtime_mode == "default"
         assert "specialist=bug_hunter" in result.activation_reason
         assert "specialist=code_reviewer" not in result.activation_reason
+
+    def test_preclassifier_routes_pdf_and_diagram_work_to_multimodal_specialist(self):
+        result = preclassify_intent("Inspect this PDF diagram and explain the visual flow.")
+
+        assert result.inferred_specialist == "multimodal_specialist"
+        assert result.inferred_archetype == "researcher"
+        assert result.inferred_route_category == "visual"
+        assert result.inferred_delegation_profile == "research"
+        assert result.inferred_runtime_mode == "default"
+        assert "specialist=multimodal_specialist" in result.activation_reason
+        assert "route_category=visual" in result.activation_reason
 
 
 def _make_tool_defs(*names: str) -> list[dict]:
@@ -327,6 +364,71 @@ def _make_agent(*tool_names: str) -> AIAgent:
 
 
 class TestRuntimeActivationRunAgentIntegration:
+    def test_multimodal_runtime_activation_applies_when_multimodal_tools_are_loaded(self):
+        agent = _make_agent("vision_analyze")
+        captured_api_kwargs = {}
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Visual analysis ready.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            result = agent.run_conversation("Inspect this PDF diagram and explain the visual flow.")
+
+        assert result["final_response"] == "Visual analysis ready."
+        state = agent.get_runtime_activation_state()
+        assert state["specialist"] == "multimodal_specialist"
+        assert state["archetype"] == "researcher"
+        assert state["route_category"] == "visual"
+        assert state["delegation_profile"] == "research"
+        assert state["runtime_mode"] == "default"
+        assert state["activation_applied"] is True
+        assert "specialist: multimodal_specialist" in state["activation_note"]
+        assert "## Route Category\nname: visual" in state["wave1_overlay_prompt"]
+
+        injected_user_message = captured_api_kwargs["messages"][-1]["content"]
+        assert "<wave2-runtime-activation>" in injected_user_message
+        assert "specialist: multimodal_specialist" in injected_user_message
+
+    @pytest.mark.parametrize("tool_name", ["browser_navigate", "browser_snapshot", None])
+    def test_multimodal_runtime_activation_falls_back_safely_when_multimodal_tools_are_unavailable(self, tool_name):
+        agent = _make_agent(*( [tool_name] if tool_name else [] ))
+        captured_api_kwargs = {}
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Safe fallback.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            result = agent.run_conversation("Inspect this PDF diagram and explain the visual flow.")
+
+        assert result["final_response"] == "Safe fallback."
+        state = agent.get_runtime_activation_state()
+        assert state["specialist"] is None
+        assert state["archetype"] == "generalist"
+        assert state["route_category"] == "unspecified_low"
+        assert state["delegation_profile"] == "general"
+        assert state["runtime_mode"] == "default"
+        assert state["activation_applied"] is False
+        assert "multimodal tools unavailable" in state["activation_reason"]
+        assert captured_api_kwargs["messages"][-1]["content"] == "Inspect this PDF diagram and explain the visual flow."
+
     def test_run_conversation_stores_and_applies_top_level_runtime_activation(self):
         agent = _make_agent("delegate_task")
         captured_api_kwargs = {}
@@ -410,7 +512,9 @@ class TestRuntimeActivationRunAgentIntegration:
         ):
             result = agent.run_conversation("Implement the delegated change in ultrawork mode.")
 
-        assert result["final_response"] == "Done."
+        assert result["final_response"].startswith(
+            "Task contract completion gate blocked success: required tool(s) unavailable in this runtime:"
+        )
         snapshot = agent.get_runtime_activation_snapshot()
         assert snapshot["current"]["archetype"] == "implementer"
         assert snapshot["current"]["runtime_mode"] == "ultrawork"
@@ -425,6 +529,151 @@ class TestRuntimeActivationRunAgentIntegration:
         assert transcript[0]["role"] == "user"
         assert "<wave2-runtime-activation>" not in (transcript[0]["content"] or "")
         db.close()
+
+    def test_run_conversation_accepts_prepared_handoff_command_objects(self):
+        agent = _make_agent()
+        prepared = prepare_work_command(
+            "handoff",
+            raw_args='{"task":"Resume the delegated task","expected_outcome":"Done","required_skills":["python"],"required_tools":["terminal"],"must_do":["inspect state"],"must_not_do":["discard context"],"context":{"ticket":"p1"}}',
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+        captured_api_kwargs = {}
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Done.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            result = agent.run_conversation(prepared)
+
+        assert result["final_response"].startswith(
+            "Task contract completion gate blocked success: required tool(s) unavailable in this runtime:"
+        )
+        state = agent.get_runtime_activation_state()
+        assert state["task_contract"] == prepared.task_contract
+        assert state["named_workflow"] is None
+        assert captured_api_kwargs["messages"][-1]["content"].startswith("[OMO command handoff]")
+
+    def test_run_conversation_supports_leading_named_agent_invocation_for_oracle(self):
+        agent = _make_agent("read_file", "search_files", "web_search", "terminal", "patch")
+        captured_api_kwargs = {}
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Done.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            result = agent.run_conversation("@oracle Compare the docs and summarize the answer.")
+
+        assert result["final_response"] == "Done."
+        state = agent.get_runtime_activation_state()
+        assert state["named_agent"] == "oracle"
+        assert state["specialist"] == "consultant"
+        assert state["archetype"] == "researcher"
+        assert state["route_category"] == "deep"
+        assert state["delegation_profile"] == "research"
+        assert state["runtime_mode"] == "default"
+        assert state["activation_applied"] is True
+        assert "named_agent: oracle" in state["activation_note"]
+        assert "named-agent invocation" in state["activation_reason"]
+
+        injected_user_message = captured_api_kwargs["messages"][-1]["content"]
+        assert injected_user_message.startswith("Compare the docs and summarize the answer.")
+        assert "@oracle" not in injected_user_message
+        assert "<wave2-runtime-activation>" in injected_user_message
+
+        assert agent._maybe_block_named_role_tool_call("terminal", {"command": "git status"}) == (
+            "Named role runtime boundary (oracle): tool 'terminal' is blocked for this role. "
+            "Use the role's permitted tools instead."
+        )
+
+    def test_run_conversation_canonicalizes_leading_named_agent_alias_invocation(self):
+        agent = _make_agent("read_file", "search_files", "web_search", "terminal", "patch")
+        captured_api_kwargs = {}
+
+        def fake_api_call(api_kwargs):
+            captured_api_kwargs.update(api_kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Explored.", tool_calls=[]),
+                    )
+                ],
+                usage=None,
+            )
+
+        with patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call):
+            result = agent.run_conversation("@explorer Trace the relevant files.")
+
+        assert result["final_response"] == "Explored."
+        state = agent.get_runtime_activation_state()
+        assert state["named_agent"] == "explore"
+        assert state["specialist"] == "investigator"
+        assert state["archetype"] == "researcher"
+        assert state["route_category"] == "deep"
+        assert state["delegation_profile"] == "research"
+        assert captured_api_kwargs["messages"][-1]["content"].startswith("Trace the relevant files.")
+        assert "@explorer" not in captured_api_kwargs["messages"][-1]["content"]
+
+    def test_prepared_work_command_uses_display_text_for_hooks_and_memory_sync(self):
+        agent = _make_agent()
+        prepared = prepare_work_command(
+            "handoff",
+            raw_args='{"task":"Resume the delegated task","expected_outcome":"Done","required_skills":["python"],"required_tools":["terminal"],"must_do":["inspect state"],"must_not_do":["discard context"],"context":{"ticket":"p1"}}',
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+        sync_calls = []
+        prefetch_calls = []
+        hook_calls = []
+
+        class _FakeMemoryManager:
+            def sync_all(self, user_message, assistant_response):
+                sync_calls.append((user_message, assistant_response))
+
+            def queue_prefetch_all(self, user_message):
+                prefetch_calls.append(user_message)
+
+        def fake_invoke_hook(name, **kwargs):
+            if name == "post_llm_call":
+                hook_calls.append(kwargs)
+
+        agent._memory_manager = _FakeMemoryManager()
+
+        with (
+            patch.object(agent, "_interruptible_api_call", return_value=SimpleNamespace(
+                choices=[SimpleNamespace(finish_reason="stop", message=SimpleNamespace(content="Done.", tool_calls=[]))],
+                usage=None,
+            )),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=fake_invoke_hook),
+        ):
+            result = agent.run_conversation(prepared)
+
+        assert result["final_response"].startswith(
+            "Task contract completion gate blocked success: required tool(s) unavailable in this runtime:"
+        )
+        assert sync_calls == [(prepared.display_text, result["final_response"])]
+        assert prefetch_calls == [prepared.display_text]
+        assert hook_calls[-1]["user_message"] == prepared.display_text
+        assert isinstance(hook_calls[-1]["user_message"], str)
 
     def test_runtime_activation_snapshot_tracks_current_and_last_across_session_reload(self, tmp_path):
         db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,4 +1,7 @@
-from agent.smart_model_routing import choose_cheap_model_route
+from agent.smart_model_routing import (
+    choose_cheap_model_route,
+    choose_primary_agent_route,
+)
 
 
 _BASE_CONFIG = {
@@ -7,6 +10,14 @@ _BASE_CONFIG = {
         "provider": "openrouter",
         "model": "google/gemini-2.5-flash",
     },
+}
+
+_PRIMARY = {
+    "model": "anthropic/claude-sonnet-4",
+    "provider": "openrouter",
+    "base_url": "https://openrouter.ai/api/v1",
+    "api_mode": "chat_completions",
+    "api_key": "***",
 }
 
 
@@ -38,6 +49,89 @@ def test_skips_tool_heavy_prompt_keywords():
     assert choose_cheap_model_route(prompt, _BASE_CONFIG) is None
 
 
+def test_primary_agent_route_requires_enabled_flag():
+    cfg = {
+        "enabled": False,
+        "primary_agent": {"provider": "anthropic", "model": "claude-sonnet-4.6"},
+    }
+    assert choose_primary_agent_route(cfg) is None
+
+
+def test_resolve_turn_route_uses_configured_primary_agent_when_prompt_is_complex(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "strong-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    result = resolve_turn_route(
+        "implement a patch for this docker error",
+        {
+            **_BASE_CONFIG,
+            "primary_agent": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4.6",
+            },
+        },
+        _PRIMARY,
+    )
+
+    assert len(calls) == 1
+    assert result["model"] == "claude-sonnet-4.6"
+    assert result["runtime"]["provider"] == "anthropic"
+    assert result["runtime"]["api_key"] == "strong-key"
+    assert result["label"] == "smart route → primary claude-sonnet-4.6 (anthropic)"
+
+
+def test_resolve_turn_route_falls_back_to_configured_primary_agent_when_cheap_runtime_cannot_be_resolved(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs["requested"])
+        if kwargs["requested"] == "openrouter":
+            raise RuntimeError("cheap route unavailable")
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "strong-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        {
+            **_BASE_CONFIG,
+            "primary_agent": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4.6",
+            },
+        },
+        _PRIMARY,
+    )
+
+    assert calls == ["openrouter", "anthropic"]
+    assert result["model"] == "claude-sonnet-4.6"
+    assert result["runtime"]["provider"] == "anthropic"
+    assert result["label"] == "smart route → primary claude-sonnet-4.6 (anthropic)"
+
+
 def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_resolved(monkeypatch):
     from agent.smart_model_routing import resolve_turn_route
 
@@ -48,13 +142,7 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     result = resolve_turn_route(
         "what time is it in tokyo?",
         _BASE_CONFIG,
-        {
-            "model": "anthropic/claude-sonnet-4",
-            "provider": "openrouter",
-            "base_url": "https://openrouter.ai/api/v1",
-            "api_mode": "chat_completions",
-            "api_key": "sk-primary",
-        },
+        _PRIMARY,
     )
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"

--- a/tests/cli/test_cli_model_picker.py
+++ b/tests/cli/test_cli_model_picker.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text="", cursor_position=None):
+        self.text = text
+        self.cursor_position = len(text) if cursor_position is None else cursor_position
+
+    def reset(self, append_to_history=False):
+        self.text = ""
+        self.cursor_position = 0
+
+
+def _make_cli_stub(initial_text="/model"):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer(initial_text))
+    cli._invalidate = MagicMock()
+    cli._model_picker_state = None
+    cli._modal_input_snapshot = None
+    cli.model = "glm-5.1"
+    cli.provider = "zai"
+    cli.requested_provider = "zai"
+    cli.api_key = ""
+    cli.base_url = "https://api.z.ai/api/coding/paas/v4"
+    cli.api_mode = "chat_completions"
+    cli.agent = None
+    return cli
+
+
+def test_model_picker_does_not_restore_triggering_slash_command_after_selection():
+    cli = _make_cli_stub("/model")
+    providers = [{
+        "slug": "zai",
+        "name": "Z.AI",
+        "models": ["glm-5.1"],
+        "total_models": 1,
+        "is_current": True,
+    }]
+    switch_result = SimpleNamespace(
+        success=True,
+        new_model="glm-5.1",
+        target_provider="zai",
+        provider_changed=False,
+        api_key="",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        api_mode="chat_completions",
+        error_message="",
+        warning_message="",
+        provider_label="Z.AI",
+        model_info=None,
+    )
+
+    with patch("cli._cprint"), \
+         patch("hermes_cli.model_switch.list_authenticated_providers", return_value=providers), \
+         patch("hermes_cli.models.provider_model_ids", return_value=[]), \
+         patch("hermes_cli.model_switch.switch_model", return_value=switch_result):
+        cli._handle_model_switch("/model")
+        assert cli._model_picker_state is not None
+        assert cli._modal_input_snapshot is None
+        assert cli._app.current_buffer.text == ""
+
+        cli._handle_model_picker_selection()
+        assert cli._model_picker_state["stage"] == "model"
+
+        cli._handle_model_picker_selection()
+        assert cli._model_picker_state is None
+        assert cli._app.current_buffer.text == ""

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -251,6 +251,41 @@ def test_cli_turn_routing_uses_cheap_model_when_simple(monkeypatch):
     assert result["label"] is not None
 
 
+def test_cli_turn_routing_uses_configured_primary_agent_when_prompt_is_complex(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "***",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://openrouter.ai/api/v1"
+    shell.api_key = "primary-key"
+    shell._smart_model_routing = {
+        "enabled": True,
+        "cheap_model": {"provider": "zai", "model": "glm-5-air"},
+        "primary_agent": {"provider": "anthropic", "model": "claude-sonnet-4.6"},
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+    }
+
+    result = shell._resolve_turn_agent_config("implement a patch for this docker error")
+
+    assert result["model"] == "claude-sonnet-4.6"
+    assert result["runtime"]["provider"] == "anthropic"
+    assert result["label"] == "smart route → primary claude-sonnet-4.6 (anthropic)"
+
+
 def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
     cli = _import_cli()
 

--- a/tests/gateway/test_api_server_authority.py
+++ b/tests/gateway/test_api_server_authority.py
@@ -1,0 +1,184 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware, security_headers_middleware
+from gateway.config import PlatformConfig
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/authority/snapshot", adapter._handle_authority_snapshot)
+    return app
+
+
+def _seed_profile(profile_root: Path, *, session_id: str = "session-123") -> None:
+    profile_root.mkdir(parents=True, exist_ok=True)
+    (profile_root / "workspace").mkdir(parents=True, exist_ok=True)
+    (profile_root / "runtime" / "orchestration").mkdir(parents=True, exist_ok=True)
+    (profile_root / "runtime" / "runs").mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "model": {
+            "default": "glm-5.1",
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+        },
+        "agent": {
+            "max_turns": 42,
+            "reasoning_effort": "high",
+            "tool_use_enforcement": "required",
+        },
+        "ui_policy_preset": "full-power",
+        "toolsets": ["terminal", "file"],
+        "terminal": {
+            "backend": "local",
+            "timeout": 180,
+            "cwd": str(profile_root / "workspace"),
+        },
+        "memory": {
+            "memory_enabled": True,
+            "user_profile_enabled": True,
+        },
+        "compression": {
+            "enabled": True,
+            "threshold": 0.5,
+        },
+    }
+    (profile_root / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    (profile_root / "SOUL.md").write_text("You are Hermes.\n", encoding="utf-8")
+
+    db = SessionDB(profile_root / "state.db")
+    db.create_session(
+        session_id,
+        source="webui",
+        model="glm-5.1",
+        model_config={
+            "provider": "zai",
+            "policyPreset": "full-power",
+            "memoryMode": "standard",
+            "loadedSkillIds": ["skill-authoring"],
+            "pinned": True,
+        },
+    )
+    db.append_message(session_id, "user", "Hello gateway authority")
+    db.append_message(session_id, "assistant", "Hi from Hermes authority")
+    db.close()
+
+    runs_payload = {
+        "runs": [
+            {
+                "id": "run-123",
+                "session_id": session_id,
+                "status": "completed",
+                "source": "webui-stream",
+                "started_at": "2026-04-17T00:00:00Z",
+                "updated_at": "2026-04-17T00:00:05Z",
+                "finished_at": "2026-04-17T00:00:05Z",
+                "last_error": None,
+            }
+        ]
+    }
+    (profile_root / "runtime" / "runs" / "index.json").write_text(json.dumps(runs_payload), encoding="utf-8")
+
+    continuations_payload = {
+        "items": [
+            {
+                "sessionId": session_id,
+                "status": "pending",
+                "reason": "needs follow-up",
+                "responsePreview": "Hi from Hermes authority",
+                "openTodos": [{"id": "todo-1", "content": "Finish review", "status": "pending"}],
+                "createdAt": "2026-04-17T00:00:00Z",
+                "updatedAt": "2026-04-17T00:00:05Z",
+                "attemptCount": 1,
+                "events": [{"type": "pending_created", "timestamp": "2026-04-17T00:00:00Z", "message": "Created"}],
+            },
+            {
+                "sessionId": "session-history",
+                "status": "resolved",
+                "reason": "done",
+                "responsePreview": "Completed",
+                "openTodos": [],
+                "createdAt": "2026-04-16T00:00:00Z",
+                "updatedAt": "2026-04-16T00:00:05Z",
+                "attemptCount": 0,
+                "events": [{"type": "resolved", "timestamp": "2026-04-16T00:00:05Z", "message": "Resolved"}],
+            },
+        ]
+    }
+    (profile_root / "runtime" / "orchestration" / "continuations.json").write_text(
+        json.dumps(continuations_payload),
+        encoding="utf-8",
+    )
+
+
+class TestAuthoritySnapshotEndpoint:
+    def test_returns_profile_scoped_authority_snapshot(self, tmp_path, monkeypatch):
+        async def _scenario():
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+            profile_root = tmp_path / "profiles" / "generic-core"
+            _seed_profile(profile_root)
+
+            adapter = _make_adapter()
+            app = _create_app(adapter)
+
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/authority/snapshot?profile_id=generic-core&search=gateway&session_id=session-123")
+                assert resp.status == 200
+                payload = await resp.json()
+
+            assert payload["profileId"] == "generic-core"
+            assert payload["config"]["modelDefault"] == "glm-5.1"
+            assert payload["config"]["policyPreset"] == "full-power"
+            assert len(payload["profiles"]) >= 1
+            assert any(profile["id"] == "generic-core" for profile in payload["profiles"])
+            assert len(payload["sessions"]) == 1
+            assert payload["sessions"][0]["id"] == "session-123"
+            assert payload["sessions"][0]["pinned"] is True
+            assert payload["session"]["id"] == "session-123"
+            assert payload["session"]["pinned"] is True
+            assert payload["session"]["messages"][0]["content"] == "Hello gateway authority"
+            assert payload["runs"][0]["id"] == "run-123"
+            assert len(payload["continuations"]) == 1
+            assert len(payload["history"]) == 1
+            assert payload["workspaces"]["current"]["path"] == str(profile_root / "workspace")
+
+        asyncio.run(_scenario())
+
+    def test_requires_auth_when_api_key_is_configured(self, tmp_path, monkeypatch):
+        async def _scenario():
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+            _seed_profile(tmp_path / "profiles" / "generic-core")
+
+            adapter = _make_adapter(api_key="sk-secret")
+            app = _create_app(adapter)
+
+            async with TestClient(TestServer(app)) as cli:
+                denied = await cli.get("/api/authority/snapshot?profile_id=generic-core")
+                assert denied.status == 401
+
+                allowed = await cli.get(
+                    "/api/authority/snapshot?profile_id=generic-core",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert allowed.status == 200
+                payload = await allowed.json()
+                assert payload["profileId"] == "generic-core"
+
+        asyncio.run(_scenario())

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -35,6 +35,15 @@ class TestHermesApiServerToolset:
         for tool in expected:
             assert tool in tools, f"Missing expected tool: {tool}"
 
+    def test_toolset_includes_code_intel_tools(self):
+        tools = resolve_toolset("hermes-api-server")
+        expected = [
+            "ast_list_defs", "ast_find_nodes",
+            "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
+        ]
+        for tool in expected:
+            assert tool in tools, f"Missing code_intel tool: {tool}"
+
     def test_toolset_includes_browser_tools(self):
         tools = resolve_toolset("hermes-api-server")
         for tool in ["browser_navigate", "browser_snapshot", "browser_click",

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from toolsets import resolve_toolset, get_toolset, validate_toolset
+from toolsets import resolve_toolset, get_toolset, get_toolset_contract, validate_toolset
 
 
 class TestHermesApiServerToolset:
@@ -22,6 +22,7 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "web_search" in tools
         assert "web_extract" in tools
+        assert "web_crawl" not in tools
 
     def test_toolset_includes_core_tools(self):
         tools = resolve_toolset("hermes-api-server")
@@ -34,6 +35,39 @@ class TestHermesApiServerToolset:
         ]
         for tool in expected:
             assert tool in tools, f"Missing expected tool: {tool}"
+
+    def test_toolset_includes_repo_code_knowledge_primitives(self):
+        tools = resolve_toolset("hermes-api-server")
+        expected = [
+            "read_file", "search_files",
+            "ast_list_defs", "ast_find_nodes",
+            "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
+        ]
+        for tool in expected:
+            assert tool in tools, f"Missing repo-code knowledge primitive: {tool}"
+
+    def test_api_server_default_covers_each_canonical_knowledge_surface_as_overlay(self):
+        api_tools = set(resolve_toolset("hermes-api-server"))
+        canonical_names = [
+            "repo-code-knowledge",
+            "web-research-knowledge",
+            "document-pdf-diagram-intelligence",
+        ]
+
+        for name in canonical_names:
+            contract = get_toolset_contract(name)
+            assert contract is not None
+            assert contract["canonical_name"] == name
+            assert contract["is_builtin"] is True
+            assert contract["is_additive"] is False
+            assert contract["is_canonical_knowledge_surface"] is True
+            assert set(contract["tools"]) <= api_tools
+
+    def test_api_server_default_is_not_replaced_by_canonical_surface_names(self):
+        contract = get_toolset_contract("hermes-api-server")
+        assert contract is not None
+        assert contract["canonical_name"] == "hermes-api-server"
+        assert contract["is_canonical_knowledge_surface"] is False
 
     def test_toolset_includes_code_intel_tools(self):
         tools = resolve_toolset("hermes-api-server")

--- a/tests/gateway/test_busy_replay_prepared_work_commands.py
+++ b/tests/gateway/test_busy_replay_prepared_work_commands.py
@@ -1,0 +1,144 @@
+import json
+from unittest.mock import MagicMock
+
+from agent.continuation_engine import should_use_continuation_engine
+from agent.intent_preclassifier import preclassify_intent
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import (
+    _get_prepared_work_command,
+    _is_discardable_pending_slash_command,
+    _pending_event_replay_text,
+)
+from hermes_cli.work_command_adapter import prepare_work_command
+
+
+def _handoff_payload() -> str:
+    return json.dumps(
+        {
+            "task": "Resume the delegated task",
+            "expected_outcome": "Implementation resumed with verification evidence",
+            "required_skills": ["python", "testing"],
+            "required_tools": ["read_file", "patch", "terminal"],
+            "must_do": ["inspect current state before acting"],
+            "must_not_do": ["discard the preserved contract"],
+            "context": {"ticket": "w2-t09"},
+        }
+    )
+
+
+def _raw_args_for(command_name: str) -> str:
+    if command_name == "handoff":
+        return _handoff_payload()
+    if command_name == "init-deep":
+        return "Investigate the migration surface"
+    if command_name == "start-work":
+        return "Continue the repo work"
+    if command_name == "ralph-loop":
+        return "Close the remaining work items"
+    if command_name == "ulw-loop":
+        return "Push the task to completion"
+    raise KeyError(command_name)
+
+
+def _event_text_for(command_name: str) -> str:
+    if command_name == "handoff":
+        return "/handoff Continue the repo work"
+    return f"/{command_name} {_raw_args_for(command_name)}"
+
+
+def _make_prepared_event(command_name: str = "handoff") -> MessageEvent:
+    event = MessageEvent(
+        text=_event_text_for(command_name),
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+        message_id="m1",
+    )
+    event._prepared_work_command = prepare_work_command(
+        command_name,
+        raw_args=_raw_args_for(command_name),
+        session_id="sess-1",
+        cwd="/tmp",
+    )
+    return event
+
+
+def test_pending_event_replay_text_uses_prepared_agent_message():
+    for command_name in ("handoff", "init-deep", "start-work", "ralph-loop", "ulw-loop"):
+        event = _make_prepared_event(command_name)
+
+        prepared = _get_prepared_work_command(event)
+
+        assert prepared is not None
+        assert _pending_event_replay_text(event) == prepared.agent_message
+        assert _pending_event_replay_text(event) != event.text
+        assert f"[OMO command {command_name}]" in _pending_event_replay_text(event)
+
+
+def test_pending_event_replay_preserves_continuation_semantics_for_work_commands():
+    expected = {
+        "handoff": ("default", False),
+        "init-deep": ("default", False),
+        "start-work": ("default", False),
+        "ralph-loop": ("ralph", True),
+        "ulw-loop": ("ultrawork", True),
+    }
+
+    for command_name, (expected_runtime_mode, should_continue) in expected.items():
+        event = _make_prepared_event(command_name)
+        prepared = _get_prepared_work_command(event)
+        replay_text = _pending_event_replay_text(event)
+
+        assert prepared is not None
+        assert replay_text == prepared.agent_message
+
+        classification = preclassify_intent({"message": prepared.task_contract["task"], "task_contract": prepared.task_contract})
+        assert classification.inferred_runtime_mode == expected_runtime_mode
+        assert should_use_continuation_engine(classification.inferred_runtime_mode, {
+            "outcomeStatus": "interrupted",
+            "activeTodos": [{"id": "todo-1", "content": "Finish the delegated task", "status": "in_progress"}],
+        }) is should_continue
+        if command_name == "start-work":
+            assert "NAMED_WORKFLOW_JSON:" in replay_text
+        elif should_continue:
+            assert f'"runtime_mode": "{expected_runtime_mode}"' in replay_text
+        else:
+            assert '"runtime_mode": "ralph"' not in replay_text
+            assert '"runtime_mode": "ultrawork"' not in replay_text
+
+
+def test_prepared_work_command_event_is_exempt_from_slash_discard_guard():
+    for command_name in ("handoff", "init-deep", "start-work", "ralph-loop", "ulw-loop"):
+        event = _make_prepared_event(command_name)
+        assert _is_discardable_pending_slash_command(event.text, event) is False
+
+
+def test_plain_control_slash_command_still_discarded_from_pending_replay():
+    event = MessageEvent(
+        text="/stop",
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+        message_id="m2",
+    )
+
+    assert _get_prepared_work_command(event) is None
+    assert _is_discardable_pending_slash_command(event.text, event) is True
+
+
+def test_plain_text_and_media_replay_behavior_is_unchanged():
+    text_event = MessageEvent(
+        text="follow-up question",
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+        message_id="m3",
+    )
+    media_event = MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=MagicMock(),
+        message_id="m4",
+        media_urls=["/tmp/image.png"],
+        media_types=["image/png"],
+    )
+
+    assert _pending_event_replay_text(text_event) == "follow-up question"
+    assert _pending_event_replay_text(media_event) == "[User sent an image: /tmp/image.png]"

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -19,7 +19,10 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
 
     Returns the resulting env dict (only TERMINAL_* and MESSAGING_CWD keys).
     """
+    from hermes_cli.config import _normalize_profile_path_settings
+
     env = dict(initial_env or {})
+    cfg = _normalize_profile_path_settings(cfg)
 
     # --- Replicate lines 54-56: generic top-level bridge (for context) ---
     for key, val in cfg.items():
@@ -182,6 +185,17 @@ class TestNestedTerminalCwdPlaceholderSkip:
         cfg = {"terminal": {"cwd": "/explicit/path"}}
         result = _simulate_config_bridge(cfg, {"TERMINAL_CWD": "/old/value"})
         assert result["TERMINAL_CWD"] == "/explicit/path"
+
+    def test_legacy_in_container_profile_cwd_is_normalized(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / "profiles" / "thindi"
+        workspace = profile_home / "workspace"
+        workspace.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        cfg = {"terminal": {"cwd": "/root/.hermes/profiles/thindi/workspace"}}
+        result = _simulate_config_bridge(cfg)
+
+        assert result["TERMINAL_CWD"] == str(workspace)
 
     def test_terminal_dot_cwd_falls_back_to_messaging_cwd(self):
         """terminal.cwd: '.' with no TERMINAL_CWD should fall to MESSAGING_CWD."""

--- a/tests/gateway/test_orchestration_continuation_gateway.py
+++ b/tests/gateway/test_orchestration_continuation_gateway.py
@@ -1,0 +1,471 @@
+import asyncio
+import importlib
+import sys
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import agent.continuation_enforcer as continuation_enforcer
+from agent.continuation_enforcer import get_continuation_record, reconcile_session_continuation, request_continuation_retry
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from agent.orchestration_state import get_session_state
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+class _ContinuationAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+class _BaseTodoAgent:
+    outcome_status = "completed"
+    run_result = {"final_response": "done", "messages": [], "api_calls": 1, "completed": True}
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.session_id = kwargs.get("session_id") or "sess-1"
+        self.tools = []
+        self.model = "openai/test-model"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return dict(self.run_result)
+
+    def get_orchestration_continuation_snapshot(self, result):
+        return {
+            "sessionId": self.session_id,
+            "outcomeStatus": self.outcome_status,
+            "todoItems": [
+                {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+            ],
+            "activeTodos": [
+                {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+            ],
+            "responsePreview": result.get("final_response") or result.get("error"),
+        }
+
+
+class _FailedTodoAgent(_BaseTodoAgent):
+    outcome_status = "failed"
+    run_result = {
+        "final_response": None,
+        "messages": [],
+        "api_calls": 1,
+        "completed": False,
+        "failed": True,
+        "error": "model backend crashed",
+    }
+
+
+class _InterruptedTodoAgent(_BaseTodoAgent):
+    outcome_status = "interrupted"
+    run_result = {
+        "final_response": "Operation interrupted while work remained pending.",
+        "messages": [],
+        "api_calls": 1,
+        "completed": False,
+        "interrupted": True,
+        "interrupt_message": "follow up",
+    }
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "hello") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+        message_type=MessageType.TEXT,
+    )
+
+
+def _install_fake_agent(monkeypatch, agent_cls):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_run_agent_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner.delivery_router = SimpleNamespace(adapters=runner.adapters)
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_model_overrides = {}
+    runner._draining = False
+    runner._restart_requested = False
+    runner._show_reasoning = False
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._busy_input_mode = "interrupt"
+    runner._background_tasks = set()
+    runner._update_runtime_status = lambda *args, **kwargs: None
+    runner._evict_cached_agent = lambda *args, **kwargs: None
+    runner._is_intentional_model_switch = lambda *args, **kwargs: False
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+def _make_handle_message_runner(session_entry: SessionEntry):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = _ContinuationAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.delivery_router = SimpleNamespace(adapters=runner.adapters)
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._draining = False
+    runner._restart_requested = False
+    runner._background_tasks = set()
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._session_model_overrides = {}
+    runner._update_prompt_pending = {}
+    runner._failed_platforms = {}
+    runner._busy_input_mode = "interrupt"
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: []
+    runner._clear_session_env = lambda _tokens: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._prepare_inbound_message_text = AsyncMock(return_value="hello")
+    return runner
+
+
+def _make_auto_resume_runner(session_entry: SessionEntry):
+    runner = _make_handle_message_runner(session_entry)
+    runner.session_store.list_sessions.return_value = [session_entry]
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "Please investigate the failing step."},
+        {"role": "assistant", "content": "I was interrupted before finishing."},
+    ]
+    runner._run_agent = AsyncMock()
+    runner._build_auto_resume_message = lambda item: f"Resume work on: {item['openTodos'][0]['content']}"
+    runner._prepare_inbound_message_text = AsyncMock(
+        side_effect=lambda *args, **kwargs: (kwargs.get("event") or args[0]).text
+    )
+    return runner
+
+
+async def _run_real_gateway_agent(monkeypatch, tmp_path, agent_cls, *, pending_event=None, interrupt_depth=0):
+    _install_fake_agent(monkeypatch, agent_cls)
+
+    adapter = _ContinuationAdapter()
+    runner = _make_run_agent_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    if pending_event is not None:
+        adapter._pending_messages[session_key] = pending_event
+
+    return await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+        _interrupt_depth=interrupt_depth,
+    )
+
+
+def test_run_agent_failed_result_keeps_orchestration_snapshot(monkeypatch, tmp_path):
+    result = asyncio.run(_run_real_gateway_agent(monkeypatch, tmp_path, _FailedTodoAgent))
+
+    assert result["orchestration"]["outcomeStatus"] == "failed"
+    assert result["orchestration"]["activeTodos"] == [
+        {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+    ]
+    assert result["orchestration"]["responsePreview"] == "model backend crashed"
+
+
+def test_run_agent_depth_capped_interrupt_still_returns_orchestration_snapshot(monkeypatch, tmp_path):
+    pending_event = MessageEvent(
+        text="follow up",
+        source=_make_source(),
+        message_id="q1",
+        message_type=MessageType.TEXT,
+    )
+
+    result = asyncio.run(
+        _run_real_gateway_agent(
+            monkeypatch,
+            tmp_path,
+            _InterruptedTodoAgent,
+            pending_event=pending_event,
+            interrupt_depth=importlib.import_module("gateway.run").GatewayRunner._MAX_INTERRUPT_DEPTH,
+        )
+    )
+
+    assert result["orchestration"]["outcomeStatus"] == "interrupted"
+    assert result["orchestration"]["activeTodos"] == [
+        {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+    ]
+
+
+def test_handle_message_reconciles_failed_status_and_agent_end_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    result = asyncio.run(_run_real_gateway_agent(monkeypatch, tmp_path, _FailedTodoAgent))
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_handle_message_runner(session_entry)
+    runner._run_agent = AsyncMock(return_value=result)
+
+    response = asyncio.run(runner._handle_message(_make_event()))
+
+    assert response == "⚠️ model backend crashed"
+    end_call = runner.hooks.emit.await_args_list[-1]
+    assert end_call.args[0] == "agent:end"
+    assert end_call.args[1]["status"] == "failed"
+
+    from agent.continuation_enforcer import get_pending_continuations
+
+    queue = get_pending_continuations()
+    assert len(queue) == 1
+    assert queue[0]["sessionId"] == "sess-1"
+    assert queue[0]["reason"] == "failed"
+
+
+def test_handle_message_reconciles_interrupted_status_and_agent_end_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pending_event = MessageEvent(
+        text="follow up",
+        source=_make_source(),
+        message_id="q1",
+        message_type=MessageType.TEXT,
+    )
+    result = asyncio.run(
+        _run_real_gateway_agent(
+            monkeypatch,
+            tmp_path,
+            _InterruptedTodoAgent,
+            pending_event=pending_event,
+            interrupt_depth=importlib.import_module("gateway.run").GatewayRunner._MAX_INTERRUPT_DEPTH,
+        )
+    )
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_handle_message_runner(session_entry)
+    runner._run_agent = AsyncMock(return_value=result)
+
+    response = asyncio.run(runner._handle_message(_make_event()))
+
+    assert response == "Operation interrupted while work remained pending."
+    end_call = runner.hooks.emit.await_args_list[-1]
+    assert end_call.args[0] == "agent:end"
+    assert end_call.args[1]["status"] == "interrupted"
+
+    from agent.continuation_enforcer import get_pending_continuations
+
+    queue = get_pending_continuations()
+    assert len(queue) == 1
+    assert queue[0]["sessionId"] == "sess-1"
+    assert queue[0]["reason"] == "interrupted"
+
+
+def test_retry_requested_auto_resume_runs_agent_and_resolves_queue(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    source = _make_source()
+    session_entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_auto_resume_runner(session_entry)
+    runner._run_agent.return_value = {
+        "final_response": "Auto-resume complete",
+        "messages": [],
+        "api_calls": 1,
+        "orchestration": {
+            "sessionId": "sess-1",
+            "outcomeStatus": "completed",
+            "activeTodos": [],
+            "responsePreview": "Auto-resume complete",
+        },
+    }
+
+    reconcile_session_continuation(
+        "sess-1",
+        outcome_status="interrupted",
+        todos=[{"id": "plan", "content": "Inspect the failing step", "status": "in_progress"}],
+        response_preview="Need another pass.",
+    )
+    request_continuation_retry("sess-1", requested_by="pan")
+
+    processed = asyncio.run(runner._process_retry_requested_continuations_once())
+
+    assert processed == 1
+    runner._run_agent.assert_awaited_once()
+    run_call = runner._run_agent.await_args
+    assert run_call.kwargs["message"] == "Resume work on: Inspect the failing step"
+    assert run_call.kwargs["session_id"] == "sess-1"
+    assert run_call.kwargs["session_key"] == session_entry.session_key
+    assert runner.adapters[Platform.TELEGRAM].sent[-1]["content"] == "Auto-resume complete"
+
+    record = get_continuation_record("sess-1")
+    assert record is not None
+    assert record["status"] == "resolved"
+    assert record["resolution"] == "completed"
+    assert record["events"][-1]["type"] == "auto_resume_delivered"
+    assert 'Auto-resume complete' in record["events"][-1]["message"]
+
+
+def test_retry_requested_auto_resume_skips_busy_session_without_double_execution(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    source = _make_source()
+    session_entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-busy",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_auto_resume_runner(session_entry)
+    runner._running_agents[session_entry.session_key] = object()
+
+    reconcile_session_continuation(
+        "sess-busy",
+        outcome_status="failed",
+        todos=[{"id": "plan", "content": "Retry the failed step", "status": "pending"}],
+        response_preview="Need another pass.",
+    )
+    request_continuation_retry("sess-busy", requested_by="pan")
+
+    processed = asyncio.run(runner._process_retry_requested_continuations_once())
+
+    assert processed == 0
+    runner._run_agent.assert_not_awaited()
+    record = get_continuation_record("sess-busy")
+    assert record is not None
+    assert record["status"] == "retry_requested"
+    assert record["events"][-1]["type"] == 'retry_released'
+    assert record["events"][-1]["message"] == 'session_busy'
+
+
+def test_builtin_agent_end_hook_records_interrupted_status(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from gateway.builtin_hooks.orchestration_state import handle
+
+    asyncio.run(
+        handle(
+            "agent:end",
+            {
+                "session_id": "sess-1",
+                "status": "interrupted",
+                "response": "Paused with work still pending.",
+            },
+        )
+    )
+
+    state = get_session_state("sess-1")
+    assert state is not None
+    assert state["status"] == "interrupted"
+    assert state["responsePreview"] == "Paused with work still pending."

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -172,3 +172,17 @@ class TestConfigIssueDataclass:
         a = ConfigIssue("error", "msg", "hint")
         b = ConfigIssue("error", "msg", "hint")
         assert a == b
+
+
+class TestDelegationCategoryValidation:
+    def test_delegation_categories_must_be_dict(self):
+        issues = validate_config_structure({
+            "delegation": {"categories": ["research"]},
+        })
+        assert any("delegation.categories should be a dict" in i.message for i in issues)
+
+    def test_delegation_category_entries_warn_when_not_dict(self):
+        issues = validate_config_structure({
+            "delegation": {"categories": {"research": "read-only"}},
+        })
+        assert any("delegation.categories.research should be a dict" in i.message for i in issues)

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -48,6 +48,9 @@ def _make_args(**kwargs):
         "auth": None,
         "preset": None,
         "env": None,
+        "catalog_name": None,
+        "as_name": None,
+        "yes": False,
         "mcp_action": None,
     }
     defaults.update(kwargs)
@@ -409,6 +412,139 @@ class TestMcpAdd:
         cmd_mcp_add(_make_args(name="foo", preset="nonexistent"))
         out = capsys.readouterr().out
         assert "Unknown MCP preset" in out
+
+    def test_add_preset_merges_preset_env_with_cli_env(self, tmp_path, capsys, monkeypatch):
+        """Preset-provided env placeholders are preserved and merged with --env."""
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_PRESETS",
+            {
+                "github": {
+                    "command": "npx",
+                    "args": ["-y", "test-mcp-server"],
+                    "env": {"TOKEN": "${TOKEN}"},
+                    "display_name": "GitHub",
+                }
+            },
+        )
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            assert config["command"] == "npx"
+            assert config["args"] == ["-y", "test-mcp-server"]
+            assert config["env"] == {"TOKEN": "${TOKEN}", "DEBUG": "true"}
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_add(_make_args(
+            name="github-local",
+            preset="github",
+            env=["DEBUG=true"],
+        ))
+        out = capsys.readouterr().out
+        assert "Required environment variables: TOKEN" in out
+
+        config = read_raw_config()
+        srv = config["mcp_servers"]["github-local"]
+        assert srv["env"] == {"TOKEN": "${TOKEN}", "DEBUG": "true"}
+
+
+class TestMcpCatalogInstall:
+    def test_catalog_lists_builtin_presets_and_bundles(self, capsys):
+        from hermes_cli.mcp_config import cmd_mcp_catalog
+
+        cmd_mcp_catalog()
+        out = capsys.readouterr().out
+        assert "Built-in MCP Presets" in out
+        assert "github" in out
+        assert "developer" in out
+        assert "Install one with: hermes mcp install" in out
+
+    def test_install_single_preset_with_alias(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_PRESETS",
+            {
+                "fetch": {
+                    "command": "npx",
+                    "args": ["-y", "test-fetch"],
+                    "display_name": "Fetch",
+                }
+            },
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_install
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_install(_make_args(catalog_name="fetch", as_name="web", yes=True))
+        out = capsys.readouterr().out
+        assert "Installed MCP preset 'fetch'" in out
+
+        config = read_raw_config()
+        assert config["mcp_servers"]["web"] == {
+            "command": "npx",
+            "args": ["-y", "test-fetch"],
+            "enabled": True,
+        }
+
+    def test_install_bundle_expands_to_plain_mcp_servers(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_PRESETS",
+            {
+                "github": {
+                    "command": "npx",
+                    "args": ["-y", "test-github"],
+                    "env": {"TOKEN": "${TOKEN}"},
+                    "display_name": "GitHub",
+                },
+                "fetch": {
+                    "command": "npx",
+                    "args": ["-y", "test-fetch"],
+                    "display_name": "Fetch",
+                },
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_BUNDLES",
+            {
+                "starter": {
+                    "display_name": "Starter",
+                    "description": "Starter bundle",
+                    "servers": [
+                        {"name": "github", "preset": "github"},
+                        {"name": "fetch", "preset": "fetch"},
+                    ],
+                }
+            },
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_install
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_install(_make_args(catalog_name="starter", yes=True))
+        out = capsys.readouterr().out
+        assert "Installed MCP bundle 'starter'" in out
+        assert "expanded into normal mcp_servers config entries" in out
+
+        config = read_raw_config()
+        assert config["mcp_servers"] == {
+            "github": {
+                "command": "npx",
+                "args": ["-y", "test-github"],
+                "env": {"TOKEN": "${TOKEN}"},
+                "enabled": True,
+            },
+            "fetch": {
+                "command": "npx",
+                "args": ["-y", "test-fetch"],
+                "enabled": True,
+            },
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_omo_style_commands.py
+++ b/tests/hermes_cli/test_omo_style_commands.py
@@ -1,0 +1,415 @@
+import json
+import queue
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.continuation_engine import should_use_continuation_engine
+from agent.intent_preclassifier import preclassify_intent
+from agent.task_contracts import ORCHESTRATION_HINTS_SCHEMA, ORCHESTRATION_HINTS_VERSION
+from hermes_cli.command_templates import WORK_STARTING_COMMANDS, build_command_invocation
+from hermes_cli.commands import resolve_command
+from hermes_cli.work_command_adapter import PreparedWorkCommand, prepare_work_command
+
+
+def _sample_contract_payload() -> dict:
+    return {
+        "task": "Resume the delegated task",
+        "expected_outcome": "A resumed implementation with fresh verification evidence",
+        "required_skills": ["python", "testing"],
+        "required_tools": ["read_file", "patch", "terminal"],
+        "must_do": ["inspect current state before acting"],
+        "must_not_do": ["do not discard the handed-off contract"],
+        "context": {"ticket": "wave5-smoke"},
+    }
+
+
+def _normalized_cwd(cwd: str) -> str:
+    return str(Path(cwd).resolve())
+
+
+def _active_snapshot() -> dict:
+    return {
+        "outcomeStatus": "interrupted",
+        "activeTodos": [{"id": "todo-1", "content": "Finish the delegated task", "status": "in_progress"}],
+    }
+
+
+class TestOMOWave5CommandTemplates:
+    def test_registry_contains_wave5_commands(self):
+        for name in {"handoff", "stop-continuation", *WORK_STARTING_COMMANDS}:
+            assert resolve_command(name) is not None
+
+    @pytest.mark.parametrize("command_name", sorted(WORK_STARTING_COMMANDS))
+    def test_work_commands_build_structured_task_contracts(self, command_name):
+        invocation = build_command_invocation(
+            command_name,
+            raw_args="Implement the requested change",
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+
+        assert invocation.task_contract["context"]["command"] == command_name
+        assert invocation.orchestration_hints["schema"] == ORCHESTRATION_HINTS_SCHEMA
+        assert invocation.orchestration_hints["schema_version"] == ORCHESTRATION_HINTS_VERSION
+        assert invocation.orchestration_hints["bounded_context"]["enabled"] is True
+        assert invocation.orchestration_hints["bounded_context"]["task_contract_precedence"] == "preserve_existing_fields"
+        assert "TASK_CONTRACT_JSON:" in invocation.prompt_text
+        assert json.loads(invocation.prompt_text.split("TASK_CONTRACT_JSON:\n", 1)[1].split("\nORCHESTRATION_HINTS_JSON:", 1)[0]) == invocation.task_contract
+
+    def test_start_work_emits_named_workflow_machine_readably(self):
+        invocation = build_command_invocation(
+            "start-work",
+            raw_args="Implement the requested change",
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+
+        assert "NAMED_WORKFLOW_JSON:" in invocation.prompt_text
+        named_workflow = json.loads(
+            invocation.prompt_text.split("NAMED_WORKFLOW_JSON:\n", 1)[1].split("\nUSER_REQUEST:", 1)[0]
+        )
+        assert named_workflow["schema"] == "hermes/named-workflow"
+        assert named_workflow["workflow_name"] == "deep_worker"
+        assert named_workflow["execution_task_contract"] == invocation.task_contract
+
+    def test_handoff_does_not_emit_named_workflow_by_default(self):
+        invocation = build_command_invocation(
+            "handoff",
+            raw_args="Resume the delegated task",
+            session_id="sess-1",
+            cwd="/tmp",
+        )
+
+        assert invocation.named_workflow is None
+        assert "NAMED_WORKFLOW_JSON:" not in invocation.prompt_text
+
+    def test_loop_commands_emit_distinct_command_runtime_markers(self):
+        cases = [
+            ("ralph-loop", "ralph"),
+            ("ulw-loop", "ultrawork"),
+        ]
+
+        for command_name, expected_runtime_mode in cases:
+            invocation = build_command_invocation(
+                command_name,
+                raw_args="Implement the requested change",
+                session_id="sess-1",
+                cwd="/tmp",
+            )
+
+            assert invocation.task_contract["context"]["command"] == command_name
+            assert invocation.task_contract["context"]["loop_family"] == command_name
+            assert invocation.task_contract["context"]["command_runtime"] == {
+                "command_name": command_name,
+                "runtime_mode": expected_runtime_mode,
+                "continuation_semantics": (
+                    {
+                        "retry_on_failed_or_interrupted": True,
+                        "stop_requires_explicit_exit": True,
+                    }
+                    if command_name == "ralph-loop"
+                    else {
+                        "completion_gate": "open_todos_block_done",
+                        "require_open_work_closure": True,
+                    }
+                ),
+            }
+            assert invocation.orchestration_hints["command"] == command_name
+            assert invocation.orchestration_hints["loop"] == {
+                "family": command_name,
+                "bounded": True,
+                "continuation_semantics": invocation.task_contract["context"]["command_runtime"]["continuation_semantics"],
+            }
+
+    def test_handoff_consumes_structured_contract_json(self):
+        payload = _sample_contract_payload()
+        invocation = build_command_invocation("handoff", raw_args=json.dumps(payload), session_id="sess-1", cwd="/tmp")
+
+        assert invocation.task_contract == payload
+        assert invocation.orchestration_hints["handoff"]["consume_existing_contract"] is True
+        assert invocation.orchestration_hints["request"] == payload["task"]
+        assert invocation.orchestration_hints["invocation_metadata"] == {
+            "command": "handoff",
+            "session_id": "sess-1",
+            "cwd": _normalized_cwd("/tmp"),
+            "input_mode": "explicit_json_contract",
+            "preserve_exact_task_contract": True,
+            "handoff_mode": "resume_or_consume_contract",
+        }
+        assert "USER_REQUEST: Resume the delegated task" in invocation.prompt_text
+
+    def test_start_work_preserves_explicit_contract_json_exactly(self):
+        payload = _sample_contract_payload()
+        payload["context"]["command_runtime"] = {
+            "command_name": "handoff",
+            "runtime_mode": "ralph",
+        }
+
+        invocation = build_command_invocation("start-work", raw_args=json.dumps(payload), session_id="sess-2", cwd="/tmp")
+
+        assert invocation.task_contract == payload
+        assert invocation.named_workflow is None
+        assert "NAMED_WORKFLOW_JSON:" not in invocation.prompt_text
+        assert invocation.orchestration_hints["request"] == payload["task"]
+        assert invocation.orchestration_hints["invocation_metadata"] == {
+            "command": "start-work",
+            "session_id": "sess-2",
+            "cwd": _normalized_cwd("/tmp"),
+            "input_mode": "explicit_json_contract",
+            "preserve_exact_task_contract": True,
+        }
+        result = preclassify_intent({"message": payload["task"], "task_contract": invocation.task_contract})
+        assert result.inferred_runtime_mode == "ralph"
+        assert should_use_continuation_engine(result.inferred_runtime_mode, _active_snapshot()) is True
+
+    @pytest.mark.parametrize(
+        ("command_name", "expected_runtime_mode"),
+        [("ralph-loop", "ralph"), ("ulw-loop", "ultrawork")],
+    )
+    def test_loop_commands_enable_continuation_from_structured_contracts(self, command_name, expected_runtime_mode):
+        invocation = build_command_invocation(
+            command_name,
+            raw_args="Finish the delegated task",
+            session_id="sess-3",
+            cwd="/tmp",
+        )
+
+        result = preclassify_intent({"message": "Finish the delegated task", "task_contract": invocation.task_contract})
+
+        assert result.inferred_runtime_mode == expected_runtime_mode
+        assert should_use_continuation_engine(result.inferred_runtime_mode, _active_snapshot()) is True
+
+    def test_prepare_work_command_reports_malformed_handoff_json(self):
+        with pytest.raises(ValueError, match=r"Malformed /handoff work command JSON"):
+            prepare_work_command("handoff", raw_args="{not valid", session_id="sess-1", cwd="/tmp")
+
+    def test_prepare_work_command_reports_invalid_contract_shape(self):
+        with pytest.raises(ValueError, match=r"Invalid /handoff task contract: required_tools"):
+            prepare_work_command(
+                "handoff",
+                raw_args=json.dumps({
+                    "task": "Resume work",
+                    "expected_outcome": "done",
+                    "required_skills": ["python"],
+                    "must_do": ["inspect"],
+                    "must_not_do": ["skip verification"],
+                    "context": {"ticket": "w2"},
+                }),
+                session_id="sess-1",
+                cwd="/tmp",
+            )
+
+
+class TestCLICommandSmoke:
+    def _make_cli(self):
+        import agent.archetypes as archetypes
+
+        if not hasattr(archetypes, "resolve_specialist_mapping"):
+            archetypes.resolve_specialist_mapping = lambda *args, **kwargs: None
+        if not hasattr(archetypes, "resolve_specialist_defaults"):
+            archetypes.resolve_specialist_defaults = lambda *args, **kwargs: {}
+
+        from cli import HermesCLI
+
+        cli = object.__new__(HermesCLI)
+        cli.session_id = "sess-cli"
+        cli._pending_input = queue.Queue()
+        return cli
+
+    def test_handoff_command_queues_structured_prompt(self):
+        cli = self._make_cli()
+
+        assert cli.process_command("/handoff Continue the login fix") is True
+        queued = cli._pending_input.get_nowait()
+
+        assert isinstance(queued, PreparedWorkCommand)
+        assert queued.command_name == "handoff"
+        assert queued.task_contract["context"]["command"] == "handoff"
+        assert queued.orchestration_hints["schema"] == ORCHESTRATION_HINTS_SCHEMA
+        assert "[OMO command handoff]" in queued.agent_message
+        assert "Continue the login fix" in queued.agent_message
+
+    def test_init_deep_command_queues_structured_prompt(self):
+        cli = self._make_cli()
+
+        assert cli.process_command("/init-deep Investigate the migration surface") is True
+        queued = cli._pending_input.get_nowait()
+
+        assert isinstance(queued, PreparedWorkCommand)
+        assert queued.command_name == "init-deep"
+        assert queued.orchestration_hints["schema_version"] == ORCHESTRATION_HINTS_VERSION
+        assert "[OMO command init-deep]" in queued.agent_message
+        assert '"initialization": {' in queued.agent_message
+        assert "Investigate the migration surface" in queued.agent_message
+
+    @pytest.mark.parametrize(
+        ("command_text", "expected_runtime_mode"),
+        [
+            ("/start-work ship it", "default"),
+            ("/ralph-loop close it", "ralph"),
+            ("/ulw-loop finish it", "ultrawork"),
+        ],
+    )
+    def test_additional_work_commands_queue_structured_prompts_with_expected_continuation_modes(
+        self, command_text, expected_runtime_mode
+    ):
+        cli = self._make_cli()
+
+        assert cli.process_command(command_text) is True
+        queued = cli._pending_input.get_nowait()
+
+        assert isinstance(queued, PreparedWorkCommand)
+        result = preclassify_intent({"message": queued.task_contract["task"], "task_contract": queued.task_contract})
+        assert result.inferred_runtime_mode == expected_runtime_mode
+        assert should_use_continuation_engine(result.inferred_runtime_mode, _active_snapshot()) is (
+            expected_runtime_mode != "default"
+        )
+        if expected_runtime_mode == "default":
+            assert "NAMED_WORKFLOW_JSON:" in queued.agent_message
+        else:
+            assert f'"runtime_mode": "{expected_runtime_mode}"' in queued.agent_message
+
+
+class TestGatewayCommandSmoke:
+    def _make_runner(self):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionEntry
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+        runner.adapters = {}
+        runner._voice_mode = {}
+        runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+        runner.session_store = MagicMock()
+        runner.session_store.get_or_create_session.return_value = SessionEntry(
+            session_key="agent:main:telegram:dm:c1:u1",
+            session_id="sess-gw",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+        )
+        runner.session_store.load_transcript.return_value = []
+        runner.session_store.has_any_sessions.return_value = True
+        runner.session_store.append_to_transcript = MagicMock()
+        runner.session_store.rewrite_transcript = MagicMock()
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._session_db = None
+        runner._reasoning_config = None
+        runner._provider_routing = {}
+        runner._fallback_model = None
+        runner._show_reasoning = False
+        runner._is_user_authorized = lambda _source: True
+        runner._set_session_env = lambda _context: []
+        runner._clear_session_env = lambda _tokens: None
+        runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+        runner._send_voice_reply = AsyncMock()
+        runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+        runner._emit_gateway_run_progress = AsyncMock()
+        runner._prepare_inbound_message_text = AsyncMock(
+            side_effect=lambda *, event, source, history: event.text
+        )
+        runner._run_agent = AsyncMock(
+            return_value={
+                "final_response": "ok",
+                "messages": [],
+                "tools": [],
+                "history_offset": 0,
+                "last_prompt_tokens": 0,
+            }
+        )
+        runner._draining = False
+        runner._restart_requested = False
+        runner._background_tasks = set()
+        runner._agent_cache = {}
+        runner._agent_cache_lock = None
+        runner._session_model_overrides = {}
+        runner._update_prompt_pending = {}
+        runner._failed_platforms = {}
+        runner._busy_input_mode = "interrupt"
+        return runner
+
+    def _make_event(self, text="/handoff Continue the repo work"):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+
+        return MessageEvent(
+            text=text,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                user_id="u1",
+                chat_id="c1",
+                user_name="tester",
+                chat_type="dm",
+            ),
+            message_id="m1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_gateway_handoff_smoke_routes_structured_prompt_to_agent(self, monkeypatch):
+        import gateway.run as gateway_run
+
+        runner = self._make_runner()
+        event = self._make_event()
+        monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+        monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100_000)
+
+        result = await runner._handle_message(event)
+
+        assert result == "ok"
+        forwarded = runner._run_agent.call_args.kwargs["message"]
+        assert "[OMO command handoff]" in forwarded
+        assert '"command": "handoff"' in forwarded
+        assert "Continue the repo work" in forwarded
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("command_text", "expected_runtime_mode", "should_continue"),
+        [
+            ("/handoff Continue the repo work", "default", False),
+            ("/init-deep Investigate the repo work", "default", False),
+            ("/start-work Continue the repo work", "default", False),
+            ("/ralph-loop Close the repo work", "ralph", True),
+            ("/ulw-loop Finish the repo work", "ultrawork", True),
+        ],
+    )
+    async def test_gateway_work_commands_preserve_continuation_semantics(self, monkeypatch, command_text, expected_runtime_mode, should_continue):
+        import gateway.run as gateway_run
+
+        runner = self._make_runner()
+        event = self._make_event(text=command_text)
+        monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+        monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100_000)
+
+        result = await runner._handle_message(event)
+
+        assert result == "ok"
+        forwarded = runner._run_agent.call_args.kwargs["message"]
+        prepared = getattr(event, "_prepared_work_command")
+        classification = preclassify_intent({"message": prepared.task_contract["task"], "task_contract": prepared.task_contract})
+        assert classification.inferred_runtime_mode == expected_runtime_mode
+        assert should_use_continuation_engine(classification.inferred_runtime_mode, _active_snapshot()) is should_continue
+        assert forwarded == prepared.agent_message
+
+    @pytest.mark.asyncio
+    async def test_gateway_handoff_returns_clean_error_for_malformed_json(self, monkeypatch):
+        import gateway.run as gateway_run
+
+        runner = self._make_runner()
+        event = self._make_event(text="/handoff {not valid")
+        monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+        monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100_000)
+
+        result = await runner._handle_message(event)
+
+        assert result == "Malformed /handoff work command JSON: expected a valid JSON object."
+        runner._run_agent.assert_not_called()

--- a/tests/hermes_cli/test_openagent_config_scaffolding.py
+++ b/tests/hermes_cli/test_openagent_config_scaffolding.py
@@ -1,0 +1,161 @@
+"""Focused tests for OpenAgent-style config bucket scaffolding."""
+
+import os
+from unittest.mock import patch
+
+import yaml
+
+from hermes_cli.config import (
+    _normalize_model_capabilities_config,
+    _normalize_openagent_config_buckets,
+    _normalize_openagent_named_bucket,
+    _normalize_runtime_fallback_config,
+    load_config,
+    save_config,
+    validate_config_structure,
+)
+
+
+class TestOpenAgentBucketHelpers:
+    def test_named_bucket_normalizes_string_shorthand(self):
+        normalized = _normalize_openagent_named_bucket({
+            "oracle": "openai/gpt-5.4",
+            "explore": {"model": "anthropic/claude-sonnet-4", "temperature": 0.2},
+            "ignored": 7,
+            "": {"model": "should-not-survive"},
+        })
+
+        assert normalized == {
+            "oracle": {"model": "openai/gpt-5.4"},
+            "explore": {"model": "anthropic/claude-sonnet-4", "temperature": 0.2},
+        }
+
+    def test_runtime_fallback_boolean_normalizes_to_enabled_dict(self):
+        assert _normalize_runtime_fallback_config(True) == {"enabled": True}
+        assert _normalize_runtime_fallback_config(False) == {"enabled": False}
+
+    def test_model_capabilities_invalid_shape_resets_to_empty_mapping(self):
+        assert _normalize_model_capabilities_config(["not", "a", "dict"]) == {}
+
+    def test_openagent_bucket_normalizer_adds_default_scaffolds(self):
+        normalized = _normalize_openagent_config_buckets({})
+
+        assert normalized["agents"] == {}
+        assert normalized["categories"] == {}
+        assert normalized["runtime_fallback"] == {"enabled": False}
+        assert normalized["model_capabilities"] == {}
+
+
+class TestLoadConfigOpenAgentBuckets:
+    def test_defaults_include_openagent_scaffolding(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["agents"] == {}
+        assert config["categories"] == {}
+        assert config["runtime_fallback"] == {"enabled": False}
+        assert config["model_capabilities"] == {}
+
+    def test_load_config_normalizes_openagent_bucket_shapes(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "\n".join([
+                "agents:",
+                "  oracle: openai/gpt-5.4",
+                "  explore:",
+                "    model: anthropic/claude-sonnet-4",
+                "    temperature: 0.2",
+                "categories:",
+                "  research: anthropic/claude-haiku-4-5",
+                "runtime_fallback: true",
+                "model_capabilities:",
+                "  enabled: true",
+                "  source_url: https://example.invalid/models.json",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["agents"]["oracle"] == {"model": "openai/gpt-5.4"}
+        assert config["agents"]["explore"] == {
+            "model": "anthropic/claude-sonnet-4",
+            "temperature": 0.2,
+        }
+        assert config["categories"]["research"] == {"model": "anthropic/claude-haiku-4-5"}
+        assert config["runtime_fallback"] == {"enabled": True}
+        assert config["model_capabilities"] == {
+            "enabled": True,
+            "source_url": "https://example.invalid/models.json",
+        }
+
+    def test_invalid_openagent_bucket_types_fall_back_without_breaking_existing_config(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "\n".join([
+                "model: openai/gpt-5.4",
+                "max_turns: 42",
+                "agents:",
+                "  - oracle",
+                "categories: true",
+                "runtime_fallback:",
+                "  - 429",
+                "model_capabilities: disabled",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["model"] == "openai/gpt-5.4"
+        assert config["agent"]["max_turns"] == 42
+        assert config["agents"] == {}
+        assert config["categories"] == {}
+        assert config["runtime_fallback"] == {"enabled": False}
+        assert config["model_capabilities"] == {}
+
+
+class TestSaveConfigOpenAgentBuckets:
+    def test_save_config_persists_normalized_openagent_buckets(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_config({
+                "agents": {"oracle": "openai/gpt-5.4"},
+                "runtime_fallback": True,
+                "model_capabilities": {"enabled": True},
+            })
+
+        saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agents"] == {"oracle": {"model": "openai/gpt-5.4"}}
+        assert saved["runtime_fallback"] == {"enabled": True}
+        assert saved["model_capabilities"] == {"enabled": True}
+        assert "categories" not in saved
+
+
+class TestValidateConfigStructureOpenAgentBuckets:
+    def test_warns_for_invalid_openagent_bucket_shapes(self):
+        issues = validate_config_structure({
+            "agents": ["oracle"],
+            "categories": True,
+            "runtime_fallback": [429],
+            "model_capabilities": "enabled",
+        })
+        messages = [issue.message for issue in issues]
+
+        assert any("agents should be a mapping" in message for message in messages)
+        assert any("categories should be a mapping" in message for message in messages)
+        assert any("runtime_fallback should be either a boolean or a config dict" in message for message in messages)
+        assert any("model_capabilities should be a config dict" in message for message in messages)
+
+    def test_accepts_runtime_fallback_boolean_without_warnings(self):
+        issues = validate_config_structure({
+            "agents": {"oracle": {"model": "openai/gpt-5.4"}},
+            "categories": {"reasoning": {"model": "anthropic/claude-sonnet-4"}},
+            "runtime_fallback": True,
+            "model_capabilities": {"enabled": True},
+        })
+
+        assert not any("runtime_fallback" in issue.message for issue in issues)

--- a/tests/hermes_cli/test_projects.py
+++ b/tests/hermes_cli/test_projects.py
@@ -1,0 +1,190 @@
+import sys
+from argparse import Namespace
+
+import pytest
+
+
+@pytest.fixture()
+def project_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / '.hermes'
+    hermes_home.mkdir()
+    monkeypatch.setenv('HERMES_HOME', str(hermes_home))
+    return hermes_home
+
+
+def test_project_list_empty(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    rc = project_command(Namespace(project_action='list', project_id=None, name=None, summary=None, repo_path=None))
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert 'No projects found' in out
+
+
+def test_project_init_creates_project_cell(project_env):
+    from hermes_cli.projects import project_command
+
+    rc = project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+
+    assert rc == 0
+    project_dir = project_env / 'project-os-v1' / 'projects' / 'alpha'
+    assert (project_dir / 'project.yaml').exists()
+    assert (project_dir / 'brief.md').exists()
+    assert (project_dir / 'reports' / '00-executive-summary.md').exists()
+    assert (project_dir / 'tasks' / 'next-actions.md').exists()
+    assert (project_dir / 'approvals.jsonl').exists()
+    assert (project_dir / 'pairing' / 'status.json').exists()
+    assert (project_env / 'project-os-v1' / 'projects' / 'registry.json').exists()
+    project_yaml = (project_dir / 'project.yaml').read_text()
+    assert 'workspace_contracts:' in project_yaml
+    assert 'approvals_file: approvals.jsonl' in project_yaml
+    assert 'sync_dir: sync' in project_yaml
+    assert 'pairing_dir: pairing' in project_yaml
+    assert str(project_env / 'project-os-v1' / 'config' / 'path-policies.yaml') in project_yaml
+    assert str(project_env / 'project-os-v1' / 'config' / 'modules.yaml') in project_yaml
+    assert str(project_env / 'project-os-v1' / 'config' / 'modules.lock.yaml') in project_yaml
+
+
+def test_project_show_displays_metadata(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+    capsys.readouterr()
+
+    rc = project_command(
+        Namespace(
+            project_action='show',
+            project_id='alpha',
+            name=None,
+            summary=None,
+            repo_path=None,
+        )
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert 'Project: alpha' in out
+    assert 'Name:          Alpha' in out
+    assert 'Summary:       Alpha project summary' in out
+    assert 'Status digest:' in out
+    assert 'not generated yet' in out
+    assert str(project_env / 'project-os-v1' / 'projects' / 'alpha') in out
+
+
+def test_project_digest_generates_digest(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+    capsys.readouterr()
+
+    rc = project_command(
+        Namespace(
+            project_action='digest',
+            project_id='alpha',
+            name=None,
+            summary=None,
+            repo_path=None,
+        )
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    digest_path = project_env / 'project-os-v1' / 'projects' / 'alpha' / 'reports' / '01-status-digest.md'
+    assert digest_path.exists()
+    assert 'Recommended next actions' in digest_path.read_text()
+    assert f'Updated status digest: {digest_path}' in out
+
+
+def test_project_status_alias_generates_digest(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+    capsys.readouterr()
+
+    rc = project_command(
+        Namespace(
+            project_action='status',
+            project_id='alpha',
+            name=None,
+            summary=None,
+            repo_path=None,
+        )
+    )
+
+    assert rc == 0
+
+
+def test_project_main_parser_dispatches_list(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_project(args):
+        captured['action'] = args.project_action
+        captured['command'] = args.command
+
+    monkeypatch.setattr(main_mod, 'cmd_project', fake_cmd_project, raising=False)
+    monkeypatch.setattr(sys, 'argv', ['hermes', 'project', 'list'])
+
+    main_mod.main()
+
+    assert captured == {'action': 'list', 'command': 'project'}
+
+
+@pytest.mark.parametrize(
+    ('argv', 'expected'),
+    [
+        (['hermes', 'project', 'show', 'alpha'], {'action': 'show', 'command': 'project', 'project_id': 'alpha'}),
+        (['hermes', 'project', 'digest', 'alpha'], {'action': 'digest', 'command': 'project', 'project_id': 'alpha'}),
+        (['hermes', 'project', 'status', 'alpha'], {'action': 'status', 'command': 'project', 'project_id': 'alpha'}),
+    ],
+)
+def test_project_main_parser_dispatches_project_actions(monkeypatch, argv, expected):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_project(args):
+        captured['action'] = args.project_action
+        captured['command'] = args.command
+        captured['project_id'] = getattr(args, 'project_id', None)
+
+    monkeypatch.setattr(main_mod, 'cmd_project', fake_cmd_project, raising=False)
+    monkeypatch.setattr(sys, 'argv', argv)
+
+    main_mod.main()
+
+    assert captured == expected

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -26,10 +26,33 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
+
+def test_configurable_toolsets_include_code_intel():
+    assert any(ts_key == "code_intel" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 
     assert "messaging" in enabled
+
+
+def test_get_platform_tools_default_cli_includes_code_intel():
+    enabled = _get_platform_tools({}, "cli")
+
+    assert "code_intel" in enabled
+
+
+def test_get_platform_tools_default_telegram_excludes_code_intel():
+    enabled = _get_platform_tools({}, "telegram")
+
+    assert "code_intel" not in enabled
+
+
+def test_get_platform_tools_default_api_server_includes_code_intel():
+    enabled = _get_platform_tools({}, "api_server")
+
+    assert "code_intel" in enabled
 
 
 def test_get_platform_tools_preserves_explicit_empty_selection():

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -51,6 +51,14 @@ class TestToolsEnableBuiltin:
         saved = mock_save.call_args[0][0]
         assert "web" in saved["platform_toolsets"]["cli"]
 
+    def test_enable_adds_code_intel_to_platform(self):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["code_intel"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "code_intel" in saved["platform_toolsets"]["cli"]
+
     def test_enable_already_present_is_idempotent(self):
         config = {"platform_toolsets": {"cli": ["web"]}}
         with patch("hermes_cli.tools_config.load_config", return_value=config), \

--- a/tests/plugins/memory/test_rasputin_provider.py
+++ b/tests/plugins/memory/test_rasputin_provider.py
@@ -1,0 +1,131 @@
+import json
+
+from plugins.memory import discover_memory_providers, load_memory_provider
+from plugins.memory.rasputin import RasputinMemoryProvider
+from plugins.memory.rasputin.client import (
+    RasputinClient,
+    RasputinClientConfig,
+    _MAX_COMMIT_TEXT_CHARS,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_provider_loading_and_discovery_manifest():
+    provider = load_memory_provider("rasputin")
+
+    assert provider is not None
+    assert provider.name == "rasputin"
+    assert provider.is_available() is True
+
+    providers = {name: (description, available) for name, description, available in discover_memory_providers()}
+    assert "rasputin" in providers
+    description, available = providers["rasputin"]
+    assert "derived-memory sidecar" in description
+    assert available is True
+
+
+def test_search_uses_post_body(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse({"results": [{"id": "r1", "text": "match"}]})
+
+    monkeypatch.setattr("plugins.memory.rasputin.client.request.urlopen", fake_urlopen)
+
+    client = RasputinClient(RasputinClientConfig(base_url="http://127.0.0.1:7777"))
+    results = client.search("x" * 12000, limit=3)
+
+    assert results == [{"id": "r1", "text": "match"}]
+    assert captured["url"] == "http://127.0.0.1:7777/search"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"query": "x" * 12000, "limit": 3}
+    assert captured["headers"]["Content-type"] == "application/json"
+
+
+def test_prepare_commit_payload_truncates_oversized_text():
+    original = "x" * (_MAX_COMMIT_TEXT_CHARS + 250)
+
+    prepared = RasputinClient._prepare_commit_payload(
+        {
+            "text": original,
+            "source": "hermes-turn",
+            "metadata": {"kind": "conversation_window"},
+        }
+    )
+
+    assert len(prepared["text"]) == _MAX_COMMIT_TEXT_CHARS
+    assert prepared["text"] == original[:_MAX_COMMIT_TEXT_CHARS]
+    assert prepared["metadata"]["kind"] == "conversation_window"
+    assert prepared["metadata"]["rasputin_truncated"] is True
+    assert prepared["metadata"]["rasputin_original_text_length"] == len(original)
+
+
+def test_commit_sends_truncated_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse({"ok": True})
+
+    monkeypatch.setattr("plugins.memory.rasputin.client.request.urlopen", fake_urlopen)
+
+    client = RasputinClient(RasputinClientConfig(base_url="http://127.0.0.1:7777"))
+    ok = client.commit({"text": "y" * (_MAX_COMMIT_TEXT_CHARS + 10), "source": "hermes-turn"})
+
+    assert ok is True
+    assert captured["url"] == "http://127.0.0.1:7777/commit"
+    assert captured["method"] == "POST"
+    assert len(captured["body"]["text"]) == _MAX_COMMIT_TEXT_CHARS
+    assert captured["body"]["metadata"]["rasputin_truncated"] is True
+
+
+def test_provider_on_pre_compress_returns_notes_and_mirrors_checkpoint():
+    provider = RasputinMemoryProvider()
+    provider._client = object()
+    provider._session_id = "session-abc"
+    provider._platform = "cli"
+    provider._agent_context = "primary"
+    provider._user_id = "user-1"
+
+    captured = {}
+
+    def _capture(payload, *, label):
+        captured["payload"] = payload
+        captured["label"] = label
+
+    provider._commit_best_effort = _capture
+
+    notes = provider.on_pre_compress(
+        [
+            {"role": "user", "content": "Please preserve the exact backlink gap and port 8642 issue."},
+            {"role": "assistant", "content": "I am preparing the final architecture recommendation now."},
+        ]
+    )
+
+    assert "backlink gap" in notes
+    assert "8642" in notes
+    assert captured["label"] == "compaction-checkpoint"
+    assert captured["payload"]["source"] == "hermes-compaction-checkpoint"
+    assert captured["payload"]["metadata"]["kind"] == "compaction_checkpoint"
+    assert captured["payload"]["metadata"]["session_id"] == "session-abc"

--- a/tests/run_agent/test_compression_continuation.py
+++ b/tests/run_agent/test_compression_continuation.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+class TestCompressionContinuationNotice:
+    def test_compression_emits_continuation_status_when_session_id_rotates(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        statuses = []
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-12345678",
+                base_url="https://example.test/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=db,
+                session_id="compression-session",
+                status_callback=lambda kind, message: statuses.append((kind, message)),
+            )
+
+        old_session_id = agent.session_id
+        original_messages = [
+            {"role": "user", "content": "Please continue the task."},
+            {"role": "assistant", "content": "Working on it."},
+            {"role": "user", "content": "Add the regression tests too."},
+            {"role": "assistant", "content": "On it."},
+        ]
+        compressed_messages = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] earlier work summary"},
+            {"role": "assistant", "content": "Recent state"},
+        ]
+
+        with (
+            patch.object(agent, "flush_memories"),
+            patch.object(agent, "commit_memory_session"),
+            patch.object(agent, "_invalidate_system_prompt"),
+            patch.object(agent, "_build_system_prompt", return_value="system prompt"),
+            patch.object(agent.context_compressor, "compress", return_value=compressed_messages),
+            patch.object(agent._todo_store, "format_for_injection", return_value=""),
+        ):
+            result_messages, new_system_prompt = agent._compress_context(
+                original_messages,
+                "system prompt",
+                approx_tokens=12345,
+                task_id="compression-session",
+            )
+
+        assert result_messages == compressed_messages
+        assert new_system_prompt == "system prompt"
+        assert agent.session_id != old_session_id
+        assert db.get_session(agent.session_id)["parent_session_id"] == old_session_id
+        assert statuses, "expected a lifecycle status message for compression continuation"
+        kind, message = statuses[-1]
+        assert kind == "lifecycle"
+        assert "same conversation" in message
+        assert "not a reset" in message
+        assert old_session_id in message
+        assert agent.session_id in message
+
+        db.close()

--- a/tests/run_agent/test_compression_threshold_override.py
+++ b/tests/run_agent/test_compression_threshold_override.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+
+def test_aiagent_uses_explicit_compression_threshold_tokens_from_config():
+    cfg = {
+        "model": {
+            "default": "gpt5.4",
+            "provider": "custom",
+            "base_url": "http://localhost:4000/v1",
+            "context_length": 200000,
+        },
+        "compression": {
+            "enabled": True,
+            "threshold": 0.50,
+            "threshold_tokens": 185000,
+            "target_ratio": 0.20,
+            "protect_last_n": 20,
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.context_compressor.get_model_context_length", return_value=200_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="gpt5.4",
+            api_key="test-key-1234567890",
+            base_url="http://localhost:4000/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.threshold_tokens == 185_000
+    assert agent.context_compressor.tail_token_budget == 37_000

--- a/tests/run_agent/test_continuation_entry_surface_matrix.py
+++ b/tests/run_agent/test_continuation_entry_surface_matrix.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+
+from agent.continuation_engine import should_use_continuation_engine
+from agent.intent_preclassifier import preclassify_intent
+from hermes_cli.command_templates import build_command_invocation
+
+
+def _active_snapshot() -> dict:
+    return {
+        "outcomeStatus": "interrupted",
+        "activeTodos": [
+            {"id": "todo-1", "content": "Finish the remaining work", "status": "in_progress"}
+        ],
+    }
+
+
+def _sample_contract_payload(runtime_mode: str | None = None) -> dict:
+    context = {"ticket": "wave-c-t5"}
+    if runtime_mode:
+        context["command_runtime"] = {
+            "command_name": "handoff",
+            "runtime_mode": runtime_mode,
+        }
+    return {
+        "task": "Resume the delegated task",
+        "expected_outcome": "Implementation resumed with verification evidence",
+        "required_skills": ["python", "testing"],
+        "required_tools": ["read_file", "patch", "terminal"],
+        "must_do": ["inspect current state before acting"],
+        "must_not_do": ["discard the preserved contract"],
+        "context": context,
+    }
+
+
+@pytest.mark.parametrize(
+    ("command_name", "expected_runtime_mode", "expected_semantics", "should_continue"),
+    [
+        ("handoff", "default", "blocks", False),
+        ("init-deep", "default", "blocks", False),
+        ("start-work", "default", "blocks", False),
+        ("ralph-loop", "ralph", "injects", True),
+        ("ulw-loop", "ultrawork", "injects", True),
+    ],
+    ids=["handoff", "init-deep", "start-work", "ralph-loop", "ulw-loop"],
+)
+def test_continuation_matrix_default_entry_surfaces(command_name, expected_runtime_mode, expected_semantics, should_continue):
+    invocation = build_command_invocation(
+        command_name,
+        raw_args="Continue the delegated task",
+        session_id="sess-1",
+        cwd="/tmp",
+    )
+
+    result = preclassify_intent(
+        {
+            "message": "Continue the delegated task",
+            "task_contract": invocation.task_contract,
+        }
+    )
+
+    assert result.inferred_runtime_mode == expected_runtime_mode
+    assert should_use_continuation_engine(result.inferred_runtime_mode, _active_snapshot()) is should_continue
+
+    if expected_semantics == "injects":
+        assert invocation.task_contract["context"]["command_runtime"]["runtime_mode"] == expected_runtime_mode
+
+
+@pytest.mark.parametrize(
+    ("command_name", "runtime_mode"),
+    [
+        ("handoff", "ralph"),
+        ("handoff", "ultrawork"),
+        ("start-work", "ralph"),
+        ("start-work", "ultrawork"),
+    ],
+    ids=[
+        "handoff-preserves-ralph",
+        "handoff-preserves-ultrawork",
+        "start-work-preserves-ralph",
+        "start-work-preserves-ultrawork",
+    ],
+)
+def test_continuation_matrix_preserve_surfaces_keep_explicit_runtime_contracts(command_name, runtime_mode):
+    payload = _sample_contract_payload(runtime_mode)
+
+    invocation = build_command_invocation(
+        command_name,
+        raw_args=json.dumps(payload),
+        session_id="sess-2",
+        cwd="/tmp",
+    )
+
+    result = preclassify_intent(
+        {
+            "message": payload["task"],
+            "task_contract": invocation.task_contract,
+        }
+    )
+
+    assert invocation.task_contract == payload
+    assert result.task_contract is not None
+    assert result.task_contract.model_dump() == payload
+    assert result.inferred_runtime_mode == runtime_mode
+    assert should_use_continuation_engine(result.inferred_runtime_mode, _active_snapshot()) is True

--- a/tests/run_agent/test_named_role_behavior_boundaries.py
+++ b/tests/run_agent/test_named_role_behavior_boundaries.py
@@ -1,0 +1,244 @@
+import json
+from importlib import import_module
+
+import agent.archetypes as archetypes
+
+if not hasattr(archetypes, "resolve_specialist_mapping"):
+    archetypes.resolve_specialist_mapping = lambda value: None
+if not hasattr(archetypes, "resolve_specialist_defaults"):
+    archetypes.resolve_specialist_defaults = lambda value: {}
+
+run_agent = import_module("run_agent")
+AIAgent = run_agent.AIAgent
+
+
+SAMPLE_CONTRACT = {
+    "task": "Verify the implementation",
+    "expected_outcome": "Verification evidence is reported with bounded context precedence.",
+    "required_skills": ["testing"],
+    "required_tools": ["read_file", "terminal"],
+    "must_do": ["inspect the repo before concluding"],
+    "must_not_do": ["do not mutate files while reviewing"],
+    "context": {"ticket": "swarm-d"},
+}
+
+
+def _make_bare_agent():
+    agent = AIAgent.__new__(AIAgent)
+    agent.skip_context_files = False
+    agent.valid_tool_names = set()
+    agent.tools = []
+    agent._tool_use_enforcement = False
+    agent.model = "gpt-5.4"
+    agent.provider = "openai"
+    agent.pass_session_id = False
+    agent.session_id = None
+    agent._memory_store = None
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+    agent._memory_manager = None
+    agent._session_db = None
+    agent._todo_store = None
+    agent.clarify_callback = None
+    agent.platform = "cli"
+    agent.runtime_activation_state = {}
+    agent._runtime_activation_state = {}
+    agent.get_runtime_activation_state = lambda: agent.runtime_activation_state
+    return agent
+
+
+def test_build_system_prompt_passes_runtime_task_contract_to_context_prompt(monkeypatch):
+    agent = _make_bare_agent()
+    agent.runtime_activation_state = {"task_contract": SAMPLE_CONTRACT}
+    captured = {}
+
+    monkeypatch.setattr(run_agent, "load_soul_md", lambda: "SOUL")
+    monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(run_agent, "build_skills_system_prompt", lambda **_kwargs: "")
+    monkeypatch.setattr(run_agent, "build_environment_hints", lambda: "")
+
+    def _fake_context_prompt(*, cwd=None, skip_soul=False, task_contract=None, max_hermes_hierarchy_layers=3):
+        captured["cwd"] = cwd
+        captured["skip_soul"] = skip_soul
+        captured["task_contract"] = task_contract
+        captured["layers"] = max_hermes_hierarchy_layers
+        return "CONTEXT"
+
+    monkeypatch.setattr(run_agent, "build_context_files_prompt", _fake_context_prompt)
+
+    prompt = agent._build_system_prompt()
+
+    assert captured["task_contract"] == SAMPLE_CONTRACT
+    assert captured["skip_soul"] is True
+    assert "CONTEXT" in prompt
+
+
+def test_named_role_completion_gate_requires_verification_evidence():
+    agent = _make_bare_agent()
+    agent.runtime_activation_state = {
+        "specialist": "code_reviewer",
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+
+    gate_error = agent._evaluate_named_role_completion_gate(
+        [{"role": "assistant", "tool_calls": [{"function": {"name": "patch"}}]}]
+    )
+
+    assert gate_error == (
+        "Reviewer/verifier completion gate blocked success: no verification evidence tool was used in this run."
+    )
+
+
+def test_named_role_completion_gate_allows_evidence_tool_usage():
+    agent = _make_bare_agent()
+    agent.runtime_activation_state = {
+        "specialist": "code_reviewer",
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+
+    gate_error = agent._evaluate_named_role_completion_gate(
+        [{"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]}]
+    )
+
+    assert gate_error is None
+
+
+def test_named_role_completion_gate_keeps_legacy_reviewer_alias_compatible():
+    agent = _make_bare_agent()
+    agent.runtime_activation_state = {
+        "specialist": "reviewer",
+        "archetype": "generalist",
+        "delegation_profile": "verification",
+    }
+
+    gate_error = agent._evaluate_named_role_completion_gate(
+        [{"role": "assistant", "tool_calls": [{"function": {"name": "patch"}}]}]
+    )
+
+    assert gate_error == (
+        "Reviewer/verifier completion gate blocked success: no verification evidence tool was used in this run."
+    )
+
+
+def test_named_role_completion_gate_does_not_treat_archetype_only_verifier_as_code_reviewer():
+    agent = _make_bare_agent()
+    agent.runtime_activation_state = {
+        "specialist": None,
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+
+    gate_error = agent._evaluate_named_role_completion_gate(
+        [{"role": "assistant", "tool_calls": [{"function": {"name": "patch"}}]}]
+    )
+
+    assert gate_error is None
+
+
+def test_get_runtime_scoped_tools_filters_mutating_tools_for_reviewer_runtime():
+    agent = _make_bare_agent()
+    agent.valid_tool_names = {"read_file", "terminal", "patch", "write_file", "memory"}
+    agent.tools = [
+        {"type": "function", "function": {"name": "patch"}},
+        {"type": "function", "function": {"name": "read_file"}},
+        {"type": "function", "function": {"name": "terminal"}},
+        {"type": "function", "function": {"name": "write_file"}},
+        {"type": "function", "function": {"name": "memory"}},
+    ]
+    agent.runtime_activation_state = {
+        "specialist": "code_reviewer",
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+
+    scoped_names = [tool["function"]["name"] for tool in agent._get_runtime_scoped_tools()]
+
+    assert scoped_names == ["read_file", "terminal"]
+
+
+def test_maybe_block_named_role_tool_call_blocks_mutating_tools_and_destructive_terminal():
+    agent = _make_bare_agent()
+    agent.runtime_activation_state = {
+        "specialist": "code_reviewer",
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+
+    assert "cannot call 'patch'" in agent._maybe_block_named_role_tool_call("patch", {})
+    assert agent._maybe_block_named_role_tool_call("terminal", {"command": "git status"}) is None
+    assert "destructive terminal commands are blocked" in agent._maybe_block_named_role_tool_call(
+        "terminal", {"command": "rm -rf tmp"}
+    )
+
+
+def test_live_tool_invoke_blocks_disallowed_mutating_tool_for_reviewer_runtime(monkeypatch):
+    agent = _make_bare_agent()
+    agent.valid_tool_names = {"patch", "read_file", "terminal"}
+    agent.runtime_activation_state = {
+        "specialist": "qa_guard",
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+
+    def _unexpected_call(*_args, **_kwargs):
+        raise AssertionError("blocked mutating tool should not reach handle_function_call")
+
+    monkeypatch.setattr(run_agent, "handle_function_call", _unexpected_call)
+
+    result = json.loads(agent._invoke_tool("patch", {"path": "x", "old_string": "a", "new_string": "b"}, "task-1"))
+
+    assert result == {
+        "error": (
+            "Reviewer/verifier runtime boundary: this role is read-only and cannot call 'patch'. "
+            "Use read-only inspection, testing, or delegation instead."
+        )
+    }
+
+
+def test_live_tool_invoke_allows_evidence_tools_and_non_destructive_terminal_for_reviewer_runtime(monkeypatch):
+    agent = _make_bare_agent()
+    agent.valid_tool_names = {"read_file", "terminal", "patch"}
+    agent.runtime_activation_state = {
+        "specialist": "code_reviewer",
+        "archetype": "verifier",
+        "delegation_profile": "verification",
+    }
+    calls = []
+
+    def _fake_handle(function_name, function_args, effective_task_id, **kwargs):
+        calls.append((function_name, function_args, effective_task_id, kwargs))
+        return json.dumps({"ok": function_name}, ensure_ascii=False)
+
+    monkeypatch.setattr(run_agent, "handle_function_call", _fake_handle)
+
+    read_result = json.loads(agent._invoke_tool("read_file", {"path": "run_agent.py"}, "task-2"))
+    terminal_result = json.loads(agent._invoke_tool("terminal", {"command": "git status --short"}, "task-2"))
+
+    assert read_result == {"ok": "read_file"}
+    assert terminal_result == {"ok": "terminal"}
+    assert calls == [
+        (
+            "read_file",
+            {"path": "run_agent.py"},
+            "task-2",
+            {
+                "tool_call_id": None,
+                "session_id": "",
+                "enabled_tools": ["read_file", "terminal"],
+                "skip_pre_tool_call_hook": True,
+            },
+        ),
+        (
+            "terminal",
+            {"command": "git status --short"},
+            "task-2",
+            {
+                "tool_call_id": None,
+                "session_id": "",
+                "enabled_tools": ["read_file", "terminal"],
+                "skip_pre_tool_call_hook": True,
+            },
+        ),
+    ]

--- a/tests/run_agent/test_orchestration_continuation.py
+++ b/tests/run_agent/test_orchestration_continuation.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("todo", "web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        instance.client = MagicMock()
+        return instance
+
+
+class TestOrchestrationContinuationSnapshot:
+    def test_snapshot_reports_active_todos_for_incomplete_run(self, agent):
+        agent._todo_store.write(
+            [
+                {"id": "plan", "content": "Inspect runtime logs", "status": "in_progress"},
+                {"id": "done", "content": "Document old issue", "status": "completed"},
+            ]
+        )
+
+        snapshot = agent.get_orchestration_continuation_snapshot(
+            {
+                "completed": False,
+                "interrupted": True,
+                "failed": False,
+                "final_response": "Interrupted during the final tool call.",
+            }
+        )
+
+        assert snapshot["outcomeStatus"] == "interrupted"
+        assert [item["id"] for item in snapshot["activeTodos"]] == ["plan"]
+        assert snapshot["responsePreview"] == "Interrupted during the final tool call."
+
+    def test_snapshot_marks_completed_when_no_open_todos_remain(self, agent):
+        agent._todo_store.write(
+            [
+                {"id": "plan", "content": "Inspect runtime logs", "status": "completed"},
+            ]
+        )
+
+        snapshot = agent.get_orchestration_continuation_snapshot(
+            {
+                "completed": True,
+                "interrupted": False,
+                "failed": False,
+                "final_response": "All requested work is complete.",
+            }
+        )
+
+        assert snapshot["outcomeStatus"] == "completed"
+        assert snapshot["activeTodos"] == []
+        assert snapshot["responsePreview"] == "All requested work is complete."

--- a/tests/run_agent/test_ralph_loop_semantics.py
+++ b/tests/run_agent/test_ralph_loop_semantics.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.continuation_engine import (
+    apply_bounded_continuation_engine,
+    build_runtime_resume_message,
+    should_use_continuation_engine,
+)
+from run_agent import AIAgent
+
+
+class _FakeChild:
+    def __init__(self, follow_up_results):
+        self.follow_up_results = list(follow_up_results)
+        self.calls = []
+        self.session_id = "child-1"
+
+    def run_conversation(self, user_message: str):
+        self.calls.append(user_message)
+        return self.follow_up_results.pop(0)
+
+
+def _make_agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-12345678",
+            base_url="https://example.test/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent.runtime_activation_state = {"runtime_mode": "ralph"}
+    agent.get_runtime_activation_state = lambda: dict(agent.runtime_activation_state)
+    return agent
+
+
+def test_ralph_loop_retries_failed_work_without_open_todos():
+    child = _FakeChild([
+        {"completed": True, "final_response": "Recovered on retry.", "api_calls": 1}
+    ])
+
+    initial_result = {
+        "failed": True,
+        "final_response": "First attempt failed.",
+        "api_calls": 1,
+    }
+
+    continuation = apply_bounded_continuation_engine(child, initial_result, runtime_mode="ralph")
+
+    assert continuation["resume_count"] == 1
+    assert continuation["attempt_count"] == 2
+    assert continuation["result"]["final_response"] == "Recovered on retry."
+    assert continuation["snapshot"]["outcomeStatus"] == "completed"
+    assert child.calls
+    assert "Ralph-loop continuation engine retry" in child.calls[0]
+    assert "Previous outcome: failed" in child.calls[0]
+
+
+def test_ralph_loop_honors_explicit_stop_signal():
+    snapshot = {
+        "outcomeStatus": "interrupted",
+        "activeTodos": [{"id": "todo-1", "content": "Stop here", "status": "in_progress"}],
+        "stopRequested": True,
+    }
+
+    assert should_use_continuation_engine("ralph", snapshot) is False
+
+
+def test_ultrawork_does_not_retry_failed_attempt_without_open_todos():
+    snapshot = {
+        "outcomeStatus": "failed",
+        "activeTodos": [],
+    }
+
+    assert should_use_continuation_engine("ultrawork", snapshot) is False
+    assert should_use_continuation_engine("ralph", snapshot) is True
+
+
+def test_mode_specific_resume_messages_are_distinct():
+    snapshot = {
+        "outcomeStatus": "interrupted",
+        "activeTodos": [{"id": "todo-1", "content": "Finish the task", "status": "in_progress"}],
+    }
+
+    ultrawork_message = build_runtime_resume_message(snapshot, runtime_mode="ultrawork", attempt=1, max_attempts=2)
+    ralph_message = build_runtime_resume_message(snapshot, runtime_mode="ralph", attempt=1, max_attempts=2)
+
+    assert "Ultrawork continuation engine resume" in ultrawork_message
+    assert "Do not stop at a status update" in ultrawork_message
+    assert "Ralph-loop continuation engine retry" in ralph_message
+    assert "Stop cleanly if the loop should end" in ralph_message
+
+
+def test_aiagent_ralph_requeues_failed_text_response_without_open_todos():
+    agent = _make_agent()
+    assistant_message = SimpleNamespace(content="First pass failed.", tool_calls=[], failed=True)
+    messages = []
+
+    queued = agent._maybe_enqueue_runtime_continuation(
+        messages=messages,
+        assistant_message=assistant_message,
+        finish_reason="stop",
+        final_response="First pass failed.",
+        runtime_resume_count=0,
+        turn_outcome=agent._build_runtime_continuation_turn_outcome(
+            assistant_message=assistant_message,
+            final_response="First pass failed.",
+            interrupted=False,
+        ),
+    )
+
+    assert queued is True
+    assert messages[-1]["role"] == "user"
+    assert "Ralph-loop continuation engine retry" in messages[-1]["content"]
+    assert "Previous outcome: failed" in messages[-1]["content"]
+
+
+def test_aiagent_ralph_requeues_interrupted_text_response_without_open_todos():
+    agent = _make_agent()
+    assistant_message = SimpleNamespace(content="Interrupted before completion.", tool_calls=[], interrupted=True)
+    messages = []
+
+    queued = agent._maybe_enqueue_runtime_continuation(
+        messages=messages,
+        assistant_message=assistant_message,
+        finish_reason="stop",
+        final_response="Interrupted before completion.",
+        runtime_resume_count=0,
+        turn_outcome=agent._build_runtime_continuation_turn_outcome(
+            assistant_message=assistant_message,
+            final_response="Interrupted before completion.",
+            interrupted=False,
+        ),
+    )
+
+    assert queued is True
+    assert messages[-1]["role"] == "user"
+    assert "Ralph-loop continuation engine retry" in messages[-1]["content"]
+    assert "Previous outcome: interrupted" in messages[-1]["content"]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4220,3 +4220,143 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+class TestNativeOrchestrationHardening:
+    def test_enabled_tools_forwarded_to_tool_loader(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("read_file")) as mock_get_tools,
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                enabled_tools=["read_file", "search_files"],
+            )
+
+        assert mock_get_tools.call_args.kwargs["enabled_tools"] == ["read_file", "search_files"]
+
+    def test_coalesce_delegate_task_calls_merges_into_batch(self):
+        call_a = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps({"goal": "Research profile configs", "category": "research"}),
+            call_id="call_a",
+        )
+        call_b = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps({"goal": "Verify runtime hooks", "category": "verification"}),
+            call_id="call_b",
+        )
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value={"auto_fanout_batch_mode": True}),
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=5),
+        ):
+            merged = AIAgent._coalesce_delegate_task_calls([call_a, call_b])
+
+        assert len(merged) == 1
+        assert merged[0].function.name == "delegate_task"
+        args = json.loads(merged[0].function.arguments)
+        assert [task["goal"] for task in args["tasks"]] == [
+            "Research profile configs",
+            "Verify runtime hooks",
+        ]
+        assert [task["category"] for task in args["tasks"]] == ["research", "verification"]
+
+    def test_coalesce_delegate_task_calls_respects_auto_fanout_max_tasks(self):
+        call_a = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps(
+                {
+                    "tasks": [
+                        {"goal": "Task A"},
+                        {"goal": "Task B"},
+                        {"goal": "Task C"},
+                    ]
+                }
+            ),
+            call_id="call_a",
+        )
+
+        with (
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={
+                    "auto_fanout_batch_mode": True,
+                    "auto_fanout_max_tasks": 2,
+                    "max_concurrent_children": 5,
+                },
+            ),
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=5),
+        ):
+            merged = AIAgent._coalesce_delegate_task_calls([call_a])
+
+        assert len(merged) == 1
+        args = json.loads(merged[0].function.arguments)
+        assert [task["goal"] for task in args["tasks"]] == ["Task A", "Task B"]
+
+    def test_coalesce_delegate_task_calls_allows_explicit_category_batch_above_root_default(self):
+        calls = [
+            _mock_tool_call(
+                name="delegate_task",
+                arguments=json.dumps({"goal": f"Research {idx}", "category": "research"}),
+                call_id=f"call_{idx}",
+            )
+            for idx in range(4)
+        ]
+
+        with (
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={
+                    "auto_fanout_batch_mode": True,
+                    "auto_fanout_max_tasks": 5,
+                    "max_concurrent_children": 3,
+                    "categories": {"research": {"max_concurrent_children": 5}},
+                },
+            ),
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=3),
+        ):
+            merged = AIAgent._coalesce_delegate_task_calls(calls)
+
+        assert len(merged) == 1
+        args = json.loads(merged[0].function.arguments)
+        assert [task["goal"] for task in args["tasks"]] == [
+            "Research 0",
+            "Research 1",
+            "Research 2",
+            "Research 3",
+        ]
+
+    def test_large_task_note_detection_prefers_todo_and_batch_delegation(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("todo", "delegate_task")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent._delegation_cfg = {
+            "auto_decompose_large_tasks": True,
+            "auto_fanout_batch_mode": True,
+            "auto_fanout_max_tasks": 4,
+            "max_concurrent_children": 5,
+        }
+        message = (
+            "Please audit all profiles, compare the runtime behavior across the board, "
+            "implement any missing orchestration hooks, run tests, verify the CLI behavior, "
+            "and fix regressions before you finish."
+        )
+
+        assert agent._should_inject_orchestration_note(message, api_call_count=1) is True
+        note = agent._build_orchestration_user_note()
+        assert "create a concise todo list" in note
+        assert "delegate_task batch call" in note

--- a/tests/run_agent/test_runtime_activation_overlay_parity.py
+++ b/tests/run_agent/test_runtime_activation_overlay_parity.py
@@ -1,0 +1,365 @@
+from importlib import import_module
+from types import SimpleNamespace
+
+import pytest
+
+import agent.archetypes as archetypes
+from agent.prompt_builder import build_wave1_overlay_prompt_from_normalized, normalize_wave1_overlay_inputs
+
+if not hasattr(archetypes, "resolve_specialist_mapping"):
+    archetypes.resolve_specialist_mapping = lambda value: None
+if not hasattr(archetypes, "resolve_specialist_defaults"):
+    archetypes.resolve_specialist_defaults = lambda value: {}
+
+run_agent = import_module("run_agent")
+AIAgent = run_agent.AIAgent
+
+
+def _sample_task_contract() -> dict:
+    return {
+        "task": "Implement the delegated change",
+        "expected_outcome": "A passing implementation with verification evidence",
+        "required_skills": ["python", "testing"],
+        "required_tools": ["read_file", "patch", "terminal"],
+        "must_do": ["inspect repo patterns before editing"],
+        "must_not_do": {"forbidden_files": ["tools/delegate_tool.py"]},
+        "context": {"repo": "/root/.hermes/hermes-agent"},
+    }
+
+
+def _make_bare_agent(delegate_depth: int = 0) -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent._delegate_depth = delegate_depth
+    agent._delegate_resolution = {}
+    return agent
+
+
+def _sample_named_workflow() -> dict:
+    return {
+        "schema": "hermes/named-workflow",
+        "schema_version": "1.0",
+        "workflow_name": "planner",
+        "mode": "plan",
+        "objective": "Plan the implementation before execution.",
+        "plan": ["inspect", "plan", "handoff"],
+        "acceptance": ["machine-readable artifact present"],
+        "taxonomy": {
+            "named_workflow": "planner",
+            "workflow": "planner",
+            "specialist": "planner",
+            "archetype": "generalist",
+            "route_category": "unspecified_low",
+            "runtime_mode": "default",
+            "delegation_profile": "general",
+        },
+        "execution_task_contract": None,
+        "consumption": {"downstream_role": "deep_worker"},
+    }
+
+
+def test_parent_runtime_activation_uses_canonical_overlay_contract(monkeypatch):
+    contract = _sample_task_contract()
+    monkeypatch.setattr(
+        run_agent,
+        "preclassify_intent",
+        lambda _message: SimpleNamespace(
+            inferred_specialist=None,
+            inferred_archetype="implementer",
+            inferred_route_category="deep",
+            inferred_runtime_mode="execution_supervisor",
+            inferred_delegation_profile="verification",
+            activation_reason="parent parity test",
+            inference_source="wave2_intent_preclassifier",
+            task_contract=contract,
+        ),
+    )
+
+    agent = _make_bare_agent(delegate_depth=0)
+    state = agent._resolve_runtime_activation_state("verify parity")
+    normalized = normalize_wave1_overlay_inputs(
+        archetype_name="implementer",
+        route_category="deep",
+        delegation_profile="verification",
+        runtime_mode="execution_supervisor",
+        task_contract=contract,
+    )
+
+    assert state["archetype"] == normalized["archetype"]
+    assert state["route_category"] == normalized["route_category"]
+    assert state["delegation_profile"] == normalized["delegation_profile"]
+    assert state["runtime_mode"] == normalized["runtime_mode"]
+    assert state["task_contract"] == normalized["task_contract"]
+    assert state["wave1_overlay_prompt"] == build_wave1_overlay_prompt_from_normalized(normalized)
+    assert state["wave1_overlay_prompt"] in state["activation_note"]
+    assert state["activation_note"].startswith("<wave2-runtime-activation>")
+    assert state["activation_note"].endswith("</wave2-runtime-activation>")
+
+
+def test_delegated_child_preserves_passed_through_wave1_state_without_reset():
+    contract = _sample_task_contract()
+    agent = _make_bare_agent(delegate_depth=1)
+    agent._delegate_resolution = {
+        "archetype": "implementer",
+        "route_category": "deep",
+        "route_category_definition": {"name": "deep", "summary": "Deep implementation lane", "intensity": "high"},
+        "delegation_profile": "verification",
+        "runtime_mode": "execution_supervisor",
+        "runtime_mode_definition": {
+            "name": "execution_supervisor",
+            "description": "Supervise delegated execution and reconcile results.",
+            "operating_posture": "oversight_and_coordination",
+            "kind": "runtime_mode",
+        },
+        "skills": ["testing", "python"],
+        "task_contract": contract,
+        "orchestration_hints": {"permission_preset": "inherit", "fallback_policy": "legacy_default_mapping"},
+    }
+
+    state = agent._resolve_runtime_activation_state("ignored in delegated child")
+    normalized = normalize_wave1_overlay_inputs(
+        archetype_name=agent._delegate_resolution["archetype"],
+        route_category=agent._delegate_resolution["route_category_definition"],
+        delegation_profile=agent._delegate_resolution["delegation_profile"],
+        runtime_mode=agent._delegate_resolution["runtime_mode_definition"],
+        skills=agent._delegate_resolution["skills"],
+        task_contract=agent._delegate_resolution["task_contract"],
+        orchestration_hints=agent._delegate_resolution["orchestration_hints"],
+    )
+
+    assert state["inference_source"] == "delegate_passthrough"
+    assert state["archetype"] == normalized["archetype"]
+    assert state["route_category"] == normalized["route_category"]
+    assert state["delegation_profile"] == normalized["delegation_profile"]
+    assert state["runtime_mode"] == normalized["runtime_mode"]
+    assert state["task_contract"] == normalized["task_contract"]
+    assert state["wave1_overlay_prompt"] == build_wave1_overlay_prompt_from_normalized(normalized)
+    assert state["wave1_overlay_prompt"] in state["activation_note"]
+    assert "## Archetype\nname: implementer" in state["wave1_overlay_prompt"]
+    assert "## Archetype\nname: generalist" not in state["wave1_overlay_prompt"]
+
+
+def test_parent_runtime_activation_proves_qa_guard_quick_overlay_end_to_end():
+    agent = _make_bare_agent(delegate_depth=0)
+    state = agent._resolve_runtime_activation_state("qa regression validate the fix")
+
+    assert state["specialist"] == "qa_guard"
+    assert state["archetype"] == "verifier"
+    assert state["route_category"] == "quick"
+    assert state["delegation_profile"] == "verification"
+    assert state["runtime_mode"] == "default"
+    assert state["inference_source"] == "wave2_intent_preclassifier"
+
+    assert "keyword-derived specialist: qa_guard" in state["activation_reason"]
+    assert "archetype=verifier" in state["activation_reason"]
+    assert "specialist=qa_guard" in state["activation_reason"]
+    assert "route_category=quick" in state["activation_reason"]
+    assert "delegation_profile=verification" in state["activation_reason"]
+    assert "runtime_mode=default" in state["activation_reason"]
+
+    assert state["activation_note"].startswith("<wave2-runtime-activation>")
+    assert state["activation_note"].endswith("</wave2-runtime-activation>")
+    assert state["wave1_overlay_prompt"] in state["activation_note"]
+
+    assert "## Archetype\nname: verifier" in state["wave1_overlay_prompt"]
+    assert "default_route_category: quick" in state["wave1_overlay_prompt"]
+    assert "default_delegation_profile: verification" in state["wave1_overlay_prompt"]
+    assert "## Route Category\nname: quick" in state["wave1_overlay_prompt"]
+    assert "summary: Fast-path routing lane for lighter-weight execution." in state["wave1_overlay_prompt"]
+    assert "intensity: low" in state["wave1_overlay_prompt"]
+    assert "## Delegation Profile\nname: verification" in state["wave1_overlay_prompt"]
+    assert "## Runtime Mode\nname: default" in state["wave1_overlay_prompt"]
+    assert "operating_posture: balanced_general_operation" in state["wave1_overlay_prompt"]
+    assert "## Skills" in state["wave1_overlay_prompt"]
+    assert "- verification" in state["wave1_overlay_prompt"]
+    assert "- testing" in state["wave1_overlay_prompt"]
+    assert "- review" in state["wave1_overlay_prompt"]
+
+    assert "## Route Category\nname: ultrabrain" not in state["wave1_overlay_prompt"]
+
+
+def test_parent_runtime_activation_proves_builder_deep_default_overlay_end_to_end():
+    agent = _make_bare_agent(delegate_depth=0)
+    state = agent._resolve_runtime_activation_state("implement the delegated change")
+
+    assert state["specialist"] == "builder"
+    assert state["archetype"] == "implementer"
+    assert state["route_category"] == "deep"
+    assert state["delegation_profile"] == "implementation"
+    assert state["runtime_mode"] == "default"
+    assert state["inference_source"] == "wave2_intent_preclassifier"
+
+    assert "keyword-derived specialist: builder" in state["activation_reason"]
+    assert "archetype=implementer" in state["activation_reason"]
+    assert "specialist=builder" in state["activation_reason"]
+    assert "route_category=deep" in state["activation_reason"]
+    assert "delegation_profile=implementation" in state["activation_reason"]
+    assert "runtime_mode=default" in state["activation_reason"]
+
+    assert state["activation_note"].startswith("<wave2-runtime-activation>")
+    assert state["activation_note"].endswith("</wave2-runtime-activation>")
+    assert state["wave1_overlay_prompt"] in state["activation_note"]
+
+    assert "## Archetype\nname: implementer" in state["wave1_overlay_prompt"]
+    assert "default_route_category: deep" in state["wave1_overlay_prompt"]
+    assert "default_delegation_profile: implementation" in state["wave1_overlay_prompt"]
+    assert "## Route Category\nname: deep" in state["wave1_overlay_prompt"]
+    assert "## Delegation Profile\nname: implementation" in state["wave1_overlay_prompt"]
+    assert "## Runtime Mode\nname: default" in state["wave1_overlay_prompt"]
+
+
+def test_named_workflow_alone_triggers_runtime_activation_injection():
+    named_workflow = _sample_named_workflow()
+    state = {
+        "specialist": None,
+        "archetype": "generalist",
+        "route_category": "unspecified_low",
+        "delegation_profile": "general",
+        "runtime_mode": "default",
+        "task_contract": None,
+        "named_workflow": named_workflow,
+        "wave1_overlay_prompt": "",
+        "activation_reason": "named workflow only",
+        "inference_source": "test",
+    }
+    agent = _make_bare_agent(delegate_depth=0)
+
+    assert agent._should_apply_runtime_activation_state(state) is True
+
+    activation_note = agent._build_runtime_activation_note(state)
+    assert activation_note.startswith("<wave2-runtime-activation>")
+    assert "<named-workflow>" in activation_note
+    assert '"workflow_name": "planner"' in activation_note
+    assert activation_note.endswith("</wave2-runtime-activation>")
+
+
+def test_delegated_child_ignores_invalid_named_workflow_passthrough():
+    contract = _sample_task_contract()
+    agent = _make_bare_agent(delegate_depth=1)
+    agent._delegate_resolution = {
+        "archetype": "implementer",
+        "route_category": "deep",
+        "delegation_profile": "implementation",
+        "runtime_mode": "default",
+        "task_contract": contract,
+        "named_workflow": {"workflow_name": "unknown-workflow", "mode": "execute"},
+    }
+
+    state = agent._resolve_runtime_activation_state("ignored in delegated child")
+
+    assert state["named_workflow"] is None
+    assert "<named-workflow>" not in state["activation_note"]
+
+
+def test_parent_runtime_activation_mixed_review_and_bug_prompt_keeps_keyword_collision_behavior_explicit():
+    agent = _make_bare_agent(delegate_depth=0)
+    state = agent._resolve_runtime_activation_state(
+        "Review this patch, reproduce the bug, and call out regressions with verification evidence."
+    )
+
+    assert state["specialist"] == "bug_hunter"
+    assert state["archetype"] == "implementer"
+    assert state["route_category"] == "deep"
+    assert state["delegation_profile"] == "implementation"
+    assert state["runtime_mode"] == "default"
+    assert state["inference_source"] == "wave2_intent_preclassifier"
+    assert "keyword-derived specialist: bug_hunter" in state["activation_reason"]
+    assert "specialist=bug_hunter" in state["activation_reason"]
+    assert "specialist=code_reviewer" not in state["activation_reason"]
+    assert "specialist: bug_hunter" in state["activation_note"]
+    assert "## Archetype\nname: implementer" in state["wave1_overlay_prompt"]
+    assert "## Route Category\nname: deep" in state["wave1_overlay_prompt"]
+    assert "## Delegation Profile\nname: implementation" in state["wave1_overlay_prompt"]
+
+
+@pytest.mark.parametrize(
+    ("prompt", "specialist", "archetype", "archetype_default_route_category", "route_category", "delegation_profile"),
+    [
+        (
+            "Review this patch, verify the risky changes, and call out regressions.",
+            "code_reviewer",
+            "verifier",
+            "quick",
+            "quick",
+            "verification",
+        ),
+        (
+            "qa regression validate the fix",
+            "qa_guard",
+            "verifier",
+            "quick",
+            "quick",
+            "verification",
+        ),
+        (
+            "Plan the rollout, decompose the work, and sequence the execution plan.",
+            "planner",
+            "generalist",
+            "unspecified_low",
+            "deep",
+            "general",
+        ),
+        (
+            "Reproduce the bug, trace the failure, and identify the root cause.",
+            "bug_hunter",
+            "implementer",
+            "deep",
+            "deep",
+            "implementation",
+        ),
+        (
+            "Analyze the API behavior, compare sources, and synthesize the findings.",
+            "analyst",
+            "researcher",
+            "deep",
+            "deep",
+            "research",
+        ),
+        (
+            "Investigate the architecture, gather evidence, and triage the issue.",
+            "investigator",
+            "researcher",
+            "deep",
+            "deep",
+            "research",
+        ),
+    ],
+    ids=["code_reviewer", "qa_guard", "planner", "bug_hunter", "analyst", "investigator"],
+)
+def test_parent_runtime_activation_specialist_overlay_matrix_preserves_explicit_taxonomy(
+    prompt: str,
+    specialist: str,
+    archetype: str,
+    archetype_default_route_category: str,
+    route_category: str,
+    delegation_profile: str,
+):
+    agent = _make_bare_agent(delegate_depth=0)
+    state = agent._resolve_runtime_activation_state(prompt)
+
+    assert state["specialist"] == specialist
+    assert state["archetype"] == archetype
+    assert state["route_category"] == route_category
+    assert state["delegation_profile"] == delegation_profile
+    assert state["runtime_mode"] == "default"
+    assert state["inference_source"] == "wave2_intent_preclassifier"
+
+    assert f"keyword-derived specialist: {specialist}" in state["activation_reason"]
+    assert f"archetype={archetype}" in state["activation_reason"]
+    assert f"specialist={specialist}" in state["activation_reason"]
+    assert f"route_category={route_category}" in state["activation_reason"]
+    assert f"delegation_profile={delegation_profile}" in state["activation_reason"]
+    assert "runtime_mode=default" in state["activation_reason"]
+
+    assert state["activation_note"].startswith("<wave2-runtime-activation>")
+    assert state["activation_note"].endswith("</wave2-runtime-activation>")
+    assert f"specialist: {specialist}" in state["activation_note"]
+    assert state["wave1_overlay_prompt"] in state["activation_note"]
+
+    assert f"## Archetype\nname: {archetype}" in state["wave1_overlay_prompt"]
+    assert f"default_route_category: {archetype_default_route_category}" in state["wave1_overlay_prompt"]
+    assert f"default_delegation_profile: {delegation_profile}" in state["wave1_overlay_prompt"]
+    assert f"## Route Category\nname: {route_category}" in state["wave1_overlay_prompt"]
+    assert f"## Delegation Profile\nname: {delegation_profile}" in state["wave1_overlay_prompt"]
+    assert "## Runtime Mode\nname: default" in state["wave1_overlay_prompt"]
+    assert "operating_posture: balanced_general_operation" in state["wave1_overlay_prompt"]
+    assert "## Skills" in state["wave1_overlay_prompt"]

--- a/tests/run_agent/test_runtime_activation_overlay_parity.py
+++ b/tests/run_agent/test_runtime_activation_overlay_parity.py
@@ -65,6 +65,7 @@ def test_parent_runtime_activation_uses_canonical_overlay_contract(monkeypatch):
         lambda _message: SimpleNamespace(
             inferred_specialist=None,
             inferred_archetype="implementer",
+            inferred_category="deep",
             inferred_route_category="deep",
             inferred_runtime_mode="execution_supervisor",
             inferred_delegation_profile="verification",
@@ -81,6 +82,7 @@ def test_parent_runtime_activation_uses_canonical_overlay_contract(monkeypatch):
         route_category="deep",
         delegation_profile="verification",
         runtime_mode="execution_supervisor",
+        skills=archetypes.resolve_archetype("implementer").default_skills,
         task_contract=contract,
     )
 
@@ -100,6 +102,7 @@ def test_delegated_child_preserves_passed_through_wave1_state_without_reset():
     agent = _make_bare_agent(delegate_depth=1)
     agent._delegate_resolution = {
         "archetype": "implementer",
+        "category": "deep",
         "route_category": "deep",
         "route_category_definition": {"name": "deep", "summary": "Deep implementation lane", "intensity": "high"},
         "delegation_profile": "verification",
@@ -128,14 +131,82 @@ def test_delegated_child_preserves_passed_through_wave1_state_without_reset():
 
     assert state["inference_source"] == "delegate_passthrough"
     assert state["archetype"] == normalized["archetype"]
+    assert state["category"] == normalized["category"]
     assert state["route_category"] == normalized["route_category"]
     assert state["delegation_profile"] == normalized["delegation_profile"]
     assert state["runtime_mode"] == normalized["runtime_mode"]
     assert state["task_contract"] == normalized["task_contract"]
     assert state["wave1_overlay_prompt"] == build_wave1_overlay_prompt_from_normalized(normalized)
     assert state["wave1_overlay_prompt"] in state["activation_note"]
+    assert "category: deep" in state["activation_note"]
+    assert "route_category: deep" in state["activation_note"]
+    assert "delegation_profile: verification" in state["activation_note"]
     assert "## Archetype\nname: implementer" in state["wave1_overlay_prompt"]
     assert "## Archetype\nname: generalist" not in state["wave1_overlay_prompt"]
+
+
+def test_delegated_child_preserves_literal_category_when_distinct_from_route_and_profile():
+    agent = _make_bare_agent(delegate_depth=1)
+    agent._delegate_resolution = {
+        "specialist": "multimodal_specialist",
+        "archetype": "researcher",
+        "category": "visual-engineering",
+        "route_category": "visual",
+        "delegation_profile": "research",
+        "runtime_mode": "default",
+        "skills": ["vision", "research"],
+    }
+
+    state = agent._resolve_runtime_activation_state("ignored in delegated child")
+    snapshot = agent._build_runtime_activation_snapshot_entry(state)
+
+    assert state["specialist"] == "multimodal_specialist"
+    assert state["archetype"] == "researcher"
+    assert state["category"] == "visual-engineering"
+    assert state["route_category"] == "visual"
+    assert state["delegation_profile"] == "research"
+    assert state["runtime_mode"] == "default"
+    assert state["inference_source"] == "delegate_passthrough"
+    assert "specialist=multimodal_specialist" in state["activation_reason"]
+    assert "archetype=researcher" in state["activation_reason"]
+    assert "category=visual-engineering" in state["activation_reason"]
+    assert "route_category=visual" in state["activation_reason"]
+    assert "delegation_profile=research" in state["activation_reason"]
+    assert "runtime_mode=default" in state["activation_reason"]
+    assert "category: visual-engineering" in state["activation_note"]
+    assert "route_category: visual" in state["activation_note"]
+    assert "delegation_profile: research" in state["activation_note"]
+    assert "## Category\nname: visual-engineering" in state["wave1_overlay_prompt"]
+    assert "## Route Category\nname: visual" in state["wave1_overlay_prompt"]
+    assert "## Delegation Profile\nname: research" in state["wave1_overlay_prompt"]
+    assert snapshot["category"] == "visual-engineering"
+    assert snapshot["route_category"] == "visual"
+    assert snapshot["delegation_profile"] == "research"
+
+
+def test_delegated_child_preserves_named_agent_identity_in_runtime_state_and_snapshot():
+    agent = _make_bare_agent(delegate_depth=1)
+    agent._delegate_resolution = {
+        "agent": "oracle",
+        "named_agent": "oracle",
+        "specialist": "consultant",
+        "archetype": "researcher",
+        "route_category": "deep",
+        "delegation_profile": "research",
+        "runtime_mode": "default",
+    }
+
+    state = agent._resolve_runtime_activation_state("ignored in delegated child")
+    snapshot = agent._build_runtime_activation_snapshot_entry(state)
+
+    assert state["named_agent"] == "oracle"
+    assert state["category"] == "deep"
+    assert "named_agent: oracle" in state["activation_note"]
+    assert "category: deep" in state["activation_note"]
+    assert "route_category: deep" in state["activation_note"]
+    assert snapshot["named_agent"] == "oracle"
+    assert snapshot["category"] == "deep"
+    assert snapshot["activation_identity"] == "oracle"
 
 
 def test_parent_runtime_activation_proves_qa_guard_quick_overlay_end_to_end():
@@ -144,6 +215,7 @@ def test_parent_runtime_activation_proves_qa_guard_quick_overlay_end_to_end():
 
     assert state["specialist"] == "qa_guard"
     assert state["archetype"] == "verifier"
+    assert state["category"] == "quick"
     assert state["route_category"] == "quick"
     assert state["delegation_profile"] == "verification"
     assert state["runtime_mode"] == "default"
@@ -152,17 +224,24 @@ def test_parent_runtime_activation_proves_qa_guard_quick_overlay_end_to_end():
     assert "keyword-derived specialist: qa_guard" in state["activation_reason"]
     assert "archetype=verifier" in state["activation_reason"]
     assert "specialist=qa_guard" in state["activation_reason"]
+    assert "category=quick" in state["activation_reason"]
     assert "route_category=quick" in state["activation_reason"]
     assert "delegation_profile=verification" in state["activation_reason"]
     assert "runtime_mode=default" in state["activation_reason"]
 
     assert state["activation_note"].startswith("<wave2-runtime-activation>")
     assert state["activation_note"].endswith("</wave2-runtime-activation>")
+    assert "category: quick" in state["activation_note"]
+    assert "route_category: quick" in state["activation_note"]
+    assert "delegation_profile: verification" in state["activation_note"]
+    assert "runtime_mode: default" in state["activation_note"]
     assert state["wave1_overlay_prompt"] in state["activation_note"]
 
     assert "## Archetype\nname: verifier" in state["wave1_overlay_prompt"]
     assert "default_route_category: quick" in state["wave1_overlay_prompt"]
     assert "default_delegation_profile: verification" in state["wave1_overlay_prompt"]
+    assert "## Category\nname: quick" in state["wave1_overlay_prompt"]
+    assert "fallback_semantics: inherits_mapped_route_category" in state["wave1_overlay_prompt"]
     assert "## Route Category\nname: quick" in state["wave1_overlay_prompt"]
     assert "summary: Fast-path routing lane for lighter-weight execution." in state["wave1_overlay_prompt"]
     assert "intensity: low" in state["wave1_overlay_prompt"]
@@ -183,6 +262,7 @@ def test_parent_runtime_activation_proves_builder_deep_default_overlay_end_to_en
 
     assert state["specialist"] == "builder"
     assert state["archetype"] == "implementer"
+    assert state["category"] == "deep"
     assert state["route_category"] == "deep"
     assert state["delegation_profile"] == "implementation"
     assert state["runtime_mode"] == "default"
@@ -191,20 +271,100 @@ def test_parent_runtime_activation_proves_builder_deep_default_overlay_end_to_en
     assert "keyword-derived specialist: builder" in state["activation_reason"]
     assert "archetype=implementer" in state["activation_reason"]
     assert "specialist=builder" in state["activation_reason"]
+    assert "category=deep" in state["activation_reason"]
     assert "route_category=deep" in state["activation_reason"]
     assert "delegation_profile=implementation" in state["activation_reason"]
     assert "runtime_mode=default" in state["activation_reason"]
 
     assert state["activation_note"].startswith("<wave2-runtime-activation>")
     assert state["activation_note"].endswith("</wave2-runtime-activation>")
+    assert "category: deep" in state["activation_note"]
+    assert "route_category: deep" in state["activation_note"]
+    assert "delegation_profile: implementation" in state["activation_note"]
+    assert "runtime_mode: default" in state["activation_note"]
     assert state["wave1_overlay_prompt"] in state["activation_note"]
 
     assert "## Archetype\nname: implementer" in state["wave1_overlay_prompt"]
     assert "default_route_category: deep" in state["wave1_overlay_prompt"]
     assert "default_delegation_profile: implementation" in state["wave1_overlay_prompt"]
+    assert "## Category\nname: deep" in state["wave1_overlay_prompt"]
     assert "## Route Category\nname: deep" in state["wave1_overlay_prompt"]
     assert "## Delegation Profile\nname: implementation" in state["wave1_overlay_prompt"]
     assert "## Runtime Mode\nname: default" in state["wave1_overlay_prompt"]
+
+
+def test_parent_runtime_activation_proves_mixed_visual_research_prompt_keeps_literal_category_distinct():
+    agent = _make_bare_agent(delegate_depth=0)
+    agent.valid_tool_names = {"vision_analyze"}
+    state = agent._resolve_runtime_activation_state(
+        "Inspect this PDF diagram, investigate the architecture, and gather evidence for the visual flow."
+    )
+
+    assert state["specialist"] == "multimodal_specialist"
+    assert state["archetype"] == "researcher"
+    assert state["category"] == "visual-engineering"
+    assert state["route_category"] == "visual"
+    assert state["delegation_profile"] == "research"
+    assert state["runtime_mode"] == "default"
+    assert state["inference_source"] == "wave2_intent_preclassifier"
+
+    assert "keyword-derived specialist: multimodal_specialist" in state["activation_reason"]
+    assert "archetype=researcher" in state["activation_reason"]
+    assert "specialist=multimodal_specialist" in state["activation_reason"]
+    assert "category=visual-engineering" in state["activation_reason"]
+    assert "route_category=visual" in state["activation_reason"]
+    assert "delegation_profile=research" in state["activation_reason"]
+    assert "runtime_mode=default" in state["activation_reason"]
+
+    assert "category: visual-engineering" in state["activation_note"]
+    assert "route_category: visual" in state["activation_note"]
+    assert "delegation_profile: research" in state["activation_note"]
+    assert "runtime_mode: default" in state["activation_note"]
+    assert "## Category\nname: visual-engineering" in state["wave1_overlay_prompt"]
+    assert "## Route Category\nname: visual" in state["wave1_overlay_prompt"]
+    assert "## Delegation Profile\nname: research" in state["wave1_overlay_prompt"]
+    assert "## Runtime Mode\nname: default" in state["wave1_overlay_prompt"]
+
+
+def test_parent_runtime_activation_explicit_overrides_keep_activation_reason_honest():
+    agent = _make_bare_agent(delegate_depth=0)
+    agent.enabled_toolsets = ["file"]
+    agent.disabled_toolsets = []
+
+    state = agent._resolve_runtime_activation_state(
+        {
+            "message": "do something",
+            "category": "visual-engineering",
+            "route_category": "deep",
+            "runtime_mode": "execution_supervisor",
+        }
+    )
+
+    assert state["category"] == "visual-engineering"
+    assert state["route_category"] == "deep"
+    assert state["delegation_profile"] == "general"
+    assert state["runtime_mode"] == "execution_supervisor"
+    assert "category=visual-engineering" in state["activation_reason"]
+    assert "route_category=deep" in state["activation_reason"]
+    assert "delegation_profile=general" in state["activation_reason"]
+    assert "runtime_mode=execution_supervisor" in state["activation_reason"]
+    assert "category=unspecified-low" not in state["activation_reason"]
+    assert "route_category=unspecified_low" not in state["activation_reason"]
+    assert "runtime_mode=default" not in state["activation_reason"]
+
+
+def test_parent_runtime_activation_baseline_reason_still_reports_final_resolved_state():
+    agent = _make_bare_agent(delegate_depth=0)
+
+    state = agent._resolve_runtime_activation_state("implement the delegated change")
+
+    assert "keyword-derived specialist: builder" in state["activation_reason"]
+    assert "specialist=builder" in state["activation_reason"]
+    assert "archetype=implementer" in state["activation_reason"]
+    assert "category=deep" in state["activation_reason"]
+    assert "route_category=deep" in state["activation_reason"]
+    assert "delegation_profile=implementation" in state["activation_reason"]
+    assert "runtime_mode=default" in state["activation_reason"]
 
 
 def test_named_workflow_alone_triggers_runtime_activation_injection():

--- a/tests/run_agent/test_ultrawork_semantics.py
+++ b/tests/run_agent/test_ultrawork_semantics.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _response(text: str):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content=text, tool_calls=[]),
+            )
+        ],
+        usage=None,
+    )
+
+
+def _make_agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    return agent
+
+
+def _set_runtime_mode(agent: AIAgent, runtime_mode: str) -> None:
+    def _activate(_message: str):
+        state = {"runtime_mode": runtime_mode}
+        agent.runtime_activation_state = dict(state)
+        agent._runtime_activation_state = dict(state)
+        return state
+
+    agent._activate_runtime_for_turn = _activate
+    agent.get_runtime_activation_state = lambda: dict(agent.runtime_activation_state)
+
+
+def test_ultrawork_requeues_when_open_todos_remain():
+    agent = _make_agent()
+    _set_runtime_mode(agent, "ultrawork")
+    agent._todo_store.write([
+        {"id": "todo-1", "content": "Finish the remaining implementation", "status": "in_progress"}
+    ])
+
+    def _api_side_effect(*_args, **_kwargs):
+        if not hasattr(_api_side_effect, "calls"):
+            _api_side_effect.calls = 0
+        _api_side_effect.calls += 1
+        if _api_side_effect.calls == 1:
+            return _response("Status update only.")
+        agent._todo_store.write([
+            {"id": "todo-1", "content": "Finish the remaining implementation", "status": "completed"}
+        ])
+        return _response("Completed after closing the todo.")
+
+    with patch.object(agent, "_interruptible_api_call", side_effect=_api_side_effect):
+        result = agent.run_conversation("Finish the implementation in ultrawork mode.")
+
+    assert result["final_response"] == "Completed after closing the todo."
+    continuation_notes = [
+        msg["content"]
+        for msg in result["messages"]
+        if msg.get("role") == "user" and "Ultrawork continuation engine resume" in str(msg.get("content"))
+    ]
+    assert len(continuation_notes) == 1
+    assert "Finish the remaining implementation" in continuation_notes[0]
+    assert result["api_calls"] == 2
+
+
+def test_default_mode_keeps_one_shot_completion_behavior():
+    agent = _make_agent()
+    _set_runtime_mode(agent, "default")
+    agent._todo_store.write([
+        {"id": "todo-1", "content": "Finish the remaining implementation", "status": "in_progress"}
+    ])
+
+    with patch.object(agent, "_interruptible_api_call", return_value=_response("Status update only.")) as api_call:
+        result = agent.run_conversation("Finish the implementation.")
+
+    assert result["final_response"] == "Status update only."
+    assert api_call.call_count == 1
+    assert not any(
+        msg.get("role") == "user" and "continuation engine" in str(msg.get("content"))
+        for msg in result["messages"]
+    )

--- a/tests/test_acp_tools_output.py
+++ b/tests/test_acp_tools_output.py
@@ -1,0 +1,268 @@
+from collections import OrderedDict
+from types import ModuleType, SimpleNamespace
+import sys
+
+import model_tools
+import toolsets
+
+
+if "acp" not in sys.modules:
+    fake_acp = ModuleType("acp")
+    fake_acp.Agent = type("Agent", (), {})
+    fake_acp.Client = type("Client", (), {})
+    sys.modules["acp"] = fake_acp
+
+if "acp.schema" not in sys.modules:
+    fake_schema = ModuleType("acp.schema")
+
+    def _schema_getattr(name: str):
+        value = type(name, (), {})
+        setattr(fake_schema, name, value)
+        return value
+
+    fake_schema.__getattr__ = _schema_getattr
+    for name in [
+        "AgentCapabilities",
+        "AuthenticateResponse",
+        "AvailableCommand",
+        "AvailableCommandsUpdate",
+        "ClientCapabilities",
+        "EmbeddedResourceContentBlock",
+        "ForkSessionResponse",
+        "ImageContentBlock",
+        "AudioContentBlock",
+        "Implementation",
+        "InitializeResponse",
+        "ListSessionsResponse",
+        "LoadSessionResponse",
+        "McpServerHttp",
+        "McpServerSse",
+        "McpServerStdio",
+        "ModelInfo",
+        "NewSessionResponse",
+        "PromptResponse",
+        "ResumeSessionResponse",
+        "SetSessionConfigOptionResponse",
+        "SetSessionModelResponse",
+        "SetSessionModeResponse",
+        "ResourceContentBlock",
+        "SessionCapabilities",
+        "SessionForkCapabilities",
+        "SessionListCapabilities",
+        "SessionModelState",
+        "SessionResumeCapabilities",
+        "SessionInfo",
+        "TextContentBlock",
+        "UnstructuredCommandInput",
+        "Usage",
+        "AuthMethodAgent",
+        "AuthMethod",
+    ]:
+        setattr(fake_schema, name, type(name, (), {}))
+    sys.modules["acp.schema"] = fake_schema
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionState
+
+
+def _tool_def(name: str, description: str = "") -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description or f"Description for {name}",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _make_state(enabled_toolsets: list[str]) -> SessionState:
+    return SessionState(
+        session_id="test-session",
+        agent=SimpleNamespace(enabled_toolsets=enabled_toolsets),
+    )
+
+
+def _install_toolset_metadata(monkeypatch, all_toolsets: OrderedDict, contracts: dict[str, dict]) -> None:
+    monkeypatch.setattr(toolsets, "get_all_toolsets", lambda: all_toolsets)
+    monkeypatch.setattr(toolsets, "get_toolset_contract", lambda name: contracts.get(name))
+
+
+def test_cmd_tools_surfaces_canonical_knowledge_first_when_visible(monkeypatch):
+    visible_tools = [
+        _tool_def("read_file"),
+        _tool_def("search_files"),
+        _tool_def("ast_list_defs"),
+        _tool_def("ast_find_nodes"),
+        _tool_def("lsp_document_symbols"),
+        _tool_def("lsp_definition"),
+        _tool_def("lsp_diagnostics"),
+        _tool_def("web_search"),
+        _tool_def("web_extract"),
+        _tool_def("browser_navigate"),
+        _tool_def("browser_snapshot"),
+        _tool_def("browser_click"),
+        _tool_def("browser_scroll"),
+        _tool_def("browser_back"),
+        _tool_def("browser_press"),
+        _tool_def("browser_get_images"),
+        _tool_def("browser_vision"),
+        _tool_def("browser_console"),
+        _tool_def("vision_analyze"),
+    ]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_tools)
+
+    all_toolsets = OrderedDict(
+        [
+            (
+                "repo-code-knowledge",
+                {"description": "Canonical repo/code surface"},
+            ),
+            (
+                "web-research-knowledge",
+                {"description": "Canonical web/research surface"},
+            ),
+            (
+                "document-pdf-diagram-intelligence",
+                {"description": "Canonical document surface"},
+            ),
+        ]
+    )
+    contracts = {
+        "repo-code-knowledge": {
+            "name": "repo-code-knowledge",
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": [
+                "ast_find_nodes",
+                "ast_list_defs",
+                "lsp_definition",
+                "lsp_diagnostics",
+                "lsp_document_symbols",
+                "read_file",
+                "search_files",
+            ],
+        },
+        "web-research-knowledge": {
+            "name": "web-research-knowledge",
+            "canonical_name": "web-research-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": ["web_extract", "web_search"],
+        },
+        "document-pdf-diagram-intelligence": {
+            "name": "document-pdf-diagram-intelligence",
+            "canonical_name": "document-pdf-diagram-intelligence",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": [
+                "browser_back",
+                "browser_click",
+                "browser_console",
+                "browser_get_images",
+                "browser_navigate",
+                "browser_press",
+                "browser_scroll",
+                "browser_snapshot",
+                "browser_vision",
+                "vision_analyze",
+            ],
+        },
+    }
+    _install_toolset_metadata(monkeypatch, all_toolsets, contracts)
+
+    output = HermesACPAgent(session_manager=SimpleNamespace())._cmd_tools(
+        "",
+        _make_state(["hermes-acp"]),
+    )
+
+    assert "Canonical built-in knowledge surfaces visible from current tool membership:" in output
+    assert "repo-code-knowledge [built-in/canonical; 7 raw tools]" in output
+    assert "web-research-knowledge [built-in/canonical; 2 raw tools]" in output
+    assert "document-pdf-diagram-intelligence [built-in/canonical; 10 raw tools]" in output
+    assert output.index("Canonical built-in knowledge surfaces visible from current tool membership:") < output.index("Raw tools (19):")
+
+
+def test_cmd_tools_keeps_raw_tool_names_visible(monkeypatch):
+    visible_tools = [
+        _tool_def("read_file", "Read files from disk"),
+        _tool_def("search_files", "Search across the repo"),
+    ]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_tools)
+    _install_toolset_metadata(monkeypatch, OrderedDict(), {})
+
+    output = HermesACPAgent(session_manager=SimpleNamespace())._cmd_tools(
+        "",
+        _make_state(["hermes-acp"]),
+    )
+
+    assert "Raw tools (2):" in output
+    assert "  read_file: Read files from disk" in output
+    assert "  search_files: Search across the repo" in output
+
+
+def test_cmd_tools_labels_additive_surfaces_without_calling_them_builtin(monkeypatch):
+    visible_tools = [
+        _tool_def("read_file"),
+        _tool_def("search_files"),
+        _tool_def("mcp_surface_lookup"),
+    ]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_tools)
+
+    all_toolsets = OrderedDict(
+        [
+            (
+                "repo-code-knowledge",
+                {"description": "Canonical repo/code surface"},
+            ),
+            (
+                "test-surface",
+                {"description": "Additive lookup surface"},
+            ),
+        ]
+    )
+    contracts = {
+        "repo-code-knowledge": {
+            "name": "repo-code-knowledge",
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": ["read_file", "search_files"],
+        },
+        "test-surface": {
+            "name": "test-surface",
+            "canonical_name": "mcp-test-surface",
+            "source": "mcp",
+            "is_builtin": False,
+            "is_additive": True,
+            "is_alias": True,
+            "tools": ["mcp_surface_lookup"],
+        },
+    }
+    _install_toolset_metadata(monkeypatch, all_toolsets, contracts)
+
+    output = HermesACPAgent(session_manager=SimpleNamespace())._cmd_tools(
+        "",
+        _make_state(["hermes-acp", "test-surface"]),
+    )
+
+    additive_line = next(
+        line for line in output.splitlines() if "mcp-test-surface" in line
+    )
+    assert "Additive tool surfaces visible from current tool membership:" in output
+    assert "additive/mcp" in additive_line
+    assert "built-in" not in additive_line
+    assert "canonical" not in additive_line

--- a/tests/test_knowledge_surface_toolsets.py
+++ b/tests/test_knowledge_surface_toolsets.py
@@ -1,0 +1,175 @@
+from toolsets import (
+    get_toolset,
+    get_toolset_contract,
+    get_toolset_info,
+    get_toolset_names,
+    resolve_toolset,
+    validate_toolset,
+)
+
+
+class TestKnowledgeSurfaceToolsets:
+    def test_canonical_knowledge_surface_toolsets_exist(self):
+        canonical_names = {
+            "repo-code-knowledge",
+            "web-research-knowledge",
+            "document-pdf-diagram-intelligence",
+        }
+
+        for name in canonical_names:
+            toolset = get_toolset(name)
+            assert toolset is not None
+            assert validate_toolset(name)
+            assert name in get_toolset_names()
+
+    def test_static_aliases_validate_and_resolve_to_canonical_toolsets(self):
+        alias_to_canonical = {
+            "repo_code_knowledge": "repo-code-knowledge",
+            "repo-knowledge": "repo-code-knowledge",
+            "web_research_knowledge": "web-research-knowledge",
+            "research-knowledge": "web-research-knowledge",
+            "document_intelligence": "document-pdf-diagram-intelligence",
+            "document-intelligence": "document-pdf-diagram-intelligence",
+        }
+
+        for alias, canonical in alias_to_canonical.items():
+            assert validate_toolset(alias)
+            alias_toolset = get_toolset(alias)
+            canonical_toolset = get_toolset(canonical)
+            assert alias_toolset is not None
+            assert canonical_toolset is not None
+            assert alias_toolset["canonical_name"] == canonical
+            assert resolve_toolset(alias) == resolve_toolset(canonical)
+
+    def test_aliases_are_not_reported_as_canonical_toolset_names(self):
+        toolset_names = set(get_toolset_names())
+
+        assert "repo-code-knowledge" in toolset_names
+        assert "web-research-knowledge" in toolset_names
+        assert "document-pdf-diagram-intelligence" in toolset_names
+
+        assert "repo_code_knowledge" not in toolset_names
+        assert "web_research_knowledge" not in toolset_names
+        assert "document_intelligence" not in toolset_names
+
+    def test_repo_code_knowledge_surface_uses_builtin_file_ast_and_lsp_primitives(self):
+        tools = set(resolve_toolset("repo-code-knowledge"))
+
+        assert tools == {
+            "read_file",
+            "search_files",
+            "ast_list_defs",
+            "ast_find_nodes",
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+        }
+
+    def test_web_research_knowledge_surface_uses_current_builtin_web_primitives(self):
+        tools = set(resolve_toolset("web-research-knowledge"))
+
+        assert tools == {"web_search", "web_extract"}
+        assert "web_crawl" not in tools
+
+    def test_document_intelligence_surface_uses_builtin_browser_and_vision_primitives(self):
+        tools = set(resolve_toolset("document-pdf-diagram-intelligence"))
+
+        assert tools == {
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
+            "vision_analyze",
+        }
+
+    def test_canonical_descriptions_use_honest_builtin_wording(self):
+        repo_desc = get_toolset("repo-code-knowledge")["description"]
+        web_desc = get_toolset("web-research-knowledge")["description"]
+        doc_desc = get_toolset("document-pdf-diagram-intelligence")["description"]
+        alias_desc = get_toolset("document_intelligence")["description"]
+
+        assert "Canonical built-in repo/code knowledge surface" in repo_desc
+        assert "AST structure lookup" in repo_desc
+
+        assert "Canonical built-in web/research knowledge surface" in web_desc
+        assert "not an additive MCP crawl stack" in web_desc
+
+        assert "Canonical built-in document/PDF/diagram intelligence surface" in doc_desc
+        assert "not a standalone PDF parser or diagram editor" in doc_desc
+        assert "Alias for canonical toolset 'document-pdf-diagram-intelligence'." in alias_desc
+
+    def test_builtin_knowledge_surface_contract_marks_builtin_not_additive(self):
+        contract = get_toolset_contract("repo_code_knowledge")
+        info = get_toolset_info("repo_code_knowledge")
+
+        assert contract == {
+            "name": "repo_code_knowledge",
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": True,
+            "aliases": ["repo_code_knowledge", "repo-knowledge"],
+            "is_canonical_knowledge_surface": True,
+            "boundary_note": (
+                "Canonical built-in control-plane surface; downstream wrappers, propagation, "
+                "and additive MCP/plugin productization stay separate."
+            ),
+            "tools": [
+                "ast_find_nodes",
+                "ast_list_defs",
+                "lsp_definition",
+                "lsp_diagnostics",
+                "lsp_document_symbols",
+                "read_file",
+                "search_files",
+            ],
+        }
+        assert info["canonical_name"] == "repo-code-knowledge"
+        assert info["source"] == "builtin"
+        assert info["is_builtin"] is True
+        assert info["is_additive"] is False
+        assert info["is_alias"] is True
+        assert info["is_canonical_knowledge_surface"] is True
+        assert info["boundary_note"] == (
+            "Canonical built-in control-plane surface; downstream wrappers, propagation, "
+            "and additive MCP/plugin productization stay separate."
+        )
+
+    def test_registry_managed_toolsets_are_classified_as_additive(self):
+        from tools.registry import registry
+
+        schema = {
+            "name": "mcp_test_surface_lookup",
+            "description": "Lookup test surface",
+            "parameters": {"type": "object", "properties": {}},
+        }
+
+        registry.register(
+            name="mcp_test_surface_lookup",
+            toolset="mcp-test-surface",
+            schema=schema,
+            handler=lambda args: "{}",
+            description="Lookup test surface",
+        )
+        registry.register_toolset_alias("test-surface", "mcp-test-surface")
+        try:
+            contract = get_toolset_contract("test-surface")
+            assert contract == {
+                "name": "test-surface",
+                "canonical_name": "mcp-test-surface",
+                "source": "mcp",
+                "is_builtin": False,
+                "is_additive": True,
+                "is_alias": True,
+                "aliases": ["test-surface"],
+                "boundary_note": "Additive registry surface; not a canonical built-in knowledge surface.",
+                "tools": ["mcp_test_surface_lookup"],
+            }
+        finally:
+            registry.deregister("mcp_test_surface_lookup")

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -197,13 +197,18 @@ class TestToolsetConsistency:
             for inc in ts["includes"]:
                 assert inc in TOOLSETS, f"{name} includes unknown toolset '{inc}'"
 
-    def test_hermes_platforms_share_core_tools(self):
-        """All hermes-* platform toolsets should have the same tools."""
-        platforms = ["hermes-cli", "hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant"]
+    def test_hermes_messaging_platforms_share_core_tools(self):
+        """Messaging-oriented hermes-* platform toolsets should share the same tools."""
+        platforms = ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant"]
         tool_sets = [set(TOOLSETS[p]["tools"]) for p in platforms]
-        # All platform toolsets should be identical
         for ts in tool_sets[1:]:
             assert ts == tool_sets[0]
+
+    def test_local_coding_toolsets_include_code_intel(self):
+        code_intel_tools = set(resolve_toolset("code_intel"))
+
+        for toolset_name in ["hermes-cli", "hermes-acp", "hermes-api-server"]:
+            assert code_intel_tools <= set(resolve_toolset(toolset_name))
 
 
 class TestPluginToolsets:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
+from agent.continuation_engine import should_use_continuation_engine
+from agent.intent_preclassifier import preclassify_intent
 from tui_gateway import server
 
 
@@ -338,6 +340,12 @@ def test_config_set_model_uses_live_switch_path(monkeypatch):
     assert resp["result"]["value"] == "new/model"
     assert resp["result"]["warning"] == "catalog unreachable"
     assert seen["args"] == ("sid", "session-key", "new/model")
+
+
+def test_routing_owner_promotes_swarm_to_native_surface():
+    assert server._routing_owner("swarm") == "native"
+    assert server._routing_owner("handoff") == "slash-live"
+    assert server._routing_owner("tools") == "native"
 
 
 def test_config_set_model_global_persists(monkeypatch):
@@ -958,6 +966,53 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     assert captured["prompt"] == "expanded prompt"
 
 
+def test_session_resume_reopens_persisted_history_into_a_fresh_runtime_session(monkeypatch):
+    reopened = []
+    captured = {}
+
+    class _DB:
+        def get_session(self, _sid):
+            return {"id": "persisted-session"}
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def reopen_session(self, sid):
+            reopened.append(sid)
+
+        def get_messages_as_conversation(self, _sid):
+            return [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: None)
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: types.SimpleNamespace(session_id=session_id, runtime_sid=sid))
+    monkeypatch.setattr(
+        server,
+        "_init_session",
+        lambda sid, key, agent, history, cols=80: captured.update(
+            {"sid": sid, "session_key": key, "history": history, "agent": agent, "cols": cols}
+        ),
+    )
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.resume", "params": {"session_id": "persisted-session", "cols": 120}}
+    )
+
+    assert resp["result"]["resumed"] == "persisted-session"
+    assert resp["result"]["message_count"] == 2
+    assert reopened == ["persisted-session"]
+    assert captured["session_key"] == "persisted-session"
+    assert captured["sid"] != "persisted-session"
+    assert captured["agent"].session_id == "persisted-session"
+    assert captured["cols"] == 120
+
+
 def test_image_attach_appends_local_image(monkeypatch):
     fake_cli = types.ModuleType("cli")
     fake_cli._IMAGE_EXTENSIONS = {".png"}
@@ -989,7 +1044,7 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
 
 def test_routing_owner_lane_locks_authoritative_route_sets():
-    assert server._NATIVE_PRODUCT_COMMANDS == frozenset({"setup", "skills", "tools"})
+    assert server._NATIVE_PRODUCT_COMMANDS == frozenset({"setup", "skills", "swarm", "tools"})
     assert server._LIVE_SLASH_COMMANDS == frozenset({"handoff", "init-deep", "model", "provider", "ralph-loop", "start-work", "ulw-loop"})
     assert server._LEGACY_SLASH_WORKER_COMMANDS == frozenset({
         "agents",
@@ -1075,7 +1130,17 @@ def test_slash_worker_locks_legacy_only_execution(monkeypatch):
             raise AssertionError("expected non-legacy rejection")
 
 
-def test_slash_exec_work_command_submits_live_prompt(monkeypatch):
+@pytest.mark.parametrize(
+    ("command_text", "canonical", "raw_args"),
+    [
+        ("handoff request", "handoff", "request"),
+        ("init-deep investigate", "init-deep", "investigate"),
+        ("start-work ship it", "start-work", "ship it"),
+        ("ralph-loop close it", "ralph-loop", "close it"),
+        ("ulw-loop finish it", "ulw-loop", "finish it"),
+    ],
+)
+def test_slash_exec_work_command_submits_live_prompt(monkeypatch, command_text, canonical, raw_args):
     captured = {}
     session = _session()
     server._sessions["sid"] = session
@@ -1090,21 +1155,68 @@ def test_slash_exec_work_command_submits_live_prompt(monkeypatch):
         lambda canonical, raw_args, session_id, cwd: f"prepared::{canonical}::{raw_args}::{session_id}",
     )
 
-    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "handoff request"}})
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": command_text}})
 
-    assert resp["result"]["output"] == "/handoff started"
-    assert captured["args"] == ("1", "sid", "session-key", "prepared::handoff::request::session-key")
+    assert resp["result"]["output"] == f"/{canonical} started"
+    assert captured["args"] == ("1", "sid", "session-key", f"prepared::{canonical}::{raw_args}::session-key")
 
 
+@pytest.mark.parametrize(
+    ("command_text", "expected_runtime_mode", "should_continue"),
+    [
+        ("handoff request", "default", False),
+        ("init-deep investigate", "default", False),
+        ("start-work ship it", "default", False),
+        ("ralph-loop close it", "ralph", True),
+        ("ulw-loop finish it", "ultrawork", True),
+    ],
+)
+def test_slash_exec_work_command_preserves_continuation_semantics(monkeypatch, command_text, expected_runtime_mode, should_continue):
+    captured = {}
+    session = _session()
+    server._sessions["sid"] = session
 
-def test_slash_exec_work_command_busy_is_deterministic(monkeypatch):
+    def _capture_submit(rid, sid, session, prepared):
+        captured["prepared"] = prepared
+        return {"result": {"status": "streaming"}}
+
+    monkeypatch.setattr(server, "_start_prompt_submit", _capture_submit)
+
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": command_text}})
+
+    prepared = captured["prepared"]
+    classification = preclassify_intent({"message": prepared.task_contract["task"], "task_contract": prepared.task_contract})
+
+    assert resp["result"]["output"] == f"/{prepared.command_name} started"
+    assert classification.inferred_runtime_mode == expected_runtime_mode
+    assert should_use_continuation_engine(classification.inferred_runtime_mode, {
+        "outcomeStatus": "interrupted",
+        "activeTodos": [{"id": "todo-1", "content": "Finish the delegated task", "status": "in_progress"}],
+    }) is should_continue
+    if prepared.command_name == "start-work":
+        assert "NAMED_WORKFLOW_JSON:" in prepared.agent_message
+    elif should_continue:
+        assert f'"runtime_mode": "{expected_runtime_mode}"' in prepared.agent_message
+
+
+@pytest.mark.parametrize(
+    "command_text",
+    [
+        "handoff request",
+        "init-deep investigate",
+        "start-work ship it",
+        "ralph-loop close it",
+        "ulw-loop finish it",
+    ],
+)
+def test_slash_exec_work_command_busy_is_deterministic(monkeypatch, command_text):
     server._sessions["sid"] = _session(running=True)
     monkeypatch.setattr(
         "hermes_cli.work_command_adapter.prepare_work_command",
         lambda canonical, raw_args, session_id, cwd: "prepared prompt",
     )
 
-    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "start-work ship it"}})
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": command_text}})
 
     assert "error" in resp
     assert resp["error"]["code"] == 4009

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -983,7 +983,28 @@ def test_session_resume_reopens_persisted_history_into_a_fresh_runtime_session(m
         def get_messages_as_conversation(self, _sid):
             return [
                 {"role": "user", "content": "hello"},
-                {"role": "assistant", "content": "world"},
+                {
+                    "role": "assistant",
+                    "content": "world",
+                    "metadata": {
+                        "swarm": {
+                            "subagents": [
+                                {
+                                    "goal": "Audit slash routes",
+                                    "id": "sa:0:Audit slash routes",
+                                    "index": 0,
+                                    "notes": ["confirmed"],
+                                    "status": "completed",
+                                    "summary": "done",
+                                    "taskCount": 1,
+                                    "thinking": [],
+                                    "tools": []
+                                }
+                            ],
+                            "turnStatus": "persisted"
+                        }
+                    }
+                },
             ]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -1006,6 +1027,8 @@ def test_session_resume_reopens_persisted_history_into_a_fresh_runtime_session(m
 
     assert resp["result"]["resumed"] == "persisted-session"
     assert resp["result"]["message_count"] == 2
+    assert resp["result"]["messages"][1]["swarm"]["turnStatus"] == "persisted"
+    assert resp["result"]["messages"][1]["swarm"]["subagents"][0]["goal"] == "Audit slash routes"
     assert reopened == ["persisted-session"]
     assert captured["session_key"] == "persisted-session"
     assert captured["sid"] != "persisted-session"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import sys
 import threading
@@ -5,6 +6,8 @@ import time
 import types
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from tui_gateway import server
 
@@ -131,10 +134,160 @@ def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):
 
 def test_setup_status_reports_provider_config(monkeypatch):
     monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "claude", "provider": "anthropic"}})
 
     resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
 
-    assert resp["result"]["provider_configured"] is False
+    assert resp["result"] == {
+        "provider": "anthropic",
+        "model": "claude",
+        "provider_configured": False,
+    }
+
+
+def test_setup_status_delegates_to_setup_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_build_setup_status_payload_impl",
+        lambda **kwargs: seen.update(kwargs) or {"provider": "anthropic", "model": "claude", "provider_configured": True},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
+
+    assert resp["result"] == {"provider": "anthropic", "model": "claude", "provider_configured": True}
+    assert seen["load_cfg"] is server._load_cfg
+    assert seen["resolve_model"] is server._resolve_model
+
+
+def test_setup_catalog_lists_native_bootstrap_providers(monkeypatch):
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "claude", "provider": "anthropic"}})
+    monkeypatch.setattr(
+        server,
+        "_native_setup_catalog",
+        lambda: [
+            {
+                "slug": "anthropic",
+                "name": "Anthropic",
+                "description": "Anthropic desc",
+                "auth_type": "api_key",
+                "configured": False,
+                "key_env_var": "ANTHROPIC_API_KEY",
+                "supports_native": True,
+                "models": ["claude-sonnet-4-5"],
+                "total_models": 1,
+            }
+        ],
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.catalog", "params": {}})
+
+    assert resp["result"] == {
+        "provider_configured": False,
+        "provider": "anthropic",
+        "model": "claude",
+        "providers": [
+            {
+                "slug": "anthropic",
+                "name": "Anthropic",
+                "description": "Anthropic desc",
+                "auth_type": "api_key",
+                "configured": False,
+                "key_env_var": "ANTHROPIC_API_KEY",
+                "supports_native": True,
+                "models": ["claude-sonnet-4-5"],
+                "total_models": 1,
+            }
+        ],
+    }
+
+
+def test_setup_catalog_delegates_to_setup_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_build_setup_catalog_payload_impl",
+        lambda **kwargs: seen.update(kwargs) or {"provider_configured": False, "provider": "", "model": "m", "providers": []},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.catalog", "params": {}})
+
+    assert resp["result"] == {"provider_configured": False, "provider": "", "model": "m", "providers": []}
+    assert seen["catalog_builder"] is server._native_setup_catalog
+
+
+def test_setup_bootstrap_persists_provider_and_model(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        server,
+        "_bootstrap_provider_config",
+        lambda provider, *, api_key="", model="", base_url="": captured.update(
+            {"provider": provider, "api_key": api_key, "model": model, "base_url": base_url}
+        )
+        or {"provider": provider, "model": model},
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "setup.bootstrap",
+            "params": {"provider": "anthropic", "api_key": "***", "model": "claude-sonnet-4-5"},
+        }
+    )
+
+    assert resp["result"] == {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-5",
+        "provider_configured": True,
+    }
+    assert captured == {"provider": "anthropic", "api_key": "***", "model": "claude-sonnet-4-5", "base_url": ""}
+
+
+def test_setup_bootstrap_delegates_to_setup_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_run_setup_bootstrap_impl",
+        lambda **kwargs: seen.update(kwargs) or {"provider": "anthropic", "model": "claude", "provider_configured": True},
+    )
+
+    params = {"provider": "anthropic", "api_key": "sekret", "model": "claude"}
+    resp = server.handle_request({"id": "1", "method": "setup.bootstrap", "params": params})
+
+    assert resp["result"] == {"provider": "anthropic", "model": "claude", "provider_configured": True}
+    assert seen["provider"] == "anthropic"
+    assert seen["bootstrapper"] is server._bootstrap_provider_config
+
+
+def test_native_setup_catalog_keeps_external_process_explicit_and_excludes_oauth_device_code(monkeypatch):
+    fake_models = types.SimpleNamespace(
+        CANONICAL_PROVIDERS=[
+            types.SimpleNamespace(slug="anthropic", tui_desc="Anthropic desc", label="Anthropic"),
+            types.SimpleNamespace(slug="copilot-acp", tui_desc="Copilot desc", label="Copilot ACP"),
+            types.SimpleNamespace(slug="nous", tui_desc="Nous desc", label="Nous")
+        ]
+    )
+
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setattr(
+        server,
+        "_setup_provider_status",
+        lambda provider: {
+            "anthropic": {"auth_type": "api_key", "configured": False, "key_env_var": "ANTHROPIC_API_KEY", "name": "Anthropic"},
+            "copilot-acp": {"auth_type": "external_process", "configured": False, "key_env_var": "", "name": "Copilot ACP"},
+            "nous": {"auth_type": "oauth_device_code", "configured": False, "key_env_var": "", "name": "Nous"},
+        }[provider],
+    )
+    monkeypatch.setattr(server, "_setup_provider_models", lambda provider: ([f"{provider}/model"], ""))
+
+    providers = server._native_setup_catalog()
+
+    assert [p["slug"] for p in providers] == ["anthropic", "copilot-acp"]
+    assert providers[0]["supports_native"] is True
+    assert providers[1]["supports_native"] is False
+    assert providers[1]["auth_type"] == "external_process"
 
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
@@ -228,6 +381,464 @@ def test_config_set_model_global_persists(monkeypatch):
     assert saved["model"]["default"] == "anthropic/claude-sonnet-4.6"
     assert saved["model"]["provider"] == "anthropic"
     assert saved["model"]["base_url"] == "https://api.anthropic.com"
+
+
+def test_tools_catalog_reports_provider_and_mcp_state(monkeypatch):
+    import hermes_cli.config as config_mod
+    import hermes_cli.tools_config as tools_config_mod
+
+    monkeypatch.setattr(tools_config_mod, "CONFIGURABLE_TOOLSETS", [("web", "Web", "search"), ("plugin_x", "Plugin", "plugin")])
+    monkeypatch.setattr(
+        tools_config_mod,
+        "TOOL_CATEGORIES",
+        {"web": {"providers": [{"name": "Firecrawl", "web_backend": "firecrawl", "env_vars": [{"key": "FIRECRAWL_API_KEY"}]}]}},
+    )
+    monkeypatch.setattr(tools_config_mod, "_get_effective_configurable_toolsets", lambda: [("web", "Web", "search"), ("plugin_x", "Plugin", "plugin")])
+    monkeypatch.setattr(tools_config_mod, "_get_platform_tools", lambda cfg, platform, include_default_mcp_servers=False: {"web", "plugin_x"})
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"web": {"backend": "firecrawl"}, "mcp_servers": {"github": {"enabled": True, "tools": {"exclude": ["create_issue"]}}}})
+    monkeypatch.setattr(config_mod, "get_env_value", lambda key: "sekret" if key == "FIRECRAWL_API_KEY" else "")
+
+    resp = server.handle_request({"id": "1", "method": "tools.catalog", "params": {}})
+
+    assert resp["result"] == {
+        "toolsets": [
+            {
+                "active_provider": "",
+                "configurable": False,
+                "description": "plugin",
+                "enabled": True,
+                "kind": "builtin",
+                "name": "plugin_x",
+                "providers": [],
+                "title": "Plugin",
+            },
+            {
+                "active_provider": "firecrawl",
+                "configurable": True,
+                "description": "search",
+                "enabled": True,
+                "kind": "builtin",
+                "name": "web",
+                "providers": [
+                    {
+                        "active": True,
+                        "badge": "",
+                        "env_vars": [
+                            {"configured": True, "key": "FIRECRAWL_API_KEY", "prompt": "FIRECRAWL_API_KEY", "url": ""}
+                        ],
+                        "name": "Firecrawl",
+                        "slug": "firecrawl",
+                        "tag": "",
+                    }
+                ],
+                "title": "Web",
+            },
+        ],
+        "mcp_servers": [{"enabled": True, "exclude": ["create_issue"], "include": [], "name": "github"}],
+    }
+
+
+def test_tools_catalog_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_build_tools_catalog_payload_impl",
+        lambda **kwargs: seen.update(kwargs) or {"toolsets": [], "mcp_servers": []},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "tools.catalog", "params": {}})
+
+    assert resp["result"] == {"toolsets": [], "mcp_servers": []}
+    assert seen["load_config"]
+    assert seen["effective_toolsets"]
+
+
+def test_toolsets_list_derives_canonical_repo_surface_enabled_from_visible_members(monkeypatch):
+    import model_tools
+    import toolsets
+
+    visible_defs = [
+        {"function": {"name": "read_file", "description": "Read file contents."}},
+        {"function": {"name": "search_files", "description": "Search files."}},
+        {"function": {"name": "ast_list_defs", "description": "List AST defs."}},
+        {"function": {"name": "ast_find_nodes", "description": "Find AST nodes."}},
+        {"function": {"name": "lsp_document_symbols", "description": "List document symbols."}},
+        {"function": {"name": "lsp_definition", "description": "Find definitions."}},
+        {"function": {"name": "lsp_diagnostics", "description": "Show diagnostics."}},
+    ]
+    info_map = {
+        "file": {
+            "description": "File tools",
+            "resolved_tools": ["read_file", "write_file", "patch", "search_files"],
+        },
+        "code_intel": {
+            "description": "Code intel",
+            "resolved_tools": [
+                "ast_list_defs",
+                "ast_find_nodes",
+                "lsp_document_symbols",
+                "lsp_definition",
+                "lsp_diagnostics",
+            ],
+        },
+        "repo-code-knowledge": {
+            "description": "Canonical repo knowledge",
+            "resolved_tools": [
+                "read_file",
+                "search_files",
+                "ast_list_defs",
+                "ast_find_nodes",
+                "lsp_document_symbols",
+                "lsp_definition",
+                "lsp_diagnostics",
+            ],
+        },
+    }
+    contract_map = {
+        "file": {
+            "canonical_name": "file",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": False,
+            "boundary_note": "Built-in toolset",
+        },
+        "code_intel": {
+            "canonical_name": "code_intel",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": False,
+            "boundary_note": "Built-in toolset",
+        },
+        "repo-code-knowledge": {
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "boundary_note": "Canonical built-in control-plane surface",
+        },
+    }
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_available_toolsets",
+        lambda: {
+            name: {
+                "description": info_map[name]["description"],
+                "tools": list(info_map[name]["resolved_tools"]),
+                **contract_map[name],
+            }
+            for name in ("file", "code_intel", "repo-code-knowledge")
+        },
+    )
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_defs)
+    monkeypatch.setattr(toolsets, "get_toolset_info", lambda name: {**info_map[name], "tool_count": len(info_map[name]["resolved_tools"])})
+    monkeypatch.setattr(toolsets, "get_toolset_contract", lambda name: contract_map[name])
+
+    server._sessions["sid"] = _session(agent=types.SimpleNamespace(enabled_toolsets=["file", "code_intel"]))
+    try:
+        resp = server.handle_request({"id": "1", "method": "toolsets.list", "params": {"session_id": "sid"}})
+    finally:
+        server._sessions.clear()
+
+    rows = {row["name"]: row for row in resp["result"]["toolsets"]}
+    assert rows["repo-code-knowledge"]["enabled"] is True
+    assert rows["repo-code-knowledge"]["canonical_name"] == "repo-code-knowledge"
+    assert rows["repo-code-knowledge"]["is_canonical_knowledge_surface"] is True
+    assert rows["file"]["enabled"] is True
+    assert rows["code_intel"]["enabled"] is True
+
+
+def test_tools_show_exposes_canonical_knowledge_surfaces_as_first_class_sections(monkeypatch):
+    import model_tools
+    import toolsets
+
+    visible_defs = [
+        {"function": {"name": "read_file", "description": "Read file contents. Extra detail."}},
+        {"function": {"name": "search_files", "description": "Search files. Extra detail."}},
+        {"function": {"name": "web_search", "description": "Search the web. Extra detail."}},
+        {"function": {"name": "web_extract", "description": "Extract web pages. Extra detail."}},
+        {"function": {"name": "browser_navigate", "description": "Navigate browser. Extra detail."}},
+        {"function": {"name": "browser_snapshot", "description": "Snapshot browser. Extra detail."}},
+        {"function": {"name": "vision_analyze", "description": "Analyze images. Extra detail."}},
+    ]
+    info_map = {
+        "repo-code-knowledge": {
+            "description": "Canonical repo knowledge",
+            "resolved_tools": ["read_file", "search_files"],
+        },
+        "web-research-knowledge": {
+            "description": "Canonical web knowledge",
+            "resolved_tools": ["web_search", "web_extract"],
+        },
+        "document-pdf-diagram-intelligence": {
+            "description": "Canonical document intelligence",
+            "resolved_tools": ["browser_navigate", "browser_snapshot", "vision_analyze"],
+        },
+    }
+    contract_map = {
+        name: {
+            "canonical_name": name,
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "boundary_note": "Canonical built-in control-plane surface",
+        }
+        for name in info_map
+    }
+    owner_map = {
+        "read_file": "file",
+        "search_files": "file",
+        "web_search": "web",
+        "web_extract": "web",
+        "browser_navigate": "browser",
+        "browser_snapshot": "browser",
+        "vision_analyze": "vision",
+    }
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_available_toolsets",
+        lambda: {
+            name: {
+                "description": info_map[name]["description"],
+                "tools": list(info_map[name]["resolved_tools"]),
+                **contract_map[name],
+            }
+            for name in info_map
+        },
+    )
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_defs)
+    monkeypatch.setattr(model_tools, "get_toolset_for_tool", lambda name: owner_map[name])
+    monkeypatch.setattr(toolsets, "get_toolset_info", lambda name: {**info_map[name], "tool_count": len(info_map[name]["resolved_tools"])})
+    monkeypatch.setattr(toolsets, "get_toolset_contract", lambda name: contract_map[name])
+
+    resp = server.handle_request({"id": "1", "method": "tools.show", "params": {}})
+
+    section_names = [section["name"] for section in resp["result"]["sections"]]
+    assert section_names == [
+        "document-pdf-diagram-intelligence",
+        "repo-code-knowledge",
+        "web-research-knowledge",
+    ]
+    sections = {section["name"]: section for section in resp["result"]["sections"]}
+    assert [tool["name"] for tool in sections["repo-code-knowledge"]["tools"]] == ["read_file", "search_files"]
+    assert [tool["name"] for tool in sections["web-research-knowledge"]["tools"]] == ["web_search", "web_extract"]
+    assert [tool["name"] for tool in sections["document-pdf-diagram-intelligence"]["tools"]] == [
+        "browser_navigate",
+        "browser_snapshot",
+        "vision_analyze",
+    ]
+    legacy_names = [section["name"] for section in resp["result"]["legacy_sections"]]
+    assert legacy_names == ["browser", "file", "vision", "web"]
+    assert resp["result"]["tools"][0]["owner_toolset"] in {"file", "web", "browser", "vision"}
+
+
+def test_tools_catalog_remains_provider_config_oriented_and_skips_visibility_derivation(monkeypatch):
+    monkeypatch.setattr(server, "_derive_visible_toolsets", lambda enabled_toolsets: (_ for _ in ()).throw(AssertionError("should not run")))
+    monkeypatch.setattr(server, "_tools_catalog_payload", lambda: {"toolsets": [{"name": "web", "enabled": True}], "mcp_servers": []})
+
+    resp = server.handle_request({"id": "1", "method": "tools.catalog", "params": {}})
+
+    assert resp["result"] == {"toolsets": [{"name": "web", "enabled": True}], "mcp_servers": []}
+
+
+def test_tools_provider_configure_updates_config_and_resets_session(monkeypatch):
+    server._sessions["sid"] = _session()
+    saved_env = {}
+    saved_cfg = {}
+    reset_calls = []
+    fake_tools = types.SimpleNamespace(
+        TOOL_CATEGORIES={"web": {"providers": [{"name": "Firecrawl", "web_backend": "firecrawl", "env_vars": [{"key": "FIRECRAWL_API_KEY"}]}]}},
+        _visible_providers=lambda cat, cfg: cat["providers"],
+    )
+    fake_config = types.SimpleNamespace(
+        load_config=lambda: {"web": {}, "mcp_servers": {}},
+        save_config=lambda cfg: saved_cfg.update(cfg),
+        save_env_value=lambda key, value: saved_env.update({key: value}),
+        get_env_value=lambda key: saved_env.get(key, ""),
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.tools_config", fake_tools)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_config)
+    monkeypatch.setitem(sys.modules, "hermes_cli.nous_subscription", types.SimpleNamespace(get_nous_subscription_features=lambda cfg: {}))
+    monkeypatch.setitem(sys.modules, "tools.tool_backend_helpers", types.SimpleNamespace(managed_nous_tools_enabled=lambda: False))
+    monkeypatch.setattr(server, "_tools_catalog_payload", lambda: {"mcp_servers": [], "toolsets": [{"name": "web"}]})
+    monkeypatch.setattr(server, "_reset_session_agent", lambda sid, session: reset_calls.append((sid, session["session_key"])) or {"model": "claude", "skills": {}, "tools": {}})
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "tools.provider.configure",
+            "params": {
+                "env": {"FIRECRAWL_API_KEY": "sekret"},
+                "provider": "firecrawl",
+                "session_id": "sid",
+                "toolset": "web",
+            },
+        }
+    )
+
+    assert saved_env == {"FIRECRAWL_API_KEY": "sekret"}
+    assert saved_cfg["web"]["backend"] == "firecrawl"
+    assert saved_cfg["web"]["use_gateway"] is False
+    assert reset_calls == [("sid", "session-key")]
+    assert resp["result"] == {
+        "mcp_servers": [],
+        "toolsets": [{"name": "web"}],
+        "info": {"model": "claude", "skills": {}, "tools": {}},
+        "provider": "firecrawl",
+        "reset": True,
+        "toolset": "web",
+    }
+
+
+def test_tools_provider_configure_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_configure_tool_provider_impl",
+        lambda **kwargs: seen.update(kwargs) or {"missing_env": ["FIRECRAWL_API_KEY"], "provider": "firecrawl", "toolset": "web"},
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "tools.provider.configure",
+            "params": {"toolset": "web", "provider": "firecrawl", "env": {"FIRECRAWL_API_KEY": "sekret"}},
+        }
+    )
+
+    assert resp["result"] == {"missing_env": ["FIRECRAWL_API_KEY"], "provider": "firecrawl", "toolset": "web"}
+    assert seen["catalog_payload_builder"] is server._tools_catalog_payload
+
+
+def test_tools_mcp_configure_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_configure_mcp_servers_impl",
+        lambda **kwargs: seen.update(kwargs) or {"changed": ["github"], "info": None, "reset": False, "unknown": [], "mcp_servers": [], "toolsets": []},
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "tools.mcp.configure", "params": {"action": "disable", "names": ["github"]}}
+    )
+
+    assert resp["result"] == {
+        "changed": ["github"],
+        "info": None,
+        "reset": False,
+        "unknown": [],
+        "mcp_servers": [],
+        "toolsets": [],
+    }
+    assert seen["catalog_payload_builder"] is server._tools_catalog_payload
+
+
+def test_tools_mcp_probe_delegates_to_tools_bridge(monkeypatch):
+    monkeypatch.setattr(server, "_probe_mcp_servers_impl", lambda **kwargs: {"servers": [{"name": "github", "reachable": True, "tools": []}]})
+
+    resp = server.handle_request({"id": "1", "method": "tools.mcp.probe", "params": {}})
+
+    assert resp["result"] == {"servers": [{"name": "github", "reachable": True, "tools": []}]}
+
+
+def test_tools_configure_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_configure_tools_impl",
+        lambda **kwargs: seen.update(kwargs) or {
+            "changed": ["web"],
+            "enabled_toolsets": ["terminal"],
+            "info": None,
+            "missing_servers": [],
+            "reset": False,
+            "unknown": [],
+        },
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "tools.configure", "params": {"action": "disable", "names": ["web"]}}
+    )
+
+    assert resp["result"] == {
+        "changed": ["web"],
+        "enabled_toolsets": ["terminal"],
+        "info": None,
+        "missing_servers": [],
+        "reset": False,
+        "unknown": [],
+    }
+    assert seen["session_lookup"]("missing") is None
+
+
+def test_skills_manage_delegates_to_bridge(monkeypatch):
+    seen = {}
+    fake_banner = types.SimpleNamespace(get_available_skills=lambda: ["alpha", "beta"])
+    fake_source_hub = types.SimpleNamespace(
+        GitHubAuth=lambda: "auth",
+        create_source_router=lambda auth: {"auth": auth},
+        unified_search=lambda *args, **kwargs: [],
+    )
+    fake_skills = types.SimpleNamespace(
+        browse_skills=lambda **kwargs: {"items": []},
+        do_audit=lambda *args, **kwargs: None,
+        do_check=lambda *args, **kwargs: None,
+        do_install=lambda *args, **kwargs: None,
+        do_uninstall=lambda *args, **kwargs: None,
+        do_update=lambda *args, **kwargs: None,
+        inspect_skill=lambda query: {"identifier": query},
+    )
+
+    monkeypatch.setitem(sys.modules, "hermes_cli.banner", fake_banner)
+    monkeypatch.setitem(sys.modules, "hermes_cli.skills_hub", fake_skills)
+    monkeypatch.setitem(sys.modules, "tools.skills_hub", fake_source_hub)
+    monkeypatch.setattr(
+        server,
+        "_dispatch_skills_manage_impl",
+        lambda params, **kwargs: seen.update({"params": params, **kwargs}) or {"skills": ["alpha", "beta"]},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "skills.manage", "params": {"action": "LIST"}})
+
+    assert resp["result"] == {"skills": ["alpha", "beta"]}
+    assert seen["params"] == {"action": "list", "query": ""}
+    assert seen["get_available_skills"] is fake_banner.get_available_skills
+    assert seen["capture_console_output"] is server._capture_console_output
+    assert seen["browse_skills"] is fake_skills.browse_skills
+    assert seen["inspect_skill"] is fake_skills.inspect_skill
+    assert seen["do_install"] is fake_skills.do_install
+    assert seen["do_update"] is fake_skills.do_update
+    assert seen["do_audit"] is fake_skills.do_audit
+    assert seen["do_uninstall"] is fake_skills.do_uninstall
+    assert seen["source_router_factory"]("auth") == {"auth": "auth"}
+    assert seen["auth_factory"]() == "auth"
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"action": "search"}, "skills.search requires query"),
+        ({"action": "install", "query": ""}, "skills.install requires query"),
+        ({"action": "list", "query": "alpha"}, "unexpected skills params for list: query"),
+        ({"action": "browse", "page": 0}, "skills.browse requires positive page"),
+        ({"action": "audit", "query": "all", "source": "github"}, "unexpected skills params for audit: source"),
+        ({"action": "wat"}, "unknown skills action: wat"),
+    ],
+)
+def test_skills_manage_contract_rejects_invalid_action_shapes(params, message):
+    resp = server.handle_request({"id": "1", "method": "skills.manage", "params": params})
+
+    assert resp["error"]["code"] == 4017
+    assert resp["error"]["message"] == message
 
 
 def test_config_set_personality_rejects_unknown_name(monkeypatch):
@@ -375,6 +986,203 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
     assert "error" in resp
     assert "failed" in resp["error"]["message"]
+
+
+def test_routing_owner_lane_locks_authoritative_route_sets():
+    assert server._NATIVE_PRODUCT_COMMANDS == frozenset({"setup", "skills", "tools"})
+    assert server._LIVE_SLASH_COMMANDS == frozenset({"handoff", "init-deep", "model", "provider", "ralph-loop", "start-work", "ulw-loop"})
+    assert server._LEGACY_SLASH_WORKER_COMMANDS == frozenset({
+        "agents",
+        "browser",
+        "config",
+        "cron",
+        "debug",
+        "fast",
+        "gquota",
+        "history",
+        "insights",
+        "platforms",
+        "plugins",
+        "profile",
+        "reload",
+        "reload-mcp",
+        "rollback",
+        "save",
+        "snapshot",
+        "status",
+        "stop",
+        "title",
+        "toolsets",
+    })
+    assert server._SLASH_EXEC_COMMANDS == server._LIVE_SLASH_COMMANDS | server._LEGACY_SLASH_WORKER_COMMANDS
+
+
+def test_command_dispatch_rejects_route_owned_commands():
+    native = server.handle_request({"id": "1", "method": "command.dispatch", "params": {"name": "tools"}})
+    live = server.handle_request({"id": "2", "method": "command.dispatch", "params": {"name": "start-work"}})
+    legacy = server.handle_request({"id": "3", "method": "command.dispatch", "params": {"name": "config"}})
+
+    assert native["error"]["message"] == "/tools is handled by native product routing; command.dispatch is fallback-only"
+    assert live["error"]["message"] == "/start-work is handled by slash.exec; command.dispatch is fallback-only"
+    assert legacy["error"]["message"] == "/config is handled by slash.exec; command.dispatch is fallback-only"
+
+
+def test_slash_worker_locks_legacy_only_execution(monkeypatch):
+    fake_cli = types.ModuleType("cli")
+
+    class FakeHermesCLI:
+        def process_command(self, command):
+            print(f"ran:{command}")
+
+    fake_cli.HermesCLI = FakeHermesCLI
+    fake_cli._cprint = lambda text: None
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    import tui_gateway.slash_worker as slash_worker
+
+    slash_worker = importlib.reload(slash_worker)
+
+    assert slash_worker._NATIVE_PRODUCT_COMMANDS == frozenset({"setup", "skills", "tools"})
+    assert slash_worker._LIVE_SLASH_COMMANDS == frozenset({"handoff", "init-deep", "model", "provider", "ralph-loop", "start-work", "ulw-loop"})
+    assert slash_worker._LEGACY_SLASH_WORKER_COMMANDS == server._LEGACY_SLASH_WORKER_COMMANDS
+
+    cli = FakeHermesCLI()
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        assert slash_worker._run(cli, "/config") == "ran:/config"
+
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        try:
+            slash_worker._run(cli, "/tools")
+        except RuntimeError as exc:
+            assert str(exc) == "/tools is handled by native product routing; slash worker is legacy-only"
+        else:
+            raise AssertionError("expected native route rejection")
+
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        try:
+            slash_worker._run(cli, "/provider claude")
+        except RuntimeError as exc:
+            assert str(exc) == "/provider is handled by slash.exec live routing; slash worker is legacy-only"
+        else:
+            raise AssertionError("expected live route rejection")
+
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        try:
+            slash_worker._run(cli, "/resume")
+        except RuntimeError as exc:
+            assert str(exc) == "/resume is not eligible for slash worker execution"
+        else:
+            raise AssertionError("expected non-legacy rejection")
+
+
+def test_slash_exec_work_command_submits_live_prompt(monkeypatch):
+    captured = {}
+    session = _session()
+    server._sessions["sid"] = session
+
+    monkeypatch.setattr(
+        server,
+        "_start_prompt_submit",
+        lambda rid, sid, session, text: captured.update({"args": (rid, sid, session["session_key"], text)}) or {"result": {"status": "streaming"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.work_command_adapter.prepare_work_command",
+        lambda canonical, raw_args, session_id, cwd: f"prepared::{canonical}::{raw_args}::{session_id}",
+    )
+
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "handoff request"}})
+
+    assert resp["result"]["output"] == "/handoff started"
+    assert captured["args"] == ("1", "sid", "session-key", "prepared::handoff::request::session-key")
+
+
+
+def test_slash_exec_work_command_busy_is_deterministic(monkeypatch):
+    server._sessions["sid"] = _session(running=True)
+    monkeypatch.setattr(
+        "hermes_cli.work_command_adapter.prepare_work_command",
+        lambda canonical, raw_args, session_id, cwd: "prepared prompt",
+    )
+
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "start-work ship it"}})
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4009
+    assert resp["error"]["message"] == "session busy"
+
+
+
+def test_slash_exec_model_uses_live_switch_path(monkeypatch):
+    server._sessions["sid"] = _session()
+    seen = {}
+
+    def _fake_apply(sid, session, raw):
+        seen["args"] = (sid, session["session_key"], raw)
+        return {"value": "new/model", "warning": "catalog unreachable"}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
+    resp = server.handle_request(
+        {"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "model new/model"}}
+    )
+
+    assert resp["result"]["output"] == "model → new/model"
+    assert resp["result"]["warning"] == "catalog unreachable"
+    assert seen["args"] == ("sid", "session-key", "new/model")
+
+
+
+def test_slash_exec_provider_alias_uses_live_model_path(monkeypatch):
+    server._sessions["sid"] = _session()
+    seen = {}
+
+    def _fake_apply(sid, session, raw):
+        seen["args"] = (sid, session["session_key"], raw)
+        return {"value": "provider/model", "warning": ""}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
+    resp = server.handle_request(
+        {"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "provider provider/model"}}
+    )
+
+    assert resp["result"]["output"] == "model → provider/model"
+    assert seen["args"] == ("sid", "session-key", "provider/model")
+
+
+
+def test_slash_exec_native_product_command_rejects_worker(monkeypatch):
+    session = _session()
+    server._sessions["sid"] = session
+    worker_ctor = []
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args, **kwargs: worker_ctor.append((args, kwargs)))
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "tools"}})
+
+    assert "error" in resp
+    assert resp["error"]["message"] == "/tools is handled by native product routing; slash.exec is legacy-only"
+    assert worker_ctor == []
+    assert session["slash_worker"] is None
+
+
+
+def test_slash_exec_legacy_command_still_uses_worker(monkeypatch):
+    session = _session()
+    server._sessions["sid"] = session
+    seen = {}
+
+    class _Worker:
+        def run(self, command):
+            seen["command"] = command
+            return "legacy output"
+
+        def close(self):
+            seen["closed"] = True
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda session_key, model: _Worker())
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "config"}})
+
+    assert resp["result"]["output"] == "legacy output"
+    assert seen["command"] == "config"
+
 
 
 def test_plugins_list_surfaces_loader_error(monkeypatch):

--- a/tests/test_wave2_integration.py
+++ b/tests/test_wave2_integration.py
@@ -1,0 +1,314 @@
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.intent_preclassifier import preclassify_intent
+from run_agent import AIAgent
+from tools.delegate_tool import delegate_task
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+class _FakeClient(MagicMock):
+    pass
+
+
+class _FakeChild(SimpleNamespace):
+    pass
+
+
+DEFAULT_CFG = {
+    "provider": "",
+    "model": "",
+    "base_url": "",
+    "api_key": "",
+    "runtime_mode": "default",
+    "route_category": "unspecified_low",
+    "default_route_category": "unspecified_low",
+    "default_delegation_profile": "general",
+    "default_category": "general",
+    "default_skills": [],
+    "task_contract": None,
+    "permission_preset": "inherit",
+    "fallback_policy": "legacy_default_mapping",
+    "max_iterations": 50,
+    "max_concurrent_children": 3,
+}
+
+
+def _sample_task_contract(required_tools=None) -> dict:
+    return {
+        "task": "Implement the delegated change",
+        "expected_outcome": "A passing implementation with verification evidence",
+        "required_skills": ["python", "testing"],
+        "required_tools": required_tools or ["terminal", "read_file", "patch"],
+        "must_do": ["inspect repo patterns before editing"],
+        "must_not_do": {"forbidden_files": ["run_agent.py"]},
+        "context": {"repo": "/root/.hermes/hermes-agent"},
+    }
+
+
+def _make_agent(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-12345678",
+            base_url="https://example.test/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = _FakeClient()
+    return agent
+
+
+def _make_mock_parent(runtime_activation_state: dict | None = None, depth: int = 0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.enabled_toolsets = ["terminal", "file", "web"]
+    parent.valid_tool_names = {"terminal", "read_file", "search_files", "patch", "web_search"}
+    parent.runtime_activation_state = runtime_activation_state or {
+        "specialist": "builder",
+        "archetype": "implementer",
+        "route_category": "deep",
+        "delegation_profile": "implementation",
+        "runtime_mode": "ultrawork",
+        "task_contract": None,
+        "activation_applied": True,
+        "activation_note": "Wave 2 Runtime Activation",
+        "wave1_overlay_prompt": "# Wave 1 Prompt Overlays\n\n## Archetype\nname: implementer",
+    }
+    parent.get_runtime_activation_state.return_value = dict(parent.runtime_activation_state)
+    return parent
+
+
+def _fake_build_child_agent(**kwargs):
+    return _FakeChild(
+        _delegate_resolution=dict(kwargs.get("delegate_resolution") or {}),
+        enabled_toolsets=list(kwargs.get("toolsets") or []),
+        enabled_tools=list(kwargs.get("enabled_tools") or []),
+        ephemeral_system_prompt=kwargs.get("wave1_overlay_prompt") or "",
+        session_id=f"child-{kwargs['task_index']}",
+        tool_progress_callback=None,
+    )
+
+
+def _fake_run_single_child(task_index, goal, child=None, parent_agent=None, **_kwargs):
+    return {
+        "task_index": task_index,
+        "status": "completed",
+        "summary": goal,
+        "api_calls": 1,
+        "duration_seconds": 0.01,
+        "resolved_inputs": child._delegate_resolution,
+        "enabled_toolsets": list(getattr(child, "enabled_toolsets", [])),
+        "enabled_tools": list(getattr(child, "enabled_tools", [])),
+        "system_prompt": getattr(child, "ephemeral_system_prompt", ""),
+    }
+
+
+def test_top_level_runtime_activation_smoke():
+    agent = _make_agent("delegate_task")
+    seen_state = {}
+
+    first_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="tool_calls",
+                message=SimpleNamespace(
+                    content="Delegating now.",
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call-1",
+                            type="function",
+                            function=SimpleNamespace(name="delegate_task", arguments='{"goal": "Implement subtask"}'),
+                        )
+                    ],
+                ),
+            )
+        ],
+        usage=None,
+    )
+    second_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="Delegation finished.", tool_calls=[]),
+            )
+        ],
+        usage=None,
+    )
+
+    def fake_delegate_task(**kwargs):
+        parent_agent = kwargs["parent_agent"]
+        seen_state.update(parent_agent.get_runtime_activation_state())
+        return json.dumps({"status": "ok"})
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=[first_response, second_response]),
+        patch("tools.delegate_tool.delegate_task", side_effect=fake_delegate_task),
+    ):
+        result = agent.run_conversation("Use ultrawork mode to implement the patch and run tests.")
+
+    assert result["final_response"] == "Delegation finished."
+    assert seen_state["specialist"] == "builder"
+    assert seen_state["archetype"] == "implementer"
+    assert seen_state["route_category"] == "deep"
+    assert seen_state["delegation_profile"] == "implementation"
+    assert seen_state["runtime_mode"] == "ultrawork"
+    assert seen_state["activation_applied"] is True
+    assert "Wave 2 Runtime Activation" in seen_state["activation_note"]
+
+
+def test_deterministic_specialist_mapping_smoke():
+    message = "Review this patch, verify the risky changes, and call out regressions."
+
+    first = preclassify_intent(message)
+    second = preclassify_intent(message)
+
+    assert first == second
+    assert first.inferred_specialist == "code_reviewer"
+    assert first.inferred_archetype == "verifier"
+    assert first.inferred_route_category == "quick"
+    assert first.inferred_delegation_profile == "verification"
+    assert first.inferred_runtime_mode == "default"
+    assert first.inferred_specialist != first.inferred_archetype
+    assert first.inferred_specialist != first.inferred_route_category
+    assert first.inferred_specialist != first.inferred_runtime_mode
+    assert first.inferred_delegation_profile != first.inferred_route_category
+
+
+@patch("tools.delegate_tool._load_config", return_value=DEFAULT_CFG)
+@patch("tools.delegate_tool._run_single_child", side_effect=_fake_run_single_child)
+@patch("tools.delegate_tool._build_child_agent", side_effect=_fake_build_child_agent)
+def test_specialist_changes_child_construction_smoke(_mock_build, _mock_run, _mock_load):
+    activation = preclassify_intent("Review this patch, verify the risky changes, and call out regressions.")
+    parent = _make_mock_parent(
+        {
+            "specialist": activation.inferred_specialist,
+            "archetype": activation.inferred_archetype,
+            "route_category": activation.inferred_route_category,
+            "delegation_profile": activation.inferred_delegation_profile,
+            "runtime_mode": activation.inferred_runtime_mode,
+            "task_contract": None,
+            "activation_applied": True,
+            "activation_note": activation.activation_reason,
+            "wave1_overlay_prompt": "# Wave 1 Prompt Overlays\n\n## Archetype\nname: verifier",
+        }
+    )
+
+    result = json.loads(delegate_task(goal="Review the implementation", parent_agent=parent))
+    payload = result["results"][0]
+    resolved = payload["resolved_inputs"]
+
+    assert parent.runtime_activation_state["specialist"] == "code_reviewer"
+    assert resolved["archetype"] == "verifier"
+    assert resolved["route_category"] == "quick"
+    assert resolved["delegation_profile"] == "verification"
+    assert resolved["runtime_mode"] == "default"
+    assert resolved["route_category"] != resolved["delegation_profile"]
+    assert "## Archetype" in payload["system_prompt"]
+
+
+@patch("tools.delegate_tool._load_config", return_value=DEFAULT_CFG)
+@patch("tools.delegate_tool._run_single_child", side_effect=_fake_run_single_child)
+@patch("tools.delegate_tool._build_child_agent", side_effect=_fake_build_child_agent)
+def test_contract_aware_delegation_smoke(_mock_build, _mock_run, _mock_load):
+    parent = _make_mock_parent()
+    parent.runtime_activation_state["task_contract"] = _sample_task_contract(["terminal", "read_file", "patch"])
+    parent.get_runtime_activation_state.return_value = dict(parent.runtime_activation_state)
+
+    result = json.loads(delegate_task(goal="Implement the fix", parent_agent=parent))
+    payload = result["results"][0]
+
+    assert payload["resolved_inputs"]["task_contract"] == parent.runtime_activation_state["task_contract"]
+    assert "terminal" in payload["enabled_toolsets"]
+    assert "read_file" in payload["enabled_tools"]
+    assert "patch" in payload["enabled_tools"]
+
+
+def test_start_work_explicit_contract_suppresses_conflicting_named_workflow_metadata():
+    contract = _sample_task_contract()
+    contract["context"]["command_runtime"] = {
+        "command_name": "handoff",
+        "runtime_mode": "ralph",
+    }
+
+    from hermes_cli.command_templates import build_command_invocation
+
+    invocation = build_command_invocation("start-work", raw_args=json.dumps(contract), session_id="sess-wave2", cwd="/tmp")
+
+    assert invocation.task_contract == contract
+    assert invocation.named_workflow is None
+    assert "NAMED_WORKFLOW_JSON:" not in invocation.prompt_text
+    inferred = preclassify_intent({"message": contract["task"], "task_contract": invocation.task_contract})
+    assert inferred.inferred_runtime_mode == "ralph"
+
+
+@patch("tools.delegate_tool._load_config", return_value=DEFAULT_CFG)
+@patch("tools.delegate_tool._run_single_child", side_effect=_fake_run_single_child)
+@patch("tools.delegate_tool._build_child_agent", side_effect=_fake_build_child_agent)
+def test_mixed_batch_smoke(_mock_build, _mock_run, _mock_load):
+    parent = _make_mock_parent()
+
+    result = json.loads(
+        delegate_task(
+            tasks=[
+                {
+                    "goal": "Research the regression",
+                    "archetype": "researcher",
+                    "route_category": "quick",
+                    "delegation_profile": "research",
+                    "runtime_mode": "default",
+                },
+                {"goal": "Verify the implementation"},
+            ],
+            parent_agent=parent,
+        )
+    )
+
+    first = result["results"][0]["resolved_inputs"]
+    second = result["results"][1]["resolved_inputs"]
+
+    assert first["archetype"] == "researcher"
+    assert first["route_category"] == "quick"
+    assert first["delegation_profile"] == "research"
+    assert first["runtime_mode"] == "default"
+
+    assert second["archetype"] == "implementer"
+    assert second["route_category"] == "deep"
+    assert second["delegation_profile"] == "implementation"
+    assert second["runtime_mode"] == "ultrawork"

--- a/tests/tools/test_ast_tools.py
+++ b/tests/tools/test_ast_tools.py
@@ -1,0 +1,191 @@
+import json
+
+from model_tools import get_tool_definitions
+from toolsets import resolve_toolset
+from tools.ast_tools import (
+    AST_TOOLS,
+    AST_FIND_NODES_SCHEMA,
+    AST_LIST_DEFS_SCHEMA,
+    ast_find_nodes_tool,
+    ast_list_defs_tool,
+)
+
+
+class TestAstToolRegistration:
+    def test_exports_expected_tools_and_schemas(self):
+        names = {tool["name"] for tool in AST_TOOLS}
+        assert names == {"ast_list_defs", "ast_find_nodes"}
+
+        for schema in [AST_LIST_DEFS_SCHEMA, AST_FIND_NODES_SCHEMA]:
+            assert "name" in schema
+            assert "description" in schema
+            assert "properties" in schema["parameters"]
+
+        assert "language" in AST_LIST_DEFS_SCHEMA["parameters"]["properties"]
+        assert "language" in AST_FIND_NODES_SCHEMA["parameters"]["properties"]
+
+    def test_code_intel_toolset_exposes_ast_tools(self):
+        code_intel_tools = set(resolve_toolset("code_intel"))
+        assert {"ast_list_defs", "ast_find_nodes"} <= code_intel_tools
+
+        model_tool_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        }
+        assert {"ast_list_defs", "ast_find_nodes"} <= model_tool_names
+
+
+class TestAstHandlers:
+    def test_list_defs_reports_top_level_items_and_optional_nested_items(self, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text(
+            "import os\n\n"
+            "class Example:\n"
+            "    def method(self):\n"
+            "        return 1\n\n"
+            "async def run():\n"
+            "    return 2\n\n"
+            "def outer():\n"
+            "    def inner():\n"
+            "        return 3\n"
+            "    return inner()\n",
+            encoding="utf-8",
+        )
+
+        top_level = json.loads(ast_list_defs_tool(path=str(source_path)))
+        nested = json.loads(ast_list_defs_tool(path=str(source_path), include_nested=True))
+
+        assert [item["name"] for item in top_level["definitions"]] == ["Example", "run", "outer"]
+        assert "inner" not in [item["name"] for item in top_level["definitions"]]
+        nested_names = [item["name"] for item in nested["definitions"]]
+        assert "inner" in nested_names
+        assert nested["definitions"][-1]["parent"] == "outer"
+
+    def test_find_nodes_filters_by_type_and_name(self, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text(
+            "def helper():\n"
+            "    return 1\n\n"
+            "def build():\n"
+            "    value = helper()\n"
+            "    return helper()\n",
+            encoding="utf-8",
+        )
+
+        calls = json.loads(ast_find_nodes_tool(path=str(source_path), node_type="Call", name="helper"))
+        defs = json.loads(ast_find_nodes_tool(path=str(source_path), node_type="FunctionDef", name="build"))
+
+        assert calls["count"] == 2
+        assert all(match["display_name"] == "helper" for match in calls["matches"])
+        assert defs["count"] == 1
+        assert defs["matches"][0]["name"] == "build"
+        assert defs["matches"][0]["parent"] is None
+
+    def test_syntax_error_returns_structured_error(self, tmp_path):
+        source_path = tmp_path / "broken.py"
+        source_path.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+        result = json.loads(ast_list_defs_tool(path=str(source_path)))
+
+        assert "error" in result
+        assert result["error_type"] == "SyntaxError"
+        assert result["path"] == str(source_path)
+        assert result["lineno"] == 1
+
+    def test_list_defs_supports_json_structural_traversal(self, tmp_path):
+        source_path = tmp_path / "config.json"
+        source_path.write_text(
+            '{\n'
+            '  "name": "demo",\n'
+            '  "build": {\n'
+            '    "entry": "src/index.js",\n'
+            '    "flags": {"watch": true}\n'
+            '  },\n'
+            '  "metadata": {"owner": "hermes"}\n'
+            '}\n',
+            encoding="utf-8",
+        )
+
+        top_level = json.loads(ast_list_defs_tool(path=str(source_path)))
+        nested = json.loads(ast_list_defs_tool(path=str(source_path), include_nested=True))
+        watch_matches = json.loads(
+            ast_find_nodes_tool(path=str(source_path), node_type="ObjectProperty", name="watch")
+        )
+
+        assert top_level["language"] == "json"
+        assert top_level["parser"] == "json_structure_v1"
+        assert top_level["confidence"] == "high"
+        assert [item["name"] for item in top_level["definitions"]] == ["name", "build", "metadata"]
+        assert "flags" in [item["name"] for item in nested["definitions"]]
+        assert watch_matches["count"] == 1
+        assert watch_matches["matches"][0]["parent"] == "flags"
+        assert watch_matches["matches"][0]["node_type"] == "ObjectProperty"
+
+    def test_javascript_heuristics_list_defs_and_find_nodes(self, tmp_path):
+        source_path = tmp_path / "sample.js"
+        source_path.write_text(
+            'export class Example {\n'
+            '  async method() {\n'
+            '    function innerHelper() {\n'
+            '      return 1;\n'
+            '    }\n'
+            '    return innerHelper();\n'
+            '  }\n'
+            '}\n\n'
+            'export async function runTask() {\n'
+            '  return 2;\n'
+            '}\n\n'
+            'const helper = () => 3;\n',
+            encoding="utf-8",
+        )
+
+        top_level = json.loads(ast_list_defs_tool(path=str(source_path)))
+        nested = json.loads(ast_list_defs_tool(path=str(source_path), include_nested=True))
+        method_matches = json.loads(
+            ast_find_nodes_tool(path=str(source_path), node_type="MethodDefinition", name="method")
+        )
+
+        assert top_level["language"] == "javascript"
+        assert top_level["parser"] == "hermes_js_structure_v1"
+        assert top_level["confidence"] == "medium"
+        assert [item["name"] for item in top_level["definitions"]] == ["Example", "runTask", "helper"]
+        nested_items = {item["name"]: item for item in nested["definitions"]}
+        assert nested_items["method"]["parent"] == "Example"
+        assert nested_items["innerHelper"]["parent"] == "method"
+        assert method_matches["count"] == 1
+        assert method_matches["matches"][0]["parent"] == "Example"
+
+    def test_typescript_heuristics_support_interfaces_and_type_aliases(self, tmp_path):
+        source_path = tmp_path / "sample.ts"
+        source_path.write_text(
+            'export interface User {\n'
+            '  name: string;\n'
+            '}\n\n'
+            'export type UserId = string;\n\n'
+            'export const loadUser = async (): Promise<User> => ({ name: "demo" });\n',
+            encoding="utf-8",
+        )
+
+        result = json.loads(ast_list_defs_tool(path=str(source_path)))
+        interface_matches = json.loads(
+            ast_find_nodes_tool(path=str(source_path), node_type="InterfaceDeclaration", name="User")
+        )
+
+        assert result["language"] == "typescript"
+        assert result["parser"] == "hermes_js_structure_v1"
+        assert [item["name"] for item in result["definitions"]] == ["User", "UserId", "loadUser"]
+        assert result["definitions"][0]["node_type"] == "InterfaceDeclaration"
+        assert interface_matches["count"] == 1
+        assert interface_matches["matches"][0]["name"] == "User"
+
+    def test_unsupported_language_returns_structured_error(self, tmp_path):
+        source_path = tmp_path / "notes.md"
+        source_path.write_text("# hello\n", encoding="utf-8")
+
+        result = json.loads(ast_list_defs_tool(path=str(source_path)))
+
+        assert "error" in result
+        assert result["error_type"] == "UnsupportedLanguage"
+        assert result["path"] == str(source_path)
+        assert result["detected_language"] == "unknown"
+        assert set(result["supported_languages"]) == {"python", "javascript", "typescript", "json"}

--- a/tests/tools/test_ast_tools.py
+++ b/tests/tools/test_ast_tools.py
@@ -11,6 +11,18 @@ from tools.ast_tools import (
 )
 
 
+class TestAstRepoCodeKnowledgeFraming:
+    def test_repo_code_knowledge_toolset_treats_ast_primitives_as_canonical(self):
+        repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
+        assert {"ast_list_defs", "ast_find_nodes"} <= repo_code_tools
+
+    def test_ast_schemas_mention_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in AST_LIST_DEFS_SCHEMA["description"]
+        assert "local source grounding" in AST_LIST_DEFS_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in AST_FIND_NODES_SCHEMA["description"]
+        assert "targeted structural lookup" in AST_FIND_NODES_SCHEMA["description"]
+
+
 class TestAstToolRegistration:
     def test_exports_expected_tools_and_schemas(self):
         names = {tool["name"] for tool in AST_TOOLS}

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -16,6 +16,19 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 class TestBrowserConsole:
     """browser_console() returns console messages + JS errors in one call."""
 
+    def test_expression_mode_delegates_to_browser_eval(self):
+        from tools.browser_tool import browser_console
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value='{"success": true, "result": "Doc title"}') as mock_eval,
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+        ):
+            result = browser_console(expression="document.title", task_id="test")
+
+        assert json.loads(result)["result"] == "Doc title"
+        mock_eval.assert_called_once_with("document.title", "test")
+        mock_cmd.assert_not_called()
+
     def test_returns_console_messages_and_errors(self):
         from tools.browser_tool import browser_console
 
@@ -116,6 +129,18 @@ class TestBrowserConsoleSchema:
         assert "clear" in props
         assert props["clear"]["type"] == "boolean"
 
+    def test_schema_describes_rendered_page_state_inspection(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+
+        console_schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_console")
+        get_images_schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_get_images")
+        vision_schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_vision")
+
+        assert "browser-rendered document viewers" in console_schema["description"]
+        assert "live page context" in console_schema["description"]
+        assert "rendered documents, slide decks, diagrams" in get_images_schema["description"]
+        assert "rendered PDF pages, slide decks, diagrams, charts" in vision_schema["description"]
+
 
 class TestBrowserConsoleToolsetWiring:
     """browser_console must be reachable via toolset resolution."""
@@ -192,6 +217,38 @@ class TestBrowserVisionAnnotate:
                 args = mock_cmd.call_args[0]
                 cmd_args = args[2] if len(args) > 2 else []
                 assert "--annotate" in cmd_args
+
+    def test_success_returns_screenshot_path_and_annotations(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        screenshot = tmp_path / "page.png"
+        screenshot.write_bytes(b"fake-image-bytes")
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Rendered PDF page with a chart"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+            patch("tools.browser_tool.call_llm", return_value=mock_response),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("agent.redact.redact_sensitive_text", side_effect=lambda text: text),
+        ):
+            mock_cmd.return_value = {
+                "success": True,
+                "data": {
+                    "path": str(screenshot),
+                    "annotations": [{"label": 1, "ref": "@e1"}],
+                },
+            }
+
+            result = json.loads(browser_vision("Inspect this document page", annotate=True, task_id="test"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Rendered PDF page with a chart"
+        assert result["screenshot_path"] == str(screenshot)
+        assert result["annotations"] == [{"label": 1, "ref": "@e1"}]
 
 
 # ── auto-recording config ────────────────────────────────────────────

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,8 @@ import sys
 import threading
 import time
 import unittest
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -569,6 +571,39 @@ class TestBlockedTools(unittest.TestCase):
         self.assertEqual(MAX_DEPTH, 2)
 
 
+class TestDelegationConfigIsolation(unittest.TestCase):
+    def test_stale_cli_config_from_other_hermes_home_is_ignored(self):
+        import cli
+
+        parent = _make_mock_parent()
+        stale_cfg = {
+            "delegation": {
+                "provider": "openai-codex",
+                "model": "gpt-5.4",
+                "max_concurrent_children": 12,
+            }
+        }
+
+        with (
+            patch.object(cli, "CLI_CONFIG", stale_cfg),
+            patch.object(cli, "_hermes_home", Path("/tmp/stale-hermes-home")),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done!",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+            self.assertEqual(_get_max_concurrent_children(), 3)
+            result = json.loads(delegate_task(goal="Ignore stale CLI config", parent_agent=parent))
+
+        self.assertIn("results", result)
+        mock_run.assert_called_once()
+
+
 class TestDelegationCredentialResolution(unittest.TestCase):
     """Tests for provider:model credential resolution in delegation config."""
 
@@ -592,6 +627,27 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_matching_provider_reuses_parent_runtime_credentials(self, mock_resolve):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "gpt-5.4"
+        parent.provider = "openai-codex"
+        parent.base_url = "https://chatgpt.com/backend-api/codex"
+        parent.api_key = "runtime-codex-key"
+        parent.api_mode = "codex_responses"
+
+        creds = _resolve_delegation_credentials(
+            {"model": "gpt-5.4", "provider": "openai-codex"},
+            parent,
+        )
+
+        self.assertEqual(creds["model"], "gpt-5.4")
+        self.assertEqual(creds["provider"], "openai-codex")
+        self.assertEqual(creds["base_url"], parent.base_url)
+        self.assertEqual(creds["api_key"], parent.api_key)
+        self.assertEqual(creds["api_mode"], parent.api_mode)
+        mock_resolve.assert_not_called()
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_full_credentials(self, mock_resolve):
@@ -1276,6 +1332,103 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
+
+
+class TestDelegationCategoryPolicy(unittest.TestCase):
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_category_profile_applies_tool_policy(self, mock_load_config, mock_build_child, mock_run_child):
+        mock_load_config.return_value = {
+            "max_concurrent_children": 5,
+            "categories": {
+                "research": {
+                    "enabled_tools": ["read_file", "search_files"],
+                    "toolsets": ["file"],
+                    "max_iterations": 7,
+                }
+            },
+        }
+        mock_build_child.return_value = MagicMock()
+        mock_run_child.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(goal="Audit the repo", category="research", parent_agent=parent))
+
+        self.assertIn("results", result)
+        kwargs = mock_build_child.call_args.kwargs
+        self.assertEqual(kwargs["toolsets"], ["file"])
+        self.assertEqual(kwargs["enabled_tools"], ["read_file", "search_files"])
+        self.assertEqual(kwargs["max_iterations"], 7)
+
+    @patch("tools.delegate_tool._load_config")
+    def test_category_concurrency_cap_rejected(self, mock_load_config):
+        mock_load_config.return_value = {
+            "max_concurrent_children": 5,
+            "categories": {
+                "implementation": {"max_concurrent_children": 1},
+            },
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(
+            tasks=[
+                {"goal": "Patch module A", "category": "implementation"},
+                {"goal": "Patch module B", "category": "implementation"},
+            ],
+            parent_agent=parent,
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("category at 1", result["error"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_category_only_batch_can_exceed_root_default(self, mock_load_config, mock_build_child, mock_run_child):
+        mock_load_config.return_value = {
+            "max_concurrent_children": 3,
+            "categories": {
+                "research": {"max_concurrent_children": 5},
+            },
+        }
+        mock_build_child.side_effect = [MagicMock() for _ in range(4)]
+        mock_run_child.side_effect = lambda *, task_index, goal, child, parent_agent: {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"Done {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        captured = {}
+
+        def _recording_executor(*args, **kwargs):
+            captured["max_workers"] = kwargs.get("max_workers")
+            return RealThreadPoolExecutor(*args, **kwargs)
+
+        with patch("tools.delegate_tool.ThreadPoolExecutor", side_effect=_recording_executor):
+            result = json.loads(delegate_task(
+                tasks=[
+                    {"goal": "Research A"},
+                    {"goal": "Research B"},
+                    {"goal": "Research C"},
+                    {"goal": "Research D"},
+                ],
+                category="research",
+                parent_agent=parent,
+            ))
+
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 4)
+        self.assertEqual(mock_build_child.call_count, 4)
+        self.assertEqual(captured["max_workers"], 4)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -22,7 +22,10 @@ from unittest.mock import MagicMock, patch
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
+    _apply_named_role_completion_gate,
     _get_max_concurrent_children,
+    _is_reviewer_like_resolution,
+    _resolve_named_agent_config,
     MAX_DEPTH,
     check_delegate_requirements,
     delegate_task,
@@ -31,6 +34,10 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_route_category_fallback_models,
+    _resolve_task_delegation_profile,
+    _resolve_wave1_task_inputs,
+    _normalize_delegation_config,
 )
 
 
@@ -69,6 +76,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
+        self.assertIn("agent", props)
+        self.assertIn("agent", props["tasks"]["items"]["properties"])
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
 
@@ -88,6 +97,206 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+    def test_includes_wave1_overlay_prompt(self):
+        prompt = _build_child_system_prompt(
+            "Do something",
+            "Context block",
+            wave1_overlay_prompt="# Wave 1 Prompt Overlays\n\n## Route Category\nname: deep",
+        )
+        self.assertIn("WAVE 1 DELEGATION INPUTS", prompt)
+        self.assertIn("# Wave 1 Prompt Overlays", prompt)
+        self.assertIn("name: deep", prompt)
+
+
+class TestWave1DelegateResolution(unittest.TestCase):
+    def test_delegation_profile_prefers_new_field_but_preserves_non_literal_legacy_alias(self):
+        cfg = {"default_delegation_profile": "general", "default_category": "general"}
+        self.assertEqual(
+            _resolve_task_delegation_profile(
+                {"delegation_profile": "verification", "category": "research"},
+                top_level_delegation_profile=None,
+                top_level_category=None,
+                cfg=cfg,
+            ),
+            "verification",
+        )
+        self.assertEqual(
+            _resolve_task_delegation_profile(
+                {"category": "research"},
+                top_level_delegation_profile=None,
+                top_level_category=None,
+                cfg=cfg,
+            ),
+            "research",
+        )
+
+    def test_wave1_inputs_keep_literal_category_surface_distinct_from_route_and_profile(self):
+        cfg = {
+            "archetype": "generalist",
+            "category": "unspecified-low",
+            "route_category": "unspecified_low",
+            "route_categories": {
+                "visual": {"summary": "Config-tuned visual lane", "intensity": "medium"},
+            },
+            "default_delegation_profile": "general",
+            "delegation_profiles": {
+                "verification": {"runtime_mode": "execution_supervisor"},
+            },
+            "default_skills": ["general_reasoning"],
+            "task_contract": None,
+            "runtime_mode": "default",
+            "runtime_modes": {
+                "execution_supervisor": {
+                    "description": "Config-tuned oversight posture",
+                    "operating_posture": "oversight_and_coordination",
+                    "kind": "runtime_mode",
+                },
+            },
+            "permission_preset": "inherit",
+            "fallback_policy": "legacy_default_mapping",
+            "default_category": "unspecified-low",
+        }
+        resolved = _resolve_wave1_task_inputs(
+            {
+                "goal": "Investigate bug",
+                "category": "visual-engineering",
+                "delegation_profile": "verification",
+                "skills": ["pytest"],
+            },
+            cfg=_normalize_delegation_config(cfg),
+        )
+        self.assertEqual(resolved["category"], "visual-engineering")
+        self.assertEqual(resolved["route_category"], "visual")
+        self.assertEqual(resolved["route_category_definition"]["summary"], "Config-tuned visual lane")
+        self.assertEqual(resolved["delegation_profile"], "verification")
+        self.assertNotEqual(resolved["category"], resolved["route_category"])
+        self.assertNotEqual(resolved["category"], resolved["delegation_profile"])
+        self.assertEqual(resolved["runtime_mode"], "execution_supervisor")
+        self.assertEqual(resolved["runtime_mode_definition"]["description"], "Config-tuned oversight posture")
+        self.assertIn("pytest", resolved["skills"])
+        self.assertIn("## Route Category", resolved["overlay_prompt"])
+        self.assertIn("## Delegation Profile", resolved["overlay_prompt"])
+        self.assertIn("## Runtime Mode", resolved["overlay_prompt"])
+
+    def test_wave1_inputs_preserve_literal_category_default_mapping_when_missing(self):
+        cfg = {
+            "archetype": "generalist",
+            "category": "unspecified-low",
+            "route_category": "unspecified_low",
+            "default_delegation_profile": "research",
+            "default_skills": ["general_reasoning"],
+            "task_contract": None,
+            "runtime_mode": "default",
+            "permission_preset": "inherit",
+            "fallback_policy": "legacy_default_mapping",
+            "default_category": "unspecified-low",
+        }
+        resolved = _resolve_wave1_task_inputs({"goal": "Find sources"}, cfg=_normalize_delegation_config(cfg))
+        self.assertEqual(resolved["archetype"], "generalist")
+        self.assertEqual(resolved["category"], "unspecified-low")
+        self.assertEqual(resolved["route_category"], "unspecified_low")
+        self.assertEqual(resolved["delegation_profile"], "research")
+        self.assertEqual(resolved["runtime_mode"], "default")
+        self.assertIsNone(resolved["task_contract"])
+
+    def test_task_route_category_wins_over_literal_category_mapping(self):
+        resolved = _resolve_wave1_task_inputs(
+            {
+                "goal": "Check precedence",
+                "category": "visual-engineering",
+                "route_category": "deep",
+                "runtime_mode": "execution_supervisor",
+                "delegation_profile": "verification",
+            },
+            cfg=_normalize_delegation_config({
+                "default_delegation_profile": "general",
+                "route_category": "unspecified_low",
+                "runtime_mode": "default",
+            }),
+        )
+
+        self.assertEqual(resolved["category"], "visual-engineering")
+        self.assertEqual(resolved["route_category"], "deep")
+        self.assertEqual(resolved["runtime_mode"], "execution_supervisor")
+        self.assertEqual(resolved["delegation_profile"], "verification")
+        self.assertIn("## Category\nname: visual-engineering", resolved["overlay_prompt"])
+        self.assertIn("mapped_route_category: visual", resolved["overlay_prompt"])
+        self.assertIn("## Route Category\nname: deep", resolved["overlay_prompt"])
+
+    def test_delegation_profile_surface_is_distinct_from_literal_category_surface(self):
+        normalized = _normalize_delegation_config(
+            {
+                "category": "visual-engineering",
+                "default_category": "visual-engineering",
+                "default_delegation_profile": "verification",
+                "delegation_profiles": {
+                    "verification": {"max_iterations": 11, "runtime_mode": "execution_supervisor"},
+                },
+                "categories": {
+                    "research": {"max_iterations": 7},
+                },
+            }
+        )
+
+        self.assertEqual(normalized["category"], "visual-engineering")
+        self.assertEqual(normalized["default_category"], "visual-engineering")
+        self.assertEqual(normalized["route_category"], "visual")
+        self.assertEqual(normalized["default_delegation_profile"], "verification")
+        self.assertIn("verification", normalized["delegation_profiles"])
+        self.assertIn("research", normalized["delegation_profiles"])
+        self.assertEqual(normalized["categories"], normalized["delegation_profiles"])
+        self.assertEqual(normalized["delegation_profiles"]["verification"]["runtime_mode"], "execution_supervisor")
+
+
+class TestRouteCategoryFallbackResolution(unittest.TestCase):
+    def test_builtin_route_category_fallbacks_degrade_to_root_config_when_no_profile_matches(self):
+        cfg = _normalize_delegation_config({
+            "model": "root-model",
+            "default_delegation_profile": "general",
+        })
+
+        fallback_models = _resolve_route_category_fallback_models(
+            cfg,
+            "deep",
+            _make_mock_parent(),
+        )
+
+        self.assertEqual(fallback_models, [{"model": "root-model"}])
+
+    def test_route_category_fallback_prefers_route_category_model_override(self):
+        cfg = _normalize_delegation_config({
+            "model": "root-model",
+            "default_delegation_profile": "general",
+            "route_categories": {
+                "quick": {
+                    "model": "quick-model",
+                },
+            },
+        })
+
+        fallback_models = _resolve_route_category_fallback_models(
+            cfg,
+            "deep",
+            _make_mock_parent(),
+        )
+
+        self.assertEqual(fallback_models, [{"model": "quick-model"}])
+
+
+class TestReviewerLikeNamedRoles(unittest.TestCase):
+    def test_verifier_archetype_counts_as_reviewer_like(self):
+        self.assertTrue(_is_reviewer_like_resolution({"archetype": "verifier"}))
+
+    def test_completion_gate_blocks_verifier_without_evidence(self):
+        entry = _apply_named_role_completion_gate(
+            {"status": "completed", "tool_trace": []},
+            resolved_inputs={"archetype": "verifier"},
+        )
+
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "verification_evidence_missing")
+        self.assertIn("no verification evidence tool", entry["error"])
 
 
 class TestStripBlockedTools(unittest.TestCase):
@@ -132,6 +341,202 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
 
     @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_full_config")
+    def test_named_agent_overrides_apply_to_defaults_tools_and_credentials(
+        self,
+        mock_load_full_config,
+        mock_resolve_creds,
+        mock_build_child,
+        mock_run_child,
+    ):
+        mock_load_full_config.return_value = {
+            "delegation": {"max_iterations": 50},
+            "agents": {
+                "writer": {
+                    "archetype": "implementer",
+                    "route_category": "deep",
+                    "allowed_tools": ["read_file", "search_files"],
+                    "blocked_tools": ["terminal"],
+                    "model": "writer-model",
+                    "provider": "writer-provider",
+                },
+                "reviewer": {
+                    "archetype": "verifier",
+                    "route_category": "quick",
+                    "allowed_tools": ["read_file", "terminal"],
+                    "blocked_tools": ["search_files"],
+                    "model": "review-model",
+                    "provider": "review-provider",
+                },
+            },
+        }
+
+        def _creds_for(cfg, _parent_agent):
+            provider = cfg.get("provider")
+            return {
+                "model": cfg.get("model"),
+                "provider": provider,
+                "base_url": f"https://{provider}.example/v1" if provider else None,
+                "api_key": f"key-for-{provider}" if provider else None,
+                "api_mode": "chat_completions" if provider else None,
+            }
+
+        mock_resolve_creds.side_effect = _creds_for
+        mock_build_child.side_effect = [MagicMock(), MagicMock()]
+        mock_run_child.side_effect = lambda *, task_index, goal, child, parent_agent: {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"Done {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        parent.valid_tool_names = {"read_file", "search_files", "terminal", "patch"}
+
+        result = json.loads(delegate_task(
+            tasks=[
+                {"goal": "Draft changelog"},
+                {"goal": "Review changes", "agent": "reviewer"},
+            ],
+            agent="writer",
+            parent_agent=parent,
+        ))
+
+        self.assertIn("results", result)
+        self.assertEqual(mock_build_child.call_count, 2)
+
+        writer_call = mock_build_child.call_args_list[0].kwargs
+        self.assertEqual(writer_call["enabled_tools"], ["read_file", "search_files"])
+        self.assertEqual(writer_call["model"], "writer-model")
+        self.assertEqual(writer_call["override_provider"], "writer-provider")
+        self.assertEqual(writer_call["delegate_resolution"]["archetype"], "implementer")
+        self.assertEqual(writer_call["delegate_resolution"]["route_category"], "deep")
+        self.assertEqual(writer_call["delegate_resolution"]["agent"], "writer")
+
+        reviewer_call = mock_build_child.call_args_list[1].kwargs
+        self.assertEqual(reviewer_call["enabled_tools"], ["read_file", "terminal"])
+        self.assertEqual(reviewer_call["model"], "review-model")
+        self.assertEqual(reviewer_call["override_provider"], "review-provider")
+        self.assertEqual(reviewer_call["delegate_resolution"]["archetype"], "verifier")
+        self.assertEqual(reviewer_call["delegate_resolution"]["route_category"], "quick")
+        self.assertEqual(reviewer_call["delegate_resolution"]["agent"], "reviewer")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_full_config")
+    def test_named_agent_unknown_returns_error(self, mock_load_full_config, mock_resolve_creds):
+        mock_load_full_config.return_value = {
+            "delegation": {"max_iterations": 50},
+            "agents": {
+                "writer": {"archetype": "implementer"},
+            },
+        }
+        mock_resolve_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(goal="Draft changelog", agent="missing-agent", parent_agent=parent))
+
+        self.assertIn("error", result)
+        self.assertIn("Unknown named agent 'missing-agent'", result["error"])
+
+    def test_named_agent_resolution_canonicalizes_alias_case_and_separator_variants(self):
+        resolved = _resolve_named_agent_config(
+            {"agent": "Multimodal_Looker"},
+            registry={
+                "multimodal-looker": {
+                    "specialist": "multimodal_specialist",
+                    "aliases": ["looker"],
+                }
+            },
+        )
+
+        self.assertEqual(resolved["name"], "multimodal-looker")
+        self.assertEqual(resolved["requested_name"], "Multimodal_Looker")
+        self.assertEqual(resolved["specialist"], "multimodal_specialist")
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_full_config")
+    def test_named_agent_alias_invocation_uses_canonical_runtime_identity(
+        self,
+        mock_load_full_config,
+        mock_resolve_creds,
+        mock_build_child,
+        mock_run_child,
+    ):
+        mock_load_full_config.return_value = {
+            "delegation": {"max_iterations": 50},
+            "agents": {
+                "explore": {
+                    "archetype": "researcher",
+                    "route_category": "deep",
+                    "allowed_tools": ["read_file", "search_files"],
+                    "aliases": ["explorer"],
+                    "model": "explore-model",
+                    "provider": "explore-provider",
+                },
+            },
+        }
+        mock_resolve_creds.side_effect = lambda cfg, _parent_agent: {
+            "model": cfg.get("model"),
+            "provider": cfg.get("provider"),
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_build_child.return_value = MagicMock()
+        mock_run_child.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done Explore task",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        parent.valid_tool_names = {"read_file", "search_files", "terminal"}
+
+        result = json.loads(delegate_task(goal="Inspect codebase", agent="explorer", parent_agent=parent))
+
+        self.assertIn("results", result)
+        build_call = mock_build_child.call_args.kwargs
+        self.assertEqual(build_call["enabled_tools"], ["read_file", "search_files"])
+        self.assertEqual(build_call["model"], "explore-model")
+        self.assertEqual(build_call["override_provider"], "explore-provider")
+        self.assertEqual(build_call["delegate_resolution"]["agent"], "explore")
+        self.assertEqual(build_call["delegate_resolution"]["named_agent"], "explore")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_full_config")
+    def test_named_agent_disabled_returns_error(self, mock_load_full_config, mock_resolve_creds):
+        mock_load_full_config.return_value = {
+            "delegation": {"max_iterations": 50},
+            "agents": {
+                "writer": {"mode": "disabled"},
+            },
+        }
+        mock_resolve_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(goal="Draft changelog", agent="writer", parent_agent=parent))
+
+        self.assertIn("error", result)
+        self.assertIn("disabled", result["error"])
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_single_task_mode(self, mock_run):
         mock_run.return_value = {
             "task_index": 0, "status": "completed",
@@ -144,6 +549,110 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["status"], "completed")
         self.assertEqual(result["results"][0]["summary"], "Done!")
         mock_run.assert_called_once()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_single_task_carries_separate_wave1_inputs(self, mock_run):
+        mock_run.side_effect = lambda *args, **kwargs: {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "resolved_inputs": getattr(kwargs.get("child") or args[2], "_delegate_resolution", None),
+        }
+        parent = _make_mock_parent()
+        task_contract = {
+            "task": "Fix tests",
+            "expected_outcome": "Passing tests",
+            "required_skills": ["python"],
+            "required_tools": ["terminal"],
+            "must_do": ["Run pytest"],
+            "must_not_do": ["Ignore failures"],
+            "context": [{"path": "tests/"}],
+        }
+        result = json.loads(delegate_task(
+            goal="Fix tests",
+            archetype="implementer",
+            route_category="deep",
+            delegation_profile="verification",
+            skills=["pytest"],
+            task_contract=task_contract,
+            parent_agent=parent,
+        ))
+        resolved = result["results"][0]["resolved_inputs"]
+        self.assertEqual(resolved["archetype"], "implementer")
+        self.assertEqual(resolved["route_category"], "deep")
+        self.assertEqual(resolved["delegation_profile"], "verification")
+        self.assertIn("pytest", resolved["skills"])
+        self.assertEqual(resolved["task_contract"], task_contract)
+        self.assertEqual(resolved["runtime_mode"], "default")
+
+    @patch("tools.delegate_tool._load_full_config")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_config_to_delegate_to_prompt_smoke_path_uses_distinct_wave1_layers(self, mock_run, mock_load_config, mock_load_full_config):
+        mock_run.side_effect = lambda *args, **kwargs: {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "system_prompt": getattr(kwargs.get("child") or args[2], "ephemeral_system_prompt", ""),
+            "resolved_inputs": getattr(kwargs.get("child") or args[2], "_delegate_resolution", None),
+        }
+        mock_load_config.return_value = {
+            "provider": "",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "runtime_mode": "default",
+            "route_category": "unspecified_low",
+            "default_route_category": "unspecified_low",
+            "default_delegation_profile": "general",
+            "default_category": "general",
+            "route_categories": {
+                "deep": {"summary": "Config-tuned deep lane", "intensity": "high"},
+            },
+            "runtime_modes": {
+                "execution_supervisor": {
+                    "description": "Config-tuned oversight posture",
+                    "operating_posture": "oversight_and_coordination",
+                    "kind": "runtime_mode",
+                },
+            },
+            "delegation_profiles": {
+                "verification": {"runtime_mode": "execution_supervisor", "max_iterations": 9},
+            },
+            "categories": {
+                "research": {"max_iterations": 7},
+            },
+            "default_skills": ["general_reasoning"],
+            "task_contract": None,
+            "permission_preset": "inherit",
+            "fallback_policy": "legacy_default_mapping",
+            "max_iterations": 50,
+            "max_concurrent_children": 3,
+        }
+        mock_load_full_config.return_value = {"delegation": dict(mock_load_config.return_value), "agents": {}}
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(
+            goal="Verify the patch",
+            route_category="deep",
+            delegation_profile="verification",
+            parent_agent=parent,
+        ))
+        payload = result["results"][0]
+        resolved = payload["resolved_inputs"]
+        prompt = payload["system_prompt"]
+
+        self.assertEqual(resolved["route_category"], "deep")
+        self.assertEqual(resolved["delegation_profile"], "verification")
+        self.assertEqual(resolved["runtime_mode"], "execution_supervisor")
+        self.assertIn("## Route Category\nname: deep\nsummary: Config-tuned deep lane", prompt)
+        self.assertIn("## Delegation Profile\nname: verification", prompt)
+        self.assertIn("## Runtime Mode\nname: execution_supervisor", prompt)
+        self.assertIn("description: Config-tuned oversight posture", prompt)
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
@@ -1337,9 +1846,10 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 class TestDelegationCategoryPolicy(unittest.TestCase):
     @patch("tools.delegate_tool._run_single_child")
     @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_full_config")
     @patch("tools.delegate_tool._load_config")
-    def test_category_profile_applies_tool_policy(self, mock_load_config, mock_build_child, mock_run_child):
-        mock_load_config.return_value = {
+    def test_category_profile_applies_tool_policy(self, mock_load_config, mock_load_full_config, mock_build_child, mock_run_child):
+        category_cfg = {
             "max_concurrent_children": 5,
             "categories": {
                 "research": {
@@ -1349,6 +1859,8 @@ class TestDelegationCategoryPolicy(unittest.TestCase):
                 }
             },
         }
+        mock_load_config.return_value = category_cfg
+        mock_load_full_config.return_value = {"delegation": category_cfg, "agents": {}}
         mock_build_child.return_value = MagicMock()
         mock_run_child.return_value = {
             "task_index": 0,
@@ -1367,14 +1879,17 @@ class TestDelegationCategoryPolicy(unittest.TestCase):
         self.assertEqual(kwargs["enabled_tools"], ["read_file", "search_files"])
         self.assertEqual(kwargs["max_iterations"], 7)
 
+    @patch("tools.delegate_tool._load_full_config")
     @patch("tools.delegate_tool._load_config")
-    def test_category_concurrency_cap_rejected(self, mock_load_config):
-        mock_load_config.return_value = {
+    def test_category_concurrency_cap_rejected(self, mock_load_config, mock_load_full_config):
+        category_cfg = {
             "max_concurrent_children": 5,
             "categories": {
                 "implementation": {"max_concurrent_children": 1},
             },
         }
+        mock_load_config.return_value = category_cfg
+        mock_load_full_config.return_value = {"delegation": category_cfg, "agents": {}}
         parent = _make_mock_parent()
 
         result = json.loads(delegate_task(
@@ -1390,14 +1905,17 @@ class TestDelegationCategoryPolicy(unittest.TestCase):
 
     @patch("tools.delegate_tool._run_single_child")
     @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_full_config")
     @patch("tools.delegate_tool._load_config")
-    def test_category_only_batch_can_exceed_root_default(self, mock_load_config, mock_build_child, mock_run_child):
-        mock_load_config.return_value = {
+    def test_category_only_batch_can_exceed_root_default(self, mock_load_config, mock_load_full_config, mock_build_child, mock_run_child):
+        category_cfg = {
             "max_concurrent_children": 3,
             "categories": {
                 "research": {"max_concurrent_children": 5},
             },
         }
+        mock_load_config.return_value = category_cfg
+        mock_load_full_config.return_value = {"delegation": category_cfg, "agents": {}}
         mock_build_child.side_effect = [MagicMock() for _ in range(4)]
         mock_run_child.side_effect = lambda *, task_index, goal, child, parent_agent: {
             "task_index": task_index,

--- a/tests/tools/test_delegate_named_workflow.py
+++ b/tests/tools/test_delegate_named_workflow.py
@@ -1,0 +1,149 @@
+from tools.delegate_tool import _build_child_agent, _resolve_wave1_task_inputs
+
+
+DEFAULT_CFG = {
+    "route_category": "unspecified_low",
+    "default_route_category": "unspecified_low",
+    "default_delegation_profile": "general",
+    "default_skills": [],
+    "task_contract": None,
+    "permission_preset": "inherit",
+    "fallback_policy": "legacy_default_mapping",
+}
+
+SAMPLE_CONTRACT = {
+    "task": "Execute the delegated implementation",
+    "expected_outcome": "The delegated child receives the structured contract unchanged.",
+    "required_skills": ["python"],
+    "required_tools": ["read_file", "patch"],
+    "must_do": ["inspect existing patterns first"],
+    "must_not_do": ["do not discard the handoff contract"],
+    "context": {"ticket": "swarm-d-delegate"},
+}
+
+SAMPLE_NAMED_WORKFLOW = {
+    "schema": "hermes/named-workflow",
+    "schema_version": "1.0",
+    "workflow_name": "planner",
+    "mode": "plan",
+    "objective": "Plan the implementation before execution.",
+    "plan": ["inspect", "plan", "handoff"],
+    "acceptance": ["machine-readable artifact present"],
+    "taxonomy": {
+        "named_workflow": "planner",
+        "workflow": "planner",
+        "specialist": "planner",
+        "archetype": "generalist",
+        "route_category": "deep",
+        "runtime_mode": "execution_supervisor",
+        "delegation_profile": "implementation",
+    },
+    "execution_task_contract": SAMPLE_CONTRACT,
+    "consumption": {"downstream_role": "deep_worker", "consumes": "execution_task_contract"},
+}
+
+
+def test_resolve_wave1_task_inputs_preserves_inherited_named_workflow():
+    resolved = _resolve_wave1_task_inputs(
+        {"goal": "Execute the delegated implementation"},
+        cfg=DEFAULT_CFG,
+        top_level_archetype="generalist",
+        top_level_route_category="deep",
+        top_level_delegation_profile="implementation",
+        top_level_runtime_mode="execution_supervisor",
+        top_level_task_contract=SAMPLE_CONTRACT,
+        top_level_named_workflow=SAMPLE_NAMED_WORKFLOW,
+    )
+
+    assert resolved["task_contract"] == SAMPLE_CONTRACT
+    assert resolved["named_workflow"] == SAMPLE_NAMED_WORKFLOW
+
+
+def test_resolve_wave1_task_inputs_builds_deep_worker_named_workflow_when_missing():
+    resolved = _resolve_wave1_task_inputs(
+        {"goal": "Execute the delegated implementation", "task_contract": SAMPLE_CONTRACT},
+        cfg=DEFAULT_CFG,
+        top_level_archetype="generalist",
+        top_level_route_category="deep",
+        top_level_delegation_profile="implementation",
+        top_level_runtime_mode="execution_supervisor",
+    )
+
+    assert resolved["named_workflow"]["workflow_name"] == "deep_worker"
+    assert resolved["named_workflow"]["execution_task_contract"] == SAMPLE_CONTRACT
+    assert resolved["named_workflow"]["taxonomy"]["route_category"] == "deep"
+
+
+def test_resolve_wave1_task_inputs_rebuilds_when_inherited_named_workflow_is_invalid():
+    invalid_named_workflow = {**SAMPLE_NAMED_WORKFLOW, "workflow_name": "unknown-workflow"}
+    resolved = _resolve_wave1_task_inputs(
+        {"goal": "Execute the delegated implementation", "task_contract": SAMPLE_CONTRACT},
+        cfg=DEFAULT_CFG,
+        top_level_archetype="generalist",
+        top_level_route_category="deep",
+        top_level_delegation_profile="implementation",
+        top_level_runtime_mode="execution_supervisor",
+        top_level_named_workflow=invalid_named_workflow,
+    )
+
+    assert resolved["named_workflow"]["workflow_name"] == "deep_worker"
+    assert resolved["named_workflow"]["execution_task_contract"] == SAMPLE_CONTRACT
+
+
+def test_build_child_agent_includes_named_workflow_artifact_in_prompt(monkeypatch):
+    import run_agent
+
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(run_agent, "AIAgent", FakeAIAgent)
+    monkeypatch.setattr("tools.delegate_tool._resolve_workspace_hint", lambda _parent: "/tmp")
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
+
+    parent_agent = type(
+        "ParentAgent",
+        (),
+        {
+            "enabled_toolsets": ["file"],
+            "valid_tool_names": {"read_file", "search_files", "patch", "terminal"},
+            "api_key": None,
+            "_client_kwargs": {},
+            "model": "test-model",
+            "provider": None,
+            "base_url": "http://example.test",
+            "api_mode": None,
+            "acp_command": None,
+            "acp_args": [],
+            "max_tokens": None,
+            "reasoning_config": None,
+            "prefill_messages": None,
+            "platform": "cli",
+            "providers_allowed": None,
+            "providers_ignored": None,
+            "providers_order": None,
+            "provider_sort": None,
+            "_delegate_depth": 0,
+            "session_id": "sess-parent",
+            "_session_db": None,
+        },
+    )()
+
+    _build_child_agent(
+        task_index=0,
+        goal="Execute the delegated implementation",
+        context="Carry out the plan",
+        toolsets=["file"],
+        max_iterations=5,
+        task_count=1,
+        parent_agent=parent_agent,
+        wave1_overlay_prompt="## Archetype\nname: generalist",
+        delegate_resolution={"named_workflow": SAMPLE_NAMED_WORKFLOW},
+    )
+
+    prompt = captured["ephemeral_system_prompt"]
+    assert "NAMED WORKFLOW ARTIFACT:" in prompt
+    assert '"workflow_name": "planner"' in prompt
+    assert '"schema": "hermes/named-workflow"' in prompt

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -128,7 +128,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            "/tmp/f.py", "foo", "bar", False
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -144,10 +146,54 @@ class TestPatchHandler:
         mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_hashline_uses_backend_file_ops_for_non_host_paths(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "replacements": 1}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path="/backend-only/worktree/sample.txt",
+                old_string="# HASHLINE sha256:" + "a" * 64 + "\nhello",
+                new_string="world",
+                task_id="backend-hashline-replace",
+            )
+        )
+
+        assert result["status"] == "ok"
+        mock_ops.patch_replace.assert_called_once_with(
+            "/backend-only/worktree/sample.txt",
+            "hello",
+            "world",
+            False,
+            expected_sha256="a" * 64,
+        )
+
+    @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(mode="replace", path=None, old_string="a", new_string="b"))
         assert "error" in result
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_rejects_malformed_hashline_before_backend_call(self, mock_get):
+        from tools.file_tools import patch_tool
+
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path="/backend-only/worktree/sample.txt",
+                old_string="# HASHLINE sha256:not-a-digest\nhello",
+                new_string="world",
+            )
+        )
+
+        assert "Invalid HASHLINE directive" in result["error"]
+        mock_get.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_strings_errors(self, mock_get):
@@ -167,6 +213,32 @@ class TestPatchHandler:
         result = json.loads(patch_tool(mode="patch", patch="*** Begin Patch\n..."))
         assert result["status"] == "ok"
         mock_ops.patch_v4a.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_mode_hashline_uses_backend_file_ops_for_non_host_paths(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "operations": 1}
+        mock_ops.patch_v4a.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        patch_text = """*** Begin Patch
+*** Hashline: /backend-only/worktree/sample.txt sha256:{hash}
+*** Update File: /backend-only/worktree/sample.txt
+@@
+-old
++new
+*** End Patch
+""".format(hash="b" * 64)
+
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="patch", patch=patch_text, task_id="backend-hashline-patch"))
+
+        assert result["status"] == "ok"
+        mock_ops.patch_v4a.assert_called_once_with(
+            "*** Begin Patch\n*** Update File: /backend-only/worktree/sample.txt\n@@\n-old\n+new\n*** End Patch\n",
+            expected_hashes={"/backend-only/worktree/sample.txt": "b" * 64},
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_mode_missing_content_errors(self, mock_get):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -8,12 +8,27 @@ import json
 import logging
 from unittest.mock import MagicMock, patch
 
+from toolsets import resolve_toolset
 from tools.file_tools import (
     READ_FILE_SCHEMA,
     WRITE_FILE_SCHEMA,
     PATCH_SCHEMA,
     SEARCH_FILES_SCHEMA,
 )
+
+
+class TestRepoCodeKnowledgeFraming:
+    def test_repo_code_knowledge_toolset_treats_file_primitives_as_canonical(self):
+        repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
+        assert {"read_file", "search_files"} <= repo_code_tools
+
+    def test_read_file_schema_mentions_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in READ_FILE_SCHEMA["description"]
+        assert "local source grounding" in READ_FILE_SCHEMA["description"]
+
+    def test_search_files_schema_mentions_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in SEARCH_FILES_SCHEMA["description"]
+        assert "codebase grounding" in SEARCH_FILES_SCHEMA["description"]
 
 
 class TestReadFileHandler:
@@ -30,6 +45,12 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert result["content"] == "line1\nline2"
         assert result["total_lines"] == 2
+        assert result["knowledge_surface"] == {
+            "surface": "repo-code-knowledge",
+            "surface_role": "local-file-grounding",
+            "operation": "read_file",
+            "source": "builtin",
+        }
         mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 500)
 
     @patch("tools.file_tools._get_file_ops")
@@ -173,6 +194,12 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="TODO", target="content", path="."))
         assert "matches" in result
+        assert result["knowledge_surface"] == {
+            "surface": "repo-code-knowledge",
+            "surface_role": "local-file-grounding",
+            "operation": "search_files",
+            "source": "builtin",
+        }
         mock_ops.search.assert_called_once()
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_hashline_edit_mode.py
+++ b/tests/tools/test_hashline_edit_mode.py
@@ -1,0 +1,97 @@
+import hashlib
+import json
+
+from tools.file_tools import patch_tool
+
+
+def _sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_replace_mode_accepts_matching_hashline(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+
+    result = json.loads(
+        patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string=f"# HASHLINE sha256:{_sha256(target)}\nhello world",
+            new_string="hello hermes",
+            task_id="hashline-ok",
+        )
+    )
+
+    assert not result.get("error")
+    assert "hello hermes\n" == target.read_text(encoding="utf-8")
+
+
+def test_replace_mode_blocks_mismatched_hashline(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+
+    result = json.loads(
+        patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string=f"# HASHLINE sha256:{'0' * 64}\nhello world",
+            new_string="hello hermes",
+            task_id="hashline-bad",
+        )
+    )
+
+    assert "HASHLINE validation failed" in result["error"]
+    assert target.read_text(encoding="utf-8") == "hello world\n"
+
+
+def test_patch_mode_validates_all_touched_files(tmp_path):
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("alpha\n", encoding="utf-8")
+    second.write_text("beta\n", encoding="utf-8")
+
+    patch_text = f"""*** Begin Patch
+*** Hashline: {first} sha256:{_sha256(first)}
+*** Update File: {first}
+@@
+-alpha
++alpha patched
+*** Hashline: {second} sha256:{_sha256(second)}
+*** Update File: {second}
+@@
+-beta
++beta patched
+*** End Patch
+"""
+
+    result = json.loads(patch_tool(mode="patch", patch=patch_text, task_id="hashline-multi"))
+
+    assert not result.get("error")
+    assert first.read_text(encoding="utf-8") == "alpha patched\n"
+    assert second.read_text(encoding="utf-8") == "beta patched\n"
+
+
+def test_patch_mode_requires_hashline_for_each_patched_file(tmp_path):
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("alpha\n", encoding="utf-8")
+    second.write_text("beta\n", encoding="utf-8")
+
+    patch_text = f"""*** Begin Patch
+*** Hashline: {first} sha256:{_sha256(first)}
+*** Update File: {first}
+@@
+-alpha
++alpha patched
+*** Update File: {second}
+@@
+-beta
++beta patched
+*** End Patch
+"""
+
+    result = json.loads(patch_tool(mode="patch", patch=patch_text, task_id="hashline-missing"))
+
+    assert "missing '*** Hashline:" in result["error"]
+    assert first.read_text(encoding="utf-8") == "alpha\n"
+    assert second.read_text(encoding="utf-8") == "beta\n"

--- a/tests/tools/test_hashline_edit_races.py
+++ b/tests/tools/test_hashline_edit_races.py
@@ -1,0 +1,185 @@
+import hashlib
+import json
+from pathlib import Path
+
+import tools.file_tools as file_tools
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_replace_mode_hashline_race_never_mutates_file(tmp_path, monkeypatch):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+    original_hash = _sha256(target)
+
+    original_conditional_write = file_tools.ShellFileOperations.conditional_write_file
+    mutated_once = False
+
+    def mutate_before_conditional_write(self, path: str, content: str, expected_sha256: str):
+        nonlocal mutated_once
+        if str(path) == str(target) and not mutated_once:
+            mutated_once = True
+            Path(path).write_text("hello world\nINTRUDE\n", encoding="utf-8")
+        return original_conditional_write(self, path, content, expected_sha256)
+
+    monkeypatch.setattr(
+        file_tools.ShellFileOperations,
+        "conditional_write_file",
+        mutate_before_conditional_write,
+    )
+
+    result = json.loads(
+        file_tools.patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string=f"# HASHLINE sha256:{original_hash}\nhello world",
+            new_string="hello hermes",
+            task_id="hashline-race-replace",
+        )
+    )
+
+    assert "HASHLINE validation failed" in result["error"]
+    assert target.read_text(encoding="utf-8") == "hello world\nINTRUDE\n"
+
+
+
+def test_patch_mode_hashline_race_fails_without_partial_mutation(tmp_path, monkeypatch):
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("alpha\n", encoding="utf-8")
+    second.write_text("beta\n", encoding="utf-8")
+
+    patch_text = f"""*** Begin Patch
+*** Hashline: {first} sha256:{_sha256(first)}
+*** Update File: {first}
+@@
+-alpha
++alpha patched
+*** Hashline: {second} sha256:{_sha256(second)}
+*** Update File: {second}
+@@
+-beta
++beta patched
+*** End Patch
+"""
+
+    original_conditional_write = file_tools.ShellFileOperations.conditional_write_file
+    mutated_once = False
+
+    def mutate_second_before_conditional_write(self, path: str, content: str, expected_sha256: str):
+        nonlocal mutated_once
+        if str(path) == str(second) and not mutated_once:
+            mutated_once = True
+            second.write_text("beta\nINTRUDE\n", encoding="utf-8")
+        return original_conditional_write(self, path, content, expected_sha256)
+
+    monkeypatch.setattr(
+        file_tools.ShellFileOperations,
+        "conditional_write_file",
+        mutate_second_before_conditional_write,
+    )
+
+    result = json.loads(file_tools.patch_tool(mode="patch", patch=patch_text, task_id="hashline-race-patch"))
+
+    assert "HASHLINE validation failed" in result["error"]
+    assert first.read_text(encoding="utf-8") == "alpha\n"
+    assert second.read_text(encoding="utf-8") == "beta\nINTRUDE\n"
+
+
+
+def test_reread_then_reapply_succeeds_after_hashline_race_failure(tmp_path, monkeypatch):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+    stale_hash = _sha256(target)
+
+    original_conditional_write = file_tools.ShellFileOperations.conditional_write_file
+    mutated_once = False
+
+    def mutate_once_before_conditional_write(self, path: str, content: str, expected_sha256: str):
+        nonlocal mutated_once
+        if str(path) == str(target) and not mutated_once:
+            mutated_once = True
+            Path(path).write_text("hello world\nINTRUDE\n", encoding="utf-8")
+        return original_conditional_write(self, path, content, expected_sha256)
+
+    monkeypatch.setattr(
+        file_tools.ShellFileOperations,
+        "conditional_write_file",
+        mutate_once_before_conditional_write,
+    )
+
+    first_result = json.loads(
+        file_tools.patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string=f"# HASHLINE sha256:{stale_hash}\nhello world",
+            new_string="hello hermes",
+            task_id="hashline-race-reread",
+        )
+    )
+
+    assert "HASHLINE validation failed" in first_result["error"]
+    assert target.read_text(encoding="utf-8") == "hello world\nINTRUDE\n"
+
+    fresh_hash = _sha256(target)
+    second_result = json.loads(
+        file_tools.patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string=f"# HASHLINE sha256:{fresh_hash}\nhello world\nINTRUDE",
+            new_string="hello hermes\nINTRUDE",
+            task_id="hashline-race-reread",
+        )
+    )
+
+    assert not second_result.get("error")
+    assert target.read_text(encoding="utf-8") == "hello hermes\nINTRUDE\n"
+
+
+
+def test_patch_mode_rollback_skips_restore_when_post_apply_state_changed(tmp_path, monkeypatch):
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("alpha\n", encoding="utf-8")
+    second.write_text("beta\n", encoding="utf-8")
+
+    patch_text = f"""*** Begin Patch
+*** Hashline: {first} sha256:{_sha256(first)}
+*** Update File: {first}
+@@
+-alpha
++alpha patched
+*** Hashline: {second} sha256:{_sha256(second)}
+*** Update File: {second}
+@@
+-beta
++beta patched
+*** End Patch
+"""
+
+    original_conditional_write = file_tools.ShellFileOperations.conditional_write_file
+    intruded = False
+
+    def mutate_first_before_second_write(self, path: str, content: str, expected_sha256: str):
+        nonlocal intruded
+        if str(path) == str(second) and not intruded:
+            intruded = True
+            first.write_text("alpha patched\nTHIRD PARTY\n", encoding="utf-8")
+            second.write_text("beta\nINTRUDE\n", encoding="utf-8")
+        return original_conditional_write(self, path, content, expected_sha256)
+
+    monkeypatch.setattr(
+        file_tools.ShellFileOperations,
+        "conditional_write_file",
+        mutate_first_before_second_write,
+    )
+
+    result = json.loads(file_tools.patch_tool(mode="patch", patch=patch_text, task_id="hashline-rollback-clobber"))
+
+    assert "HASHLINE validation failed" in result["error"]
+    assert "rollback could not safely proceed for" in result["error"]
+    assert str(first) in result["error"]
+    assert first.read_text(encoding="utf-8") == "alpha patched\nTHIRD PARTY\n"
+    assert second.read_text(encoding="utf-8") == "beta\nINTRUDE\n"

--- a/tests/tools/test_lsp_rename_references.py
+++ b/tests/tools/test_lsp_rename_references.py
@@ -1,0 +1,386 @@
+import io
+import json
+
+from tools.lsp_tools import lsp_prepare_rename_tool, lsp_references_tool, lsp_rename_tool
+
+
+def _frame(payload):
+    body = json.dumps(payload).encode("utf-8")
+    return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+
+
+class _FakeProcess:
+    def __init__(self, frames):
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(b"".join(frames))
+        self.stderr = io.BytesIO()
+        self.returncode = None
+        self.command = None
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def terminate(self):
+        self.returncode = 0
+
+    def kill(self):
+        self.returncode = -9
+
+
+class TestLspRenameAndReferences:
+    def test_prepare_rename_returns_structured_range_and_placeholder(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = old_name\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "range": {
+                                "start": {"line": 0, "character": 8},
+                                "end": {"line": 0, "character": 16},
+                            },
+                            "placeholder": "old_name",
+                        },
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", lambda command, **kwargs: fake_process)
+
+        result = json.loads(
+            lsp_prepare_rename_tool(
+                path=str(source_path),
+                line=0,
+                character=10,
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["ok"] is True
+        assert result["can_rename"] is True
+        assert result["prepare_rename"]["placeholder"] == "old_name"
+        assert result["prepare_rename"]["range"]["start"] == {"line": 0, "character": 8}
+
+    def test_references_and_rename_return_realistic_workspace_edit_preview(self, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        main_path = workspace / "main.py"
+        helper_path = workspace / "helper.py"
+        helper_path.write_text(
+            "def old_name(value):\n    return value + 1\n",
+            encoding="utf-8",
+        )
+        main_path.write_text(
+            "from helper import old_name\n\nresult = old_name(1)\n",
+            encoding="utf-8",
+        )
+
+        reference_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": [
+                            {
+                                "uri": helper_path.resolve().as_uri(),
+                                "range": {
+                                    "start": {"line": 0, "character": 4},
+                                    "end": {"line": 0, "character": 12},
+                                },
+                            },
+                            {
+                                "uri": main_path.resolve().as_uri(),
+                                "range": {
+                                    "start": {"line": 0, "character": 19},
+                                    "end": {"line": 0, "character": 27},
+                                },
+                            },
+                            {
+                                "uri": main_path.resolve().as_uri(),
+                                "range": {
+                                    "start": {"line": 2, "character": 9},
+                                    "end": {"line": 2, "character": 17},
+                                },
+                            },
+                        ],
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+        rename_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "range": {
+                                "start": {"line": 0, "character": 4},
+                                "end": {"line": 0, "character": 12},
+                            },
+                            "placeholder": "old_name",
+                        },
+                    }
+                ),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "result": {
+                            "changes": {
+                                helper_path.resolve().as_uri(): [
+                                    {
+                                        "range": {
+                                            "start": {"line": 0, "character": 4},
+                                            "end": {"line": 0, "character": 12},
+                                        },
+                                        "newText": "new_name",
+                                    }
+                                ],
+                                main_path.resolve().as_uri(): [
+                                    {
+                                        "range": {
+                                            "start": {"line": 0, "character": 19},
+                                            "end": {"line": 0, "character": 27},
+                                        },
+                                        "newText": "new_name",
+                                    },
+                                    {
+                                        "range": {
+                                            "start": {"line": 2, "character": 9},
+                                            "end": {"line": 2, "character": 17},
+                                        },
+                                        "newText": "new_name",
+                                    },
+                                ],
+                            }
+                        },
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 4, "result": None}),
+            ]
+        )
+        processes = [reference_process, rename_process]
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", lambda command, **kwargs: processes.pop(0))
+
+        references_result = json.loads(
+            lsp_references_tool(
+                path=str(helper_path),
+                line=0,
+                character=6,
+                server_command="fake-lsp --stdio",
+                workspace_root=str(workspace),
+            )
+        )
+        rename_result = json.loads(
+            lsp_rename_tool(
+                path=str(helper_path),
+                line=0,
+                character=6,
+                new_name="new_name",
+                server_command="fake-lsp --stdio",
+                workspace_root=str(workspace),
+            )
+        )
+
+        assert references_result["ok"] is True
+        assert references_result["reference_count"] == 3
+        assert {entry["path"] for entry in references_result["references"]} == {
+            str(helper_path.resolve()),
+            str(main_path.resolve()),
+        }
+
+        assert rename_result["ok"] is True
+        assert rename_result["prepare_rename"]["placeholder"] == "old_name"
+        assert rename_result["workspace_edit"]["edit_count"] == 3
+        assert rename_result["workspace_edit"]["touched_paths"] == [
+            str(helper_path.resolve()),
+            str(main_path.resolve()),
+        ]
+        assert rename_result["workspace_edit"]["preview_by_path"][str(helper_path.resolve())] == (
+            "def new_name(value):\n    return value + 1\n"
+        )
+        assert rename_result["workspace_edit"]["preview_by_path"][str(main_path.resolve())] == (
+            "from helper import new_name\n\nresult = new_name(1)\n"
+        )
+
+    def test_rename_fails_safely_when_prepare_rename_rejects_symbol(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = 1\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame({"jsonrpc": "2.0", "id": 2, "result": None}),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", lambda command, **kwargs: fake_process)
+
+        result = json.loads(
+            lsp_rename_tool(
+                path=str(source_path),
+                line=0,
+                character=0,
+                new_name="renamed",
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["error"] == "LSP server reported that the selected symbol cannot be renamed"
+        assert result["failure_kind"] == "prepare_rename_rejected"
+        assert result["prepare_rename"] == {"can_rename": False}
+
+    def test_prepare_rename_classifies_method_not_found_as_unsupported_capability(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = old_name\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "error": {"code": -32601, "message": "Method not found: textDocument/prepareRename"},
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", lambda command, **kwargs: fake_process)
+
+        result = json.loads(
+            lsp_prepare_rename_tool(
+                path=str(source_path),
+                line=0,
+                character=10,
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["failure_kind"] == "unsupported_capability"
+        assert result["requested_method"] == "textDocument/prepareRename"
+        assert result["lsp_error_code"] == -32601
+        assert result["lsp_error_message"] == "Method not found: textDocument/prepareRename"
+
+    def test_references_classifies_method_not_found_as_unsupported_capability(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = old_name\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "error": {"code": -32601, "message": "Method not found: textDocument/references"},
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", lambda command, **kwargs: fake_process)
+
+        result = json.loads(
+            lsp_references_tool(
+                path=str(source_path),
+                line=0,
+                character=10,
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["failure_kind"] == "unsupported_capability"
+        assert result["requested_method"] == "textDocument/references"
+        assert result["lsp_error_code"] == -32601
+        assert result["lsp_error_message"] == "Method not found: textDocument/references"
+
+    def test_rename_classifies_protocol_failure_after_prepare_rename_as_unsupported_capability(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = old_name\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "range": {
+                                "start": {"line": 0, "character": 8},
+                                "end": {"line": 0, "character": 16},
+                            },
+                            "placeholder": "old_name",
+                        },
+                    }
+                ),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "error": {"code": -32601, "message": "Method not found: textDocument/rename"},
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 4, "result": None}),
+            ]
+        )
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", lambda command, **kwargs: fake_process)
+
+        result = json.loads(
+            lsp_rename_tool(
+                path=str(source_path),
+                line=0,
+                character=10,
+                new_name="new_name",
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["failure_kind"] == "unsupported_capability"
+        assert result["requested_method"] == "textDocument/rename"
+        assert result["lsp_error_code"] == -32601
+        assert result["lsp_error_message"] == "Method not found: textDocument/rename"
+
+    def test_references_report_missing_server_for_supported_language(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = old_name\n", encoding="utf-8")
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: None)
+
+        result = json.loads(lsp_references_tool(path=str(source_path), line=0, character=8))
+
+        assert result["failure_kind"] == "missing_server"
+        assert result["language"] == "python"
+        assert "candidate_commands" in result
+
+    def test_rename_reports_unsupported_language_when_auto_detect_has_no_mapping(self, tmp_path):
+        source_path = tmp_path / "sample.customlang"
+        source_path.write_text("symbol\n", encoding="utf-8")
+
+        result = json.loads(lsp_rename_tool(path=str(source_path), line=0, character=0, new_name="other"))
+
+        assert result["failure_kind"] == "unsupported_language"
+        assert result["language"] == "plaintext"
+        assert result["candidate_commands"] == []

--- a/tests/tools/test_lsp_tools.py
+++ b/tests/tools/test_lsp_tools.py
@@ -8,23 +8,39 @@ from tools.lsp_tools import (
     LSP_DIAGNOSTICS_SCHEMA,
     LSP_DOCUMENT_SYMBOLS_SCHEMA,
     LSP_DEFINITION_SCHEMA,
+    LSP_PREPARE_RENAME_SCHEMA,
+    LSP_REFERENCES_SCHEMA,
+    LSP_RENAME_SCHEMA,
     get_host_lsp_capabilities,
     lsp_definition_tool,
     lsp_diagnostics_tool,
     lsp_document_symbols_tool,
+    lsp_prepare_rename_tool,
+    lsp_references_tool,
+    lsp_rename_tool,
 )
 
 
 class TestLspRepoCodeKnowledgeFraming:
     def test_repo_code_knowledge_toolset_treats_lsp_primitives_as_canonical(self):
         repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
-        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= repo_code_tools
+        assert {
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+            "lsp_prepare_rename",
+            "lsp_references",
+            "lsp_rename",
+        } <= repo_code_tools
 
     def test_lsp_schemas_mention_repo_code_knowledge_grounding(self):
         assert "repo/code knowledge primitive" in LSP_DOCUMENT_SYMBOLS_SCHEMA["description"]
         assert "semantic local source grounding" in LSP_DOCUMENT_SYMBOLS_SCHEMA["description"]
         assert "repo/code knowledge primitive" in LSP_DEFINITION_SCHEMA["description"]
         assert "repo/code knowledge primitive" in LSP_DIAGNOSTICS_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_PREPARE_RENAME_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_REFERENCES_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_RENAME_SCHEMA["description"]
 
 
 def _frame(payload):
@@ -57,12 +73,22 @@ class _FakeProcess:
 class TestLspToolRegistration:
     def test_exports_expected_tools_and_schemas(self):
         names = {tool["name"] for tool in LSP_TOOLS}
-        assert names == {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+        assert names == {
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+            "lsp_prepare_rename",
+            "lsp_references",
+            "lsp_rename",
+        }
 
         for schema in [
             LSP_DOCUMENT_SYMBOLS_SCHEMA,
             LSP_DEFINITION_SCHEMA,
             LSP_DIAGNOSTICS_SCHEMA,
+            LSP_PREPARE_RENAME_SCHEMA,
+            LSP_REFERENCES_SCHEMA,
+            LSP_RENAME_SCHEMA,
         ]:
             assert "name" in schema
             assert "description" in schema
@@ -70,7 +96,14 @@ class TestLspToolRegistration:
 
     def test_code_intel_toolset_lists_lsp_tools(self):
         code_intel_tools = set(resolve_toolset("code_intel"))
-        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= code_intel_tools
+        assert {
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+            "lsp_prepare_rename",
+            "lsp_references",
+            "lsp_rename",
+        } <= code_intel_tools
 
     def test_model_tool_definitions_expose_lsp_tools_when_server_exists(self, monkeypatch):
         monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: "/usr/bin/fake-lsp")
@@ -78,7 +111,14 @@ class TestLspToolRegistration:
             tool["function"]["name"]
             for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
         }
-        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= model_tool_names
+        assert {
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+            "lsp_prepare_rename",
+            "lsp_references",
+            "lsp_rename",
+        } <= model_tool_names
 
     def test_model_tool_definitions_hide_lsp_tools_when_no_server_exists(self, monkeypatch):
         monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: None)
@@ -86,7 +126,14 @@ class TestLspToolRegistration:
             tool["function"]["name"]
             for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
         }
-        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}.isdisjoint(model_tool_names)
+        assert {
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+            "lsp_prepare_rename",
+            "lsp_references",
+            "lsp_rename",
+        }.isdisjoint(model_tool_names)
 
     def test_host_capability_helper_reports_language_specific_auto_detection(self, monkeypatch):
         available_binaries = {
@@ -119,7 +166,14 @@ class TestLspToolRegistration:
         descriptions = {
             tool["function"]["name"]: tool["function"]["description"]
             for tool in tool_definitions
-            if tool["function"]["name"] in {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+            if tool["function"]["name"] in {
+                "lsp_document_symbols",
+                "lsp_definition",
+                "lsp_diagnostics",
+                "lsp_prepare_rename",
+                "lsp_references",
+                "lsp_rename",
+            }
         }
 
         assert descriptions

--- a/tests/tools/test_lsp_tools.py
+++ b/tests/tools/test_lsp_tools.py
@@ -15,6 +15,18 @@ from tools.lsp_tools import (
 )
 
 
+class TestLspRepoCodeKnowledgeFraming:
+    def test_repo_code_knowledge_toolset_treats_lsp_primitives_as_canonical(self):
+        repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= repo_code_tools
+
+    def test_lsp_schemas_mention_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in LSP_DOCUMENT_SYMBOLS_SCHEMA["description"]
+        assert "semantic local source grounding" in LSP_DOCUMENT_SYMBOLS_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_DEFINITION_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_DIAGNOSTICS_SCHEMA["description"]
+
+
 def _frame(payload):
     body = json.dumps(payload).encode("utf-8")
     return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body

--- a/tests/tools/test_lsp_tools.py
+++ b/tests/tools/test_lsp_tools.py
@@ -1,0 +1,262 @@
+import io
+import json
+
+from model_tools import get_tool_definitions
+from toolsets import resolve_toolset
+from tools.lsp_tools import (
+    LSP_TOOLS,
+    LSP_DIAGNOSTICS_SCHEMA,
+    LSP_DOCUMENT_SYMBOLS_SCHEMA,
+    LSP_DEFINITION_SCHEMA,
+    get_host_lsp_capabilities,
+    lsp_definition_tool,
+    lsp_diagnostics_tool,
+    lsp_document_symbols_tool,
+)
+
+
+def _frame(payload):
+    body = json.dumps(payload).encode("utf-8")
+    return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+
+
+class _FakeProcess:
+    def __init__(self, frames):
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(b"".join(frames))
+        self.stderr = io.BytesIO()
+        self.returncode = None
+        self.command = None
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def terminate(self):
+        self.returncode = 0
+
+    def kill(self):
+        self.returncode = -9
+
+
+class TestLspToolRegistration:
+    def test_exports_expected_tools_and_schemas(self):
+        names = {tool["name"] for tool in LSP_TOOLS}
+        assert names == {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+
+        for schema in [
+            LSP_DOCUMENT_SYMBOLS_SCHEMA,
+            LSP_DEFINITION_SCHEMA,
+            LSP_DIAGNOSTICS_SCHEMA,
+        ]:
+            assert "name" in schema
+            assert "description" in schema
+            assert "properties" in schema["parameters"]
+
+    def test_code_intel_toolset_lists_lsp_tools(self):
+        code_intel_tools = set(resolve_toolset("code_intel"))
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= code_intel_tools
+
+    def test_model_tool_definitions_expose_lsp_tools_when_server_exists(self, monkeypatch):
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: "/usr/bin/fake-lsp")
+        model_tool_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        }
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= model_tool_names
+
+    def test_model_tool_definitions_hide_lsp_tools_when_no_server_exists(self, monkeypatch):
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: None)
+        model_tool_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        }
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}.isdisjoint(model_tool_names)
+
+    def test_host_capability_helper_reports_language_specific_auto_detection(self, monkeypatch):
+        available_binaries = {
+            "pylsp": "/usr/bin/pylsp",
+            "typescript-language-server": "/usr/bin/typescript-language-server",
+        }
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: available_binaries.get(name))
+
+        capabilities = get_host_lsp_capabilities()
+
+        assert capabilities["available"] is True
+        assert capabilities["auto_detect_languages"] == [
+            "javascript",
+            "javascriptreact",
+            "python",
+            "typescript",
+            "typescriptreact",
+        ]
+        assert capabilities["auto_detect_commands"]["python"] == ["pylsp"]
+        assert capabilities["auto_detect_commands"]["typescript"] == ["typescript-language-server --stdio"]
+
+    def test_model_tool_definitions_enrich_lsp_descriptions_with_host_languages(self, monkeypatch):
+        available_binaries = {
+            "pylsp": "/usr/bin/pylsp",
+            "rust-analyzer": "/usr/bin/rust-analyzer",
+        }
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: available_binaries.get(name))
+
+        tool_definitions = get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        descriptions = {
+            tool["function"]["name"]: tool["function"]["description"]
+            for tool in tool_definitions
+            if tool["function"]["name"] in {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+        }
+
+        assert descriptions
+        for description in descriptions.values():
+            assert "Auto-detect currently supports: python, rust." in description
+            assert "server_command" in description
+
+
+class TestLspHandlers:
+    def test_document_symbols_returns_structured_error_when_no_server_is_available(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("def demo():\n    return 1\n", encoding="utf-8")
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: None)
+
+        result = json.loads(lsp_document_symbols_tool(path=str(source_path)))
+
+        assert "error" in result
+        assert "No LSP server found" in result["error"]
+        assert result["language"] == "python"
+        assert result["requested_method"] == "textDocument/documentSymbol"
+
+    def test_document_symbols_round_trip_uses_explicit_server_command(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("class Example:\n    pass\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": [
+                            {
+                                "name": "Example",
+                                "kind": 5,
+                                "range": {
+                                    "start": {"line": 0, "character": 0},
+                                    "end": {"line": 1, "character": 8},
+                                },
+                                "selectionRange": {
+                                    "start": {"line": 0, "character": 6},
+                                    "end": {"line": 0, "character": 13},
+                                },
+                                "children": [],
+                            }
+                        ],
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+
+        def _fake_popen(command, **kwargs):
+            fake_process.command = command
+            return fake_process
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", _fake_popen)
+
+        result = json.loads(
+            lsp_document_symbols_tool(
+                path=str(source_path),
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["ok"] is True
+        assert result["server_command"] == ["fake-lsp", "--stdio"]
+        assert fake_process.command == ["fake-lsp", "--stdio"]
+        assert result["symbols"][0]["name"] == "Example"
+        sent_payload = fake_process.stdin.getvalue().decode("utf-8")
+        assert "textDocument/documentSymbol" in sent_payload
+        assert "textDocument/didOpen" in sent_payload
+
+    def test_definition_and_diagnostics_round_trip(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = helper()\n", encoding="utf-8")
+
+        definition_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": [
+                            {
+                                "uri": source_path.resolve().as_uri(),
+                                "range": {
+                                    "start": {"line": 0, "character": 0},
+                                    "end": {"line": 0, "character": 5},
+                                },
+                            }
+                        ],
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+        diagnostics_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "kind": "full",
+                            "items": [
+                                {
+                                    "message": "Undefined name 'helper'",
+                                    "severity": 1,
+                                    "source": "fake-lsp",
+                                    "range": {
+                                        "start": {"line": 0, "character": 8},
+                                        "end": {"line": 0, "character": 14},
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+        processes = [definition_process, diagnostics_process]
+
+        def _fake_popen(command, **kwargs):
+            return processes.pop(0)
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", _fake_popen)
+
+        definition_result = json.loads(
+            lsp_definition_tool(
+                path=str(source_path),
+                line=0,
+                character=8,
+                server_command="fake-lsp --stdio",
+            )
+        )
+        diagnostics_result = json.loads(
+            lsp_diagnostics_tool(
+                path=str(source_path),
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert definition_result["ok"] is True
+        assert definition_result["definitions"][0]["path"] == str(source_path.resolve())
+        assert diagnostics_result["ok"] is True
+        assert diagnostics_result["diagnostics"][0]["message"] == "Undefined name 'helper'"
+        assert diagnostics_result["diagnostics"][0]["severity"] == 1

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -676,6 +676,19 @@ class TestVisionRegistration:
         assert "image_url" in props
         assert "question" in props
 
+    def test_schema_describes_local_and_rendered_image_support(self):
+        from tools.registry import registry
+
+        entry = registry._tools.get("vision_analyze")
+        schema = entry.schema
+        props = schema["parameters"]["properties"]
+
+        assert "HTTP/HTTPS URL or local image file path" in schema["description"]
+        assert "screenshots, diagrams, charts, photos, and page captures" in schema["description"]
+        assert "Not for raw PDF parsing" in schema["description"]
+        assert "file:// image URI" in props["image_url"]["description"]
+        assert "first understand the image itself" in props["question"]["description"]
+
     def test_handler_is_callable(self):
         from tools.registry import registry
 

--- a/tests/tools/test_web_tools.py
+++ b/tests/tools/test_web_tools.py
@@ -1,0 +1,98 @@
+import inspect
+import importlib
+
+import pytest
+
+from tools.registry import registry
+
+web_tools = importlib.import_module("tools.web_tools")
+
+
+class TestWebToolSchemas:
+    def test_web_search_schema_frames_builtin_grounding_primitive(self):
+        description = web_tools.WEB_SEARCH_SCHEMA["description"]
+
+        assert "Hermes built-in web/research grounding primitive" in description
+        assert "live web search" in description
+        assert "current external information" in description
+
+    def test_web_extract_schema_frames_text_first_boundary_and_browser_fallback(self):
+        description = web_tools.WEB_EXTRACT_SCHEMA["description"]
+
+        assert "Hermes built-in web/research grounding primitive" in description
+        assert "text-first extraction" in description
+        assert "browser-driven navigation and document/PDF intelligence are outside this tool's scope" in description
+        assert "fall back to Hermes browser/document tools" in description
+
+
+class TestWebToolRegistry:
+    def test_registry_exposes_only_public_web_search_and_extract_entries(self):
+        search_entry = registry.get_entry("web_search")
+        extract_entry = registry.get_entry("web_extract")
+        crawl_entry = registry.get_entry("web_crawl")
+
+        assert search_entry is not None
+        assert search_entry.toolset == "web"
+        assert search_entry.schema["name"] == "web_search"
+
+        assert extract_entry is not None
+        assert extract_entry.toolset == "web"
+        assert extract_entry.schema["name"] == "web_extract"
+        assert extract_entry.is_async is True
+
+        assert crawl_entry is None
+
+    def test_web_crawl_docstring_keeps_canonical_defer_truth_explicit(self):
+        doc = inspect.getdoc(web_tools.web_crawl_tool)
+
+        assert doc is not None
+        assert "lives in ``tools/web_tools.py``" in doc
+        assert "not" in doc and "canonical built-in web/research surface today" in doc
+        assert "``web_search``" in doc
+        assert "``web_extract``" in doc
+
+
+class TestWebToolAvailabilityChecks:
+    @pytest.mark.parametrize("tool_name", ["web_search", "web_extract"])
+    def test_registry_check_fn_uses_configured_backend_readiness(self, monkeypatch, tool_name):
+        entry = registry.get_entry(tool_name)
+        seen = []
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "parallel"})
+
+        def fake_is_backend_available(backend):
+            seen.append(backend)
+            return backend == "parallel"
+
+        monkeypatch.setattr(web_tools, "_is_backend_available", fake_is_backend_available)
+
+        assert entry is not None
+        assert entry.check_fn() is True
+        assert seen == ["parallel"]
+
+    @pytest.mark.parametrize("tool_name", ["web_search", "web_extract"])
+    def test_registry_check_fn_falls_back_to_any_available_backend(self, monkeypatch, tool_name):
+        entry = registry.get_entry(tool_name)
+        seen = []
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+
+        def fake_is_backend_available(backend):
+            seen.append(backend)
+            return backend == "tavily"
+
+        monkeypatch.setattr(web_tools, "_is_backend_available", fake_is_backend_available)
+
+        assert entry is not None
+        assert entry.check_fn() is True
+        assert seen == ["exa", "parallel", "firecrawl", "tavily"]
+
+    @pytest.mark.parametrize("tool_name", ["web_search", "web_extract"])
+    def test_registry_check_fn_reports_unavailable_when_no_backend_is_ready(self, monkeypatch, tool_name):
+        entry = registry.get_entry(tool_name)
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: False)
+
+        assert entry is not None
+        assert entry.check_fn() is False

--- a/tools/ast_tools.py
+++ b/tools/ast_tools.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Hermes-native structural code inspection for Python, JSON, JavaScript, and TypeScript."""
+"""Hermes-native structural code inspection for local repo/code grounding.
+
+These AST tools remain lightweight built-in structure inspectors, but their primary
+product framing is the canonical `repo-code-knowledge` surface: helping the model
+inspect local source definitions and structural nodes without reaching for external
+indexers or networked code search.
+"""
 
 from __future__ import annotations
 
@@ -42,7 +48,7 @@ LANGUAGE_BY_SUFFIX = {
 
 AST_LIST_DEFS_SCHEMA = {
     "name": "ast_list_defs",
-    "description": "List structural definitions from local Python, JSON, JavaScript, or TypeScript files using Hermes-native parsers.",
+    "description": "List structural definitions from local Python, JSON, JavaScript, or TypeScript files using Hermes-native parsers. This is a built-in repo/code knowledge primitive for local source grounding and structural inventory.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -59,7 +65,7 @@ AST_LIST_DEFS_SCHEMA = {
 
 AST_FIND_NODES_SCHEMA = {
     "name": "ast_find_nodes",
-    "description": "Find structural nodes from local Python, JSON, JavaScript, or TypeScript files by node type and/or display name.",
+    "description": "Find structural nodes from local Python, JSON, JavaScript, or TypeScript files by node type and/or display name. This is a built-in repo/code knowledge primitive for local source grounding and targeted structural lookup.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/ast_tools.py
+++ b/tools/ast_tools.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Hermes-native structural code inspection for Python, JSON, JavaScript, and TypeScript."""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_LANGUAGES = ("python", "javascript", "typescript", "json")
+LANGUAGE_ALIASES = {
+    "py": "python",
+    "python": "python",
+    "js": "javascript",
+    "jsx": "javascript",
+    "mjs": "javascript",
+    "cjs": "javascript",
+    "javascript": "javascript",
+    "ts": "typescript",
+    "tsx": "typescript",
+    "typescript": "typescript",
+    "json": "json",
+}
+LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".json": "json",
+}
+
+AST_LIST_DEFS_SCHEMA = {
+    "name": "ast_list_defs",
+    "description": "List structural definitions from local Python, JSON, JavaScript, or TypeScript files using Hermes-native parsers.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to a Python, JSON, JavaScript, or TypeScript source file"},
+            "language": {
+                "type": "string",
+                "description": "Optional language override. Supported: python, javascript, typescript, json",
+            },
+            "include_nested": {"type": "boolean", "description": "Include nested class/function/method or nested structural definitions", "default": False},
+        },
+        "required": ["path"],
+    },
+}
+
+AST_FIND_NODES_SCHEMA = {
+    "name": "ast_find_nodes",
+    "description": "Find structural nodes from local Python, JSON, JavaScript, or TypeScript files by node type and/or display name.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to a Python, JSON, JavaScript, or TypeScript source file"},
+            "language": {
+                "type": "string",
+                "description": "Optional language override. Supported: python, javascript, typescript, json",
+            },
+            "node_type": {"type": "string", "description": "Optional structural node type, for example FunctionDef, ClassDeclaration, MethodDefinition, ObjectProperty"},
+            "name": {"type": "string", "description": "Optional display-name filter (case-insensitive substring match)"},
+            "include_source": {"type": "boolean", "description": "Include a source snippet or structural value preview for each match", "default": False},
+            "max_results": {"type": "integer", "description": "Maximum number of matches to return", "default": 100},
+        },
+        "required": ["path"],
+    },
+}
+
+
+_CLASS_RE = re.compile(r"^\s*(?:export\s+)?(?:default\s+)?class\s+([A-Za-z_$][\w$]*)\b")
+_FUNCTION_RE = re.compile(r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(")
+_VARIABLE_RE = re.compile(
+    r"^\s*(?:export\s+)?(?:default\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:function\b|\([^)]*\)\s*(?::[^=]+)?=>|[A-Za-z_$][\w$]*\s*=>)"
+)
+_INTERFACE_RE = re.compile(r"^\s*(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)\b")
+_TYPE_ALIAS_RE = re.compile(r"^\s*(?:export\s+)?type\s+([A-Za-z_$][\w$]*)\b")
+_METHOD_RE = re.compile(
+    r"^\s*(?:(?:public|private|protected|static|readonly|abstract|override)\s+)*(?:async\s+)?([A-Za-z_$][\w$]*)\s*\("
+)
+_METHOD_EXCLUDED = {"if", "for", "while", "switch", "catch", "function", "class", "return"}
+
+
+PYTHON_LIMITATIONS = []
+JSON_LIMITATIONS = [
+    "JSON support is structural and does not provide exact source spans.",
+    "JSON nodes are limited to object properties and array items rather than executable AST constructs.",
+]
+JS_TS_LIMITATIONS = [
+    "JavaScript/TypeScript support is heuristic and focuses on declarations, methods, and assignment-based function definitions.",
+    "Heuristic parsing does not attempt full ECMAScript syntax coverage or call-expression traversal.",
+]
+
+
+def _check_ast_requirements() -> bool:
+    return True
+
+
+def _supported_languages() -> list[str]:
+    return list(SUPPORTED_LANGUAGES)
+
+
+def _normalize_language(language: str | None) -> str | None:
+    if not language:
+        return None
+    return LANGUAGE_ALIASES.get(language.strip().lower())
+
+
+def _detect_language(source_path: Path, language: str | None) -> str | None:
+    normalized = _normalize_language(language)
+    if language and not normalized:
+        return None
+    if normalized:
+        return normalized
+    return LANGUAGE_BY_SUFFIX.get(source_path.suffix.lower())
+
+
+def _resolve_source_path(path: str) -> Path | None:
+    source_path = Path(path).expanduser()
+    if not source_path.exists():
+        return None
+    return source_path.resolve()
+
+
+def _unsupported_language_error(path: Path, language: str | None = None) -> str:
+    return tool_error(
+        "Unsupported language for Hermes AST tooling v1",
+        error_type="UnsupportedLanguage",
+        path=str(path),
+        detected_language=language or "unknown",
+        supported_languages=_supported_languages(),
+    )
+
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _attach_parents(node: ast.AST) -> None:
+    for parent in ast.walk(node):
+        for child in ast.iter_child_nodes(parent):
+            setattr(child, "_hermes_parent", parent)
+
+
+def _find_parent_name(node: ast.AST) -> str | None:
+    current = getattr(node, "_hermes_parent", None)
+    while current is not None:
+        name = getattr(current, "name", None)
+        if name:
+            return name
+        current = getattr(current, "_hermes_parent", None)
+    return None
+
+
+def _node_range(node: ast.AST) -> dict[str, Any]:
+    return {
+        "lineno": getattr(node, "lineno", None),
+        "end_lineno": getattr(node, "end_lineno", None),
+        "col_offset": getattr(node, "col_offset", None),
+        "end_col_offset": getattr(node, "end_col_offset", None),
+    }
+
+
+def _expr_name(node: ast.AST | None) -> str | None:
+    if node is None:
+        return None
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _expr_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Call):
+        return _expr_name(node.func)
+    if isinstance(node, ast.alias):
+        return node.asname or node.name
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    return None
+
+
+def _decorators(node: ast.AST) -> list[str]:
+    values = []
+    for decorator in getattr(node, "decorator_list", []):
+        values.append(_expr_name(decorator) or ast.dump(decorator, include_attributes=False))
+    return values
+
+
+def _serialize_named_node(node: ast.AST, parent: str | None) -> dict[str, Any]:
+    payload = {
+        "name": getattr(node, "name", None),
+        "display_name": getattr(node, "name", None),
+        "node_type": type(node).__name__,
+        "parent": parent,
+        "docstring": ast.get_docstring(node, clean=False) if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) else None,
+        "decorators": _decorators(node),
+        "is_async": isinstance(node, ast.AsyncFunctionDef),
+    }
+    payload.update(_node_range(node))
+    return payload
+
+
+def _is_named_definition(node: ast.AST) -> bool:
+    return isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+
+
+def _list_nested_defs(node: ast.AST, items: list[dict[str, Any]]) -> None:
+    parent_name = getattr(node, "name", None)
+    body = getattr(node, "body", [])
+    for child in body:
+        if _is_named_definition(child):
+            items.append(_serialize_named_node(child, parent_name))
+            _list_nested_defs(child, items)
+
+
+def _display_name(node: ast.AST) -> str | None:
+    name = getattr(node, "name", None)
+    if isinstance(name, str):
+        return name
+    return _expr_name(node)
+
+
+def _serialize_match(node: ast.AST, source: str, include_source: bool) -> dict[str, Any]:
+    payload = {
+        "node_type": type(node).__name__,
+        "name": getattr(node, "name", None),
+        "display_name": _display_name(node),
+        "parent": _find_parent_name(node),
+    }
+    payload.update(_node_range(node))
+    if include_source:
+        payload["source"] = ast.get_source_segment(source, node)
+    return payload
+
+
+def _parse_python_module(path: Path) -> dict[str, Any] | str:
+    try:
+        source = _read_source(path)
+        module = ast.parse(source, filename=str(path), type_comments=True)
+        _attach_parents(module)
+        return {
+            "path": path,
+            "source": source,
+            "module": module,
+            "language": "python",
+            "parser": "python_ast",
+            "confidence": "high",
+            "limitations": list(PYTHON_LIMITATIONS),
+        }
+    except SyntaxError as exc:
+        return tool_error(
+            f"SyntaxError: {exc.msg}",
+            error_type="SyntaxError",
+            path=str(path),
+            lineno=exc.lineno,
+            offset=exc.offset,
+            text=exc.text,
+        )
+    except Exception as exc:
+        logger.debug("AST parse failed", exc_info=True)
+        return tool_error(str(exc), error_type=type(exc).__name__, path=str(path))
+
+
+def _json_value_type(value: Any) -> str:
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    return "string"
+
+
+def _json_preview(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _json_node(
+    *,
+    name: str,
+    node_type: str,
+    parent: str | None,
+    json_path: str,
+    value: Any,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "display_name": name,
+        "node_type": node_type,
+        "parent": parent,
+        "json_path": json_path,
+        "value_type": _json_value_type(value),
+        "source": _json_preview(value),
+        "lineno": None,
+        "end_lineno": None,
+        "col_offset": None,
+        "end_col_offset": None,
+    }
+
+
+def _json_child_path(base_path: str, child: str) -> str:
+    if base_path == "$":
+        return f"$.{child}"
+    return f"{base_path}.{child}"
+
+
+def _collect_json_nodes(value: Any, *, parent: str | None, json_path: str, items: list[dict[str, Any]]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = _json_child_path(json_path, key)
+            items.append(
+                _json_node(
+                    name=key,
+                    node_type="ObjectProperty",
+                    parent=parent,
+                    json_path=child_path,
+                    value=child,
+                )
+            )
+            if isinstance(child, (dict, list)):
+                _collect_json_nodes(child, parent=key, json_path=child_path, items=items)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            item_name = f"[{index}]"
+            child_path = f"{json_path}{item_name}"
+            items.append(
+                _json_node(
+                    name=item_name,
+                    node_type="ArrayItem",
+                    parent=parent,
+                    json_path=child_path,
+                    value=child,
+                )
+            )
+            if isinstance(child, (dict, list)):
+                _collect_json_nodes(child, parent=item_name, json_path=child_path, items=items)
+
+
+def _parse_json_document(path: Path) -> dict[str, Any] | str:
+    try:
+        source = _read_source(path)
+        document = json.loads(source)
+    except json.JSONDecodeError as exc:
+        return tool_error(
+            f"JSONDecodeError: {exc.msg}",
+            error_type="JSONDecodeError",
+            path=str(path),
+            lineno=exc.lineno,
+            colno=exc.colno,
+            pos=exc.pos,
+        )
+    except Exception as exc:
+        logger.debug("JSON parse failed", exc_info=True)
+        return tool_error(str(exc), error_type=type(exc).__name__, path=str(path))
+
+    definitions: list[dict[str, Any]] = []
+    _collect_json_nodes(document, parent=None, json_path="$", items=definitions)
+    return {
+        "path": path,
+        "source": source,
+        "document": document,
+        "definitions": definitions,
+        "language": "json",
+        "parser": "json_structure_v1",
+        "confidence": "high",
+        "limitations": list(JSON_LIMITATIONS),
+    }
+
+
+def _strip_js_comments(source: str) -> list[str]:
+    cleaned_lines = []
+    in_block_comment = False
+    for raw_line in source.splitlines():
+        line = raw_line
+        if in_block_comment:
+            if "*/" in line:
+                line = line.split("*/", 1)[1]
+                in_block_comment = False
+            else:
+                cleaned_lines.append("")
+                continue
+        while "/*" in line:
+            before, after = line.split("/*", 1)
+            if "*/" in after:
+                after = after.split("*/", 1)[1]
+                line = before + " " + after
+            else:
+                line = before
+                in_block_comment = True
+                break
+        if "//" in line:
+            line = line.split("//", 1)[0]
+        cleaned_lines.append(line)
+    return cleaned_lines
+
+
+def _count_braces(line: str) -> tuple[int, int]:
+    return line.count("{"), line.count("}")
+
+
+def _line_has_block_start(line: str) -> bool:
+    return bool(re.search(r"\{\s*$", line))
+
+
+def _heuristic_node(
+    *,
+    name: str,
+    node_type: str,
+    parent: str | None,
+    line_number: int,
+    raw_line: str,
+    is_async: bool = False,
+) -> dict[str, Any]:
+    col_offset = raw_line.find(name)
+    return {
+        "name": name,
+        "display_name": name,
+        "node_type": node_type,
+        "parent": parent,
+        "docstring": None,
+        "decorators": [],
+        "is_async": is_async,
+        "lineno": line_number,
+        "end_lineno": line_number,
+        "col_offset": col_offset if col_offset >= 0 else None,
+        "end_col_offset": (col_offset + len(name)) if col_offset >= 0 else None,
+        "source": raw_line.strip() or None,
+    }
+
+
+def _match_js_ts_declaration(line: str, *, inside_class: bool) -> tuple[str, str, bool, bool] | None:
+    match = _CLASS_RE.match(line)
+    if match:
+        return match.group(1), "ClassDeclaration", _line_has_block_start(line), False
+
+    match = _FUNCTION_RE.match(line)
+    if match:
+        return match.group(1), "FunctionDeclaration", _line_has_block_start(line), "async function" in line
+
+    match = _VARIABLE_RE.match(line)
+    if match:
+        return match.group(1), "VariableDeclarator", _line_has_block_start(line), bool(re.search(r"=\s*async\b", line))
+
+    match = _INTERFACE_RE.match(line)
+    if match:
+        return match.group(1), "InterfaceDeclaration", _line_has_block_start(line), False
+
+    match = _TYPE_ALIAS_RE.match(line)
+    if match:
+        return match.group(1), "TypeAliasDeclaration", False, False
+
+    if inside_class:
+        match = _METHOD_RE.match(line)
+        if match and match.group(1) not in _METHOD_EXCLUDED:
+            return match.group(1), "MethodDefinition", _line_has_block_start(line), line.lstrip().startswith("async ") or " async " in line
+
+    return None
+
+
+def _parse_js_ts_structure(path: Path, language: str) -> dict[str, Any] | str:
+    try:
+        source = _read_source(path)
+    except Exception as exc:
+        logger.debug("JS/TS read failed", exc_info=True)
+        return tool_error(str(exc), error_type=type(exc).__name__, path=str(path))
+
+    cleaned_lines = _strip_js_comments(source)
+    raw_lines = source.splitlines()
+    definitions: list[dict[str, Any]] = []
+    stack: list[dict[str, Any]] = []
+    depth = 0
+
+    for line_number, (raw_line, line) in enumerate(zip(raw_lines, cleaned_lines), start=1):
+        while stack and depth <= stack[-1]["depth"]:
+            stack.pop()
+
+        parent = stack[-1]["name"] if stack else None
+        inside_class = bool(stack) and stack[-1]["node_type"] == "ClassDeclaration"
+        matched = _match_js_ts_declaration(line, inside_class=inside_class)
+        if matched:
+            name, node_type, opens_block, is_async = matched
+            item = _heuristic_node(
+                name=name,
+                node_type=node_type,
+                parent=parent,
+                line_number=line_number,
+                raw_line=raw_line,
+                is_async=is_async,
+            )
+            definitions.append(item)
+            if opens_block:
+                stack.append({"name": name, "node_type": node_type, "depth": depth})
+
+        open_braces, close_braces = _count_braces(line)
+        depth += open_braces - close_braces
+        if depth < 0:
+            depth = 0
+
+    return {
+        "path": path,
+        "source": source,
+        "definitions": definitions,
+        "language": language,
+        "parser": "hermes_js_structure_v1",
+        "confidence": "medium",
+        "limitations": list(JS_TS_LIMITATIONS),
+    }
+
+
+def _parse_source(path: str, language: str | None) -> dict[str, Any] | str:
+    source_path = _resolve_source_path(path)
+    if source_path is None:
+        return tool_error(f"File not found: {path}", path=str(Path(path).expanduser()))
+
+    detected_language = _detect_language(source_path, language)
+    if detected_language == "python":
+        return _parse_python_module(source_path)
+    if detected_language == "json":
+        return _parse_json_document(source_path)
+    if detected_language in {"javascript", "typescript"}:
+        return _parse_js_ts_structure(source_path, detected_language)
+    return _unsupported_language_error(source_path, language=detected_language)
+
+
+def _result_metadata(parsed: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": str(parsed["path"]),
+        "language": parsed["language"],
+        "parser": parsed["parser"],
+        "confidence": parsed["confidence"],
+        "limitations": parsed["limitations"],
+    }
+
+
+def _structural_matches(
+    definitions: list[dict[str, Any]],
+    *,
+    node_type: str | None,
+    name: str | None,
+    include_source: bool,
+    max_results: int,
+) -> list[dict[str, Any]]:
+    target_name = name.lower() if name else None
+    matches: list[dict[str, Any]] = []
+    for item in definitions:
+        if node_type and item.get("node_type") != node_type:
+            continue
+        display_name = item.get("display_name") or item.get("name")
+        if target_name and not display_name:
+            continue
+        if target_name and target_name not in display_name.lower():
+            continue
+        match = {
+            key: value
+            for key, value in item.items()
+            if include_source or key != "source"
+        }
+        matches.append(match)
+        if len(matches) >= max_results:
+            break
+    return matches
+
+
+def ast_list_defs_tool(*, path: str, include_nested: bool = False, language: str | None = None) -> str:
+    parsed = _parse_source(path, language)
+    if isinstance(parsed, str):
+        return parsed
+
+    if parsed["language"] == "python":
+        module = parsed["module"]
+        definitions = []
+        for node in module.body:
+            if _is_named_definition(node):
+                definitions.append(_serialize_named_node(node, None))
+                if include_nested:
+                    _list_nested_defs(node, definitions)
+    else:
+        definitions = parsed["definitions"] if include_nested else [
+            item for item in parsed["definitions"] if item.get("parent") is None
+        ]
+
+    payload = {
+        "ok": True,
+        **_result_metadata(parsed),
+        "definitions": definitions,
+    }
+    return tool_result(payload)
+
+
+def ast_find_nodes_tool(
+    *,
+    path: str,
+    node_type: str | None = None,
+    name: str | None = None,
+    include_source: bool = False,
+    max_results: int = 100,
+    language: str | None = None,
+) -> str:
+    parsed = _parse_source(path, language)
+    if isinstance(parsed, str):
+        return parsed
+
+    if not node_type and not name:
+        return tool_error("Provide at least one filter: node_type or name", path=str(parsed["path"]))
+
+    if parsed["language"] == "python":
+        source = parsed["source"]
+        module = parsed["module"]
+        target_name = name.lower() if name else None
+        matches = []
+        for node in ast.walk(module):
+            if node_type and type(node).__name__ != node_type:
+                continue
+            display_name = _display_name(node)
+            if target_name and not display_name:
+                continue
+            if target_name and target_name not in display_name.lower():
+                continue
+            matches.append(_serialize_match(node, source, include_source))
+            if len(matches) >= max_results:
+                break
+    else:
+        matches = _structural_matches(
+            parsed["definitions"],
+            node_type=node_type,
+            name=name,
+            include_source=include_source,
+            max_results=max_results,
+        )
+
+    payload = {
+        "ok": True,
+        **_result_metadata(parsed),
+        "count": len(matches),
+        "matches": matches,
+    }
+    return tool_result(payload)
+
+
+AST_TOOLS = [
+    {"name": "ast_list_defs", "function": ast_list_defs_tool},
+    {"name": "ast_find_nodes", "function": ast_find_nodes_tool},
+]
+
+
+def _handle_ast_list_defs(args, **_kwargs):
+    return ast_list_defs_tool(
+        path=args.get("path", ""),
+        include_nested=args.get("include_nested", False),
+        language=args.get("language"),
+    )
+
+
+def _handle_ast_find_nodes(args, **_kwargs):
+    return ast_find_nodes_tool(
+        path=args.get("path", ""),
+        language=args.get("language"),
+        node_type=args.get("node_type"),
+        name=args.get("name"),
+        include_source=args.get("include_source", False),
+        max_results=args.get("max_results", 100),
+    )
+
+
+registry.register(
+    name="ast_list_defs",
+    toolset="code_intel",
+    schema=AST_LIST_DEFS_SCHEMA,
+    handler=_handle_ast_list_defs,
+    check_fn=_check_ast_requirements,
+    emoji="🌳",
+)
+registry.register(
+    name="ast_find_nodes",
+    toolset="code_intel",
+    schema=AST_FIND_NODES_SCHEMA,
+    handler=_handle_ast_find_nodes,
+    check_fn=_check_ast_requirements,
+    emoji="🔍",
+)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -837,7 +837,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_get_images",
-        "description": "Get a list of all images on the current page with their URLs and alt text. Useful for finding images to analyze with the vision tool. Requires browser_navigate to be called first.",
+        "description": "Get a list of images visible from the current browser page with their URLs and alt text. Useful when inspecting rendered documents, slide decks, diagrams, or complex pages before handing specific images to the vision tools. Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {},
@@ -846,7 +846,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_vision",
-        "description": "Take a screenshot of the current page and analyze it with vision AI. Use this when you need to visually understand what's on the page - especially useful for CAPTCHAs, visual verification challenges, complex layouts, or when the text snapshot doesn't capture important visual information. Returns both the AI analysis and a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
+        "description": "Take a screenshot of the current browser page and analyze the rendered view with vision AI. Use this for rendered PDF pages, slide decks, diagrams, charts, visual verification challenges, or any layout where browser_snapshot misses important visual information. Returns both the AI analysis and a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -865,7 +865,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_console",
-        "description": "Get browser console output and JavaScript errors from the current page. Returns console.log/warn/error/info messages and uncaught JS exceptions. Use this to detect silent JavaScript errors, failed API calls, and application warnings. Requires browser_navigate to be called first. When 'expression' is provided, evaluates JavaScript in the page context and returns the result — use this for DOM inspection, reading page state, or extracting data programmatically.",
+        "description": "Get browser console output and JavaScript errors from the current page. Returns console.log/warn/error/info messages and uncaught JS exceptions. Use this to detect silent JavaScript errors, failed API calls, and application warnings in web apps or browser-rendered document viewers. Requires browser_navigate to be called first. When 'expression' is provided, evaluates JavaScript in the live page context and returns the result — use this for DOM inspection, browser page-state checks, or extracting structured data from rendered pages.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -1761,10 +1761,14 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
 
 def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
     """Get browser console messages and JavaScript errors, or evaluate JS in the page.
-    
-    When ``expression`` is provided, evaluates JavaScript in the page context
-    (like the DevTools console) and returns the result.  Otherwise returns
-    console output (log/warn/error/info) and uncaught exceptions.
+
+    When ``expression`` is provided, evaluates JavaScript in the live page
+    context (like the DevTools console) and returns the result. Otherwise it
+    returns console output (log/warn/error/info) and uncaught exceptions.
+
+    Use this for browser page-state inspection, DOM checks, and structured
+    extraction from rendered pages or browser-based document viewers. It
+    inspects the live page state; it is not a raw document parser.
     
     Args:
         clear: If True, clear the message/error buffers after reading
@@ -1943,7 +1947,11 @@ def _maybe_stop_recording(task_id: str):
 
 def browser_get_images(task_id: Optional[str] = None) -> str:
     """
-    Get all images on the current page.
+    Get images exposed by the current browser page.
+
+    Useful for inspecting rendered documents, slide decks, diagrams, and
+    complex pages before handing a specific image to ``vision_analyze`` or
+    using ``browser_vision`` on the full rendered page.
     
     Args:
         task_id: Task identifier for session isolation
@@ -2002,11 +2010,11 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
 def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
-    
-    This tool captures what's visually displayed in the browser and sends it
-    to Gemini for analysis. Useful for understanding visual content that the
-    text-based snapshot may not capture (CAPTCHAs, verification challenges,
-    images, complex layouts, etc.).
+
+    This tool captures the rendered browser view and analyzes it with the
+    configured vision model. It is especially useful for rendered PDF pages,
+    slide decks, diagrams, charts, verification challenges, or any page where
+    the accessibility-tree snapshot misses important visual structure.
     
     The screenshot is saved persistently and its file path is returned alongside
     the analysis, so it can be shared with users via MEDIA:<path> in the response.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -20,13 +20,31 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import shlex
+import sys
 import threading
 import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+from agent.archetypes import resolve_archetype, resolve_archetype_defaults, resolve_specialist_mapping
+from agent.continuation_engine import apply_bounded_continuation_engine, build_continuation_snapshot
+from agent.prompt_builder import build_wave1_overlay_prompt_from_normalized, normalize_wave1_overlay_inputs
+from agent.route_categories import BUILTIN_ROUTE_CATEGORIES, DEFAULT_ROUTE_CATEGORY
+from agent.runtime_modes import DEFAULT_RUNTIME_MODE_NAME, resolve_runtime_mode
+from agent.task_contracts import (
+    build_named_workflow_artifact,
+    validate_named_workflow_artifact,
+    validate_task_contract,
+)
+from agent.task_store import TaskStatus, TaskStore
+from tools.background_delegate_tools import (
+    BackgroundDelegateLaunchError,
+    launch_background_delegate_task,
+)
 from toolsets import TOOLSETS
 
 
@@ -82,8 +100,40 @@ def _get_max_concurrent_children() -> int:
 DEFAULT_MAX_ITERATIONS = 50
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
-DEFAULT_DELEGATION_CATEGORY = "general"
-DEFAULT_CATEGORY_PROFILES = {
+DEFAULT_DELEGATION_PROFILE = "general"
+_REVIEWER_ARCHETYPES = frozenset({"verifier"})
+_REVIEWER_SPECIALISTS = frozenset({"code_reviewer", "qa_guard"})
+_REVIEWER_DELEGATION_PROFILES = frozenset({"verification"})
+_REVIEWER_READ_ONLY_TOOLS = frozenset({
+    "browser_console",
+    "browser_get_images",
+    "browser_navigate",
+    "browser_scroll",
+    "browser_snapshot",
+    "browser_vision",
+    "clarify",
+    "ha_get_state",
+    "ha_list_entities",
+    "ha_list_services",
+    "process",
+    "read_file",
+    "search_files",
+    "session_search",
+    "skill_view",
+    "skills_list",
+    "task",
+    "terminal",
+    "vision_analyze",
+    "web_extract",
+    "web_search",
+})
+_REVIEWER_MUTATING_REQUIRED_TOOLS = frozenset({
+    "write_file",
+    "patch",
+    "memory",
+    "send_message",
+})
+DEFAULT_DELEGATION_PROFILES = {
     "general": {"max_concurrent_children": _DEFAULT_MAX_CONCURRENT_CHILDREN},
     "research": {
         "max_concurrent_children": 3,
@@ -106,6 +156,9 @@ DEFAULT_CATEGORY_PROFILES = {
         "toolsets": ["terminal", "file", "web"],
     },
 }
+# Back-compat export for pre-Wave-1 tests/imports.
+DEFAULT_DELEGATION_CATEGORY = DEFAULT_DELEGATION_PROFILE
+DEFAULT_CATEGORY_PROFILES = DEFAULT_DELEGATION_PROFILES
 
 
 def check_delegate_requirements() -> bool:
@@ -117,7 +170,9 @@ def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
     *,
+    wave1_overlay_prompt: Optional[str] = None,
     workspace_path: Optional[str] = None,
+    named_workflow: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Build a focused system prompt for a child agent."""
     parts = [
@@ -127,6 +182,14 @@ def _build_child_system_prompt(
     ]
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
+    if wave1_overlay_prompt and wave1_overlay_prompt.strip():
+        parts.append(f"\nWAVE 1 DELEGATION INPUTS:\n{wave1_overlay_prompt.strip()}")
+    if isinstance(named_workflow, dict) and named_workflow:
+        parts.append(
+            "\nNAMED WORKFLOW ARTIFACT:\n"
+            f"{json.dumps(named_workflow, indent=2, ensure_ascii=False)}\n"
+            "Consume this structured artifact behaviorally. If it includes an execution_task_contract, follow that contract before freeform execution."
+        )
     if workspace_path and str(workspace_path).strip():
         parts.append(
             "\nWORKSPACE PATH:\n"
@@ -187,6 +250,518 @@ def _normalize_category_name(value: Optional[str]) -> str:
     return value.strip().lower().replace(" ", "_").replace("-", "_")
 
 
+def _normalize_named_string_list(values: Any) -> List[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    return list(dict.fromkeys(str(value).strip() for value in values if str(value).strip()))
+
+
+def _canonicalize_archetype_name(value: Optional[str]) -> str:
+    return resolve_archetype(value).name
+
+
+def _get_parent_runtime_activation_defaults(parent_agent) -> Dict[str, Any]:
+    if parent_agent is None:
+        return {}
+
+    state = None
+    getter = getattr(parent_agent, "get_runtime_activation_state", None)
+    if callable(getter):
+        try:
+            state = getter()
+        except Exception as exc:
+            logger.debug("Could not read parent runtime activation state via getter: %s", exc)
+
+    if not isinstance(state, dict):
+        state = getattr(parent_agent, "runtime_activation_state", None)
+    if not isinstance(state, dict):
+        state = getattr(parent_agent, "_runtime_activation_state", None)
+    if not isinstance(state, dict):
+        return {}
+
+    return {
+        "specialist": str(state.get("specialist") or "").strip() or None,
+        "archetype": str(state.get("archetype") or "").strip() or None,
+        "route_category": str(state.get("route_category") or "").strip() or None,
+        "delegation_profile": str(state.get("delegation_profile") or "").strip() or None,
+        "runtime_mode": str(state.get("runtime_mode") or "").strip() or None,
+        "task_contract": state.get("task_contract"),
+        "named_workflow": state.get("named_workflow"),
+        "activation_applied": bool(state.get("activation_applied")),
+    }
+
+
+def _resolve_contract_tool_requirements(
+    task_contract: Optional[Dict[str, Any]],
+    *,
+    parent_agent=None,
+) -> Dict[str, List[str]]:
+    if not isinstance(task_contract, dict):
+        return {"toolsets": [], "enabled_tools": [], "required_tools": []}
+
+    required_tools = _normalize_named_string_list(task_contract.get("required_tools"))
+    if not required_tools:
+        return {"toolsets": [], "enabled_tools": [], "required_tools": []}
+
+    parent_tool_names = set(getattr(parent_agent, "valid_tool_names", set()) or [])
+    resolved_toolsets: List[str] = []
+    resolved_enabled_tools: List[str] = []
+
+    for required in required_tools:
+        if required in TOOLSETS:
+            resolved_toolsets.append(required)
+            toolset_tools = TOOLSETS.get(required, {}).get("tools", [])
+            resolved_enabled_tools.extend(
+                tool_name
+                for tool_name in toolset_tools
+                if tool_name not in DELEGATE_BLOCKED_TOOLS
+                and (not parent_tool_names or tool_name in parent_tool_names)
+            )
+            continue
+
+        if required in DELEGATE_BLOCKED_TOOLS:
+            continue
+        if not parent_tool_names or required in parent_tool_names:
+            resolved_enabled_tools.append(required)
+
+    return {
+        "toolsets": list(dict.fromkeys(resolved_toolsets)),
+        "enabled_tools": list(dict.fromkeys(resolved_enabled_tools)),
+        "required_tools": required_tools,
+    }
+
+
+def _is_reviewer_like_resolution(resolved_inputs: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(resolved_inputs, dict):
+        return False
+    specialist = str(resolved_inputs.get("specialist") or "").strip().lower()
+    return bool(specialist in _REVIEWER_SPECIALISTS)
+
+
+def _apply_named_role_tool_policy(
+    *,
+    resolved_inputs: Dict[str, Any],
+    toolsets: Optional[List[str]],
+    enabled_tools: Optional[List[str]],
+    parent_agent=None,
+) -> tuple[Optional[List[str]], Optional[List[str]]]:
+    if not _is_reviewer_like_resolution(resolved_inputs):
+        return toolsets, enabled_tools
+
+    contract = resolved_inputs.get("task_contract") if isinstance(resolved_inputs, dict) else None
+    required_tools = []
+    if isinstance(contract, dict):
+        required_tools = _normalize_named_string_list(contract.get("required_tools"))
+    forbidden_required = sorted(tool for tool in required_tools if tool in _REVIEWER_MUTATING_REQUIRED_TOOLS)
+    if forbidden_required:
+        raise ValueError(
+            "Reviewer/verifier delegations are read-only and cannot require mutating tools: "
+            + ", ".join(forbidden_required)
+        )
+
+    parent_tool_names = set(getattr(parent_agent, "valid_tool_names", set()) or [])
+    available_read_only = sorted(
+        tool_name for tool_name in parent_tool_names if tool_name in _REVIEWER_READ_ONLY_TOOLS
+    )
+
+    requested_tools = _normalize_named_string_list(enabled_tools)
+    if requested_tools:
+        filtered_tools = [tool for tool in requested_tools if tool in _REVIEWER_READ_ONLY_TOOLS]
+    else:
+        filtered_tools = list(available_read_only)
+
+    if not filtered_tools and available_read_only:
+        filtered_tools = list(available_read_only)
+
+    existing_hints = resolved_inputs.get("orchestration_hints")
+    resolved_inputs["orchestration_hints"] = dict(existing_hints) if isinstance(existing_hints, dict) else {}
+    resolved_inputs["orchestration_hints"].update(
+        {
+            "behavior_boundary": "reviewer_read_only",
+            "completion_gate": "verification_evidence_required",
+            "read_only_tools": filtered_tools,
+        }
+    )
+
+    normalized_toolsets = _normalize_named_string_list(toolsets)
+    if "terminal" in filtered_tools and "terminal" not in normalized_toolsets:
+        normalized_toolsets.append("terminal")
+    if any(tool in filtered_tools for tool in ("read_file", "search_files")) and "file" not in normalized_toolsets:
+        normalized_toolsets.append("file")
+    if any(tool in filtered_tools for tool in ("web_search", "web_extract", "browser_navigate", "browser_snapshot", "browser_console", "browser_scroll", "browser_get_images", "browser_vision", "vision_analyze")) and "web" not in normalized_toolsets:
+        normalized_toolsets.append("web")
+    if any(tool in filtered_tools for tool in ("task",)) and "orchestration" not in normalized_toolsets:
+        normalized_toolsets.append("orchestration")
+
+    return normalized_toolsets or None, filtered_tools or None
+
+
+def _apply_named_role_completion_gate(
+    entry: Dict[str, Any],
+    *,
+    resolved_inputs: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not _is_reviewer_like_resolution(resolved_inputs):
+        return entry
+
+    tool_trace = entry.get("tool_trace") or []
+    tool_names = {
+        str(item.get("tool") or "").strip()
+        for item in tool_trace
+        if isinstance(item, dict)
+    }
+    evidence_tools = tool_names.intersection(_REVIEWER_READ_ONLY_TOOLS)
+    if entry.get("status") == "completed" and not evidence_tools:
+        entry["status"] = "failed"
+        entry["error"] = (
+            "Reviewer/verifier completion gate blocked success: no verification evidence tool "
+            "was used in this run."
+        )
+        entry["exit_reason"] = "verification_evidence_missing"
+    return entry
+
+
+def _resolve_route_category_entry(category_name: Optional[str], cfg: Dict[str, Any]) -> Dict[str, str]:
+    normalized_name = _normalize_category_name(category_name) or DEFAULT_ROUTE_CATEGORY
+    registry = cfg.get("route_categories") if isinstance(cfg, dict) else {}
+    if isinstance(registry, dict) and normalized_name in registry and isinstance(registry[normalized_name], dict):
+        entry = registry[normalized_name]
+        return {
+            "name": normalized_name,
+            "summary": str(entry.get("summary") or "").strip(),
+            "intensity": str(entry.get("intensity") or "").strip(),
+        }
+    builtin = BUILTIN_ROUTE_CATEGORIES.get(normalized_name)
+    if builtin is None:
+        raise ValueError(
+            f"Unknown route_category '{normalized_name}'. "
+            f"Expected one of: {', '.join(sorted(BUILTIN_ROUTE_CATEGORIES))}"
+        )
+    return {
+        "name": builtin.name,
+        "summary": builtin.summary,
+        "intensity": builtin.intensity,
+    }
+
+
+def _resolve_runtime_mode_entry(
+    runtime_mode_name: Optional[str],
+    cfg: Dict[str, Any],
+) -> Dict[str, str]:
+    resolved_builtin = resolve_runtime_mode(runtime_mode_name)
+    normalized_name = str(runtime_mode_name or resolved_builtin.name).strip() or resolved_builtin.name
+    registry = cfg.get("runtime_modes") if isinstance(cfg, dict) else {}
+    if isinstance(registry, dict) and normalized_name in registry and isinstance(registry[normalized_name], dict):
+        entry = registry[normalized_name]
+        return {
+            "name": normalized_name,
+            "description": str(entry.get("description") or resolved_builtin.description).strip(),
+            "operating_posture": str(entry.get("operating_posture") or resolved_builtin.operating_posture).strip(),
+            "kind": str(entry.get("kind") or resolved_builtin.kind).strip() or resolved_builtin.kind,
+        }
+    return {
+        "name": resolved_builtin.name,
+        "description": resolved_builtin.description,
+        "operating_posture": resolved_builtin.operating_posture,
+        "kind": resolved_builtin.kind,
+    }
+
+
+def _resolve_profile_runtime_mode(
+    task: Dict[str, Any],
+    top_level_runtime_mode: Optional[str],
+    cfg: Dict[str, Any],
+    delegation_profile: str,
+) -> Dict[str, str]:
+    explicit_runtime_mode = str(task.get("runtime_mode") or "").strip()
+    if explicit_runtime_mode:
+        return _resolve_runtime_mode_entry(explicit_runtime_mode, cfg)
+
+    inherited_runtime_mode = str(top_level_runtime_mode or "").strip()
+    if inherited_runtime_mode:
+        return _resolve_runtime_mode_entry(inherited_runtime_mode, cfg)
+
+    profile = _resolve_category_profile(cfg, delegation_profile)
+    profile_runtime_mode = str(profile.get("runtime_mode") or "").strip()
+    if profile_runtime_mode:
+        return _resolve_runtime_mode_entry(profile_runtime_mode, cfg)
+
+    configured_runtime_mode = str(cfg.get("runtime_mode") or "").strip()
+    return _resolve_runtime_mode_entry(configured_runtime_mode or DEFAULT_RUNTIME_MODE_NAME, cfg)
+
+
+def _resolve_task_delegation_profile_details(
+    task: Dict[str, Any],
+    top_level_delegation_profile: Optional[str],
+    top_level_category: Optional[str],
+    cfg: Dict[str, Any],
+) -> Dict[str, Any]:
+    explicit_profile = _normalize_category_name(task.get("delegation_profile"))
+    if explicit_profile:
+        return {
+            "value": explicit_profile,
+            "source": "delegation_profile",
+            "compatibility_only": False,
+            "legacy_category_input": None,
+        }
+
+    legacy_task_category = _normalize_category_name(task.get("category"))
+    if legacy_task_category:
+        return {
+            "value": legacy_task_category,
+            "source": "legacy_task_category",
+            "compatibility_only": True,
+            "legacy_category_input": str(task.get("category") or "").strip() or None,
+        }
+
+    inherited_profile = _normalize_category_name(top_level_delegation_profile)
+    if inherited_profile:
+        return {
+            "value": inherited_profile,
+            "source": "inherited_delegation_profile",
+            "compatibility_only": False,
+            "legacy_category_input": None,
+        }
+
+    inherited_legacy_category = _normalize_category_name(top_level_category)
+    if inherited_legacy_category:
+        return {
+            "value": inherited_legacy_category,
+            "source": "inherited_legacy_category",
+            "compatibility_only": True,
+            "legacy_category_input": str(top_level_category or "").strip() or None,
+        }
+
+    configured_profile = _normalize_category_name(cfg.get("default_delegation_profile"))
+    if configured_profile:
+        return {
+            "value": configured_profile,
+            "source": "default_delegation_profile",
+            "compatibility_only": False,
+            "legacy_category_input": None,
+        }
+
+    configured_legacy_category = _normalize_category_name(cfg.get("default_category"))
+    if configured_legacy_category:
+        return {
+            "value": configured_legacy_category,
+            "source": "default_legacy_category",
+            "compatibility_only": True,
+            "legacy_category_input": str(cfg.get("default_category") or "").strip() or None,
+        }
+
+    return {
+        "value": DEFAULT_DELEGATION_CATEGORY,
+        "source": "builtin_default_delegation_profile",
+        "compatibility_only": False,
+        "legacy_category_input": None,
+    }
+
+
+def _resolve_task_delegation_profile(
+    task: Dict[str, Any],
+    top_level_delegation_profile: Optional[str],
+    top_level_category: Optional[str],
+    cfg: Dict[str, Any],
+) -> str:
+    return _resolve_task_delegation_profile_details(
+        task,
+        top_level_delegation_profile=top_level_delegation_profile,
+        top_level_category=top_level_category,
+        cfg=cfg,
+    )["value"]
+
+
+def _resolve_wave1_task_inputs(
+    task: Dict[str, Any],
+    *,
+    cfg: Dict[str, Any],
+    top_level_archetype: Optional[str] = None,
+    inherited_parent_archetype: Optional[str] = None,
+    inherited_parent_specialist: Optional[str] = None,
+    top_level_route_category: Optional[str] = None,
+    inherited_parent_route_category: Optional[str] = None,
+    top_level_delegation_profile: Optional[str] = None,
+    inherited_parent_delegation_profile: Optional[str] = None,
+    top_level_runtime_mode: Optional[str] = None,
+    top_level_skills: Any = None,
+    top_level_task_contract: Optional[Dict[str, Any]] = None,
+    top_level_named_workflow: Optional[Dict[str, Any]] = None,
+    top_level_category: Optional[str] = None,
+) -> Dict[str, Any]:
+    explicit_task_archetype = str(task.get("archetype") or "").strip()
+    explicit_task_specialist = str(task.get("specialist") or "").strip()
+    inherited_named_workflow = top_level_named_workflow if isinstance(top_level_named_workflow, dict) else None
+    explicit_top_level_archetype = str(top_level_archetype or "").strip()
+    inherited_archetype = str(inherited_parent_archetype or "").strip()
+    requested_specialist = explicit_task_specialist or str(inherited_parent_specialist or "").strip()
+    specialist_mapping = resolve_specialist_mapping(requested_specialist)
+    resolved_specialist = specialist_mapping.name if specialist_mapping is not None else None
+    if specialist_mapping is not None and not explicit_task_archetype and not explicit_top_level_archetype:
+        inherited_archetype = specialist_mapping.archetype_name
+    configured_archetype = str(cfg.get("archetype") or "").strip()
+    requested_archetype = (
+        explicit_task_archetype
+        or explicit_top_level_archetype
+        or inherited_archetype
+        or configured_archetype
+    )
+    archetype_override_present = bool(explicit_task_archetype or explicit_top_level_archetype)
+    resolved_archetype = _canonicalize_archetype_name(requested_archetype)
+    archetype_defaults = resolve_archetype_defaults(resolved_archetype)
+
+    if archetype_override_present:
+        default_route_category = str(archetype_defaults.get("default_route_category") or DEFAULT_ROUTE_CATEGORY).strip()
+        default_delegation_profile = _normalize_category_name(archetype_defaults.get("default_delegation_profile"))
+        default_skills = _normalize_named_string_list(archetype_defaults.get("default_skills"))
+    else:
+        default_route_category = str(
+            cfg.get("route_category")
+            or cfg.get("default_route_category")
+            or archetype_defaults.get("default_route_category")
+            or DEFAULT_ROUTE_CATEGORY
+        ).strip()
+        default_delegation_profile = _normalize_category_name(
+            cfg.get("default_delegation_profile")
+            or archetype_defaults.get("default_delegation_profile")
+        )
+        default_skills = _normalize_named_string_list(
+            cfg.get("default_skills") or archetype_defaults.get("default_skills")
+        )
+
+    explicit_route_category = _normalize_category_name(task.get("route_category"))
+    explicit_top_level_route_category = _normalize_category_name(top_level_route_category)
+    inherited_route_category = _normalize_category_name(inherited_parent_route_category)
+    resolved_route_category_name = (
+        explicit_route_category
+        or explicit_top_level_route_category
+        or ("" if archetype_override_present else inherited_route_category)
+        or _normalize_category_name(default_route_category)
+        or DEFAULT_ROUTE_CATEGORY
+    )
+    resolved_route_category = _resolve_route_category_entry(resolved_route_category_name, cfg)
+
+    delegation_profile_resolution = _resolve_task_delegation_profile_details(
+        task,
+        top_level_delegation_profile=top_level_delegation_profile,
+        top_level_category=None if archetype_override_present else top_level_category,
+        cfg={
+            **cfg,
+            "default_delegation_profile": default_delegation_profile or cfg.get("default_delegation_profile"),
+        },
+    )
+    if (
+        not top_level_delegation_profile
+        and not archetype_override_present
+        and inherited_parent_delegation_profile
+        and not _normalize_category_name(task.get("category"))
+        and not _normalize_category_name(top_level_category)
+    ):
+        delegation_profile_resolution = _resolve_task_delegation_profile_details(
+            task,
+            top_level_delegation_profile=inherited_parent_delegation_profile,
+            top_level_category=top_level_category,
+            cfg={
+                **cfg,
+                "default_delegation_profile": default_delegation_profile or cfg.get("default_delegation_profile"),
+            },
+        )
+    resolved_delegation_profile = delegation_profile_resolution["value"]
+
+    resolved_skills = list(default_skills)
+    resolved_skills.extend(_normalize_named_string_list(top_level_skills))
+    resolved_skills.extend(_normalize_named_string_list(task.get("skills")))
+    resolved_skills = list(dict.fromkeys(skill for skill in resolved_skills if skill))
+
+    raw_task_contract = task.get("task_contract")
+    if raw_task_contract is None:
+        raw_task_contract = top_level_task_contract if top_level_task_contract is not None else cfg.get("task_contract")
+    resolved_task_contract = None
+    if raw_task_contract not in (None, "", {}):
+        try:
+            resolved_task_contract = validate_task_contract(raw_task_contract).model_dump()
+        except Exception as exc:
+            raise ValueError(f"Invalid task_contract for delegated task '{task.get('goal', '')}': {exc}") from exc
+
+    explicit_named_workflow = task.get("named_workflow")
+    resolved_named_workflow = None
+    for source_name, candidate_named_workflow in (
+        ("explicit", explicit_named_workflow),
+        ("inherited", inherited_named_workflow),
+    ):
+        if not isinstance(candidate_named_workflow, dict) or not candidate_named_workflow:
+            continue
+        try:
+            resolved_named_workflow = validate_named_workflow_artifact(candidate_named_workflow).model_dump(by_alias=True)
+            break
+        except Exception as exc:
+            if source_name == "explicit":
+                raise ValueError(f"Invalid named_workflow for delegated task '{task.get('goal', '')}': {exc}") from exc
+            logger.debug(
+                "Ignoring invalid inherited named_workflow for delegated task '%s': %s",
+                task.get("goal", ""),
+                exc,
+            )
+
+    resolved_runtime_mode = _resolve_profile_runtime_mode(
+        task,
+        top_level_runtime_mode=top_level_runtime_mode,
+        cfg=cfg,
+        delegation_profile=resolved_delegation_profile,
+    )
+    orchestration_hints = {
+        "permission_preset": str(cfg.get("permission_preset") or archetype_defaults.get("permission_preset") or "inherit").strip(),
+        "fallback_policy": str(cfg.get("fallback_policy") or archetype_defaults.get("fallback_policy") or "legacy_default_mapping").strip(),
+    }
+    normalized_overlay_inputs = normalize_wave1_overlay_inputs(
+        archetype_name=resolved_archetype,
+        route_category=resolved_route_category,
+        delegation_profile=resolved_delegation_profile,
+        runtime_mode=resolved_runtime_mode,
+        skills=resolved_skills,
+        task_contract=resolved_task_contract,
+        orchestration_hints=orchestration_hints,
+    )
+    if resolved_named_workflow is None:
+        resolved_named_workflow = build_named_workflow_artifact(
+            objective=str(task.get("goal") or "").strip(),
+            specialist=resolved_specialist,
+            archetype=normalized_overlay_inputs["archetype"],
+            route_category=normalized_overlay_inputs["route_category"],
+            runtime_mode=normalized_overlay_inputs["runtime_mode"],
+            delegation_profile=normalized_overlay_inputs["delegation_profile"],
+            task_contract=normalized_overlay_inputs["task_contract"],
+        )
+    overlay_prompt = build_wave1_overlay_prompt_from_normalized(normalized_overlay_inputs)
+
+    return {
+        "specialist": resolved_specialist,
+        "archetype": normalized_overlay_inputs["archetype"],
+        "route_category": normalized_overlay_inputs["route_category"],
+        "route_category_definition": normalized_overlay_inputs["route_category_definition"],
+        "route_category_source": "explicit_or_inherited_route_category" if (
+            explicit_route_category or explicit_top_level_route_category or inherited_route_category
+        ) else "default_route_category",
+        "delegation_profile": normalized_overlay_inputs["delegation_profile"],
+        "delegation_profile_source": delegation_profile_resolution["source"],
+        "delegation_profile_compatibility_only": bool(delegation_profile_resolution["compatibility_only"]),
+        "legacy_category_input": delegation_profile_resolution["legacy_category_input"],
+        "skills": normalized_overlay_inputs["skills"],
+        "task_contract": normalized_overlay_inputs["task_contract"],
+        "named_workflow": resolved_named_workflow,
+        "runtime_mode": normalized_overlay_inputs["runtime_mode"],
+        "runtime_mode_definition": normalized_overlay_inputs["runtime_mode_definition"],
+        "permission_preset": orchestration_hints["permission_preset"],
+        "fallback_policy": orchestration_hints["fallback_policy"],
+        "orchestration_hints": orchestration_hints,
+        "overlay_prompt": overlay_prompt,
+    }
+
+
 def _normalize_category_profile(raw: Any) -> Dict[str, Any]:
     if not isinstance(raw, dict):
         return {}
@@ -195,9 +770,12 @@ def _normalize_category_profile(raw: Any) -> Dict[str, Any]:
         profile["toolsets"] = [str(t).strip() for t in raw["toolsets"] if str(t).strip()]
     if isinstance(raw.get("enabled_tools"), list):
         profile["enabled_tools"] = [str(t).strip() for t in raw["enabled_tools"] if str(t).strip()]
-    for key in ("model", "provider", "base_url", "api_key", "reasoning_effort", "acp_command"):
+    for key in ("model", "provider", "base_url", "api_key", "reasoning_effort", "acp_command", "routing_description"):
         if isinstance(raw.get(key), str) and raw.get(key).strip():
             profile[key] = raw.get(key).strip()
+    runtime_mode = str(raw.get("runtime_mode") or "").strip()
+    if runtime_mode:
+        profile["runtime_mode"] = _resolve_runtime_mode_entry(runtime_mode, {}).get("name", runtime_mode)
     if isinstance(raw.get("acp_args"), list):
         profile["acp_args"] = [str(v) for v in raw["acp_args"]]
     for key in ("max_iterations", "max_concurrent_children"):
@@ -205,7 +783,7 @@ def _normalize_category_profile(raw: Any) -> Dict[str, Any]:
             try:
                 profile[key] = max(1, int(raw.get(key)))
             except (TypeError, ValueError):
-                logger.warning("Ignoring invalid delegation category %s=%r", key, raw.get(key))
+                logger.warning("Ignoring invalid delegation profile %s=%r", key, raw.get(key))
     return profile
 
 
@@ -222,47 +800,78 @@ def _normalize_delegation_config(cfg: Any) -> Dict[str, Any]:
     if not isinstance(cfg, dict):
         cfg = {}
     normalized = dict(cfg)
-    categories = {name: dict(profile) for name, profile in DEFAULT_CATEGORY_PROFILES.items()}
+    profiles = {name: dict(profile) for name, profile in DEFAULT_DELEGATION_PROFILES.items()}
+
+    raw_profiles = cfg.get("delegation_profiles") if isinstance(cfg, dict) else None
+    if isinstance(raw_profiles, dict):
+        for name, raw_profile in raw_profiles.items():
+            normalized_name = _normalize_category_name(name)
+            if not normalized_name:
+                continue
+            profiles[normalized_name] = _merge_category_profile(
+                profiles.get(normalized_name, {}),
+                _normalize_category_profile(raw_profile),
+            )
+
     raw_categories = cfg.get("categories") if isinstance(cfg, dict) else None
     if isinstance(raw_categories, dict):
         for name, raw_profile in raw_categories.items():
             normalized_name = _normalize_category_name(name)
             if not normalized_name:
                 continue
-            categories[normalized_name] = _merge_category_profile(
-                categories.get(normalized_name, {}),
+            profiles[normalized_name] = _merge_category_profile(
+                profiles.get(normalized_name, {}),
                 _normalize_category_profile(raw_profile),
             )
-    normalized["categories"] = categories
+
+    normalized["delegation_profiles"] = profiles
+    normalized["categories"] = profiles
+
+    default_profile = _normalize_category_name(cfg.get("default_delegation_profile")) if isinstance(cfg, dict) else ""
     default_category = _normalize_category_name(cfg.get("default_category")) if isinstance(cfg, dict) else ""
-    normalized["default_category"] = default_category or DEFAULT_DELEGATION_CATEGORY
+    resolved_default_profile = default_profile or default_category or DEFAULT_DELEGATION_PROFILE
+    normalized["default_delegation_profile"] = resolved_default_profile
+    normalized["default_category"] = resolved_default_profile
     return normalized
 
 
-def _resolve_task_category(task: Dict[str, Any], top_level_category: Optional[str], cfg: Dict[str, Any]) -> str:
-    explicit = _normalize_category_name(task.get("category"))
-    if explicit:
-        return explicit
-    inherited = _normalize_category_name(top_level_category)
-    if inherited:
-        return inherited
-    return _normalize_category_name(cfg.get("default_category")) or DEFAULT_DELEGATION_CATEGORY
+def _resolve_task_category(
+    task: Dict[str, Any],
+    top_level_category: Optional[str],
+    cfg: Dict[str, Any],
+    top_level_delegation_profile: Optional[str] = None,
+) -> str:
+    return _resolve_task_delegation_profile(
+        task,
+        top_level_delegation_profile=top_level_delegation_profile,
+        top_level_category=top_level_category,
+        cfg=cfg,
+    )
 
 
 def _resolve_category_profile(cfg: Dict[str, Any], category: str) -> Dict[str, Any]:
-    categories = cfg.get("categories") if isinstance(cfg, dict) else {}
-    profile = categories.get(category) if isinstance(categories, dict) else None
+    profiles = {}
+    if isinstance(cfg, dict):
+        profiles = cfg.get("delegation_profiles") or cfg.get("categories") or {}
+    profile = profiles.get(category) if isinstance(profiles, dict) else None
     if profile:
         return _merge_category_profile({}, profile)
-    return _merge_category_profile({}, categories.get(DEFAULT_DELEGATION_CATEGORY, {})) if isinstance(categories, dict) else {}
+    fallback_name = cfg.get("default_delegation_profile") or DEFAULT_DELEGATION_PROFILE if isinstance(cfg, dict) else DEFAULT_DELEGATION_PROFILE
+    if isinstance(profiles, dict):
+        return _merge_category_profile({}, profiles.get(fallback_name, {}) or profiles.get(DEFAULT_DELEGATION_PROFILE, {}))
+    return {}
 
 
 def _enforce_category_concurrency(
     task_list: List[Dict[str, Any]],
     cfg: Dict[str, Any],
     top_level_category: Optional[str] = None,
+    top_level_delegation_profile: Optional[str] = None,
 ) -> Optional[str]:
-    categories = [_resolve_task_category(task, top_level_category, cfg) for task in task_list]
+    categories = [
+        _resolve_task_category(task, top_level_category, cfg, top_level_delegation_profile)
+        for task in task_list
+    ]
     counts = Counter(categories)
     for category, count in counts.items():
         profile = _resolve_category_profile(cfg, category)
@@ -285,6 +894,7 @@ def _resolve_batch_concurrency_limit(
     task_list: List[Dict[str, Any]],
     top_level_category: Optional[str],
     cfg: Dict[str, Any],
+    top_level_delegation_profile: Optional[str] = None,
 ) -> tuple[int, Optional[str]]:
     """Return the effective concurrency limit for one delegation batch.
 
@@ -296,13 +906,22 @@ def _resolve_batch_concurrency_limit(
     if not task_list:
         return base_limit, None
 
-    resolved_categories = [_resolve_task_category(task, top_level_category, cfg) for task in task_list]
+    resolved_categories = [
+        _resolve_task_category(task, top_level_category, cfg, top_level_delegation_profile)
+        for task in task_list
+    ]
     if len(set(resolved_categories)) != 1:
         return base_limit, None
 
     category_name = resolved_categories[0]
-    explicit_top_level = _normalize_category_name(top_level_category)
-    explicit_per_task = all(_normalize_category_name(task.get("category")) == category_name for task in task_list)
+    explicit_top_level = _normalize_category_name(top_level_delegation_profile) or _normalize_category_name(top_level_category)
+    explicit_per_task = all(
+        (
+            _normalize_category_name(task.get("delegation_profile"))
+            or _normalize_category_name(task.get("category"))
+        ) == category_name
+        for task in task_list
+    )
     if explicit_top_level != category_name and not explicit_per_task:
         return base_limit, None
 
@@ -443,6 +1062,8 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    wave1_overlay_prompt: Optional[str] = None,
+    delegate_resolution: Optional[Dict[str, Any]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -495,7 +1116,21 @@ def _build_child_agent(
         })
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
-    child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
+    resolved_named_workflow = None
+    if isinstance(delegate_resolution, dict):
+        candidate_named_workflow = delegate_resolution.get("named_workflow")
+        if isinstance(candidate_named_workflow, dict) and candidate_named_workflow:
+            try:
+                resolved_named_workflow = validate_named_workflow_artifact(candidate_named_workflow).model_dump(by_alias=True)
+            except Exception as exc:
+                logger.debug("Ignoring invalid delegate_resolution named_workflow while building child prompt: %s", exc)
+    child_prompt = _build_child_system_prompt(
+        goal,
+        context,
+        wave1_overlay_prompt=wave1_overlay_prompt,
+        workspace_path=workspace_hint,
+        named_workflow=resolved_named_workflow,
+    )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
@@ -581,6 +1216,7 @@ def _build_child_agent(
         iteration_budget=None,  # fresh budget per subagent
     )
     child._print_fn = getattr(parent_agent, '_print_fn', None)
+    child._delegate_resolution = dict(delegate_resolution or {})
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
 
@@ -681,6 +1317,15 @@ def _run_single_child(
                 logger.debug("Progress callback start failed: %s", e)
 
         result = child.run_conversation(user_message=goal)
+        resolution = getattr(child, "_delegate_resolution", None) or {}
+        runtime_mode = resolution.get("runtime_mode") if isinstance(resolution, dict) else None
+        continuation_state = apply_bounded_continuation_engine(
+            child,
+            result,
+            runtime_mode=runtime_mode,
+        )
+        result = continuation_state["result"]
+        final_snapshot = continuation_state["snapshot"]
 
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, '_flush'):
@@ -694,14 +1339,20 @@ def _run_single_child(
         summary = result.get("final_response") or ""
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
-        api_calls = result.get("api_calls", 0)
+        api_calls = int(result.get("api_calls", 0) or 0)
+        api_calls += sum(int(snapshot.get("apiCalls", 0) or 0) for snapshot in continuation_state.get("snapshots", [])[1:])
+        outcome_status = str(final_snapshot.get("outcomeStatus") or "").strip().lower()
+        has_open_todos = bool(final_snapshot.get("activeTodos"))
 
-        if interrupted:
+        if outcome_status == "completed" and not has_open_todos:
+            status = "completed"
+        elif outcome_status == "interrupted" or interrupted:
+            status = "interrupted"
+        elif outcome_status == "failed":
+            status = "failed"
+        elif has_open_todos:
             status = "interrupted"
         elif summary:
-            # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
             status = "completed"
         else:
             status = "failed"
@@ -745,7 +1396,11 @@ def _run_single_child(
                         tool_trace[-1].update(result_meta)
 
         # Determine exit reason
-        if interrupted:
+        if status == "completed":
+            exit_reason = "completed"
+        elif continuation_state.get("exhausted"):
+            exit_reason = "continuation_exhausted"
+        elif outcome_status == "interrupted" or interrupted:
             exit_reason = "interrupted"
         elif completed:
             exit_reason = "completed"
@@ -770,9 +1425,23 @@ def _run_single_child(
                 "output": _output_tokens if isinstance(_output_tokens, (int, float)) else 0,
             },
             "tool_trace": tool_trace,
+            "orchestration": final_snapshot,
+            "continuation": {
+                "mode": continuation_state.get("mode"),
+                "attempt_count": continuation_state.get("attempt_count"),
+                "resume_count": continuation_state.get("resume_count"),
+                "final_outcome_status": outcome_status,
+                "open_todos": final_snapshot.get("activeTodos") or [],
+                "exhausted": bool(continuation_state.get("exhausted")),
+            },
         }
-        if status == "failed":
+        if resolution:
+            entry["resolved_inputs"] = resolution
+        entry = _apply_named_role_completion_gate(entry, resolved_inputs=resolution)
+        if entry.get("status") == "failed" and not entry.get("error"):
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+        elif entry.get("status") == "interrupted" and not summary:
+            entry["error"] = result.get("error") or "Subagent stopped with unfinished work remaining."
 
         if child_progress_cb:
             try:
@@ -854,13 +1523,175 @@ def _run_single_child(
         except Exception:
             logger.debug("Failed to close child agent after delegation")
 
+
+def _build_persistent_launch_spec(
+    *,
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+    enabled_tools: Optional[List[str]],
+    resolved_inputs: Dict[str, Any],
+    creds: Dict[str, Any],
+    max_iterations: int,
+    parent_agent,
+    acp_command: Optional[str],
+    acp_args: Optional[List[str]],
+    wave1_overlay_prompt: Optional[str],
+) -> Dict[str, Any]:
+    parent_api_key = getattr(parent_agent, "api_key", None)
+    if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
+        parent_api_key = parent_agent._client_kwargs.get("api_key")
+
+    return {
+        "runner": "delegate",
+        "task_index": 0,
+        "goal": goal,
+        "context": context,
+        "toolsets": list(toolsets or []),
+        "enabled_tools": list(enabled_tools or []),
+        "model": creds.get("model") or getattr(parent_agent, "model", None),
+        "provider": creds.get("provider") or getattr(parent_agent, "provider", None),
+        "base_url": creds.get("base_url") or getattr(parent_agent, "base_url", None),
+        "api_key": creds.get("api_key") or parent_api_key,
+        "api_mode": creds.get("api_mode") or getattr(parent_agent, "api_mode", None),
+        "acp_command": acp_command,
+        "acp_args": list(acp_args or []),
+        "max_iterations": max_iterations,
+        "wave1_overlay_prompt": wave1_overlay_prompt,
+        "delegate_resolution": dict(resolved_inputs or {}),
+        "parent_enabled_toolsets": list(getattr(parent_agent, "enabled_toolsets", None) or []),
+        "parent_valid_tool_names": sorted(getattr(parent_agent, "valid_tool_names", set()) or []),
+        "platform": getattr(parent_agent, "platform", None),
+        "providers_allowed": getattr(parent_agent, "providers_allowed", None),
+        "providers_ignored": getattr(parent_agent, "providers_ignored", None),
+        "providers_order": getattr(parent_agent, "providers_order", None),
+        "provider_sort": getattr(parent_agent, "provider_sort", None),
+        "reasoning_config": getattr(parent_agent, "reasoning_config", None),
+        "max_tokens": getattr(parent_agent, "max_tokens", None),
+        "prefill_messages": getattr(parent_agent, "prefill_messages", None),
+        "parent_session_id": getattr(parent_agent, "session_id", None),
+    }
+
+
+def _build_persistent_parent_agent(launch_spec: Dict[str, Any]):
+    parent = SimpleNamespace()
+    parent.base_url = launch_spec.get("base_url")
+    parent.api_key = launch_spec.get("api_key")
+    parent.provider = launch_spec.get("provider")
+    parent.api_mode = launch_spec.get("api_mode")
+    parent.model = launch_spec.get("model")
+    parent.platform = launch_spec.get("platform")
+    parent.providers_allowed = launch_spec.get("providers_allowed")
+    parent.providers_ignored = launch_spec.get("providers_ignored")
+    parent.providers_order = launch_spec.get("providers_order")
+    parent.provider_sort = launch_spec.get("provider_sort")
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.enabled_toolsets = list(launch_spec.get("parent_enabled_toolsets") or []) or None
+    parent.valid_tool_names = set(launch_spec.get("parent_valid_tool_names") or [])
+    parent.reasoning_config = launch_spec.get("reasoning_config")
+    parent.max_tokens = launch_spec.get("max_tokens")
+    parent.prefill_messages = launch_spec.get("prefill_messages")
+    parent.session_id = launch_spec.get("parent_session_id")
+    parent.acp_command = launch_spec.get("acp_command")
+    parent.acp_args = list(launch_spec.get("acp_args") or [])
+    return parent
+
+
+def launch_persistent_delegate_task(task_id: str, *, store: Optional[TaskStore] = None, process_registry_obj=None) -> dict[str, Any]:
+    return launch_background_delegate_task(
+        task_id,
+        store=store,
+        process_registry_obj=process_registry_obj,
+    )
+
+
+def run_persistent_delegate_task(task_id: str, store_root: Optional[str] = None) -> None:
+    task_store = TaskStore(store_root)
+    record = task_store.require_task(task_id)
+    launch_spec = dict(record.launch_spec or {})
+    if launch_spec.get("runner") != "delegate":
+        raise ValueError(f"task {task_id} is not a delegate-backed persistent task")
+
+    task_store.transition_task(task_id, TaskStatus.running)
+    parent = _build_persistent_parent_agent(launch_spec)
+    try:
+        child = _build_child_agent(
+            task_index=0,
+            goal=str(launch_spec.get("goal") or record.goal),
+            context=launch_spec.get("context") or record.context,
+            toolsets=launch_spec.get("toolsets"),
+            enabled_tools=launch_spec.get("enabled_tools"),
+            model=launch_spec.get("model"),
+            max_iterations=int(launch_spec.get("max_iterations") or DEFAULT_MAX_ITERATIONS),
+            task_count=1,
+            parent_agent=parent,
+            override_provider=launch_spec.get("provider"),
+            override_base_url=launch_spec.get("base_url"),
+            override_api_key=launch_spec.get("api_key"),
+            override_api_mode=launch_spec.get("api_mode"),
+            override_acp_command=launch_spec.get("acp_command"),
+            override_acp_args=launch_spec.get("acp_args"),
+            wave1_overlay_prompt=launch_spec.get("wave1_overlay_prompt"),
+            delegate_resolution=launch_spec.get("delegate_resolution") or record.resolved_inputs,
+        )
+        result = _run_single_child(0, record.goal, child=child, parent_agent=parent)
+        continuation = dict(result.get("continuation") or {})
+        orchestration = dict(result.get("orchestration") or {})
+        open_todos = continuation.get("open_todos") or orchestration.get("activeTodos") or []
+        if result.get("status") == "completed" and not open_todos:
+            task_store.clear_continuation(task_id)
+            final_status = TaskStatus.completed
+        else:
+            task_store.update_continuation(
+                task_id,
+                mode=continuation.get("mode") or record.runtime_mode,
+                status="retry_requested" if open_todos else "resolved",
+                open_todos=open_todos,
+                latest_response_preview=orchestration.get("responsePreview") or result.get("summary"),
+                last_outcome_status=continuation.get("final_outcome_status") or orchestration.get("outcomeStatus"),
+                resume_count=continuation.get("resume_count"),
+                attempt_count=continuation.get("attempt_count"),
+            )
+            final_status = TaskStatus.failed
+        task_store.record_result(
+            task_id,
+            status=final_status,
+            result=result,
+            summary=result.get("summary"),
+            error=result.get("error") or ("unfinished work remains" if open_todos else None),
+        )
+    except Exception as exc:
+        task_store.record_result(
+            task_id,
+            status=TaskStatus.failed,
+            result={"error": str(exc)},
+            summary=None,
+            error=str(exc),
+        )
+        raise
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     category: Optional[str] = None,
+    archetype: Optional[str] = None,
+    route_category: Optional[str] = None,
+    delegation_profile: Optional[str] = None,
+    runtime_mode: Optional[str] = None,
+    skills: Optional[List[str]] = None,
+    task_contract: Optional[Dict[str, Any]] = None,
     max_iterations: Optional[int] = None,
+    persistent: bool = False,
+    background: bool = False,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
@@ -902,11 +1733,28 @@ def delegate_task(
     except ValueError as exc:
         return tool_error(str(exc))
 
+    parent_activation_defaults = _get_parent_runtime_activation_defaults(parent_agent)
+    explicit_top_level_archetype = str(archetype or "").strip() or None
+    explicit_top_level_route_category = str(route_category or "").strip() or None
+    explicit_top_level_delegation_profile = str(delegation_profile or "").strip() or None
+    inherited_parent_specialist = parent_activation_defaults.get("specialist")
+    inherited_parent_archetype = parent_activation_defaults.get("archetype")
+    inherited_parent_route_category = parent_activation_defaults.get("route_category")
+    inherited_parent_delegation_profile = parent_activation_defaults.get("delegation_profile")
+    effective_archetype = explicit_top_level_archetype or inherited_parent_archetype
+    effective_route_category = explicit_top_level_route_category or inherited_parent_route_category
+    effective_delegation_profile = explicit_top_level_delegation_profile or inherited_parent_delegation_profile
+    effective_runtime_mode = runtime_mode or parent_activation_defaults.get("runtime_mode")
+    effective_task_contract = task_contract if task_contract is not None else parent_activation_defaults.get("task_contract")
+    effective_named_workflow = parent_activation_defaults.get("named_workflow")
+    effective_category = category or effective_delegation_profile
+
     # Normalize to task list
     max_children, limit_category = _resolve_batch_concurrency_limit(
         task_list=tasks or [],
-        top_level_category=category,
+        top_level_category=effective_category,
         cfg=cfg,
+        top_level_delegation_profile=effective_delegation_profile,
     )
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
@@ -925,7 +1773,13 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "category": category}]
+        task_list = [{
+            "goal": goal,
+            "context": context,
+            "toolsets": toolsets,
+            "acp_command": acp_command,
+            "acp_args": acp_args,
+        }]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -937,7 +1791,12 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
-    category_error = _enforce_category_concurrency(task_list, cfg, top_level_category=category)
+    category_error = _enforce_category_concurrency(
+        task_list,
+        cfg,
+        top_level_category=effective_category,
+        top_level_delegation_profile=effective_delegation_profile,
+    )
     if category_error:
         return tool_error(category_error)
 
@@ -960,13 +1819,60 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
-            task_category = _resolve_task_category(t, category, cfg)
-            category_profile = _resolve_category_profile(cfg, task_category)
+            try:
+                resolved_inputs = _resolve_wave1_task_inputs(
+                    t,
+                    cfg=cfg,
+                    top_level_archetype=explicit_top_level_archetype,
+                    inherited_parent_archetype=inherited_parent_archetype,
+                    inherited_parent_specialist=inherited_parent_specialist,
+                    top_level_route_category=explicit_top_level_route_category,
+                    inherited_parent_route_category=inherited_parent_route_category,
+                    top_level_delegation_profile=explicit_top_level_delegation_profile,
+                    inherited_parent_delegation_profile=inherited_parent_delegation_profile,
+                    top_level_runtime_mode=effective_runtime_mode,
+                    top_level_skills=skills,
+                    top_level_task_contract=effective_task_contract,
+                    top_level_named_workflow=effective_named_workflow,
+                    top_level_category=effective_category,
+                )
+            except (TypeError, ValueError, KeyError) as exc:
+                return tool_error(str(exc))
+            resolved_profile = resolved_inputs["delegation_profile"]
+            category_profile = _resolve_category_profile(cfg, resolved_profile)
             merged_cfg = _merge_category_profile(cfg, category_profile)
             category_creds = _resolve_delegation_credentials(merged_cfg, parent_agent)
-            task_toolsets = t.get("toolsets") or category_profile.get("toolsets") or toolsets
-            task_enabled_tools = category_profile.get("enabled_tools")
+            contract_tool_policy = _resolve_contract_tool_requirements(
+                resolved_inputs.get("task_contract"),
+                parent_agent=parent_agent,
+            )
+            task_toolsets = list(dict.fromkeys(
+                _normalize_named_string_list(t.get("toolsets") or category_profile.get("toolsets") or toolsets)
+                + contract_tool_policy["toolsets"]
+            )) or None
+            task_enabled_tools = list(dict.fromkeys(
+                _normalize_named_string_list(category_profile.get("enabled_tools"))
+                + contract_tool_policy["enabled_tools"]
+            )) or None
+            task_toolsets, task_enabled_tools = _apply_named_role_tool_policy(
+                resolved_inputs=resolved_inputs,
+                toolsets=task_toolsets,
+                enabled_tools=task_enabled_tools,
+                parent_agent=parent_agent,
+            )
             task_max_iter = int(category_profile.get("max_iterations") or effective_max_iter)
+            task_overlay_prompt = build_wave1_overlay_prompt_from_normalized(
+                normalize_wave1_overlay_inputs(
+                    archetype_name=resolved_inputs["archetype"],
+                    route_category=resolved_inputs.get("route_category_definition") or resolved_inputs["route_category"],
+                    delegation_profile=resolved_inputs["delegation_profile"],
+                    runtime_mode=resolved_inputs.get("runtime_mode_definition") or resolved_inputs["runtime_mode"],
+                    skills=resolved_inputs.get("skills"),
+                    task_contract=resolved_inputs.get("task_contract"),
+                    orchestration_hints=resolved_inputs.get("orchestration_hints"),
+                )
+            )
+            resolved_inputs["overlay_prompt"] = task_overlay_prompt
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=task_toolsets, enabled_tools=task_enabled_tools, model=category_creds["model"] or creds["model"],
@@ -976,17 +1882,121 @@ def delegate_task(
                 override_api_mode=category_creds["api_mode"] or creds["api_mode"],
                 override_acp_command=t.get("acp_command") or category_profile.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or category_profile.get("acp_args") or acp_args,
+                wave1_overlay_prompt=task_overlay_prompt,
+                delegate_resolution={key: value for key, value in resolved_inputs.items() if key != "overlay_prompt"},
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
-            children.append((i, t, child))
+            children.append((i, t, child, task_max_iter, task_overlay_prompt))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
 
+    if persistent or background:
+        if n_tasks != 1:
+            return tool_error("Persistent/background delegation currently supports exactly one task.")
+        _i, _t, child, task_max_iter, task_overlay_prompt = children[0]
+        delegate_resolution = dict(getattr(child, "_delegate_resolution", {}) or {})
+        resolved_hints = dict(delegate_resolution.get("orchestration_hints") or {})
+        launch_spec = _build_persistent_launch_spec(
+            goal=_t["goal"],
+            context=_t.get("context"),
+            toolsets=list(getattr(child, "enabled_toolsets", None) or []),
+            enabled_tools=list(getattr(child, "enabled_tools", None) or []),
+            resolved_inputs=delegate_resolution,
+            creds={
+                "model": getattr(child, "model", None),
+                "provider": getattr(child, "provider", None),
+                "base_url": getattr(child, "base_url", None),
+                "api_key": getattr(child, "api_key", None),
+                "api_mode": getattr(child, "api_mode", None),
+            },
+            max_iterations=task_max_iter,
+            parent_agent=parent_agent,
+            acp_command=getattr(child, "acp_command", None),
+            acp_args=getattr(child, "acp_args", None),
+            wave1_overlay_prompt=task_overlay_prompt,
+        )
+        store = TaskStore()
+        record = store.create_task(
+            goal=_t["goal"],
+            context=_t.get("context"),
+            owner_session_id=getattr(parent_agent, "session_id", None),
+            parent_session_id=getattr(parent_agent, "session_id", None),
+            archetype=delegate_resolution.get("archetype"),
+            specialist=delegate_resolution.get("specialist"),
+            route_category=delegate_resolution.get("route_category"),
+            delegation_profile=delegate_resolution.get("delegation_profile"),
+            runtime_mode=delegate_resolution.get("runtime_mode"),
+            skills=list(delegate_resolution.get("skills") or []),
+            task_contract=delegate_resolution.get("task_contract"),
+            permissions={
+                "permission_preset": delegate_resolution.get("permission_preset") or resolved_hints.get("permission_preset") or cfg.get("permission_preset"),
+                "fallback_policy": delegate_resolution.get("fallback_policy") or resolved_hints.get("fallback_policy") or cfg.get("fallback_policy"),
+            },
+            resolved_inputs=delegate_resolution,
+            launch_spec=launch_spec,
+        )
+        if background:
+            try:
+                launch_result = launch_background_delegate_task(record.id, store=store)
+            except BackgroundDelegateLaunchError as exc:
+                try:
+                    child.close()
+                except Exception:
+                    logger.debug("Failed to close prebuilt child after background launch failure")
+                try:
+                    if hasattr(parent_agent, "_active_children") and child in parent_agent._active_children:
+                        parent_agent._active_children.remove(child)
+                except Exception:
+                    pass
+                return tool_error(f"Background delegate launch failed: {exc}")
+            try:
+                child.close()
+            except Exception:
+                logger.debug("Failed to close prebuilt child after persistent launch")
+            try:
+                if hasattr(parent_agent, "_active_children") and child in parent_agent._active_children:
+                    parent_agent._active_children.remove(child)
+            except Exception:
+                pass
+            return json.dumps(launch_result, ensure_ascii=False)
+
+        store.transition_task(record.id, TaskStatus.queued)
+        store.transition_task(record.id, TaskStatus.running)
+        try:
+            result = _run_single_child(0, _t["goal"], child, parent_agent)
+            status = TaskStatus.completed if result.get("status") == "completed" else TaskStatus.failed
+            store.record_result(
+                record.id,
+                status=status,
+                result=result,
+                summary=result.get("summary"),
+                error=result.get("error"),
+            )
+        except Exception as exc:
+            store.record_result(
+                record.id,
+                status=TaskStatus.failed,
+                result={"error": str(exc)},
+                summary=None,
+                error=str(exc),
+            )
+            raise
+        return json.dumps(
+            {
+                "task_id": record.id,
+                "persistent": True,
+                "background": False,
+                "results": [result],
+                "total_duration_seconds": round(time.monotonic() - overall_start, 2),
+            },
+            ensure_ascii=False,
+        )
+
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
-        _i, _t, child = children[0]
+        _i, _t, child, _task_max_iter, _task_overlay_prompt = children[0]
         result = _run_single_child(0, _t["goal"], child, parent_agent)
         results.append(result)
     else:
@@ -996,7 +2006,7 @@ def delegate_task(
 
         with ThreadPoolExecutor(max_workers=min(max_children, n_tasks)) as executor:
             futures = {}
-            for i, t, child in children:
+            for i, t, child, _task_max_iter, _task_overlay_prompt in children:
                 future = executor.submit(
                     _run_single_child,
                     task_index=i,
@@ -1362,7 +2372,32 @@ DELEGATE_TASK_SCHEMA = {
                         },
                         "category": {
                             "type": "string",
-                            "description": "Optional delegation policy category (e.g. research, implementation, verification). Category profiles can constrain concurrency, tool access, and model/runtime defaults.",
+                            "description": "Legacy delegation-profile alias (e.g. research, implementation, verification). Category profiles can still constrain concurrency, tool access, and model/runtime defaults.",
+                        },
+                        "archetype": {
+                            "type": "string",
+                            "description": "Optional Wave 1 archetype override for this task.",
+                        },
+                        "route_category": {
+                            "type": "string",
+                            "description": "Optional Wave 1 route category override for this task. Distinct from delegation_profile/category.",
+                        },
+                        "delegation_profile": {
+                            "type": "string",
+                            "description": "Optional Wave 1 delegation profile override for this task. Distinct from route_category.",
+                        },
+                        "runtime_mode": {
+                            "type": "string",
+                            "description": "Optional Wave 1 runtime mode override for this task. Distinct from route_category and delegation_profile/category.",
+                        },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional additive Wave 1 skills overlay for this task.",
+                        },
+                        "task_contract": {
+                            "type": "object",
+                            "description": "Optional canonical structured Wave 1 task contract for this task.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -1387,7 +2422,32 @@ DELEGATE_TASK_SCHEMA = {
             },
             "category": {
                 "type": "string",
-                "description": "Optional delegation policy category (e.g. research, implementation, verification). Applies to all tasks unless a task overrides it.",
+                "description": "Legacy delegation-profile alias. Applies to all tasks unless a task overrides it. Preserves pre-Wave-1 delegation behavior when archetype/task_contract are absent.",
+            },
+            "archetype": {
+                "type": "string",
+                "description": "Optional Wave 1 archetype/task blueprint to seed defaults without replacing route category, delegation profile, skills, or task_contract.",
+            },
+            "route_category": {
+                "type": "string",
+                "description": "Optional Wave 1 route category (for example: ultrabrain, deep, quick, visual, writing, unspecified_low, unspecified_high). Distinct from delegation_profile/category.",
+            },
+            "delegation_profile": {
+                "type": "string",
+                "description": "Optional Wave 1 delegation profile. Distinct from route_category; falls back to the legacy category/default-mapping path when omitted.",
+            },
+            "runtime_mode": {
+                "type": "string",
+                "description": "Optional Wave 1 runtime mode. Resolved separately from route_category and delegation_profile/category, then rendered as its own prompt layer.",
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional additive Wave 1 skills overlay. These remain separate from route category, delegation profile, and task_contract.",
+            },
+            "task_contract": {
+                "type": "object",
+                "description": "Optional canonical structured Wave 1 task contract. When omitted, legacy delegation behavior is preserved through default mapping.",
             },
             "max_iterations": {
                 "type": "integer",
@@ -1395,6 +2455,14 @@ DELEGATE_TASK_SCHEMA = {
                     "Max tool-calling turns per subagent (default: 50). "
                     "Only set lower for simple tasks."
                 ),
+            },
+            "persistent": {
+                "type": "boolean",
+                "description": "Persist the delegated task in the Wave 3 task store, even when run in the foreground.",
+            },
+            "background": {
+                "type": "boolean",
+                "description": "Launch the delegated task as a persistent background task using Hermes process_registry and return immediately with task/process IDs.",
             },
             "acp_command": {
                 "type": "string",
@@ -1432,7 +2500,15 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         category=args.get("category"),
+        archetype=args.get("archetype"),
+        route_category=args.get("route_category"),
+        delegation_profile=args.get("delegation_profile"),
+        runtime_mode=args.get("runtime_mode"),
+        skills=args.get("skills"),
+        task_contract=args.get("task_contract"),
         max_iterations=args.get("max_iterations"),
+        persistent=bool(args.get("persistent", False)),
+        background=bool(args.get("background", False)),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         parent_agent=kw.get("parent_agent")),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 import os
 import threading
 import time
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
@@ -80,6 +82,30 @@ def _get_max_concurrent_children() -> int:
 DEFAULT_MAX_ITERATIONS = 50
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+DEFAULT_DELEGATION_CATEGORY = "general"
+DEFAULT_CATEGORY_PROFILES = {
+    "general": {"max_concurrent_children": _DEFAULT_MAX_CONCURRENT_CHILDREN},
+    "research": {
+        "max_concurrent_children": 3,
+        "max_iterations": 25,
+        "enabled_tools": [
+            "read_file", "search_files", "session_search", "skills_list", "skill_view",
+            "web_search", "web_extract", "browser_navigate", "browser_snapshot",
+            "browser_console", "browser_scroll", "browser_get_images", "vision_analyze",
+            "browser_vision",
+        ],
+    },
+    "implementation": {
+        "max_concurrent_children": 2,
+        "max_iterations": 35,
+        "toolsets": ["terminal", "file"],
+    },
+    "verification": {
+        "max_concurrent_children": 3,
+        "max_iterations": 20,
+        "toolsets": ["terminal", "file", "web"],
+    },
+}
 
 
 def check_delegate_requirements() -> bool:
@@ -153,6 +179,143 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "delegation", "clarify", "memory", "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
+
+
+def _normalize_category_name(value: Optional[str]) -> str:
+    if not value or not isinstance(value, str):
+        return ""
+    return value.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _normalize_category_profile(raw: Any) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    profile: Dict[str, Any] = {}
+    if isinstance(raw.get("toolsets"), list):
+        profile["toolsets"] = [str(t).strip() for t in raw["toolsets"] if str(t).strip()]
+    if isinstance(raw.get("enabled_tools"), list):
+        profile["enabled_tools"] = [str(t).strip() for t in raw["enabled_tools"] if str(t).strip()]
+    for key in ("model", "provider", "base_url", "api_key", "reasoning_effort", "acp_command"):
+        if isinstance(raw.get(key), str) and raw.get(key).strip():
+            profile[key] = raw.get(key).strip()
+    if isinstance(raw.get("acp_args"), list):
+        profile["acp_args"] = [str(v) for v in raw["acp_args"]]
+    for key in ("max_iterations", "max_concurrent_children"):
+        if raw.get(key) is not None:
+            try:
+                profile[key] = max(1, int(raw.get(key)))
+            except (TypeError, ValueError):
+                logger.warning("Ignoring invalid delegation category %s=%r", key, raw.get(key))
+    return profile
+
+
+def _merge_category_profile(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(base or {})
+    for key, value in (override or {}).items():
+        if value in (None, "", [], {}):
+            continue
+        merged[key] = list(value) if isinstance(value, list) else value
+    return merged
+
+
+def _normalize_delegation_config(cfg: Any) -> Dict[str, Any]:
+    if not isinstance(cfg, dict):
+        cfg = {}
+    normalized = dict(cfg)
+    categories = {name: dict(profile) for name, profile in DEFAULT_CATEGORY_PROFILES.items()}
+    raw_categories = cfg.get("categories") if isinstance(cfg, dict) else None
+    if isinstance(raw_categories, dict):
+        for name, raw_profile in raw_categories.items():
+            normalized_name = _normalize_category_name(name)
+            if not normalized_name:
+                continue
+            categories[normalized_name] = _merge_category_profile(
+                categories.get(normalized_name, {}),
+                _normalize_category_profile(raw_profile),
+            )
+    normalized["categories"] = categories
+    default_category = _normalize_category_name(cfg.get("default_category")) if isinstance(cfg, dict) else ""
+    normalized["default_category"] = default_category or DEFAULT_DELEGATION_CATEGORY
+    return normalized
+
+
+def _resolve_task_category(task: Dict[str, Any], top_level_category: Optional[str], cfg: Dict[str, Any]) -> str:
+    explicit = _normalize_category_name(task.get("category"))
+    if explicit:
+        return explicit
+    inherited = _normalize_category_name(top_level_category)
+    if inherited:
+        return inherited
+    return _normalize_category_name(cfg.get("default_category")) or DEFAULT_DELEGATION_CATEGORY
+
+
+def _resolve_category_profile(cfg: Dict[str, Any], category: str) -> Dict[str, Any]:
+    categories = cfg.get("categories") if isinstance(cfg, dict) else {}
+    profile = categories.get(category) if isinstance(categories, dict) else None
+    if profile:
+        return _merge_category_profile({}, profile)
+    return _merge_category_profile({}, categories.get(DEFAULT_DELEGATION_CATEGORY, {})) if isinstance(categories, dict) else {}
+
+
+def _enforce_category_concurrency(
+    task_list: List[Dict[str, Any]],
+    cfg: Dict[str, Any],
+    top_level_category: Optional[str] = None,
+) -> Optional[str]:
+    categories = [_resolve_task_category(task, top_level_category, cfg) for task in task_list]
+    counts = Counter(categories)
+    for category, count in counts.items():
+        profile = _resolve_category_profile(cfg, category)
+        cap = profile.get("max_concurrent_children")
+        if cap is None:
+            continue
+        try:
+            cap_int = max(1, int(cap))
+        except (TypeError, ValueError):
+            continue
+        if count > cap_int:
+            return (
+                f"Too many '{category}' delegation tasks: {count} provided, but "
+                f"category policy caps this category at {cap_int}."
+            )
+    return None
+
+
+def _resolve_batch_concurrency_limit(
+    task_list: List[Dict[str, Any]],
+    top_level_category: Optional[str],
+    cfg: Dict[str, Any],
+) -> tuple[int, Optional[str]]:
+    """Return the effective concurrency limit for one delegation batch.
+
+    The root ``max_concurrent_children`` remains the default/global guardrail.
+    When every task is explicitly assigned to the same category, that category's
+    higher concurrency cap may override the root default for that batch.
+    """
+    base_limit = _get_max_concurrent_children()
+    if not task_list:
+        return base_limit, None
+
+    resolved_categories = [_resolve_task_category(task, top_level_category, cfg) for task in task_list]
+    if len(set(resolved_categories)) != 1:
+        return base_limit, None
+
+    category_name = resolved_categories[0]
+    explicit_top_level = _normalize_category_name(top_level_category)
+    explicit_per_task = all(_normalize_category_name(task.get("category")) == category_name for task in task_list)
+    if explicit_top_level != category_name and not explicit_per_task:
+        return base_limit, None
+
+    profile = _resolve_category_profile(cfg, category_name)
+    category_limit = profile.get("max_concurrent_children")
+    try:
+        category_limit = max(1, int(category_limit))
+    except (TypeError, ValueError):
+        return base_limit, None
+
+    if category_limit > base_limit:
+        return category_limit, category_name
+    return base_limit, None
 
 
 def _build_child_progress_callback(task_index: int, goal: str, parent_agent, task_count: int = 1) -> Optional[callable]:
@@ -267,10 +430,11 @@ def _build_child_agent(
     goal: str,
     context: Optional[str],
     toolsets: Optional[List[str]],
-    model: Optional[str],
-    max_iterations: int,
-    task_count: int,
-    parent_agent,
+    enabled_tools: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    task_count: int = 1,
+    parent_agent=None,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
@@ -317,6 +481,18 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+
+    child_enabled_tools = None
+    if enabled_tools is not None:
+        parent_tool_names = set(getattr(parent_agent, "valid_tool_names", set()) or [])
+        child_enabled_tools = sorted({
+            str(name).strip()
+            for name in enabled_tools
+            if isinstance(name, str)
+            and str(name).strip()
+            and str(name).strip() in parent_tool_names
+            and str(name).strip() not in DELEGATE_BLOCKED_TOOLS
+        })
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
@@ -386,6 +562,7 @@ def _build_child_agent(
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
+        enabled_tools=child_enabled_tools,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",
@@ -682,6 +859,7 @@ def delegate_task(
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    category: Optional[str] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -710,7 +888,7 @@ def delegate_task(
         })
 
     # Load config
-    cfg = _load_config()
+    cfg = _normalize_delegation_config(_load_config())
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
@@ -725,9 +903,19 @@ def delegate_task(
         return tool_error(str(exc))
 
     # Normalize to task list
-    max_children = _get_max_concurrent_children()
+    max_children, limit_category = _resolve_batch_concurrency_limit(
+        task_list=tasks or [],
+        top_level_category=category,
+        cfg=cfg,
+    )
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
+            if limit_category:
+                return tool_error(
+                    f"Too many tasks: {len(tasks)} provided, but category '{limit_category}' allows at most "
+                    f"{max_children} concurrent tasks in a single batch. Either reduce the task count or increase "
+                    f"delegation.categories.{limit_category}.max_concurrent_children in config.yaml."
+                )
             return tool_error(
                 f"Too many tasks: {len(tasks)} provided, but "
                 f"max_concurrent_children is {max_children}. "
@@ -737,7 +925,7 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "category": category}]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -748,6 +936,10 @@ def delegate_task(
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    category_error = _enforce_category_concurrency(task_list, cfg, top_level_category=category)
+    if category_error:
+        return tool_error(category_error)
 
     overall_start = time.monotonic()
     results = []
@@ -768,15 +960,22 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_category = _resolve_task_category(t, category, cfg)
+            category_profile = _resolve_category_profile(cfg, task_category)
+            merged_cfg = _merge_category_profile(cfg, category_profile)
+            category_creds = _resolve_delegation_credentials(merged_cfg, parent_agent)
+            task_toolsets = t.get("toolsets") or category_profile.get("toolsets") or toolsets
+            task_enabled_tools = category_profile.get("enabled_tools")
+            task_max_iter = int(category_profile.get("max_iterations") or effective_max_iter)
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
-                max_iterations=effective_max_iter, task_count=n_tasks, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_acp_command=t.get("acp_command") or acp_command,
-                override_acp_args=t.get("acp_args") or acp_args,
+                toolsets=task_toolsets, enabled_tools=task_enabled_tools, model=category_creds["model"] or creds["model"],
+                max_iterations=task_max_iter, task_count=n_tasks, parent_agent=parent_agent,
+                override_provider=category_creds["provider"] or creds["provider"], override_base_url=category_creds["base_url"] or creds["base_url"],
+                override_api_key=category_creds["api_key"] or creds["api_key"],
+                override_api_mode=category_creds["api_mode"] or creds["api_mode"],
+                override_acp_command=t.get("acp_command") or category_profile.get("acp_command") or acp_command,
+                override_acp_args=t.get("acp_args") or category_profile.get("acp_args") or acp_args,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -795,7 +994,7 @@ def delegate_task(
         completed_count = 0
         spinner_ref = getattr(parent_agent, '_delegate_spinner', None)
 
-        with ThreadPoolExecutor(max_workers=max_children) as executor:
+        with ThreadPoolExecutor(max_workers=min(max_children, n_tasks)) as executor:
             futures = {}
             for i, t, child in children:
                 future = executor.submit(
@@ -1001,6 +1200,33 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "api_mode": None,
         }
 
+    parent_provider = str(getattr(parent_agent, "provider", "") or "").strip()
+    parent_base_url = str(getattr(parent_agent, "base_url", "") or "").strip()
+    parent_api_key = str(getattr(parent_agent, "api_key", "") or "").strip()
+    parent_api_mode = str(getattr(parent_agent, "api_mode", "") or "").strip()
+    runtime_parent_providers = {
+        "openai-codex",
+        "nous",
+        "qwen-oauth",
+        "google-gemini-cli",
+        "copilot-acp",
+    }
+    if (
+        configured_provider == parent_provider
+        and configured_provider in runtime_parent_providers
+        and parent_base_url
+        and parent_api_key
+    ):
+        return {
+            "model": configured_model,
+            "provider": parent_provider,
+            "base_url": parent_base_url,
+            "api_key": parent_api_key,
+            "api_mode": parent_api_mode or None,
+            "command": getattr(parent_agent, "acp_command", None),
+            "args": list(getattr(parent_agent, "acp_args", []) or []),
+        }
+
     # Provider is configured — resolve full credentials
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -1034,24 +1260,30 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Prefer the live CLI runtime config when it was loaded for the current
+    HERMES_HOME. If ``cli`` was imported earlier under a different home/profile
+    (common in tests that isolate HERMES_HOME after collection), its module-level
+    ``CLI_CONFIG`` is stale and must not leak into delegation.
     """
     try:
-        from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
-            return cfg
+        import cli as cli_mod
+        from hermes_constants import get_hermes_home
+
+        current_home = Path(get_hermes_home()).resolve()
+        cli_home = getattr(cli_mod, "_hermes_home", None)
+        cli_home_resolved = Path(cli_home).resolve() if cli_home is not None else None
+        if cli_home_resolved == current_home:
+            cfg = getattr(cli_mod, "CLI_CONFIG", {}).get("delegation", {})
+            if cfg:
+                return _normalize_delegation_config(cfg)
     except Exception:
         pass
     try:
         from hermes_cli.config import load_config
         full = load_config()
-        return full.get("delegation", {})
+        return _normalize_delegation_config(full.get("delegation", {}))
     except Exception:
-        return {}
+        return _normalize_delegation_config({})
 
 
 # ---------------------------------------------------------------------------
@@ -1128,6 +1360,10 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
                         },
+                        "category": {
+                            "type": "string",
+                            "description": "Optional delegation policy category (e.g. research, implementation, verification). Category profiles can constrain concurrency, tool access, and model/runtime defaults.",
+                        },
                         "acp_command": {
                             "type": "string",
                             "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
@@ -1148,6 +1384,10 @@ DELEGATE_TASK_SCHEMA = {
                     "its own subagent with isolated context and terminal session. "
                     "When provided, top-level goal/context/toolsets are ignored."
                 ),
+            },
+            "category": {
+                "type": "string",
+                "description": "Optional delegation policy category (e.g. research, implementation, verification). Applies to all tasks unless a task overrides it.",
             },
             "max_iterations": {
                 "type": "integer",
@@ -1191,6 +1431,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        category=args.get("category"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,10 +16,12 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import copy
 import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import re
 import shlex
 import sys
 import threading
@@ -30,10 +32,16 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
-from agent.archetypes import resolve_archetype, resolve_archetype_defaults, resolve_specialist_mapping
+from agent.archetypes import get_tool_restrictions, resolve_archetype, resolve_archetype_defaults, resolve_specialist_mapping
 from agent.continuation_engine import apply_bounded_continuation_engine, build_continuation_snapshot
 from agent.prompt_builder import build_wave1_overlay_prompt_from_normalized, normalize_wave1_overlay_inputs
-from agent.route_categories import BUILTIN_ROUTE_CATEGORIES, DEFAULT_ROUTE_CATEGORY
+from agent.route_categories import (
+    BUILTIN_ROUTE_CATEGORIES,
+    DEFAULT_LITERAL_CATEGORY,
+    DEFAULT_ROUTE_CATEGORY,
+    resolve_literal_category,
+    resolve_route_category,
+)
 from agent.runtime_modes import DEFAULT_RUNTIME_MODE_NAME, resolve_runtime_mode
 from agent.task_contracts import (
     build_named_workflow_artifact,
@@ -260,6 +268,87 @@ def _normalize_named_string_list(values: Any) -> List[str]:
     return list(dict.fromkeys(str(value).strip() for value in values if str(value).strip()))
 
 
+def _canonicalize_named_agent_lookup_key(value: Any) -> str:
+    token = str(value or "").strip().lower()
+    if not token:
+        return ""
+    token = re.sub(r"[\s_]+", "-", token)
+    token = re.sub(r"-+", "-", token)
+    return token.strip("-")
+
+
+def _resolve_named_agent_config(
+    task: Dict[str, Any],
+    *,
+    registry: Dict[str, Dict[str, Any]],
+    top_level_agent: Optional[str] = None,
+) -> Dict[str, Any]:
+    requested_name = str(task.get("agent") or top_level_agent or "").strip()
+    if not requested_name:
+        return {}
+    if not isinstance(registry, dict):
+        raise ValueError(f"Unknown named agent '{requested_name}'.")
+
+    lookup_key = _canonicalize_named_agent_lookup_key(requested_name)
+    canonical_name = None
+    for raw_name, raw_entry in registry.items():
+        if not isinstance(raw_entry, dict):
+            continue
+        if _canonicalize_named_agent_lookup_key(raw_name) == lookup_key:
+            canonical_name = raw_name
+            break
+        for alias in _normalize_named_string_list(raw_entry.get("aliases")):
+            if _canonicalize_named_agent_lookup_key(alias) == lookup_key:
+                canonical_name = raw_name
+                break
+        if canonical_name:
+            break
+
+    resolved = registry.get(canonical_name) if canonical_name else None
+    if not isinstance(resolved, dict) or not resolved:
+        raise ValueError(f"Unknown named agent '{requested_name}'.")
+    return {"name": canonical_name, "requested_name": requested_name, **copy.deepcopy(resolved)}
+
+
+def _apply_named_agent_task_defaults(task: Dict[str, Any], named_agent: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(task, dict):
+        task = {}
+    if not isinstance(named_agent, dict) or not named_agent:
+        return dict(task)
+
+    merged = dict(task)
+    if named_agent.get("name") not in (None, ""):
+        merged["agent"] = copy.deepcopy(named_agent["name"])
+    for key in ("agent", "model", "provider", "archetype", "specialist", "route_category", "runtime_mode"):
+        if merged.get(key) in (None, "") and named_agent.get(key) not in (None, ""):
+            merged[key] = copy.deepcopy(named_agent[key])
+    return merged
+
+
+def _apply_named_agent_tool_restrictions(
+    *,
+    named_agent: Dict[str, Any],
+    toolsets: Optional[List[str]],
+    enabled_tools: Optional[List[str]],
+    parent_agent=None,
+) -> tuple[Optional[List[str]], Optional[List[str]]]:
+    if not isinstance(named_agent, dict) or not named_agent:
+        return toolsets, enabled_tools
+
+    blocked_tools = set(_normalize_named_string_list(named_agent.get("blocked_tools")))
+    allowed_tools = set(_normalize_named_string_list(named_agent.get("allowed_tools")))
+    if not blocked_tools and not allowed_tools:
+        return toolsets, enabled_tools
+
+    parent_tool_names = set(getattr(parent_agent, "valid_tool_names", set()) or [])
+    restricted_tools = set(_normalize_named_string_list(enabled_tools)) if enabled_tools is not None else set(parent_tool_names)
+    if allowed_tools:
+        restricted_tools &= allowed_tools
+    restricted_tools -= blocked_tools
+    restricted_tools -= set(DELEGATE_BLOCKED_TOOLS)
+    return toolsets, sorted(tool for tool in restricted_tools if tool in parent_tool_names)
+
+
 def _canonicalize_archetype_name(value: Optional[str]) -> str:
     return resolve_archetype(value).name
 
@@ -339,7 +428,13 @@ def _is_reviewer_like_resolution(resolved_inputs: Optional[Dict[str, Any]]) -> b
     if not isinstance(resolved_inputs, dict):
         return False
     specialist = str(resolved_inputs.get("specialist") or "").strip().lower()
-    return bool(specialist in _REVIEWER_SPECIALISTS)
+    archetype = str(
+        resolved_inputs.get("archetype")
+        or resolved_inputs.get("resolved_archetype")
+        or resolved_inputs.get("inferred_archetype")
+        or ""
+    ).strip().lower()
+    return bool(specialist in _REVIEWER_SPECIALISTS or archetype == "verifier")
 
 
 def _apply_named_role_tool_policy(
@@ -426,7 +521,8 @@ def _apply_named_role_completion_gate(
 
 
 def _resolve_route_category_entry(category_name: Optional[str], cfg: Dict[str, Any]) -> Dict[str, str]:
-    normalized_name = _normalize_category_name(category_name) or DEFAULT_ROUTE_CATEGORY
+    resolved_builtin = resolve_route_category(category_name)
+    normalized_name = str(category_name or resolved_builtin.name).strip() or resolved_builtin.name
     registry = cfg.get("route_categories") if isinstance(cfg, dict) else {}
     if isinstance(registry, dict) and normalized_name in registry and isinstance(registry[normalized_name], dict):
         entry = registry[normalized_name]
@@ -447,6 +543,26 @@ def _resolve_route_category_entry(category_name: Optional[str], cfg: Dict[str, A
         "intensity": builtin.intensity,
     }
 
+
+def _resolve_literal_category_name(category_name: Optional[str]) -> str:
+    return resolve_literal_category(category_name).name
+
+
+def _is_literal_category_input(category_name: Optional[str]) -> bool:
+    normalized_input = str(category_name or "").strip()
+    if not normalized_input:
+        return False
+    return _resolve_literal_category_name(normalized_input) != DEFAULT_LITERAL_CATEGORY or _normalize_category_name(normalized_input) in {
+        _normalize_category_name(DEFAULT_LITERAL_CATEGORY),
+        "visual",
+        "ultrabrain",
+        "deep",
+        "quick",
+        "writing",
+        "artistry",
+        "unspecified_low",
+        "unspecified_high",
+    }
 
 def _resolve_runtime_mode_entry(
     runtime_mode_name: Optional[str],
@@ -510,7 +626,7 @@ def _resolve_task_delegation_profile_details(
         }
 
     legacy_task_category = _normalize_category_name(task.get("category"))
-    if legacy_task_category:
+    if legacy_task_category and not _is_literal_category_input(task.get("category")):
         return {
             "value": legacy_task_category,
             "source": "legacy_task_category",
@@ -528,7 +644,7 @@ def _resolve_task_delegation_profile_details(
         }
 
     inherited_legacy_category = _normalize_category_name(top_level_category)
-    if inherited_legacy_category:
+    if inherited_legacy_category and not _is_literal_category_input(top_level_category):
         return {
             "value": inherited_legacy_category,
             "source": "inherited_legacy_category",
@@ -633,6 +749,16 @@ def _resolve_wave1_task_inputs(
             cfg.get("default_skills") or archetype_defaults.get("default_skills")
         )
 
+    explicit_task_category_input = str(task.get("category") or "").strip()
+    explicit_top_level_category_input = str(top_level_category or "").strip()
+    configured_category_input = str(cfg.get("category") or cfg.get("default_category") or "").strip()
+    resolved_literal_category = resolve_literal_category(
+        explicit_task_category_input
+        or explicit_top_level_category_input
+        or configured_category_input
+        or DEFAULT_LITERAL_CATEGORY
+    )
+
     explicit_route_category = _normalize_category_name(task.get("route_category"))
     explicit_top_level_route_category = _normalize_category_name(top_level_route_category)
     inherited_route_category = _normalize_category_name(inherited_parent_route_category)
@@ -640,6 +766,7 @@ def _resolve_wave1_task_inputs(
         explicit_route_category
         or explicit_top_level_route_category
         or ("" if archetype_override_present else inherited_route_category)
+        or _normalize_category_name(resolved_literal_category.route_category)
         or _normalize_category_name(default_route_category)
         or DEFAULT_ROUTE_CATEGORY
     )
@@ -689,6 +816,8 @@ def _resolve_wave1_task_inputs(
 
     explicit_named_workflow = task.get("named_workflow")
     resolved_named_workflow = None
+    inherited_named_workflow_invalid = False
+    named_workflow_source = None
     for source_name, candidate_named_workflow in (
         ("explicit", explicit_named_workflow),
         ("inherited", inherited_named_workflow),
@@ -697,10 +826,12 @@ def _resolve_wave1_task_inputs(
             continue
         try:
             resolved_named_workflow = validate_named_workflow_artifact(candidate_named_workflow).model_dump(by_alias=True)
+            named_workflow_source = source_name
             break
         except Exception as exc:
             if source_name == "explicit":
                 raise ValueError(f"Invalid named_workflow for delegated task '{task.get('goal', '')}': {exc}") from exc
+            inherited_named_workflow_invalid = True
             logger.debug(
                 "Ignoring invalid inherited named_workflow for delegated task '%s': %s",
                 task.get("goal", ""),
@@ -719,6 +850,7 @@ def _resolve_wave1_task_inputs(
     }
     normalized_overlay_inputs = normalize_wave1_overlay_inputs(
         archetype_name=resolved_archetype,
+        category=resolved_literal_category,
         route_category=resolved_route_category,
         delegation_profile=resolved_delegation_profile,
         runtime_mode=resolved_runtime_mode,
@@ -726,7 +858,7 @@ def _resolve_wave1_task_inputs(
         task_contract=resolved_task_contract,
         orchestration_hints=orchestration_hints,
     )
-    if resolved_named_workflow is None:
+    if resolved_named_workflow is None and not inherited_named_workflow_invalid:
         resolved_named_workflow = build_named_workflow_artifact(
             objective=str(task.get("goal") or "").strip(),
             specialist=resolved_specialist,
@@ -736,11 +868,18 @@ def _resolve_wave1_task_inputs(
             delegation_profile=normalized_overlay_inputs["delegation_profile"],
             task_contract=normalized_overlay_inputs["task_contract"],
         )
+        if resolved_named_workflow is not None:
+            named_workflow_source = "generated_from_resolved_inputs"
     overlay_prompt = build_wave1_overlay_prompt_from_normalized(normalized_overlay_inputs)
 
     return {
+        "named_agent": str(task.get("agent") or "").strip() or None,
         "specialist": resolved_specialist,
         "archetype": normalized_overlay_inputs["archetype"],
+        "category": resolved_literal_category.name,
+        "category_source": "explicit_or_inherited_category" if (
+            explicit_task_category_input or explicit_top_level_category_input
+        ) else "default_category",
         "route_category": normalized_overlay_inputs["route_category"],
         "route_category_definition": normalized_overlay_inputs["route_category_definition"],
         "route_category_source": "explicit_or_inherited_route_category" if (
@@ -753,6 +892,8 @@ def _resolve_wave1_task_inputs(
         "skills": normalized_overlay_inputs["skills"],
         "task_contract": normalized_overlay_inputs["task_contract"],
         "named_workflow": resolved_named_workflow,
+        "named_workflow_source": named_workflow_source,
+        "named_workflow_inherited_invalid": inherited_named_workflow_invalid,
         "runtime_mode": normalized_overlay_inputs["runtime_mode"],
         "runtime_mode_definition": normalized_overlay_inputs["runtime_mode_definition"],
         "permission_preset": orchestration_hints["permission_preset"],
@@ -827,11 +968,19 @@ def _normalize_delegation_config(cfg: Any) -> Dict[str, Any]:
     normalized["delegation_profiles"] = profiles
     normalized["categories"] = profiles
 
+    explicit_category_input = str(cfg.get("category") or cfg.get("default_category") or "").strip()
+    resolved_literal_category = resolve_literal_category(explicit_category_input)
+    normalized["category"] = resolved_literal_category.name
+    normalized["default_category"] = resolved_literal_category.name
+
     default_profile = _normalize_category_name(cfg.get("default_delegation_profile")) if isinstance(cfg, dict) else ""
-    default_category = _normalize_category_name(cfg.get("default_category")) if isinstance(cfg, dict) else ""
-    resolved_default_profile = default_profile or default_category or DEFAULT_DELEGATION_PROFILE
+    resolved_default_profile = default_profile or DEFAULT_DELEGATION_PROFILE
     normalized["default_delegation_profile"] = resolved_default_profile
-    normalized["default_category"] = resolved_default_profile
+
+    explicit_route_category = _normalize_category_name(cfg.get("route_category") or cfg.get("default_route_category"))
+    resolved_route_category = explicit_route_category or _normalize_category_name(resolved_literal_category.route_category) or DEFAULT_ROUTE_CATEGORY
+    normalized["route_category"] = resolved_route_category
+    normalized["default_route_category"] = resolved_route_category
     return normalized
 
 
@@ -860,6 +1009,94 @@ def _resolve_category_profile(cfg: Dict[str, Any], category: str) -> Dict[str, A
     if isinstance(profiles, dict):
         return _merge_category_profile({}, profiles.get(fallback_name, {}) or profiles.get(DEFAULT_DELEGATION_PROFILE, {}))
     return {}
+
+
+def _resolve_exact_category_profile(cfg: Dict[str, Any], category: str) -> Dict[str, Any]:
+    if not isinstance(cfg, dict):
+        return {}
+    normalized_category = _normalize_category_name(category)
+    if not normalized_category:
+        return {}
+    profiles = cfg.get("delegation_profiles") or cfg.get("categories") or {}
+    if not isinstance(profiles, dict):
+        return {}
+    profile = profiles.get(normalized_category)
+    if not isinstance(profile, dict):
+        return {}
+    return _merge_category_profile({}, profile)
+
+
+def _resolve_route_category_fallback_config(
+    cfg: Dict[str, Any],
+    fallback_name: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(cfg, dict):
+        return None
+
+    normalized_fallback_name = _normalize_category_name(fallback_name)
+    if not normalized_fallback_name:
+        return None
+    if normalized_fallback_name == "default":
+        return dict(cfg)
+
+    fallback_profile = _resolve_exact_category_profile(cfg, normalized_fallback_name)
+    if fallback_profile:
+        return _merge_category_profile(cfg, fallback_profile)
+
+    if normalized_fallback_name not in BUILTIN_ROUTE_CATEGORIES:
+        return None
+
+    route_categories = cfg.get("route_categories") if isinstance(cfg, dict) else None
+    route_category_profile = (
+        route_categories.get(normalized_fallback_name)
+        if isinstance(route_categories, dict)
+        else None
+    )
+    if isinstance(route_category_profile, dict):
+        return _merge_category_profile(cfg, route_category_profile)
+
+    return dict(cfg)
+
+
+def _resolve_route_category_fallback_models(
+    cfg: Dict[str, Any],
+    route_category_name: Optional[str],
+    parent_agent,
+) -> List[Dict[str, Any]]:
+    normalized_route_category = _normalize_category_name(route_category_name)
+    route_category = BUILTIN_ROUTE_CATEGORIES.get(normalized_route_category)
+    if route_category is None:
+        return []
+
+    fallback_chain: List[Dict[str, Any]] = []
+    seen_targets: set[tuple[Optional[str], Optional[str], Optional[str], Optional[str]]] = set()
+
+    for fallback_name in route_category.fallback_models:
+        fallback_cfg = _resolve_route_category_fallback_config(cfg, fallback_name)
+        if not fallback_cfg:
+            continue
+
+        try:
+            fallback_creds = _resolve_delegation_credentials(fallback_cfg, parent_agent)
+        except ValueError:
+            continue
+
+        target = (
+            fallback_creds.get("provider"),
+            fallback_creds.get("model"),
+            fallback_creds.get("base_url"),
+            fallback_creds.get("api_key"),
+        )
+        if target in seen_targets or not any(target[:3]):
+            continue
+        seen_targets.add(target)
+        fallback_chain.append({
+            key: value
+            for key, value in fallback_creds.items()
+            if key in {"provider", "model", "base_url", "api_key"} and value
+        })
+
+    return fallback_chain
 
 
 def _enforce_category_concurrency(
@@ -1051,8 +1288,10 @@ def _build_child_agent(
     toolsets: Optional[List[str]],
     enabled_tools: Optional[List[str]] = None,
     model: Optional[str] = None,
+    fallback_model: Optional[List[Dict[str, Any]] | Dict[str, Any]] = None,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
     task_count: int = 1,
+    task: Optional[Dict[str, Any]] = None,
     parent_agent=None,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
@@ -1062,6 +1301,9 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_service_tier: Optional[str] = None,
+    override_request_overrides: Optional[Dict[str, Any]] = None,
+    override_reasoning_config: Optional[Dict[str, Any]] = None,
     wave1_overlay_prompt: Optional[str] = None,
     delegate_resolution: Optional[Dict[str, Any]] = None,
 ):
@@ -1167,10 +1409,10 @@ def _build_child_agent(
 
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
-    child_reasoning = parent_reasoning
+    child_reasoning = copy.deepcopy(override_reasoning_config) if isinstance(override_reasoning_config, dict) else parent_reasoning
     try:
         delegation_cfg = _load_config()
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
+        delegation_effort = str((override_request_overrides or {}).get("reasoning_effort") or delegation_cfg.get("reasoning_effort") or "").strip()
         if delegation_effort:
             from hermes_constants import parse_reasoning_effort
             parsed = parse_reasoning_effort(delegation_effort)
@@ -1192,9 +1434,12 @@ def _build_child_agent(
         api_mode=effective_api_mode,
         acp_command=effective_acp_command,
         acp_args=effective_acp_args,
+        fallback_model=fallback_model,
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
+        service_tier=override_service_tier,
+        request_overrides=dict(override_request_overrides or {}),
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
         enabled_tools=child_enabled_tools,
@@ -1215,6 +1460,48 @@ def _build_child_agent(
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
     )
+
+    effective_archetype = None
+    effective_specialist = None
+    if isinstance(delegate_resolution, dict):
+        effective_archetype = str(delegate_resolution.get("archetype") or "").strip() or None
+        effective_specialist = str(delegate_resolution.get("specialist") or "").strip() or None
+
+    # Apply archetype/specialist tool restrictions at dispatch level
+    try:
+        blocked, allowed = get_tool_restrictions(
+            effective_archetype or 'generalist',
+            effective_specialist,
+        )
+    except Exception:
+        blocked, allowed = frozenset(), frozenset()
+
+    task = task if isinstance(task, dict) else {}
+    # Also check named-agent overrides for blocked/allowed tools
+    named_blocked = frozenset(task.get('_named_agent_blocked_tools', []))
+    named_allowed = frozenset(task.get('_named_agent_allowed_tools', []))
+    blocked = blocked | named_blocked
+    if named_allowed:
+        allowed = named_allowed if not allowed else (allowed & named_allowed)
+
+    if blocked or allowed:
+        filtered = []
+        for t in child.tools:
+            tool_name = t.get('function', {}).get('name', '') if isinstance(t, dict) else getattr(t, 'name', '')
+            if tool_name in blocked:
+                continue
+            if allowed and tool_name not in allowed:
+                continue
+            filtered.append(t)
+        removed = len(child.tools) - len(filtered)
+        if removed > 0:
+            logging.getLogger(__name__).info(
+                'Tool restriction applied: removed %d tools from child agent (blocked=%s, allowed=%s)',
+                removed, blocked or 'none', allowed or 'all'
+            )
+        child.tools = filtered
+        child.valid_tool_names = [t.get('function', {}).get('name', '') if isinstance(t, dict) else getattr(t, 'name', '') for t in filtered]
+
     child._print_fn = getattr(parent_agent, '_print_fn', None)
     child._delegate_resolution = dict(delegate_resolution or {})
     # Set delegation depth so children can't spawn grandchildren
@@ -1395,14 +1682,16 @@ def _run_single_child(
                         # Fallback for messages without tool_call_id
                         tool_trace[-1].update(result_meta)
 
-        # Determine exit reason
-        if status == "completed":
-            exit_reason = "completed"
-        elif continuation_state.get("exhausted"):
+        # Determine exit reason from raw completion signals rather than the
+        # synthesized status. The synthesized status can become "completed"
+        # for reporting purposes even when the child actually stopped because it
+        # ran out of iteration budget without completing.
+        completion_confirmed = (outcome_status == "completed" and not has_open_todos) or bool(completed)
+        if continuation_state.get("exhausted"):
             exit_reason = "continuation_exhausted"
         elif outcome_status == "interrupted" or interrupted:
             exit_reason = "interrupted"
-        elif completed:
+        elif completion_confirmed:
             exit_reason = "completed"
         else:
             exit_reason = "max_iterations"
@@ -1448,7 +1737,7 @@ def _run_single_child(
                 child_progress_cb(
                     "subagent.complete",
                     preview=summary[:160] if summary else entry.get("error", ""),
-                    status=status,
+                    status=entry.get("status") or status,
                     duration_seconds=duration,
                     summary=summary[:500] if summary else entry.get("error", ""),
                 )
@@ -1537,6 +1826,7 @@ def _build_persistent_launch_spec(
     acp_command: Optional[str],
     acp_args: Optional[List[str]],
     wave1_overlay_prompt: Optional[str],
+    fallback_model: Optional[List[Dict[str, Any]] | Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
@@ -1556,6 +1846,7 @@ def _build_persistent_launch_spec(
         "api_mode": creds.get("api_mode") or getattr(parent_agent, "api_mode", None),
         "acp_command": acp_command,
         "acp_args": list(acp_args or []),
+        "fallback_model": copy.deepcopy(fallback_model),
         "max_iterations": max_iterations,
         "wave1_overlay_prompt": wave1_overlay_prompt,
         "delegate_resolution": dict(resolved_inputs or {}),
@@ -1603,6 +1894,52 @@ def _build_persistent_parent_agent(launch_spec: Dict[str, Any]):
     return parent
 
 
+def _extract_delegate_open_todos(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+    continuation = dict(result.get("continuation") or {})
+    orchestration = dict(result.get("orchestration") or {})
+    open_todos = continuation.get("open_todos") or orchestration.get("activeTodos") or []
+    return [dict(item) for item in open_todos if isinstance(item, dict)]
+
+
+def _record_persistent_delegate_completion(
+    task_store: TaskStore,
+    task_id: str,
+    *,
+    result: Dict[str, Any],
+    runtime_mode: Optional[str],
+) -> None:
+    record = task_store.require_task(task_id)
+    continuation = dict(result.get("continuation") or {})
+    orchestration = dict(result.get("orchestration") or {})
+    open_todos = _extract_delegate_open_todos(result)
+
+    if result.get("status") == "completed" and not open_todos:
+        task_store.clear_continuation(task_id)
+        final_status = TaskStatus.completed
+        final_error = result.get("error")
+    else:
+        task_store.update_continuation(
+            task_id,
+            mode=continuation.get("mode") or record.runtime_mode or runtime_mode,
+            status="retry_requested" if open_todos else (continuation.get("status") or "resolved"),
+            open_todos=open_todos,
+            latest_response_preview=orchestration.get("responsePreview") or result.get("summary"),
+            last_outcome_status=continuation.get("final_outcome_status") or orchestration.get("outcomeStatus"),
+            resume_count=continuation.get("resume_count"),
+            attempt_count=continuation.get("attempt_count"),
+        )
+        final_status = TaskStatus.failed
+        final_error = result.get("error") or ("unfinished work remains" if open_todos else None)
+
+    task_store.record_result(
+        task_id,
+        status=final_status,
+        result=result,
+        summary=result.get("summary"),
+        error=final_error,
+    )
+
+
 def launch_persistent_delegate_task(task_id: str, *, store: Optional[TaskStore] = None, process_registry_obj=None) -> dict[str, Any]:
     return launch_background_delegate_task(
         task_id,
@@ -1630,6 +1967,7 @@ def run_persistent_delegate_task(task_id: str, store_root: Optional[str] = None)
             model=launch_spec.get("model"),
             max_iterations=int(launch_spec.get("max_iterations") or DEFAULT_MAX_ITERATIONS),
             task_count=1,
+            task=launch_spec,
             parent_agent=parent,
             override_provider=launch_spec.get("provider"),
             override_base_url=launch_spec.get("base_url"),
@@ -1637,34 +1975,16 @@ def run_persistent_delegate_task(task_id: str, store_root: Optional[str] = None)
             override_api_mode=launch_spec.get("api_mode"),
             override_acp_command=launch_spec.get("acp_command"),
             override_acp_args=launch_spec.get("acp_args"),
+            fallback_model=launch_spec.get("fallback_model"),
             wave1_overlay_prompt=launch_spec.get("wave1_overlay_prompt"),
             delegate_resolution=launch_spec.get("delegate_resolution") or record.resolved_inputs,
         )
         result = _run_single_child(0, record.goal, child=child, parent_agent=parent)
-        continuation = dict(result.get("continuation") or {})
-        orchestration = dict(result.get("orchestration") or {})
-        open_todos = continuation.get("open_todos") or orchestration.get("activeTodos") or []
-        if result.get("status") == "completed" and not open_todos:
-            task_store.clear_continuation(task_id)
-            final_status = TaskStatus.completed
-        else:
-            task_store.update_continuation(
-                task_id,
-                mode=continuation.get("mode") or record.runtime_mode,
-                status="retry_requested" if open_todos else "resolved",
-                open_todos=open_todos,
-                latest_response_preview=orchestration.get("responsePreview") or result.get("summary"),
-                last_outcome_status=continuation.get("final_outcome_status") or orchestration.get("outcomeStatus"),
-                resume_count=continuation.get("resume_count"),
-                attempt_count=continuation.get("attempt_count"),
-            )
-            final_status = TaskStatus.failed
-        task_store.record_result(
+        _record_persistent_delegate_completion(
+            task_store,
             task_id,
-            status=final_status,
             result=result,
-            summary=result.get("summary"),
-            error=result.get("error") or ("unfinished work remains" if open_todos else None),
+            runtime_mode=record.runtime_mode,
         )
     except Exception as exc:
         task_store.record_result(
@@ -1682,6 +2002,7 @@ def delegate_task(
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    agent: Optional[str] = None,
     category: Optional[str] = None,
     archetype: Optional[str] = None,
     route_category: Optional[str] = None,
@@ -1719,7 +2040,9 @@ def delegate_task(
         })
 
     # Load config
-    cfg = _normalize_delegation_config(_load_config())
+    full_cfg = _load_full_config()
+    cfg = _load_config()
+    named_agent_registry = full_cfg.get("agents", {}) if isinstance(full_cfg, dict) else {}
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
@@ -1777,6 +2100,7 @@ def delegate_task(
             "goal": goal,
             "context": context,
             "toolsets": toolsets,
+            "agent": agent,
             "acp_command": acp_command,
             "acp_args": acp_args,
         }]
@@ -1819,9 +2143,25 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task = dict(t)
+            resolved_named_agent = {}
+            try:
+                resolved_named_agent = _resolve_named_agent_config(
+                    task,
+                    registry=named_agent_registry,
+                    top_level_agent=agent,
+                )
+            except ValueError as exc:
+                return tool_error(str(exc))
+
+            if str(resolved_named_agent.get("mode") or "").strip().lower() == "disabled":
+                agent_name = resolved_named_agent.get("name") or task.get("agent") or agent
+                return tool_error(f"Named agent '{agent_name}' is disabled in config.")
+
+            task = _apply_named_agent_task_defaults(task, resolved_named_agent)
             try:
                 resolved_inputs = _resolve_wave1_task_inputs(
-                    t,
+                    task,
                     cfg=cfg,
                     top_level_archetype=explicit_top_level_archetype,
                     inherited_parent_archetype=inherited_parent_archetype,
@@ -1842,18 +2182,36 @@ def delegate_task(
             category_profile = _resolve_category_profile(cfg, resolved_profile)
             merged_cfg = _merge_category_profile(cfg, category_profile)
             category_creds = _resolve_delegation_credentials(merged_cfg, parent_agent)
+            if resolved_named_agent:
+                named_agent_cred_cfg = dict(merged_cfg)
+                for key in ("model", "provider", "base_url", "api_key"):
+                    value = resolved_named_agent.get(key)
+                    if value not in (None, ""):
+                        named_agent_cred_cfg[key] = value
+                category_creds = _resolve_delegation_credentials(named_agent_cred_cfg, parent_agent)
+            route_category_fallback_models = _resolve_route_category_fallback_models(
+                cfg,
+                resolved_inputs.get("route_category"),
+                parent_agent,
+            )
             contract_tool_policy = _resolve_contract_tool_requirements(
                 resolved_inputs.get("task_contract"),
                 parent_agent=parent_agent,
             )
             task_toolsets = list(dict.fromkeys(
-                _normalize_named_string_list(t.get("toolsets") or category_profile.get("toolsets") or toolsets)
+                _normalize_named_string_list(task.get("toolsets") or category_profile.get("toolsets") or toolsets)
                 + contract_tool_policy["toolsets"]
             )) or None
             task_enabled_tools = list(dict.fromkeys(
                 _normalize_named_string_list(category_profile.get("enabled_tools"))
                 + contract_tool_policy["enabled_tools"]
             )) or None
+            task_toolsets, task_enabled_tools = _apply_named_agent_tool_restrictions(
+                named_agent=resolved_named_agent,
+                toolsets=task_toolsets,
+                enabled_tools=task_enabled_tools,
+                parent_agent=parent_agent,
+            )
             task_toolsets, task_enabled_tools = _apply_named_role_tool_policy(
                 resolved_inputs=resolved_inputs,
                 toolsets=task_toolsets,
@@ -1873,21 +2231,25 @@ def delegate_task(
                 )
             )
             resolved_inputs["overlay_prompt"] = task_overlay_prompt
+            effective_agent_name = resolved_named_agent.get("name") or task.get("agent") or agent
+            if effective_agent_name:
+                resolved_inputs["agent"] = effective_agent_name
             child = _build_child_agent(
-                task_index=i, goal=t["goal"], context=t.get("context"),
+                task_index=i, goal=task["goal"], context=task.get("context"),
                 toolsets=task_toolsets, enabled_tools=task_enabled_tools, model=category_creds["model"] or creds["model"],
-                max_iterations=task_max_iter, task_count=n_tasks, parent_agent=parent_agent,
+                fallback_model=route_category_fallback_models or None,
+                max_iterations=task_max_iter, task_count=n_tasks, task=task, parent_agent=parent_agent,
                 override_provider=category_creds["provider"] or creds["provider"], override_base_url=category_creds["base_url"] or creds["base_url"],
                 override_api_key=category_creds["api_key"] or creds["api_key"],
                 override_api_mode=category_creds["api_mode"] or creds["api_mode"],
-                override_acp_command=t.get("acp_command") or category_profile.get("acp_command") or acp_command,
-                override_acp_args=t.get("acp_args") or category_profile.get("acp_args") or acp_args,
+                override_acp_command=task.get("acp_command") or category_profile.get("acp_command") or acp_command,
+                override_acp_args=task.get("acp_args") or category_profile.get("acp_args") or acp_args,
                 wave1_overlay_prompt=task_overlay_prompt,
                 delegate_resolution={key: value for key, value in resolved_inputs.items() if key != "overlay_prompt"},
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
-            children.append((i, t, child, task_max_iter, task_overlay_prompt))
+            children.append((i, task, child, task_max_iter, task_overlay_prompt))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -1916,6 +2278,7 @@ def delegate_task(
             acp_command=getattr(child, "acp_command", None),
             acp_args=getattr(child, "acp_args", None),
             wave1_overlay_prompt=task_overlay_prompt,
+            fallback_model=route_category_fallback_models or None,
         )
         store = TaskStore()
         record = store.create_task(
@@ -1966,13 +2329,11 @@ def delegate_task(
         store.transition_task(record.id, TaskStatus.running)
         try:
             result = _run_single_child(0, _t["goal"], child, parent_agent)
-            status = TaskStatus.completed if result.get("status") == "completed" else TaskStatus.failed
-            store.record_result(
+            _record_persistent_delegate_completion(
+                store,
                 record.id,
-                status=status,
                 result=result,
-                summary=result.get("summary"),
-                error=result.get("error"),
+                runtime_mode=record.runtime_mode,
             )
         except Exception as exc:
             store.record_result(
@@ -2267,8 +2628,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
-def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+def _load_full_config() -> dict:
+    """Load full Hermes config from CLI_CONFIG or persistent config.
 
     Prefer the live CLI runtime config when it was loaded for the current
     HERMES_HOME. If ``cli`` was imported earlier under a different home/profile
@@ -2283,17 +2644,23 @@ def _load_config() -> dict:
         cli_home = getattr(cli_mod, "_hermes_home", None)
         cli_home_resolved = Path(cli_home).resolve() if cli_home is not None else None
         if cli_home_resolved == current_home:
-            cfg = getattr(cli_mod, "CLI_CONFIG", {}).get("delegation", {})
-            if cfg:
-                return _normalize_delegation_config(cfg)
+            cfg = getattr(cli_mod, "CLI_CONFIG", {})
+            if isinstance(cfg, dict) and cfg:
+                return dict(cfg)
     except Exception:
         pass
     try:
         from hermes_cli.config import load_config
         full = load_config()
-        return _normalize_delegation_config(full.get("delegation", {}))
+        return dict(full) if isinstance(full, dict) else {}
     except Exception:
-        return _normalize_delegation_config({})
+        return {}
+
+
+def _load_config() -> dict:
+    """Load normalized delegation config from full Hermes config."""
+    full = _load_full_config()
+    return _normalize_delegation_config(full.get("delegation", {}))
 
 
 # ---------------------------------------------------------------------------
@@ -2358,6 +2725,10 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "agent": {
+                "type": "string",
+                "description": "Named agent to use from config agents registry. Applies blocked_tools, allowed_tools, model/provider overrides from the named agent config.",
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2365,6 +2736,10 @@ DELEGATE_TASK_SCHEMA = {
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {"type": "string", "description": "Task-specific context"},
+                        "agent": {
+                            "type": "string",
+                            "description": "Named agent to use from config agents registry. Applies blocked_tools, allowed_tools, model/provider overrides from the named agent config.",
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -2499,6 +2874,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        agent=args.get("agent"),
         category=args.get("category"),
         archetype=args.get("archetype"),
         route_category=args.get("route_category"),

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import os
 import re
 import difflib
+import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
@@ -400,6 +401,12 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
+
+    def _python_cmd(self) -> str:
+        """Return an available Python command inside the terminal environment."""
+        if self._has_command("python3"):
+            return "python3"
+        return "python"
     
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
@@ -742,13 +749,147 @@ class ShellFileOperations(FileOperations):
             bytes_written=bytes_written,
             dirs_created=dirs_created
         )
+
+    def conditional_write_file(self, path: str, content: str, expected_sha256: str) -> WriteResult:
+        """Write only if the current file snapshot still matches expected_sha256."""
+        path = self._expand_path(path)
+
+        if _is_write_denied(path):
+            return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+
+        parent = os.path.dirname(path)
+        dirs_created = False
+        if parent:
+            mkdir_cmd = f"mkdir -p {self._escape_shell_arg(parent)}"
+            mkdir_result = self._exec(mkdir_cmd)
+            if mkdir_result.exit_code == 0:
+                dirs_created = True
+
+        python_cmd = self._python_cmd()
+        script = r'''import hashlib, sys
+path = sys.argv[1]
+expected = sys.argv[2].lower()
+data = sys.stdin.buffer.read()
+try:
+    with open(path, "rb") as fh:
+        current = fh.read()
+except FileNotFoundError:
+    print(f"HASHLINE validation failed: file not found: {path}")
+    raise SystemExit(3)
+current_hash = hashlib.sha256(current).hexdigest()
+if current_hash != expected:
+    print(
+        f"HASHLINE validation failed for {path}: expected sha256:{expected}, "
+        f"got sha256:{current_hash}. Re-read the file before editing."
+    )
+    raise SystemExit(3)
+with open(path, "wb") as fh:
+    fh.write(data)
+'''
+        write_cmd = (
+            f"{python_cmd} -c {self._escape_shell_arg(script)} "
+            f"{self._escape_shell_arg(path)} {self._escape_shell_arg(str(expected_sha256 or '').lower())}"
+        )
+        write_result = self._exec(write_cmd, stdin_data=content)
+        if write_result.exit_code != 0:
+            message = write_result.stdout.strip() or f"Failed to write file: {path}"
+            return WriteResult(error=message)
+
+        return WriteResult(
+            bytes_written=len(content.encode("utf-8")),
+            dirs_created=dirs_created,
+        )
+
+    def conditional_delete_file(self, path: str, expected_sha256: str) -> WriteResult:
+        """Delete only if the current file snapshot still matches expected_sha256."""
+        path = self._expand_path(path)
+        if _is_write_denied(path):
+            return WriteResult(error=f"Delete denied: {path} is a protected path")
+
+        python_cmd = self._python_cmd()
+        script = r'''import hashlib, os, sys
+path = sys.argv[1]
+expected = sys.argv[2].lower()
+try:
+    with open(path, "rb") as fh:
+        current = fh.read()
+except FileNotFoundError:
+    print(f"HASHLINE validation failed: file not found: {path}")
+    raise SystemExit(3)
+current_hash = hashlib.sha256(current).hexdigest()
+if current_hash != expected:
+    print(
+        f"HASHLINE validation failed for {path}: expected sha256:{expected}, "
+        f"got sha256:{current_hash}. Re-read the file before editing."
+    )
+    raise SystemExit(3)
+os.remove(path)
+'''
+        delete_cmd = (
+            f"{python_cmd} -c {self._escape_shell_arg(script)} "
+            f"{self._escape_shell_arg(path)} {self._escape_shell_arg(str(expected_sha256 or '').lower())}"
+        )
+        delete_result = self._exec(delete_cmd)
+        if delete_result.exit_code != 0:
+            message = delete_result.stdout.strip() or f"Failed to delete {path}"
+            return WriteResult(error=message)
+        return WriteResult()
+
+    def conditional_move_file(self, src: str, dst: str, expected_sha256: str) -> WriteResult:
+        """Move only if the source file snapshot still matches expected_sha256."""
+        src = self._expand_path(src)
+        dst = self._expand_path(dst)
+        for p in (src, dst):
+            if _is_write_denied(p):
+                return WriteResult(error=f"Move denied: {p} is a protected path")
+
+        parent = os.path.dirname(dst)
+        if parent:
+            mkdir_cmd = f"mkdir -p {self._escape_shell_arg(parent)}"
+            mkdir_result = self._exec(mkdir_cmd)
+            if mkdir_result.exit_code != 0:
+                return WriteResult(error=f"Failed to prepare destination directory for {dst}: {mkdir_result.stdout}")
+
+        python_cmd = self._python_cmd()
+        script = r'''import hashlib, os, shutil, sys
+src = sys.argv[1]
+dst = sys.argv[2]
+expected = sys.argv[3].lower()
+try:
+    with open(src, "rb") as fh:
+        current = fh.read()
+except FileNotFoundError:
+    print(f"HASHLINE validation failed: file not found: {src}")
+    raise SystemExit(3)
+current_hash = hashlib.sha256(current).hexdigest()
+if current_hash != expected:
+    print(
+        f"HASHLINE validation failed for {src}: expected sha256:{expected}, "
+        f"got sha256:{current_hash}. Re-read the file before editing."
+    )
+    raise SystemExit(3)
+if os.path.exists(dst):
+    print(f"Failed to move {src} -> {dst}: destination already exists")
+    raise SystemExit(2)
+shutil.move(src, dst)
+'''
+        move_cmd = (
+            f"{python_cmd} -c {self._escape_shell_arg(script)} "
+            f"{self._escape_shell_arg(src)} {self._escape_shell_arg(dst)} "
+            f"{self._escape_shell_arg(str(expected_sha256 or '').lower())}"
+        )
+        move_result = self._exec(move_cmd)
+        if move_result.exit_code != 0:
+            message = move_result.stdout.strip() or f"Failed to move {src} -> {dst}"
+            return WriteResult(error=message)
+        return WriteResult()
     
     # =========================================================================
     # PATCH Implementation (Replace Mode)
     # =========================================================================
     
     def patch_replace(self, path: str, old_string: str, new_string: str,
-                      replace_all: bool = False) -> PatchResult:
+                      replace_all: bool = False, expected_sha256: str = None) -> PatchResult:
         """
         Replace text in a file using fuzzy matching.
 
@@ -776,6 +917,15 @@ class ShellFileOperations(FileOperations):
             return PatchResult(error=f"Failed to read file: {path}")
         
         content = read_result.stdout
+        if expected_sha256:
+            current_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            if current_hash.lower() != str(expected_sha256).lower():
+                return PatchResult(
+                    error=(
+                        f"HASHLINE validation failed for {path}: expected sha256:{expected_sha256}, "
+                        f"got sha256:{current_hash}. Re-read the file before editing."
+                    )
+                )
         
         # Import and use fuzzy matching
         from tools.fuzzy_match import fuzzy_find_and_replace
@@ -791,7 +941,10 @@ class ShellFileOperations(FileOperations):
             return PatchResult(error=f"Could not find match for old_string in {path}")
         
         # Write back
-        write_result = self.write_file(path, new_content)
+        if expected_sha256:
+            write_result = self.conditional_write_file(path, new_content, expected_sha256)
+        else:
+            write_result = self.write_file(path, new_content)
         if write_result.error:
             return PatchResult(error=f"Failed to write changes: {write_result.error}")
         
@@ -808,7 +961,7 @@ class ShellFileOperations(FileOperations):
             lint=lint_result.to_dict() if lint_result else None
         )
     
-    def patch_v4a(self, patch_content: str) -> PatchResult:
+    def patch_v4a(self, patch_content: str, expected_hashes: Optional[Dict[str, str]] = None) -> PatchResult:
         """
         Apply a V4A format patch.
         
@@ -835,7 +988,7 @@ class ShellFileOperations(FileOperations):
             return PatchResult(error=f"Failed to parse patch: {parse_error}")
         
         # Apply operations
-        result = apply_v4a_operations(operations, self)
+        result = apply_v4a_operations(operations, self, expected_hashes=expected_hashes)
         return result
     
     def _check_lint(self, path: str) -> LintResult:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,21 +8,22 @@ breaking existing file-tool callers.
 """
 
 import errno
-import hashlib
 import json
 import logging
 import os
-import re
 import threading
 from pathlib import Path
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import ShellFileOperations
+from tools.patch_parser import (
+    get_touched_paths,
+    parse_patch_hashlines,
+    parse_replace_hashline,
+    parse_v4a_patch,
+)
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
-
-_REPLACE_HASHLINE_RE = re.compile(r"^\s*#\s*HASHLINE\s+sha256:([0-9a-fA-F]{64})\s*$")
-_PATCH_HASHLINE_RE = re.compile(r"^\*\*\*\s+Hashline:\s+(.+?)\s+sha256:([0-9a-fA-F]{64})\s*$")
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
@@ -128,58 +129,14 @@ def _check_sensitive_path(filepath: str) -> str | None:
     return None
 
 
-def _compute_file_sha256(path: str) -> str:
-    digest = hashlib.sha256()
-    with open(os.path.expanduser(path), "rb") as fh:
-        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+def _extract_replace_hashline(payload: str) -> tuple[str | None, str, str | None]:
+    expectation, stripped_payload, error = parse_replace_hashline(payload)
+    return (expectation.expected_sha256 if expectation else None), stripped_payload, error
 
 
-def _extract_replace_hashline(payload: str) -> tuple[str | None, str]:
-    if not isinstance(payload, str):
-        return None, payload
-    if "\n" in payload:
-        first_line, remainder = payload.split("\n", 1)
-    else:
-        first_line, remainder = payload, ""
-    match = _REPLACE_HASHLINE_RE.match(first_line)
-    if not match:
-        return None, payload
-    return match.group(1).lower(), remainder
-
-
-def _extract_patch_hashlines(payload: str) -> tuple[dict[str, str], str]:
-    if not isinstance(payload, str):
-        return {}, payload
-    expected_hashes: dict[str, str] = {}
-    kept_lines: list[str] = []
-    for line in payload.splitlines():
-        match = _PATCH_HASHLINE_RE.match(line)
-        if match:
-            expected_hashes[match.group(1).strip()] = match.group(2).lower()
-            continue
-        kept_lines.append(line)
-    rebuilt = "\n".join(kept_lines)
-    if payload.endswith("\n"):
-        rebuilt += "\n"
-    return expected_hashes, rebuilt
-
-
-def _validate_hashline_expectation(path: str, expected_sha256: str) -> str | None:
-    expanded = os.path.expanduser(path)
-    if not os.path.exists(expanded):
-        return f"HASHLINE validation failed: file not found: {path}"
-    try:
-        current_hash = _compute_file_sha256(expanded)
-    except Exception as exc:
-        return f"HASHLINE validation failed for {path}: {exc}"
-    if current_hash.lower() != str(expected_sha256 or "").lower():
-        return (
-            f"HASHLINE validation failed for {path}: expected sha256:{expected_sha256}, "
-            f"got sha256:{current_hash}. Re-read the file before editing."
-        )
-    return None
+def _extract_patch_hashlines(payload: str) -> tuple[dict[str, str], str, str | None]:
+    expectations, stripped_payload, error = parse_patch_hashlines(payload)
+    return {path: expectation.expected_sha256 for path, expectation in expectations.items()}, stripped_payload, error
 
 
 def _is_expected_write_exception(exc: Exception) -> bool:
@@ -707,35 +664,31 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     """Patch a file using replace mode or V4A patch format."""
     old_string_hash = None
     patch_hashes: dict[str, str] = {}
+    patch_operations = []
+
     if mode == "replace" and isinstance(old_string, str):
-        old_string_hash, old_string = _extract_replace_hashline(old_string)
+        old_string_hash, old_string, replace_hashline_error = _extract_replace_hashline(old_string)
+        if replace_hashline_error:
+            return tool_error(replace_hashline_error)
     elif mode == "patch" and isinstance(patch, str):
-        patch_hashes, patch = _extract_patch_hashlines(patch)
-    # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
+        patch_hashes, patch, patch_hashline_error = _extract_patch_hashlines(patch)
+        if patch_hashline_error:
+            return tool_error(patch_hashline_error)
+        patch_operations, parse_error = parse_v4a_patch(patch)
+        if parse_error:
+            return tool_error(f"Failed to parse patch: {parse_error}")
+
+    # Check sensitive paths for both replace (explicit path) and V4A patch operations.
     _paths_to_check = []
     if path:
         _paths_to_check.append(path)
-    if mode == "patch" and patch:
-        import re as _re
-        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
-            _paths_to_check.append(_m.group(1).strip())
+    if mode == "patch" and patch_operations:
+        _paths_to_check.extend(get_touched_paths(patch_operations))
     for _p in _paths_to_check:
         sensitive_err = _check_sensitive_path(_p)
         if sensitive_err:
             return tool_error(sensitive_err)
-    if mode == "replace" and old_string_hash:
-        hashline_err = _validate_hashline_expectation(path or "", old_string_hash)
-        if hashline_err:
-            return tool_error(hashline_err)
-    if mode == "patch" and patch_hashes:
-        for _p in _paths_to_check:
-            if _p not in patch_hashes:
-                return tool_error(
-                    f"HASHLINE validation failed: missing '*** Hashline: {_p} sha256:...' for patched file {_p}"
-                )
-            hashline_err = _validate_hashline_expectation(_p, patch_hashes[_p])
-            if hashline_err:
-                return tool_error(hashline_err)
+
     try:
         # Check staleness for all files this patch will touch.
         stale_warnings = []
@@ -745,20 +698,29 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 stale_warnings.append(_sw)
 
         file_ops = _get_file_ops(task_id)
-        
+
         if mode == "replace":
             if not path:
                 return tool_error("path required")
             if old_string is None or new_string is None:
                 return tool_error("old_string and new_string required")
-            result = file_ops.patch_replace(path, old_string, new_string, replace_all)
+            patch_kwargs = {}
+            if old_string_hash:
+                patch_kwargs["expected_sha256"] = old_string_hash
+            result = file_ops.patch_replace(
+                path,
+                old_string,
+                new_string,
+                replace_all,
+                **patch_kwargs,
+            )
         elif mode == "patch":
             if not patch:
                 return tool_error("patch content required")
-            result = file_ops.patch_v4a(patch)
+            result = file_ops.patch_v4a(patch, expected_hashes=patch_hashes or None)
         else:
             return tool_error(f"Unknown mode: {mode}")
-        
+
         result_dict = result.to_dict()
         if stale_warnings:
             result_dict["_warning"] = stale_warnings[0] if len(stale_warnings) == 1 else " | ".join(stale_warnings)
@@ -890,7 +852,7 @@ WRITE_FILE_SCHEMA = {
 
 PATCH_SCHEMA = {
     "name": "patch",
-    "description": "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. Returns a unified diff. Auto-runs syntax checks after editing.\n\nReplace mode (default): find a unique string and replace it.\nPatch mode: apply V4A multi-file patches for bulk changes.",
+    "description": "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. Returns a unified diff. Auto-runs syntax checks after editing.\n\nHermes-native anchored safe-edit contract: in replace mode, prefix old_string with '# HASHLINE sha256:<64-hex-digest>' to require the file snapshot to match before and during the write. In patch mode, add '*** Hashline: path/to/file sha256:<64-hex-digest>' for each existing file being updated, deleted, or moved. Malformed or stale anchors are rejected before mutation.\n\nReplace mode (default): find a unique string and replace it.\nPatch mode: apply V4A multi-file patches for bulk changes.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
-"""File Tools Module - LLM agent file manipulation tools."""
+"""File tools for local file retrieval, search, and editing.
+
+These tools remain general-purpose filesystem primitives, but they are also
+part of Hermes's built-in ``repo-code-knowledge`` surface. Their wording and
+result metadata should therefore make local repo/code grounding obvious without
+breaking existing file-tool callers.
+"""
 
 import errno
+import hashlib
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 from tools.binary_extensions import has_binary_extension
@@ -13,6 +21,8 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+_REPLACE_HASHLINE_RE = re.compile(r"^\s*#\s*HASHLINE\s+sha256:([0-9a-fA-F]{64})\s*$")
+_PATCH_HASHLINE_RE = re.compile(r"^\*\*\*\s+Hashline:\s+(.+?)\s+sha256:([0-9a-fA-F]{64})\s*$")
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
@@ -115,6 +125,60 @@ def _check_sensitive_path(filepath: str) -> str | None:
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
+    return None
+
+
+def _compute_file_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(os.path.expanduser(path), "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _extract_replace_hashline(payload: str) -> tuple[str | None, str]:
+    if not isinstance(payload, str):
+        return None, payload
+    if "\n" in payload:
+        first_line, remainder = payload.split("\n", 1)
+    else:
+        first_line, remainder = payload, ""
+    match = _REPLACE_HASHLINE_RE.match(first_line)
+    if not match:
+        return None, payload
+    return match.group(1).lower(), remainder
+
+
+def _extract_patch_hashlines(payload: str) -> tuple[dict[str, str], str]:
+    if not isinstance(payload, str):
+        return {}, payload
+    expected_hashes: dict[str, str] = {}
+    kept_lines: list[str] = []
+    for line in payload.splitlines():
+        match = _PATCH_HASHLINE_RE.match(line)
+        if match:
+            expected_hashes[match.group(1).strip()] = match.group(2).lower()
+            continue
+        kept_lines.append(line)
+    rebuilt = "\n".join(kept_lines)
+    if payload.endswith("\n"):
+        rebuilt += "\n"
+    return expected_hashes, rebuilt
+
+
+def _validate_hashline_expectation(path: str, expected_sha256: str) -> str | None:
+    expanded = os.path.expanduser(path)
+    if not os.path.exists(expanded):
+        return f"HASHLINE validation failed: file not found: {path}"
+    try:
+        current_hash = _compute_file_sha256(expanded)
+    except Exception as exc:
+        return f"HASHLINE validation failed for {path}: {exc}"
+    if current_hash.lower() != str(expected_sha256 or "").lower():
+        return (
+            f"HASHLINE validation failed for {path}: expected sha256:{expected_sha256}, "
+            f"got sha256:{current_hash}. Re-read the file before editing."
+        )
     return None
 
 
@@ -500,6 +564,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
 
+        result_dict = _annotate_repo_code_knowledge_result(
+            result_dict,
+            operation="read_file",
+        )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -595,6 +663,20 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     return None
 
 
+def _annotate_repo_code_knowledge_result(result_dict: dict, *, operation: str) -> dict:
+    """Add additive repo/code knowledge metadata to file-tool results."""
+    result_dict.setdefault(
+        "knowledge_surface",
+        {
+            "surface": "repo-code-knowledge",
+            "surface_role": "local-file-grounding",
+            "operation": operation,
+            "source": "builtin",
+        },
+    )
+    return result_dict
+
+
 def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     """Write content to a file."""
     sensitive_err = _check_sensitive_path(path)
@@ -623,6 +705,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default") -> str:
     """Patch a file using replace mode or V4A patch format."""
+    old_string_hash = None
+    patch_hashes: dict[str, str] = {}
+    if mode == "replace" and isinstance(old_string, str):
+        old_string_hash, old_string = _extract_replace_hashline(old_string)
+    elif mode == "patch" and isinstance(patch, str):
+        patch_hashes, patch = _extract_patch_hashlines(patch)
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     if path:
@@ -635,6 +723,19 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p)
         if sensitive_err:
             return tool_error(sensitive_err)
+    if mode == "replace" and old_string_hash:
+        hashline_err = _validate_hashline_expectation(path or "", old_string_hash)
+        if hashline_err:
+            return tool_error(hashline_err)
+    if mode == "patch" and patch_hashes:
+        for _p in _paths_to_check:
+            if _p not in patch_hashes:
+                return tool_error(
+                    f"HASHLINE validation failed: missing '*** Hashline: {_p} sha256:...' for patched file {_p}"
+                )
+            hashline_err = _validate_hashline_expectation(_p, patch_hashes[_p])
+            if hashline_err:
+                return tool_error(hashline_err)
     try:
         # Check staleness for all files this patch will touch.
         stale_warnings = []
@@ -725,7 +826,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content)
-        result_dict = result.to_dict()
+        result_dict = _annotate_repo_code_knowledge_result(
+            result.to_dict(),
+            operation="search_files",
+        )
 
         if count >= 3:
             result_dict["_warning"] = (
@@ -759,7 +863,7 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. This is also a built-in repo/code knowledge primitive for local source grounding. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -803,7 +907,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. This is also a built-in repo/code knowledge primitive for local source retrieval and codebase grounding. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/lsp_tools.py
+++ b/tools/lsp_tools.py
@@ -93,6 +93,19 @@ _DIAGNOSTIC_SEVERITIES = {
 class LspProtocolError(RuntimeError):
     """Raised when an LSP server returns malformed or error responses."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        method: str | None = None,
+        code: int | str | None = None,
+        detail: str | None = None,
+    ):
+        super().__init__(message)
+        self.method = method
+        self.code = code
+        self.detail = detail or message
+
 
 class _LspSession:
     def __init__(self, command: list[str], cwd: str):
@@ -160,7 +173,12 @@ class _LspSession:
                 error = message["error"] or {}
                 code = error.get("code", "unknown")
                 detail = error.get("message", "Unknown LSP error")
-                raise LspProtocolError(f"LSP request failed ({method}, code={code}): {detail}")
+                raise LspProtocolError(
+                    f"LSP request failed ({method}, code={code}): {detail}",
+                    method=method,
+                    code=code,
+                    detail=detail,
+                )
             return message.get("result")
 
     def shutdown(self) -> None:
@@ -227,6 +245,59 @@ LSP_DIAGNOSTICS_SCHEMA = {
             "server_command": {"type": "string", "description": "Optional explicit server command"},
         },
         "required": ["path"],
+    },
+}
+
+LSP_PREPARE_RENAME_SCHEMA = {
+    "name": "lsp_prepare_rename",
+    "description": "Validate whether a symbol can be renamed at a zero-based line/character position using a local LSP server. Returns the validated rename range and placeholder when the server supports prepareRename. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "line": {"type": "integer", "description": "Zero-based line number"},
+            "character": {"type": "integer", "description": "Zero-based character offset on the line"},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path", "line", "character"],
+    },
+}
+
+LSP_REFERENCES_SCHEMA = {
+    "name": "lsp_references",
+    "description": "Find references at a zero-based line/character position using a local LSP server. Returns structured locations suitable for rename/reference verification. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "line": {"type": "integer", "description": "Zero-based line number"},
+            "character": {"type": "integer", "description": "Zero-based character offset on the line"},
+            "include_declaration": {"type": "boolean", "description": "Whether declaration locations should be included", "default": True},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path", "line", "character"],
+    },
+}
+
+LSP_RENAME_SCHEMA = {
+    "name": "lsp_rename",
+    "description": "Rename a symbol at a zero-based line/character position using a local LSP server. Hermes validates prepareRename first, then returns a structured workspace edit preview instead of mutating files directly. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "line": {"type": "integer", "description": "Zero-based line number"},
+            "character": {"type": "integer", "description": "Zero-based character offset on the line"},
+            "new_name": {"type": "string", "description": "New identifier name to request from the LSP server"},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path", "line", "character", "new_name"],
     },
 }
 
@@ -393,6 +464,128 @@ def _normalize_diagnostics(result: Any) -> list[dict[str, Any]]:
     return normalized
 
 
+def _offset_for_position(text: str, line: int, character: int) -> int:
+    if line < 0 or character < 0:
+        raise ValueError("LSP position must use non-negative line and character values")
+    lines = text.splitlines(keepends=True)
+    if text:
+        logical_line_count = len(lines)
+    else:
+        lines = [""]
+        logical_line_count = 1
+    if line >= logical_line_count:
+        raise ValueError(f"LSP position line {line} is outside the document")
+    prefix = sum(len(lines[index]) for index in range(min(line, len(lines))))
+    current_line = lines[line] if line < len(lines) else ""
+    line_text = current_line.rstrip("\r\n")
+    if character > len(line_text):
+        raise ValueError(f"LSP position character {character} is outside line {line}")
+    return prefix + character
+
+
+def _apply_text_edits(text: str, edits: list[dict[str, Any]]) -> str:
+    replacements = []
+    for edit in edits:
+        edit_range = edit.get("range") or {}
+        start = edit_range.get("start") or {}
+        end = edit_range.get("end") or {}
+        start_offset = _offset_for_position(text, start.get("line", 0), start.get("character", 0))
+        end_offset = _offset_for_position(text, end.get("line", 0), end.get("character", 0))
+        if end_offset < start_offset:
+            raise ValueError("LSP edit range end precedes start")
+        replacements.append((start_offset, end_offset, edit.get("new_text", "")))
+
+    updated = text
+    for start_offset, end_offset, new_text in sorted(replacements, key=lambda item: (item[0], item[1]), reverse=True):
+        updated = updated[:start_offset] + new_text + updated[end_offset:]
+    return updated
+
+
+def _normalize_prepare_rename_result(result: Any) -> dict[str, Any]:
+    if result in (None, False):
+        return {"can_rename": False}
+    if isinstance(result, dict) and "range" in result:
+        return {
+            "can_rename": True,
+            "range": _normalize_range(result.get("range")),
+            "placeholder": result.get("placeholder"),
+            "default_behavior": result.get("defaultBehavior"),
+        }
+    return {
+        "can_rename": True,
+        "range": _normalize_range(result),
+        "placeholder": None,
+        "default_behavior": None,
+    }
+
+
+def _normalize_text_edit(edit: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "range": _normalize_range(edit.get("range")),
+        "new_text": edit.get("newText", ""),
+    }
+
+
+def _normalize_workspace_edit(result: Any) -> dict[str, Any]:
+    workspace_edit = result if isinstance(result, dict) else {}
+    changes = []
+    preview_by_path: dict[str, str] = {}
+    touched_paths: set[str] = set()
+    edit_count = 0
+    resource_operations = []
+
+    for uri, edits in (workspace_edit.get("changes") or {}).items():
+        path = _uri_to_path(uri)
+        normalized_edits = [_normalize_text_edit(edit) for edit in edits or [] if isinstance(edit, dict)]
+        edit_count += len(normalized_edits)
+        if path:
+            touched_paths.add(path)
+            source_path = Path(path)
+            if source_path.exists():
+                preview_by_path[path] = _apply_text_edits(_read_source(source_path), normalized_edits)
+        changes.append({"uri": uri, "path": path, "edits": normalized_edits})
+
+    document_changes = []
+    for change in workspace_edit.get("documentChanges") or []:
+        if not isinstance(change, dict):
+            continue
+        kind = change.get("kind")
+        if kind:
+            resource_operations.append(change)
+            document_changes.append({"kind": kind, **{k: v for k, v in change.items() if k != "kind"}})
+            continue
+
+        text_document = change.get("textDocument") or {}
+        uri = text_document.get("uri")
+        path = _uri_to_path(uri)
+        normalized_edits = [_normalize_text_edit(edit) for edit in change.get("edits", []) if isinstance(edit, dict)]
+        edit_count += len(normalized_edits)
+        if path:
+            touched_paths.add(path)
+            source_path = Path(path)
+            if source_path.exists():
+                preview_by_path[path] = _apply_text_edits(_read_source(source_path), normalized_edits)
+        document_changes.append(
+            {
+                "kind": "textDocumentEdit",
+                "uri": uri,
+                "path": path,
+                "version": text_document.get("version"),
+                "edits": normalized_edits,
+            }
+        )
+
+    return {
+        "changes": changes,
+        "document_changes": document_changes,
+        "resource_operations": resource_operations,
+        "touched_paths": sorted(touched_paths),
+        "edit_count": edit_count,
+        "resource_operation_count": len(resource_operations),
+        "preview_by_path": preview_by_path,
+    }
+
+
 def _read_source(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -409,9 +602,81 @@ def _build_initialize_params(workspace_root: Path) -> dict[str, Any]:
                 "definition": {"dynamicRegistration": False},
                 "documentSymbol": {"hierarchicalDocumentSymbolSupport": True},
                 "diagnostic": {"dynamicRegistration": False},
+                "references": {"dynamicRegistration": False},
+                "rename": {"dynamicRegistration": False, "prepareSupport": True},
             }
         },
     }
+
+
+def _build_missing_server_error(
+    *,
+    source_path: Path,
+    language_id: str,
+    requested_method: str,
+    candidates: list[str],
+) -> str:
+    if not candidates:
+        return tool_error(
+            f"LSP auto-detect does not support language '{language_id}'",
+            path=str(source_path),
+            language=language_id,
+            requested_method=requested_method,
+            failure_kind="unsupported_language",
+            supported_languages=sorted(_AUTO_DETECT_COMMANDS.keys()),
+            candidate_commands=[],
+        )
+    return tool_error(
+        f"No LSP server found for language '{language_id}'",
+        path=str(source_path),
+        language=language_id,
+        requested_method=requested_method,
+        failure_kind="missing_server",
+        candidate_commands=candidates,
+    )
+
+
+def _is_unsupported_capability_error(error: LspProtocolError) -> bool:
+    detail = (error.detail or str(error)).lower()
+    if error.code == -32601:
+        return True
+    return any(
+        needle in detail
+        for needle in (
+            "method not found",
+            "unsupported method",
+            "unsupported capability",
+            "does not support",
+            "not supported",
+        )
+    )
+
+
+def _build_protocol_error(
+    error: LspProtocolError,
+    *,
+    path: str,
+    requested_method: str,
+    language: str | None = None,
+    server_command: list[str] | None = None,
+    workspace_root: str | None = None,
+) -> str:
+    extra: dict[str, Any] = {
+        "path": path,
+        "requested_method": requested_method,
+        "lsp_error_message": error.detail,
+    }
+    if language is not None:
+        extra["language"] = language
+    if server_command is not None:
+        extra["server_command"] = server_command
+    if workspace_root is not None:
+        extra["workspace_root"] = workspace_root
+    if error.code is not None:
+        extra["lsp_error_code"] = error.code
+    if _is_unsupported_capability_error(error):
+        extra["failure_kind"] = "unsupported_capability"
+    return tool_error(str(error), **extra)
 
 
 def _run_lsp_request(
@@ -431,12 +696,11 @@ def _run_lsp_request(
         language_id = _detect_language(source_path, language)
         command, candidates = _normalize_command(server_command, language_id)
         if not command:
-            return tool_error(
-                f"No LSP server found for language '{language_id}'",
-                path=str(source_path),
-                language=language_id,
+            return _build_missing_server_error(
+                source_path=source_path,
+                language_id=language_id,
                 requested_method=requested_method,
-                candidate_commands=candidates,
+                candidates=candidates,
             )
 
         workspace_path = Path(workspace_root).expanduser().resolve() if workspace_root else source_path.parent
@@ -474,9 +738,25 @@ def _run_lsp_request(
             payload["definitions"] = _normalize_locations(raw_result)
         elif requested_method == "textDocument/diagnostic":
             payload["diagnostics"] = _normalize_diagnostics(raw_result)
+        elif requested_method == "textDocument/references":
+            payload["references"] = _normalize_locations(raw_result)
+            payload["reference_count"] = len(payload["references"])
+        elif requested_method == "textDocument/prepareRename":
+            payload["prepare_rename"] = _normalize_prepare_rename_result(raw_result)
+            payload["can_rename"] = payload["prepare_rename"]["can_rename"]
         else:
             payload["result"] = raw_result
         return tool_result(payload)
+    except LspProtocolError as exc:
+        logger.debug("LSP request failed", exc_info=True)
+        return _build_protocol_error(
+            exc,
+            path=path,
+            requested_method=requested_method,
+            language=language_id if "language_id" in locals() else None,
+            server_command=command if "command" in locals() else None,
+            workspace_root=str(workspace_path) if "workspace_path" in locals() else None,
+        )
     except Exception as exc:
         logger.debug("LSP request failed", exc_info=True)
         return tool_error(str(exc), path=path, requested_method=requested_method)
@@ -538,10 +818,155 @@ def lsp_diagnostics_tool(
     )
 
 
+def lsp_prepare_rename_tool(
+    *,
+    path: str,
+    line: int,
+    character: int,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/prepareRename",
+        request_params={
+            "textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())},
+            "position": {"line": line, "character": character},
+        },
+    )
+
+
+def lsp_references_tool(
+    *,
+    path: str,
+    line: int,
+    character: int,
+    include_declaration: bool = True,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/references",
+        request_params={
+            "textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())},
+            "position": {"line": line, "character": character},
+            "context": {"includeDeclaration": include_declaration},
+        },
+    )
+
+
+def lsp_rename_tool(
+    *,
+    path: str,
+    line: int,
+    character: int,
+    new_name: str,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    requested_method = "textDocument/rename"
+    try:
+        source_path = Path(path).expanduser()
+        if not source_path.exists():
+            return tool_error(f"File not found: {path}", path=str(source_path), requested_method=requested_method)
+        source_path = source_path.resolve()
+        language_id = _detect_language(source_path, language)
+        command, candidates = _normalize_command(server_command, language_id)
+        if not command:
+            return _build_missing_server_error(
+                source_path=source_path,
+                language_id=language_id,
+                requested_method=requested_method,
+                candidates=candidates,
+            )
+
+        workspace_path = Path(workspace_root).expanduser().resolve() if workspace_root else source_path.parent
+        uri = _path_to_uri(source_path)
+        position = {"line": line, "character": character}
+        session = _LspSession(command, cwd=str(workspace_path))
+        try:
+            session.request("initialize", _build_initialize_params(workspace_path))
+            session.notify("initialized", {})
+            session.notify(
+                "textDocument/didOpen",
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": language_id,
+                        "version": 1,
+                        "text": _read_source(source_path),
+                    }
+                },
+            )
+            prepare_raw_result = session.request(
+                "textDocument/prepareRename",
+                {"textDocument": {"uri": uri}, "position": position},
+            )
+            prepare_result = _normalize_prepare_rename_result(prepare_raw_result)
+            if not prepare_result["can_rename"]:
+                return tool_error(
+                    "LSP server reported that the selected symbol cannot be renamed",
+                    path=str(source_path),
+                    language=language_id,
+                    requested_method=requested_method,
+                    failure_kind="prepare_rename_rejected",
+                    prepare_rename=prepare_result,
+                    server_command=command,
+                    workspace_root=str(workspace_path),
+                )
+            rename_raw_result = session.request(
+                requested_method,
+                {"textDocument": {"uri": uri}, "position": position, "newName": new_name},
+            )
+        finally:
+            session.shutdown()
+
+        normalized_edit = _normalize_workspace_edit(rename_raw_result)
+        return tool_result(
+            {
+                "ok": True,
+                "path": str(source_path),
+                "language": language_id,
+                "requested_method": requested_method,
+                "server_command": command,
+                "workspace_root": str(workspace_path),
+                "new_name": new_name,
+                "prepare_rename": prepare_result,
+                "workspace_edit": normalized_edit,
+            }
+        )
+    except LspProtocolError as exc:
+        logger.debug("LSP rename request failed", exc_info=True)
+        return _build_protocol_error(
+            exc,
+            path=path,
+            requested_method=requested_method,
+            language=language_id if "language_id" in locals() else None,
+            server_command=command if "command" in locals() else None,
+            workspace_root=str(workspace_path) if "workspace_path" in locals() else None,
+        )
+    except Exception as exc:
+        logger.debug("LSP rename request failed", exc_info=True)
+        return tool_error(str(exc), path=path, requested_method=requested_method)
+
+
 LSP_TOOLS = [
     {"name": "lsp_document_symbols", "function": lsp_document_symbols_tool},
     {"name": "lsp_definition", "function": lsp_definition_tool},
     {"name": "lsp_diagnostics", "function": lsp_diagnostics_tool},
+    {"name": "lsp_prepare_rename", "function": lsp_prepare_rename_tool},
+    {"name": "lsp_references", "function": lsp_references_tool},
+    {"name": "lsp_rename", "function": lsp_rename_tool},
 ]
 
 
@@ -574,6 +999,41 @@ def _handle_lsp_diagnostics(args, **_kwargs):
     )
 
 
+def _handle_lsp_prepare_rename(args, **_kwargs):
+    return lsp_prepare_rename_tool(
+        path=args.get("path", ""),
+        line=args.get("line", 0),
+        character=args.get("character", 0),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+def _handle_lsp_references(args, **_kwargs):
+    return lsp_references_tool(
+        path=args.get("path", ""),
+        line=args.get("line", 0),
+        character=args.get("character", 0),
+        include_declaration=args.get("include_declaration", True),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+def _handle_lsp_rename(args, **_kwargs):
+    return lsp_rename_tool(
+        path=args.get("path", ""),
+        line=args.get("line", 0),
+        character=args.get("character", 0),
+        new_name=args.get("new_name", ""),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
 registry.register(
     name="lsp_document_symbols",
     toolset="code_intel",
@@ -597,4 +1057,28 @@ registry.register(
     handler=_handle_lsp_diagnostics,
     check_fn=_check_lsp_requirements,
     emoji="🚨",
+)
+registry.register(
+    name="lsp_prepare_rename",
+    toolset="code_intel",
+    schema=LSP_PREPARE_RENAME_SCHEMA,
+    handler=_handle_lsp_prepare_rename,
+    check_fn=_check_lsp_requirements,
+    emoji="✏️",
+)
+registry.register(
+    name="lsp_references",
+    toolset="code_intel",
+    schema=LSP_REFERENCES_SCHEMA,
+    handler=_handle_lsp_references,
+    check_fn=_check_lsp_requirements,
+    emoji="🔎",
+)
+registry.register(
+    name="lsp_rename",
+    toolset="code_intel",
+    schema=LSP_RENAME_SCHEMA,
+    handler=_handle_lsp_rename,
+    check_fn=_check_lsp_requirements,
+    emoji="📝",
 )

--- a/tools/lsp_tools.py
+++ b/tools/lsp_tools.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Local-first LSP tools for document symbols, definitions, and diagnostics."""
+"""Local-first LSP tools for repo/code grounding via document symbols, definitions, and diagnostics.
+
+These LSP helpers stay local-first and host-dependent, but their primary product
+framing is the canonical `repo-code-knowledge` surface: deeper semantic grounding
+inside a local codebase when AST-only structure is not enough.
+"""
 
 from __future__ import annotations
 
@@ -180,7 +185,7 @@ class _LspSession:
 
 LSP_DOCUMENT_SYMBOLS_SCHEMA = {
     "name": "lsp_document_symbols",
-    "description": "Get document symbols for a source file using a local Language Server Protocol server. Supports explicit server_command or local auto-detection by language.",
+    "description": "Get document symbols for a source file using a local Language Server Protocol server. Supports explicit server_command or local auto-detection by language. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -195,7 +200,7 @@ LSP_DOCUMENT_SYMBOLS_SCHEMA = {
 
 LSP_DEFINITION_SCHEMA = {
     "name": "lsp_definition",
-    "description": "Resolve definitions at a zero-based line/character position using a local LSP server.",
+    "description": "Resolve definitions at a zero-based line/character position using a local LSP server. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -212,7 +217,7 @@ LSP_DEFINITION_SCHEMA = {
 
 LSP_DIAGNOSTICS_SCHEMA = {
     "name": "lsp_diagnostics",
-    "description": "Request file diagnostics from a local LSP server using textDocument/diagnostic.",
+    "description": "Request file diagnostics from a local LSP server using textDocument/diagnostic. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -250,7 +255,7 @@ def get_lsp_host_capability_description() -> str:
     if languages:
         return (
             f"Auto-detect currently supports: {', '.join(languages)}. "
-            "Use server_command to target any other installed local LSP server."
+            "Use server_command to target any other installed local LSP server for repo/code grounding."
         )
     return "Auto-detect is unavailable on this host. Use server_command to target an installed local LSP server."
 

--- a/tools/lsp_tools.py
+++ b/tools/lsp_tools.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Local-first LSP tools for document symbols, definitions, and diagnostics."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+
+_LANGUAGE_IDS = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascriptreact",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescriptreact",
+    ".go": "go",
+    ".rs": "rust",
+    ".json": "json",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".sh": "shellscript",
+    ".bash": "shellscript",
+}
+
+_AUTO_DETECT_COMMANDS = {
+    "python": [["pylsp"], ["pyright-langserver", "--stdio"], ["jedi-language-server"]],
+    "javascript": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "javascriptreact": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "typescript": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "typescriptreact": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "go": [["gopls"]],
+    "rust": [["rust-analyzer"]],
+    "json": [["vscode-json-language-server", "--stdio"]],
+    "yaml": [["yaml-language-server", "--stdio"]],
+    "shellscript": [["bash-language-server", "start"]],
+}
+
+_SYMBOL_KINDS = {
+    1: "File",
+    2: "Module",
+    3: "Namespace",
+    4: "Package",
+    5: "Class",
+    6: "Method",
+    7: "Property",
+    8: "Field",
+    9: "Constructor",
+    10: "Enum",
+    11: "Interface",
+    12: "Function",
+    13: "Variable",
+    14: "Constant",
+    15: "String",
+    16: "Number",
+    17: "Boolean",
+    18: "Array",
+    19: "Object",
+    20: "Key",
+    21: "Null",
+    22: "EnumMember",
+    23: "Struct",
+    24: "Event",
+    25: "Operator",
+    26: "TypeParameter",
+}
+
+_DIAGNOSTIC_SEVERITIES = {
+    1: "Error",
+    2: "Warning",
+    3: "Information",
+    4: "Hint",
+}
+
+
+class LspProtocolError(RuntimeError):
+    """Raised when an LSP server returns malformed or error responses."""
+
+
+class _LspSession:
+    def __init__(self, command: list[str], cwd: str):
+        self.command = command
+        self.process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self._next_id = 1
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        if not self.process.stdin:
+            raise LspProtocolError("LSP server stdin is unavailable")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        self.process.stdin.write(header + body)
+        self.process.stdin.flush()
+
+    def _read_message(self) -> dict[str, Any]:
+        if not self.process.stdout:
+            raise LspProtocolError("LSP server stdout is unavailable")
+
+        content_length = None
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                raise LspProtocolError("LSP server closed stdout before a response was received")
+            if line in (b"\r\n", b"\n"):
+                break
+            key, _, value = line.decode("utf-8", errors="replace").partition(":")
+            if key.lower() == "content-length":
+                try:
+                    content_length = int(value.strip())
+                except ValueError as exc:
+                    raise LspProtocolError("LSP response had an invalid Content-Length header") from exc
+
+        if content_length is None:
+            raise LspProtocolError("LSP response missing Content-Length header")
+
+        body = self.process.stdout.read(content_length)
+        if len(body) != content_length:
+            raise LspProtocolError("LSP response body was truncated")
+
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise LspProtocolError("LSP response body was not valid JSON") from exc
+
+    def notify(self, method: str, params: dict[str, Any]) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def request(self, method: str, params: dict[str, Any]) -> Any:
+        request_id = self._next_id
+        self._next_id += 1
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+
+        while True:
+            message = self._read_message()
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                error = message["error"] or {}
+                code = error.get("code", "unknown")
+                detail = error.get("message", "Unknown LSP error")
+                raise LspProtocolError(f"LSP request failed ({method}, code={code}): {detail}")
+            return message.get("result")
+
+    def shutdown(self) -> None:
+        try:
+            self.request("shutdown", {})
+        except Exception:
+            logger.debug("Best-effort LSP shutdown failed", exc_info=True)
+        try:
+            self.notify("exit", {})
+        except Exception:
+            logger.debug("Best-effort LSP exit failed", exc_info=True)
+        try:
+            if self.process.poll() is None:
+                self.process.terminate()
+                self.process.wait(timeout=1)
+        except Exception:
+            try:
+                self.process.kill()
+            except Exception:
+                logger.debug("Best-effort LSP kill failed", exc_info=True)
+
+
+LSP_DOCUMENT_SYMBOLS_SCHEMA = {
+    "name": "lsp_document_symbols",
+    "description": "Get document symbols for a source file using a local Language Server Protocol server. Supports explicit server_command or local auto-detection by language.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "language": {"type": "string", "description": "Optional LSP language id override (for example: python, typescript, rust)"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory passed to the language server"},
+            "server_command": {"type": "string", "description": "Optional explicit server command, for example 'pylsp' or 'typescript-language-server --stdio'"},
+        },
+        "required": ["path"],
+    },
+}
+
+LSP_DEFINITION_SCHEMA = {
+    "name": "lsp_definition",
+    "description": "Resolve definitions at a zero-based line/character position using a local LSP server.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "line": {"type": "integer", "description": "Zero-based line number"},
+            "character": {"type": "integer", "description": "Zero-based character offset on the line"},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path", "line", "character"],
+    },
+}
+
+LSP_DIAGNOSTICS_SCHEMA = {
+    "name": "lsp_diagnostics",
+    "description": "Request file diagnostics from a local LSP server using textDocument/diagnostic.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path"],
+    },
+}
+
+
+def get_host_lsp_capabilities() -> dict[str, Any]:
+    auto_detect_commands: dict[str, list[str]] = {}
+    for language, candidates in sorted(_AUTO_DETECT_COMMANDS.items()):
+        available_commands = []
+        for candidate in candidates:
+            binary = candidate[0] if candidate else None
+            if binary and shutil.which(binary):
+                available_commands.append(" ".join(candidate))
+        if available_commands:
+            auto_detect_commands[language] = available_commands
+
+    return {
+        "available": bool(auto_detect_commands),
+        "auto_detect_languages": list(auto_detect_commands.keys()),
+        "auto_detect_commands": auto_detect_commands,
+    }
+
+
+def get_lsp_host_capability_description() -> str:
+    capabilities = get_host_lsp_capabilities()
+    languages = capabilities["auto_detect_languages"]
+    if languages:
+        return (
+            f"Auto-detect currently supports: {', '.join(languages)}. "
+            "Use server_command to target any other installed local LSP server."
+        )
+    return "Auto-detect is unavailable on this host. Use server_command to target an installed local LSP server."
+
+
+def _check_lsp_requirements() -> bool:
+    return get_host_lsp_capabilities()["available"]
+
+
+def _detect_language(path: Path, language: str | None) -> str:
+    if language:
+        return language
+    return _LANGUAGE_IDS.get(path.suffix.lower(), "plaintext")
+
+
+def _normalize_command(server_command: str | list[str] | None, language: str) -> tuple[list[str] | None, list[str]]:
+    if server_command:
+        if isinstance(server_command, str):
+            command = shlex.split(server_command)
+        else:
+            command = list(server_command)
+        if not command:
+            raise ValueError("server_command must not be empty")
+        return command, []
+
+    candidates = _AUTO_DETECT_COMMANDS.get(language, [])
+    for candidate in candidates:
+        if shutil.which(candidate[0]):
+            return candidate, [" ".join(entry) for entry in candidates]
+    return None, [" ".join(entry) for entry in candidates]
+
+
+def _path_to_uri(path: Path) -> str:
+    return path.resolve().as_uri()
+
+
+def _uri_to_path(uri: str | None) -> str | None:
+    if not uri:
+        return None
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return uri
+    return unquote(parsed.path)
+
+
+def _normalize_range(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not value:
+        return None
+    return {
+        "start": value.get("start"),
+        "end": value.get("end"),
+    }
+
+
+def _normalize_symbol(item: dict[str, Any]) -> dict[str, Any]:
+    if "location" in item:
+        location = item.get("location") or {}
+        return {
+            "name": item.get("name"),
+            "detail": item.get("detail"),
+            "kind": item.get("kind"),
+            "kind_name": _SYMBOL_KINDS.get(item.get("kind"), "Unknown"),
+            "container_name": item.get("containerName"),
+            "uri": location.get("uri"),
+            "path": _uri_to_path(location.get("uri")),
+            "range": _normalize_range(location.get("range")),
+        }
+
+    return {
+        "name": item.get("name"),
+        "detail": item.get("detail"),
+        "kind": item.get("kind"),
+        "kind_name": _SYMBOL_KINDS.get(item.get("kind"), "Unknown"),
+        "range": _normalize_range(item.get("range")),
+        "selection_range": _normalize_range(item.get("selectionRange")),
+        "children": [_normalize_symbol(child) for child in item.get("children", [])],
+    }
+
+
+def _normalize_locations(result: Any) -> list[dict[str, Any]]:
+    if result is None:
+        return []
+    if isinstance(result, dict):
+        items = [result]
+    else:
+        items = list(result)
+
+    normalized = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if "targetUri" in item:
+            uri = item.get("targetUri")
+            normalized.append(
+                {
+                    "uri": uri,
+                    "path": _uri_to_path(uri),
+                    "target_range": _normalize_range(item.get("targetRange")),
+                    "target_selection_range": _normalize_range(item.get("targetSelectionRange")),
+                    "origin_selection_range": _normalize_range(item.get("originSelectionRange")),
+                }
+            )
+            continue
+
+        uri = item.get("uri")
+        normalized.append(
+            {
+                "uri": uri,
+                "path": _uri_to_path(uri),
+                "range": _normalize_range(item.get("range")),
+            }
+        )
+    return normalized
+
+
+def _normalize_diagnostics(result: Any) -> list[dict[str, Any]]:
+    if result is None:
+        return []
+    items = result.get("items", []) if isinstance(result, dict) else result
+    normalized = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        severity = item.get("severity")
+        normalized.append(
+            {
+                "message": item.get("message"),
+                "severity": severity,
+                "severity_name": _DIAGNOSTIC_SEVERITIES.get(severity, "Unknown"),
+                "code": item.get("code"),
+                "source": item.get("source"),
+                "range": _normalize_range(item.get("range")),
+                "tags": item.get("tags", []),
+            }
+        )
+    return normalized
+
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _build_initialize_params(workspace_root: Path) -> dict[str, Any]:
+    root_uri = _path_to_uri(workspace_root)
+    return {
+        "processId": None,
+        "clientInfo": {"name": "hermes-agent", "version": "phase-3"},
+        "rootUri": root_uri,
+        "workspaceFolders": [{"uri": root_uri, "name": workspace_root.name or str(workspace_root)}],
+        "capabilities": {
+            "textDocument": {
+                "definition": {"dynamicRegistration": False},
+                "documentSymbol": {"hierarchicalDocumentSymbolSupport": True},
+                "diagnostic": {"dynamicRegistration": False},
+            }
+        },
+    }
+
+
+def _run_lsp_request(
+    *,
+    path: str,
+    requested_method: str,
+    request_params: dict[str, Any],
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | list[str] | None = None,
+) -> str:
+    try:
+        source_path = Path(path).expanduser()
+        if not source_path.exists():
+            return tool_error(f"File not found: {path}", path=str(source_path), requested_method=requested_method)
+        source_path = source_path.resolve()
+        language_id = _detect_language(source_path, language)
+        command, candidates = _normalize_command(server_command, language_id)
+        if not command:
+            return tool_error(
+                f"No LSP server found for language '{language_id}'",
+                path=str(source_path),
+                language=language_id,
+                requested_method=requested_method,
+                candidate_commands=candidates,
+            )
+
+        workspace_path = Path(workspace_root).expanduser().resolve() if workspace_root else source_path.parent
+        uri = _path_to_uri(source_path)
+        session = _LspSession(command, cwd=str(workspace_path))
+        try:
+            session.request("initialize", _build_initialize_params(workspace_path))
+            session.notify("initialized", {})
+            session.notify(
+                "textDocument/didOpen",
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": language_id,
+                        "version": 1,
+                        "text": _read_source(source_path),
+                    }
+                },
+            )
+            raw_result = session.request(requested_method, request_params)
+        finally:
+            session.shutdown()
+
+        payload = {
+            "ok": True,
+            "path": str(source_path),
+            "language": language_id,
+            "requested_method": requested_method,
+            "server_command": command,
+            "workspace_root": str(workspace_path),
+        }
+        if requested_method == "textDocument/documentSymbol":
+            payload["symbols"] = [_normalize_symbol(item) for item in raw_result or []]
+        elif requested_method == "textDocument/definition":
+            payload["definitions"] = _normalize_locations(raw_result)
+        elif requested_method == "textDocument/diagnostic":
+            payload["diagnostics"] = _normalize_diagnostics(raw_result)
+        else:
+            payload["result"] = raw_result
+        return tool_result(payload)
+    except Exception as exc:
+        logger.debug("LSP request failed", exc_info=True)
+        return tool_error(str(exc), path=path, requested_method=requested_method)
+
+
+def lsp_document_symbols_tool(
+    *,
+    path: str,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/documentSymbol",
+        request_params={"textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())}},
+    )
+
+
+def lsp_definition_tool(
+    *,
+    path: str,
+    line: int,
+    character: int,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/definition",
+        request_params={
+            "textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())},
+            "position": {"line": line, "character": character},
+        },
+    )
+
+
+def lsp_diagnostics_tool(
+    *,
+    path: str,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/diagnostic",
+        request_params={"textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())}},
+    )
+
+
+LSP_TOOLS = [
+    {"name": "lsp_document_symbols", "function": lsp_document_symbols_tool},
+    {"name": "lsp_definition", "function": lsp_definition_tool},
+    {"name": "lsp_diagnostics", "function": lsp_diagnostics_tool},
+]
+
+
+def _handle_lsp_document_symbols(args, **_kwargs):
+    return lsp_document_symbols_tool(
+        path=args.get("path", ""),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+def _handle_lsp_definition(args, **_kwargs):
+    return lsp_definition_tool(
+        path=args.get("path", ""),
+        line=args.get("line", 0),
+        character=args.get("character", 0),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+def _handle_lsp_diagnostics(args, **_kwargs):
+    return lsp_diagnostics_tool(
+        path=args.get("path", ""),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+registry.register(
+    name="lsp_document_symbols",
+    toolset="code_intel",
+    schema=LSP_DOCUMENT_SYMBOLS_SCHEMA,
+    handler=_handle_lsp_document_symbols,
+    check_fn=_check_lsp_requirements,
+    emoji="🛰️",
+)
+registry.register(
+    name="lsp_definition",
+    toolset="code_intel",
+    schema=LSP_DEFINITION_SCHEMA,
+    handler=_handle_lsp_definition,
+    check_fn=_check_lsp_requirements,
+    emoji="📍",
+)
+registry.register(
+    name="lsp_diagnostics",
+    toolset="code_intel",
+    schema=LSP_DIAGNOSTICS_SCHEMA,
+    handler=_handle_lsp_diagnostics,
+    check_fn=_check_lsp_requirements,
+    emoji="🚨",
+)

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -29,10 +29,15 @@ Usage:
 """
 
 import difflib
+import hashlib
 import re
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Any
 from enum import Enum
+
+
+REPLACE_HASHLINE_RE = re.compile(r"^\s*#\s*HASHLINE\s+sha256:([0-9a-fA-F]{64})\s*$")
+PATCH_HASHLINE_RE = re.compile(r"^\*\*\*\s+Hashline:\s+(.+?)\s+sha256:([0-9a-fA-F]{64})\s*$")
 
 
 class OperationType(Enum):
@@ -64,6 +69,89 @@ class PatchOperation:
     new_path: Optional[str] = None  # For move operations
     hunks: List[Hunk] = field(default_factory=list)
     content: Optional[str] = None  # For add file operations
+
+
+@dataclass(frozen=True)
+class HashlineExpectation:
+    """Hermes-native anchored safe-edit expectation for an existing file."""
+    file_path: str
+    expected_sha256: str
+
+
+@dataclass(frozen=True)
+class FileSnapshot:
+    """Filesystem state snapshot used to make rollback conditional."""
+    exists: bool
+    sha256: Optional[str] = None
+
+
+def parse_replace_hashline(payload: str) -> Tuple[Optional[HashlineExpectation], str, Optional[str]]:
+    """Parse an optional replace-mode HASHLINE directive from the first line."""
+    if not isinstance(payload, str):
+        return None, payload, None
+    if "\n" in payload:
+        first_line, remainder = payload.split("\n", 1)
+    else:
+        first_line, remainder = payload, ""
+    if "HASHLINE" not in first_line.upper():
+        return None, payload, None
+    match = REPLACE_HASHLINE_RE.match(first_line)
+    if not match:
+        return None, payload, (
+            "Invalid HASHLINE directive. Expected first line in the form "
+            "'# HASHLINE sha256:<64-hex-digest>'."
+        )
+    return HashlineExpectation(file_path="", expected_sha256=match.group(1).lower()), remainder, None
+
+
+def parse_patch_hashlines(
+    patch_content: str,
+) -> Tuple[dict[str, HashlineExpectation], str, Optional[str]]:
+    """Parse and strip V4A patch-level Hashline directives."""
+    if not isinstance(patch_content, str):
+        return {}, patch_content, None
+
+    expected_hashes: dict[str, HashlineExpectation] = {}
+    kept_lines: list[str] = []
+    for line in patch_content.splitlines():
+        if line.startswith("*** Hashline:"):
+            match = PATCH_HASHLINE_RE.match(line)
+            if not match:
+                return {}, patch_content, (
+                    "Invalid '*** Hashline:' directive. Expected "
+                    "'*** Hashline: path/to/file sha256:<64-hex-digest>'."
+                )
+            path = match.group(1).strip()
+            expected_hashes[path] = HashlineExpectation(
+                file_path=path,
+                expected_sha256=match.group(2).lower(),
+            )
+            continue
+        kept_lines.append(line)
+
+    rebuilt = "\n".join(kept_lines)
+    if patch_content.endswith("\n"):
+        rebuilt += "\n"
+    return expected_hashes, rebuilt, None
+
+
+def get_anchor_required_paths(operations: List[PatchOperation]) -> List[str]:
+    """Return existing-file mutation paths that require HASHLINE protection."""
+    required: list[str] = []
+    for op in operations:
+        if op.operation in {OperationType.UPDATE, OperationType.DELETE, OperationType.MOVE}:
+            required.append(op.file_path)
+    return required
+
+
+def get_touched_paths(operations: List[PatchOperation]) -> List[str]:
+    """Return all file paths touched by the patch for path-policy checks."""
+    touched: list[str] = []
+    for op in operations:
+        touched.append(op.file_path)
+        if op.operation == OperationType.MOVE and op.new_path:
+            touched.append(op.new_path)
+    return touched
 
 
 def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[str]]:
@@ -237,6 +325,32 @@ def _count_occurrences(text: str, pattern: str) -> int:
     return count
 
 
+def _snapshot_file_state(file_ops: Any, path: str) -> Tuple[Optional[FileSnapshot], Optional[str]]:
+    """Capture whether a path exists and, if present, its sha256 digest."""
+    read_result = file_ops.read_file_raw(path)
+    if read_result.error:
+        if str(read_result.error).startswith("File not found:"):
+            return FileSnapshot(exists=False), None
+        return None, f"{path}: {read_result.error}"
+    return FileSnapshot(
+        exists=True,
+        sha256=hashlib.sha256(read_result.content.encode("utf-8")).hexdigest(),
+    ), None
+
+
+def _verify_snapshot_match(file_ops: Any, path: str, expected: FileSnapshot) -> Optional[str]:
+    """Return an error string if the current file state diverged from expected."""
+    current, error = _snapshot_file_state(file_ops, path)
+    if error:
+        return error
+    if current != expected:
+        return (
+            f"rollback could not safely proceed for {path}: current state no longer matches "
+            f"the post-apply state"
+        )
+    return None
+
+
 def _validate_operations(
     operations: List[PatchOperation],
     file_ops: Any,
@@ -323,7 +437,8 @@ def _validate_operations(
 
 
 def apply_v4a_operations(operations: List[PatchOperation],
-                          file_ops: Any) -> 'PatchResult':
+                          file_ops: Any,
+                          expected_hashes: Optional[dict[str, str]] = None) -> 'PatchResult':
     """Apply V4A patch operations using a file operations interface.
 
     Uses a two-phase validate-then-apply approach:
@@ -352,12 +467,41 @@ def apply_v4a_operations(operations: List[PatchOperation],
                   + "\n".join(f"  • {e}" for e in validation_errors),
         )
 
+    if expected_hashes:
+        missing_anchor_paths = [path for path in get_anchor_required_paths(operations) if path not in expected_hashes]
+        if missing_anchor_paths:
+            return PatchResult(
+                success=False,
+                error="\n".join(
+                    f"HASHLINE validation failed: missing '*** Hashline: {path} sha256:...' for patched file {path}"
+                    for path in missing_anchor_paths
+                ),
+            )
+        hash_errors: List[str] = []
+        for path, expected_sha256 in expected_hashes.items():
+            read_result = file_ops.read_file_raw(path)
+            if read_result.error:
+                hash_errors.append(f"HASHLINE validation failed: file not found: {path}")
+                continue
+            current_hash = hashlib.sha256(read_result.content.encode("utf-8")).hexdigest()
+            if current_hash.lower() != str(expected_sha256 or "").lower():
+                hash_errors.append(
+                    f"HASHLINE validation failed for {path}: expected sha256:{expected_sha256}, "
+                    f"got sha256:{current_hash}. Re-read the file before editing."
+                )
+        if hash_errors:
+            return PatchResult(
+                success=False,
+                error="\n".join(hash_errors),
+            )
+
     # ---- Phase 2: apply ----
     files_modified = []
     files_created = []
     files_deleted = []
     all_diffs = []
     errors = []
+    rollback_actions: List[tuple[str, str, Any]] = []
 
     for op in operations:
         try:
@@ -366,35 +510,136 @@ def apply_v4a_operations(operations: List[PatchOperation],
                 if result[0]:
                     files_created.append(op.file_path)
                     all_diffs.append(result[1])
+                    post_apply, snapshot_error = _snapshot_file_state(file_ops, op.file_path)
+                    if snapshot_error:
+                        errors.append(f"Failed to snapshot {op.file_path} after add: {snapshot_error}")
+                    else:
+                        rollback_actions.append(("delete", op.file_path, {"post_apply": post_apply}))
                 else:
                     errors.append(f"Failed to add {op.file_path}: {result[1]}")
 
             elif op.operation == OperationType.DELETE:
-                result = _apply_delete(op, file_ops)
+                original = file_ops.read_file_raw(op.file_path)
+                result = _apply_delete(
+                    op,
+                    file_ops,
+                    expected_sha256=(expected_hashes or {}).get(op.file_path),
+                )
                 if result[0]:
                     files_deleted.append(op.file_path)
                     all_diffs.append(result[1])
+                    if not original.error:
+                        post_apply, snapshot_error = _snapshot_file_state(file_ops, op.file_path)
+                        if snapshot_error:
+                            errors.append(f"Failed to snapshot {op.file_path} after delete: {snapshot_error}")
+                        else:
+                            rollback_actions.append((
+                                "write",
+                                op.file_path,
+                                {"content": original.content, "post_apply": post_apply},
+                            ))
                 else:
                     errors.append(f"Failed to delete {op.file_path}: {result[1]}")
 
             elif op.operation == OperationType.MOVE:
-                result = _apply_move(op, file_ops)
+                original = file_ops.read_file_raw(op.file_path)
+                result = _apply_move(
+                    op,
+                    file_ops,
+                    expected_sha256=(expected_hashes or {}).get(op.file_path),
+                )
                 if result[0]:
                     files_modified.append(f"{op.file_path} -> {op.new_path}")
                     all_diffs.append(result[1])
+                    if not original.error:
+                        source_post_apply, source_snapshot_error = _snapshot_file_state(file_ops, op.file_path)
+                        dest_post_apply, dest_snapshot_error = _snapshot_file_state(file_ops, op.new_path)
+                        snapshot_error = source_snapshot_error or dest_snapshot_error
+                        if snapshot_error:
+                            errors.append(f"Failed to snapshot move state for {op.file_path}: {snapshot_error}")
+                        else:
+                            rollback_actions.append((
+                                "move_back",
+                                op.file_path,
+                                {
+                                    "new_path": op.new_path,
+                                    "content": original.content,
+                                    "source_post_apply": source_post_apply,
+                                    "dest_post_apply": dest_post_apply,
+                                },
+                            ))
                 else:
                     errors.append(f"Failed to move {op.file_path}: {result[1]}")
 
             elif op.operation == OperationType.UPDATE:
-                result = _apply_update(op, file_ops)
+                original = file_ops.read_file_raw(op.file_path)
+                result = _apply_update(
+                    op,
+                    file_ops,
+                    expected_sha256=(expected_hashes or {}).get(op.file_path),
+                )
                 if result[0]:
                     files_modified.append(op.file_path)
                     all_diffs.append(result[1])
+                    if not original.error:
+                        post_apply, snapshot_error = _snapshot_file_state(file_ops, op.file_path)
+                        if snapshot_error:
+                            errors.append(f"Failed to snapshot {op.file_path} after update: {snapshot_error}")
+                        else:
+                            rollback_actions.append((
+                                "write",
+                                op.file_path,
+                                {"content": original.content, "post_apply": post_apply},
+                            ))
                 else:
                     errors.append(f"Failed to update {op.file_path}: {result[1]}")
 
         except Exception as e:
             errors.append(f"Error processing {op.file_path}: {str(e)}")
+
+        if errors:
+            break
+
+    rollback_errors: List[str] = []
+    if errors and rollback_actions:
+        for action, path, payload in reversed(rollback_actions):
+            try:
+                if action == "delete":
+                    verify_error = _verify_snapshot_match(file_ops, path, payload["post_apply"])
+                    if verify_error:
+                        rollback_errors.append(verify_error)
+                        continue
+                    delete_result = file_ops.delete_file(path)
+                    if delete_result.error:
+                        rollback_errors.append(f"rollback delete {path}: {delete_result.error}")
+                elif action == "write":
+                    verify_error = _verify_snapshot_match(file_ops, path, payload["post_apply"])
+                    if verify_error:
+                        rollback_errors.append(verify_error)
+                        continue
+                    write_result = file_ops.write_file(path, payload["content"])
+                    if write_result.error:
+                        rollback_errors.append(f"rollback write {path}: {write_result.error}")
+                elif action == "move_back":
+                    info = payload or {}
+                    moved_path = info.get("new_path")
+                    verify_error = _verify_snapshot_match(file_ops, path, info["source_post_apply"])
+                    if verify_error:
+                        rollback_errors.append(verify_error)
+                        continue
+                    verify_error = _verify_snapshot_match(file_ops, moved_path, info["dest_post_apply"])
+                    if verify_error:
+                        rollback_errors.append(verify_error)
+                        continue
+                    move_result = file_ops.move_file(moved_path, path)
+                    if move_result.error:
+                        rollback_errors.append(f"rollback move {moved_path} -> {path}: {move_result.error}")
+                    else:
+                        write_result = file_ops.write_file(path, info.get("content", ""))
+                        if write_result.error:
+                            rollback_errors.append(f"rollback restore {path}: {write_result.error}")
+            except Exception as exc:
+                rollback_errors.append(f"rollback {action} {path}: {exc}")
 
     # Run lint on all modified/created files
     lint_results = {}
@@ -406,6 +651,14 @@ def apply_v4a_operations(operations: List[PatchOperation],
     combined_diff = '\n'.join(all_diffs)
 
     if errors:
+        error_text = "Apply phase failed"
+        if rollback_errors:
+            error_text += " (rollback incomplete — run `git diff` to assess)"
+        else:
+            error_text += " (rollback restored earlier changes)"
+        error_text += ":\n" + "\n".join(f"  • {e}" for e in errors)
+        if rollback_errors:
+            error_text += "\nRollback issues:\n" + "\n".join(f"  • {e}" for e in rollback_errors)
         return PatchResult(
             success=False,
             diff=combined_diff,
@@ -413,8 +666,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
             files_created=files_created,
             files_deleted=files_deleted,
             lint=lint_results if lint_results else None,
-            error="Apply phase failed (state may be inconsistent — run `git diff` to assess):\n"
-                  + "\n".join(f"  • {e}" for e in errors),
+            error=error_text,
         )
 
     return PatchResult(
@@ -448,7 +700,11 @@ def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff
 
 
-def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
+def _apply_delete(
+    op: PatchOperation,
+    file_ops: Any,
+    expected_sha256: Optional[str] = None,
+) -> Tuple[bool, str]:
     """Apply a delete file operation."""
     # Read before deleting so we can produce a real unified diff.
     # Validation already confirmed existence; this guards against races.
@@ -456,7 +712,10 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     if read_result.error:
         return False, f"Cannot delete {op.file_path}: file not found"
 
-    result = file_ops.delete_file(op.file_path)
+    if expected_sha256 and hasattr(file_ops, "conditional_delete_file"):
+        result = file_ops.conditional_delete_file(op.file_path, expected_sha256)
+    else:
+        result = file_ops.delete_file(op.file_path)
     if result.error:
         return False, result.error
 
@@ -469,9 +728,16 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff or f"# Deleted: {op.file_path}"
 
 
-def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
+def _apply_move(
+    op: PatchOperation,
+    file_ops: Any,
+    expected_sha256: Optional[str] = None,
+) -> Tuple[bool, str]:
     """Apply a move file operation."""
-    result = file_ops.move_file(op.file_path, op.new_path)
+    if expected_sha256 and hasattr(file_ops, "conditional_move_file"):
+        result = file_ops.conditional_move_file(op.file_path, op.new_path, expected_sha256)
+    else:
+        result = file_ops.move_file(op.file_path, op.new_path)
     if result.error:
         return False, result.error
 
@@ -479,7 +745,7 @@ def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff
 
 
-def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
+def _apply_update(op: PatchOperation, file_ops: Any, expected_sha256: Optional[str] = None) -> Tuple[bool, str]:
     """Apply an update file operation."""
     # Deferred import: breaks the patch_parser ↔ fuzzy_match circular dependency
     from tools.fuzzy_match import fuzzy_find_and_replace
@@ -564,7 +830,10 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
                 new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
     
     # Write new content
-    write_result = file_ops.write_file(op.file_path, new_content)
+    if expected_sha256 and hasattr(file_ops, "conditional_write_file"):
+        write_result = file_ops.conditional_write_file(op.file_path, new_content, expected_sha256)
+    else:
+        write_result = file_ops.write_file(op.file_path, new_content)
     if write_result.error:
         return False, write_result.error
     

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -2,17 +2,19 @@
 """
 Vision Tools Module
 
-This module provides vision analysis tools that work with image URLs.
-Uses the centralized auxiliary vision router, which can select OpenRouter,
-Nous, Codex, native Anthropic, or a custom OpenAI-compatible endpoint.
+This module provides vision analysis tools for screenshots, diagrams, charts,
+photos, and other image inputs. It uses the centralized auxiliary vision
+router, which can select OpenRouter, Nous, Codex, native Anthropic, or a
+custom OpenAI-compatible endpoint.
 
 Available tools:
-- vision_analyze_tool: Analyze images from URLs with custom prompts
+- vision_analyze_tool: Analyze remote or local image inputs with custom prompts
 
 Features:
-- Downloads images from URLs and converts to base64 for API compatibility
-- Comprehensive image description
-- Context-aware analysis based on user queries
+- Downloads remote images and converts them to base64 for API compatibility
+- Supports local image files and file:// image URIs
+- Comprehensive visual description plus question answering
+- Helpful for screenshots, rendered document captures, diagrams, and charts
 - Automatic temporary file cleanup
 - Proper error handling and validation
 - Debug logging support
@@ -21,7 +23,7 @@ Usage:
     from vision_tools import vision_analyze_tool
     import asyncio
     
-    # Analyze an image
+    # Analyze an image or screenshot
     result = await vision_analyze_tool(
         image_url="https://example.com/image.jpg",
         user_prompt="What architectural style is this building?"
@@ -749,17 +751,17 @@ from tools.registry import registry, tool_error
 
 VISION_ANALYZE_SCHEMA = {
     "name": "vision_analyze",
-    "description": "Analyze images using AI vision. Provides a comprehensive description and answers a specific question about the image content.",
+    "description": "Analyze an image with AI vision from an HTTP/HTTPS URL or local image file path. Best for screenshots, diagrams, charts, photos, and page captures. Not for raw PDF parsing.",
     "parameters": {
         "type": "object",
         "properties": {
             "image_url": {
                 "type": "string",
-                "description": "Image URL (http/https) or local file path to analyze."
+                "description": "HTTP/HTTPS image URL, file:// image URI, or local image file path to analyze."
             },
             "question": {
                 "type": "string",
-                "description": "Your specific question or request about the image to resolve. The AI will automatically provide a complete image description AND answer your specific question."
+                "description": "Your specific question or request about the image. The model will first understand the image itself, then answer this request."
             }
         },
         "required": ["image_url", "question"]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1,16 +1,32 @@
 #!/usr/bin/env python3
 """
-Standalone Web Tools Module
+Standalone Web and Research Knowledge Tools
 
-This module provides generic web tools that work with multiple backend providers.
-Backend is selected during ``hermes tools`` setup (web.backend in config.yaml).
-When available, Hermes can route Firecrawl calls through a Nous-hosted tool-gateway
-for Nous Subscribers only.
+This module defines Hermes-native built-in web/research grounding primitives.
+The canonical built-in surface currently exposed from this file is:
+- web_search_tool: live web search for current external information
+- web_extract_tool: text-first extraction from specific public URLs
 
-Available tools:
-- web_search_tool: Search the web for information
-- web_extract_tool: Extract content from specific web pages
-- web_crawl_tool: Crawl websites with specific instructions
+A crawl implementation also exists in this module, but it is not currently part of
+Hermes's canonical built-in web/research surface unless another layer explicitly
+registers or exposes it.
+
+Backend behavior:
+- Hermes presents a stable built-in interface while routing to the configured backend
+  selected during ``hermes tools`` setup (web.backend in config.yaml).
+- Result shape and retrieval behavior can vary somewhat by backend/provider.
+- When available, Hermes can route Firecrawl calls through a Nous-hosted tool gateway
+  for Nous Subscribers only.
+
+Text-first boundary:
+- These tools are for live web/research grounding and page text retrieval.
+- ``web_extract`` is text-first: it returns markdown/plain extracted content when a
+  backend can fetch the URL directly, and it may summarize long pages with an
+  auxiliary text model.
+- If direct retrieval fails, times out, or the task requires interactive navigation,
+  login handling, or visual inspection, use Hermes browser/document surfaces instead.
+- URL-accessed PDFs may still be converted into text when the backend supports it,
+  but document/PDF intelligence remains outside this module's product boundary.
 
 Backend compatibility:
 - Exa: https://exa.ai (search, extract)
@@ -28,15 +44,17 @@ Debug Mode:
 - Captures all tool calls, results, and compression metrics
 
 Usage:
-    from web_tools import web_search_tool, web_extract_tool, web_crawl_tool
-    
+    from web_tools import web_search_tool, web_extract_tool
+
     # Search the web
     results = web_search_tool("Python machine learning libraries", limit=3)
-    
-    # Extract content from URLs  
+
+    # Extract text-first content from URLs
     content = web_extract_tool(["https://example.com"], format="markdown")
-    
-    # Crawl a website
+
+    # Crawl is implemented here for internal/explicit use only; it is not part of
+    # Hermes's canonical built-in web/research surface unless a later layer
+    # explicitly registers or exposes it.
     crawl_data = web_crawl_tool("example.com", "Find contact information")
 """
 
@@ -570,7 +588,7 @@ async def process_content_with_llm(
                 f"\n\n[Content truncated — showing first {MAX_OUTPUT_SIZE:,} of "
                 f"{len(content):,} chars. LLM summarization timed out. "
                 f"To fix: increase auxiliary.web_extract.timeout in config.yaml, "
-                f"or use a faster auxiliary model. Use browser_navigate for the full page.]"
+                f"or use a faster auxiliary model. If you need the full page or interactive access, use the browser/document surfaces.]"
             )
         return truncated
 
@@ -1034,13 +1052,12 @@ async def _parallel_extract(urls: List[str]) -> List[Dict[str, Any]]:
 
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
-    Search the web for information using available search API backend.
+    Search the live web using Hermes's built-in web/research grounding surface.
 
-    This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
-
-    Note: This function returns search result metadata only (URLs, titles, descriptions).
-    Use web_extract_tool to get full content from specific URLs.
+    Hermes keeps the interface stable while routing to the configured backend.
+    This tool returns search-result metadata only (titles, URLs, descriptions)
+    so the model can identify promising external sources before deeper retrieval
+    with ``web_extract_tool``.
     
     Args:
         query (str): The search query to look up
@@ -1170,10 +1187,12 @@ async def web_extract_tool(
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
 ) -> str:
     """
-    Extract content from specific web pages using available extraction API backend.
+    Extract text-first content from specific public URLs using Hermes's built-in
+    web/research grounding surface.
 
-    This function provides a generic interface for web content extraction that
-    can work with multiple backends. Currently uses Firecrawl.
+    Hermes keeps the interface stable while routing to the configured backend.
+    This tool is for direct URL retrieval and optional auxiliary summarization,
+    not browser-driven interaction or document/PDF intelligence workflows.
 
     Args:
         urls (List[str]): List of URLs to extract content from
@@ -1302,7 +1321,7 @@ async def web_extract_tool(
                             logger.warning("Firecrawl scrape timed out for %s", url)
                             results.append({
                                 "url": url, "title": "", "content": "",
-                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
+                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. If direct extraction is not enough, fall back to the browser/document surfaces.",
                             })
                             continue
 
@@ -1499,11 +1518,18 @@ async def web_crawl_tool(
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
 ) -> str:
     """
-    Crawl a website with specific instructions using available crawling API backend.
-    
-    This function provides a generic interface for web crawling that can work
-    with multiple backends. Currently uses Firecrawl.
-    
+    Crawl a website with specific instructions using an available crawling backend.
+
+    This implementation lives in ``tools/web_tools.py`` but is intentionally not
+    part of Hermes's canonical built-in web/research surface today. The current
+    built-in surface exposed via registry/toolsets remains ``web_search`` and
+    ``web_extract`` only unless some other layer explicitly registers or exposes
+    crawl later.
+
+    The function provides a generic interface for crawling across supported
+    backends. Today that means Tavily crawl support and Firecrawl/direct-gateway
+    crawl support when configured.
+
     Args:
         url (str): The base URL to crawl (can include or exclude https://)
         instructions (str): Instructions for what to crawl/extract using LLM intelligence (optional)
@@ -1627,7 +1653,9 @@ async def web_crawl_tool(
             _debug.save()
             return cleaned_result
 
-        # web_crawl requires Firecrawl or the Firecrawl tool-gateway — Parallel has no crawl API
+        # web_crawl is implemented here for explicit/internal use only and
+        # requires Firecrawl or the Firecrawl tool-gateway on this path.
+        # Parallel has no crawl API.
         if not check_firecrawl_api_key():
             return json.dumps({
                 "error": "web_crawl requires Firecrawl. Set FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
@@ -1986,6 +2014,8 @@ if __name__ == "__main__":
         exit(1)
 
     print("🛠️  Web tools ready for use!")
+    print("   Canonical built-in Hermes surface from this module: web_search + web_extract")
+    print("   web_crawl is implemented here but not registered as a built-in public tool")
     
     if nous_available:
         print(f"🧠 LLM content processing available with {default_summarizer_model}")
@@ -1999,24 +2029,27 @@ if __name__ == "__main__":
         print("🐛 Debug mode disabled (set WEB_TOOLS_DEBUG=true to enable)")
     
     print("\nBasic usage:")
-    print("  from web_tools import web_search_tool, web_extract_tool, web_crawl_tool")
+    print("  from web_tools import web_search_tool, web_extract_tool")
     print("  import asyncio")
     print("")
     print("  # Search (synchronous)")
     print("  results = web_search_tool('Python tutorials')")
     print("")
-    print("  # Extract and crawl (asynchronous)")
+    print("  # Extract from the canonical built-in surface (asynchronous)")
     print("  async def main():")
     print("      content = await web_extract_tool(['https://example.com'])")
-    print("      crawl_data = await web_crawl_tool('example.com', 'Find docs')")
     print("  asyncio.run(main())")
+    print("")
+    print("  # Optional/internal crawl implementation in this module (not registry-exposed)")
+    print("  # from web_tools import web_crawl_tool")
+    print("  # crawl_data = await web_crawl_tool('example.com', 'Find docs')")
     
     if nous_available:
         print("\nLLM-enhanced usage:")
         print("  # Content automatically processed for pages >5000 chars (default)")
         print("  content = await web_extract_tool(['https://python.org/about/'])")
         print("")
-        print("  # Customize processing parameters")
+        print("  # Optional/internal crawl implementation (still not part of the built-in surface)")
         print("  crawl_data = await web_crawl_tool(")
         print("      'docs.python.org',")
         print("      'Find key concepts',")
@@ -2047,13 +2080,13 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information on any topic. Returns up to 5 relevant results with titles, URLs, and descriptions.",
+    "description": "Hermes built-in web/research grounding primitive for live web search. Use it to gather current external information and candidate sources before deeper retrieval. Hermes keeps the interface stable, but exact ranking and result details can vary by configured backend. Returns up to 5 results with titles, URLs, and descriptions.",
     "parameters": {
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": "The search query to look up on the web"
+                "description": "Search query for live web/research grounding"
             }
         },
         "required": ["query"]
@@ -2062,14 +2095,14 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Hermes built-in web/research grounding primitive for text-first extraction from public URLs. Returns extracted page text in markdown form when the configured backend can fetch the URL directly, and may summarize long pages with an auxiliary text model. URL-accessed PDFs may still be converted to text, but browser-driven navigation and document/PDF intelligence are outside this tool's scope. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If direct extraction fails, times out, or the task needs interactive/visual access, fall back to Hermes browser/document tools.",
     "parameters": {
         "type": "object",
         "properties": {
             "urls": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "List of URLs to extract content from (max 5 URLs per call)",
+                "description": "List of public URLs to extract text content from directly (max 5 URLs per call)",
                 "maxItems": 5
             }
         },

--- a/toolsets.py
+++ b/toolsets.py
@@ -66,8 +66,9 @@ _HERMES_CORE_TOOLS = [
 _CODE_INTEL_TOOLS = [
     # AST structure and lightweight local source analysis
     "ast_list_defs", "ast_find_nodes",
-    # LSP-backed symbol lookup, definitions, and diagnostics
+    # LSP-backed symbol lookup, definitions, diagnostics, and rename/reference flows
     "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
+    "lsp_prepare_rename", "lsp_references", "lsp_rename",
 ]
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -71,6 +71,42 @@ _CODE_INTEL_TOOLS = [
 ]
 
 
+# Canonical built-in knowledge-surface names for the Priority 1 control-plane
+# freeze. These intentionally distinguish the product-facing knowledge
+# families from older low-level family buckets like `web`, `browser`, `vision`,
+# and `code_intel` without changing behavior yet.
+_KNOWLEDGE_SURFACE_ALIASES = {
+    "repo_code_knowledge": "repo-code-knowledge",
+    "repo-knowledge": "repo-code-knowledge",
+    "web_research_knowledge": "web-research-knowledge",
+    "research-knowledge": "web-research-knowledge",
+    "document_intelligence": "document-pdf-diagram-intelligence",
+    "document-intelligence": "document-pdf-diagram-intelligence",
+}
+
+_CANONICAL_KNOWLEDGE_SURFACES = {
+    "repo-code-knowledge",
+    "web-research-knowledge",
+    "document-pdf-diagram-intelligence",
+}
+
+_REPO_CODE_KNOWLEDGE_TOOLS = [
+    "read_file", "search_files",
+    *_CODE_INTEL_TOOLS,
+]
+
+_WEB_RESEARCH_KNOWLEDGE_TOOLS = [
+    "web_search", "web_extract",
+]
+
+_DOCUMENT_INTELLIGENCE_TOOLS = [
+    "browser_navigate", "browser_snapshot", "browser_click",
+    "browser_scroll", "browser_back", "browser_press",
+    "browser_get_images", "browser_vision", "browser_console",
+    "vision_analyze",
+]
+
+
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
 TOOLSETS = {
@@ -192,6 +228,27 @@ TOOLSETS = {
         "description": "Code intelligence tools for AST structure, symbol lookup, definitions, and diagnostics",
         "tools": _CODE_INTEL_TOOLS,
         "includes": []
+    },
+
+    "repo-code-knowledge": {
+        "description": "Canonical built-in repo/code knowledge surface for local file reading, file search, AST structure lookup, and LSP symbol/definition/diagnostic inspection.",
+        "tools": _REPO_CODE_KNOWLEDGE_TOOLS,
+        "includes": [],
+        "aliases": ["repo_code_knowledge", "repo-knowledge"],
+    },
+
+    "web-research-knowledge": {
+        "description": "Canonical built-in web/research knowledge surface for live web search and page extraction. This is a built-in web intelligence surface, not an additive MCP crawl stack.",
+        "tools": _WEB_RESEARCH_KNOWLEDGE_TOOLS,
+        "includes": [],
+        "aliases": ["web_research_knowledge", "research-knowledge"],
+    },
+
+    "document-pdf-diagram-intelligence": {
+        "description": "Canonical built-in document/PDF/diagram intelligence surface for browser navigation, page inspection, image collection, and vision analysis. This is built-in document intelligence, not a standalone PDF parser or diagram editor.",
+        "tools": _DOCUMENT_INTELLIGENCE_TOOLS,
+        "includes": [],
+        "aliases": ["document_intelligence", "document-intelligence"],
     },
     
     "code_execution": {
@@ -441,9 +498,17 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         Dict: Toolset definition with description, tools, and includes
         None: If toolset not found
     """
-    toolset = TOOLSETS.get(name)
+    canonical_name = _KNOWLEDGE_SURFACE_ALIASES.get(name, name)
+    toolset = TOOLSETS.get(canonical_name)
     if toolset:
-        return toolset
+        if canonical_name == name:
+            return toolset
+        aliased_toolset = dict(toolset)
+        aliased_toolset["description"] = (
+            f"{toolset['description']} Alias for canonical toolset '{canonical_name}'."
+        )
+        aliased_toolset["canonical_name"] = canonical_name
+        return aliased_toolset
 
     try:
         from tools.registry import registry
@@ -492,6 +557,8 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     """
     if visited is None:
         visited = set()
+
+    name = _KNOWLEDGE_SURFACE_ALIASES.get(name, name)
     
     # Special aliases that represent all tools across every toolset
     # This ensures future toolsets are automatically included without changes.
@@ -574,6 +641,36 @@ def _get_registry_toolset_aliases() -> Dict[str, str]:
         return {}
 
 
+def get_toolset_contract(name: str) -> Optional[Dict[str, Any]]:
+    """Return control-plane classification metadata for a toolset or alias."""
+    canonical_name = _KNOWLEDGE_SURFACE_ALIASES.get(name, name)
+    toolset = TOOLSETS.get(canonical_name)
+    if toolset:
+        return {
+            "name": name,
+            "canonical_name": canonical_name,
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": name != canonical_name,
+            "aliases": list(toolset.get("aliases", [])),
+            "is_canonical_knowledge_surface": canonical_name in _CANONICAL_KNOWLEDGE_SURFACES,
+            "boundary_note": (
+                "Canonical built-in control-plane surface; downstream wrappers, propagation, "
+                "and additive MCP/plugin productization stay separate."
+                if canonical_name in _CANONICAL_KNOWLEDGE_SURFACES
+                else "Built-in toolset; not an additive registry surface."
+            ),
+            "tools": resolve_toolset(canonical_name),
+        }
+
+    try:
+        from tools.registry import registry
+        return registry.get_registered_toolset_contract(name)
+    except Exception:
+        return None
+
+
 def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     """
     Get all available toolsets with their definitions.
@@ -583,7 +680,10 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict: All toolset definitions
     """
-    result = dict(TOOLSETS)
+    result = {}
+    for name, toolset in TOOLSETS.items():
+        contract = get_toolset_contract(name) or {}
+        result[name] = {**toolset, **contract}
     aliases = _get_registry_toolset_aliases()
     for ts_name in _get_plugin_toolset_names():
         display_name = ts_name
@@ -595,7 +695,8 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
             continue
         toolset = get_toolset(display_name)
         if toolset:
-            result[display_name] = toolset
+            contract = get_toolset_contract(display_name) or {}
+            result[display_name] = {**toolset, **contract}
     return result
 
 
@@ -634,6 +735,8 @@ def validate_toolset(name: str) -> bool:
     """
     # Accept special alias names for convenience
     if name in {"all", "*"}:
+        return True
+    if name in _KNOWLEDGE_SURFACE_ALIASES:
         return True
     if name in TOOLSETS:
         return True
@@ -681,6 +784,7 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         return None
     
     resolved_tools = resolve_toolset(name)
+    contract = get_toolset_contract(name) or {}
     
     return {
         "name": name,
@@ -689,7 +793,16 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         "includes": toolset["includes"],
         "resolved_tools": resolved_tools,
         "tool_count": len(resolved_tools),
-        "is_composite": bool(toolset["includes"])
+        "is_composite": bool(toolset["includes"]),
+        "canonical_name": contract.get("canonical_name", name),
+        "source": contract.get("source"),
+        "is_builtin": contract.get("is_builtin", False),
+        "is_additive": contract.get("is_additive", False),
+        "is_alias": contract.get("is_alias", False),
+        "is_canonical_knowledge_surface": contract.get(
+            "is_canonical_knowledge_surface", False
+        ),
+        "boundary_note": contract.get("boundary_note"),
     }
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -26,8 +26,8 @@ Usage:
 from typing import List, Dict, Any, Set, Optional
 
 
-# Shared tool list for CLI and all messaging platform toolsets.
-# Edit this once to update all platforms simultaneously.
+# Shared tool list for messaging-style Hermes platform toolsets.
+# CLI/editor/API defaults can layer additional development-oriented tools on top.
 _HERMES_CORE_TOOLS = [
     # Web
     "web_search", "web_extract",
@@ -60,6 +60,14 @@ _HERMES_CORE_TOOLS = [
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+]
+
+
+_CODE_INTEL_TOOLS = [
+    # AST structure and lightweight local source analysis
+    "ast_list_defs", "ast_find_nodes",
+    # LSP-backed symbol lookup, definitions, and diagnostics
+    "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
 ]
 
 
@@ -179,6 +187,12 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    "code_intel": {
+        "description": "Code intelligence tools for AST structure, symbol lookup, definitions, and diagnostics",
+        "tools": _CODE_INTEL_TOOLS,
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
@@ -244,6 +258,7 @@ TOOLSETS = {
             "web_search", "web_extract",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
+            *_CODE_INTEL_TOOLS,
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
             "browser_navigate", "browser_snapshot", "browser_click",
@@ -266,6 +281,8 @@ TOOLSETS = {
             "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
+            # Code intelligence
+            *_CODE_INTEL_TOOLS,
             # Vision + image generation
             "vision_analyze", "image_generate",
             # Skills
@@ -292,7 +309,7 @@ TOOLSETS = {
     
     "hermes-cli": {
         "description": "Full interactive CLI toolset - all default tools plus cronjob management",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": [*_HERMES_CORE_TOOLS, *_CODE_INTEL_TOOLS],
         "includes": []
     },
     

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -68,7 +68,7 @@ _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _SLASH_WORKER_TIMEOUT_S = max(5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45))
 _LIVE_WORK_COMMANDS = frozenset({"handoff", "init-deep", "start-work", "ralph-loop", "ulw-loop"})
-_NATIVE_PRODUCT_COMMANDS = frozenset({"setup", "skills", "tools"})
+_NATIVE_PRODUCT_COMMANDS = frozenset({"setup", "skills", "swarm", "tools"})
 _LIVE_SLASH_COMMANDS = frozenset({"model", "provider"}) | _LIVE_WORK_COMMANDS
 _LEGACY_SLASH_WORKER_COMMANDS = frozenset({
     "agents",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1230,7 +1230,11 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             continue
         if not (m.get("content") or "").strip():
             continue
-        messages.append({"role": role, "text": m.get("content") or ""})
+        payload = {"role": role, "text": m.get("content") or ""}
+        swarm = (m.get("metadata") or {}).get("swarm") if isinstance(m.get("metadata"), dict) else None
+        if role == "assistant" and isinstance(swarm, dict):
+            payload["swarm"] = swarm
+        messages.append(payload)
 
     return messages
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -24,6 +24,38 @@ except Exception:
     pass
 
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
+from tui_gateway.setup_services import (
+    bootstrap_provider_config as _bootstrap_provider_config_impl,
+    build_setup_catalog_payload as _build_setup_catalog_payload_impl,
+    build_setup_status_payload as _build_setup_status_payload_impl,
+    native_setup_catalog as _native_setup_catalog_impl,
+    persist_bootstrap_model as _persist_bootstrap_model_impl,
+    run_setup_bootstrap as _run_setup_bootstrap_impl,
+    setup_provider_models as _setup_provider_models_impl,
+    setup_provider_status as _setup_provider_status_impl,
+)
+from tui_gateway.skills_services import (
+    SKILLS_AUDIT_ACTION as _SKILLS_AUDIT_ACTION,
+    SKILLS_BROWSE_ACTION as _SKILLS_BROWSE_ACTION,
+    SKILLS_CHECK_ACTION as _SKILLS_CHECK_ACTION,
+    SKILLS_INSPECT_ACTION as _SKILLS_INSPECT_ACTION,
+    SKILLS_INSTALL_ACTION as _SKILLS_INSTALL_ACTION,
+    SKILLS_LIST_ACTION as _SKILLS_LIST_ACTION,
+    SKILLS_MANAGE_ACTIONS as _SKILLS_MANAGE_ACTIONS,
+    SKILLS_SEARCH_ACTION as _SKILLS_SEARCH_ACTION,
+    SKILLS_UNINSTALL_ACTION as _SKILLS_UNINSTALL_ACTION,
+    SKILLS_UPDATE_ACTION as _SKILLS_UPDATE_ACTION,
+    dispatch_skills_manage as _dispatch_skills_manage_impl,
+    normalize_skills_action as _normalize_skills_action_impl,
+)
+from tui_gateway.tools_services import (
+    build_tools_catalog_payload as _build_tools_catalog_payload_impl,
+    configure_mcp_servers as _configure_mcp_servers_impl,
+    configure_tool_provider as _configure_tool_provider_impl,
+    configure_tools as _configure_tools_impl,
+    probe_mcp_servers as _probe_mcp_servers_impl,
+    slugify_name as _slugify_name_impl,
+)
 
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
@@ -35,6 +67,44 @@ _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _SLASH_WORKER_TIMEOUT_S = max(5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45))
+_LIVE_WORK_COMMANDS = frozenset({"handoff", "init-deep", "start-work", "ralph-loop", "ulw-loop"})
+_NATIVE_PRODUCT_COMMANDS = frozenset({"setup", "skills", "tools"})
+_LIVE_SLASH_COMMANDS = frozenset({"model", "provider"}) | _LIVE_WORK_COMMANDS
+_LEGACY_SLASH_WORKER_COMMANDS = frozenset({
+    "agents",
+    "browser",
+    "config",
+    "cron",
+    "debug",
+    "fast",
+    "gquota",
+    "history",
+    "insights",
+    "platforms",
+    "plugins",
+    "profile",
+    "reload",
+    "reload-mcp",
+    "rollback",
+    "save",
+    "snapshot",
+    "status",
+    "stop",
+    "title",
+    "toolsets",
+})
+_SLASH_EXEC_COMMANDS = _LIVE_SLASH_COMMANDS | _LEGACY_SLASH_WORKER_COMMANDS
+
+
+def _routing_owner(name: str) -> str:
+    canonical = _resolve_slash_command_name(name)
+    if canonical in _NATIVE_PRODUCT_COMMANDS:
+        return "native"
+    if canonical in _LIVE_SLASH_COMMANDS:
+        return "slash-live"
+    if canonical in _LEGACY_SLASH_WORKER_COMMANDS:
+        return "slash-legacy"
+    return "dispatch"
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
@@ -218,6 +288,25 @@ def _sess(params, rid):
     return (None, err) if err else (s, _wait_agent(s, rid))
 
 
+def _parse_slash_command(command: str) -> tuple[str, str]:
+    parts = command.strip().lstrip("/").split(None, 1)
+    if not parts:
+        return "", ""
+    return parts[0].lower(), (parts[1].strip() if len(parts) > 1 else "")
+
+
+def _resolve_slash_command_name(name: str) -> str:
+    if not name:
+        return ""
+    try:
+        from hermes_cli.commands import resolve_command
+
+        resolved = resolve_command(name)
+        return resolved.name if resolved else name
+    except Exception:
+        return name
+
+
 def _normalize_completion_path(path_part: str) -> str:
     expanded = os.path.expanduser(path_part)
     if os.name != "nt":
@@ -264,6 +353,19 @@ def _save_cfg(cfg: dict):
             _cfg_mtime = path.stat().st_mtime
         except Exception:
             _cfg_mtime = None
+
+
+def _slugify_name(value: str) -> str:
+    return _slugify_name_impl(value)
+
+
+def _capture_console_output(fn, *args, **kwargs) -> str:
+    from rich.console import Console
+
+    console = Console(record=True, width=100, force_terminal=False, color_system=None)
+    kwargs.setdefault("console", console)
+    fn(*args, **kwargs)
+    return console.export_text(clear=False).strip()
 
 
 def _set_session_context(session_key: str) -> list:
@@ -395,6 +497,69 @@ def _load_enabled_toolsets() -> list[str] | None:
         return None
 
 
+def _visible_tool_payload(enabled_toolsets: list[str] | None) -> tuple[list[dict], set[str]]:
+    from model_tools import get_tool_definitions
+
+    tools = get_tool_definitions(enabled_toolsets=enabled_toolsets, quiet_mode=True)
+    visible_names = {
+        str(tool.get("function", {}).get("name", "") or "")
+        for tool in tools
+        if str(tool.get("function", {}).get("name", "") or "")
+    }
+    return tools, visible_names
+
+
+def _tool_summary_row(tool: dict) -> dict:
+    fn = tool.get("function", {}) or {}
+    name = str(fn.get("name", "") or "")
+    desc = str(fn.get("description", "") or "").split("\n")[0]
+    if ". " in desc:
+        desc = desc[:desc.index(". ") + 1]
+    return {"name": name, "description": desc}
+
+
+def _derive_visible_toolsets(enabled_toolsets: list[str] | None) -> tuple[list[dict], list[dict], set[str]]:
+    from model_tools import get_available_toolsets
+    from toolsets import get_toolset_contract, get_toolset_info
+
+    visible_tools, visible_names = _visible_tool_payload(enabled_toolsets)
+    visible_rows_by_name = {
+        row["name"]: row
+        for row in (_tool_summary_row(tool) for tool in visible_tools)
+        if row["name"]
+    }
+
+    items = []
+    for name, metadata in sorted(get_available_toolsets().items()):
+        info = get_toolset_info(name) or {}
+        contract = get_toolset_contract(name) or {}
+        resolved_tools = list(info.get("resolved_tools") or metadata.get("tools") or contract.get("tools") or [])
+        visible_members = [tool_name for tool_name in resolved_tools if tool_name in visible_names]
+        items.append({
+            "name": name,
+            "description": info.get("description") or metadata.get("description", ""),
+            "tool_count": len(resolved_tools),
+            "enabled": bool(visible_members),
+            "tools": resolved_tools,
+            "resolved_tools": resolved_tools,
+            "visible_tools": [visible_rows_by_name[tool_name] for tool_name in visible_members if tool_name in visible_rows_by_name],
+            "visible_tool_names": visible_members,
+            "available": metadata.get("available", True),
+            "requirements": list(metadata.get("requirements") or []),
+            "canonical_name": contract.get("canonical_name", metadata.get("canonical_name", name)),
+            "source": contract.get("source", metadata.get("source")),
+            "is_builtin": contract.get("is_builtin", metadata.get("is_builtin", False)),
+            "is_additive": contract.get("is_additive", metadata.get("is_additive", False)),
+            "is_alias": contract.get("is_alias", metadata.get("is_alias", False)),
+            "is_canonical_knowledge_surface": contract.get(
+                "is_canonical_knowledge_surface",
+                metadata.get("is_canonical_knowledge_surface", False),
+            ),
+            "boundary_note": contract.get("boundary_note", metadata.get("boundary_note")),
+        })
+    return items, visible_tools, visible_names
+
+
 def _session_tool_progress_mode(sid: str) -> str:
     return str(_sessions.get(sid, {}).get("tool_progress_mode", "all") or "all")
 
@@ -432,6 +597,33 @@ def _persist_model_switch(result) -> None:
     else:
         model_cfg.pop("base_url", None)
     save_config(cfg)
+
+
+def _setup_provider_models(provider: str, max_models: int = 24) -> tuple[list[str], str]:
+    return _setup_provider_models_impl(provider, max_models=max_models)
+
+
+def _setup_provider_status(provider: str) -> dict:
+    return _setup_provider_status_impl(provider)
+
+
+def _native_setup_catalog() -> list[dict]:
+    return _native_setup_catalog_impl(provider_status=_setup_provider_status, provider_models=_setup_provider_models)
+
+
+def _persist_bootstrap_model(provider: str, model: str, *, base_url: str = "", api_mode: str | None = None) -> None:
+    _persist_bootstrap_model_impl(provider, model, base_url=base_url, api_mode=api_mode)
+
+
+def _bootstrap_provider_config(provider: str, *, api_key: str = "", model: str = "", base_url: str = "") -> dict:
+    return _bootstrap_provider_config_impl(
+        provider,
+        api_key=api_key,
+        model=model,
+        base_url=base_url,
+        provider_models=_setup_provider_models,
+        persist_model=_persist_bootstrap_model,
+    )
 
 
 def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
@@ -1357,6 +1549,10 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    return _start_prompt_submit(rid, sid, session, text)
+
+
+def _start_prompt_submit(rid, sid: str, session: dict, text: str) -> dict:
     with session["history_lock"]:
         if session.get("running"):
             return _err(rid, 4009, "session busy")
@@ -1878,13 +2074,59 @@ def _(rid, params: dict) -> dict:
     return _err(rid, 4002, f"unknown config key: {key}")
 
 
+def _setup_status_payload() -> dict:
+    from hermes_cli.main import _has_any_provider_configured
+
+    return _build_setup_status_payload_impl(
+        load_cfg=_load_cfg,
+        resolve_model=_resolve_model,
+        provider_configured=_has_any_provider_configured,
+    )
+
+
+def _setup_catalog_payload() -> dict:
+    from hermes_cli.main import _has_any_provider_configured
+
+    return _build_setup_catalog_payload_impl(
+        load_cfg=_load_cfg,
+        resolve_model=_resolve_model,
+        provider_configured=_has_any_provider_configured,
+        catalog_builder=_native_setup_catalog,
+    )
+
+
+def _setup_bootstrap_payload(params: dict) -> dict:
+    return _run_setup_bootstrap_impl(
+        provider=str(params.get("provider", "") or ""),
+        api_key=str(params.get("api_key", "") or ""),
+        model=str(params.get("model", "") or ""),
+        base_url=str(params.get("base_url", "") or ""),
+        bootstrapper=_bootstrap_provider_config,
+    )
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
     try:
-        from hermes_cli.main import _has_any_provider_configured
-        return _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
+        return _ok(rid, _setup_status_payload())
     except Exception as e:
         return _err(rid, 5016, str(e))
+
+
+@method("setup.catalog")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _setup_catalog_payload())
+    except Exception as e:
+        return _err(rid, 5034, str(e))
+
+
+@method("setup.bootstrap")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _setup_bootstrap_payload(params))
+    except Exception as e:
+        return _err(rid, 5035, str(e))
 
 
 # ── Methods: tools & system ──────────────────────────────────────────
@@ -2059,6 +2301,13 @@ def _(rid, params: dict) -> dict:
     resolved = _resolve_name(name)
     if resolved != name:
         name = resolved
+
+    owner = _routing_owner(name)
+    if owner == "native":
+        return _err(rid, 4002, f"/{name} is handled by native product routing; command.dispatch is fallback-only")
+    if owner.startswith("slash"):
+        return _err(rid, 4002, f"/{name} is handled by slash.exec; command.dispatch is fallback-only")
+
     session = _sessions.get(params.get("session_id", ""))
 
     qcmds = _load_cfg().get("quick_commands", {})
@@ -2260,10 +2509,10 @@ def _(rid, params: dict) -> dict:
 
 def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     """Apply side effects that must also hit the gateway's live agent."""
-    parts = command.lstrip("/").split(None, 1)
-    if not parts:
+    name, arg = _parse_slash_command(command)
+    if not name:
         return ""
-    name, arg, agent = parts[0], (parts[1].strip() if len(parts) > 1 else ""), session.get("agent")
+    agent = session.get("agent")
 
     try:
         if name == "model" and arg and agent:
@@ -2298,6 +2547,42 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     return ""
 
 
+def _run_live_work_slash(rid, sid: str, session: dict, command: str) -> dict:
+    from hermes_cli.work_command_adapter import WorkCommandContractError, prepare_work_command
+
+    name, arg = _parse_slash_command(command)
+    try:
+        prepared = prepare_work_command(
+            name,
+            raw_args=arg,
+            session_id=session["session_key"],
+            cwd=os.environ.get("TERMINAL_CWD") or os.getcwd(),
+        )
+    except WorkCommandContractError as exc:
+        return _err(rid, 4002, str(exc))
+    except Exception as exc:
+        return _err(rid, 5030, str(exc))
+
+    started = _start_prompt_submit(rid, sid, session, prepared)
+    if started.get("error"):
+        return started
+    return _ok(rid, {"output": f"/{name} started"})
+
+
+def _run_live_model_slash(rid, sid: str, session: dict, arg: str) -> dict:
+    if not arg:
+        return _err(rid, 4002, "model value required")
+    try:
+        result = _apply_model_switch(sid, session, arg)
+    except Exception as exc:
+        return _err(rid, 5001, str(exc))
+
+    payload = {"output": f"model → {result['value']}"}
+    if result.get("warning"):
+        payload["warning"] = result["warning"]
+    return _ok(rid, payload)
+
+
 @method("slash.exec")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
@@ -2308,6 +2593,23 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
 
+    sid = params.get("session_id", "")
+    name, arg = _parse_slash_command(cmd)
+    name = _resolve_slash_command_name(name)
+    normalized_cmd = f"{name}{(' ' + arg) if arg else ''}"
+    owner = _routing_owner(name)
+
+    if owner == "slash-live":
+        if name in _LIVE_WORK_COMMANDS:
+            return _run_live_work_slash(rid, sid, session, normalized_cmd)
+        return _run_live_model_slash(rid, sid, session, arg)
+
+    if owner == "native":
+        return _err(rid, 4002, f"/{name} is handled by native product routing; slash.exec is legacy-only")
+
+    if owner != "slash-legacy":
+        return _err(rid, 4002, f"/{name} is not eligible for slash.exec; use native routing or command.dispatch")
+
     worker = session.get("slash_worker")
     if not worker:
         try:
@@ -2317,8 +2619,8 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5030, f"slash worker start failed: {e}")
 
     try:
-        output = worker.run(cmd)
-        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
+        output = worker.run(normalized_cmd)
+        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, normalized_cmd)
         payload = {"output": output or "(no output)"}
         if warning:
             payload["warning"] = warning
@@ -2565,53 +2867,289 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5030, str(e))
 
 
+def _tools_catalog_payload() -> dict:
+    from hermes_cli.config import get_env_value, load_config
+    from hermes_cli.nous_subscription import get_nous_subscription_features
+    from hermes_cli.tools_config import (
+        CONFIGURABLE_TOOLSETS,
+        TOOL_CATEGORIES,
+        _get_effective_configurable_toolsets,
+        _get_platform_tools,
+    )
+    from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+    return _build_tools_catalog_payload_impl(
+        load_config=load_config,
+        get_env_value=get_env_value,
+        configurable_toolsets=CONFIGURABLE_TOOLSETS,
+        tool_categories=TOOL_CATEGORIES,
+        effective_toolsets=_get_effective_configurable_toolsets,
+        get_platform_tools=_get_platform_tools,
+        get_subscription_features=get_nous_subscription_features,
+        managed_nous_tools_enabled=managed_nous_tools_enabled,
+    )
+
+
+def _tools_provider_configure_payload(params: dict) -> dict:
+    from hermes_cli.config import get_env_value, load_config, save_config, save_env_value
+    from hermes_cli.nous_subscription import get_nous_subscription_features
+    from hermes_cli.tools_config import TOOL_CATEGORIES
+    from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+    return _configure_tool_provider_impl(
+        toolset=str(params.get("toolset", "") or ""),
+        provider_name=str(params.get("provider", "") or ""),
+        model=str(params.get("model", "") or ""),
+        env_values=params.get("env") or {},
+        session_id=str(params.get("session_id", "") or ""),
+        session_lookup=_sessions.get,
+        reset_session_agent=_reset_session_agent,
+        catalog_payload_builder=_tools_catalog_payload,
+        load_config=load_config,
+        save_config=save_config,
+        save_env_value=save_env_value,
+        get_env_value=get_env_value,
+        tool_categories=TOOL_CATEGORIES,
+        get_subscription_features=get_nous_subscription_features,
+        managed_nous_tools_enabled=managed_nous_tools_enabled,
+    )
+
+
+def _tools_mcp_configure_payload(params: dict) -> dict:
+    from hermes_cli.config import load_config, save_config
+
+    return _configure_mcp_servers_impl(
+        action=str(params.get("action", "") or ""),
+        names=params.get("names", []) or [],
+        session_id=str(params.get("session_id", "") or ""),
+        session_lookup=_sessions.get,
+        reset_session_agent=_reset_session_agent,
+        catalog_payload_builder=_tools_catalog_payload,
+        load_config=load_config,
+        save_config=save_config,
+    )
+
+
+def _tools_mcp_probe_payload() -> dict:
+    from hermes_cli.config import load_config
+    from tools.mcp_tool import probe_mcp_server_tools
+
+    return _probe_mcp_servers_impl(
+        load_config=load_config,
+        probe_mcp_server_tools=probe_mcp_server_tools,
+    )
+
+
+def _validate_skills_manage_params(params: dict) -> dict:
+    action = _normalize_skills_action_impl(params.get("action"))
+    if action not in _SKILLS_MANAGE_ACTIONS:
+        raise ValueError(f"unknown skills action: {action}")
+
+    allowed_keys_by_action = {
+        _SKILLS_LIST_ACTION: frozenset({"action"}),
+        _SKILLS_SEARCH_ACTION: frozenset({"action", "query"}),
+        _SKILLS_BROWSE_ACTION: frozenset({"action", "page", "page_size", "query", "source"}),
+        _SKILLS_INSPECT_ACTION: frozenset({"action", "query"}),
+        _SKILLS_INSTALL_ACTION: frozenset({"action", "query"}),
+        _SKILLS_CHECK_ACTION: frozenset({"action", "query"}),
+        _SKILLS_UPDATE_ACTION: frozenset({"action", "query"}),
+        _SKILLS_AUDIT_ACTION: frozenset({"action", "query"}),
+        _SKILLS_UNINSTALL_ACTION: frozenset({"action", "query"}),
+    }
+    unexpected_keys = sorted(str(key) for key in params.keys() if key not in allowed_keys_by_action[action])
+    if unexpected_keys:
+        raise ValueError(f"unexpected skills params for {action}: {', '.join(unexpected_keys)}")
+
+    query = str(params.get("query", "") or "")
+    if action in {_SKILLS_SEARCH_ACTION, _SKILLS_INSPECT_ACTION, _SKILLS_INSTALL_ACTION, _SKILLS_UNINSTALL_ACTION} and not query.strip():
+        raise ValueError(f"skills.{action} requires query")
+
+    if action == _SKILLS_BROWSE_ACTION:
+        for key in ("page", "page_size"):
+            raw = params.get(key)
+            if raw is None or str(raw).strip() == "":
+                continue
+            value = int(raw)
+            if value <= 0:
+                raise ValueError(f"skills.browse requires positive {key}")
+
+    return dict(params, action=action, query=query)
+
+
+def _skills_manage_payload(params: dict) -> dict:
+    validated = _validate_skills_manage_params(params)
+
+    from hermes_cli.banner import get_available_skills
+    from hermes_cli.skills_hub import browse_skills, do_audit, do_check, do_install, do_uninstall, do_update, inspect_skill
+    from tools.skills_hub import GitHubAuth, create_source_router, unified_search
+
+    return _dispatch_skills_manage_impl(
+        validated,
+        get_available_skills=get_available_skills,
+        capture_console_output=_capture_console_output,
+        auth_factory=GitHubAuth,
+        source_router_factory=create_source_router,
+        unified_search=unified_search,
+        browse_skills=browse_skills,
+        inspect_skill=inspect_skill,
+        do_install=do_install,
+        do_check=do_check,
+        do_update=do_update,
+        do_audit=do_audit,
+        do_uninstall=do_uninstall,
+    )
+
+
+def _tools_configure_payload(params: dict) -> dict:
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.tools_config import (
+        CONFIGURABLE_TOOLSETS,
+        _get_platform_tools,
+        _get_plugin_toolset_keys,
+        _save_platform_tools,
+    )
+
+    return _configure_tools_impl(
+        action=str(params.get("action", "") or ""),
+        targets=params.get("names", []) or [],
+        session_id=str(params.get("session_id", "") or ""),
+        session_lookup=_sessions.get,
+        reset_session_agent=_reset_session_agent,
+        load_config=load_config,
+        save_config=save_config,
+        configurable_toolsets=CONFIGURABLE_TOOLSETS,
+        plugin_toolset_keys=_get_plugin_toolset_keys,
+        get_platform_tools=_get_platform_tools,
+        save_platform_tools=_save_platform_tools,
+    )
+
+
 @method("tools.list")
 def _(rid, params: dict) -> dict:
     try:
-        from toolsets import get_all_toolsets, get_toolset_info
         session = _sessions.get(params.get("session_id", ""))
-        enabled = set(getattr(session["agent"], "enabled_toolsets", []) or []) if session else set(_load_enabled_toolsets() or [])
-
-        items = []
-        for name in sorted(get_all_toolsets().keys()):
-            info = get_toolset_info(name)
-            if not info:
-                continue
-            items.append({
-                "name": name,
-                "description": info["description"],
-                "tool_count": info["tool_count"],
-                "enabled": name in enabled if enabled else True,
-                "tools": info["resolved_tools"],
-            })
+        enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
+        toolsets, _, _ = _derive_visible_toolsets(enabled)
+        items = [{
+            "name": item["name"],
+            "description": item["description"],
+            "tool_count": item["tool_count"],
+            "enabled": item["enabled"],
+            "tools": item["resolved_tools"],
+            "canonical_name": item["canonical_name"],
+            "source": item["source"],
+            "is_builtin": item["is_builtin"],
+            "is_additive": item["is_additive"],
+            "is_alias": item["is_alias"],
+            "is_canonical_knowledge_surface": item["is_canonical_knowledge_surface"],
+            "boundary_note": item["boundary_note"],
+            "visible_tools": item["visible_tools"],
+        } for item in toolsets]
         return _ok(rid, {"toolsets": items})
     except Exception as e:
         return _err(rid, 5031, str(e))
 
 
+@method("tools.catalog")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_catalog_payload())
+    except Exception as e:
+        return _err(rid, 5036, str(e))
+
+
+@method("tools.provider.configure")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_provider_configure_payload(params))
+    except ValueError as e:
+        message = str(e)
+        if message == "toolset required":
+            return _err(rid, 4019, message)
+        if message == "provider required":
+            return _err(rid, 4020, message)
+        return _err(rid, 5037, message)
+    except TypeError as e:
+        return _err(rid, 4021, str(e))
+    except LookupError as e:
+        message = str(e)
+        if message.startswith("toolset has no native provider flow"):
+            return _err(rid, 4022, message)
+        if message.startswith("unknown provider for "):
+            return _err(rid, 4023, message)
+        return _err(rid, 5037, message)
+    except Exception as e:
+        return _err(rid, 5037, str(e))
+
+
+@method("tools.mcp.configure")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_mcp_configure_payload(params))
+    except ValueError as e:
+        message = str(e)
+        if message.startswith("unknown mcp action: "):
+            return _err(rid, 4024, message)
+        if message == "server names required":
+            return _err(rid, 4025, message)
+        return _err(rid, 5038, message)
+    except Exception as e:
+        return _err(rid, 5038, str(e))
+
+
+@method("tools.mcp.probe")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_mcp_probe_payload())
+    except Exception as e:
+        return _err(rid, 5039, str(e))
+
+
 @method("tools.show")
 def _(rid, params: dict) -> dict:
     try:
-        from model_tools import get_toolset_for_tool, get_tool_definitions
+        from model_tools import get_toolset_for_tool
 
         session = _sessions.get(params.get("session_id", ""))
         enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
-        tools = get_tool_definitions(enabled_toolsets=enabled, quiet_mode=True)
-        sections = {}
+        toolsets, tools, _ = _derive_visible_toolsets(enabled)
+        visible_rows = []
+        for tool in sorted(tools, key=lambda t: t.get("function", {}).get("name", "")):
+            row = _tool_summary_row(tool)
+            if not row["name"]:
+                continue
+            row["owner_toolset"] = get_toolset_for_tool(row["name"]) or "unknown"
+            visible_rows.append(row)
 
-        for tool in sorted(tools, key=lambda t: t["function"]["name"]):
-            name = tool["function"]["name"]
-            desc = str(tool["function"].get("description", "") or "").split("\n")[0]
-            if ". " in desc:
-                desc = desc[:desc.index(". ") + 1]
-            sections.setdefault(get_toolset_for_tool(name) or "unknown", []).append({
-                "name": name,
-                "description": desc,
+        sections = [
+            {
+                "name": item["name"],
+                "canonical_name": item["canonical_name"],
+                "description": item["description"],
+                "source": item["source"],
+                "is_builtin": item["is_builtin"],
+                "is_additive": item["is_additive"],
+                "is_alias": item["is_alias"],
+                "is_canonical_knowledge_surface": item["is_canonical_knowledge_surface"],
+                "boundary_note": item["boundary_note"],
+                "tools": item["visible_tools"],
+            }
+            for item in toolsets
+            if item["enabled"] and item["is_canonical_knowledge_surface"]
+        ]
+
+        legacy_sections = {}
+        for row in visible_rows:
+            legacy_sections.setdefault(row["owner_toolset"], []).append({
+                "name": row["name"],
+                "description": row["description"],
             })
 
         return _ok(rid, {
-            "sections": [{"name": name, "tools": rows} for name, rows in sorted(sections.items())],
-            "total": len(tools),
+            "sections": sections,
+            "legacy_sections": [{"name": name, "tools": rows} for name, rows in sorted(legacy_sections.items())],
+            "tools": visible_rows,
+            "total": len(visible_rows),
         })
     except Exception as e:
         return _err(rid, 5034, str(e))
@@ -2619,52 +3157,15 @@ def _(rid, params: dict) -> dict:
 
 @method("tools.configure")
 def _(rid, params: dict) -> dict:
-    action = str(params.get("action", "") or "").strip().lower()
-    targets = [str(name).strip() for name in params.get("names", []) or [] if str(name).strip()]
-    if action not in {"disable", "enable"}:
-        return _err(rid, 4017, f"unknown tools action: {action}")
-    if not targets:
-        return _err(rid, 4018, "names required")
-
     try:
-        from hermes_cli.config import load_config, save_config
-        from hermes_cli.tools_config import (
-            CONFIGURABLE_TOOLSETS,
-            _apply_mcp_change,
-            _apply_toolset_change,
-            _get_platform_tools,
-            _get_plugin_toolset_keys,
-        )
-
-        cfg = load_config()
-        valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS} | _get_plugin_toolset_keys()
-        toolset_targets = [name for name in targets if ":" not in name]
-        mcp_targets = [name for name in targets if ":" in name]
-        unknown = [name for name in toolset_targets if name not in valid_toolsets]
-        toolset_targets = [name for name in toolset_targets if name in valid_toolsets]
-
-        if toolset_targets:
-            _apply_toolset_change(cfg, "cli", toolset_targets, action)
-
-        missing_servers = _apply_mcp_change(cfg, mcp_targets, action) if mcp_targets else set()
-        save_config(cfg)
-
-        session = _sessions.get(params.get("session_id", ""))
-        info = _reset_session_agent(params.get("session_id", ""), session) if session else None
-        enabled = sorted(_get_platform_tools(load_config(), "cli", include_default_mcp_servers=False))
-        changed = [
-            name for name in targets
-            if name not in unknown and (":" not in name or name.split(":", 1)[0] not in missing_servers)
-        ]
-
-        return _ok(rid, {
-            "changed": changed,
-            "enabled_toolsets": enabled,
-            "info": info,
-            "missing_servers": sorted(missing_servers),
-            "reset": bool(session),
-            "unknown": unknown,
-        })
+        return _ok(rid, _tools_configure_payload(params))
+    except ValueError as e:
+        message = str(e)
+        if message.startswith("unknown tools action: "):
+            return _err(rid, 4017, message)
+        if message == "names required":
+            return _err(rid, 4018, message)
+        return _err(rid, 5035, message)
     except Exception as e:
         return _err(rid, 5035, str(e))
 
@@ -2672,21 +3173,23 @@ def _(rid, params: dict) -> dict:
 @method("toolsets.list")
 def _(rid, params: dict) -> dict:
     try:
-        from toolsets import get_all_toolsets, get_toolset_info
         session = _sessions.get(params.get("session_id", ""))
-        enabled = set(getattr(session["agent"], "enabled_toolsets", []) or []) if session else set(_load_enabled_toolsets() or [])
-
-        items = []
-        for name in sorted(get_all_toolsets().keys()):
-            info = get_toolset_info(name)
-            if not info:
-                continue
-            items.append({
-                "name": name,
-                "description": info["description"],
-                "tool_count": info["tool_count"],
-                "enabled": name in enabled if enabled else True,
-            })
+        enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
+        toolsets, _, _ = _derive_visible_toolsets(enabled)
+        items = [{
+            "name": item["name"],
+            "description": item["description"],
+            "tool_count": item["tool_count"],
+            "enabled": item["enabled"],
+            "canonical_name": item["canonical_name"],
+            "source": item["source"],
+            "is_builtin": item["is_builtin"],
+            "is_additive": item["is_additive"],
+            "is_alias": item["is_alias"],
+            "is_canonical_knowledge_surface": item["is_canonical_knowledge_surface"],
+            "boundary_note": item["boundary_note"],
+            "tools": item["resolved_tools"],
+        } for item in toolsets]
         return _ok(rid, {"toolsets": items})
     except Exception as e:
         return _err(rid, 5032, str(e))
@@ -2728,29 +3231,10 @@ def _(rid, params: dict) -> dict:
 
 @method("skills.manage")
 def _(rid, params: dict) -> dict:
-    action, query = params.get("action", "list"), params.get("query", "")
     try:
-        if action == "list":
-            from hermes_cli.banner import get_available_skills
-            return _ok(rid, {"skills": get_available_skills()})
-        if action == "search":
-            from hermes_cli.skills_hub import unified_search, GitHubAuth, create_source_router
-            raw = unified_search(query, create_source_router(GitHubAuth()), source_filter="all", limit=20) or []
-            return _ok(rid, {"results": [{"name": r.name, "description": r.description} for r in raw]})
-        if action == "install":
-            from hermes_cli.skills_hub import do_install
-            class _Q:
-                def print(self, *a, **k): pass
-            do_install(query, skip_confirm=True, console=_Q())
-            return _ok(rid, {"installed": True, "name": query})
-        if action == "browse":
-            from hermes_cli.skills_hub import browse_skills
-            pg = int(params.get("page", 0) or 0) or (int(query) if query.isdigit() else 1)
-            return _ok(rid, browse_skills(page=pg, page_size=int(params.get("page_size", 20))))
-        if action == "inspect":
-            from hermes_cli.skills_hub import inspect_skill
-            return _ok(rid, {"info": inspect_skill(query) or {}})
-        return _err(rid, 4017, f"unknown skills action: {action}")
+        return _ok(rid, _skills_manage_payload(params))
+    except ValueError as e:
+        return _err(rid, 4017, str(e))
     except Exception as e:
         return _err(rid, 5024, str(e))
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.swarm.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.swarm.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { resetUiState } from '../app/uiStore.js'
+
+describe('createGatewayEventHandler swarm boundary', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    resetTurnState()
+    resetUiState()
+  })
+
+  it('records delegated subagent progress inline in turn state without opening a dedicated overlay', () => {
+    const handler = createGatewayEventHandler(buildCtx())
+
+    handler({ type: 'message.start' })
+    handler({
+      type: 'subagent.start',
+      payload: { goal: 'Audit slash routes', task_count: 2, task_index: 0 }
+    })
+    handler({
+      type: 'subagent.thinking',
+      payload: { goal: 'Audit slash routes', task_count: 2, task_index: 0, text: 'Checking authoritative route owners' }
+    })
+    handler({
+      type: 'subagent.tool',
+      payload: { goal: 'Audit slash routes', task_count: 2, task_index: 0, tool_name: 'read_file', tool_preview: 'createSlashHandler.ts' }
+    })
+    handler({
+      type: 'subagent.progress',
+      payload: { goal: 'Audit slash routes', task_count: 2, task_index: 0, text: 'Confirmed no swarm live route' }
+    })
+    handler({
+      type: 'subagent.complete',
+      payload: {
+        duration_seconds: 1.5,
+        goal: 'Audit slash routes',
+        status: 'completed',
+        summary: 'No dedicated swarm command found',
+        task_count: 2,
+        task_index: 0
+      }
+    })
+
+    expect(getTurnState().subagents).toEqual([
+      {
+        durationSeconds: 1.5,
+        goal: 'Audit slash routes',
+        id: 'sa:0:Audit slash routes',
+        index: 0,
+        notes: ['Confirmed no swarm live route'],
+        status: 'completed',
+        summary: 'No dedicated swarm command found',
+        taskCount: 2,
+        thinking: ['Checking authoritative route owners'],
+        tools: ['Read File("createSlashHandler.ts")']
+      }
+    ])
+    expect(getOverlayState()).toEqual({
+      approval: null,
+      clarify: null,
+      modelPicker: false,
+      pager: null,
+      picker: false,
+      secret: null,
+      setupWizard: false,
+      sudo: null,
+      swarm: false
+    })
+  })
+
+  it('keeps completed subagents completed when later progress arrives', () => {
+    const handler = createGatewayEventHandler(buildCtx())
+
+    handler({ type: 'message.start' })
+    handler({ type: 'subagent.start', payload: { goal: 'Review T7', task_index: 0 } })
+    handler({
+      type: 'subagent.complete',
+      payload: { goal: 'Review T7', status: 'completed', summary: 'done', task_index: 0 }
+    })
+    handler({
+      type: 'subagent.progress',
+      payload: { goal: 'Review T7', task_index: 0, text: 'late note still visible' }
+    })
+
+    expect(getTurnState().subagents[0]).toMatchObject({
+      goal: 'Review T7',
+      notes: ['late note still visible'],
+      status: 'completed',
+      summary: 'done'
+    })
+  })
+})
+
+const buildCtx = () => ({
+  composer: {
+    dequeue: vi.fn(() => undefined),
+    queueEditRef: { current: null },
+    sendQueued: vi.fn()
+  },
+  gateway: {
+    rpc: vi.fn(() => Promise.resolve(null))
+  },
+  session: {
+    STARTUP_RESUME_ID: '',
+    colsRef: { current: 80 },
+    newSession: vi.fn(),
+    resetSession: vi.fn(),
+    resumeById: vi.fn(),
+    setCatalog: vi.fn()
+  },
+  system: {
+    bellOnComplete: false,
+    stdout: undefined,
+    sys: vi.fn()
+  },
+  transcript: {
+    appendMessage: vi.fn(),
+    panel: vi.fn(),
+    setHistoryItems: vi.fn()
+  }
+}) satisfies Parameters<typeof createGatewayEventHandler>[0]

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -1,13 +1,63 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createSlashHandler } from '../app/createSlashHandler.js'
+import {
+  createSlashHandler,
+  LEGACY_SLASH_EXEC_COMMANDS,
+  LIVE_SLASH_EXEC_COMMANDS,
+  NATIVE_PRODUCT_ROUTE_COMMANDS
+} from '../app/createSlashHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
-import { getUiState, resetUiState } from '../app/uiStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 
 describe('createSlashHandler', () => {
   beforeEach(() => {
     resetOverlayState()
     resetUiState()
+  })
+
+  it('locks the authoritative route boundary lists', () => {
+    expect(NATIVE_PRODUCT_ROUTE_COMMANDS).toEqual(['setup', 'skills', 'swarm', 'tools'])
+    expect(LIVE_SLASH_EXEC_COMMANDS).toEqual(['handoff', 'init-deep', 'model', 'provider', 'ralph-loop', 'start-work', 'ulw-loop'])
+    expect(LEGACY_SLASH_EXEC_COMMANDS).toEqual([
+      'agents',
+      'browser',
+      'config',
+      'cron',
+      'debug',
+      'fast',
+      'gquota',
+      'history',
+      'insights',
+      'platforms',
+      'plugins',
+      'profile',
+      'reload',
+      'reload-mcp',
+      'rollback',
+      'save',
+      'snapshot',
+      'status',
+      'stop',
+      'title',
+      'toolsets'
+    ])
+  })
+
+  it('opens the native setup wizard locally', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/setup')).toBe(true)
+    expect(getOverlayState().setupWizard).toBe(true)
+  })
+
+  it('toggles the native swarm surface locally', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/swarm')).toBe(true)
+    expect(getOverlayState().swarm).toBe(true)
+
+    expect(createSlashHandler(ctx)('/swarm close')).toBe(true)
+    expect(getOverlayState().swarm).toBe(false)
   })
 
   it('opens the resume picker locally', () => {
@@ -39,11 +89,101 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenNthCalledWith(3, 'MCP tool: /tools enable github:create_issue')
   })
 
+  it('opens the native tools catalog pager', async () => {
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn((method: string) => {
+          if (method === 'tools.catalog') {
+            return Promise.resolve({
+              mcp_servers: [{ enabled: true, name: 'github' }],
+              toolsets: [{ description: 'web tools', enabled: true, kind: 'builtin', name: 'web', title: 'Web' }]
+            })
+          }
+
+          return Promise.resolve({})
+        })
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/tools')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.page).toHaveBeenCalledWith(expect.stringContaining('Tool configuration'), 'Tools')
+    })
+  })
+
+  it('configures a native tool provider and resets visible history', async () => {
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn((method: string, params?: Record<string, unknown>) => {
+          if (method === 'tools.provider.configure') {
+            expect(params).toEqual({
+              env: { FIRECRAWL_API_KEY: 'sekret' },
+              provider: 'firecrawl',
+              session_id: null,
+              toolset: 'web'
+            })
+
+            return Promise.resolve({
+              info: { model: 'claude', skills: {}, tools: {} },
+              reset: true
+            })
+          }
+
+          return Promise.resolve({})
+        })
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/tools provider web firecrawl FIRECRAWL_API_KEY=sekret')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.session.resetVisibleHistory).toHaveBeenCalledWith({ model: 'claude', skills: {}, tools: {} })
+    })
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('provider configured: web → firecrawl')
+  })
+
+  it('routes native skills search through gateway RPC', async () => {
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn((method: string, params?: Record<string, unknown>) => {
+          if (method === 'skills.manage') {
+            expect(params).toEqual({ action: 'search', query: 'memory tools' })
+
+            return Promise.resolve({
+              results: [{ description: 'Persistent memory helpers', identifier: 'official/memory/tools', name: 'memory-tools' }]
+            })
+          }
+
+          return Promise.resolve({})
+        })
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/skills search memory tools')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(expect.stringContaining('memory-tools'))
+    })
+  })
+
   it('drops stale slash.exec output after a newer slash', async () => {
     let resolveLate: (v: { output?: string }) => void
     let slashExecCalls = 0
 
     const ctx = buildCtx({
+      local: {
+        ...buildLocal(),
+        catalog: {
+          canon: {
+            '/config': '/config',
+            '/profile': '/profile'
+          }
+        }
+      },
       gateway: {
         gw: {
           getLogTail: vi.fn(() => ''),
@@ -68,24 +208,149 @@ describe('createSlashHandler', () => {
     })
 
     const h = createSlashHandler(ctx)
-    expect(h('/slow')).toBe(true)
-    expect(h('/fast')).toBe(true)
+    expect(h('/config')).toBe(true)
+    expect(h('/profile')).toBe(true)
     resolveLate!({ output: 'too late' })
     await vi.waitFor(() => {
-      expect(ctx.transcript.sys).toHaveBeenCalled()
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('fresh')
     })
 
     expect(ctx.transcript.sys).not.toHaveBeenCalledWith('too late')
   })
 
-  it('dispatches command.dispatch with typed alias', async () => {
+  it('routes cataloged legacy commands through slash.exec only', async () => {
+    const ctx = buildCtx({
+      local: {
+        ...buildLocal(),
+        catalog: {
+          canon: {
+            '/config': '/config'
+          }
+        }
+      },
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string, params?: Record<string, unknown>) => {
+            if (method === 'slash.exec') {
+              expect(params).toEqual({ command: 'config', session_id: null })
+
+              return Promise.resolve({ output: 'config output' })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/config')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('config output')
+    })
+
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+  })
+
+  it.each([
+    ['/handoff request', 'handoff request', '/handoff started'],
+    ['/init-deep investigate', 'init-deep investigate', '/init-deep started'],
+    ['/start-work ship it', 'start-work ship it', '/start-work started'],
+    ['/ralph-loop close it', 'ralph-loop close it', '/ralph-loop started'],
+    ['/ulw-loop finish it', 'ulw-loop finish it', '/ulw-loop started']
+  ])('routes live slash commands through slash.exec even without catalog canon: %s', async (input, expectedCommand, expectedOutput) => {
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string, params?: Record<string, unknown>) => {
+            if (method === 'slash.exec') {
+              expect(params).toEqual({ command: expectedCommand, session_id: null })
+
+              return Promise.resolve({ output: expectedOutput })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h(input)).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(expectedOutput)
+    })
+
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+  })
+
+  it('dispatches command.dispatch without probing slash.exec for uncataloged commands', async () => {
     const ctx = buildCtx({
       gateway: {
         gw: {
           getLogTail: vi.fn(() => ''),
           request: vi.fn((method: string) => {
+            if (method === 'command.dispatch') {
+              return Promise.resolve({ type: 'alias', target: 'help' })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/zzz')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
+    })
+
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('promotes /swarm into the authoritative native slash route list', () => {
+    const ctx = buildCtx()
+
+    const h = createSlashHandler(ctx)
+    expect(h('/swarm')).toBe(true)
+
+    expect(getOverlayState().swarm).toBe(true)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('swarm surface open')
+  })
+
+  it.each([
+    ['/handoff request', '/handoff'],
+    ['/init-deep investigate', '/init-deep'],
+    ['/start-work ship it', '/start-work'],
+    ['/ralph-loop close it', '/ralph-loop'],
+    ['/ulw-loop finish it', '/ulw-loop']
+  ])('does not fall back to command.dispatch when slash.exec reports a busy session: %s', async (input, canon) => {
+    const ctx = buildCtx({
+      local: {
+        ...buildLocal(),
+        catalog: {
+          canon: {
+            [canon]: canon
+          }
+        }
+      },
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
             if (method === 'slash.exec') {
-              return Promise.reject(new Error('no'))
+              return Promise.reject(new Error('session busy'))
             }
 
             if (method === 'command.dispatch') {
@@ -100,10 +365,13 @@ describe('createSlashHandler', () => {
     })
 
     const h = createSlashHandler(ctx)
-    expect(h('/zzz')).toBe(true)
+    expect(h(input)).toBe(true)
+
     await vi.waitFor(() => {
-      expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('error: session busy')
     })
+
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
   })
 
   it('resolves unique local aliases through the catalog', () => {
@@ -120,6 +388,52 @@ describe('createSlashHandler', () => {
 
     expect(createSlashHandler(ctx)('/h')).toBe(true)
     expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
+    const sections = ctx.transcript.panel.mock.calls[0]?.[1] ?? []
+    expect(JSON.stringify(sections)).toContain('/swarm [open|close|toggle]')
+  })
+
+  it('opens native setup from /model when no provider is configured', async () => {
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn((method: string) => {
+          if (method === 'setup.status') {
+            return Promise.resolve({ provider_configured: false })
+          }
+
+          return Promise.resolve({})
+        })
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/model')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(getOverlayState().setupWizard).toBe(true)
+    })
+  })
+
+  it('routes /provider to the live model command', async () => {
+    patchUiState({ sid: 'sid' })
+
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn((method: string) => {
+          if (method === 'setup.status') {
+            return Promise.resolve({ provider_configured: true })
+          }
+
+          return Promise.resolve({ value: 'claude' })
+        })
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/provider claude')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', { key: 'model', session_id: 'sid', value: 'claude' })
+    })
   })
 })
 

--- a/ui-tui/src/__tests__/swarmOverlay.test.ts
+++ b/ui-tui/src/__tests__/swarmOverlay.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSwarmOverlayModel } from '../components/swarmOverlay.js'
+
+describe('buildSwarmOverlayModel', () => {
+  it('summarizes empty swarm state', () => {
+    expect(buildSwarmOverlayModel([])).toEqual({
+      empty: true,
+      headline: 'Swarm · idle',
+      summary: 'No active subagents yet',
+      total: 0
+    })
+  })
+
+  it('summarizes active and completed subagents for the dedicated swarm surface', () => {
+    expect(
+      buildSwarmOverlayModel([
+        { id: 'sa:0', index: 0, notes: [], status: 'running', summary: '', thinking: [], tools: [] },
+        { id: 'sa:1', index: 1, notes: [], status: 'completed', summary: 'done', thinking: [], tools: [] },
+        { id: 'sa:2', index: 2, notes: [], status: 'failed', summary: 'boom', thinking: [], tools: [] }
+      ])
+    ).toEqual({
+      empty: false,
+      headline: 'Swarm · 3 subagents',
+      summary: '1 running · 1 completed · 1 failed',
+      total: 3
+    })
+  })
+})

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -7,6 +7,43 @@ import { findSlashCommand } from './slash/registry.js'
 import type { SlashRunCtx } from './slash/types.js'
 import { getUiState } from './uiStore.js'
 
+export const NATIVE_PRODUCT_ROUTE_COMMANDS = ['setup', 'skills', 'swarm', 'tools'] as const
+export const LIVE_SLASH_EXEC_COMMANDS = ['handoff', 'init-deep', 'model', 'provider', 'ralph-loop', 'start-work', 'ulw-loop'] as const
+export const LEGACY_SLASH_EXEC_COMMANDS = [
+  'agents',
+  'browser',
+  'config',
+  'cron',
+  'debug',
+  'fast',
+  'gquota',
+  'history',
+  'insights',
+  'platforms',
+  'plugins',
+  'profile',
+  'reload',
+  'reload-mcp',
+  'rollback',
+  'save',
+  'snapshot',
+  'status',
+  'stop',
+  'title',
+  'toolsets'
+] as const
+
+const NATIVE_PRODUCT_ROUTE_COMMAND_SET = new Set<string>(NATIVE_PRODUCT_ROUTE_COMMANDS)
+const SLASH_EXEC_COMMANDS = new Set<string>([...LIVE_SLASH_EXEC_COMMANDS, ...LEGACY_SLASH_EXEC_COMMANDS])
+
+const resolveCatalogCanonical = (name: string, canon?: null | Record<string, string>): null | string => {
+  if (!canon) {
+    return null
+  }
+
+  return canon[`/${name}`.toLowerCase()]?.slice(1) ?? null
+}
+
 export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => boolean {
   const { gw } = ctx.gateway
   const { catalog } = ctx.local
@@ -36,8 +73,9 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
     }
 
     const runCtx: SlashRunCtx = { ...ctx, flight, guarded, guardedErr, sid, stale, ui }
-
     const found = findSlashCommand(parsed.name)
+    const canonical = resolveCatalogCanonical(parsed.name, catalog?.canon)
+    const routeName = canonical ?? parsed.name
 
     if (found) {
       found.run(parsed.arg, runCtx, cmd)
@@ -67,47 +105,57 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
     }
 
-    gw.request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: sid })
-      .then(r => {
+    if (NATIVE_PRODUCT_ROUTE_COMMAND_SET.has(routeName)) {
+      sys(`error: /${routeName} is handled by native product routing`)
+
+      return true
+    }
+
+    if (SLASH_EXEC_COMMANDS.has(routeName)) {
+      gw.request<SlashExecResponse>('slash.exec', { command: `${routeName}${argTail}`.trim(), session_id: sid })
+        .then(r => {
+          if (stale()) {
+            return
+          }
+
+          const body = r?.output || `/${routeName}: no output`
+          const text = r?.warning ? `warning: ${r.warning}\n${body}` : body
+          const long = text.length > 180 || text.split('\n').filter(Boolean).length > 2
+
+          long ? page(text, routeName[0]!.toUpperCase() + routeName.slice(1)) : sys(text)
+        })
+        .catch(guardedErr)
+
+      return true
+    }
+
+    gw.request('command.dispatch', { arg: parsed.arg, name: canonical ?? parsed.name, session_id: sid })
+      .then((raw: unknown) => {
         if (stale()) {
           return
         }
 
-        const body = r?.output || `/${parsed.name}: no output`
-        const text = r?.warning ? `warning: ${r.warning}\n${body}` : body
-        const long = text.length > 180 || text.split('\n').filter(Boolean).length > 2
+        const d = asCommandDispatch(raw)
 
-        long ? page(text, parsed.name[0]!.toUpperCase() + parsed.name.slice(1)) : sys(text)
+        if (!d) {
+          return sys('error: invalid response: command.dispatch')
+        }
+
+        if (d.type === 'exec' || d.type === 'plugin') {
+          return sys(d.output || '(no output)')
+        }
+
+        if (d.type === 'alias') {
+          return handler(`/${d.target}${argTail}`)
+        }
+
+        if (d.type === 'skill') {
+          sys(`⚡ loading skill: ${d.name}`)
+
+          return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: skill payload missing message`)
+        }
       })
-      .catch(() => {
-        gw.request('command.dispatch', { arg: parsed.arg, name: parsed.name, session_id: sid })
-          .then((raw: unknown) => {
-            if (stale()) {
-              return
-            }
-
-            const d = asCommandDispatch(raw)
-
-            if (!d) {
-              return sys('error: invalid response: command.dispatch')
-            }
-
-            if (d.type === 'exec' || d.type === 'plugin') {
-              return sys(d.output || '(no output)')
-            }
-
-            if (d.type === 'alias') {
-              return handler(`/${d.target}${argTail}`)
-            }
-
-            if (d.type === 'skill') {
-              sys(`⚡ loading skill: ${d.name}`)
-
-              return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: skill payload missing message`)
-            }
-          })
-          .catch(guardedErr)
-      })
+      .catch(guardedErr)
 
     return true
   }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -57,7 +57,9 @@ export interface OverlayState {
   pager: null | PagerState
   picker: boolean
   secret: null | SecretReq
+  setupWizard: boolean
   sudo: null | SudoReq
+  swarm: boolean
 }
 
 export interface PagerState {
@@ -257,8 +259,9 @@ export interface AppLayoutActions {
   answerSecret: (value: string) => void
   answerSudo: (pw: string) => void
   onModelSelect: (value: string) => void
+  onSetupComplete: (message: string) => void
   resumeById: (id: string) => void
-  setStickyPrompt: (value: string) => void
+  setStickyPrompt: StateSetter<string>
 }
 
 export interface AppLayoutComposerProps {
@@ -329,6 +332,7 @@ export interface AppOverlaysProps {
   onModelSelect: (value: string) => void
   onPickerSelect: (sessionId: string) => void
   onSecretSubmit: (value: string) => void
+  onSetupComplete: (message: string) => void
   onSudoSubmit: (pw: string) => void
   pagerPageSize: number
 }

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -9,13 +9,15 @@ const buildOverlayState = (): OverlayState => ({
   pager: null,
   picker: false,
   secret: null,
-  sudo: null
+  setupWizard: false,
+  sudo: null,
+  swarm: false
 })
 
 export const $overlayState = atom<OverlayState>(buildOverlayState())
 
-export const $isBlocked = computed($overlayState, ({ approval, clarify, modelPicker, pager, picker, secret, sudo }) =>
-  Boolean(approval || clarify || modelPicker || pager || picker || secret || sudo)
+export const $isBlocked = computed($overlayState, ({ approval, clarify, modelPicker, pager, picker, secret, setupWizard, sudo }) =>
+  Boolean(approval || clarify || modelPicker || pager || picker || secret || setupWizard || sudo)
 )
 
 export const getOverlayState = () => $overlayState.get()

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -4,7 +4,7 @@ import { nextDetailsMode, parseDetailsMode } from '../../../domain/details.js'
 import type { ConfigGetValueResponse, ConfigSetResponse, SessionUndoResponse } from '../../../gatewayTypes.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import type { DetailsMode, Msg, PanelSection } from '../../../types.js'
-import { patchOverlayState } from '../../overlayStore.js'
+import { getOverlayState, patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
 import type { SlashCommand } from '../types.js'
 
@@ -15,11 +15,11 @@ const flagFromArg = (arg: string, current: boolean): boolean | null => {
 
   const mode = arg.trim().toLowerCase()
 
-  if (mode === 'on') {
+  if (mode === 'on' || mode === 'open') {
     return true
   }
 
-  if (mode === 'off') {
+  if (mode === 'off' || mode === 'close') {
     return false
   }
 
@@ -50,7 +50,8 @@ export const coreCommands: SlashCommand[] = [
         {
           rows: [
             ['/details [hidden|collapsed|expanded|cycle]', 'set agent detail visibility mode'],
-            ['/fortune [random|daily]', 'show a random or daily local fortune']
+            ['/fortune [random|daily]', 'show a random or daily local fortune'],
+            ['/swarm [open|close|toggle]', 'toggle the active-turn swarm surface']
           ],
           title: 'TUI'
         },
@@ -151,6 +152,21 @@ export const coreCommands: SlashCommand[] = [
       patchUiState({ detailsMode: next })
       gateway.rpc<ConfigSetResponse>('config.set', { key: 'details_mode', value: next }).catch(() => {})
       transcript.sys(`details: ${next}`)
+    }
+  },
+
+  {
+    help: 'toggle active-turn swarm surface',
+    name: 'swarm',
+    run: (arg, ctx) => {
+      const next = flagFromArg(arg, getOverlayState().swarm)
+
+      if (next === null) {
+        return ctx.transcript.sys('usage: /swarm [open|close|toggle]')
+      }
+
+      patchOverlayState({ swarm: next })
+      ctx.transcript.sys(`swarm surface ${next ? 'open' : 'closed'}`)
     }
   },
 

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -11,6 +11,9 @@ import { MaskedPrompt } from './maskedPrompt.js'
 import { ModelPicker } from './modelPicker.js'
 import { ApprovalPrompt, ClarifyPrompt } from './prompts.js'
 import { SessionPicker } from './sessionPicker.js'
+import { SwarmOverlay } from './swarmOverlay.js'
+
+import { SetupWizard } from '../app/setup/SetupWizard.js'
 
 export function PromptZone({
   cols,
@@ -76,13 +79,14 @@ export function FloatingOverlays({
   completions,
   onModelSelect,
   onPickerSelect,
+  onSetupComplete,
   pagerPageSize
-}: Pick<AppOverlaysProps, 'cols' | 'compIdx' | 'completions' | 'onModelSelect' | 'onPickerSelect' | 'pagerPageSize'>) {
+}: Pick<AppOverlaysProps, 'cols' | 'compIdx' | 'completions' | 'onModelSelect' | 'onPickerSelect' | 'onSetupComplete' | 'pagerPageSize'>) {
   const { gw } = useGateway()
   const overlay = useStore($overlayState)
   const ui = useStore($uiState)
 
-  const hasAny = overlay.modelPicker || overlay.pager || overlay.picker || completions.length
+  const hasAny = overlay.modelPicker || overlay.pager || overlay.picker || overlay.setupWizard || overlay.swarm || completions.length
 
   if (!hasAny) {
     return null
@@ -112,6 +116,24 @@ export function FloatingOverlays({
             sessionId={ui.sid}
             t={ui.theme}
           />
+        </FloatBox>
+      )}
+
+      {overlay.setupWizard && (
+        <FloatBox color={ui.theme.color.bronze}>
+          <SetupWizard
+            cols={cols}
+            gw={gw}
+            onCancel={() => patchOverlayState({ setupWizard: false })}
+            onComplete={onSetupComplete}
+            t={ui.theme}
+          />
+        </FloatBox>
+      )}
+
+      {overlay.swarm && (
+        <FloatBox color={ui.theme.color.gold}>
+          <SwarmOverlay />
         </FloatBox>
       )}
 

--- a/ui-tui/src/components/swarmOverlay.tsx
+++ b/ui-tui/src/components/swarmOverlay.tsx
@@ -1,0 +1,80 @@
+import { Box, Text } from '@hermes/ink'
+import { useStore } from '@nanostores/react'
+
+import { $turnState } from '../app/turnStore.js'
+import { $uiState } from '../app/uiStore.js'
+import type { SubagentProgress } from '../types.js'
+
+import { SubagentAccordion } from './thinking.js'
+
+export interface SwarmOverlayModel {
+  empty: boolean
+  headline: string
+  summary: string
+  total: number
+}
+
+const STATUS_ORDER = ['running', 'completed', 'failed', 'interrupted'] as const
+
+type SwarmStatus = (typeof STATUS_ORDER)[number]
+
+export function buildSwarmOverlayModel(subagents: SubagentProgress[]): SwarmOverlayModel {
+  const counts: Record<SwarmStatus, number> = {
+    completed: 0,
+    failed: 0,
+    interrupted: 0,
+    running: 0
+  }
+
+  for (const item of subagents) {
+    const key = (STATUS_ORDER as readonly string[]).includes(item.status) ? (item.status as SwarmStatus) : 'running'
+    counts[key] += 1
+  }
+
+  const total = subagents.length
+  const fragments = STATUS_ORDER.filter(status => counts[status] > 0).map(status => `${counts[status]} ${status}`)
+
+  return {
+    empty: total === 0,
+    headline: total === 0 ? 'Swarm · idle' : `Swarm · ${total} subagent${total === 1 ? '' : 's'}`,
+    summary: fragments.length ? fragments.join(' · ') : 'No active subagents yet',
+    total
+  }
+}
+
+export function SwarmOverlay() {
+  const turn = useStore($turnState)
+  const ui = useStore($uiState)
+  const model = buildSwarmOverlayModel(turn.subagents)
+
+  return (
+    <Box flexDirection="column" minWidth={56} paddingX={1} paddingY={1}>
+      <Text bold color={ui.theme.color.gold}>
+        {model.headline}
+      </Text>
+      <Text color={ui.theme.color.dim}>{model.summary}</Text>
+
+      {model.empty ? (
+        <Box marginTop={1}>
+          <Text color={ui.theme.color.dim}>No active subagents yet. Run delegated work, then use /swarm to focus the live board.</Text>
+        </Box>
+      ) : (
+        <Box flexDirection="column" marginTop={1}>
+          {turn.subagents.map((item, index) => (
+            <SubagentAccordion
+              branch={index === turn.subagents.length - 1 ? 'last' : 'mid'}
+              expanded
+              item={item}
+              key={item.id}
+              t={ui.theme}
+            />
+          ))}
+        </Box>
+      )}
+
+      <Box marginTop={1}>
+        <Text color={ui.theme.color.dim}>Use /swarm close to dismiss.</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -239,7 +239,7 @@ function Chevron({
   )
 }
 
-function SubagentAccordion({
+export function SubagentAccordion({
   branch,
   expanded,
   item,


### PR DESCRIPTION
## Summary
- restore and close the DG3 category resolver/intake parity wave
- align literal category, route category, runtime mode, and delegation profile surfaces
- make delegated runtime activation explanation surfaces truthful about final resolved state
- add/update DG3 proof coverage across runtime activation, category routing, delegate resolution, and config

## Verification
- `python3 -m pytest -q tests/run_agent/test_runtime_activation_overlay_parity.py tests/agent/test_runtime_activation.py`
- `python3 -m pytest -q tests/agent/test_route_categories.py tests/agent/test_prompt_builder.py tests/hermes_cli/test_config.py tests/tools/test_delegate.py tests/run_agent/test_runtime_activation_overlay_parity.py tests/agent/test_runtime_activation.py`

🤖 This PR was created by an AI coding agent
🤖 This was written by an AI coding agent
