### PR TITLE
fix(todo): accept JSON-string todo lists

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -114,6 +114,44 @@ class TestTodoToolFunction:
         ))
         assert result["summary"]["in_progress"] == 1
 
+    def test_write_accepts_json_string_list(self):
+        store = TodoStore()
+        result = json.loads(todo_tool(
+            todos=json.dumps([
+                {"id": "1", "content": "New", "status": "in_progress"},
+            ]),
+            store=store,
+        ))
+        assert result["summary"]["in_progress"] == 1
+        assert result["todos"][0]["content"] == "New"
+
+    def test_write_rejects_invalid_json_string(self):
+        store = TodoStore()
+        result = json.loads(todo_tool(todos='[{"id": "1"', store=store))
+        assert result["success"] is False
+        assert "Invalid JSON string" in result["error"]
+        assert store.read() == []
+
+    def test_write_rejects_json_string_non_list(self):
+        store = TodoStore()
+        result = json.loads(todo_tool(
+            todos=json.dumps({"id": "1", "content": "New"}),
+            store=store,
+        ))
+        assert result["success"] is False
+        assert "must be a list" in result["error"]
+        assert store.read() == []
+
+    def test_write_rejects_json_string_non_object_items(self):
+        store = TodoStore()
+        result = json.loads(todo_tool(
+            todos=json.dumps(["not an object"]),
+            store=store,
+        ))
+        assert result["success"] is False
+        assert "index 0" in result["error"]
+        assert store.read() == []
+
     def test_no_store_returns_error(self):
         result = json.loads(todo_tool())
         assert "error" in result

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -153,8 +153,26 @@ class TodoStore:
         return [todos[i] for i in sorted(last_index.values())]
 
 
+def _normalize_todos_arg(todos: Any) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """Accept JSON-string todo lists while rejecting malformed input cleanly."""
+    if isinstance(todos, str):
+        try:
+            todos = json.loads(todos)
+        except json.JSONDecodeError as exc:
+            return None, f"Invalid JSON string for 'todos': {exc.msg}"
+
+    if not isinstance(todos, list):
+        return None, "'todos' must be a list of todo objects"
+
+    for index, item in enumerate(todos):
+        if not isinstance(item, dict):
+            return None, f"Todo item at index {index} must be an object"
+
+    return todos, None
+
+
 def todo_tool(
-    todos: Optional[List[Dict[str, Any]]] = None,
+    todos: Optional[List[Dict[str, Any]] | str] = None,
     merge: bool = False,
     store: Optional[TodoStore] = None,
 ) -> str:
@@ -173,7 +191,10 @@ def todo_tool(
         return tool_error("TodoStore not initialized")
 
     if todos is not None:
-        items = store.write(todos, merge)
+        normalized_todos, error = _normalize_todos_arg(todos)
+        if error is not None:
+            return tool_error(error, success=False)
+        items = store.write(normalized_todos, merge)
     else:
         items = store.read()
 


### PR DESCRIPTION
## Summary
- Fixes #14185
- Parse `todos` when a provider sends it as a JSON string instead of an array.
- Reject invalid JSON, non-list values, and non-object list entries with clean tool errors before reaching `TodoStore.write()`.

## Root cause
Some tool-call paths can pass the `todos` argument as a JSON-encoded string. The todo store assumed it was already a list of objects, so string input was iterated character-by-character and crashed when validation called `.get()`.

## Tests
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts='' tests/tools/test_todo_tool.py -q`
- `git diff --check`

Note: I also tried `uv run --frozen --python 3.11 --extra dev ruff check tools/todo_tool.py tests/tools/test_todo_tool.py`, but this environment does not install a `ruff` executable (`No such file or directory`).