### PR TITLE
fix(qqbot): add backoff upper-bound for QQCloseError reconnect (salvage #13074)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -535,6 +535,9 @@ class QQAdapter(BasePlatformAdapter):
                     quick_disconnect_count = 0
                 else:
                     backoff_idx += 1
+                    if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        return
 
             except Exception as exc:
                 if not self._running:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -379,6 +379,7 @@ AUTHOR_MAP = {
     "zhang9w0v5@qq.com": "zhang9w0v5",
     "fuleinist@outlook.com": "fuleinist",
     "43494187+Llugaes@users.noreply.github.com": "Llugaes",
+    "fengtianyu88@users.noreply.github.com": "fengtianyu88",
 }
 
 


### PR DESCRIPTION
Salvages #13074 by @fengtianyu88 onto current main.

The QQCloseError branch of `_listen_loop` incremented `backoff_idx` on failed reconnect but never bailed out once it exceeded `MAX_RECONNECT_ATTEMPTS` — unlike the generic-Exception branch (lines 486/549) which already checks. Result: a QQ server persistently closing the connection would retry forever in an exponentially-backed-off tight loop, leaking resources and masking the underlying service issue.

Adds the same `backoff_idx >= MAX_RECONNECT_ATTEMPTS` check + `logger.error` + `return` pattern that the sibling branches already use. Parity fix.

Closes #13074. Author attribution preserved via cherry-pick.