### PR TITLE
fix: remove saved custom providers from both config schemas

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2753,11 +2753,11 @@ def _save_custom_provider(
 
 def _remove_custom_provider(config):
     """Let the user remove a saved custom provider from config.yaml."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import get_compatible_custom_providers, load_config, save_config
 
     cfg = load_config()
-    providers = cfg.get("custom_providers") or []
-    if not isinstance(providers, list) or not providers:
+    providers = get_compatible_custom_providers(cfg)
+    if not providers:
         print("No custom providers configured.")
         return
 
@@ -2806,8 +2806,48 @@ def _remove_custom_provider(config):
         print("No change.")
         return
 
-    removed = providers.pop(idx)
-    cfg["custom_providers"] = providers
+    removed = providers[idx]
+
+    def _normalize_identifier(value):
+        return str(value or "").strip().rstrip("/").lower()
+
+    removed_provider_key = _normalize_identifier(removed.get("provider_key"))
+    removed_name = _normalize_identifier(removed.get("name"))
+    removed_base_url = _normalize_identifier(removed.get("base_url"))
+    removed_model = _normalize_identifier(removed.get("model"))
+
+    def _matches_removed_provider(entry, provider_key=""):
+        if not isinstance(entry, dict):
+            return False
+        entry_provider_key = _normalize_identifier(provider_key or entry.get("provider_key"))
+        entry_base_url = _normalize_identifier(
+            entry.get("base_url") or entry.get("url") or entry.get("api")
+        )
+        entry_model = _normalize_identifier(
+            entry.get("model") or entry.get("default_model")
+        )
+        if removed_provider_key and entry_provider_key == removed_provider_key:
+            return True
+        return (
+            _normalize_identifier(entry.get("name")) == removed_name
+            and entry_base_url == removed_base_url
+            and entry_model == removed_model
+        )
+
+    legacy_providers = cfg.get("custom_providers")
+    if isinstance(legacy_providers, list):
+        cfg["custom_providers"] = [
+            entry for entry in legacy_providers if not _matches_removed_provider(entry)
+        ]
+
+    providers_cfg = cfg.get("providers")
+    if isinstance(providers_cfg, dict):
+        cfg["providers"] = {
+            key: entry
+            for key, entry in providers_cfg.items()
+            if not _matches_removed_provider(entry, provider_key=key)
+        }
+
     save_config(cfg)
     removed_name = (
         removed.get("name", "unnamed") if isinstance(removed, dict) else str(removed)

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import types
 
-from hermes_cli.config import load_config, save_config
+from hermes_cli.config import get_compatible_custom_providers, load_config, save_config
 
 
 class _BrokenTerminalMenu:
@@ -69,6 +69,64 @@ def test_remove_custom_provider_falls_back_on_terminalmenu_runtime_error(tmp_pat
     reloaded = load_config()
     assert reloaded["custom_providers"] == [
         {"name": "Local B", "base_url": "http://localhost:8002/v1"},
+    ]
+
+
+def test_remove_custom_provider_removes_matching_provider_from_both_schemas(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.main import _remove_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
+    )
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {
+            "name": "OpenAI Direct (Primary)",
+            "base_url": "https://api.openai.com/v1",
+            "model": "gpt-5-mini",
+        }
+    ]
+    cfg["providers"] = {
+        "openai-direct-primary": {
+            "name": "OpenAI Direct (Primary)",
+            "api": "https://api.openai.com/v1",
+            "default_model": "gpt-5-mini",
+        },
+        "secondary-proxy": {
+            "name": "Secondary Proxy",
+            "api": "https://proxy.example.com/v1",
+            "default_model": "gpt-4.1-mini",
+        },
+    }
+    save_config(cfg)
+
+    responses = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    _remove_custom_provider(cfg)
+
+    reloaded = load_config()
+    assert reloaded["custom_providers"] == []
+    assert reloaded["providers"] == {
+        "secondary-proxy": {
+            "name": "Secondary Proxy",
+            "api": "https://proxy.example.com/v1",
+            "default_model": "gpt-4.1-mini",
+        }
+    }
+    assert get_compatible_custom_providers(reloaded) == [
+        {
+            "name": "Secondary Proxy",
+            "base_url": "https://proxy.example.com/v1",
+            "provider_key": "secondary-proxy",
+            "model": "gpt-4.1-mini",
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- remove custom providers from the same compatibility view shown in setup
- delete matching entries from both legacy `custom_providers` and keyed `providers` config sections
- add a regression test for duplicated providers across both schemas

## Testing
- python3 -m pytest -o addopts= tests/hermes_cli/test_terminal_menu_fallbacks.py
- python3 -m pytest -o addopts= tests/hermes_cli/test_setup.py::test_setup_syncs_custom_provider_removal_from_disk tests/hermes_cli/test_setup.py::test_select_provider_and_model_warns_if_named_custom_provider_disappears

Closes #5525.
