### PR TITLE
docs: note git-lfs prerequisite for tinker-atropos submodule (salvage #11886)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 
 | Requirement | Notes |
 |-------------|-------|
-| **Git** | With `--recurse-submodules` support |
+| **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
 | **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -383,6 +383,7 @@ AUTHOR_MAP = {
     "l.moncany@gmail.com": "lmoncany",
     "fatinghenji@users.noreply.github.com": "fatinghenji",
     "xin.peng.dr@gmail.com": "xinpengdr",
+    "mike@mikewaters.net": "mikewaters",
 }
 
 

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -32,7 +32,7 @@ We value contributions in this order:
 
 | Requirement | Notes |
 |-------------|-------|
-| **Git** | With `--recurse-submodules` support |
+| **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
 | **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |


### PR DESCRIPTION
Salvages #11886 by @mikewaters onto current main.

`CONTRIBUTING.md` (and the mirrored `website/docs/developer-guide/contributing.md`) listed Git as a prerequisite with `--recurse-submodules` support, but omitted `git-lfs`. The `tinker-atropos/` submodule depends transitively on [BLEUBERI](https://github.com/lilakk/BLEUBERI.git), which uses Git LFS for data — without `git-lfs` installed, `uv pip install -e "./tinker-atropos"` fails with LFS-pointer errors.

Two-commit cherry-pick (sibling edits to CONTRIBUTING.md and the docs-site mirror).

Closes #11886. Author attribution preserved via cherry-pick.