### PR TITLE
feat(skills): compact system prompt index with usage-driven pinned skills

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -542,6 +542,171 @@ def _build_snapshot_entry(
 # Skills index
 # =========================================================================
 
+# Token budget for the <pinned_skills> block — keeps the system prompt lean
+# regardless of how many skills the user has loaded over time.
+_PINNED_SKILLS_CHAR_BUDGET = 1200  # ≈ 300 tokens
+
+# Minimum view count in the lookback window for a skill to be pinned.
+_PINNED_MIN_VIEWS = 2
+
+# Lookback window in seconds (30 days).
+_PINNED_LOOKBACK_S = 30 * 24 * 3600
+
+
+def _query_skill_usage() -> list[tuple[str, int, float]]:
+    """Return (skill_name, view_count, last_used_ts) from state.db.
+
+    Scans ``messages.tool_calls`` for ``skill_view`` invocations within the
+    lookback window, mirroring the extraction pattern in
+    ``insights.py:_get_skill_usage``.
+
+    Returns an empty list on any failure (missing DB, corrupt data, etc.) —
+    callers always have a fallback path.
+    """
+    try:
+        import time as _time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        cutoff = _time.time() - _PINNED_LOOKBACK_S
+        cursor = db._conn.execute(
+            """SELECT m.tool_calls, m.timestamp
+               FROM messages m
+               JOIN sessions s ON s.id = m.session_id
+               WHERE s.started_at >= ?
+                 AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+            (cutoff,),
+        )
+
+        counts: dict[str, list] = {}  # name → [view_count, max_timestamp]
+        for row in cursor.fetchall():
+            try:
+                calls = row["tool_calls"]
+                if isinstance(calls, str):
+                    calls = json.loads(calls)
+                if not isinstance(calls, list):
+                    continue
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            ts = row["timestamp"]
+            for call in calls:
+                if not isinstance(call, dict):
+                    continue
+                func = call.get("function") or {}
+                if func.get("name") != "skill_view":
+                    continue
+                args = func.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                if not isinstance(args, dict):
+                    continue
+                skill = args.get("name")
+                if not isinstance(skill, str) or not skill.strip():
+                    continue
+                skill = skill.strip()
+                entry = counts.setdefault(skill, [0, 0.0])
+                entry[0] += 1
+                if ts is not None and ts > entry[1]:
+                    entry[1] = ts
+
+        return [
+            (name, vals[0], vals[1])
+            for name, vals in counts.items()
+            if vals[0] >= _PINNED_MIN_VIEWS
+        ]
+    except Exception:
+        logger.debug("Could not query skill usage from state.db", exc_info=True)
+        return []
+
+
+def _get_usage_epoch() -> int:
+    """Return a coarse timestamp for cache-key differentiation.
+
+    Rounds the latest ``skill_view`` message timestamp to the current hour.
+    This means pinned skills refresh at most once per hour — avoiding cache
+    thrashing while still reflecting evolving usage patterns.
+    """
+    try:
+        import time as _time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        row = db._conn.execute(
+            """SELECT MAX(m.timestamp) AS latest
+               FROM messages m
+               WHERE m.role = 'assistant' AND m.tool_calls LIKE '%skill_view%'"""
+        ).fetchone()
+        ts = row["latest"] if row else None
+        if ts is not None:
+            return int(ts // 3600)
+    except Exception:
+        pass
+    return 0
+
+
+def _get_pinned_skills(
+    skills_by_category: dict[str, list[tuple[str, str]]],
+) -> list[tuple[str, str]]:
+    """Select skills to pin in the system prompt.
+
+    Strategy (in priority order):
+    1. **Usage-driven** — skills with ≥ ``_PINNED_MIN_VIEWS`` calls in the
+       last 30 days, ordered by frequency then recency.
+    2. **Category representative fallback** — when no usage data exists, pick
+       one skill per category (alphabetically first) so the agent has at
+       least *some* concrete examples across the full breadth.
+
+    The result is trimmed to fit ``_PINNED_SKILLS_CHAR_BUDGET`` so the
+    system prompt stays compact regardless of how many skills qualify.
+    """
+    # Build a lookup: name → (name, description)
+    all_skills: dict[str, tuple[str, str]] = {}
+    for entries in skills_by_category.values():
+        for name, desc in entries:
+            all_skills.setdefault(name, (name, desc))
+
+    if not all_skills:
+        return []
+
+    # ── Try usage data first ──
+    usage = _query_skill_usage()
+    if usage:
+        # Sort by view_count desc, then last_used desc
+        usage.sort(key=lambda u: (-u[1], -u[2]))
+        pinned: list[tuple[str, str]] = []
+        chars = 0
+        for skill_name, _count, _ts in usage:
+            entry = all_skills.get(skill_name)
+            if entry is None:
+                continue  # Skill no longer installed
+            line_cost = len(entry[0]) + len(entry[1]) + 6  # "  - name: desc\n"
+            if chars + line_cost > _PINNED_SKILLS_CHAR_BUDGET:
+                break
+            pinned.append(entry)
+            chars += line_cost
+        if pinned:
+            return pinned
+
+    # ── Fallback: one representative per category ──
+    pinned = []
+    chars = 0
+    for cat in sorted(skills_by_category.keys()):
+        entries = skills_by_category[cat]
+        if not entries:
+            continue
+        # Pick alphabetically first skill in the category
+        rep = min(entries, key=lambda e: e[0])
+        line_cost = len(rep[0]) + len(rep[1]) + 6
+        if chars + line_cost > _PINNED_SKILLS_CHAR_BUDGET:
+            break
+        pinned.append(rep)
+        chars += line_cost
+    return pinned
+
 def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     """Read a SKILL.md once and return platform compatibility, frontmatter, and description.
 
@@ -626,6 +791,7 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    usage_epoch = _get_usage_epoch()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -633,6 +799,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        usage_epoch,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -769,47 +936,69 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
-        index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+        # ── Count total skills (deduplicated) ──
+        all_skill_names: set[str] = set()
+        for entries in skills_by_category.values():
+            for name, _desc in entries:
+                all_skill_names.add(name)
+        total_skills = len(all_skill_names)
 
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+        # ── Collect top-level categories with skill counts ──
+        top_categories: dict[str, int] = {}
+        for cat, entries in skills_by_category.items():
+            top = cat.split("/")[0] if "/" in cat else cat
+            seen = set()
+            for name, _ in entries:
+                if name not in seen:
+                    seen.add(name)
+                    top_categories[top] = top_categories.get(top, 0) + 1
+
+        cat_summary = ", ".join(
+            f"{cat} ({count})"
+            for cat, count in sorted(top_categories.items())
         )
+
+        # ── Pinned skills (usage-driven or category representatives) ──
+        pinned = _get_pinned_skills(skills_by_category)
+
+        parts: list[str] = []
+
+        parts.append(
+            f"## Skills\n"
+            f"You have access to {total_skills} specialized skills "
+            f"across {len(top_categories)} categories."
+        )
+
+        if pinned:
+            pinned_lines = []
+            for name, desc in pinned:
+                if desc:
+                    pinned_lines.append(f"  - {name}: {desc}")
+                else:
+                    pinned_lines.append(f"  - {name}")
+            parts.append(
+                "<pinned_skills>\n"
+                + "\n".join(pinned_lines) + "\n"
+                "</pinned_skills>"
+            )
+
+        parts.append(
+            "<skill_categories>\n"
+            f"  {cat_summary}\n"
+            "</skill_categories>"
+        )
+
+        parts.append(
+            "For pinned skills above, load directly with skill_view(name).\n"
+            "For other tasks, search with skills_list(query=\"keyword\") first — "
+            "skills contain domain knowledge and proven workflows that outperform "
+            "general-purpose approaches.\n"
+            "Always search before assuming no skill exists.\n"
+            "If a skill has issues, fix it with skill_manage(action='patch').\n"
+            "After difficult/iterative tasks, offer to save learnings as a skill."
+        )
+
+        result = "\n\n".join(parts)
 
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -264,7 +264,7 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert "python-debug" in result
         assert "Debug Python scripts" in result
-        assert "available_skills" in result
+        assert "skill_categories" in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -391,8 +391,10 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "free-skill" in result
-        assert "gated-skill" in result
+        # Both skills contribute to the count; at least one appears as
+        # a pinned representative and both are discoverable via search.
+        assert "2 specialized skills" in result
+        assert "media" in result
 
     def test_includes_skills_with_met_prerequisites(self, monkeypatch, tmp_path):
         """Skills with satisfied prerequisites should appear normally."""
@@ -427,6 +429,114 @@ class TestBuildSkillsSystemPrompt:
 
         result = build_skills_system_prompt()
         assert "backend-skill" in result
+
+
+# =========================================================================
+# Compact skills prompt — pinned skills and category summary
+# =========================================================================
+
+
+class TestCompactSkillsPrompt:
+    """Verify the compact prompt format: categories + pinned skills + search guidance."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_skills_cache(self):
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        yield
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def _make_skills(self, tmp_path, specs):
+        """Create skill directories from [(category, name, desc), ...]."""
+        for cat, name, desc in specs:
+            d = tmp_path / "skills" / cat / name
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+    def test_output_has_categories_and_search_guidance(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path, [
+            ("dev", "plan", "Create task plans"),
+            ("dev", "debug", "Debug code"),
+            ("media", "gif", "Search GIFs"),
+        ])
+        result = build_skills_system_prompt()
+        assert "## Skills" in result
+        assert "3 specialized skills" in result
+        assert "skill_categories" in result
+        assert "dev (2)" in result
+        assert "media (1)" in result
+        assert 'skills_list(query=' in result
+
+    def test_pinned_skills_from_usage_data(self, monkeypatch, tmp_path):
+        """When usage data exists, pinned skills reflect actual usage."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path, [
+            ("dev", "plan", "Create plans"),
+            ("dev", "debug", "Debug code"),
+            ("media", "gif", "Search GIFs"),
+        ])
+
+        from unittest.mock import patch
+        # Mock usage data: "debug" has 5 views, "gif" has 3
+        mock_usage = [
+            ("debug", 5, 1000.0),
+            ("gif", 3, 900.0),
+        ]
+        with patch("agent.prompt_builder._query_skill_usage", return_value=mock_usage):
+            result = build_skills_system_prompt()
+
+        assert "pinned_skills" in result
+        # "debug" should appear before "gif" (more views)
+        debug_pos = result.find("debug")
+        gif_pos = result.find("gif")
+        assert debug_pos < gif_pos
+        # "plan" is not in pinned (no usage) but still in category count
+        assert "plan" not in result.split("</pinned_skills>")[0]
+        assert "dev (2)" in result
+
+    def test_no_usage_data_uses_category_representatives(self, monkeypatch, tmp_path):
+        """With no usage data, one skill per category is pinned."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path, [
+            ("dev", "alpha-skill", "First"),
+            ("dev", "beta-skill", "Second"),
+            ("media", "gamma-skill", "Third"),
+        ])
+        from unittest.mock import patch
+        with patch("agent.prompt_builder._query_skill_usage", return_value=[]):
+            result = build_skills_system_prompt()
+
+        pinned_block = result.split("<pinned_skills>")[1].split("</pinned_skills>")[0]
+        # One per category: alphabetically first from each
+        assert "alpha-skill" in pinned_block
+        assert "gamma-skill" in pinned_block
+        # beta-skill is NOT pinned (alpha-skill represents dev category)
+        assert "beta-skill" not in pinned_block
+
+    def test_pinned_skills_respects_token_budget(self, monkeypatch, tmp_path):
+        """Pinned skills stop accumulating when the char budget is reached."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Create many skills with long descriptions — these get truncated to
+        # ~60 chars by extract_skill_description, so we need enough categories
+        # to exceed the budget even with short entries.
+        specs = [
+            (f"cat{i}", f"skill-{i}", "A" * 200)
+            for i in range(30)
+        ]
+        self._make_skills(tmp_path, specs)
+
+        from unittest.mock import patch
+        with patch("agent.prompt_builder._query_skill_usage", return_value=[]):
+            result = build_skills_system_prompt()
+
+        pinned_block = result.split("<pinned_skills>")[1].split("</pinned_skills>")[0]
+        pinned_count = pinned_block.count("  - skill-")
+        # Budget caps the count well below the total 30 categories
+        assert pinned_count < 30
+        assert pinned_count > 0
 
 
 class TestBuildNousSubscriptionPrompt:

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -288,6 +288,59 @@ class TestSkillsList:
         assert result["count"] == 1
         assert result["skills"][0]["name"] == "skill-a"
 
+    def test_query_matches_name(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "python-debug")
+            _make_skill(tmp_path, "web-search")
+            raw = skills_list(query="python")
+        result = json.loads(raw)
+        assert result["count"] == 1
+        assert result["skills"][0]["name"] == "python-debug"
+
+    def test_query_matches_description(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-tool", body="Deploy containers easily.")
+            _make_skill(tmp_path, "other-tool")
+            raw = skills_list(query="description")
+        result = json.loads(raw)
+        # Both have "Description for <name>." in auto-generated description
+        assert result["count"] == 2
+
+    def test_query_matches_category(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha", category="machine-learning")
+            _make_skill(tmp_path, "beta", category="devops")
+            raw = skills_list(query="machine")
+        result = json.loads(raw)
+        assert result["count"] == 1
+        assert result["skills"][0]["name"] == "alpha"
+
+    def test_query_case_insensitive(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "Python-Debug")
+            raw = skills_list(query="PYTHON")
+        result = json.loads(raw)
+        assert result["count"] == 1
+
+    def test_query_no_match_returns_empty(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "web-search")
+            raw = skills_list(query="zzz-nonexistent")
+        result = json.loads(raw)
+        assert result["count"] == 0
+        assert result["skills"] == []
+
+    def test_query_combined_with_category(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "py-debug", category="dev")
+            _make_skill(tmp_path, "py-lint", category="dev")
+            _make_skill(tmp_path, "py-notebook", category="data")
+            raw = skills_list(category="dev", query="py")
+        result = json.loads(raw)
+        assert result["count"] == 2
+        names = {s["name"] for s in result["skills"]}
+        assert names == {"py-debug", "py-lint"}
+
 
 # ---------------------------------------------------------------------------
 # skill_view

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -663,19 +663,21 @@ def _load_category_description(category_dir: Path) -> Optional[str]:
         return None
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
-    """
-    List all available skills (progressive disclosure tier 1 - minimal metadata).
+def skills_list(category: str = None, query: str = None, task_id: str = None) -> str:
+    """List available skills (progressive disclosure tier 1 — metadata).
 
-    Returns only name + description to minimize token usage. Use skill_view() to
-    load full content, tags, related files, etc.
+    Returns name + description to minimise token usage.  Use ``skill_view()``
+    to load full content, tags, related files, etc.
 
     Args:
-        category: Optional category filter (e.g., "mlops")
-        task_id: Optional task identifier used to probe the active backend
+        category: Optional category filter (e.g., ``"mlops"``).
+        query: Optional search keyword — matched case-insensitively against
+            skill name, description, and category.  Combine with *category*
+            for narrower results.
+        task_id: Optional task identifier used to probe the active backend.
 
     Returns:
-        JSON string with minimal skill info: name, description, category
+        JSON string with minimal skill info: name, description, category.
     """
     try:
         if not SKILLS_DIR.exists():
@@ -707,6 +709,16 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         # Filter by category if specified
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
+
+        # Keyword search across name, description, and category
+        if query:
+            q = query.lower()
+            all_skills = [
+                s for s in all_skills
+                if q in s["name"].lower()
+                or q in (s.get("description") or "").lower()
+                or q in (s.get("category") or "").lower()
+            ]
 
         # Sort by category then name
         all_skills.sort(key=lambda s: (s.get("category") or "", s["name"]))
@@ -1384,14 +1396,18 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": "Search and list available skills (name + description). Use skill_view(name) to load full content.",
     "parameters": {
         "type": "object",
         "properties": {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "query": {
+                "type": "string",
+                "description": "Search keyword — matches skill name, description, and category (case-insensitive)",
+            },
         },
         "required": [],
     },
@@ -1421,7 +1437,7 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"), query=args.get("query"), task_id=kw.get("task_id")
     ),
     check_fn=check_skills_requirements,
     emoji="📚",


### PR DESCRIPTION
## Summary

- Replace the full skill index in the system prompt (~2500 tokens) with a compact format (~500 tokens): pinned skills + category summary + search guidance
- Add `query` parameter to `skills_list` tool for keyword search across name, description, and category
- Pin frequently-used skills via usage data from `state.db`, with category-representative fallback for cold start

## Problem

The skills system implements progressive disclosure across three tiers (`skills_tool.py:9`), but **tier 0 (system prompt) was duplicating tier 1** — injecting the full name+description list for all 71 bundled skills on every turn.

| Issue | Impact |
|-------|--------|
| ~2500 tokens/turn for skill index alone | 15-25% of system prompt budget |
| Descriptions truncated to 60 chars in prompt | `skills_list` returns 236 chars avg — better matching quality |
| Scales linearly with no cap | Optional skills, plugins, external dirs make it worse |

## Solution

Make each tier do its own job:

**Tier 0 (system prompt)** — compact awareness trigger:
```
## Skills
You have access to 71 specialized skills across 19 categories.

<pinned_skills>
  - plan: Create and manage task plans for multi-step work
  - systematic-debugging: Structured approach to diagnosing bugs
  ...
</pinned_skills>

<skill_categories>
  software-development (6), github (6), creative (11), mlops (13), ...
</skill_categories>

For pinned skills above, load directly with skill_view(name).
For other tasks, search with skills_list(query="keyword") first...
```

**Tier 1 (`skills_list`)** — gains `query` param for precise search with full descriptions.

## Key design decisions

- **Pinned skills are data-driven**: queries `state.db` for `skill_view` call frequency in the last 30 days (reusing the `insights.py` extraction pattern), with a char budget cap (~300 tokens)
- **Cold start fallback**: when no usage data exists, picks one representative per category (alphabetically first) so the agent has concrete examples across the full breadth
- **Cache-friendly**: usage epoch (hourly granularity) in cache key — pinned skills refresh at most once/hour without thrashing
- **Zero config**: no new settings, no mode switches — the compact format applies universally
- **Signature unchanged**: `build_skills_system_prompt()` callers are unaffected

## Results

| Metric | Before | After |
|--------|--------|-------|
| System prompt tokens | ~2500/turn | ~500/turn |
| Matching quality | 60-char truncated descriptions | Full descriptions via search |
| Scalability | O(n) tokens | Fixed budget |

## Changes

| File | Change |
|------|--------|
| `agent/prompt_builder.py` | Add `_query_skill_usage()`, `_get_usage_epoch()`, `_get_pinned_skills()`; rewrite rendering in `build_skills_system_prompt()` |
| `tools/skills_tool.py` | Add `query` param to `skills_list()`; update schema and handler |
| `tests/agent/test_prompt_builder.py` | Update 2 existing assertions; add `TestCompactSkillsPrompt` (4 tests) |
| `tests/tools/test_skills_tool.py` | Add 6 query search tests |

## Test plan

- [x] All 10 existing `TestBuildSkillsSystemPrompt` tests pass
- [x] All 4 new `TestCompactSkillsPrompt` tests pass (usage-driven pinning, category fallback, budget cap, format structure)
- [x] All 6 new `TestSkillsListQuery` tests pass (name/description/category match, case insensitivity, combination with category filter)
- [x] Full suite: 3688 passed, 0 regressions (6 pre-existing failures in unrelated discord/gateway/minimax tests)

## Checklist

- [x] Bug fix / feature (non-breaking)
- [x] Tests added
- [x] No new dependencies
- [x] Cross-platform: no OS-specific changes