### PR TITLE
fix: resolve minor lint warnings in patch_parser, skill_commands, and usage_pricing

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -94,7 +94,7 @@ def _run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
     except subprocess.TimeoutExpired:
         return f"[inline-shell timeout after {timeout}s: {command}]"
     except FileNotFoundError:
-        return f"[inline-shell error: bash not found]"
+        return "[inline-shell error: bash not found]"
     except Exception as exc:
         return f"[inline-shell error: {exc}]"
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -76,7 +76,8 @@ class CostResult:
     notes: tuple[str, ...] = ()
 
 
-_UTC_NOW = lambda: datetime.now(timezone.utc)
+def _UTC_NOW() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 # Official docs snapshot entries. Models whose published pricing and cache

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -33,6 +33,7 @@ import re
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Any
 from enum import Enum
+from tools.file_operations import PatchResult
 
 
 class OperationType(Enum):
@@ -263,7 +264,7 @@ def _validate_operations(
 
             simulated = read_result.content
             for hunk in op.hunks:
-                search_lines = [l.content for l in hunk.lines if l.prefix in (' ', '-')]
+                search_lines = [line.content for line in hunk.lines if line.prefix in (' ', '-')]
                 if not search_lines:
                     # Addition-only hunk: validate context hint uniqueness
                     if hunk.context_hint:
@@ -282,7 +283,7 @@ def _validate_operations(
                     continue
 
                 search_pattern = '\n'.join(search_lines)
-                replace_lines = [l.content for l in hunk.lines if l.prefix in (' ', '+')]
+                replace_lines = [line.content for line in hunk.lines if line.prefix in (' ', '+')]
                 replacement = '\n'.join(replace_lines)
 
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(
@@ -329,7 +330,7 @@ def _validate_operations(
 
 
 def apply_v4a_operations(operations: List[PatchOperation],
-                          file_ops: Any) -> 'PatchResult':
+                          file_ops: Any) -> PatchResult:
     """Apply V4A patch operations using a file operations interface.
 
     Uses a two-phase validate-then-apply approach:


### PR DESCRIPTION
## Summary

Resolve three minor lint warnings reported by ruff across three files.

### Changes

- **tools/patch_parser.py**
  - Add missing top-level import of `PatchResult` from `tools.file_operations`
  - Replace quoted forward reference `'PatchResult'` with direct type annotation
  - Rename ambiguous loop variable `l` to `line` in two list comprehensions (E741)

- **agent/skill_commands.py**
  - Remove extraneous `f`-prefix from string literal with no placeholders (F541)

- **agent/usage_pricing.py**
  - Replace lambda expression with `def` statement per PEP-8 E731

### Verification

- All modified files pass `python3 -m py_compile`
- All modified files pass `ruff check` with zero warnings
- Full test suites for the affected modules pass:
  - `tests/tools/test_patch_parser.py` — 21 passed
  - `tests/agent/test_usage_pricing.py` — 9 passed
  - `tests/agent/test_skill_commands.py` — 36 passed

Closes no open issues; this is a maintenance-only PR.