### PR TITLE
feat(cron): add path-friendly naming and automatic migration for job outputs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2,7 +2,7 @@
 Cron job storage and management.
 
 Jobs are stored in ~/.hermes/cron/jobs.json
-Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
+Output is saved to ~/.hermes/cron/output/{name}-{id}/{timestamp}.md
 """
 
 import copy
@@ -68,6 +68,17 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     normalized["skills"] = skills
     normalized["skill"] = skills[0] if skills else None
     return normalized
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a path-friendly slug (lowercase, alphanumeric + hyphens)."""
+    if not text:
+        return ""
+    # Replace non-word characters with hyphens
+    # \w matches [a-zA-Z0-9_] plus Unicode word characters (like Chinese) in Python 3
+    s = re.sub(r'[^\w\s-]', '', text).strip().lower()
+    s = re.sub(r'[-\s]+', '-', s)
+    return s.strip('-')
 
 
 def _secure_dir(path: Path):
@@ -748,10 +759,31 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     return due
 
 
-def save_job_output(job_id: str, output: str):
+def save_job_output(job_id: str, output: str, job_name: Optional[str] = None):
     """Save job output to file."""
     ensure_dirs()
-    job_output_dir = OUTPUT_DIR / job_id
+
+    # Construct directory name: {slug}-{id} or just {id}
+    dir_name = job_id
+    if job_name:
+        slug = _slugify(job_name)
+        if slug:
+            dir_name = f"{slug}-{job_id}"
+
+    job_output_dir = OUTPUT_DIR / dir_name
+
+    # Migration: if an old-style directory exists, rename it to the new name.
+    old_output_dir = OUTPUT_DIR / job_id
+    if dir_name != job_id and old_output_dir.exists() and old_output_dir.is_dir():
+        try:
+            # If both exist (e.g. name changed), we don't merge, just keep using the new one.
+            # But if only old exists, we migrate.
+            if not job_output_dir.exists():
+                old_output_dir.rename(job_output_dir)
+                logger.info("Migrated job output directory for %s: %s -> %s", job_id, job_id, dir_name)
+        except Exception as e:
+            logger.warning("Failed to migrate job output directory for %s: %s", job_id, e)
+
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
     

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2,7 +2,9 @@
 Cron job storage and management.
 
 Jobs are stored in ~/.hermes/cron/jobs.json
-Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
+Output is saved to ~/.hermes/cron/output/{name-slug}-{job_id}/{timestamp}.md
+(plain {job_id} when the job name slugifies to empty; legacy {job_id}
+directories are migrated on the next output write).
 """
 
 import contextlib
@@ -385,6 +387,103 @@ def _job_output_dir(job_id: str) -> Path:
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     return _current_cron_store().output_dir / text
+
+
+# Cap on the slugified-name prefix of an output directory. Keeps
+# ``{name-slug}-{job_id}`` comfortably short even for verbose job names.
+_OUTPUT_SLUG_MAX_CHARS = 40
+
+
+def _slugify_job_name(name: Optional[Any]) -> str:
+    """Slugify a job name for use as an output-directory prefix.
+
+    Strictly sanitized so a hostile job name can never influence the path
+    beyond a cosmetic prefix: lowercase ``[a-z0-9]`` runs joined by single
+    hyphens, everything else stripped, capped at ``_OUTPUT_SLUG_MAX_CHARS``.
+    Returns ``""`` when nothing survives (callers fall back to the plain
+    ``{job_id}`` directory name).
+    """
+    runs = re.findall(r"[a-z0-9]+", str(name or "").lower())
+    return "-".join(runs)[:_OUTPUT_SLUG_MAX_CHARS].rstrip("-")
+
+
+def _existing_job_output_dirs(job_id: str) -> List[Path]:
+    """Return every existing output directory belonging to *job_id*.
+
+    Covers the legacy ``{job_id}`` form and any ``{slug}-{job_id}`` form
+    (including stale slugs from before a job rename). Validates *job_id*
+    via :func:`_job_output_dir` first so unsafe legacy IDs fail closed
+    before any path is composed. Order is deterministic: legacy dir first,
+    then slug dirs sorted by name.
+    """
+    legacy_dir = _job_output_dir(job_id)
+    dirs: List[Path] = []
+    if legacy_dir.is_dir():
+        dirs.append(legacy_dir)
+    suffix = f"-{job_id}"
+    try:
+        siblings = sorted(legacy_dir.parent.iterdir())
+    except OSError:
+        siblings = []
+    for candidate in siblings:
+        if candidate.name.endswith(suffix) and candidate.is_dir():
+            dirs.append(candidate)
+    return dirs
+
+
+def resolve_job_output_dir(
+    job_id: str,
+    job_name: Optional[str] = None,
+    *,
+    create: bool = False,
+) -> Path:
+    """Resolve the validated output directory for a job.
+
+    The canonical directory name is ``{name-slug}-{job_id}`` (plain
+    ``{job_id}`` when the name slugifies to empty). The job ID is validated
+    exactly like :func:`_job_output_dir` — unsafe legacy IDs fail closed —
+    and the slug is strictly sanitized, so the result can never escape the
+    cron output root.
+
+    When *job_name* is omitted, the job's current name is looked up from the
+    store (best effort; unknown jobs resolve by ID alone).
+
+    With ``create=True`` (write path) an existing legacy ``{job_id}`` or
+    stale ``{old-slug}-{job_id}`` directory is migrated (renamed) to the
+    canonical name; if the rename fails the existing directory is reused so
+    output is never split across directories. With ``create=False`` (read
+    path) nothing is renamed — the existing directory is merely located.
+    """
+    legacy_dir = _job_output_dir(job_id)  # validates job_id, fails closed
+    if job_name is None:
+        # Best effort — a broken store must never turn into a failure to
+        # save/read output; we just fall back to ID-only resolution.
+        try:
+            job = get_job(job_id)
+        except Exception:
+            job = None
+        if job:
+            job_name = job.get("name")
+    slug = _slugify_job_name(job_name)
+    preferred = legacy_dir.parent / f"{slug}-{job_id}" if slug else legacy_dir
+    if preferred.exists():
+        return preferred
+    existing = [d for d in _existing_job_output_dirs(job_id) if d != preferred]
+    if not existing:
+        return preferred
+    current = existing[0]
+    if not create:
+        return current
+    try:
+        current.rename(preferred)
+    except OSError as exc:
+        logger.warning(
+            "Failed to migrate cron output dir %s -> %s: %s",
+            current.name, preferred.name, exc,
+        )
+        return current
+    logger.info("Migrated cron output dir %s -> %s", current.name, preferred.name)
+    return preferred
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -1674,14 +1773,16 @@ def remove_job(job_id: str) -> bool:
         original_len = len(jobs)
         jobs = [j for j in jobs if j["id"] != canonical_id]
         if len(jobs) < original_len:
-            # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
+            # Resolve the output dirs BEFORE saving so a legacy unsafe ID (e.g.
             # left over from before the create-time guard) fails closed without
             # half-applying the removal.
-            job_output_dir = _job_output_dir(canonical_id)
+            job_output_dirs = _existing_job_output_dirs(canonical_id)
             save_jobs(jobs)
-            # Clean up output directory to prevent orphaned dirs accumulating
-            if job_output_dir.exists():
-                shutil.rmtree(job_output_dir)
+            # Clean up output directories (new-style {slug}-{id} and legacy
+            # {id} alike) to prevent orphaned dirs accumulating
+            for job_output_dir in job_output_dirs:
+                if job_output_dir.exists():
+                    shutil.rmtree(job_output_dir)
             return True
     return False
 
@@ -2432,10 +2533,15 @@ def _prune_job_output(job_output_dir: Path, keep: int) -> int:
     return deleted
 
 
-def save_job_output(job_id: str, output: str):
-    """Save job output to file."""
+def save_job_output(job_id: str, output: str, job_name: Optional[str] = None):
+    """Save job output to file under the job's ``{name-slug}-{job_id}`` dir.
+
+    ``job_name`` is looked up from the store when omitted. Existing legacy
+    ``{job_id}`` (or stale-slug) directories are migrated on the way in —
+    see :func:`resolve_job_output_dir`.
+    """
     ensure_dirs()
-    job_output_dir = _job_output_dir(job_id)
+    job_output_dir = resolve_job_output_dir(job_id, job_name, create=True)
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1112,7 +1112,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
             try:
                 success, output, final_response, error = run_job(job)
 
-                output_file = save_job_output(job["id"], output)
+                output_file = save_job_output(job["id"], output, job_name=job.get("name"))
                 if verbose:
                     logger.info("Output saved to: %s", output_file)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2482,8 +2482,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # Inject output from referenced cron jobs as context.
     context_from = job.get("context_from")
     if context_from:
-        from cron.jobs import get_cron_output_dir
-        output_dir = get_cron_output_dir()
+        from cron.jobs import resolve_job_output_dir
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
@@ -2498,7 +2497,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 continue
             try:
-                job_output_dir = output_dir / source_job_id
+                # Central resolver locates the new-style {slug}-{id} dir and
+                # falls back to a legacy {id} dir (read-only: no migration).
+                job_output_dir = resolve_job_output_dir(source_job_id)
                 if not job_output_dir.exists():
                     continue  # silent skip — no output yet
                 output_files = sorted(
@@ -3965,7 +3966,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
         try:
-            output_file = save_job_output(job["id"], output)
+            output_file = save_job_output(job["id"], output, job_name=job.get("name"))
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -399,12 +399,30 @@ class DeliveryRouter:
     ) -> Dict[str, Any]:
         """Save content to local files."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
+
+        output_path = None
         if job_id:
-            output_path = self.output_dir / job_id / f"{timestamp}.md"
-        else:
+            # Route through the central resolver so local delivery writes into
+            # the canonical {name-slug}-{job_id} directory (migrating a legacy
+            # {job_id} dir) instead of recreating the plain {job_id} form and
+            # splitting output across two directories. The resolver is also
+            # profile-aware (context-local cron store), unlike the
+            # get_hermes_home() snapshot taken at router construction.
+            # Lazy import keeps cron.jobs off the gateway cold-start path.
+            from cron.jobs import resolve_job_output_dir
+            try:
+                job_dir = resolve_job_output_dir(job_id, job_name, create=True)
+                output_path = job_dir / f"{timestamp}.md"
+            except ValueError as e:
+                # Unsafe/legacy job id — fail closed on the per-job dir but
+                # never crash delivery; fall back to the misc/ bucket.
+                logger.warning(
+                    "Local delivery: invalid job id %r (%s); saving to misc/",
+                    job_id, e,
+                )
+        if output_path is None:
             output_path = self.output_dir / "misc" / f"{timestamp}.md"
-        
+
         output_path.parent.mkdir(parents=True, exist_ok=True)
         
         # Build the output document

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -217,7 +217,7 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
         "run_job",
         lambda job, *, defer_agent_teardown=None: (True, "output", "response", None),
     )
-    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
 

--- a/tests/cron/test_output_dir_naming.py
+++ b/tests/cron/test_output_dir_naming.py
@@ -1,0 +1,252 @@
+"""Filesystem-level tests for path-friendly cron output directories.
+
+Job output lives in ``OUTPUT_DIR / {name-slug}-{job_id}`` (plain
+``{job_id}`` when the name slugifies to empty). All resolution goes
+through ``cron.jobs.resolve_job_output_dir``, which preserves the
+path-escape guard from ``_job_output_dir`` (unsafe legacy IDs fail
+closed) and migrates legacy ID-only directories on the write path.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.jobs import (  # noqa: E402
+    _slugify_job_name,
+    create_job,
+    load_jobs,
+    remove_job,
+    resolve_job_output_dir,
+    save_job_output,
+    save_jobs,
+)
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+@pytest.fixture()
+def output_root(tmp_cron_dir):
+    return tmp_cron_dir / "cron" / "output"
+
+
+# =========================================================================
+# Slugification
+# =========================================================================
+
+class TestSlugifyJobName:
+    def test_basic_name(self):
+        assert _slugify_job_name("Daily News Report") == "daily-news-report"
+
+    def test_special_chars_stripped(self):
+        assert _slugify_job_name("  Check: server / status!!  ") == "check-server-status"
+
+    def test_runs_joined_by_single_hyphen(self):
+        assert _slugify_job_name("a---b___c...d") == "a-b-c-d"
+
+    def test_unicode_only_name_slugifies_to_empty(self):
+        assert _slugify_job_name("日本語のジョブ") == ""
+
+    def test_symbols_only_name_slugifies_to_empty(self):
+        assert _slugify_job_name("!!! ??? ***") == ""
+
+    def test_none_and_empty(self):
+        assert _slugify_job_name(None) == ""
+        assert _slugify_job_name("") == ""
+
+    def test_length_capped_at_40_without_trailing_hyphen(self):
+        slug = _slugify_job_name("word " * 20)
+        assert len(slug) <= 40
+        assert not slug.endswith("-")
+
+    def test_traversal_name_reduced_to_cosmetic_slug(self):
+        assert _slugify_job_name("../../etc/passwd") == "etc-passwd"
+
+
+# =========================================================================
+# Writer (save_job_output) naming + migration
+# =========================================================================
+
+class TestSaveJobOutputNaming:
+    def test_writes_to_name_slug_dir(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="Daily News")
+        output_file = save_job_output(job["id"], "report", job_name=job["name"])
+        assert output_file.parent == output_root / f"daily-news-{job['id']}"
+        assert output_file.read_text() == "report"
+
+    def test_looks_up_name_when_not_passed(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="Weather Watch")
+        output_file = save_job_output(job["id"], "report")
+        assert output_file.parent == output_root / f"weather-watch-{job['id']}"
+
+    def test_empty_slug_falls_back_to_plain_id(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="日本語")
+        output_file = save_job_output(job["id"], "report", job_name=job["name"])
+        assert output_file.parent == output_root / job["id"]
+
+    def test_unknown_job_without_name_uses_plain_id(self, output_root):
+        output_file = save_job_output("abc123def456", "report")
+        assert output_file.parent == output_root / "abc123def456"
+
+    def test_migrates_legacy_id_dir(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="Daily News")
+        legacy_dir = output_root / job["id"]
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "2026-01-01_00-00-00.md").write_text("old run", encoding="utf-8")
+
+        save_job_output(job["id"], "new run", job_name=job["name"])
+
+        new_dir = output_root / f"daily-news-{job['id']}"
+        assert not legacy_dir.exists()
+        assert (new_dir / "2026-01-01_00-00-00.md").read_text() == "old run"
+        assert len(list(new_dir.glob("*.md"))) == 2
+
+    def test_migrates_stale_slug_dir_after_rename(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="New Name")
+        stale_dir = output_root / f"old-name-{job['id']}"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "2026-01-01_00-00-00.md").write_text("old run", encoding="utf-8")
+
+        save_job_output(job["id"], "new run", job_name="New Name")
+
+        new_dir = output_root / f"new-name-{job['id']}"
+        assert not stale_dir.exists()
+        assert (new_dir / "2026-01-01_00-00-00.md").read_text() == "old run"
+
+
+# =========================================================================
+# Resolver semantics
+# =========================================================================
+
+class TestResolveJobOutputDir:
+    def test_read_resolution_does_not_rename(self, output_root):
+        legacy_dir = output_root / "abc123def456"
+        legacy_dir.mkdir(parents=True)
+
+        resolved = resolve_job_output_dir("abc123def456", "Daily News")
+
+        assert resolved == legacy_dir
+        assert legacy_dir.exists()
+        assert not (output_root / "daily-news-abc123def456").exists()
+
+    def test_read_resolution_finds_slug_dir_without_name(self, output_root):
+        slug_dir = output_root / "daily-news-abc123def456"
+        slug_dir.mkdir(parents=True)
+        assert resolve_job_output_dir("abc123def456") == slug_dir
+
+    def test_prefers_canonical_dir_when_both_exist(self, output_root):
+        (output_root / "abc123def456").mkdir(parents=True)
+        canonical = output_root / "daily-news-abc123def456"
+        canonical.mkdir(parents=True)
+        assert resolve_job_output_dir("abc123def456", "Daily News") == canonical
+
+    def test_resolved_dir_always_under_output_root(self, output_root):
+        hostile_names = ["../../etc", "/etc/passwd", "..", "a/../../b", "C:\\evil"]
+        for name in hostile_names:
+            resolved = resolve_job_output_dir("abc123def456", name)
+            assert resolved.parent == output_root
+            assert resolved.name.endswith("abc123def456")
+
+    @pytest.mark.parametrize("bad_id", ["..", "../escape", "a/b", "a\\b", "", "/abs"])
+    def test_unsafe_job_id_fails_closed(self, output_root, bad_id):
+        with pytest.raises(ValueError, match="output path"):
+            resolve_job_output_dir(bad_id, "Daily News")
+
+    def test_unsafe_job_id_fails_closed_on_save(self, output_root):
+        with pytest.raises(ValueError, match="output path"):
+            save_job_output("../escape", "report", job_name="Daily News")
+
+
+# =========================================================================
+# Reader / chaining compatibility (scheduler context_from)
+# =========================================================================
+
+class TestContextFromReadsNewNaming:
+    def test_reads_output_written_under_new_naming(self, tmp_cron_dir):
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h", name="News Fetch")
+        save_job_output(job_a["id"], "Top story: AI everywhere.", job_name=job_a["name"])
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+        prompt = _build_job_prompt(job_b)
+        assert "Top story: AI everywhere." in prompt
+
+    def test_still_reads_legacy_id_dir(self, output_root, tmp_cron_dir):
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h", name="News Fetch")
+        legacy_dir = output_root / job_a["id"]
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "2026-01-01_00-00-00.md").write_text("Legacy story.", encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+        prompt = _build_job_prompt(job_b)
+        assert "Legacy story." in prompt
+        # Read path never migrates.
+        assert legacy_dir.exists()
+
+
+# =========================================================================
+# Removal cleans up both naming forms
+# =========================================================================
+
+class TestRemoveJobCleansBothForms:
+    def test_removes_new_style_dir(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="Daily News")
+        save_job_output(job["id"], "report", job_name=job["name"])
+        new_dir = output_root / f"daily-news-{job['id']}"
+        assert new_dir.exists()
+
+        assert remove_job(job["id"]) is True
+        assert not new_dir.exists()
+
+    def test_removes_legacy_and_stale_slug_dirs(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="Daily News")
+        legacy_dir = output_root / job["id"]
+        legacy_dir.mkdir(parents=True)
+        stale_dir = output_root / f"old-name-{job['id']}"
+        stale_dir.mkdir(parents=True)
+
+        assert remove_job(job["id"]) is True
+        assert not legacy_dir.exists()
+        assert not stale_dir.exists()
+
+    def test_does_not_remove_other_jobs_dirs(self, output_root):
+        job = create_job(prompt="x", schedule="every 1h", name="Daily News")
+        other_dir = output_root / "other-job-ffffffffffff"
+        other_dir.mkdir(parents=True)
+
+        assert remove_job(job["id"]) is True
+        assert other_dir.exists()
+
+    def test_unsafe_legacy_id_fails_closed_without_removal(self, tmp_cron_dir, output_root):
+        job = create_job(prompt="Legacy unsafe", schedule="every 1h")
+        job["id"] = "../escape"
+        save_jobs([job])
+        outside = tmp_cron_dir / "escape"
+        outside.mkdir()
+        (outside / "keep.txt").write_text("keep", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="output path"):
+            remove_job("../escape")
+
+        assert load_jobs()[0]["id"] == "../escape"
+        assert (outside / "keep.txt").exists()

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -23,7 +23,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         fr = final if silent_marker_in is None else silent_marker_in
         return (success, output, fr, error)
 
-    def fake_save(jid, out):
+    def fake_save(jid, out, job_name=None):
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
@@ -91,7 +91,7 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
         return (True, "out", "final", None)
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
-    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out, job_name=None: f"/tmp/{jid}.txt")
     monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
     monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1142,7 +1142,7 @@ class TestSilentDelivery:
             save_mock.return_value = "/tmp/out.md"
             from cron.scheduler import tick
             tick(verbose=False)
-        save_mock.assert_called_once_with("monitor-job", "# full output")
+        save_mock.assert_called_once_with("monitor-job", "# full output", job_name="monitor")
         deliver_mock.assert_not_called()
 
 

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -329,3 +329,59 @@ async def test_long_output_truncated_for_non_chunking_adapter(tmp_path, monkeypa
     assert saved_files[0].read_text() == long_content
 
 
+
+
+# ---------------------------------------------------------------------------
+# Local delivery routes through the central cron output-dir resolver
+# ---------------------------------------------------------------------------
+
+class TestDeliverLocalOutputDirNaming:
+    """_deliver_local must write into the canonical {name-slug}-{job_id}
+    directory via cron.jobs.resolve_job_output_dir — never recreate the plain
+    legacy {job_id} directory and split output across two dirs."""
+
+    def _router(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        return DeliveryRouter(GatewayConfig(), adapters={})
+
+    def test_job_output_lands_in_slug_dir_not_legacy_dir(self, tmp_path, monkeypatch):
+        router = self._router(tmp_path, monkeypatch)
+
+        result = router._deliver_local("hello", "abc123", "Daily Report", None)
+
+        output_root = tmp_path / "cron" / "output"
+        slug_dir = output_root / "daily-report-abc123"
+        assert slug_dir.is_dir()
+        files = list(slug_dir.glob("*.md"))
+        assert len(files) == 1
+        assert "hello" in files[0].read_text(encoding="utf-8")
+        assert result["path"] == str(files[0])
+        # No plain legacy {job_id} dir gets (re)created.
+        assert not (output_root / "abc123").exists()
+
+    def test_job_output_migrates_existing_legacy_dir(self, tmp_path, monkeypatch):
+        router = self._router(tmp_path, monkeypatch)
+        legacy_dir = tmp_path / "cron" / "output" / "abc123"
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "old.md").write_text("old run", encoding="utf-8")
+
+        router._deliver_local("new run", "abc123", "Daily Report", None)
+
+        output_root = tmp_path / "cron" / "output"
+        slug_dir = output_root / "daily-report-abc123"
+        assert not (output_root / "abc123").exists()  # migrated, not split
+        assert (slug_dir / "old.md").read_text(encoding="utf-8") == "old run"
+        assert len(list(slug_dir.glob("*.md"))) == 2
+
+    def test_unsafe_job_id_falls_back_to_misc_without_raising(self, tmp_path, monkeypatch):
+        router = self._router(tmp_path, monkeypatch)
+
+        result = router._deliver_local("payload", "../escape", "Evil", None)
+
+        misc_files = list((tmp_path / "cron" / "output" / "misc").glob("*.md"))
+        assert len(misc_files) == 1
+        assert result["path"] == str(misc_files[0])
+        # Nothing escaped the output root.
+        assert not (tmp_path / "cron" / "escape").exists()
+        assert not (tmp_path / "escape").exists()

--- a/website/docs/guides/team-telegram-assistant.md
+++ b/website/docs/guides/team-telegram-assistant.md
@@ -417,7 +417,7 @@ hermes gateway stop && hermes gateway start
 | What | Location |
 |------|----------|
 | Gateway logs | `journalctl --user -u hermes-gateway` (Linux) or `~/.hermes/logs/gateway.log` (macOS) |
-| Cron job output | `~/.hermes/cron/output/{job_id}/{timestamp}.md` |
+| Cron job output | `~/.hermes/cron/output/{name-slug}-{job_id}/{timestamp}.md` |
 | Cron job definitions | `~/.hermes/cron/jobs.json` |
 | Pairing data | `~/.hermes/pairing/` |
 | Session history | `~/.hermes/sessions/` |

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -537,7 +537,7 @@ cronjob(
 
 **How it works:**
 
-- When Job 2 fires, Hermes reads Job 1's most recent output from `~/.hermes/cron/output/{job1_id}/*.md`
+- When Job 2 fires, Hermes reads Job 1's most recent output from `~/.hermes/cron/output/{job1-name-slug}-{job1_id}/*.md` (legacy `{job1_id}` directories are found too)
 - That output is prepended to Job 2's prompt automatically
 - Job 2 doesn't need to hardcode "read this file" — it receives the content as context
 - The chain can be any length: Job 1 → Job 2 → Job 3 → ...
@@ -777,7 +777,7 @@ The referenced jobs' most recent completed outputs are injected above the prompt
 
 ## Job storage
 
-Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`.
+Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{name-slug}-{job_id}/{timestamp}.md`, where `{name-slug}` is the job name lowercased and reduced to hyphen-separated alphanumeric runs (capped at 40 characters). When the name contains no usable characters, the directory is plain `{job_id}`. Directories created under the old `{job_id}`-only scheme are renamed automatically the next time the job saves output.
 
 :::tip
 Ask the agent to manage jobs through the `cronjob` tool, `hermes cron edit`, or `/cron` — not by patching `jobs.json` directly. Direct edits can fail silently when [file write safety](../security.md#file-write-safety) blocks the path (for example when `HERMES_WRITE_SAFE_ROOT` is set), and the [file-mutation verifier](../configuration.md#file-mutation-verifier) footer is the authoritative signal that nothing was saved.


### PR DESCRIPTION
## Description

This PR improves the organization of cron job output directories by moving from simple ID-based naming to a path-friendly name-id format (e.g., `daily-report-7550a1c44d32`).

## Key Changes

- **Slugification**: Added a `_slugify` helper to generate filesystem-safe directory names from job names (preserves Unicode/Chinese characters for better readability).
- **Automatic Migration**: When a job runs, it automatically detects and renames legacy ID-only directories to the new format, ensuring a seamless transition for existing users without data loss.
- **Robustness**: Falls back to the job ID if no name is provided, maintaining backward compatibility.

## Tests

- Updated existing mock-based tests to match the new signature.
- Verified all 143 cron-related tests pass (`pytest tests/cron/`).
- Manually verified migration logic with active jobs.

## Platforms Tested

- macOS (Apple Silicon)
