### PR TITLE
fix(browser): guard command timeout cache reset

### DIFF
--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -115,6 +115,33 @@ class TestCommandTimeoutCache:
             _get_command_timeout()
         mock_read.assert_called_once()
 
+    def test_stale_resolved_flag_without_cached_value_uses_default(self):
+        import tools.browser_tool as bt
+
+        bt._command_timeout_resolved = True
+        bt._cached_command_timeout = None
+
+        assert bt._get_command_timeout() == bt.DEFAULT_COMMAND_TIMEOUT
+
+    def test_browser_navigate_handles_missing_cached_timeout(self):
+        import json
+        import tools.browser_tool as bt
+
+        with patch("tools.browser_tool._get_command_timeout", return_value=None), \
+             patch("tools.browser_tool._is_local_backend", return_value=True), \
+             patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool.check_website_access", return_value=None), \
+             patch("tools.browser_tool._get_session_info", return_value={"_first_nav": False}), \
+             patch(
+                 "tools.browser_tool._run_browser_command",
+                 return_value={"success": True, "data": {"url": "https://example.com", "title": "Example"}},
+             ) as run_cmd:
+            result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert run_cmd.call_args_list[0].args == ("task-1", "open", ["https://example.com"])
+        assert run_cmd.call_args_list[0].kwargs["timeout"] == 60
+
 
 # ---------------------------------------------------------------------------
 # Caching: _discover_homebrew_node_dirs

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -185,9 +185,8 @@ def _get_command_timeout() -> int:
     """
     global _cached_command_timeout, _command_timeout_resolved
     if _command_timeout_resolved:
-        return _cached_command_timeout  # type: ignore[return-value]
+        return _cached_command_timeout or DEFAULT_COMMAND_TIMEOUT
 
-    _command_timeout_resolved = True
     result = DEFAULT_COMMAND_TIMEOUT
     try:
         from hermes_cli.config import read_raw_config
@@ -198,6 +197,7 @@ def _get_command_timeout() -> int:
     except Exception as e:
         logger.debug("Could not read command_timeout from config: %s", e)
     _cached_command_timeout = result
+    _command_timeout_resolved = True
     return result
 
 
@@ -1386,7 +1386,7 @@ def _run_browser_command(
         Parsed JSON response from agent-browser
     """
     if timeout is None:
-        timeout = _get_command_timeout()
+        timeout = _get_command_timeout() or DEFAULT_COMMAND_TIMEOUT
     args = args or []
     
     # Build the command
@@ -1748,7 +1748,8 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         session_info["_first_nav"] = False
         _maybe_start_recording(nav_session_key)
 
-    result = _run_browser_command(nav_session_key, "open", [url], timeout=max(_get_command_timeout(), 60))
+    command_timeout = _get_command_timeout() or DEFAULT_COMMAND_TIMEOUT
+    result = _run_browser_command(nav_session_key, "open", [url], timeout=max(command_timeout, 60))
 
     # Remember which session served this nav so snapshot/click/fill/...
     # on the same task_id hit it (critical when hybrid routing has both a


### PR DESCRIPTION
## Summary
- Fixes #14331.
- Ensures `_get_command_timeout()` never returns `None` after browser cleanup/cache reset states.
- Sets the resolved flag only after the timeout cache has been assigned, and adds defensive fallbacks at browser command call sites.

## Root cause
`_command_timeout_resolved` could be true while `_cached_command_timeout` was still `None`, so `browser_navigate()` could evaluate `max(None, 60)` and crash.

## Tests
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts='' tests/tools/test_browser_hardening.py tests/tools/test_browser_cleanup.py tests/tools/test_browser_ssrf_local.py -q`
- `git diff --check`