### PR TITLE
fix(gateway): normalize iOS unicode dashes in slash command args (salvage #7700)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -752,7 +752,10 @@ class MessageEvent:
         if not self.is_command():
             return self.text
         parts = self.text.split(maxsplit=1)
-        return parts[1] if len(parts) > 1 else ""
+        args = parts[1] if len(parts) > 1 else ""
+        # iOS auto-corrects -- to — (em dash) and - to – (en dash)
+        args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
+        return args
 
 
 @dataclass 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -387,6 +387,7 @@ AUTHOR_MAP = {
     "65117428+WadydX@users.noreply.github.com": "WadydX",
     "216480837+isaachuangGMICLOUD@users.noreply.github.com": "isaachuangGMICLOUD",
     "nukuom976228@gmail.com": "hsy5571616",
+    "11462216+Nan93@users.noreply.github.com": "Nan93",
 }
 
 


### PR DESCRIPTION
Salvages #7700 by @Nan93 onto current main.

iOS keyboard auto-corrects `--` to `—` (em dash) and `-` to `–` (en dash). Users sending `/model —help` or `/memory —list` from iOS hit command parsers that expected ASCII `--` and `-`, and silently got an empty arg or a miscategorized flag. One-line fix in `MessageEvent.get_command_args()` — only runs on slash commands, so regular conversational use of em/en dashes elsewhere is untouched.

Handles all three forms: `——` → `--`, `—` → `--`, `–` → `-` (U+2014 and U+2013).

## Attribution note
Original commit authored as `root <root@famous-cats-2.localdomain>` (no GitHub linkage), re-authored to @Nan93's GitHub noreply email so the contribution attributes to their profile.

Closes #7700.