### PR TITLE
fix(feishu): route send_message media attachments

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1100,6 +1100,70 @@ class TestSendToPlatformDiscordMedia:
         assert call_kwargs["media_files"] == [("/fake/img.png", False)]
 
 
+class TestSendToPlatformFeishuMedia:
+    """_send_to_platform routes Feishu media correctly."""
+
+    def test_media_files_passed_on_last_chunk_only(self):
+        call_log = []
+
+        async def mock_send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):
+            call_log.append(
+                {
+                    "message": message,
+                    "media_files": media_files or [],
+                    "thread_id": thread_id,
+                }
+            )
+            return {"success": True, "platform": "feishu", "chat_id": chat_id, "message_id": "1"}
+
+        long_msg = "A" * 5000 + " " + "B" * 5000
+
+        with patch("tools.send_message_tool._send_feishu", side_effect=mock_send_feishu):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "oc_chat",
+                    long_msg,
+                    thread_id="oc_thread",
+                    media_files=[("/fake/img.png", False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert len(call_log) == 2
+        assert call_log[0]["media_files"] == []
+        assert call_log[1]["media_files"] == [("/fake/img.png", False)]
+        assert all(call["thread_id"] == "oc_thread" for call in call_log)
+
+    def test_media_only_routes_to_feishu_without_warning_or_error(self):
+        async def mock_send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):
+            return {
+                "success": True,
+                "platform": "feishu",
+                "chat_id": chat_id,
+                "message_id": "img1",
+                "warnings": ["upstream-warning"],
+            }
+
+        with patch("tools.send_message_tool._send_feishu", side_effect=mock_send_feishu) as send_mock:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "oc_chat",
+                    "   ",
+                    media_files=[("/fake/img.png", False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert result["warnings"] == ["upstream-warning"]
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.kwargs["media_files"] == [("/fake/img.png", False)]
+        assert send_mock.await_args.args[2].strip() == ""
+
+
 class TestSendMatrixUrlEncoding:
     """_send_matrix URL-encodes Matrix room IDs in the API path."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -529,10 +529,26 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-media platforms ---
+    if platform == Platform.FEISHU and media_files:
+        last_result = None
+        for idx, chunk in enumerate(chunks):
+            is_last = idx == len(chunks) - 1
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, and signal; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -540,7 +556,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, and signal"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, and feishu"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary
- route `send_message` Feishu delivery through `_send_feishu(..., media_files=...)` when attachments are present
- attach media only on the final text chunk so chunked sends behave like other native-media platforms
- allow media-only Feishu sends to use the native Feishu path instead of the generic unsupported-media fallback
- update native-media support strings to include Feishu
- add regression coverage for chunked Feishu media routing and media-only Feishu delivery

## Root cause
`_send_feishu()` already accepted and processed `media_files`, but `_send_to_platform()` sent Feishu through the generic non-media path and never passed attachments along. That caused `MEDIA:` attachments to be dropped for Feishu targets.

## Test plan
- `pytest -q tests/tools/test_send_message_tool.py -k "TestSendToPlatformFeishuMedia or TestSendToPlatformDiscordMedia::test_media_files_passed_on_last_chunk_only"`
- `pytest -q tests/gateway/test_feishu.py -k "send_image_file_uploads_image_and_sends_image_message or send_image_file_with_caption_uses_single_post_message"`

Fixes #10136