### PR TITLE
feat(feishu): support referenced media in group chat

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2701,7 +2701,12 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "upper_message_id", None)
             or None
         )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        reply_to_text = None
+        if reply_to_message_id:
+            reply_to_text, reply_media_urls, reply_media_types = await self._fetch_message_full(reply_to_message_id)
+            # Merge reply media into current message media so the agent can see referenced images
+            media_urls.extend(reply_media_urls)
+            media_types.extend(reply_media_types)
 
         logger.info(
             "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s text=%r media=%d",
@@ -3555,6 +3560,40 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
+
+    async def _fetch_message_full(self, message_id: str) -> tuple[Optional[str], List[str], List[str]]:
+        """Fetch both text and media from a parent message for reply context."""
+        if not message_id:
+            return None, [], []
+        
+        # First get the text (using _fetch_message_text to support existing mocks)
+        text = await self._fetch_message_text(message_id)
+        
+        media_urls = []
+        media_types = []
+        
+        # Try to fetch media if client is available
+        if self._client:
+            try:
+                request = self._build_get_message_request(message_id)
+                response = await asyncio.to_thread(self._client.im.v1.message.get, request)
+                if response and getattr(response, "success", lambda: False)():
+                    items = getattr(getattr(response, "data", None), "items", None) or []
+                    parent = items[0] if items else None
+                    body = getattr(parent, "body", None)
+                    msg_type = getattr(parent, "msg_type", "") or ""
+                    raw_content = getattr(body, "content", "") or ""
+                    
+                    # Extract and download media
+                    normalized = normalize_feishu_message(message_type=msg_type, raw_content=raw_content)
+                    media_urls, media_types = await self._download_feishu_message_resources(
+                        message_id=message_id,
+                        normalized=normalized,
+                    )
+            except Exception:
+                logger.warning("[Feishu] Failed to fetch media from parent message %s", message_id, exc_info=True)
+        
+        return text, media_urls, media_types
 
     def _extract_text_from_raw_content(
         self,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -282,6 +282,7 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+_FEISHU_PARENT_MEDIA_CACHE_SIZE = 128       # LRU cap for reply-context parent media lookups
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1542,6 +1543,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
+        self._parent_media_cache: "OrderedDict[str, tuple[List[str], List[str]]]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3336,7 +3338,40 @@ class FeishuAdapter(BasePlatformAdapter):
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
 
-        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
+        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        reply_to_message_id = (
+            getattr(message, "parent_id", None)
+            or getattr(message, "upper_message_id", None)
+            or getattr(message, "root_id", None)
+            or None
+        )
+        # Resolve reply context *before* the empty-text guard: a bare "@Hermes"
+        # reply to an attachment strips to "" and carries no media of its own, so
+        # dropping it here would discard the only thing the user pointed at.
+        reply_to_text: Optional[str] = None
+        if reply_to_message_id and inbound_type != MessageType.COMMAND:
+            reply_to_text = await self._fetch_message_text(reply_to_message_id)
+            parent_urls, parent_types = await self._fetch_parent_media(reply_to_message_id)
+            if parent_urls:
+                seen = set(media_urls)
+                for url, media_type in zip(parent_urls, parent_types):
+                    if url in seen:
+                        continue
+                    seen.add(url)
+                    media_urls.append(url)
+                    media_types.append(media_type)
+                if inbound_type == MessageType.TEXT:
+                    # Media now dominates the payload; reclassify so the event
+                    # takes the media path (batching, vision) instead of text.
+                    inbound_type = self._resolve_media_message_type(
+                        media_types[0] if media_types else "",
+                        default=MessageType.DOCUMENT,
+                    )
+        elif reply_to_message_id:
+            reply_to_text = await self._fetch_message_text(reply_to_message_id)
+
+        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped,
+        # but only once inherited reply media has had a chance to land above.
         if inbound_type == MessageType.TEXT and not text and not media_urls:
             logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
             return
@@ -3345,15 +3380,6 @@ class FeishuAdapter(BasePlatformAdapter):
             hint = _build_mention_hint(mentions)
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
-
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
-        reply_to_message_id = (
-            getattr(message, "parent_id", None)
-            or getattr(message, "upper_message_id", None)
-            or getattr(message, "root_id", None)
-            or None
-        )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -3742,7 +3768,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _text_batch_is_compatible(existing: MessageEvent, incoming: MessageEvent) -> bool:
-        """Only merge text events when reply/thread context is identical."""
+        """Only merge text events when reply/thread context is identical.
+
+        Events carrying attachments are never merged: the merge path rewrites
+        ``existing.text`` and would silently drop the incoming event's media
+        (including attachments inherited from a reply-to message).
+        """
+        if existing.media_urls or incoming.media_urls:
+            return False
         return (
             existing.reply_to_message_id == incoming.reply_to_message_id
             and existing.reply_to_text == incoming.reply_to_text
@@ -4308,6 +4341,63 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
+
+    async def _fetch_parent_media(self, message_id: str) -> tuple[List[str], List[str]]:
+        """Download media attached to a reply-to message.
+
+        Feishu only forwards the parent's ``message_id`` on a reply, so a user who
+        answers an image or file with "@Hermes what is this?" would otherwise reach
+        the agent with no attachment at all. Results are cached because the same
+        parent is commonly referenced by several replies in a row.
+        """
+        if not self._client or not message_id:
+            return [], []
+
+        cached = self._parent_media_cache.get(message_id)
+        if cached is not None:
+            self._parent_media_cache.move_to_end(message_id)
+            return list(cached[0]), list(cached[1])
+
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await self._run_blocking(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message lookup failed")
+                logger.warning(
+                    "[Feishu] Failed to fetch parent media %s: [%s] %s", message_id, code, msg
+                )
+                return [], []
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            parent = items[0] if items else None
+            if parent is None:
+                return [], []
+            body = getattr(parent, "body", None)
+            normalized = normalize_feishu_message(
+                message_type=getattr(parent, "msg_type", "") or "",
+                raw_content=getattr(body, "content", "") or "",
+                mentions=getattr(parent, "mentions", None),
+                bot=self._bot_identity(),
+            )
+            media_urls, media_types = await self._download_feishu_message_resources(
+                message_id=message_id,
+                normalized=normalized,
+            )
+            if media_urls:
+                logger.info(
+                    "[Feishu] Inherited %d attachment(s) from parent message %s",
+                    len(media_urls),
+                    message_id,
+                )
+            self._parent_media_cache[message_id] = (list(media_urls), list(media_types))
+            while len(self._parent_media_cache) > _FEISHU_PARENT_MEDIA_CACHE_SIZE:
+                self._parent_media_cache.popitem(last=False)
+            return media_urls, media_types
+        except Exception:
+            logger.warning(
+                "[Feishu] Failed to fetch parent media %s", message_id, exc_info=True
+            )
+            return [], []
 
     def _extract_text_from_raw_content(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2447,6 +2447,282 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         self.assertNotIn("@Hermes @Alice", event.text)
 
 
+class TestFeishuReferencedMedia(unittest.TestCase):
+    """Attachments on a reply-to message must reach the agent.
+
+    Feishu only forwards the parent's ``message_id`` on a reply, so replying to
+    an image with "@Hermes what is this?" used to arrive with zero attachments.
+    """
+
+    def _build_adapter(self, *, parent_media=None, parent_text=None):
+        from collections import OrderedDict
+
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_user_id = ""
+        adapter._bot_name = "Hermes"
+        adapter._message_text_cache = OrderedDict()
+        adapter._parent_media_cache = OrderedDict()
+        adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
+        adapter._fetch_message_text = AsyncMock(return_value=parent_text)
+        adapter._fetch_parent_media = AsyncMock(return_value=parent_media or ([], []))
+        adapter.get_chat_info = AsyncMock(return_value={"name": "Test Chat"})
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
+        )
+        adapter._resolve_source_chat_type = Mock(return_value="group")
+        adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
+        adapter._resolve_channel_prompt = Mock(return_value=None)
+        adapter._dispatch_inbound_event = AsyncMock()
+        return adapter
+
+    @staticmethod
+    def _reply_message(*, text, message_id="m_reply", parent_id="om_parent"):
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        return SimpleNamespace(
+            content=json.dumps({"text": text}),
+            message_type="text",
+            message_id=message_id,
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=parent_id,
+            upper_message_id=None,
+            thread_id=None,
+        )
+
+    def test_reply_to_image_inherits_attachment(self):
+        adapter = self._build_adapter(
+            parent_media=(["/tmp/cached/photo.png"], ["image/png"]),
+            parent_text="see this",
+        )
+        message = self._reply_message(text="@_user_1 what is in this picture?")
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_reply",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.media_urls, ["/tmp/cached/photo.png"])
+        self.assertEqual(event.media_types, ["image/png"])
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertIn("what is in this picture?", event.text)
+
+    def test_reply_to_document_inherits_attachment(self):
+        adapter = self._build_adapter(
+            parent_media=(["/tmp/cached/spec.pdf"], ["application/pdf"]),
+        )
+        message = self._reply_message(text="@_user_1 summarize it")
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_reply",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.media_urls, ["/tmp/cached/spec.pdf"])
+        self.assertEqual(event.media_types, ["application/pdf"])
+
+    def test_bare_mention_reply_to_attachment_survives_empty_text_guard(self):
+        """Regression: a bare "@Hermes" strips to "" and owns no media.
+
+        The empty-text guard must not fire before parent media is merged, or the
+        user's only referenced attachment is silently dropped.
+        """
+        adapter = self._build_adapter(
+            parent_media=(["/tmp/cached/photo.png"], ["image/png"]),
+        )
+        message = self._reply_message(text="@_user_1")
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_reply",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_awaited_once()
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.media_urls, ["/tmp/cached/photo.png"])
+
+    def test_parent_without_media_still_dropped_when_text_empty(self):
+        """A bare "@Hermes" reply to a plain text message stays filtered."""
+        adapter = self._build_adapter(parent_media=([], []), parent_text="hello")
+        message = self._reply_message(text="@_user_1")
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_reply",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_not_awaited()
+
+    def test_own_media_is_not_duplicated_by_parent_media(self):
+        adapter = self._build_adapter(
+            parent_media=(["/tmp/cached/photo.png"], ["image/png"]),
+        )
+        adapter._download_feishu_message_resources = AsyncMock(
+            return_value=(["/tmp/cached/photo.png"], ["image/png"])
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"image_key": "img_1"}),
+            message_type="image",
+            message_id="m_reply",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_reply",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.media_urls, ["/tmp/cached/photo.png"])
+
+    def test_command_reply_does_not_inherit_media(self):
+        """A slash command must not silently pick up the parent's attachment."""
+        adapter = self._build_adapter(
+            parent_media=(["/tmp/cached/photo.png"], ["image/png"]),
+        )
+        message = self._reply_message(text="@_user_1 /model")
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_reply",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.media_urls, [])
+        adapter._fetch_parent_media.assert_not_awaited()
+
+
+class TestFeishuFetchParentMedia(unittest.TestCase):
+    """_fetch_parent_media reuses the standard resource pipeline."""
+
+    def _build_adapter(self):
+        from collections import OrderedDict
+
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_user_id = ""
+        adapter._bot_name = "Hermes"
+        adapter._parent_media_cache = OrderedDict()
+        adapter._client = Mock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        adapter._run_blocking = AsyncMock()
+        adapter._download_feishu_message_resources = AsyncMock(
+            return_value=(["/tmp/cached/photo.png"], ["image/png"])
+        )
+        return adapter
+
+    @staticmethod
+    def _ok_response():
+        parent = SimpleNamespace(
+            body=SimpleNamespace(content=json.dumps({"image_key": "img_1"})),
+            msg_type="image",
+            mentions=None,
+        )
+        response = Mock()
+        response.success = Mock(return_value=True)
+        response.data = SimpleNamespace(items=[parent])
+        return response
+
+    def test_downloads_parent_media_via_shared_pipeline(self):
+        adapter = self._build_adapter()
+        adapter._run_blocking = AsyncMock(return_value=self._ok_response())
+
+        urls, types = asyncio.run(adapter._fetch_parent_media("om_parent"))
+        self.assertEqual(urls, ["/tmp/cached/photo.png"])
+        self.assertEqual(types, ["image/png"])
+        adapter._download_feishu_message_resources.assert_awaited_once()
+
+    def test_result_is_cached_so_repeated_replies_skip_redownload(self):
+        adapter = self._build_adapter()
+        adapter._run_blocking = AsyncMock(return_value=self._ok_response())
+
+        asyncio.run(adapter._fetch_parent_media("om_parent"))
+        asyncio.run(adapter._fetch_parent_media("om_parent"))
+        self.assertEqual(adapter._download_feishu_message_resources.await_count, 1)
+
+    def test_failed_lookup_returns_empty_and_does_not_raise(self):
+        adapter = self._build_adapter()
+        response = Mock()
+        response.success = Mock(return_value=False)
+        response.code = 230002
+        response.msg = "permission denied"
+        adapter._run_blocking = AsyncMock(return_value=response)
+
+        urls, types = asyncio.run(adapter._fetch_parent_media("om_parent"))
+        self.assertEqual(urls, [])
+        self.assertEqual(types, [])
+
+    def test_exception_is_swallowed(self):
+        adapter = self._build_adapter()
+        adapter._run_blocking = AsyncMock(side_effect=RuntimeError("boom"))
+
+        urls, types = asyncio.run(adapter._fetch_parent_media("om_parent"))
+        self.assertEqual(urls, [])
+        self.assertEqual(types, [])
+
+    def test_no_client_returns_empty(self):
+        adapter = self._build_adapter()
+        adapter._client = None
+
+        urls, types = asyncio.run(adapter._fetch_parent_media("om_parent"))
+        self.assertEqual(urls, [])
+
+
+class TestFeishuTextBatchMediaSafety(unittest.TestCase):
+    """Text batching must never swallow attachments."""
+
+    @staticmethod
+    def _event(*, text, media_urls=None):
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        return MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=SimpleNamespace(thread_id=None),
+            raw_message=None,
+            message_id="m1",
+            media_urls=list(media_urls or []),
+            media_types=["image/png"] * len(media_urls or []),
+            reply_to_message_id="om_parent",
+            reply_to_text="parent",
+        )
+
+    def test_events_with_media_are_not_merged(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        existing = self._event(text="first", media_urls=["/tmp/a.png"])
+        incoming = self._event(text="second")
+        self.assertFalse(FeishuAdapter._text_batch_is_compatible(existing, incoming))
+
+    def test_incoming_media_blocks_merge(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        existing = self._event(text="first")
+        incoming = self._event(text="second", media_urls=["/tmp/b.png"])
+        self.assertFalse(FeishuAdapter._text_batch_is_compatible(existing, incoming))
+
+    def test_plain_text_events_still_merge(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        existing = self._event(text="first")
+        incoming = self._event(text="second")
+        self.assertTrue(FeishuAdapter._text_batch_is_compatible(existing, incoming))
+
+
 class TestChatLockEviction(unittest.TestCase):
     """_get_chat_lock is LRU-bounded so _chat_locks cannot grow unbounded."""
 


### PR DESCRIPTION
## What does this PR do?

This PR lets Feishu/Lark inherit media attachments from a referenced (reply-to) message in group chats.

**Problem:** When a user replies to a message containing an image or file and mentions Hermes, only the parent message's *text* was fetched and forwarded. The attachments were dropped entirely, so the agent could not see or analyze the very thing the user was pointing at. On current `main` this is still the case: `plugins/platforms/feishu/adapter.py` fetches parent text only, while a working resource-download pipeline already exists a few hundred lines away and goes unused on this path.

**Solution:**
- Added `_fetch_parent_media()`, which reuses the existing `_download_feishu_message_resources()` pipeline rather than duplicating download logic, and passes `bot=self._bot_identity()` so self-mentions in the parent render consistently with the rest of the adapter
- Moved reply resolution in `_process_inbound_message` to run **before** the empty-text guard, then merged inherited attachments into the inbound event's media
- Excluded events carrying attachments from text debouncing, since the batch-merge path rewrites `existing.text` and could silently discard inherited media

The ordering change is the load-bearing part. A bare `@Hermes` reply strips to `""` and owns no media of its own, so with the guard running first the message returned early and the parent was never looked up — exactly the scenario this PR targets. A regression test pins the ordering.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/feishu/adapter.py`: added `_fetch_parent_media()`, downloading parent attachments through the existing `_download_feishu_message_resources()` pipeline, with an LRU cache (128) since one parent is commonly referenced by several consecutive replies
- `plugins/platforms/feishu/adapter.py`: moved reply resolution ahead of the empty-text guard in `_process_inbound_message`, and de-duplicated inherited media against the message's own attachments
- `plugins/platforms/feishu/adapter.py`: slash commands opt out of inheritance, so `/model` cannot silently absorb a parent image
- `plugins/platforms/feishu/adapter.py`: `_text_batch_is_compatible()` now refuses to merge events carrying media
- `tests/gateway/test_feishu.py`: 14 cases across `TestFeishuReferencedMedia`, `TestFeishuFetchParentMedia`, and `TestFeishuTextBatchMediaSafety`

## How to Test

1. In a Feishu/Lark group chat, send a message containing an image or file
2. Reply to it, mention the Hermes bot, and ask about the content
3. Verify the agent receives the parent's attachment and can analyze it
4. Repeat with a bare `@Hermes` and no other text — this is the case that previously failed silently
5. Reply to a plain-text message with a bare `@Hermes` and verify it is still filtered out as before

`pytest tests/gateway/test_feishu.py` goes from 75 to 89 passing. Reverting the adapter to `main` while keeping the new tests fails 10 of them, confirming the tests exercise the actual defect.

## Checklist

### Code

- [x] I've read the `https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md`
- [x] My commit messages follow `https://www.conventionalcommits.org/` (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for `https://github.com/NousResearch/hermes-agent/pulls` to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_feishu.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.x (Apple Silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the `https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility` — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
