### PR TITLE
fix(docker): exclude runtime data/ from build context (salvage #13926)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@ node_modules
 .env
 
 *.md
+
+# Runtime data (bind-mounted at /opt/data; must not leak into build context)
+data/

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -378,6 +378,7 @@ AUTHOR_MAP = {
     "363708+christopherwoodall@users.noreply.github.com": "christopherwoodall",
     "zhang9w0v5@qq.com": "zhang9w0v5",
     "fuleinist@outlook.com": "fuleinist",
+    "43494187+Llugaes@users.noreply.github.com": "Llugaes",
 }
 
 


### PR DESCRIPTION
Salvages #13926 by @Llugaes onto current main.

`HERMES_HOME=/opt/data` inside the Docker image, with `/opt/data` bind-mounted from the host at runtime. If a user (or CI) runs `docker build` from a directory containing a populated `data/` tree (session DBs, skill checkpoints, logs), that content gets shipped into the image layer unnecessarily — bloating builds and risking secret leakage into image tarballs.

Adds `data/` to `.dockerignore` so the runtime-only directory is never part of the build context, regardless of where `docker build` runs.

## Attribution note
Original commit used an unlinked corporate email (`xiangji.chen@centurygame.com`), re-authored to @Llugaes's GitHub noreply email so the contribution attributes to their profile.

Closes #13926.