### PR TITLE
fix(browser): strip proxy env from agent-browser subprocess

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -445,6 +445,59 @@ class TestRunBrowserCommandPathConstruction:
         assert "/opt/homebrew/bin" in result_path
         assert "/opt/homebrew/sbin" in result_path
 
+    def test_subprocess_env_strips_proxy_vars(self, tmp_path):
+        """Parent proxy settings must not be inherited by agent-browser."""
+        captured_env = {}
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": None,
+        }
+        fake_json = json.dumps({"success": True})
+        hermes_home = str(tmp_path / "hermes-home")
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/local/bin/agent-browser"), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(
+                 os.environ,
+                 {
+                     "PATH": "/usr/bin:/bin",
+                     "HOME": "/home/test",
+                     "HERMES_HOME": hermes_home,
+                     "HTTP_PROXY": "http://127.0.0.1:7890",
+                     "https_proxy": "http://127.0.0.1:7890",
+                     "ALL_PROXY": "socks5://127.0.0.1:7891",
+                     "no_proxy": "localhost,127.0.0.1",
+                     "HtTp_PrOxY": "http://mixed-case.invalid",
+                     "BROWSERBASE_API_KEY": "bb-test-key",
+                 },
+                 clear=True,
+             ):
+            with patch("builtins.open", mock_open(read_data=fake_json)):
+                _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        assert captured_env["HERMES_HOME"] == hermes_home
+        assert captured_env["BROWSERBASE_API_KEY"] == "bb-test-key"
+        assert all(
+            key.lower() not in {"http_proxy", "https_proxy", "all_proxy", "no_proxy"}
+            for key in captured_env
+        )
+
     def test_subprocess_path_includes_termux_fallback_dirs(self, tmp_path):
         """Termux fallback dirs should survive browser PATH rebuilding."""
         captured_env = {}

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -109,6 +109,19 @@ _SANE_PATH_DIRS = (
     "/bin",
 )
 _SANE_PATH = os.pathsep.join(_SANE_PATH_DIRS)
+_BROWSER_PROXY_ENV_NAMES = frozenset({
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+})
+
+
+def _strip_browser_proxy_env(env: dict[str, str]) -> None:
+    """Prevent parent proxy settings from hijacking agent-browser IPC traffic."""
+    for key in list(env):
+        if key.lower() in _BROWSER_PROXY_ENV_NAMES:
+            env.pop(key, None)
 
 
 @functools.lru_cache(maxsize=1)
@@ -1177,6 +1190,7 @@ def _run_browser_command(
                      command, task_id, task_socket_dir, len(task_socket_dir))
         
         browser_env = {**os.environ}
+        _strip_browser_proxy_env(browser_env)
 
         # Ensure subprocesses inherit the same browser-specific PATH fallbacks
         # used during CLI discovery.


### PR DESCRIPTION
Fixes #14372

## Root cause
`_run_browser_command()` copied the full parent `os.environ` into the local `agent-browser` subprocess. When users run Hermes behind Clash/V2Ray/corporate proxy settings, proxy variables such as `HTTP_PROXY`, `https_proxy`, or `ALL_PROXY` can be inherited by the browser daemon and interfere with its local browser/CDP traffic, surfacing as `ERR_EMPTY_RESPONSE`.

## Fix
- Strip proxy-related environment variables from the local browser subprocess environment before spawning `agent-browser`.
- Match proxy keys case-insensitively so mixed-case shell exports are also removed.
- Preserve unrelated browser/runtime environment such as `HERMES_HOME`, `PATH`, and cloud browser credentials.

## Relationship to #6030
#6030 addresses a broader subprocess-environment hardening root cause, but it is currently dirty and also touches RL training. This PR is intentionally narrower: it only salvages the browser proxy failure reported in #14372 with a focused regression test.

## Tests
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_browser_homebrew_paths.py::TestRunBrowserCommandPathConstruction::test_subprocess_env_strips_proxy_vars -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_browser_homebrew_paths.py::TestRunBrowserCommandPathConstruction::test_subprocess_path_includes_sane_path_homebrew tests/tools/test_browser_homebrew_paths.py::TestRunBrowserCommandPathConstruction::test_subprocess_path_includes_homebrew_node_dirs -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_browser_homebrew_paths.py -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_browser_hardening.py tests/tools/test_browser_ssrf_local.py -q --tb=short`
- `git diff --check`