### PR TITLE
fix(session): validate and repair tool_call arguments on both shapes (supersedes #13057)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3029,27 +3029,32 @@ class AIAgent:
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
                 
-                # Validate tool_calls JSON before persisting (#12731)
-                # Detect truncated/corrupted arguments and repair or reject them
+                # Validate tool_calls JSON before persisting (#12731).
+                # Covers both dict shapes produced above: nested {"function": {...}}
+                # and flat {"name", "arguments"}.
                 if tool_calls_data:
                     validated_tool_calls = []
                     for tc in tool_calls_data:
-                        if isinstance(tc, dict) and "function" in tc:
-                            args = tc["function"].get("arguments", "")
-                            if args:
-                                try:
-                                    json.loads(args)
-                                except (json.JSONDecodeError, TypeError):
-                                    # Arguments are invalid JSON — try to repair
-                                    repaired = _repair_tool_call_arguments(args, tc["function"].get("name", "?"))
+                        if not isinstance(tc, dict):
+                            validated_tool_calls.append(tc)
+                            continue
+                        fn = tc["function"] if isinstance(tc.get("function"), dict) else tc
+                        args = fn.get("arguments", "")
+                        if args:
+                            try:
+                                json.loads(args)
+                            except (json.JSONDecodeError, TypeError):
+                                name = fn.get("name", "?")
+                                repaired = _repair_tool_call_arguments(args, name)
+                                if fn is tc:
+                                    tc = {**tc, "arguments": repaired}
+                                else:
                                     tc = {**tc, "function": {**tc["function"], "arguments": repaired}}
-                                    logger.warning(
-                                        "Repaired corrupted tool_call arguments for %s before session flush",
-                                        tc["function"].get("name", "?"),
-                                    )
-                            validated_tool_calls.append(tc)
-                        else:
-                            validated_tool_calls.append(tc)
+                                logger.warning(
+                                    "Repaired corrupted tool_call arguments for %s before session flush",
+                                    name,
+                                )
+                        validated_tool_calls.append(tc)
                     tool_calls_data = validated_tool_calls
                 
                 self._session_db.append_message(

--- a/run_agent.py
+++ b/run_agent.py
@@ -3028,6 +3028,30 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                
+                # Validate tool_calls JSON before persisting (#12731)
+                # Detect truncated/corrupted arguments and repair or reject them
+                if tool_calls_data:
+                    validated_tool_calls = []
+                    for tc in tool_calls_data:
+                        if isinstance(tc, dict) and "function" in tc:
+                            args = tc["function"].get("arguments", "")
+                            if args:
+                                try:
+                                    json.loads(args)
+                                except (json.JSONDecodeError, TypeError):
+                                    # Arguments are invalid JSON — try to repair
+                                    repaired = _repair_tool_call_arguments(args, tc["function"].get("name", "?"))
+                                    tc = {**tc, "function": {**tc["function"], "arguments": repaired}}
+                                    logger.warning(
+                                        "Repaired corrupted tool_call arguments for %s before session flush",
+                                        tc["function"].get("name", "?"),
+                                    )
+                            validated_tool_calls.append(tc)
+                        else:
+                            validated_tool_calls.append(tc)
+                    tool_calls_data = validated_tool_calls
+                
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -202,3 +202,98 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Part 3: tool_call argument validation on flush (#12731)
+# ---------------------------------------------------------------------------
+
+class TestFlushToolCallValidation:
+    """_flush_messages_to_session_db must repair corrupted tool_call arguments
+    before persisting, in both shapes the caller produces."""
+
+    def _make_agent(self, session_db):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="validation-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        return agent
+
+    def _first_tool_call(self, rows):
+        for row in rows:
+            tcs = row.get("tool_calls")
+            if tcs:
+                return tcs[0]
+        raise AssertionError("no tool_call row persisted")
+
+    def test_nested_shape_corrupted_args_are_repaired(self):
+        """{'function': {'arguments': ...}} — the shape already covered by the PR."""
+        from hermes_state import SessionDB
+        import json as _json
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            agent = self._make_agent(db)
+
+            corrupted = '{"path": "/etc/hosts", "content": "abc...[tru'
+            messages = [{
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": corrupted},
+                }],
+            }]
+            agent._flush_messages_to_session_db(messages, None)
+
+            tc = self._first_tool_call(db.get_messages("validation-session"))
+            args = tc["function"]["arguments"]
+            _json.loads(args)  # must be valid JSON — no exception
+
+    def test_flat_shape_corrupted_args_are_repaired(self):
+        """{'name', 'arguments'} — the shape Branch A produces; previously slipped through."""
+        from hermes_state import SessionDB
+        import json as _json
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            agent = self._make_agent(db)
+
+            corrupted = '{"path": "/etc/hosts", "content": "abc...[tru'
+            messages = [{
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"name": "write_file", "arguments": corrupted}],
+            }]
+            agent._flush_messages_to_session_db(messages, None)
+
+            tc = self._first_tool_call(db.get_messages("validation-session"))
+            args = tc["arguments"]
+            _json.loads(args)
+
+    def test_valid_args_pass_through_unchanged(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            agent = self._make_agent(db)
+
+            valid = '{"path": "/tmp/x"}'
+            messages = [{
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"name": "write_file", "arguments": valid}],
+            }]
+            agent._flush_messages_to_session_db(messages, None)
+
+            tc = self._first_tool_call(db.get_messages("validation-session"))
+            assert tc["arguments"] == valid


### PR DESCRIPTION
## Summary

Supersedes #13057 by @MestreY0d4-Uninter — rebased onto current `main` (the original was 427 commits behind; most red CI there was stale-branch drift) and extends the validator to cover the second tool_call dict shape the caller produces.

Fixes #12731.

## What's here

1. **Commit 1** (cherry-picked from #13057, authorship preserved): adds validation in `_flush_messages_to_session_db` to detect and repair corrupted tool_call `arguments` JSON before SQLite persistence, using the existing `_repair_tool_call_arguments` helper.

2. **Commit 2** (co-authored with @MestreY0d4-Uninter): widens the validator to handle the second shape. `_flush_messages_to_session_db` builds `tool_calls_data` two ways:
   - flat `{"name", "arguments"}` — when `msg.tool_calls` is an SDK object list
   - nested `{"function": {"name", "arguments"}, ...}` — when `msg["tool_calls"]` is already a dict list
   
   The original validator in #13057 only matched the nested shape, so corrupted args arriving via the flat path still slipped through to SQLite. The revised block checks both.

## Tests

- All 6 cited existing tests still pass: `tests/run_agent/test_repair_tool_call_arguments.py`, `tests/run_agent/test_compression_persistence.py`
- Added 3 new cases in `test_compression_persistence.py::TestFlushToolCallValidation`:
  - nested shape with corrupted args → repaired
  - flat shape with corrupted args → repaired (this is the newly-covered path)
  - valid args pass through unchanged

```
uv run pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_compression_persistence.py
=> 26 passed
```

Full `tests/run_agent/` suite: 912 passed, 7 skipped. The 2 remaining failures (`test_flush_memories_codex.py::TestFlushMemoriesUsesAuxiliaryClient::test_flush_executes_memory_tool_calls`, `test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted`) reproduce on clean `main` without this branch applied — they're pre-existing environment-dependent failures (aux-provider detection), unrelated to this change.

## Test plan

- [x] `uv run pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_compression_persistence.py`
- [x] Manual: start a session, trigger a tool call, interrupt with a slash command mid-stream, confirm the next turn doesn't hit `'content' is a required property`