### PR TITLE
fix(browser): verify daemon pid before orphan reap

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -89,12 +89,38 @@ class TestReapOrphanedBrowserSessions:
                 return  # pretend process exists
             # Don't actually kill anything
 
-        with patch("os.kill", side_effect=mock_kill):
+        with patch("os.kill", side_effect=mock_kill), patch(
+            "tools.browser_tool._read_process_cmdline",
+            return_value="node /usr/local/bin/agent-browser daemon",
+        ):
             _reap_orphaned_browser_sessions()
 
         # Should have checked existence (sig 0) then killed (SIGTERM)
         assert (12345, 0) in kill_calls
         assert (12345, signal.SIGTERM) in kill_calls
+
+    def test_alive_pid_must_match_agent_browser_before_kill(self, fake_tmpdir):
+        """A planted PID file for a non-browser process must not be SIGTERMed."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_fake123456", pid=12345)
+
+        kill_calls = []
+
+        def mock_kill(pid, sig):
+            kill_calls.append((pid, sig))
+            if sig == 0:
+                return  # pretend the planted PID exists
+
+        with patch("os.kill", side_effect=mock_kill), patch(
+            "tools.browser_tool._read_process_cmdline",
+            return_value="/bin/sleep 600",
+        ):
+            _reap_orphaned_browser_sessions()
+
+        assert (12345, 0) in kill_calls
+        assert (12345, signal.SIGTERM) not in kill_calls
+        assert d.exists()
 
     def test_tracked_session_is_not_reaped(self, fake_tmpdir):
         """Sessions tracked in _active_sessions are left alone (legacy path)."""
@@ -230,7 +256,10 @@ class TestOwnerPidCrossProcess:
                 return  # daemon still alive
             # SIGTERM to daemon — noop in test
 
-        with patch("os.kill", side_effect=mock_kill):
+        with patch("os.kill", side_effect=mock_kill), patch(
+            "tools.browser_tool._read_process_cmdline",
+            return_value="node /usr/local/bin/agent-browser daemon",
+        ):
             _reap_orphaned_browser_sessions()
 
         # Owner checked (returned dead), daemon checked (alive), daemon killed

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -552,6 +552,61 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
                      session_name, exc)
 
 
+def _read_process_cmdline(pid: int) -> Optional[str]:
+    """Best-effort command-line read for process identity checks."""
+    proc_cmdline = Path(f"/proc/{pid}/cmdline")
+    try:
+        raw = proc_cmdline.read_bytes()
+    except OSError:
+        raw = b""
+    if raw:
+        return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    cmdline = (result.stdout or "").strip()
+    return cmdline or None
+
+
+def _is_agent_browser_daemon_process(pid: int, session_name: str) -> bool:
+    """Return True only when a PID looks like an agent-browser daemon.
+
+    The orphan reaper scans predictable temp paths.  A same-user process can
+    plant a fake socket directory with a PID file, so never SIGTERM a live PID
+    unless its command line matches the daemon we expect.
+    """
+    cmdline = _read_process_cmdline(pid)
+    if not cmdline:
+        logger.warning(
+            "Refusing to reap browser daemon PID %d for session %s: "
+            "could not verify process command line",
+            pid,
+            session_name,
+        )
+        return False
+
+    if "agent-browser" not in cmdline.lower():
+        logger.warning(
+            "Refusing to reap browser daemon PID %d for session %s: "
+            "process command line does not look like agent-browser: %r",
+            pid,
+            session_name,
+            cmdline[:200],
+        )
+        return False
+
+    return True
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -654,6 +709,9 @@ def _reap_orphaned_browser_sessions():
             continue
         except PermissionError:
             # Alive but owned by someone else — leave it alone
+            continue
+
+        if not _is_agent_browser_daemon_process(daemon_pid, session_name):
             continue
 
         # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.


### PR DESCRIPTION
## Summary\n- Fixes #14073.\n- Adds a best-effort command-line identity check before the browser orphan reaper sends SIGTERM to a live PID from a legacy socket-dir pid file.\n- Keeps normal orphan cleanup for verified agent-browser daemons, but refuses to kill planted/non-agent-browser PIDs from predictable temp paths.\n- Adds regression coverage for a fake socket dir pointing at a non-browser process.\n\n## Root cause\nThe orphan reaper already uses owner_pid files for newer sessions, but its legacy fallback still trusted bare pid files in predictable temp directories. A same-user local actor could create an agent-browser-like directory and point the pid file at an unrelated same-user process.\n\n## Tests\n- source /Users/stephenyu/Documents/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_browser_orphan_reaper.py\n- source /Users/stephenyu/Documents/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_browser_hardening.py tests/tools/test_browser_ssrf_local.py tests/tools/test_browser_homebrew_paths.py\n- git diff --check