### PR TITLE
fix: normalize kimi short aliases before provider routing

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -142,6 +142,7 @@ _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
 # with ``model=deepseek/deepseek-v4-flash``, so these names are not aliases
 # of ``deepseek-chat`` and must not be folded into it.
 _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
+_KIMI_SHORT_ALIAS_RE = re.compile(r"^k2p(\d+)$", re.IGNORECASE)
 
 
 def _normalize_for_deepseek(model_name: str) -> str:
@@ -240,6 +241,27 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     normalized_target = _normalize_provider_alias(target_provider)
     if normalized_prefix and normalized_prefix == normalized_target:
         return remainder.strip()
+    return model_name
+
+
+def _expand_known_provider_aliases(model_name: str, target_provider: str) -> str:
+    """Expand provider-specific shorthand aliases into canonical model IDs.
+
+    Some user configs reuse short aliases like ``k2p6`` for Kimi models.
+    Native Kimi providers reject those aliases, and aggregators cannot
+    infer the vendor prefix from them, so expand the shorthand before the
+    provider-specific normalization rules run.
+    """
+    normalized_target = _normalize_provider_alias(target_provider)
+    match = _KIMI_SHORT_ALIAS_RE.fullmatch(model_name.strip())
+    if (
+        match
+        and (
+            normalized_target in _AGGREGATOR_PROVIDERS
+            or normalized_target in {"kimi-coding", "kimi-coding-cn", "moonshot"}
+        )
+    ):
+        return f"kimi-k2.{match.group(1)}"
     return model_name
 
 
@@ -387,6 +409,7 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         return name
 
     provider = _normalize_provider_alias(target_provider)
+    name = _expand_known_provider_aliases(name, provider)
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
@@ -462,4 +485,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -180,6 +180,20 @@ class TestIssue6211NativeProviderPrefixNormalization:
         assert normalize_model_for_provider(model, target_provider) == expected
 
 
+class TestKimiShortAliasNormalization:
+    @pytest.mark.parametrize("provider,expected", [
+        ("kimi-coding", "kimi-k2.6"),
+        ("kimi-coding-cn", "kimi-k2.6"),
+        ("moonshot", "kimi-k2.6"),
+        ("openrouter", "moonshotai/kimi-k2.6"),
+    ])
+    def test_expands_kimi_short_aliases_for_supported_providers(self, provider, expected):
+        assert normalize_model_for_provider("k2p6", provider) == expected
+
+    def test_leaves_kimi_short_alias_untouched_for_unrelated_provider(self):
+        assert normalize_model_for_provider("k2p6", "custom") == "k2p6"
+
+
 # ── detect_vendor ──────────────────────────────────────────────────────
 
 class TestDetectVendor:


### PR DESCRIPTION
## Summary
- expand Kimi short aliases like `k2p6` into canonical `kimi-k2.x` model IDs before provider-specific normalization runs
- let native Kimi providers receive the Moonshot-native model slug, while aggregators like OpenRouter still get the vendor-prefixed form
- add regression coverage so unrelated providers keep unknown short aliases untouched

Fixes #14309

## Testing
- python3 -m pytest -o addopts='' tests/hermes_cli/test_model_normalize.py