### PR TITLE
fix(gateway): read nested per-model context_length in session info banner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4856,13 +4856,14 @@ class GatewayRunner:
         base_url = None
         api_key = None
 
+        cfg_data: Dict[str, Any] = {}
         try:
             cfg_path = _hermes_home / "config.yaml"
             if cfg_path.exists():
                 import yaml as _info_yaml
                 with open(cfg_path, encoding="utf-8") as f:
-                    data = _info_yaml.safe_load(f) or {}
-                model_cfg = data.get("model", {})
+                    cfg_data = _info_yaml.safe_load(f) or {}
+                model_cfg = cfg_data.get("model", {})
                 if isinstance(model_cfg, dict):
                     raw_ctx = model_cfg.get("context_length")
                     if raw_ctx is not None:
@@ -4883,6 +4884,32 @@ class GatewayRunner:
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        # Fall back to the nested per-model context_length under
+        # providers.<name>.models.<model> (new schema) or
+        # custom_providers[].models.<model> (legacy schema) — mirrors the
+        # resolution AIAgent.__init__ uses so the displayed value matches
+        # what the ContextCompressor actually budgets with.
+        if config_context_length is None and base_url and cfg_data:
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+                _normalized_base = base_url.rstrip("/")
+                for _cp_entry in get_compatible_custom_providers(cfg_data):
+                    _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+                    if _cp_url and _cp_url == _normalized_base:
+                        _cp_models = _cp_entry.get("models", {})
+                        if isinstance(_cp_models, dict):
+                            _cp_model_cfg = _cp_models.get(model, {})
+                            if isinstance(_cp_model_cfg, dict):
+                                _cp_ctx = _cp_model_cfg.get("context_length")
+                                if _cp_ctx is not None:
+                                    try:
+                                        config_context_length = int(_cp_ctx)
+                                    except (TypeError, ValueError):
+                                        pass
+                        break
+            except Exception:
+                pass
 
         context_length = get_model_context_length(
             model,


### PR DESCRIPTION
## Summary

Fixes #5089 (also partially addresses concerns raised in #2513, #12977 for the banner-display path).

The session-reset / info banner in `_format_session_info` (`gateway/run.py`) resolved the context window only from the top-level `model.context_length` key. When users configure context_length under either the newer `providers.<name>.models.<model>` dict schema or the legacy `custom_providers[].models.<model>` list schema, the banner fell through to `get_model_context_length()`'s probe chain. Remote OpenAI-compatible proxies frequently omit `context_length` from `/models` responses, so the probe failed silently and the banner displayed:

```
◆ Context: 128K tokens (default — set model.context_length in config to override)
```

— even though the runtime `ContextCompressor` was already budgeting with the correct value (resolved by `AIAgent.__init__` at `run_agent.py:1608-1643`). A display-vs-truth inconsistency rather than a functional bug, but confusing and repeatedly reported (#5089, #2513).

## Fix

After the existing top-level lookup, walk `get_compatible_custom_providers(cfg)`, match the entry by `base_url` against the resolved runtime base_url, and read `entry["models"][model]["context_length"]`. Pass that through to `get_model_context_length()` as `config_context_length`; step 0 short-circuits the probe.

This mirrors the exact resolution `AIAgent.__init__` already performs, so the banner's displayed value matches what the compressor actually uses.

## Why this is an improvement over existing open PRs

Four other open PRs target #5089:

- **#5096**, **#8240**, **#10690**: each hand-rolls traversal of the legacy `custom_providers:` list only. They do **not** cover the newer `providers:` dict schema that users land on via `hermes model` (and which `config.yaml` templates now use).
- **#12380**: broader in scope (touches `/model` display + gateway fallback paths) but still traverses lists manually.

This PR routes through `get_compatible_custom_providers()` — the existing compat shim at `hermes_cli/config.py:2078` that already bridges both schemas for the rest of the runtime. One lookup, both schemas, stays consistent with `AIAgent.__init__`, and eliminates future drift between the banner and the compressor.

## Reproduction

`~/.hermes/config.yaml` (new-schema form — the legacy list form reproduces identically):

```yaml
model:
  default: kimi-k2.6
  provider: my-proxy
providers:
  my-proxy:
    name: my-proxy
    api: https://my-openai-proxy.example/v1
    api_key: ${MY_PROXY_KEY}
    models:
      kimi-k2.6:
        context_length: 262144
```

Restart gateway, trigger `/reset`:

- **Before:** `◆ Context: 128K tokens (default — set model.context_length in config to override)`
- **After:** `◆ Context: 262K tokens (config)`

## Verification

Simulated the patched block against a real-world config (exact code shape of the fix, not a standalone re-implementation):

```
after top-level: None
after nested fallback: 262144
Banner would display: 262K tokens (config)
```

No functional change to the compressor or any runtime code path — this only affects what `_format_session_info` displays.

## Test plan

- [ ] Existing tests in `tests/gateway/test_session_info.py` still pass.
- [ ] Manual: gateway restart with new-schema `providers:` config → banner shows nested context_length.
- [ ] Manual: gateway restart with legacy `custom_providers:` list config → banner shows nested context_length (unchanged behavior vs #5096 et al).
- [ ] Manual: gateway restart without any nested context_length → probe still runs as before.