### PR TITLE
fix(ssh): forward skill-allowlisted env vars over SSH via SendEnv

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -66,6 +66,89 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
+    def test_no_send_env_when_no_passthrough_registered(self, monkeypatch):
+        """Without registered passthrough vars, no -o SendEnv flags appear."""
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough",
+            lambda: frozenset(),
+        )
+        env = SSHEnvironment(host="h", user="u")
+        cmd = env._build_ssh_command()
+        assert "SendEnv" not in " ".join(cmd)
+
+    def test_send_env_added_for_registered_passthrough_var(self, monkeypatch):
+        """Issue #14091: skill-declared env vars must be forwarded via -o SendEnv."""
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough",
+            lambda: frozenset({"NEXTCLOUD_URL", "NEXTCLOUD_USER"}),
+        )
+        monkeypatch.setenv("NEXTCLOUD_URL", "https://x.example")
+        monkeypatch.setenv("NEXTCLOUD_USER", "alice")
+        env = SSHEnvironment(host="h", user="u")
+        cmd = env._build_ssh_command()
+        joined = " ".join(cmd)
+        assert "SendEnv=NEXTCLOUD_URL" in joined
+        assert "SendEnv=NEXTCLOUD_USER" in joined
+
+    def test_send_env_skips_unset_vars(self, monkeypatch):
+        """Allowlisted but unset vars should NOT produce -o SendEnv noise."""
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough",
+            lambda: frozenset({"REAL_VAR", "GHOST_VAR"}),
+        )
+        monkeypatch.setenv("REAL_VAR", "present")
+        monkeypatch.delenv("GHOST_VAR", raising=False)
+        env = SSHEnvironment(host="h", user="u")
+        joined = " ".join(env._build_ssh_command())
+        assert "SendEnv=REAL_VAR" in joined
+        assert "SendEnv=GHOST_VAR" not in joined
+
+    def test_send_env_is_deterministic(self, monkeypatch):
+        """Sorted order keeps the SSH command stable for ControlMaster reuse."""
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough",
+            lambda: frozenset({"BBB", "AAA", "CCC"}),
+        )
+        for n in ("AAA", "BBB", "CCC"):
+            monkeypatch.setenv(n, "x")
+        env = SSHEnvironment(host="h", user="u")
+        cmd = env._build_ssh_command()
+        # Find the order of SendEnv flags in the cmd list.
+        send_envs = [a.split("=", 1)[1] for a in cmd if a.startswith("SendEnv=")]
+        assert send_envs == ["AAA", "BBB", "CCC"]
+
+    def test_passthrough_failure_is_non_fatal(self, monkeypatch):
+        """If env_passthrough import/lookup blows up, SSH still works."""
+        def boom():
+            raise RuntimeError("passthrough exploded")
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough", boom
+        )
+        env = SSHEnvironment(host="h", user="u")
+        cmd = env._build_ssh_command()  # must not raise
+        assert "SendEnv" not in " ".join(cmd)
+
+    def test_subprocess_env_includes_passthrough_values(self, monkeypatch):
+        """-o SendEnv only ships names; the ssh client reads values from its env."""
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough",
+            lambda: frozenset({"NEXTCLOUD_PASS"}),
+        )
+        monkeypatch.setenv("NEXTCLOUD_PASS", "hunter2")
+        env = SSHEnvironment(host="h", user="u")
+        sub_env = env._build_subprocess_env()
+        assert sub_env is not None
+        assert sub_env["NEXTCLOUD_PASS"] == "hunter2"
+
+    def test_subprocess_env_is_none_when_no_passthrough(self, monkeypatch):
+        """No passthrough → don't override default child env semantics."""
+        monkeypatch.setattr(
+            "tools.env_passthrough.get_all_passthrough",
+            lambda: frozenset(),
+        )
+        env = SSHEnvironment(host="h", user="u")
+        assert env._build_subprocess_env() is None
+
 
 class TestControlSocketPath:
     """Regression tests for issue #11840.

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -84,6 +84,13 @@ class SSHEnvironment(BaseEnvironment):
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])
+        # Forward skill-declared / user-allowlisted env vars to the remote
+        # session via ``-o SendEnv=NAME``. The remote sshd must permit them
+        # via ``AcceptEnv`` (commonly ``AcceptEnv *`` for Hermes hosts).
+        # See issue #14091 — without this, ``required_environment_variables``
+        # never reach the remote shell even when set on the Hermes host.
+        for name in self._passthrough_env_vars():
+            cmd.extend(["-o", f"SendEnv={name}"])
         if self.port != 22:
             cmd.extend(["-p", str(self.port)])
         if self.key_path:
@@ -92,6 +99,24 @@ class SSHEnvironment(BaseEnvironment):
             cmd.extend(extra_args)
         cmd.append(f"{self.user}@{self.host}")
         return cmd
+
+    def _passthrough_env_vars(self) -> list[str]:
+        """Return the env-var names that should be forwarded over SSH.
+
+        Sourced from ``tools.env_passthrough.get_all_passthrough()`` which
+        unions skill-declared ``required_environment_variables`` with the
+        user's ``terminal.env_passthrough`` config. Only vars actually
+        present in ``os.environ`` are forwarded — sending an unset name
+        is harmless but noisy. Names are sorted for deterministic command
+        construction (helps with ControlMaster reuse and tests).
+        """
+        try:
+            from tools.env_passthrough import get_all_passthrough
+
+            allowlist = get_all_passthrough()
+        except Exception:
+            return []
+        return sorted(name for name in allowlist if name in os.environ)
 
     def _establish_connection(self):
         cmd = self._build_ssh_command()
@@ -267,7 +292,28 @@ class SSHEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", shlex.quote(cmd_string)])
 
-        return _popen_bash(cmd, stdin_data)
+        # ``-o SendEnv`` only ships var names; the OpenSSH client reads the
+        # values from its own environment. Pass them explicitly via env=.
+        env = self._build_subprocess_env()
+        return _popen_bash(cmd, stdin_data, env=env)
+
+    def _build_subprocess_env(self) -> dict[str, str] | None:
+        """Compose the environment for the spawned ``ssh`` process.
+
+        Starts from the current process environment (so SSH agent, locale,
+        etc. work) and ensures every passthrough var is present. Returns
+        ``None`` when no passthrough vars exist so we don't override the
+        default child-env semantics unnecessarily.
+        """
+        names = self._passthrough_env_vars()
+        if not names:
+            return None
+        env = os.environ.copy()
+        for name in names:
+            # Already filtered to ``name in os.environ`` but be defensive.
+            if name in os.environ:
+                env[name] = os.environ[name]
+        return env
 
     def cleanup(self):
         if self._sync_manager:


### PR DESCRIPTION
Fixes #14091

## The bug

`tools/env_passthrough.py` already builds an allowlist of env vars that should reach sandboxed environments — populated from skill `required_environment_variables` frontmatter and `terminal.env_passthrough` config. The `local` and `code_execution` backends consult `is_env_passthrough()` / `get_all_passthrough()`, but **`SSHEnvironment` never did**.

Result: when `terminal_backend: ssh`, every `ssh ... bash -c` subprocess inherits a stripped child environment that excludes the allowlist, and the remote `bash` session sees no skill-declared variables — even with `AcceptEnv *` configured on the remote sshd.

The reporter's diagnosis is correct: the SSH command was missing `-o SendEnv=NAME`.

## Fix

In `_build_ssh_command()`:
- Append `-o SendEnv=<NAME>` for every var in `get_all_passthrough()` that is actually present in `os.environ`.
- Names are sorted for deterministic command construction (so ControlMaster connection reuse stays stable).

In `_run_bash()`:
- `-o SendEnv` only forwards *names*; the OpenSSH client reads *values* from its own process environment. Pass them explicitly via a new `_build_subprocess_env()` so allowlisted vars are guaranteed to be present even if a future caller scrubs the parent env.

Failure to import or call `get_all_passthrough()` is non-fatal — SSH still works, just without forwarding (matches the existing best-effort posture in `skills_tool.py`).

## Why this is the right layer

- **Same allowlist source as `local` / `code_execution`** — single source of truth (`get_all_passthrough()`), so security guarantees stay consistent (Hermes provider credentials are still blocked from skill registration per GHSA-rhgp-j443-p4rf).
- **Doesn't bypass remote sshd policy** — admins still need `AcceptEnv` on the remote (the issue notes `AcceptEnv *`); we just stop silently dropping the names client-side.
- **Zero behavior change when no skill/config registers anything** — empty allowlist ⇒ no `SendEnv` flags, no env override.

## Verification

```
uv run --frozen --python 3.11 --extra dev pytest -o addopts='' \
  tests/tools/test_ssh_environment.py \
  tests/tools/test_ssh_bulk_upload.py \
  tests/tools/test_sync_back_backends.py -q
52 passed, 11 skipped
```

7 new targeted tests in `TestBuildSSHCommand`:
- `test_no_send_env_when_no_passthrough_registered` — zero behavior change when allowlist empty
- `test_send_env_added_for_registered_passthrough_var` — the actual #14091 case
- `test_send_env_skips_unset_vars` — allowlisted-but-unset vars don't leak as empty `SendEnv` lines
- `test_send_env_is_deterministic` — sorted order for ControlMaster reuse stability
- `test_passthrough_failure_is_non_fatal` — SSH keeps working if env_passthrough breaks
- `test_subprocess_env_includes_passthrough_values` — values propagated to ssh client process env
- `test_subprocess_env_is_none_when_no_passthrough` — don't override default child-env semantics unnecessarily

## Notes

- Minimal, focused diff. Uses the existing `env_passthrough` infrastructure rather than introducing a parallel mechanism.
- Doesn't touch `skills_tool.py`'s `setup_needed` reporting — that's accurate for the *registration* side; the bug was purely on the SSH consumer side.
- No new dependencies.