### PR TITLE
fix(discord): stabilize thread home routing and docs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5091,9 +5091,9 @@ class GatewayRunner:
         reroute_note = None
 
         # In Discord text-channel threads, the stable home destination should be the
-        # parent channel rather than the specific thread. Forum posts keep their own
-        # thread ID because deliveries without metadata.thread_id target chat_id
-        # directly, and a forum parent is not a normal send destination.
+        # parent channel rather than the specific thread. Forum/media posts keep
+        # their own thread ID because deliveries without metadata.thread_id target
+        # chat_id directly, and those parents are not normal send destinations.
         if platform_name == "discord" and getattr(source, "chat_type", None) == "thread":
             raw = getattr(event, "raw_message", None)
             channel = getattr(raw, "channel", None)
@@ -5101,7 +5101,8 @@ class GatewayRunner:
             parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
             parent_type = getattr(parent, "type", None)
             parent_type_value = getattr(parent_type, "value", parent_type)
-            is_forum_parent = parent_type_value == 15 or getattr(parent.__class__, "__name__", "") == "ForumChannel"
+            parent_class_name = getattr(parent.__class__, "__name__", "")
+            is_forum_parent = parent_type_value in (15, 16) or parent_class_name in {"ForumChannel", "MediaChannel"}
             if parent is not None and parent_id is not None and not is_forum_parent:
                 chat_id = str(parent_id)
                 parent_name = getattr(parent, "name", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5088,6 +5088,32 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
+        reroute_note = None
+
+        # In Discord text-channel threads, the stable home destination should be the
+        # parent channel rather than the specific thread. Forum posts keep their own
+        # thread ID because deliveries without metadata.thread_id target chat_id
+        # directly, and a forum parent is not a normal send destination.
+        if platform_name == "discord" and getattr(source, "chat_type", None) == "thread":
+            raw = getattr(event, "raw_message", None)
+            channel = getattr(raw, "channel", None)
+            parent = getattr(channel, "parent", None)
+            parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
+            parent_type = getattr(parent, "type", None)
+            parent_type_value = getattr(parent_type, "value", parent_type)
+            is_forum_parent = parent_type_value == 15 or getattr(parent.__class__, "__name__", "") == "ForumChannel"
+            if parent is not None and parent_id is not None and not is_forum_parent:
+                chat_id = str(parent_id)
+                parent_name = getattr(parent, "name", None)
+                guild = getattr(parent, "guild", None) or getattr(channel, "guild", None)
+                guild_name = getattr(guild, "name", None)
+                if parent_name and guild_name:
+                    chat_name = f"{guild_name} / #{parent_name}"
+                elif parent_name:
+                    chat_name = parent_name
+                else:
+                    chat_name = chat_id
+                reroute_note = "Using the parent channel for stable Discord home delivery; explicit thread deliveries still use thread metadata."
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
@@ -5106,10 +5132,13 @@ class GatewayRunner:
         except Exception as e:
             return f"Failed to save home channel: {e}"
         
-        return (
+        response = (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."
         )
+        if reroute_note:
+            response += f"\n{reroute_note}"
+        return response
     
     @staticmethod
     def _get_guild_id(event: MessageEvent) -> Optional[int]:

--- a/tests/gateway/test_set_home_command.py
+++ b/tests/gateway/test_set_home_command.py
@@ -12,6 +12,15 @@ class ForumChannel:
     pass
 
 
+class MediaChannel:
+    pass
+
+
+class FakeType:
+    def __init__(self, value):
+        self.value = value
+
+
 @pytest.mark.asyncio
 async def test_sethome_uses_parent_channel_for_discord_thread(monkeypatch, tmp_path):
     import gateway.run as gateway_run
@@ -64,7 +73,7 @@ async def test_sethome_keeps_forum_thread_as_home_target(monkeypatch, tmp_path):
     parent.id = 222
     parent.name = "ideas"
     parent.guild = guild
-    parent.type = 15
+    parent.type = FakeType(15)
     channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
     raw_message = SimpleNamespace(channel=channel)
 
@@ -90,6 +99,88 @@ async def test_sethome_keeps_forum_thread_as_home_target(monkeypatch, tmp_path):
     assert "stable Discord home delivery" not in result
     config = yaml.safe_load((tmp_path / "config.yaml").read_text())
     assert config["DISCORD_HOME_CHANNEL"] == "333"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_media_thread_as_home_target(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = MediaChannel()
+    parent.id = 444
+    parent.name = "media"
+    parent.guild = guild
+    parent.type = FakeType(16)
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_name="GSV / media / post-1",
+            chat_type="thread",
+            thread_id="555",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-media",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / media / post-1" in result
+    assert "(ID: 555)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "555"
+
+
+@pytest.mark.asyncio
+async def test_sethome_uses_media_class_name_fallback_when_type_missing(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = MediaChannel()
+    parent.id = 666
+    parent.name = "media"
+    parent.guild = guild
+    parent.type = None
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="777",
+            chat_name="GSV / media / post-2",
+            chat_type="thread",
+            thread_id="777",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-media-fallback",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / media / post-2" in result
+    assert "(ID: 777)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "777"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_set_home_command.py
+++ b/tests/gateway/test_set_home_command.py
@@ -1,0 +1,185 @@
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+class ForumChannel:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_sethome_uses_parent_channel_for_discord_thread(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = SimpleNamespace(id=987654321, name="agent-ops", guild=guild)
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1496043680090558464",
+            chat_name="hermes-apl",
+            chat_type="thread",
+            thread_id="1496043680090558464",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m1",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / #agent-ops" in result
+    assert "987654321" in result
+    assert "stable Discord home delivery" in result
+    assert (tmp_path / "config.yaml").exists()
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "987654321"
+    assert gateway_run.os.environ["DISCORD_HOME_CHANNEL"] == "987654321"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_forum_thread_as_home_target(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = ForumChannel()
+    parent.id = 222
+    parent.name = "ideas"
+    parent.guild = guild
+    parent.type = 15
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="333",
+            chat_name="GSV / ideas / post-1",
+            chat_type="thread",
+            thread_id="333",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-forum",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / ideas / post-1" in result
+    assert "(ID: 333)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "333"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_thread_when_parent_object_is_missing(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    channel = SimpleNamespace(parent=None, parent_id=987654321, guild=SimpleNamespace(name="GSV"))
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1496043680090558464",
+            chat_name="GSV / #agent-ops / hermes-apl",
+            chat_type="thread",
+            thread_id="1496043680090558464",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-missing-parent",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "(ID: 1496043680090558464)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "1496043680090558464"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_current_chat_for_non_thread_discord(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="444",
+            chat_name="GSV / #agent-ops",
+            chat_type="group",
+            user_id="u1",
+            user_name="tester",
+        ),
+        message_id="m3",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / #agent-ops" in result
+    assert "(ID: 444)" in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "444"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_current_chat_for_non_thread_sources(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_name="Primary DM",
+            chat_type="dm",
+            user_id="u1",
+            user_name="tester",
+        ),
+        message_id="m2",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "Primary DM" in result
+    assert "12345" in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["TELEGRAM_HOME_CHANNEL"] == "12345"
+    assert gateway_run.os.environ["TELEGRAM_HOME_CHANNEL"] == "12345"

--- a/tests/tools/test_cass_tool.py
+++ b/tests/tools/test_cass_tool.py
@@ -1,0 +1,177 @@
+"""Tests for tools/cass_tool.py — CASS CLI wrappers for session intelligence."""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+
+class _RunRecorder:
+    def __init__(self, returncode=0, stdout=None, stderr=""):
+        self.calls = []
+        self.returncode = returncode
+        self.stdout = stdout if stdout is not None else json.dumps({"ok": True})
+        self.stderr = stderr
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, self.returncode, self.stdout, self.stderr)
+
+
+def test_check_cass_requirements_uses_path_lookup():
+    from tools.cass_tool import check_cass_requirements
+
+    with patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"):
+        assert check_cass_requirements() is True
+
+    with patch("tools.cass_tool.shutil.which", return_value=None):
+        assert check_cass_requirements() is False
+
+
+def test_cass_search_builds_robot_json_command_with_filters():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": [{"title": "match"}]}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        result = json.loads(
+            cass_search(
+                "Sylveste Clavain",
+                limit=3,
+                mode="lexical",
+                workspace="/home/mk/projects/Sylveste",
+                agent="claude_code",
+                since="2026-04-01",
+                until="2026-04-23",
+            )
+        )
+
+    cmd, kwargs = runner.calls[0]
+    assert cmd == [
+        "cass",
+        "search",
+        "--json",
+        "--limit",
+        "3",
+        "--mode",
+        "lexical",
+        "--workspace",
+        "/home/mk/projects/Sylveste",
+        "--agent",
+        "claude_code",
+        "--since",
+        "2026-04-01",
+        "--until",
+        "2026-04-23",
+        "--max-content-length",
+        "2000",
+        "--",
+        "Sylveste Clavain",
+    ]
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
+    assert result["success"] is True
+    assert result["command"] == "search"
+    assert result["data"]["hits"][0]["title"] == "match"
+
+
+def test_cass_search_rejects_empty_query_before_running_subprocess():
+    from tools.cass_tool import cass_search
+
+    with patch("tools.cass_tool.subprocess.run") as run:
+        result = json.loads(cass_search("   "))
+
+    run.assert_not_called()
+    assert result["success"] is False
+    assert "query" in result["error"].lower()
+
+
+def test_cass_search_clamps_limit_to_bounded_positive_range():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        json.loads(cass_search("not unbounded", limit=0))
+        json.loads(cass_search("not huge", limit=5000))
+
+    assert runner.calls[0][0][runner.calls[0][0].index("--limit") + 1] == "1"
+    assert runner.calls[1][0][runner.calls[1][0].index("--limit") + 1] == "25"
+
+
+def test_cass_search_uses_separator_for_hyphen_leading_query():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        json.loads(cass_search("-h", limit=1))
+
+    assert runner.calls[0][0][-2:] == ["--", "-h"]
+
+
+def test_missing_cass_returns_clear_error():
+    from tools.cass_tool import cass_status
+
+    with patch("tools.cass_tool.shutil.which", return_value=None):
+        result = json.loads(cass_status())
+
+    assert result["success"] is False
+    assert "cass" in result["error"].lower()
+    assert "install" in result["hint"].lower()
+
+
+def test_semantic_unavailable_error_suggests_lexical_fallback():
+    from tools.cass_tool import cass_search
+
+    payload = {
+        "error": {
+            "code": 15,
+            "kind": "semantic-unavailable",
+            "message": "Semantic search not available: vector index missing",
+            "hint": "Run cass index --semantic --embedder hash, or use --mode lexical",
+            "retryable": False,
+        }
+    }
+    runner = _RunRecorder(returncode=15, stdout=json.dumps(payload))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        result = json.loads(cass_search("intercore", mode="hybrid"))
+
+    assert result["success"] is False
+    assert result["code"] == 15
+    assert result["kind"] == "semantic-unavailable"
+    assert "--mode lexical" in result["hint"]
+
+
+def test_cass_context_and_analytics_parse_json_results():
+    from tools.cass_tool import cass_analytics, cass_context
+
+    runner = _RunRecorder(stdout=json.dumps({"items": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        context_result = json.loads(cass_context("/tmp/session.jsonl", limit=2))
+        analytics_result = json.loads(cass_analytics(kind="tokens", days=7, workspace="/repo"))
+
+    assert context_result["success"] is True
+    assert analytics_result["success"] is True
+    assert runner.calls[0][0] == ["cass", "context", "--json", "--limit", "2", "--", "/tmp/session.jsonl"]
+    assert runner.calls[1][0] == [
+        "cass",
+        "analytics",
+        "tokens",
+        "--json",
+        "--days",
+        "7",
+        "--workspace",
+        "/repo",
+    ]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -292,6 +292,7 @@ class TestBuiltinDiscovery:
     def test_matches_previous_manual_builtin_tool_set(self):
         expected = {
             "tools.browser_tool",
+            "tools.cass_tool",
             "tools.clarify_tool",
             "tools.code_execution_tool",
             "tools.cronjob_tools",

--- a/tools/cass_tool.py
+++ b/tools/cass_tool.py
@@ -1,0 +1,505 @@
+"""CASS CLI tools for cross-agent session intelligence.
+
+CASS (Coding Agent Session Search) indexes coding-agent histories across
+providers such as Claude Code, Codex, and Gemini.  Hermes uses these wrappers as
+an explicit continuity backend instead of shelling out through the generic
+terminal tool for every recall query.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections.abc import Iterable
+from typing import Any
+
+from tools.registry import registry, tool_error, tool_result
+
+_CASS_INSTALL_HINT = (
+    "Install cass and ensure it is on PATH. Expected binary name: cass. "
+    "See https://github.com/Dicklesworthstone/coding_agent_session_search"
+)
+_ALLOWED_SEARCH_MODES = {"lexical", "semantic", "hybrid"}
+_ALLOWED_EXPORT_FORMATS = {"markdown", "text", "json", "html"}
+_ALLOWED_ANALYTICS_KINDS = {"status", "tokens", "tools", "models"}
+_ALLOWED_GROUP_BY = {"hour", "day", "week", "month", "none"}
+_SEARCH_DEFAULT_LIMIT = 5
+_SEARCH_MAX_LIMIT = 25
+_DEFAULT_SEARCH_CONTENT_LENGTH = 2000
+
+
+def check_cass_requirements() -> bool:
+    """Return True when the CASS CLI is available on PATH."""
+    return shutil.which("cass") is not None
+
+
+def _parse_json_maybe(text: str) -> Any | None:
+    text = (text or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _normalize_cli_error(
+    *,
+    command: str,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+) -> str:
+    parsed = _parse_json_maybe(stdout) or _parse_json_maybe(stderr)
+    if isinstance(parsed, dict) and isinstance(parsed.get("error"), dict):
+        error = parsed["error"]
+        kind = error.get("kind")
+        message = error.get("message") or stderr or stdout or f"cass {command} failed"
+        hint = error.get("hint") or ""
+        if kind == "semantic-unavailable" and "--mode lexical" not in hint:
+            hint = (hint + " Use --mode lexical as a fallback.").strip()
+        return tool_result(
+            success=False,
+            command=command,
+            error=message,
+            code=error.get("code", returncode),
+            kind=kind,
+            hint=hint,
+            retryable=error.get("retryable"),
+        )
+
+    message = (stderr or stdout or f"cass {command} exited with status {returncode}").strip()
+    return tool_error(message, success=False, command=command, code=returncode)
+
+
+def _run_cass(args: list[str], *, command: str, timeout: int = 120) -> str:
+    if not check_cass_requirements():
+        return tool_error(
+            "cass CLI not found on PATH",
+            success=False,
+            command=command,
+            hint=_CASS_INSTALL_HINT,
+        )
+
+    argv = ["cass", *args]
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        return tool_error(
+            f"cass {command} timed out after {timeout}s",
+            success=False,
+            command=command,
+            code="timeout",
+        )
+    except OSError as exc:
+        return tool_error(str(exc), success=False, command=command)
+
+    if result.returncode != 0:
+        return _normalize_cli_error(
+            command=command,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    parsed = _parse_json_maybe(result.stdout)
+    return tool_result({
+        "success": True,
+        "command": command,
+        "data": parsed if parsed is not None else result.stdout,
+    })
+
+
+def _as_list(value: str | Iterable[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _append_repeated(args: list[str], flag: str, values: str | Iterable[str] | None) -> None:
+    for value in _as_list(values):
+        args.extend([flag, value])
+
+
+def _bounded_int(value: int | str | None, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        number = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        number = default
+    return min(max(number, minimum), maximum)
+
+
+def cass_status() -> str:
+    """Return CASS index health and database status."""
+    return _run_cass(["status", "--json"], command="status", timeout=30)
+
+
+def cass_search(
+    query: str,
+    limit: int = 5,
+    mode: str = "lexical",
+    workspace: str | list[str] | None = None,
+    agent: str | list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    days: int | None = None,
+    offset: int = 0,
+    fields: str | None = None,
+    max_content_length: int | None = None,
+    source: str | None = None,
+) -> str:
+    """Search indexed coding-agent sessions with CASS."""
+    if not (query or "").strip():
+        return tool_error("query is required", success=False, command="search")
+    if mode not in _ALLOWED_SEARCH_MODES:
+        return tool_error(
+            f"mode must be one of: {', '.join(sorted(_ALLOWED_SEARCH_MODES))}",
+            success=False,
+            command="search",
+        )
+
+    bounded_limit = _bounded_int(
+        limit,
+        default=_SEARCH_DEFAULT_LIMIT,
+        minimum=1,
+        maximum=_SEARCH_MAX_LIMIT,
+    )
+    bounded_content_length = _bounded_int(
+        max_content_length,
+        default=_DEFAULT_SEARCH_CONTENT_LENGTH,
+        minimum=200,
+        maximum=10_000,
+    )
+    args = [
+        "search",
+        "--json",
+        "--limit",
+        str(bounded_limit),
+        "--mode",
+        mode,
+    ]
+    if offset:
+        args.extend(["--offset", str(max(0, int(offset)))])
+    _append_repeated(args, "--workspace", workspace)
+    _append_repeated(args, "--agent", agent)
+    if since:
+        args.extend(["--since", since])
+    if until:
+        args.extend(["--until", until])
+    if days is not None:
+        args.extend(["--days", str(max(0, int(days)))])
+    if fields:
+        args.extend(["--fields", fields])
+    if max_content_length is not None:
+        args.extend(["--max-content-length", str(bounded_content_length)])
+    else:
+        args.extend(["--max-content-length", str(_DEFAULT_SEARCH_CONTENT_LENGTH)])
+    if source:
+        args.extend(["--source", source])
+    args.extend(["--", query])
+
+    return _run_cass(args, command="search")
+
+
+def cass_context(path: str, limit: int = 5) -> str:
+    """Find sessions related to a CASS source/session path."""
+    if not (path or "").strip():
+        return tool_error("path is required", success=False, command="context")
+    args = ["context", "--json", "--limit", str(_bounded_int(limit, default=5, minimum=1, maximum=25)), "--", path]
+    return _run_cass(args, command="context")
+
+
+def cass_timeline(
+    since: str | None = None,
+    until: str | None = None,
+    today: bool = False,
+    agent: str | list[str] | None = None,
+    group_by: str = "day",
+    source: str | None = None,
+) -> str:
+    """Return activity timeline data from indexed CASS sessions."""
+    if group_by not in {"hour", "day", "none"}:
+        return tool_error("group_by must be one of: hour, day, none", success=False, command="timeline")
+    args = ["timeline", "--json", "--group-by", group_by]
+    if today:
+        args.append("--today")
+    if since:
+        args.extend(["--since", since])
+    if until:
+        args.extend(["--until", until])
+    _append_repeated(args, "--agent", agent)
+    if source:
+        args.extend(["--source", source])
+    return _run_cass(args, command="timeline")
+
+
+def cass_export(
+    session_path: str,
+    format: str = "markdown",
+    output_path: str | None = None,
+    include_tools: bool = False,
+) -> str:
+    """Export a CASS session transcript."""
+    if not (session_path or "").strip():
+        return tool_error("session_path is required", success=False, command="export")
+    if format not in _ALLOWED_EXPORT_FORMATS:
+        return tool_error(
+            f"format must be one of: {', '.join(sorted(_ALLOWED_EXPORT_FORMATS))}",
+            success=False,
+            command="export",
+        )
+    args = ["export", "--format", format]
+    if output_path:
+        args.extend(["--output", output_path])
+    if include_tools:
+        args.append("--include-tools")
+    args.extend(["--", session_path])
+    return _run_cass(args, command="export")
+
+
+def cass_analytics(
+    kind: str = "tokens",
+    days: int | None = 7,
+    workspace: str | list[str] | None = None,
+    agent: str | list[str] | None = None,
+    source: str | None = None,
+    group_by: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> str:
+    """Return token/tool/model analytics from CASS rollups."""
+    if kind not in _ALLOWED_ANALYTICS_KINDS:
+        return tool_error(
+            f"kind must be one of: {', '.join(sorted(_ALLOWED_ANALYTICS_KINDS))}",
+            success=False,
+            command="analytics",
+        )
+    args = ["analytics", kind, "--json"]
+    if kind != "status":
+        if days is not None:
+            args.extend(["--days", str(max(0, int(days)))])
+        if since:
+            args.extend(["--since", since])
+        if until:
+            args.extend(["--until", until])
+        _append_repeated(args, "--workspace", workspace)
+        _append_repeated(args, "--agent", agent)
+        if source:
+            args.extend(["--source", source])
+        if group_by:
+            if group_by not in _ALLOWED_GROUP_BY - {"none"}:
+                return tool_error(
+                    "group_by must be one of: hour, day, week, month",
+                    success=False,
+                    command="analytics",
+                )
+            args.extend(["--group-by", group_by])
+    return _run_cass(args, command="analytics")
+
+
+_CASS_STATUS_SCHEMA = {
+    "name": "cass_status",
+    "description": "Check CASS index health and database status for coding-agent session history.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+_CASS_SEARCH_SCHEMA = {
+    "name": "cass_search",
+    "description": (
+        "Search coding-agent session history indexed by CASS across Claude Code, Codex, Gemini, and other agents. "
+        "Use lexical mode for reliable keyword recall; semantic/hybrid require a CASS vector index."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Maximum number of hits to return (bounded 1-25).", "default": 5, "minimum": 1, "maximum": 25},
+            "mode": {"type": "string", "enum": sorted(_ALLOWED_SEARCH_MODES), "default": "lexical"},
+            "workspace": {"type": "string", "description": "Workspace path filter."},
+            "agent": {"type": "string", "description": "Agent slug filter, e.g. claude_code."},
+            "since": {"type": "string", "description": "Start date/time filter."},
+            "until": {"type": "string", "description": "End date/time filter."},
+            "days": {"type": "integer", "description": "Filter to last N days."},
+            "offset": {"type": "integer", "default": 0},
+            "fields": {"type": "string", "description": "Optional CASS fields selector."},
+            "max_content_length": {"type": "integer", "description": "Content/snippet truncation length (bounded 200-10000).", "default": 2000, "minimum": 200, "maximum": 10000},
+            "source": {"type": "string", "description": "CASS source filter."},
+        },
+        "required": ["query"],
+    },
+}
+
+_CASS_CONTEXT_SCHEMA = {
+    "name": "cass_context",
+    "description": "Find CASS sessions related to a source/session file path.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "CASS source/session path."},
+            "limit": {"type": "integer", "default": 5},
+        },
+        "required": ["path"],
+    },
+}
+
+_CASS_TIMELINE_SCHEMA = {
+    "name": "cass_timeline",
+    "description": "Show activity timeline for indexed CASS sessions.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "since": {"type": "string"},
+            "until": {"type": "string"},
+            "today": {"type": "boolean", "default": False},
+            "agent": {"type": "string"},
+            "group_by": {"type": "string", "enum": ["hour", "day", "none"], "default": "day"},
+            "source": {"type": "string"},
+        },
+        "required": [],
+    },
+}
+
+_CASS_EXPORT_SCHEMA = {
+    "name": "cass_export",
+    "description": "Export a CASS session transcript as markdown, text, JSON, or HTML.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_path": {"type": "string", "description": "Path to a CASS source/session file."},
+            "format": {"type": "string", "enum": sorted(_ALLOWED_EXPORT_FORMATS), "default": "markdown"},
+            "output_path": {"type": "string", "description": "Optional output file path. If omitted, returns stdout content."},
+            "include_tools": {"type": "boolean", "default": False},
+        },
+        "required": ["session_path"],
+    },
+}
+
+_CASS_ANALYTICS_SCHEMA = {
+    "name": "cass_analytics",
+    "description": "Query CASS token, tool, model, or analytics status rollups.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string", "enum": sorted(_ALLOWED_ANALYTICS_KINDS), "default": "tokens"},
+            "days": {"type": "integer", "default": 7},
+            "workspace": {"type": "string"},
+            "agent": {"type": "string"},
+            "source": {"type": "string"},
+            "group_by": {"type": "string", "enum": ["hour", "day", "week", "month"]},
+            "since": {"type": "string"},
+            "until": {"type": "string"},
+        },
+        "required": [],
+    },
+}
+
+registry.register(
+    name="cass_status",
+    toolset="cass",
+    schema=_CASS_STATUS_SCHEMA,
+    handler=lambda args, **kw: cass_status(),
+    check_fn=check_cass_requirements,
+    description="Check CASS health and indexing status",
+    emoji="🗂️",
+)
+
+registry.register(
+    name="cass_search",
+    toolset="cass",
+    schema=_CASS_SEARCH_SCHEMA,
+    handler=lambda args, **kw: cass_search(
+        query=args.get("query", ""),
+        limit=args.get("limit", 5),
+        mode=args.get("mode", "lexical"),
+        workspace=args.get("workspace"),
+        agent=args.get("agent"),
+        since=args.get("since"),
+        until=args.get("until"),
+        days=args.get("days"),
+        offset=args.get("offset", 0),
+        fields=args.get("fields"),
+        max_content_length=args.get("max_content_length"),
+        source=args.get("source"),
+    ),
+    check_fn=check_cass_requirements,
+    description="Search CASS coding-agent session history",
+    emoji="🔎",
+    max_result_size_chars=60_000,
+)
+
+registry.register(
+    name="cass_context",
+    toolset="cass",
+    schema=_CASS_CONTEXT_SCHEMA,
+    handler=lambda args, **kw: cass_context(
+        path=args.get("path", ""),
+        limit=args.get("limit", 5),
+    ),
+    check_fn=check_cass_requirements,
+    description="Find related CASS sessions for a path",
+    emoji="🧭",
+    max_result_size_chars=40_000,
+)
+
+registry.register(
+    name="cass_timeline",
+    toolset="cass",
+    schema=_CASS_TIMELINE_SCHEMA,
+    handler=lambda args, **kw: cass_timeline(
+        since=args.get("since"),
+        until=args.get("until"),
+        today=args.get("today", False),
+        agent=args.get("agent"),
+        group_by=args.get("group_by", "day"),
+        source=args.get("source"),
+    ),
+    check_fn=check_cass_requirements,
+    description="Show CASS activity timeline",
+    emoji="🕰️",
+    max_result_size_chars=40_000,
+)
+
+registry.register(
+    name="cass_export",
+    toolset="cass",
+    schema=_CASS_EXPORT_SCHEMA,
+    handler=lambda args, **kw: cass_export(
+        session_path=args.get("session_path", ""),
+        format=args.get("format", "markdown"),
+        output_path=args.get("output_path"),
+        include_tools=args.get("include_tools", False),
+    ),
+    check_fn=check_cass_requirements,
+    description="Export CASS session transcripts",
+    emoji="📤",
+    max_result_size_chars=80_000,
+)
+
+registry.register(
+    name="cass_analytics",
+    toolset="cass",
+    schema=_CASS_ANALYTICS_SCHEMA,
+    handler=lambda args, **kw: cass_analytics(
+        kind=args.get("kind", "tokens"),
+        days=args.get("days", 7),
+        workspace=args.get("workspace"),
+        agent=args.get("agent"),
+        source=args.get("source"),
+        group_by=args.get("group_by"),
+        since=args.get("since"),
+        until=args.get("until"),
+    ),
+    check_fn=check_cass_requirements,
+    description="Query CASS analytics rollups",
+    emoji="📊",
+    max_result_size_chars=80_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -50,6 +50,8 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
+    # Cross-agent coding session intelligence (CASS)
+    "cass_status", "cass_search", "cass_context", "cass_timeline", "cass_export", "cass_analytics",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -76,6 +78,12 @@ TOOLSETS = {
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
+        "includes": []
+    },
+
+    "cass": {
+        "description": "CASS coding-agent session history search, context, export, and analytics",
+        "tools": ["cass_status", "cass_search", "cass_context", "cass_timeline", "cass_export", "cass_analytics"],
         "includes": []
     },
     

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -157,9 +157,13 @@ Run `/usage` periodically to see your token consumption. Run `/insights` for a b
 
 Use `/sethome` in your preferred Telegram or Discord chat to designate it as the home channel. Cron job results and scheduled task outputs are delivered here. Without it, the agent has nowhere to send proactive messages.
 
+For Discord, the best personal pattern is a durable parent channel (for example `#agent-ops`) plus one thread per task. If you run `/sethome` from a normal thread, Hermes stores the parent channel so deliveries still land in the stable channel instead of a single task thread.
+
 ### Use /title to Organize Sessions
 
 Name your sessions with `/title auth-refactor` or `/title research-llm-quantization`. Named sessions are easy to find with `hermes sessions list` and resume with `hermes -r "auth-refactor"`. Unnamed sessions pile up and become impossible to distinguish.
+
+For Beads-driven work in Discord, include the issue ID in the title or opening message (`hermes-mge discord workflow`). That makes later pickup prompts like `pick up hermes-mge` much more reliable across threads and sessions.
 
 ### DM Pairing for Team Access
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -17,7 +17,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
 | **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. |
-| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. For `/sethome`, a normal text-channel thread stores the parent channel as the stable home destination, while forum-post threads keep their own thread ID. |
+| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. For `/sethome`, a normal text-channel thread stores the parent channel as the stable home destination, while forum/media post threads keep their own thread ID. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
@@ -447,7 +447,7 @@ No extra configuration is needed — any skill installed via `hermes skills inst
 For a single operator using Hermes heavily in Discord, the smoothest pattern is:
 
 1. **Pick one durable parent channel** (for example `#agent-ops`) as the home base for deliveries.
-2. **Run `/sethome` there once**. If you happen to run `/sethome` from a normal thread under that channel, Hermes stores the parent channel ID so cron jobs and cross-platform deliveries still land in the stable parent channel.
+2. **Run `/sethome` there once**. If you happen to run `/sethome` from a normal thread under that channel, Hermes stores the parent channel ID so cron jobs and cross-platform deliveries still land in the stable parent channel. Forum/media post threads keep their own thread ID.
 3. **Use one thread per substantial task**. Start a new thread for each feature, bug, or research lane so transcript history stays isolated and easy to revisit.
 4. **Lead with the work item ID** when you want continuity, e.g. `pick up hermes-mge; continue ...`. This gives Hermes a strong retrieval handle for Beads issues and past session search.
 5. **Name the session with `/title`** if you expect to resume it from another surface later. A good default is the Beads ID plus a short slug, such as `/title hermes-mge discord workflow`.
@@ -465,7 +465,7 @@ Type `/sethome` in any Discord channel where the bot is present.
 
 - In a **regular channel**, that channel becomes the home channel.
 - In a **normal text-channel thread**, Hermes stores the **parent channel** as the home destination so scheduled deliveries do not get stranded in one ephemeral thread.
-- In a **forum post thread**, Hermes keeps the **thread itself** as the destination, because forum parents are not directly messageable like normal text channels.
+- In a **forum or media post thread**, Hermes keeps the **thread itself** as the destination, because those parents are not directly messageable like normal text channels.
 
 ### Manual Configuration
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -17,7 +17,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
 | **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. |
-| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
+| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. For `/sethome`, a normal text-channel thread stores the parent channel as the stable home destination, while forum-post threads keep their own thread ID. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
@@ -442,13 +442,30 @@ Hermes automatically registers installed skills as **native Discord Application 
 
 No extra configuration is needed — any skill installed via `hermes skills install` is automatically registered as a Discord slash command on the next gateway restart.
 
+## Recommended Personal Workflow
+
+For a single operator using Hermes heavily in Discord, the smoothest pattern is:
+
+1. **Pick one durable parent channel** (for example `#agent-ops`) as the home base for deliveries.
+2. **Run `/sethome` there once**. If you happen to run `/sethome` from a normal thread under that channel, Hermes stores the parent channel ID so cron jobs and cross-platform deliveries still land in the stable parent channel.
+3. **Use one thread per substantial task**. Start a new thread for each feature, bug, or research lane so transcript history stays isolated and easy to revisit.
+4. **Lead with the work item ID** when you want continuity, e.g. `pick up hermes-mge; continue ...`. This gives Hermes a strong retrieval handle for Beads issues and past session search.
+5. **Name the session with `/title`** if you expect to resume it from another surface later. A good default is the Beads ID plus a short slug, such as `/title hermes-mge discord workflow`.
+6. **Resume in place when possible**. If the original thread is still the right lane, keep talking there. If you need to move surfaces or recover after a reset, use `/resume <name>` or explicitly say `pick up <bead-id>`.
+
+This gives you a stable inbox for proactive deliveries plus disposable task threads for execution.
+
 ## Home Channel
 
 You can designate a "home channel" where the bot sends proactive messages (such as cron job output, reminders, and notifications). There are two ways to set it:
 
 ### Using the Slash Command
 
-Type `/sethome` in any Discord channel where the bot is present. That channel becomes the home channel.
+Type `/sethome` in any Discord channel where the bot is present.
+
+- In a **regular channel**, that channel becomes the home channel.
+- In a **normal text-channel thread**, Hermes stores the **parent channel** as the home destination so scheduled deliveries do not get stranded in one ephemeral thread.
+- In a **forum post thread**, Hermes keeps the **thread itself** as the destination, because forum parents are not directly messageable like normal text channels.
 
 ### Manual Configuration
 


### PR DESCRIPTION
## Summary
- store the parent channel as the Discord home destination when `/sethome` is run from a normal text-channel thread
- keep forum and media post threads targeting themselves because those parents are not normal send destinations
- document the recommended personal Discord workflow and `/sethome` behavior for normal vs. forum/media threads
- add regression coverage for normal threads, forum threads, media threads, and conservative fallback behavior when parent metadata is incomplete

Supersedes #14088.

## Problem

`/sethome` in Discord threads needed two different behaviors:

1. In a normal text-channel thread, the stable destination for cron jobs and cross-platform deliveries should be the **parent channel**, not one ephemeral task thread.
2. In a forum or media post thread, the **thread itself** must remain the destination, because the parent container is not a normal send target.

Before this PR, the upstream fix lane only covered the basic text-thread reroute. This PR carries that fix forward, tightens the distinction for forum/media post containers, and documents the behavior so operators know what Hermes will store.

## Changes Made

- `gateway/run.py`
  - reroute `/sethome` from a normal Discord text thread to its parent channel
  - preserve the thread ID for forum and media post threads
  - return a user-facing note when `/sethome` intentionally stores the parent channel for stable delivery
- `tests/gateway/test_set_home_command.py`
  - add regression coverage for:
    - normal text-thread reroute to parent
    - forum-thread preservation
    - media-thread preservation
    - class-name fallback when parent type metadata is missing
    - conservative fallback when the parent object is missing
    - unchanged behavior for non-thread Discord and non-Discord sources
- `website/docs/user-guide/messaging/discord.md`
  - document the recommended parent-channel-plus-task-threads workflow
  - document `/sethome` behavior for regular channels, normal text threads, and forum/media post threads
- `website/docs/guides/tips.md`
  - document the recommended Discord home-channel plus task-thread pattern
  - document using Beads IDs in titles/opening prompts for reliable `pick up <id>` recovery

## Preserved Behavior

- non-thread Discord `/sethome` behavior is unchanged
- non-Discord `/sethome` behavior is unchanged
- when thread parent metadata is incomplete, Hermes keeps the current thread as the home target instead of guessing

## Testing

Ran targeted regression coverage:

```bash
python3 -m pytest tests/gateway/test_set_home_command.py -q
```

Result:
- `7 passed`

## Scope Note

This PR is intentionally limited to `/sethome` home-target routing, tests, and matching docs. It does not change Discord session isolation, reply routing, or broader thread/session workflow behavior outside the `/sethome` path.

## Checklist

- [x] Narrow, single-lane change
- [x] Conventional commit title
- [x] Regression tests added
- [x] Targeted test command run locally
- [x] Docs updated for user-visible behavior
- [x] Supersession noted for the earlier PR in the same lane
