### PR TITLE
fix(gateway): preserve custom runtime model

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -367,6 +367,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
         "api_mode": runtime.get("api_mode"),
+        "model": runtime.get("model"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
@@ -1102,6 +1103,12 @@ class GatewayRunner:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
             )
+
+        runtime_model = str(runtime_kwargs.get("model") or "").strip()
+        if not model and runtime_model:
+            model = runtime_model
+        runtime_kwargs = dict(runtime_kwargs)
+        runtime_kwargs.pop("model", None)
 
         # When the config has no model.default but a provider was resolved
         # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -523,6 +523,9 @@ def _resolve_openrouter_runtime(
     # Also provide a placeholder API key for local servers that don't require
     # authentication — the OpenAI SDK requires a non-empty api_key string.
     effective_provider = "custom" if requested_norm == "custom" else "openrouter"
+    configured_model = str(
+        model_cfg.get("default") or model_cfg.get("model") or ""
+    ).strip()
 
     # For custom endpoints, check if a credential pool exists
     if effective_provider == "custom" and base_url:
@@ -530,12 +533,14 @@ def _resolve_openrouter_runtime(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
         )
         if pool_result:
+            if configured_model:
+                pool_result["model"] = configured_model
             return pool_result
 
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
-    return {
+    runtime = {
         "provider": effective_provider,
         "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
         or _detect_api_mode_for_url(base_url)
@@ -544,6 +549,9 @@ def _resolve_openrouter_runtime(
         "api_key": api_key,
         "source": source,
     }
+    if effective_provider == "custom" and configured_model:
+        runtime["model"] = configured_model
+    return runtime
 
 
 def _resolve_explicit_runtime(

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -81,6 +81,52 @@ def _explode_runtime_resolution():
     )
 
 
+def test_runtime_agent_kwargs_preserves_runtime_model(monkeypatch):
+    """The gateway runtime bridge should keep model names from runtime resolution."""
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda requested=None: {
+            "provider": "custom",
+            "api_key": "no-key-required",
+            "base_url": "http://192.168.1.13:11434/v1",
+            "api_mode": "chat_completions",
+            "model": "qwen3-coder:latest",
+        },
+    )
+
+    runtime = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert runtime["model"] == "qwen3-coder:latest"
+
+
+def test_session_runtime_inherits_custom_model_from_runtime(monkeypatch):
+    """Gateway-created agents should not drop custom runtime model names."""
+    runner = _make_runner()
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "api_key": "no-key-required",
+            "base_url": "http://192.168.1.13:11434/v1",
+            "api_mode": "chat_completions",
+            "model": "qwen3-coder:latest",
+        },
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key="agent:main:telegram:dm"
+    )
+
+    assert model == "qwen3-coder:latest"
+    assert runtime["provider"] == "custom"
+    assert "model" not in runtime
+
+
 def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1414,6 +1414,56 @@ def test_named_custom_runtime_no_model_when_absent(monkeypatch):
     assert "model" not in resolved
 
 
+def test_plain_custom_runtime_propagates_config_model(monkeypatch):
+    """Plain provider=custom should carry model.default to gateway callers."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "default": "qwen3-coder:latest",
+            "base_url": "http://192.168.1.13:11434/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp._resolve_openrouter_runtime(requested_provider="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://192.168.1.13:11434/v1"
+    assert resolved["api_key"] == "no-key-required"
+    assert resolved["model"] == "qwen3-coder:latest"
+
+
+def test_plain_custom_runtime_propagates_config_model_pool_path(monkeypatch):
+    """Credential-pool custom runtimes still need the configured model name."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "default": "qwen3-coder:latest",
+            "base_url": "http://192.168.1.13:11434/v1",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://192.168.1.13:11434/v1",
+            "api_key": "pool-key",
+            "source": "pool:custom:ollama-lan",
+        },
+    )
+
+    resolved = rp._resolve_openrouter_runtime(requested_provider="custom")
+
+    assert resolved["api_key"] == "pool-key"
+    assert resolved["model"] == "qwen3-coder:latest"
+
+
 # ---------------------------------------------------------------------------
 # GHSA-76xc-57q6-vm5m — Ollama URL substring leak
 #


### PR DESCRIPTION
## Summary
- Fixes #14189.
- Preserves `model.default`/`model.model` on plain `provider: custom` runtime resolution, including credential-pool custom endpoints.
- Carries the runtime model through the gateway bridge and uses it when the session/config model is empty, while removing it from runtime kwargs before constructing `AIAgent` so callers do not double-pass `model`.

## Root cause
Remote/custom Ollama-compatible endpoints could resolve provider credentials as `provider=custom` but drop the configured model name before gateway-created agents were constructed. The gateway then fell back to the provider catalog default for `custom`, which is empty, causing OpenAI-compatible local servers to reject requests with `model is required`.

## Tests
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_plain_custom_runtime_propagates_config_model tests/hermes_cli/test_runtime_provider_resolution.py::test_plain_custom_runtime_propagates_config_model_pool_path tests/gateway/test_session_model_override_routing.py::test_runtime_agent_kwargs_preserves_runtime_model tests/gateway/test_session_model_override_routing.py::test_session_runtime_inherits_custom_model_from_runtime -q` -> `4 passed`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/gateway/test_session_model_override_routing.py -q` -> `77 passed`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_compress_command.py tests/gateway/test_compress_focus.py tests/gateway/test_session_model_override_routing.py -q` -> `8 passed`
- `git diff --check`

## Notes
- I also tried `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_agent_cache.py tests/gateway/test_model_switch_persistence.py -q`; the only failure was the existing macOS-local terminal cleanup assertion in `tests/gateway/test_agent_cache.py::TestAgentCacheIdleResume::test_close_vs_release_full_teardown_difference`, unrelated to this model routing change.