### PR TITLE
fix(image-gen): persist plugin provider on reconfigure

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1019,6 +1019,11 @@ def _configure_tool_category(ts_key: str, cat: dict, config: dict):
 
 def _is_provider_active(provider: dict, config: dict) -> bool:
     """Check if a provider entry matches the currently active config."""
+    plugin_name = provider.get("image_gen_plugin_name")
+    if plugin_name:
+        image_cfg = config.get("image_gen", {})
+        return isinstance(image_cfg, dict) and image_cfg.get("provider") == plugin_name
+
     managed_feature = provider.get("managed_nous_feature")
     if managed_feature:
         features = get_nous_subscription_features(config)
@@ -1026,6 +1031,13 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
         if feature is None:
             return False
         if managed_feature == "image_gen":
+            image_cfg = config.get("image_gen", {})
+            if isinstance(image_cfg, dict):
+                configured_provider = image_cfg.get("provider")
+                if configured_provider not in (None, "", "fal"):
+                    return False
+                if image_cfg.get("use_gateway") is False:
+                    return False
             return feature.managed_by_nous
         if provider.get("tts_provider"):
             return (
@@ -1048,6 +1060,16 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
     if provider.get("web_backend"):
         current = config.get("web", {}).get("backend")
         return current == provider["web_backend"]
+    if provider.get("imagegen_backend"):
+        image_cfg = config.get("image_gen", {})
+        if not isinstance(image_cfg, dict):
+            return False
+        configured_provider = image_cfg.get("provider")
+        return (
+            provider["imagegen_backend"] == "fal"
+            and configured_provider in (None, "", "fal")
+            and not image_cfg.get("use_gateway")
+        )
     return False
 
 
@@ -1245,6 +1267,18 @@ def _configure_imagegen_model_for_plugin(plugin_name: str, config: dict) -> None
     _print_success(f"  Model set to: {chosen}")
 
 
+def _select_plugin_image_gen_provider(plugin_name: str, config: dict) -> None:
+    """Persist a plugin-backed image generation provider selection."""
+    img_cfg = config.setdefault("image_gen", {})
+    if not isinstance(img_cfg, dict):
+        img_cfg = {}
+        config["image_gen"] = img_cfg
+    img_cfg["provider"] = plugin_name
+    img_cfg["use_gateway"] = False
+    _print_success(f"  image_gen.provider set to: {plugin_name}")
+    _configure_imagegen_model_for_plugin(plugin_name, config)
+
+
 def _configure_provider(provider: dict, config: dict):
     """Configure a single provider - prompt for API keys and set config."""
     env_vars = provider.get("env_vars", [])
@@ -1305,13 +1339,7 @@ def _configure_provider(provider: dict, config: dict):
         # and route model selection to the plugin's own catalog.
         plugin_name = provider.get("image_gen_plugin_name")
         if plugin_name:
-            img_cfg = config.setdefault("image_gen", {})
-            if not isinstance(img_cfg, dict):
-                img_cfg = {}
-                config["image_gen"] = img_cfg
-            img_cfg["provider"] = plugin_name
-            _print_success(f"  image_gen.provider set to: {plugin_name}")
-            _configure_imagegen_model_for_plugin(plugin_name, config)
+            _select_plugin_image_gen_provider(plugin_name, config)
             return
         # Imagegen backends prompt for model selection after backend pick.
         backend = provider.get("imagegen_backend")
@@ -1359,13 +1387,7 @@ def _configure_provider(provider: dict, config: dict):
         _print_success(f"  {provider['name']} configured!")
         plugin_name = provider.get("image_gen_plugin_name")
         if plugin_name:
-            img_cfg = config.setdefault("image_gen", {})
-            if not isinstance(img_cfg, dict):
-                img_cfg = {}
-                config["image_gen"] = img_cfg
-            img_cfg["provider"] = plugin_name
-            _print_success(f"  image_gen.provider set to: {plugin_name}")
-            _configure_imagegen_model_for_plugin(plugin_name, config)
+            _select_plugin_image_gen_provider(plugin_name, config)
             return
         # Imagegen backends prompt for model selection after env vars are in.
         backend = provider.get("imagegen_backend")
@@ -1539,16 +1561,39 @@ def _reconfigure_provider(provider: dict, config: dict):
         config.setdefault("web", {})["backend"] = provider["web_backend"]
         _print_success(f"  Web backend set to: {provider['web_backend']}")
 
+    if managed_feature and managed_feature not in ("web", "tts", "browser"):
+        section = config.setdefault(managed_feature, {})
+        if not isinstance(section, dict):
+            section = {}
+            config[managed_feature] = section
+        section["use_gateway"] = True
+    elif not managed_feature:
+        for cat_key, cat in TOOL_CATEGORIES.items():
+            if provider in cat.get("providers", []):
+                section = config.get(cat_key)
+                if isinstance(section, dict) and section.get("use_gateway"):
+                    section["use_gateway"] = False
+                break
+
     if not env_vars:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
             _print_info("  Requests for this tool will be billed to your Nous subscription.")
+        plugin_name = provider.get("image_gen_plugin_name")
+        if plugin_name:
+            _select_plugin_image_gen_provider(plugin_name, config)
+            return
         # Imagegen backends prompt for model selection on reconfig too.
         backend = provider.get("imagegen_backend")
         if backend:
             _configure_imagegen_model(backend, config)
+            if backend == "fal":
+                img_cfg = config.setdefault("image_gen", {})
+                if isinstance(img_cfg, dict):
+                    img_cfg["provider"] = "fal"
+                    img_cfg["use_gateway"] = False
         return
 
     for var in env_vars:
@@ -1567,9 +1612,19 @@ def _reconfigure_provider(provider: dict, config: dict):
             _print_info("    Kept current")
 
     # Imagegen backends prompt for model selection on reconfig too.
+    plugin_name = provider.get("image_gen_plugin_name")
+    if plugin_name:
+        _select_plugin_image_gen_provider(plugin_name, config)
+        return
+
     backend = provider.get("imagegen_backend")
     if backend:
         _configure_imagegen_model(backend, config)
+        if backend == "fal":
+            img_cfg = config.setdefault("image_gen", {})
+            if isinstance(img_cfg, dict):
+                img_cfg["provider"] = "fal"
+                img_cfg["use_gateway"] = False
 
 
 def _reconfigure_simple_requirements(ts_key: str):

--- a/tests/hermes_cli/test_image_gen_picker.py
+++ b/tests/hermes_cli/test_image_gen_picker.py
@@ -6,6 +6,8 @@ Covers `_plugin_image_gen_providers`, `_visible_providers`, and
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from agent import image_gen_registry
@@ -172,3 +174,78 @@ class TestConfigWriting:
 
         assert config["image_gen"]["provider"] == "noenv"
         assert config["image_gen"]["model"] == "noenv-model-v1"
+
+    def test_reconfiguring_plugin_provider_writes_provider_and_model(self, monkeypatch, tmp_path):
+        """The reconfigure path should switch image_gen away from managed FAL
+        and onto the selected plugin provider."""
+        from hermes_cli import tools_config
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        image_gen_registry.register_provider(_FakeProvider("testopenai"))
+        monkeypatch.setattr(tools_config, "_prompt_choice", lambda *a, **kw: 0)
+        monkeypatch.setattr(tools_config, "_prompt", lambda *a, **kw: "")
+        monkeypatch.setattr(
+            tools_config,
+            "get_env_value",
+            lambda key: "sk-test" if key == "OPENAI_API_KEY" else "",
+        )
+
+        config = {"image_gen": {"use_gateway": True}}
+        provider_row = {
+            "name": "OpenAI",
+            "env_vars": [{"key": "OPENAI_API_KEY", "prompt": "OpenAI API key"}],
+            "image_gen_plugin_name": "testopenai",
+        }
+
+        tools_config._reconfigure_provider(provider_row, config)
+
+        assert config["image_gen"]["provider"] == "testopenai"
+        assert config["image_gen"]["model"] == "testopenai-model-v1"
+        assert config["image_gen"]["use_gateway"] is False
+
+    def test_plugin_provider_active_overrides_managed_nous_active_label(self, monkeypatch):
+        from hermes_cli import tools_config
+
+        monkeypatch.setattr(
+            tools_config,
+            "get_nous_subscription_features",
+            lambda config: SimpleNamespace(
+                features={"image_gen": SimpleNamespace(managed_by_nous=True)}
+            ),
+        )
+
+        config = {"image_gen": {"provider": "openai", "use_gateway": False}}
+        nous_row = {
+            "name": "Nous Subscription",
+            "managed_nous_feature": "image_gen",
+        }
+        openai_row = {
+            "name": "OpenAI",
+            "image_gen_plugin_name": "openai",
+        }
+
+        assert tools_config._is_provider_active(openai_row, config) is True
+        assert tools_config._is_provider_active(nous_row, config) is False
+
+    def test_reconfiguring_fal_clears_plugin_provider(self, monkeypatch):
+        from hermes_cli import tools_config
+
+        monkeypatch.setattr(tools_config, "_prompt_choice", lambda *a, **kw: 0)
+        monkeypatch.setattr(tools_config, "_prompt", lambda *a, **kw: "")
+        monkeypatch.setattr(
+            tools_config,
+            "get_env_value",
+            lambda key: "fal-key" if key == "FAL_KEY" else "",
+        )
+
+        config = {"image_gen": {"provider": "openai", "use_gateway": False}}
+        provider_row = {
+            "name": "FAL.ai",
+            "env_vars": [{"key": "FAL_KEY", "prompt": "FAL API key"}],
+            "imagegen_backend": "fal",
+        }
+
+        tools_config._reconfigure_provider(provider_row, config)
+
+        assert config["image_gen"]["provider"] == "fal"
+        assert config["image_gen"]["use_gateway"] is False


### PR DESCRIPTION
## What does this PR do?

Fixes the Image Generation reconfigure path so selecting a plugin-backed provider, like OpenAI, actually persists the selected provider in `image_gen.provider` and disables managed gateway routing for that tool.

The setup path already handled plugin image providers, but the reconfigure path only refreshed credentials/model prompts. That meant a user could select OpenAI and still have Hermes behave as if the managed Nous/FAL image route was active.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/tools_config.py` so plugin-backed image generation providers share one persistence helper.
- Made active-provider detection prefer explicit plugin image providers over the managed Nous entitlement label.
- Made image generation reconfigure write `image_gen.provider` for plugin providers and clear that plugin selection when switching back to FAL.
- Added regression coverage in `tests/hermes_cli/test_image_gen_picker.py` for plugin reconfigure, active-provider display, and FAL fallback selection.

## How to Test

1. Configure Image Generation to a managed/FAL route, then reconfigure Image Generation and select OpenAI.
2. Confirm `config.yaml` writes `image_gen.provider: openai`, `image_gen.use_gateway: false`, and an OpenAI image model.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_image_gen_picker.py`.
4. Run `scripts/run_tests.sh -n 4` for the full suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed:

```text
source venv/bin/activate && scripts/run_tests.sh tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_image_gen_picker.py
47 passed in 1.75s
```

Full suite attempted with 4 workers:

```text
source venv/bin/activate && scripts/run_tests.sh -n 4
33 failed, 14678 passed, 39 skipped, 206 warnings in 357.21s (0:05:57)
```

No failures were in `tests/hermes_cli/test_image_gen_picker.py` or `tests/hermes_cli/test_tools_config.py`. Full-suite failing tests reported by pytest:

```text
tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once
tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card
tests/gateway/test_dingtalk.py::TestCardLifecycle::test_intermediate_send_stays_streaming
tests/gateway/test_dingtalk.py::TestCardLifecycle::test_done_fires_only_when_reply_to_is_set
tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_fires_done
tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_false_tracks_sibling
tests/gateway/test_dingtalk.py::TestCardLifecycle::test_next_send_auto_closes_sibling_streaming_cards
tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured
tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none
tests/agent/test_minimax_provider.py::TestMinimaxSwitchModelCredentialGuard::test_switch_to_minimax_does_not_resolve_anthropic_token
tests/gateway/test_agent_cache.py::TestAgentCacheIdleResume::test_close_vs_release_full_teardown_difference
tests/gateway/test_api_server.py::TestAdapterInit::test_default_config
tests/hermes_cli/test_backup.py::TestProfileRestoration::test_import_creates_profile_wrappers
tests/hermes_cli/test_plugin_scanner_recursion.py::TestKindField::test_unknown_kind_falls_back_to_standalone
tests/hermes_cli/test_tips.py::TestTipsCorpus::test_max_length_reasonable
tests/hermes_cli/test_provider_config_validation.py::TestNormalizeCustomProviderEntry::test_unknown_keys_logged
tests/hermes_cli/test_provider_config_validation.py::TestNormalizeCustomProviderEntry::test_camel_case_warning_logged
tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted
tests/run_agent/test_run_agent.py::TestBuildApiKwargsAnthropicMaxTokens::test_max_tokens_passed_to_anthropic
tests/run_agent/test_run_agent.py::TestBuildApiKwargsAnthropicMaxTokens::test_max_tokens_none_when_unset
tests/run_agent/test_run_agent.py::TestAnthropicImageFallback::test_build_api_kwargs_converts_multimodal_user_image_to_text
tests/run_agent/test_run_agent.py::TestAnthropicImageFallback::test_build_api_kwargs_reuses_cached_image_analysis_for_duplicate_images
tests/test_ctx_halving_fix.py::TestEphemeralMaxOutputTokens::test_ephemeral_override_is_used_on_first_call
tests/test_ctx_halving_fix.py::TestEphemeralMaxOutputTokens::test_ephemeral_override_is_consumed_after_one_call
tests/test_ctx_halving_fix.py::TestEphemeralMaxOutputTokens::test_subsequent_call_uses_self_max_tokens
tests/test_ctx_halving_fix.py::TestEphemeralMaxOutputTokens::test_no_ephemeral_uses_self_max_tokens_directly
tests/run_agent/test_flush_memories_codex.py::TestFlushMemoriesUsesAuxiliaryClient::test_flush_executes_memory_tool_calls
tests/tools/test_browser_camofox.py::TestCamofoxVisionConfig::test_camofox_vision_uses_configured_temperature_and_timeout
tests/tools/test_browser_cdp_tool.py::test_registered_in_browser_toolset
tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears
tests/tools/test_write_deny.py::TestWriteDenyExactPaths::test_hermes_env
tests/tools/test_zombie_process_cleanup.py::TestAgentCloseMethod::test_close_calls_cleanup_functions
tests/tools/test_zombie_process_cleanup.py::TestAgentCloseMethod::test_close_survives_partial_failures
```
