### PR TITLE
fix(tirith): detect Android/Termux as Linux ABI-compatible (salvage #10825)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -381,6 +381,7 @@ AUTHOR_MAP = {
     "43494187+Llugaes@users.noreply.github.com": "Llugaes",
     "fengtianyu88@users.noreply.github.com": "fengtianyu88",
     "l.moncany@gmail.com": "lmoncany",
+    "fatinghenji@users.noreply.github.com": "fatinghenji",
 }
 
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -186,9 +186,10 @@ def _detect_target() -> str | None:
     system = platform.system()
     machine = platform.machine().lower()
 
+    # Android (Termux) is ABI-compatible with Linux — reuse Linux binaries.
     if system == "Darwin":
         plat = "apple-darwin"
-    elif system == "Linux":
+    elif system in ("Linux", "Android"):
         plat = "unknown-linux-gnu"
     else:
         return None


### PR DESCRIPTION
Salvages #10825 by @fatinghenji onto current main.

`tirith_security._detect_target()` picked the right binary triple by matching `platform.system()`. On Termux (Android), `platform.system()` returns `"Android"` — not `"Linux"` — so tirith silently bailed with `None` and security scanning was disabled. Android and Linux are ABI-compatible on the same CPU family, so reusing the Linux binary just works.

One-line fix: match `("Linux", "Android")`.

Closes #10825. Author attribution preserved via cherry-pick.