### PR TITLE
fix(qqbot): infer image mime for generic file attachments

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1124,9 +1124,10 @@ class QQAdapter(BasePlatformAdapter):
             if not isinstance(att, dict):
                 continue
 
-            ct = str(att.get("content_type", "")).strip().lower()
+            raw_ct = str(att.get("content_type", "")).strip().lower()
             url_raw = str(att.get("url", "")).strip()
             filename = str(att.get("filename", ""))
+            ct = self._normalize_attachment_content_type(raw_ct, filename)
             if url_raw.startswith("//"):
                 url = f"https:{url_raw}"
             elif url_raw:
@@ -1136,8 +1137,9 @@ class QQAdapter(BasePlatformAdapter):
                 continue
 
             logger.debug(
-                "[%s] Processing attachment: content_type=%s, url=%s, filename=%s",
+                "[%s] Processing attachment: content_type=%s normalized_content_type=%s, url=%s, filename=%s",
                 self._log_tag,
+                raw_ct,
                 ct,
                 url[:80],
                 filename,
@@ -1257,6 +1259,15 @@ class QQAdapter(BasePlatformAdapter):
         if any(fn.endswith(ext) for ext in _VOICE_EXTENSIONS):
             return True
         return False
+
+    @staticmethod
+    def _normalize_attachment_content_type(content_type: str, filename: str) -> str:
+        """Infer a real MIME type when QQ sends generic file content types."""
+        ct = content_type.strip().lower()
+        if ct and ct not in {"file", "application/octet-stream", "binary/octet-stream"}:
+            return ct
+        guessed_type = mimetypes.guess_type(filename.strip())[0] if filename.strip() else None
+        return (guessed_type or ct).lower()
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -151,6 +151,78 @@ class TestIsVoiceContentType:
 
 
 # ---------------------------------------------------------------------------
+# _normalize_attachment_content_type
+# ---------------------------------------------------------------------------
+
+class TestNormalizeAttachmentContentType:
+    def _fn(self, content_type, filename):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter._normalize_attachment_content_type(content_type, filename)
+
+    def test_generic_file_uses_filename_mime(self):
+        assert self._fn("file", "design.png") == "image/png"
+
+    def test_generic_octet_stream_uses_filename_mime(self):
+        assert self._fn("application/octet-stream", "notes.webp") == "image/webp"
+
+    def test_specific_mime_is_preserved(self):
+        assert self._fn("image/jpeg", "document.pdf") == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# _process_attachments
+# ---------------------------------------------------------------------------
+
+class TestProcessAttachments:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    def test_generic_file_png_is_treated_as_image(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._download_and_cache = mock.AsyncMock(return_value="/tmp/design.png")
+
+        attachments = [{
+            "content_type": "file",
+            "url": "https://multimedia.nt.qq.com.cn/design.png",
+            "filename": "design.png",
+        }]
+
+        with mock.patch("gateway.platforms.qqbot.adapter.os.path.isfile", return_value=True):
+            result = asyncio.run(adapter._process_attachments(attachments))
+
+        adapter._download_and_cache.assert_awaited_once_with(
+            "https://multimedia.nt.qq.com.cn/design.png",
+            "image/png",
+        )
+        assert result["image_urls"] == ["/tmp/design.png"]
+        assert result["image_media_types"] == ["image/png"]
+        assert result["voice_transcripts"] == []
+        assert result["attachment_info"] == ""
+
+    def test_generic_file_zip_stays_attachment(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._download_and_cache = mock.AsyncMock(return_value="/tmp/assets.zip")
+
+        attachments = [{
+            "content_type": "file",
+            "url": "https://multimedia.nt.qq.com.cn/assets.zip",
+            "filename": "assets.zip",
+        }]
+
+        result = asyncio.run(adapter._process_attachments(attachments))
+
+        adapter._download_and_cache.assert_awaited_once_with(
+            "https://multimedia.nt.qq.com.cn/assets.zip",
+            "application/zip",
+        )
+        assert result["image_urls"] == []
+        assert result["image_media_types"] == []
+        assert result["voice_transcripts"] == []
+        assert result["attachment_info"] == "[Attachment: assets.zip]"
+
+
+# ---------------------------------------------------------------------------
 # Voice attachment SSRF protection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- infer a concrete MIME type from QQ attachment filenames when QQ reports generic file content types
- route inferred image attachments through the existing image cache path so they populate media_urls/media_types
- add regression coverage for generic file image attachments and non-image file attachments

## Testing
- python3 -m pytest -o addopts='' tests/gateway/test_qqbot.py

Closes #14324