### PR TITLE
docs: add GMI Cloud to compatible providers list (salvage #7397)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -385,6 +385,7 @@ AUTHOR_MAP = {
     "xin.peng.dr@gmail.com": "xinpengdr",
     "mike@mikewaters.net": "mikewaters",
     "65117428+WadydX@users.noreply.github.com": "WadydX",
+    "216480837+isaachuangGMICLOUD@users.noreply.github.com": "isaachuangGMICLOUD",
 }
 
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -965,6 +965,7 @@ Any service with an OpenAI-compatible API works. Some popular options:
 | [Groq](https://groq.com) | `https://api.groq.com/openai/v1` | Ultra-fast inference |
 | [DeepSeek](https://deepseek.com) | `https://api.deepseek.com/v1` | DeepSeek models |
 | [Fireworks AI](https://fireworks.ai) | `https://api.fireworks.ai/inference/v1` | Fast open model hosting |
+| [GMI Cloud](https://www.gmicloud.ai/) | `https://api.gmi-serving.com/v1` | Managed OpenAI-compatible inference |
 | [Cerebras](https://cerebras.ai) | `https://api.cerebras.ai/v1` | Wafer-scale chip inference |
 | [Mistral AI](https://mistral.ai) | `https://api.mistral.ai/v1` | Mistral models |
 | [OpenAI](https://openai.com) | `https://api.openai.com/v1` | Direct OpenAI access |


### PR DESCRIPTION
Salvages #7397 by @isaachuangGMICLOUD onto current main.

Adds GMI Cloud (`https://api.gmi-serving.com/v1`) to the OpenAI-compatible providers table in `website/docs/integrations/providers.md`, alongside Groq, DeepSeek, Fireworks, Cerebras, Mistral, etc.

## Attribution note
Original commit used a local hostname-derived email, re-authored to @isaachuangGMICLOUD's GitHub noreply email so the contribution attributes to their profile.

Closes #7397.