### PR TITLE
fix(agent): omit stream_options for Gemini streaming

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2157,6 +2157,16 @@ class AIAgent:
             "api_mode": getattr(self, "api_mode", "") or "",
         }
 
+    def _chat_stream_options_supported(self) -> bool:
+        """Return whether chat-completions streaming should request usage chunks."""
+        provider = (getattr(self, "provider", "") or "").strip().lower()
+        base_url = (getattr(self, "base_url", "") or "").strip().lower()
+        if provider in {"gemini", "google", "google-gemini", "google-ai-studio"}:
+            return False
+        if "generativelanguage.googleapis.com" in base_url:
+            return False
+        return True
+
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
         window is smaller than the main model's compression threshold.
@@ -5600,7 +5610,6 @@ class AIAgent:
             stream_kwargs = {
                 **api_kwargs,
                 "stream": True,
-                "stream_options": {"include_usage": True},
                 "timeout": _httpx.Timeout(
                     connect=30.0,
                     read=_stream_read_timeout,
@@ -5608,6 +5617,8 @@ class AIAgent:
                     pool=30.0,
                 ),
             }
+            if self._chat_stream_options_supported():
+                stream_kwargs["stream_options"] = {"include_usage": True}
             request_client_holder["client"] = self._create_request_openai_client(
                 reason="chat_completion_stream_request"
             )

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -100,6 +100,68 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_google_gemini_endpoint_omits_stream_options(self, mock_close, mock_create):
+        """Google's Gemini direct endpoint rejects OpenAI-only stream_options."""
+        from run_agent import AIAgent
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([
+            _make_stream_chunk(content="Paris", finish_reason="stop", model="gemini"),
+        ])
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            model="gemini-3-flash-preview",
+            provider="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert response.choices[0].message.content == "Paris"
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["stream"] is True
+        assert "stream_options" not in call_kwargs
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_openai_compatible_streaming_keeps_stream_options(self, mock_close, mock_create):
+        """OpenAI-compatible aggregators still request final usage chunks."""
+        from run_agent import AIAgent
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([
+            _make_stream_chunk(content="ok", finish_reason="stop", model="test-model"),
+            _make_empty_chunk(usage=SimpleNamespace(prompt_tokens=2, completion_tokens=1)),
+        ])
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            model="test/model",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert response.choices[0].message.content == "ok"
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["stream_options"] == {"include_usage": True}
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_tool_call_response(self, mock_close, mock_create):
         """Tool call stream accumulates ID, name, and arguments."""
         from run_agent import AIAgent
@@ -1354,4 +1416,3 @@ class TestSilentRetryMidToolCall:
         assert "Stream stalled" not in content, (
             f"Text-only stall should not emit tool-call warning: {content!r}"
         )
-


### PR DESCRIPTION
Fixes #14387

## Root cause
Hermes always added OpenAI-specific `stream_options={"include_usage": true}` to chat-completions streaming calls. The direct Google/Gemini endpoint rejects that keyword, causing streaming requests to fail before a response can be read.

## Fix
- Add a small chat-completions capability guard for streaming usage chunks.
- Omit `stream_options` for Gemini/Google direct endpoints.
- Keep requesting `stream_options` for OpenAI-compatible aggregators such as OpenRouter so usage accounting behavior is preserved.

## Tests
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_streaming.py::TestStreamingAccumulator::test_google_gemini_endpoint_omits_stream_options tests/run_agent/test_streaming.py::TestStreamingAccumulator::test_openai_compatible_streaming_keeps_stream_options -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_streaming.py -q --tb=short`
- `git diff --check`