### PR TITLE
fix(agent): propagate extra_content through _nr_to_assistant_message shim (Gemini 3 thought_signature)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6788,7 +6788,7 @@ class AIAgent:
                     function=SimpleNamespace(name=tc.name, arguments=tc.arguments),
                 )
                 if tc.provider_data:
-                    for key in ("call_id", "response_item_id"):
+                    for key in ("call_id", "response_item_id", "extra_content"):
                         if tc.provider_data.get(key):
                             setattr(tc_ns, key, tc.provider_data[key])
                 tc_list.append(tc_ns)


### PR DESCRIPTION
## Summary

Gemini 3 Flash/Pro tool-calling replay fails with HTTP 400 `INVALID_ARGUMENT` — *"Function call is missing a thought_signature in functionCall parts"* — on the `chat_completions` api_mode, despite the existing fix from [`dfd50cec`](https://github.com/NousResearch/hermes-agent/commit/dfd50cec) being in place.

Root cause: the `_nr_to_assistant_message` shim (introduced by [`d30ee2e5`](https://github.com/NousResearch/hermes-agent/commit/d30ee2e5) *"unify transport dispatch + collapse normalize shims"*) extracts only four `provider_data` keys into the `SimpleNamespace` that downstream code reads — `codex_reasoning_items`, `reasoning_details`, `call_id`, `response_item_id`. It silently drops `extra_content`, which is where the `chat_completions` transport stashes Gemini's `thought_signature` (correctly, via `normalize_response` in `agent/transports/chat_completions.py`).

Downstream, `_build_assistant_message` reads `extra_content` via `getattr(tool_call, "extra_content", None)` per `dfd50cec` — correct design, but the shim has already stripped it, so `getattr` returns `None` and the signature is never echoed back on the next turn.

## Fix

One-word change: add `"extra_content"` to the tuple of keys the shim propagates.

```diff
                 if tc.provider_data:
-                    for key in ("call_id", "response_item_id"):
+                    for key in ("call_id", "response_item_id", "extra_content"):
                         if tc.provider_data.get(key):
                             setattr(tc_ns, key, tc.provider_data[key])
```

The existing `getattr` in `_build_assistant_message` then finds the attribute, the fix from `dfd50cec` does its job, and Google accepts the replay request.

## Verification

- **Before:** fresh session on `gemini-3-flash-preview` via `https://generativelanguage.googleapis.com/v1beta/openai` — first user message triggers a tool call, model returns with `extra_content.google.thought_signature`, client replays on next turn without the signature, Google returns 400 at position 2.
- **After the fix:** same flow succeeds — thought_signature is propagated through the shim, replayed correctly, Google accepts.

Runtime inspection confirmed the failure mode before applying the fix: `type=SimpleNamespace model_extra='MISSING' provider_data='MISSING' public_attrs=['function', 'id', 'type']` — `extra_content` never reaches `_build_assistant_message`.

## Related

- [`dfd50cec`](https://github.com/NousResearch/hermes-agent/commit/dfd50cec) — original `extra_content` preservation in `_build_assistant_message` (correct but operates downstream of the bug)
- [`d30ee2e5`](https://github.com/NousResearch/hermes-agent/commit/d30ee2e5) — refactor that introduced the shim gap
- v0.5.0 release (#2997) fixed the analogous issue in the streaming path; the non-streaming shim path never got the equivalent fix.
- [Google docs: thought_signatures](https://ai.google.dev/gemini-api/docs/thought-signatures) confirm the required echo semantics.