### PR TITLE
docs(contributing): align Node.js prerequisite with package.json engines (salvage #11690)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 | **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
-| **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |
+| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge |
 
 ### Clone and install
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 | **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
-| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge |
+| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 
 ### Clone and install
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -384,6 +384,7 @@ AUTHOR_MAP = {
     "fatinghenji@users.noreply.github.com": "fatinghenji",
     "xin.peng.dr@gmail.com": "xinpengdr",
     "mike@mikewaters.net": "mikewaters",
+    "65117428+WadydX@users.noreply.github.com": "WadydX",
 }
 
 

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -35,7 +35,7 @@ We value contributions in this order:
 | **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
-| **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |
+| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 
 ### Clone and Install
 


### PR DESCRIPTION
Salvages #11690 by @WadydX onto current main.

`CONTRIBUTING.md` + `website/docs/developer-guide/contributing.md` advertised Node.js 18+ as the minimum, but the root `package.json` declares `"engines": { "node": ">=20.0.0" }`. New contributors on Node 18 would fail `npm install` without warning. Both docs bumped to 20+ with a pointer to the engines field.

Closes #11690. Author attribution preserved via cherry-pick.