### PR TITLE
fix(mcp): respect ssl_verify config for StreamableHTTP/SSE servers (salvage #13038)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -380,6 +380,7 @@ AUTHOR_MAP = {
     "fuleinist@outlook.com": "fuleinist",
     "43494187+Llugaes@users.noreply.github.com": "Llugaes",
     "fengtianyu88@users.noreply.github.com": "fengtianyu88",
+    "l.moncany@gmail.com": "lmoncany",
 }
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -994,6 +994,7 @@ class MCPServerTask:
         url = config["url"]
         headers = dict(config.get("headers") or {})
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        ssl_verify = config.get("ssl_verify", True)
 
         # OAuth 2.1 PKCE: route through the central MCPOAuthManager so the
         # same provider instance is reused across reconnects, pre-flow
@@ -1024,6 +1025,7 @@ class MCPServerTask:
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
+                "verify": ssl_verify,
             }
             if headers:
                 client_kwargs["headers"] = headers
@@ -1052,6 +1054,7 @@ class MCPServerTask:
             _http_kwargs: dict = {
                 "headers": headers,
                 "timeout": float(connect_timeout),
+                "verify": ssl_verify,
             }
             if _oauth_auth is not None:
                 _http_kwargs["auth"] = _oauth_auth


### PR DESCRIPTION
Salvages #13038 by @lmoncany onto current main.

Adds `ssl_verify: bool = True` config knob to MCP server entries in config.yaml. Threads it through both httpx client constructions in `_run_http` — the StreamableHTTP path (line 1025) and the SSE fallback path (line 1054). Default `True` means no behavior change; users running a self-hosted MCP server with a self-signed cert on their LAN can now set `ssl_verify: false` in their server config block.

Clean 3-line addition, symmetric across both transport branches.

Closes #13038. Author attribution preserved via cherry-pick.