### PR TITLE
[IMPORTANT] fix(anthropic_adapter): add SKIP_ANTHROPIC_NAME_SANITIZATION env var

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1476,14 +1476,22 @@ def build_anthropic_kwargs(
 
         # 2. Sanitize system prompt — replace product name references
         #    to avoid Anthropic's server-side content filters.
-        for block in system:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text", "")
-                text = text.replace("Hermes Agent", "Claude Code")
-                text = text.replace("Hermes agent", "Claude Code")
-                text = text.replace("hermes-agent", "claude-code")
-                text = text.replace("Nous Research", "Anthropic")
-                block["text"] = text
+        #    Skip this when using a non-native Anthropic provider (MiniMax,
+        #    OpenRouter, etc.) — the replacement corrupts the agent's self-
+        #    awareness (wrong identity, wrong source paths) and serves no
+        #    purpose outside Anthropic's own API endpoints.
+        skip_name_sanitization = os.environ.get(
+            "SKIP_ANTHROPIC_NAME_SANITIZATION", ""
+        ).lower() in ("1", "true", "yes")
+        if not skip_name_sanitization:
+            for block in system:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    text = text.replace("Hermes Agent", "Claude Code")
+                    text = text.replace("Hermes agent", "Claude Code")
+                    text = text.replace("hermes-agent", "claude-code")
+                    text = text.replace("Nous Research", "Anthropic")
+                    block["text"] = text
 
         # 3. Prefix tool names with mcp_ (Claude Code convention)
         if anthropic_tools:


### PR DESCRIPTION
## Problem

In `agent/anthropic_adapter.py`, the `build_anthropic_kwargs()` function applies product-name string replacements to the system prompt **unconditionally**, even when the agent is not running on Anthropic's native API:

```python
text = text.replace("Hermes Agent", "Claude Code")
text = text.replace("hermes-agent", "claude-code")
text = text.replace("Nous Research", "Anthropic")
```

This was added to avoid Anthropic's server-side content filters when using the native `api.anthropic.com` endpoint. However, it runs for **all providers**, causing serious self-awareness corruption for any user on a third-party Anthropic-compatible endpoint:

- **Wrong identity**: The agent believes it is "Claude Code" instead of "Hermes Agent"
- **Wrong source paths**: `~/.hermes/hermes-agent/` becomes `~/.hermes/claude-code/` — a path that does not exist
- **Broken system awareness**: The agent cannot accurately describe its own environment

## Impact

This affects **every user** running Hermes with a non-native Anthropic provider:
- MiniMax
- OpenRouter
- Together / AnyScale / Fireworks
- Self-hosted Anthropic-compatible proxies
- Any other third-party inference provider

This is an extremely common setup.

## Fix

Introduce `SKIP_ANTHROPIC_NAME_SANITIZATION` env var. When set to `1`, `true`, or `yes` in `~/.hermes/.env`, the product-name replacement is skipped. The Claude Code system prefix and `mcp_` tool-prefix remain active — only the name replacement is disabled.

## Changes

- Wrap the name replacement block in `if not skip_name_sanitization:`
- Check `SKIP_ANTHROPIC_NAME_SANITIZATION` env var (accepted values: `1`, `true`, `yes`)

## Usage

Add to `~/.hermes/.env`:
```
SKIP_ANTHROPIC_NAME_SANITIZATION=1
```
Then restart the Hermes gateway.

## Backwards Compatibility

This is **fully opt-in** — existing users on native Anthropic API with OAuth tokens see zero behavioral change unless they explicitly set the flag.

## Testing

- All 116 existing tests in `tests/agent/test_anthropic_adapter.py` pass
- Platform: macOS (Apple Silicon)

---

Fixes: #8927
