### PR TITLE
fix: skip non-API-key auth providers in env-var credential detection (salvage #7313)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -847,6 +847,10 @@ def list_authenticated_providers(
         # source of truth.  models.dev can have wrong mappings (e.g.
         # minimax-cn → MINIMAX_API_KEY instead of MINIMAX_CN_API_KEY).
         pconfig = PROVIDER_REGISTRY.get(hermes_id)
+        # Skip non-API-key auth providers here — they are handled in
+        # section 2 (HERMES_OVERLAYS) with proper auth store checking.
+        if pconfig and pconfig.auth_type != "api_key":
+            continue
         if pconfig and pconfig.api_key_env_vars:
             env_vars = list(pconfig.api_key_env_vars)
         else:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -382,6 +382,7 @@ AUTHOR_MAP = {
     "fengtianyu88@users.noreply.github.com": "fengtianyu88",
     "l.moncany@gmail.com": "lmoncany",
     "fatinghenji@users.noreply.github.com": "fatinghenji",
+    "xin.peng.dr@gmail.com": "xinpengdr",
 }
 
 


### PR DESCRIPTION
Salvages #7313 by @xinpengdr onto current main.

`list_authenticated_providers()` has two sections for finding providers the user can use: section 1 walks models.dev + auth.py `PROVIDER_REGISTRY` checking env var presence, section 2 walks `HERMES_OVERLAYS` checking the auth store. For providers with non-api_key auth (OAuth flows like copilot, codex, gemini, nous), only section 2 knows how to actually verify credentials — section 1 scans for API-key env vars that don't exist for these providers and skips them anyway, but leaves a gap where the scan runs before the real check.

One-line fix: in section 1, skip entries whose `auth_type != "api_key"` so they cleanly fall through to section 2's proper auth-store lookup.

## Attribution note
Original commit's author was `xin@us.com` (unlinked), re-authored to @xinpengdr's public GitHub email.

Closes #7313.