### PR TITLE
fix(slack): surface Socket Mode task failures

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -225,6 +225,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token)
             self._socket_mode_task = asyncio.create_task(self._handler.start_async())
+            self._socket_mode_task.add_done_callback(self._handle_socket_mode_task_done)
 
             self._running = True
             logger.info(
@@ -240,14 +241,42 @@ class SlackAdapter(BasePlatformAdapter):
             if lock_acquired and not self._running:
                 self._release_platform_lock()
 
+    def _handle_socket_mode_task_done(self, task: asyncio.Task) -> None:
+        """Promote unexpected Socket Mode task exits into gateway fatal state."""
+        if not self._running:
+            return
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+
+        if exc is None:
+            message = "Slack Socket Mode task exited unexpectedly"
+        else:
+            message = f"Slack Socket Mode task failed: {type(exc).__name__}: {exc}"
+        logger.error("[Slack] %s", message, exc_info=exc)
+        self._set_fatal_error("slack_socket_mode_task_exit", message, retryable=True)
+        try:
+            asyncio.create_task(self._notify_fatal_error())
+        except RuntimeError:
+            logger.debug("[Slack] Could not schedule fatal-error notification", exc_info=True)
+
     async def disconnect(self) -> None:
         """Disconnect from Slack."""
+        self._running = False
         if self._handler:
             try:
                 await self._handler.close_async()
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning("[Slack] Error while closing Socket Mode handler: %s", e, exc_info=True)
-        self._running = False
+
+        if self._socket_mode_task and not self._socket_mode_task.done():
+            self._socket_mode_task.cancel()
+            try:
+                await self._socket_mode_task
+            except asyncio.CancelledError:
+                pass
+        self._socket_mode_task = None
 
         self._release_platform_lock()
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -149,6 +149,100 @@ class TestAppMentionHandler:
         assert "assistant_thread_context_changed" in registered_events
         assert "/hermes" in registered_commands
 
+    def test_connect_monitors_socket_mode_task(self):
+        """connect() should watch the background Socket Mode task for failures."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        mock_app = MagicMock()
+        mock_app.event.return_value = lambda fn: fn
+        mock_app.command.return_value = lambda fn: fn
+        mock_app.action.return_value = lambda fn: fn
+
+        mock_web_client = AsyncMock()
+        mock_web_client.auth_test = AsyncMock(return_value={
+            "user_id": "U_BOT",
+            "user": "testbot",
+            "team_id": "T_FAKE",
+            "team": "FakeTeam",
+        })
+        mock_task = MagicMock()
+
+        with patch.object(_slack_mod, "AsyncApp", return_value=mock_app), \
+             patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client), \
+             patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
+             patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
+             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
+             patch("asyncio.create_task", return_value=mock_task):
+            assert asyncio.run(adapter.connect()) is True
+
+        mock_task.add_done_callback.assert_called_once_with(
+            adapter._handle_socket_mode_task_done
+        )
+
+    @pytest.mark.asyncio
+    async def test_socket_mode_task_failure_marks_retryable_fatal(self):
+        """A dead Socket Mode task should trigger the gateway fatal/reconnect path."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+
+        async def fail_socket_mode():
+            raise RuntimeError("socket died")
+
+        task = asyncio.create_task(fail_socket_mode())
+        await asyncio.sleep(0)
+        adapter._handle_socket_mode_task_done(task)
+        await asyncio.sleep(0)
+
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "slack_socket_mode_task_exit"
+        assert adapter.fatal_error_retryable is True
+        assert "socket died" in adapter.fatal_error_message
+        fatal_handler.assert_awaited_once_with(adapter)
+
+    @pytest.mark.asyncio
+    async def test_socket_mode_task_completion_marks_retryable_fatal(self):
+        """Normal task completion is unexpected while Slack is marked running."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+
+        async def finish_socket_mode():
+            return None
+
+        task = asyncio.create_task(finish_socket_mode())
+        await asyncio.sleep(0)
+        adapter._handle_socket_mode_task_done(task)
+        await asyncio.sleep(0)
+
+        assert adapter.fatal_error_code == "slack_socket_mode_task_exit"
+        assert "exited unexpectedly" in adapter.fatal_error_message
+        fatal_handler.assert_awaited_once_with(adapter)
+
+    @pytest.mark.asyncio
+    async def test_socket_mode_task_done_ignored_after_disconnect(self):
+        """disconnect() flips running false before task callbacks can fire."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = False
+
+        async def finish_socket_mode():
+            return None
+
+        task = asyncio.create_task(finish_socket_mode())
+        await asyncio.sleep(0)
+        adapter._handle_socket_mode_task_done(task)
+
+        assert adapter.has_fatal_error is False
+        fatal_handler.assert_not_awaited()
+
 
 class TestSlackConnectCleanup:
     """Regression coverage for failed connect() cleanup."""


### PR DESCRIPTION
## Root cause

Slack `connect()` marked the adapter running immediately after spawning the Socket Mode background task. If that task failed or exited later, Hermes did not promote the failure into the gateway fatal/reconnect path, leaving Slack dead while the gateway process still looked healthy.

Closes #14326.

## Fix

- Attach a done-callback to the Socket Mode background task.
- If the task exits while Slack is still marked running, set a retryable fatal error and notify the gateway runner.
- Mark Slack not running before normal disconnect cleanup so expected task completion/cancellation does not create a false fatal state.
- Cancel and clear the Socket Mode task during disconnect.

## Tests

- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/gateway/test_slack.py::TestAppMentionHandler::test_connect_monitors_socket_mode_task tests/gateway/test_slack.py::TestAppMentionHandler::test_socket_mode_task_failure_marks_retryable_fatal tests/gateway/test_slack.py::TestAppMentionHandler::test_socket_mode_task_completion_marks_retryable_fatal tests/gateway/test_slack.py::TestAppMentionHandler::test_socket_mode_task_done_ignored_after_disconnect -q` -> `4 passed`
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/gateway/test_slack.py tests/gateway/test_platform_reconnect.py -q` -> `149 passed`
- `git diff --check`