### PR TITLE
fix(gateway): treat recycled PID with unreadable start_time as stale (#14176)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -748,6 +748,16 @@ def get_running_pid(
         current_start = _get_process_start_time(pid)
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
             continue
+        # If the PID record carries a recorded start_time but we can't read
+        # the current process's start_time, the PID may have been recycled by
+        # the OS to a process the current user can't introspect (typical on
+        # Linux when /proc/<pid>/stat is owned by another UID). The downstream
+        # _looks_like_gateway_process heuristic can give a false positive in
+        # that situation — e.g. another long-lived python process — leaving
+        # a stale PID file that blocks future starts. Be conservative and
+        # skip this candidate. See #14176.
+        if recorded_start is not None and current_start is None:
+            continue
 
         if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
             return pid

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -184,6 +184,46 @@ class TestGatewayPidState:
         assert not pid_path.exists()
         assert not lock_path.exists()
 
+    def test_get_running_pid_treats_recycled_pid_with_unreadable_start_time_as_stale(self, tmp_path, monkeypatch):
+        """Regression: #14176 — stale PID file from a recycled PID owned by a
+        different user blocks future starts.
+
+        On Linux, when the PID file's pid has been recycled by the OS to a
+        process the current user can't introspect (typical when /proc/<pid>/stat
+        is owned by another UID), ``_get_process_start_time`` returns ``None``.
+        The recorded start_time mismatch check therefore can't fire, and the
+        ``_looks_like_gateway_process`` heuristic can give a false positive on
+        a long-lived python or hermes-related process — leaving a stale PID
+        file that blocks ``hermes gateway start``. Be conservative and treat
+        the file as stale when we can't confirm the start_time match.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+
+        # Use the test process's own PID so os.kill(pid, 0) succeeds (live).
+        live_pid = os.getpid()
+        pid_path.write_text(json.dumps({
+            "pid": live_pid,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 12345,  # arbitrary recorded time
+        }))
+        lock_path.write_text(json.dumps({
+            "pid": live_pid,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 12345,
+        }))
+
+        # Simulate /proc unreadable / start_time inaccessible on the recycled PID.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: None)
+        # Even a permissive _looks_like_gateway_process must not leak through.
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda _pid: True)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_falls_back_to_live_lock_record(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"


### PR DESCRIPTION
## What does this PR do?

`gateway/status.py::find_gateway_pids()` iterates over the PIDs recorded in `~/.hermes/gateway.lock` to decide whether the gateway is "still running". For each candidate it:

1. Checks the PID is alive (`os.kill(pid, 0)`).
2. Compares the recorded `start_time` against the live process's `start_time` to detect PID recycling.
3. Falls back to `_looks_like_gateway_process(pid)` / `_record_looks_like_gateway(record)` heuristics.

When the recycled PID is owned by a **different** UID (typical on Linux when `/proc/<pid>/stat` is owned by another user, or under rootless container setups), `_get_process_start_time` returns `None`. The recorded-vs-live mismatch check then can't fire (`current_start is None`), and `_looks_like_gateway_process` can give a false positive on any long-lived python or hermes-related process the user happens to own. Result: the gateway thinks it's still running, refuses to start, and the user has to manually `rm ~/.hermes/gateway.pid` to recover.

Reporter (#14176) sees this in production with a systemd user service that restarts the gateway nightly — every few weeks the next PID up the queue lands on a recycled foreign PID, the lock file goes stale, and `hermes gateway start` fails with "Gateway already running".

Fix: be conservative. When the PID record carries a `recorded_start` but we can't read the candidate's `current_start`, skip the candidate (treat as stale) instead of falling through to the heuristic. Outside `/proc`-readable territory we don't have enough information to confirm this is the same gateway process, so prefer "no" over "maybe".

## Related Issue

Fixes #14176

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py` (+10 / −0): in the `find_gateway_pids()` candidate loop, skip any PID whose recorded `start_time` exists but whose live `start_time` is unreadable. Same code path as the existing recorded-vs-live mismatch case, just covering the unreadable variant.
- `tests/gateway/test_status.py` (+40 / −0): one new regression case under `TestGatewayPidState`, `test_get_running_pid_treats_recycled_pid_with_unreadable_start_time_as_stale`. Monkeypatches `_get_process_start_time` to return `None` and `_looks_like_gateway_process` to return `True` (the strongest stress for the false-positive path) and asserts the PID file is cleaned and `get_running_pid()` returns `None`.

Core diff:

```diff
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
             continue
+        # If the PID record carries a recorded start_time but we can't read
+        # the current process's start_time, the PID may have been recycled by
+        # the OS to a process the current user can't introspect (typical on
+        # Linux when /proc/<pid>/stat is owned by another UID). The downstream
+        # _looks_like_gateway_process heuristic can give a false positive in
+        # that situation — e.g. another long-lived python process — leaving
+        # a stale PID file that blocks future starts. Be conservative and
+        # skip this candidate. See #14176.
+        if recorded_start is not None and current_start is None:
+            continue

         if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
             return pid
```

## How to Test

Reporter-style repro on a Linux host:

1. Run the gateway, kill -9 the parent process to leave `~/.hermes/gateway.pid` and `~/.hermes/gateway.lock` populated with the dead PID.
2. Start a long-lived python process under a different UID (e.g. another `hermes` daemon under another account) that the test user can see via `ps` but NOT via `/proc/<pid>/stat`. Note its PID.
3. Edit the lock file to point at that recycled PID, keeping the original `start_time` field intact.
4. Run `hermes gateway start`.

Before: refuses to start with "Gateway already running".
After: detects the start_time mismatch is unverifiable, treats the entry as stale, cleans the lock file, and starts a fresh gateway.

Automated regression suite:

```
pytest tests/gateway/test_status.py::TestGatewayPidState -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/gateway/test_status.py::TestGatewayPidState -q` and all tests pass (11/11)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11.14 via uv

### Documentation & Housekeeping

- [x] Documentation updates — N/A (internal helper, no user-visible API change beyond bug fix)
- [x] `cli-config.yaml.example` — N/A (no new config)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — change is conservative on every platform; the false positive fix matters most on Linux but doesn't regress macOS/Windows behavior
- [x] Tool descriptions/schemas — N/A

## Not in scope

- The reporter's bash script idea (a dedicated `hermes gateway clean-pid` command) — that's nice-to-have but a separate UX surface; the in-band fix here is the higher-impact change since it stops the bad state from forming.
- Auditing `gateway.target` / `Restart=` semantics in the example systemd unit (the issue's secondary note) — that's a docs change for `docs/deploy/` that deserves its own PR.
- Hardening atexit-vs-SIGKILL paths so a `kill -9` of the gateway doesn't leave a PID file behind — a real concern but out of scope for the reported bug, which is about PID-file *interpretation*, not creation.

## Screenshots / Logs

### Verification

```
$ python3 -m py_compile gateway/status.py tests/gateway/test_status.py
OK

$ uv run --no-project --with pytest --with pytest-xdist --with pyyaml \
       --with python-dotenv --with prompt_toolkit --with rich --with httpx \
       --with fastapi --with pydantic python -m pytest \
       tests/gateway/test_status.py::TestGatewayPidState -q
...........                                                              [100%]
11 passed in 0.51s
```

(11 = 10 existing + 1 new regression case, all green.)
