### PR TITLE
feat(cli): make /model autocomplete provider-aware

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9733,10 +9733,22 @@ class HermesCLI:
         # Create the input area with multiline (shift+enter), autocomplete, and paste handling
         from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 
+        def _model_completion_providers():
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            from hermes_cli.model_switch import list_authenticated_providers
+
+            cfg = load_config()
+            return list_authenticated_providers(
+                current_provider=cli_ref.provider or "",
+                user_providers=cfg.get("providers"),
+                custom_providers=get_compatible_custom_providers(cfg),
+                max_models=80,
+            )
 
         _completer = SlashCommandCompleter(
             skill_commands_provider=lambda: _skill_commands,
             command_filter=cli_ref._command_available,
+            model_providers_provider=_model_completion_providers,
         )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -838,13 +838,17 @@ class SlashCommandCompleter(Completer):
         self,
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
         command_filter: Callable[[str], bool] | None = None,
+        model_providers_provider: Callable[[], list[dict[str, Any]]] | None = None,
     ) -> None:
         self._skill_commands_provider = skill_commands_provider
         self._command_filter = command_filter
+        self._model_providers_provider = model_providers_provider
         # Cached project file list for fuzzy @ completions
         self._file_cache: list[str] = []
         self._file_cache_time: float = 0.0
         self._file_cache_cwd: str = ""
+        self._model_provider_cache: list[dict[str, Any]] = []
+        self._model_provider_cache_time: float = 0.0
 
     def _command_allowed(self, slash_command: str) -> bool:
         if self._command_filter is None:
@@ -1222,38 +1226,115 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
-    def _model_completions(self, sub_text: str, sub_lower: str):
-        """Yield completions for /model from config aliases + built-in aliases."""
-        seen = set()
-        # Config-based direct aliases (preferred — include provider info)
+    def _load_default_model_providers(self) -> list[dict[str, Any]]:
+        """Load authenticated model providers for /model completion."""
         try:
-            from hermes_cli.model_switch import (
-                _ensure_direct_aliases, DIRECT_ALIASES, MODEL_ALIASES,
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            from hermes_cli.model_switch import list_authenticated_providers
+
+            cfg = load_config()
+            model_cfg = cfg.get("model", {})
+            current_provider = ""
+            if isinstance(model_cfg, dict):
+                current_provider = str(model_cfg.get("provider", "") or "")
+            custom_providers = get_compatible_custom_providers(cfg)
+            return list_authenticated_providers(
+                current_provider=current_provider,
+                user_providers=cfg.get("providers"),
+                custom_providers=custom_providers,
+                max_models=80,
             )
-            _ensure_direct_aliases()
-            for name, da in DIRECT_ALIASES.items():
-                if name.startswith(sub_lower) and name != sub_lower:
-                    seen.add(name)
-                    yield Completion(
-                        name,
-                        start_position=-len(sub_text),
-                        display=name,
-                        display_meta=f"{da.model} ({da.provider})",
-                    )
-            # Built-in catalog aliases not already covered
-            for name in sorted(MODEL_ALIASES.keys()):
-                if name in seen:
-                    continue
-                if name.startswith(sub_lower) and name != sub_lower:
-                    identity = MODEL_ALIASES[name]
-                    yield Completion(
-                        name,
-                        start_position=-len(sub_text),
-                        display=name,
-                        display_meta=f"{identity.vendor}/{identity.family}",
-                    )
         except Exception:
-            pass
+            return []
+
+    def _get_model_completion_providers(self) -> list[dict[str, Any]]:
+        """Return cached authenticated providers used by /model completion."""
+        now = time.monotonic()
+        if (
+            self._model_provider_cache_time
+            and now - self._model_provider_cache_time < 15.0
+        ):
+            return self._model_provider_cache
+
+        try:
+            if self._model_providers_provider is not None:
+                providers = self._model_providers_provider() or []
+            else:
+                providers = self._load_default_model_providers()
+        except Exception:
+            providers = []
+
+        self._model_provider_cache = [
+            p for p in providers
+            if isinstance(p, dict) and p.get("slug") and isinstance(p.get("models"), list)
+        ]
+        self._model_provider_cache_time = now
+        return self._model_provider_cache
+
+    @staticmethod
+    def _model_completion_score(
+        model: str,
+        provider_slug: str,
+        query: str,
+        provider_index: int,
+        model_index: int,
+    ) -> tuple[int, int, int, str]:
+        """Sort exact/prefix matches first while preserving provider/model order."""
+        model_lower = model.lower()
+        provider_lower = provider_slug.lower()
+        if not query:
+            rank = 3
+        elif model_lower == query:
+            rank = 0
+        elif model_lower.startswith(query):
+            rank = 1
+        elif "/" in model_lower and model_lower.split("/", 1)[1].startswith(query):
+            rank = 1
+        else:
+            rank = 2
+        return (rank, provider_index, model_index, f"{provider_lower}:{model_lower}")
+
+    def _model_completions(self, sub_text: str, sub_lower: str):
+        """Yield /model completions from authenticated provider model catalogs."""
+        query = sub_lower.strip()
+        rows: list[tuple[tuple[int, int, int, str], str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        for provider_index, provider in enumerate(self._get_model_completion_providers()):
+            slug = str(provider.get("slug") or "").strip()
+            if not slug:
+                continue
+            name = str(provider.get("name") or slug).strip() or slug
+            current = bool(provider.get("is_current"))
+            for model_index, raw_model in enumerate(provider.get("models") or []):
+                model = str(raw_model or "").strip()
+                if not model:
+                    continue
+                model_lower = model.lower()
+                if query and query not in model_lower:
+                    continue
+                key = (slug.lower(), model_lower)
+                if key in seen:
+                    continue
+                seen.add(key)
+                completion_text = f"{model} --provider {slug}"
+                meta = f"{name}  --provider {slug}"
+                if current:
+                    meta = f"current  {meta}"
+                rows.append((
+                    self._model_completion_score(model, slug, query, provider_index, model_index),
+                    completion_text,
+                    model,
+                    meta,
+                ))
+
+        for _, completion_text, display, meta in sorted(rows)[:80]:
+            yield Completion(
+                completion_text,
+                start_position=-len(sub_text),
+                display=display,
+                display_meta=meta,
+            )
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -185,65 +185,64 @@ class TestModelSwitchPersistence:
 # ---------------------------------------------------------------------------
 
 class TestModelTabCompletion:
-    """SlashCommandCompleter provides model alias completions for /model."""
+    """SlashCommandCompleter provides authenticated model completions for /model."""
 
-    def test_model_completions_yields_direct_aliases(self, monkeypatch):
-        """_model_completions yields direct aliases with model and provider info."""
+    @staticmethod
+    def _providers():
+        return [
+            {
+                "slug": "openai-codex",
+                "name": "OpenAI Codex",
+                "is_current": True,
+                "models": ["gpt-5.4", "gpt-5.4-mini"],
+            },
+            {
+                "slug": "openrouter",
+                "name": "OpenRouter",
+                "is_current": False,
+                "models": ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4"],
+            },
+            {
+                "slug": "copilot",
+                "name": "GitHub Copilot",
+                "is_current": False,
+                "models": ["claude-sonnet-4.6", "gpt-5.4"],
+            },
+        ]
+
+    def test_model_completions_insert_explicit_provider(self):
+        """Completions use concrete authenticated models and include --provider."""
         from hermes_cli.commands import SlashCommandCompleter
-        from hermes_cli.model_switch import DirectAlias
-        import hermes_cli.model_switch as ms
 
-        test_aliases = {
-            "opus": DirectAlias("claude-opus-4-6", "anthropic", ""),
-            "qwen": DirectAlias("qwen3.5:397b", "custom", "https://ollama.com/v1"),
-        }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        completer = SlashCommandCompleter(model_providers_provider=self._providers)
+        completions = list(completer._model_completions("sonnet", "sonnet"))
 
-        completer = SlashCommandCompleter()
-        completions = list(completer._model_completions("", ""))
+        texts = [c.text for c in completions]
+        assert "anthropic/claude-sonnet-4.6 --provider openrouter" in texts
+        assert "claude-sonnet-4.6 --provider copilot" in texts
+        assert "sonnet" not in texts
 
-        names = [c.text for c in completions]
-        assert "opus" in names
-        assert "qwen" in names
-
-    def test_model_completions_filters_by_prefix(self, monkeypatch):
-        """Completions filter by typed prefix."""
+    def test_model_completions_filter_by_model_substring(self):
+        """The search query matches model IDs, not provider aliases."""
         from hermes_cli.commands import SlashCommandCompleter
-        from hermes_cli.model_switch import DirectAlias
-        import hermes_cli.model_switch as ms
 
-        test_aliases = {
-            "opus": DirectAlias("claude-opus-4-6", "anthropic", ""),
-            "qwen": DirectAlias("qwen3.5:397b", "custom", "https://ollama.com/v1"),
-        }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        completer = SlashCommandCompleter(model_providers_provider=self._providers)
+        completions = list(completer._model_completions("mini", "mini"))
 
-        completer = SlashCommandCompleter()
-        completions = list(completer._model_completions("o", "o"))
+        texts = [c.text for c in completions]
+        assert texts == ["gpt-5.4-mini --provider openai-codex"]
 
-        names = [c.text for c in completions]
-        assert "opus" in names
-        assert "qwen" not in names
-
-    def test_model_completions_shows_metadata(self, monkeypatch):
-        """Completions include model name and provider in display_meta."""
+    def test_model_completions_keep_same_model_from_multiple_providers(self):
+        """Duplicate model IDs stay distinct when providers differ."""
         from hermes_cli.commands import SlashCommandCompleter
-        from hermes_cli.model_switch import DirectAlias
-        import hermes_cli.model_switch as ms
 
-        test_aliases = {
-            "glm": DirectAlias("glm-4.7", "custom", "https://ollama.com/v1"),
-        }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        completer = SlashCommandCompleter(model_providers_provider=self._providers)
+        completions = list(completer._model_completions("gpt-5.4", "gpt-5.4"))
 
-        completer = SlashCommandCompleter()
-        completions = list(completer._model_completions("g", "g"))
-
-        assert len(completions) >= 1
-        glm_comp = [c for c in completions if c.text == "glm"][0]
-        meta_str = str(glm_comp.display_meta)
-        assert "glm-4.7" in meta_str
-        assert "custom" in meta_str
+        texts = [c.text for c in completions]
+        assert "gpt-5.4 --provider openai-codex" in texts
+        assert "openai/gpt-5.4 --provider openrouter" in texts
+        assert "gpt-5.4 --provider copilot" in texts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -665,6 +665,52 @@ def test_complete_slash_surfaces_completer_error(monkeypatch):
     assert "no completer" in resp["error"]["message"]
 
 
+def test_complete_slash_reuses_model_provider_cache(monkeypatch):
+    server._clear_model_completion_provider_cache()
+    server._sessions["sid"] = _session(
+        agent=types.SimpleNamespace(provider="openai-codex")
+    )
+    calls = 0
+
+    def fake_list_authenticated_providers(**kwargs):
+        nonlocal calls
+        calls += 1
+        assert kwargs["current_provider"] == "openai-codex"
+        return [
+            {
+                "slug": "openai-codex",
+                "name": "OpenAI Codex",
+                "is_current": True,
+                "models": ["gpt-5.4"],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        fake_list_authenticated_providers,
+    )
+    monkeypatch.setattr("agent.skill_commands.get_skill_commands", lambda: {})
+
+    try:
+        params = {"text": "/model gpt", "session_id": "sid"}
+        resp_1 = server.handle_request(
+            {"id": "1", "method": "complete.slash", "params": params}
+        )
+        resp_2 = server.handle_request(
+            {"id": "2", "method": "complete.slash", "params": params}
+        )
+
+        assert "error" not in resp_1
+        assert "error" not in resp_2
+        assert calls == 1
+        assert resp_1["result"]["items"][0]["text"] == (
+            "gpt-5.4 --provider openai-codex"
+        )
+    finally:
+        server._sessions.pop("sid", None)
+        server._clear_model_completion_provider_cache()
+
+
 def test_input_detect_drop_attaches_image(monkeypatch):
     fake_cli = types.ModuleType("cli")
     fake_cli._detect_file_drop = lambda raw: {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3255,8 +3255,37 @@ def _(rid, params: dict) -> dict:
 
         from agent.skill_commands import get_skill_commands
 
+        session_id = str(params.get("session_id") or "")
+
+        def _model_completion_providers() -> list[dict]:
+            from hermes_cli.model_switch import list_authenticated_providers
+
+            cfg = _load_cfg()
+            session = _sessions.get(session_id)
+            agent = session.get("agent") if session else None
+            model_cfg = cfg.get("model", {})
+            current_provider = getattr(agent, "provider", "") or ""
+            if not current_provider and isinstance(model_cfg, dict):
+                current_provider = str(model_cfg.get("provider", "") or "")
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+                custom_providers = get_compatible_custom_providers(cfg)
+            except Exception:
+                custom_providers = (
+                    cfg.get("custom_providers")
+                    if isinstance(cfg.get("custom_providers"), list)
+                    else []
+                )
+            return list_authenticated_providers(
+                current_provider=current_provider,
+                user_providers=cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {},
+                custom_providers=custom_providers,
+                max_models=80,
+            )
+
         completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: get_skill_commands()
+            skill_commands_provider=lambda: get_skill_commands(),
+            model_providers_provider=_model_completion_providers,
         )
         doc = Document(text, len(text))
         items = [

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -42,6 +42,11 @@ _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
+_model_completion_cache_lock = threading.Lock()
+_model_completion_provider_cache: dict[
+    tuple[str, str, float | None], tuple[float, list[dict]]
+] = {}
+_MODEL_COMPLETION_PROVIDER_CACHE_TTL_S = 15.0
 _SLASH_WORKER_TIMEOUT_S = max(
     5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45)
 )
@@ -371,6 +376,61 @@ def _save_cfg(cfg: dict):
             _cfg_mtime = None
 
 
+def _clear_model_completion_provider_cache(session_id: str | None = None) -> None:
+    with _model_completion_cache_lock:
+        if session_id is None:
+            _model_completion_provider_cache.clear()
+            return
+        for key in list(_model_completion_provider_cache):
+            if key[0] == session_id:
+                _model_completion_provider_cache.pop(key, None)
+
+
+def _model_completion_providers_for_session(session_id: str) -> list[dict]:
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    cfg = _load_cfg()
+    session = _sessions.get(session_id)
+    agent = session.get("agent") if session else None
+    model_cfg = cfg.get("model", {})
+    user_providers = cfg.get("providers")
+    current_provider = getattr(agent, "provider", "") or ""
+    if not current_provider and isinstance(model_cfg, dict):
+        current_provider = str(model_cfg.get("provider", "") or "")
+
+    cache_key = (session_id or "", current_provider, _cfg_mtime)
+    now = time.monotonic()
+    with _model_completion_cache_lock:
+        cached = _model_completion_provider_cache.get(cache_key)
+        if cached and now - cached[0] < _MODEL_COMPLETION_PROVIDER_CACHE_TTL_S:
+            return copy.deepcopy(cached[1])
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        custom_providers = get_compatible_custom_providers(cfg)
+    except Exception:
+        custom_providers = (
+            cfg.get("custom_providers")
+            if isinstance(cfg.get("custom_providers"), list)
+            else []
+        )
+    providers = list_authenticated_providers(
+        current_provider=current_provider,
+        user_providers=user_providers if isinstance(user_providers, dict) else {},
+        custom_providers=custom_providers,
+        max_models=80,
+    )
+
+    with _model_completion_cache_lock:
+        _model_completion_provider_cache[cache_key] = (now, copy.deepcopy(providers))
+        for key, (cached_at, _) in list(_model_completion_provider_cache.items()):
+            if now - cached_at > _MODEL_COMPLETION_PROVIDER_CACHE_TTL_S:
+                _model_completion_provider_cache.pop(key, None)
+
+    return providers
+
+
 def _set_session_context(session_key: str) -> list:
     try:
         from gateway.session_context import set_session_vars
@@ -624,6 +684,9 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
         os.environ["HERMES_INFERENCE_PROVIDER"] = result.target_provider
     if persist_global:
         _persist_model_switch(result)
+        _clear_model_completion_provider_cache()
+    else:
+        _clear_model_completion_provider_cache(sid)
     return {"value": result.new_model, "warning": result.warning_message or ""}
 
 
@@ -1652,6 +1715,7 @@ def _(rid, params: dict) -> dict:
     session = _sessions.pop(sid, None)
     if not session:
         return _ok(rid, {"closed": False})
+    _clear_model_completion_provider_cache(str(sid or ""))
     try:
         from tools.approval import unregister_gateway_notify
 
@@ -3257,35 +3321,11 @@ def _(rid, params: dict) -> dict:
 
         session_id = str(params.get("session_id") or "")
 
-        def _model_completion_providers() -> list[dict]:
-            from hermes_cli.model_switch import list_authenticated_providers
-
-            cfg = _load_cfg()
-            session = _sessions.get(session_id)
-            agent = session.get("agent") if session else None
-            model_cfg = cfg.get("model", {})
-            current_provider = getattr(agent, "provider", "") or ""
-            if not current_provider and isinstance(model_cfg, dict):
-                current_provider = str(model_cfg.get("provider", "") or "")
-            try:
-                from hermes_cli.config import get_compatible_custom_providers
-                custom_providers = get_compatible_custom_providers(cfg)
-            except Exception:
-                custom_providers = (
-                    cfg.get("custom_providers")
-                    if isinstance(cfg.get("custom_providers"), list)
-                    else []
-                )
-            return list_authenticated_providers(
-                current_provider=current_provider,
-                user_providers=cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {},
-                custom_providers=custom_providers,
-                max_models=80,
-            )
-
         completer = SlashCommandCompleter(
             skill_commands_provider=lambda: get_skill_commands(),
-            model_providers_provider=_model_completion_providers,
+            model_providers_provider=lambda: _model_completion_providers_for_session(
+                session_id
+            ),
         )
         doc = Document(text, len(text))
         items = [

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
+import { getUiState } from '../app/uiStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
@@ -50,7 +51,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
       }
 
       const req = isSlash
-        ? gw.request<CompletionResponse>('complete.slash', { text: input })
+        ? gw.request<CompletionResponse>('complete.slash', { text: input, session_id: getUiState().sid })
         : gw.request<CompletionResponse>('complete.path', { word: pathWord })
 
       req

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -1,7 +1,8 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
-import { getUiState } from '../app/uiStore.js'
+import { $uiState } from '../app/uiStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
@@ -9,6 +10,7 @@ import { asRpcResult } from '../lib/rpc.js'
 const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
 
 export function useCompletion(input: string, blocked: boolean, gw: GatewayClient) {
+  const { sid } = useStore($uiState)
   const [completions, setCompletions] = useState<CompletionItem[]>([])
   const [compIdx, setCompIdx] = useState(0)
   const [compReplace, setCompReplace] = useState(0)
@@ -28,13 +30,16 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
       return
     }
 
-    if (input === ref.current) {
+    const isSlash = input.startsWith('/')
+    const requestSid = sid ?? null
+    const requestKey = isSlash ? `${input}\u0000${requestSid ?? ''}` : input
+
+    if (requestKey === ref.current) {
       return
     }
 
-    ref.current = input
+    ref.current = requestKey
 
-    const isSlash = input.startsWith('/')
     const pathWord = isSlash ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
 
     if (!isSlash && !pathWord) {
@@ -46,17 +51,17 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     const pathReplace = input.length - (pathWord?.length ?? 0)
 
     const t = setTimeout(() => {
-      if (ref.current !== input) {
+      if (ref.current !== requestKey) {
         return
       }
 
       const req = isSlash
-        ? gw.request<CompletionResponse>('complete.slash', { text: input, session_id: getUiState().sid })
+        ? gw.request<CompletionResponse>('complete.slash', { text: input, session_id: requestSid })
         : gw.request<CompletionResponse>('complete.path', { word: pathWord })
 
       req
         .then(raw => {
-          if (ref.current !== input) {
+          if (ref.current !== requestKey) {
             return
           }
 
@@ -67,7 +72,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
           setCompReplace(isSlash ? (r?.replace_from ?? 1) : pathReplace)
         })
         .catch((e: unknown) => {
-          if (ref.current !== input) {
+          if (ref.current !== requestKey) {
             return
           }
 
@@ -84,7 +89,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     }, 60)
 
     return () => clearTimeout(t)
-  }, [blocked, gw, input])
+  }, [blocked, gw, input, sid])
 
   return { completions, compIdx, setCompIdx, compReplace }
 }


### PR DESCRIPTION
## Summary

- Build `/model` autocomplete suggestions from authenticated provider catalogs instead of static alias lists.
- Emit deterministic completions as `<model> --provider <provider_slug>` so duplicate model names across providers stay clear.
- Wire the same provider-aware completion behavior through classic CLI and TUI slash completion.
- Add regression coverage for authenticated-only model completions and provider disambiguation.

Closes #14352.
Related to #13621 and prior autocomplete work in #1641.

## Testing

- `source venv/bin/activate && python -m py_compile hermes_cli/commands.py cli.py tui_gateway/server.py`
- `cd ui-tui && npm run type-check`
- `cd ui-tui && npm run lint`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_ollama_cloud_auth.py::TestModelTabCompletion tests/hermes_cli/test_commands.py::TestSlashCommandCompleter tests/test_tui_gateway_server.py::test_complete_slash_surfaces_completer_error -q -n 4` — 16 passed
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_commands.py tests/hermes_cli/test_ollama_cloud_auth.py tests/test_tui_gateway_server.py -q -n 4` — 199 passed
- Manual smoke test: verified `/model sonnet` and `/model gpt-5.4` autocomplete now return concrete `model --provider slug` options from authenticated providers.

## Full-suite note

- `scripts/run_tests.sh ...` could not run in my local venv because `venv/bin/python` has no `pip`, and the wrapper tries to install `pytest-split`.
- I ran the full suite directly with `source venv/bin/activate && python -m pytest tests/ -q -n 4`; it reported `76 failed, 14683 passed, 53 skipped`.
- I also ran the same direct full-suite command in a clean detached `upstream/main` worktree at `fa8f0c6f`, which produced the same `76 failed, 14683 passed, 53 skipped` result. The full-suite failures appear to be pre-existing/local baseline failures, not introduced by this branch.
