### PR TITLE
fix(weixin): align send_image_file with base adapter contract

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -363,6 +363,27 @@ class TestWeixinChunkDelivery:
         assert first_try["client_id"] == retry["client_id"]
 
 
+class TestWeixinMediaDelivery:
+    def test_send_image_file_accepts_base_adapter_image_path_keyword(self):
+        adapter = _make_adapter()
+
+        with patch.object(adapter, "send_document", new_callable=AsyncMock) as send_document_mock:
+            asyncio.run(
+                adapter.send_image_file(
+                    chat_id="wxid_test123",
+                    image_path="/tmp/demo.jpg",
+                    caption="图在这",
+                )
+            )
+
+        send_document_mock.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/demo.jpg",
+            caption="图在这",
+            metadata=None,
+        )
+
+
 class TestWeixinRemoteMediaSafety:
     def test_download_remote_media_blocks_unsafe_urls(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- rename `WeixinAdapter.send_image_file` parameter from `path` to `image_path`
- align the adapter with `BasePlatformAdapter` and current gateway callers
- add a regression test covering the exact keyword-call path used by gateway delivery

## Why
`gateway/platforms/base.py` and `cron/scheduler.py` call `send_image_file(..., image_path=...)`, but `gateway/platforms/weixin.py` still expects `path`. That raises:

```
TypeError: WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'\n```\n\nThis breaks **outbound Weixin image delivery** from MEDIA/local-file paths. Inbound media receive is handled separately by `_collect_media()` / `_download_image()` and is unaffected.\n\n## Test plan\n- `/home/sunfly/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_weixin.py tests/gateway/test_send_image_file.py -q`\n- result: 58 passed\n\nFixes #8783\nRefs #13769