### PR TITLE
add stateless claude cli inference transport with persisted model overrides

### DIFF
--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,0 +1,261 @@
+"""OpenAI-compatible shim that forwards Hermes requests to local Claude CLI.
+
+The Claude CLI is used only as an auth/inference transport. Hermes remains the
+orchestrator, so this adapter is deliberately stateless: every request sends
+the full Hermes transcript and never resumes or creates a Claude backend
+session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from types import SimpleNamespace
+from typing import Any
+
+from agent.copilot_acp_client import _extract_tool_calls_from_text, _format_messages_as_prompt
+
+CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+def _resolve_command() -> str:
+    return os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip() or "claude"
+
+
+def _normalize_model(model: str | None) -> str:
+    text = str(model or "").strip()
+    if not text:
+        return "sonnet"
+    if "/" in text:
+        text = text.split("/", 1)[1]
+    lowered = text.lower()
+    if lowered in {"opus", "sonnet", "haiku"}:
+        return lowered
+    if lowered.startswith("claude-"):
+        return text.replace(".", "-")
+    return text
+
+
+def _build_stdin_payload(prompt_text: str) -> str:
+    """Encode a single full-transcript prompt for Claude CLI stream-json input."""
+    payload = {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": prompt_text,
+                }
+            ],
+        },
+    }
+    return json.dumps(payload, ensure_ascii=False) + "\n"
+
+
+class _ClaudeChatCompletions:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeChatNamespace:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self.completions = _ClaudeChatCompletions(client)
+
+
+class ClaudeCLIClient:
+    """Minimal OpenAI-client-compatible facade for Claude CLI."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ):
+        extra_args = list(acp_args or args or [])
+        if extra_args:
+            raise ValueError(
+                "Claude CLI transport does not accept extra CLI args. "
+                "Use HERMES_CLAUDE_CLI_COMMAND for a wrapper command if needed."
+            )
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = acp_command or command or _resolve_command()
+        self.chat = _ClaudeChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    @staticmethod
+    def _effective_timeout_seconds(timeout: Any) -> float:
+        if isinstance(timeout, (int, float)):
+            return float(timeout)
+        values: list[float] = []
+        for attr in ("connect", "read", "write", "pool", "timeout"):
+            value = getattr(timeout, attr, None)
+            if isinstance(value, (int, float)):
+                values.append(float(value))
+        return max(values) if values else _DEFAULT_TIMEOUT_SECONDS
+
+    @staticmethod
+    def _build_usage(usage_data: dict[str, Any] | None) -> SimpleNamespace:
+        usage_data = usage_data if isinstance(usage_data, dict) else {}
+        input_tokens = int(usage_data.get("input_tokens") or 0)
+        output_tokens = int(usage_data.get("output_tokens") or 0)
+        cache_read = int(usage_data.get("cache_read_input_tokens") or 0)
+        cache_creation = int(usage_data.get("cache_creation_input_tokens") or 0)
+        prompt_tokens = input_tokens + cache_read + cache_creation
+        total_tokens = prompt_tokens + output_tokens
+        return SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=total_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cache_read),
+        )
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: Any = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            list(messages or []),
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        response_text, reasoning_text, usage_data = self._run_prompt(
+            prompt_text,
+            model=model,
+            timeout_seconds=self._effective_timeout_seconds(timeout),
+        )
+        usage = self._build_usage(usage_data)
+
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "claude-cli",
+        )
+
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        model: str | None,
+        timeout_seconds: float,
+    ) -> tuple[str, str, dict[str, Any]]:
+        cmd = [
+            self._command,
+            "-p",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--include-partial-messages",
+            "--verbose",
+            "--tools",
+            "",
+            "--no-session-persistence",
+            "--model",
+            _normalize_model(model),
+        ]
+        stdin_payload = _build_stdin_payload(prompt_text)
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=stdin_payload,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude CLI command '{self._command}'. "
+                "Install Claude Code or set HERMES_CLAUDE_CLI_COMMAND."
+            ) from exc
+
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip()
+            raise RuntimeError(stderr or f"Claude CLI exited with status {proc.returncode}")
+
+        final_text = ""
+        assistant_text = ""
+        delta_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        usage_data: dict[str, Any] | None = None
+
+        for raw_line in (proc.stdout or "").splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except Exception:
+                continue
+            item_type = item.get("type")
+            if item_type == "assistant":
+                message = item.get("message") or {}
+                content = message.get("content") or []
+                parts = [
+                    str(block.get("text") or "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+                if parts:
+                    assistant_text = "".join(parts).strip()
+                msg_usage = message.get("usage")
+                if isinstance(msg_usage, dict):
+                    usage_data = msg_usage
+            elif item_type == "result":
+                final_text = str(item.get("result") or "").strip()
+                result_usage = item.get("usage")
+                if isinstance(result_usage, dict):
+                    usage_data = result_usage
+            elif item_type == "stream_event":
+                event = item.get("event") or {}
+                event_usage = event.get("usage")
+                if isinstance(event_usage, dict):
+                    usage_data = event_usage
+                if event.get("type") == "content_block_delta":
+                    delta = event.get("delta") or {}
+                    text = delta.get("text")
+                    if isinstance(text, str) and text:
+                        delta_parts.append(text)
+                elif event.get("type") == "thinking_delta":
+                    delta = event.get("delta") or {}
+                    thinking = delta.get("thinking")
+                    if isinstance(thinking, str) and thinking:
+                        reasoning_parts.append(thinking)
+
+        response_text = final_text or assistant_text or "".join(delta_parts).strip()
+        reasoning_text = "".join(reasoning_parts).strip()
+        return response_text, reasoning_text, usage_data or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1184,7 +1184,7 @@ class GatewayRunner:
                 resolved_session_key = None
 
         model = _resolve_gateway_model(user_config)
-        override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
+        override = self._get_session_model_override(resolved_session_key) if resolved_session_key else None
         if override:
             override_model = override.get("model", model)
             override_runtime = {
@@ -1200,8 +1200,33 @@ class GatewayRunner:
                     override_runtime.get("provider"),
                 )
                 return override_model, override_runtime
-            # Override exists but has no api_key — fall through to env-based
-            # resolution and apply model/provider from the override on top.
+            # Override exists but has no api_key — re-resolve runtime for the
+            # override provider so restart-resumed sessions still land on the
+            # same provider lane instead of inheriting the global default.
+            override_provider = str(override.get("provider") or "").strip()
+            override_base_url = str(override.get("base_url") or "").strip() or None
+            if override_provider:
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                    override_runtime = resolve_runtime_provider(
+                        requested=override_provider,
+                        explicit_base_url=override_base_url,
+                    )
+                    if override.get("api_mode"):
+                        override_runtime["api_mode"] = override.get("api_mode")
+                    logger.debug(
+                        "Session model override (persisted): session=%s config_model=%s -> override_model=%s provider=%s",
+                        (resolved_session_key or "")[:30], model, override_model,
+                        override_runtime.get("provider"),
+                    )
+                    return override_model, override_runtime
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to resolve persisted session model override for %s: %s",
+                        (resolved_session_key or "")[:30],
+                        exc,
+                    )
             logger.debug(
                 "Session model override (no api_key, fallback): session=%s config_model=%s override_model=%s",
                 resolved_session_key or "", model, override_model,
@@ -1236,6 +1261,68 @@ class GatewayRunner:
                 pass
 
         return model, runtime_kwargs
+
+    def _get_session_model_override(self, session_key: Optional[str]) -> Optional[Dict[str, str]]:
+        """Return the effective session-scoped /model override for ``session_key``.
+
+        Prefers the live in-memory override map, then falls back to the
+        persisted SessionStore entry so gateway restarts keep the same
+        per-session model/provider lane.
+        """
+        if not session_key:
+            return None
+        override = self._session_model_overrides.get(session_key)
+        if override:
+            return dict(override)
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return None
+        try:
+            getter = getattr(store, "get_session_model_override", None)
+            persisted = getter(session_key) if callable(getter) else None
+            if persisted:
+                self._session_model_overrides[session_key] = dict(persisted)
+                return dict(persisted)
+        except Exception:
+            logger.debug("Failed to load persisted session model override", exc_info=True)
+        return None
+
+    def _persist_session_model_override(
+        self,
+        session_key: str,
+        *,
+        model: str,
+        provider: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_mode: Optional[str] = None,
+    ) -> None:
+        """Persist a session-scoped /model override in memory and SessionStore."""
+        if not session_key:
+            return
+        override = {
+            "model": model,
+            "provider": provider,
+            "api_key": api_key,
+            "base_url": base_url,
+            "api_mode": api_mode,
+        }
+        self._session_model_overrides[session_key] = override
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return
+        try:
+            setter = getattr(store, "set_session_model_override", None)
+            if callable(setter):
+                setter(
+                    session_key,
+                    model=model,
+                    provider=provider,
+                    base_url=base_url,
+                    api_mode=api_mode,
+                )
+        except Exception:
+            logger.debug("Failed to persist session model override", exc_info=True)
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
@@ -5301,6 +5388,9 @@ class GatewayRunner:
                 self._set_session_reasoning_override(session_key, None)
                 if hasattr(self, "_pending_model_notes"):
                     self._pending_model_notes.pop(session_key, None)
+                clearer = getattr(self.session_store, "clear_session_model_override", None)
+                if callable(clearer):
+                    clearer(session_key)
                 response = (response or "") + (
                     "\n\n🔄 Session auto-reset — the conversation exceeded the "
                     "maximum context size and could not be compressed further. "
@@ -5597,6 +5687,9 @@ class GatewayRunner:
         self._set_session_reasoning_override(session_key, None)
         if hasattr(self, "_pending_model_notes"):
             self._pending_model_notes.pop(session_key, None)
+        clearer = getattr(self.session_store, "clear_session_model_override", None)
+        if callable(clearer):
+            clearer(session_key)
 
         # Clear session-scoped dangerous-command approvals and /yolo state.
         # /new is a conversation-boundary operation — approval state from the
@@ -6099,7 +6192,7 @@ class GatewayRunner:
         # Check for session override
         source = event.source
         session_key = self._session_key_for_source(source)
-        override = self._session_model_overrides.get(session_key, {})
+        override = self._get_session_model_override(session_key) or {}
         if override:
             current_model = override.get("model", current_model)
             current_provider = override.get("provider", current_provider)
@@ -6182,13 +6275,14 @@ class GatewayRunner:
                             f"via {result.provider_label or result.target_provider}. "
                             f"Adjust your self-identification accordingly.]"
                         )
-                        _self._session_model_overrides[_session_key] = {
-                            "model": result.new_model,
-                            "provider": result.target_provider,
-                            "api_key": result.api_key,
-                            "base_url": result.base_url,
-                            "api_mode": result.api_mode,
-                        }
+                        _self._persist_session_model_override(
+                            _session_key,
+                            model=result.new_model,
+                            provider=result.target_provider,
+                            api_key=result.api_key,
+                            base_url=result.base_url,
+                            api_mode=result.api_mode,
+                        )
 
                         # Evict cached agent so the next turn creates a fresh
                         # agent from the override rather than relying on the
@@ -6310,13 +6404,14 @@ class GatewayRunner:
         )
 
         # Store session override so next agent creation uses the new model
-        self._session_model_overrides[session_key] = {
-            "model": result.new_model,
-            "provider": result.target_provider,
-            "api_key": result.api_key,
-            "base_url": result.base_url,
-            "api_mode": result.api_mode,
-        }
+        self._persist_session_model_override(
+            session_key,
+            model=result.new_model,
+            provider=result.target_provider,
+            api_key=result.api_key,
+            base_url=result.base_url,
+            api_mode=result.api_mode,
+        )
 
         # Evict cached agent so the next turn creates a fresh agent from the
         # override rather than relying on cache signature mismatch detection.
@@ -9130,7 +9225,7 @@ class GatewayRunner:
         subsequent messages.  Fields with ``None`` values are skipped so
         partial overrides don't clobber valid config defaults.
         """
-        override = self._session_model_overrides.get(session_key)
+        override = self._get_session_model_override(session_key)
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
@@ -9142,7 +9237,7 @@ class GatewayRunner:
 
     def _is_intentional_model_switch(self, session_key: str, agent_model: str) -> bool:
         """Return True if *agent_model* matches an active /model session override."""
-        override = self._session_model_overrides.get(session_key)
+        override = self._get_session_model_override(session_key)
         return override is not None and override.get("model") == agent_model
 
     def _release_running_agent_state(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -472,6 +472,15 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Session-scoped /model selection persisted across gateway restarts.
+    # This is intentionally separate from config.yaml defaults: it should
+    # follow the current session lane until /new or /reset starts a fresh
+    # session, matching OpenClaw's per-session model override behavior.
+    model_override: Optional[str] = None
+    provider_override: Optional[str] = None
+    override_base_url: Optional[str] = None
+    override_api_mode: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -498,6 +507,10 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "model_override": self.model_override,
+            "provider_override": self.provider_override,
+            "override_base_url": self.override_base_url,
+            "override_api_mode": self.override_api_mode,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -546,6 +559,10 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            model_override=data.get("model_override"),
+            provider_override=data.get("provider_override"),
+            override_base_url=data.get("override_base_url"),
+            override_api_mode=data.get("override_api_mode"),
         )
 
 
@@ -942,6 +959,58 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def get_session_model_override(self, session_key: str) -> Optional[Dict[str, str]]:
+        """Return a persisted session-scoped model override, if any."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry or not entry.model_override:
+                return None
+            return {
+                "model": entry.model_override,
+                "provider": entry.provider_override,
+                "base_url": entry.override_base_url,
+                "api_mode": entry.override_api_mode,
+            }
+
+    def set_session_model_override(
+        self,
+        session_key: str,
+        *,
+        model: str,
+        provider: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_mode: Optional[str] = None,
+    ) -> bool:
+        """Persist a session-scoped /model selection for restart-safe resume."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry:
+                return False
+            entry.model_override = model
+            entry.provider_override = provider
+            entry.override_base_url = base_url
+            entry.override_api_mode = api_mode
+            entry.updated_at = _now()
+            self._save()
+            return True
+
+    def clear_session_model_override(self, session_key: str) -> bool:
+        """Remove any persisted session-scoped /model selection."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry:
+                return False
+            entry.model_override = None
+            entry.provider_override = None
+            entry.override_base_url = None
+            entry.override_api_mode = None
+            entry.updated_at = _now()
+            self._save()
+            return True
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -75,6 +75,7 @@ DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CLAUDE_CLI_BASE_URL = "claude-cli://local"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -174,6 +175,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude CLI",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CLI_BASE_URL,
+        base_url_env_var="CLAUDE_CLI_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1142,6 +1150,7 @@ def resolve_provider(
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
         "claude": "anthropic", "claude-code": "anthropic",
+        "claude-code-cli": "claude-cli",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -3412,27 +3421,35 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "copilot-acp":
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    elif provider_id == "claude-cli":
+        command = os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip() or "claude"
+        args = []
+    else:
+        return {"configured": False, "provider": provider_id}
+
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    tcp_marker = base_url.startswith("acp+tcp://")
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": bool(resolved_command or tcp_marker),
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": bool(resolved_command or tcp_marker),
     }
 
 
@@ -3449,10 +3466,10 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "google-gemini-cli":
         return get_gemini_oauth_auth_status()
-    if target == "copilot-acp":
+    pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
         return get_external_process_provider_status(target)
     # API-key providers
-    pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
@@ -3517,25 +3534,45 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "copilot-acp":
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+        missing_code = "missing_copilot_cli"
+        missing_help = (
+            f"Could not find the Copilot CLI command '{command}'. "
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        )
+    elif provider_id == "claude-cli":
+        command = os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip() or "claude"
+        args = []
+        missing_code = "missing_claude_cli"
+        missing_help = (
+            f"Could not find the Claude CLI command '{command}'. "
+            "Install Claude Code or set HERMES_CLAUDE_CLI_COMMAND."
+        )
+    else:
+        raise AuthError(
+            f"Provider '{provider_id}' has no external-process resolver.",
+            provider=provider_id,
+            code="invalid_provider",
+        )
+
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            missing_help,
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=missing_code,
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1774,6 +1774,8 @@ def select_provider_and_model(args=None):
         _model_flow_google_gemini_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-cli":
+        _model_flow_claude_cli(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -3842,6 +3844,65 @@ def _model_flow_copilot_acp(config, current_model=""):
         )
         or selected
     )
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_cli(config, current_model=""):
+    """Claude CLI flow using the local Claude Code CLI as a separate selector option."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.model_normalize import normalize_model_for_provider
+
+    del config
+
+    provider_id = "claude-cli"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "claude"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude CLI uses the local `claude` command as an auth/inference lane.")
+    print("  Hermes still owns orchestration, tools, logging, and turn state.")
+    print("  Command: {}".format(resolved_command))
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Set HERMES_CLAUDE_CLI_COMMAND if Claude Code is installed elsewhere.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = list(_PROVIDER_MODELS.get("claude-cli", []))
+    selected = _prompt_model_selection(model_list, current_model=current_model) if model_list else None
+    if not selected:
+        print("No change.")
+        return
+
+    selected = normalize_model_for_provider(selected, "claude-cli")
     _save_model_choice(selected)
 
     cfg = load_config()

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -80,6 +80,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "claude-cli",
     "openai-codex",
 })
 
@@ -408,13 +409,13 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
             return bare
         return _dots_to_hyphens(bare)
 
-    # --- Copilot / Copilot ACP: delegate to the Copilot-specific
+    # --- Copilot / Copilot ACP / Claude CLI: delegate to the provider-specific
     #     normalizer.  It knows about the alias table (vendor-prefix
     #     stripping for Anthropic/OpenAI, dash-to-dot repair for Claude)
     #     and live-catalog lookups.  Without this, vendor-prefixed or
-    #     dash-notation Claude IDs survive to the Copilot API and hit
-    #     HTTP 400 "model_not_supported".  See issue #6879.
-    if provider in {"copilot", "copilot-acp"}:
+    #     dash-notation Claude IDs survive to the backend and hit
+    #     unsupported-model errors.
+    if provider in {"copilot", "copilot-acp", "claude-cli"}:
         try:
             from hermes_cli.models import normalize_copilot_model_id
 
@@ -423,10 +424,10 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
                 return normalized
         except Exception:
             # Fall through to the generic strip-vendor behaviour below
-            # if the Copilot-specific path is unavailable for any reason.
+            # if the provider-specific path is unavailable for any reason.
             pass
 
-    # --- Copilot / Copilot ACP / openai-codex fallback:
+    # --- Copilot / Copilot ACP / Claude CLI / openai-codex fallback:
     #     strip matching provider prefix, keep dots ---
     if provider in _STRIP_VENDOR_ONLY_PROVIDERS:
         stripped = _strip_matching_provider_prefix(name, provider)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1175,6 +1175,17 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
+        if not has_creds and hermes_slug == "claude-cli":
+            try:
+                from agent.anthropic_adapter import read_claude_code_credentials
+                from hermes_cli.auth import get_external_process_provider_status
+
+                status = get_external_process_provider_status("claude-cli")
+                cc_creds = read_claude_code_credentials()
+                if status.get("configured") and cc_creds and cc_creds.get("accessToken"):
+                    has_creds = True
+            except Exception as exc:
+                logger.debug("Claude CLI external creds check failed: %s", exc)
         if not has_creds:
             continue
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -201,6 +201,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "claude-opus-4.7",
+        "claude-opus-4.6",
+        "claude-sonnet-4.6",
+        "claude-sonnet-4.5",
+        "claude-haiku-4.5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -770,6 +777,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway (200+ models, $5 free credit, no markup)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
+    ProviderEntry("claude-cli",     "Claude CLI",               "Claude CLI (uses local Claude Code / Max/Pro subscription path)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models — pro, omni, flash)"),
     ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 Preview — direct API via tokenhub.tencentmaas.com)"),
@@ -832,6 +840,7 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "claude-code-cli": "claude-cli",
     "deep-seek": "deepseek",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",
@@ -1579,7 +1588,10 @@ def detect_static_provider_for_model(
 
     # --- Step 1: check static provider catalogs for a direct match ---
     for pid, models in _PROVIDER_MODELS.items():
-        if pid in current_keys or pid in _AGGREGATOR_PROVIDERS:
+        # Claude CLI is an explicit provider lane, not the canonical owner of
+        # bare Claude model names. Preserve OpenRouter slugging for inputs like
+        # `claude-opus-4.6` unless the user explicitly selected `claude-cli`.
+        if pid in current_keys or pid in _AGGREGATOR_PROVIDERS or pid == "claude-cli":
             continue
         if any(name_lower == m.lower() for m in models):
             return (pid, name)
@@ -1916,6 +1928,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "claude-cli":
+        return list(_PROVIDER_MODELS.get("claude-cli", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -77,6 +77,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-cli": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="claude-cli://local",
+        base_url_env_var="CLAUDE_CLI_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -251,6 +257,7 @@ ALIASES: Dict[str, str] = {
     # anthropic
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "claude-code-cli": "claude-cli",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -341,6 +348,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude CLI",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1090,10 +1090,11 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig and pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/run_agent.py
+++ b/run_agent.py
@@ -1045,8 +1045,9 @@ class AIAgent:
         if (
             api_mode is None
             and self.api_mode == "chat_completions"
-            and self.provider != "copilot-acp"
+            and self.provider not in {"copilot-acp", "claude-cli"}
             and not str(self.base_url or "").lower().startswith("acp://copilot")
+            and not str(self.base_url or "").lower().startswith("claude-cli://")
             and not str(self.base_url or "").lower().startswith("acp+tcp://")
             and not self._is_azure_openai_url()
             and (
@@ -1346,7 +1347,7 @@ class AIAgent:
                     client_kwargs = {"api_key": api_key, "base_url": base_url}
                 if _provider_timeout is not None:
                     client_kwargs["timeout"] = _provider_timeout
-                if self.provider == "copilot-acp":
+                if self.provider in {"copilot-acp", "claude-cli"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
@@ -1586,7 +1587,7 @@ class AIAgent:
                 logger.warning(
                     "Session DB create_session failed (session_search still available): %s", e
                 )
-        
+
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
         self._todo_store = TodoStore()
@@ -2173,6 +2174,9 @@ class AIAgent:
             _sm_timeout = get_provider_request_timeout(self.provider, self.model)
             if _sm_timeout is not None:
                 self._client_kwargs["timeout"] = _sm_timeout
+            if self.provider in {"copilot-acp", "claude-cli"}:
+                self._client_kwargs["command"] = self.acp_command
+                self._client_kwargs["args"] = list(self.acp_args or [])
             self.client = self._create_openai_client(
                 dict(self._client_kwargs),
                 reason="switch_model",
@@ -5186,6 +5190,17 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
+        if self.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("claude-cli://"):
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(**client_kwargs)
+            logger.info(
+                "Claude CLI client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
         if self.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
             from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 
@@ -6451,6 +6466,14 @@ class AIAgent:
             last_chunk_time["t"] = time.time()
             self._touch_activity("waiting for provider response (streaming)")
             stream = request_client_holder["client"].chat.completions.create(**stream_kwargs)
+
+            # Some OpenAI-compatible shims ignore `stream=True` and return a
+            # completed response object immediately. Treat that as a clean
+            # fallback to the non-streaming shape instead of trying to iterate
+            # it as a stream (which raises TypeError on SimpleNamespace-backed
+            # adapter responses like Claude CLI).
+            if hasattr(stream, "choices") and not hasattr(stream, "__iter__"):
+                return stream
 
             # Capture rate limit headers from the initial HTTP response.
             # The OpenAI SDK Stream object exposes the underlying httpx

--- a/tests/agent/test_claude_cli_client.py
+++ b/tests/agent/test_claude_cli_client.py
@@ -1,0 +1,226 @@
+"""Focused regressions for the stateless Claude CLI transport."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.claude_cli_client import ClaudeCLIClient
+
+
+class _Proc(SimpleNamespace):
+    pass
+
+
+def _stdin_text(kwargs: dict) -> str:
+    payload = json.loads(kwargs["input"])
+    return payload["message"]["content"][0]["text"]
+
+
+def _assert_safe_stateless_cmd(cmd: list[str]) -> None:
+    assert cmd[:2] == ["claude", "-p"]
+    assert "--input-format" in cmd
+    assert cmd[cmd.index("--input-format") + 1] == "stream-json"
+    assert "--output-format" in cmd
+    assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+    assert "--tools" in cmd
+    assert cmd[cmd.index("--tools") + 1] == ""
+    assert "--no-session-persistence" in cmd
+    assert "--permission-mode" not in cmd
+    assert "bypassPermissions" not in cmd
+    assert "--resume" not in cmd
+    assert "--session-id" not in cmd
+
+
+def _stdout(result_text: str = "OK", *, usage: dict | None = None) -> str:
+    usage = usage or {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 10,
+        "cache_read_input_tokens": 20,
+        "output_tokens": 3,
+    }
+    payloads = [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": result_text}],
+                "usage": usage,
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": result_text,
+            "usage": usage,
+        },
+    ]
+    return "\n".join(json.dumps(item) for item in payloads)
+
+
+def test_full_transcript_is_sent_every_turn():
+    client = ClaudeCLIClient(command="claude")
+    prompts: list[str] = []
+
+    def _run(cmd, **kwargs):
+        _assert_safe_stateless_cmd(cmd)
+        prompts.append(_stdin_text(kwargs))
+        assert "Original request" not in cmd
+        assert kwargs["text"] is True
+        return _Proc(returncode=0, stdout=_stdout("Hello"), stderr="")
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=_run):
+        client.chat.completions.create(
+            model="claude-sonnet-4.6",
+            messages=[
+                {"role": "system", "content": "System guidance"},
+                {"role": "user", "content": "Original request"},
+            ],
+        )
+        client.chat.completions.create(
+            model="claude-sonnet-4.6",
+            messages=[
+                {"role": "system", "content": "System guidance"},
+                {"role": "user", "content": "Original request"},
+                {"role": "assistant", "content": "Previous answer"},
+                {"role": "user", "content": "Follow up"},
+            ],
+        )
+
+    assert len(prompts) == 2
+    assert "Original request" in prompts[0]
+    assert "Original request" in prompts[1]
+    assert "Previous answer" in prompts[1]
+    assert "Follow up" in prompts[1]
+
+
+def test_arbitrary_extra_args_are_not_accepted(monkeypatch):
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_ARGS", "--dangerous")
+    client = ClaudeCLIClient(command="claude")
+
+    def _run(cmd, **kwargs):
+        _assert_safe_stateless_cmd(cmd)
+        assert "--dangerous" not in cmd
+        return _Proc(returncode=0, stdout=_stdout("OK"), stderr="")
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=_run):
+        client.chat.completions.create(model="sonnet", messages=[{"role": "user", "content": "hi"}])
+
+    with pytest.raises(ValueError, match="does not accept extra CLI args"):
+        ClaudeCLIClient(command="claude", args=["--dangerous"])
+
+
+def test_timeout_object_is_converted_to_subprocess_timeout():
+    client = ClaudeCLIClient(command="claude")
+
+    class _Timeout:
+        connect = 1.0
+        read = 12.5
+        write = 3.0
+        pool = 2.0
+
+    def _run(cmd, **kwargs):
+        _assert_safe_stateless_cmd(cmd)
+        assert kwargs["timeout"] == 12.5
+        return _Proc(returncode=0, stdout=_stdout("OK"), stderr="")
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=_run):
+        client.chat.completions.create(
+            model="claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=_Timeout(),
+        )
+
+
+def test_stream_json_result_reasoning_and_usage_are_parsed():
+    client = ClaudeCLIClient(command="claude")
+    payloads = [
+        {"type": "stream_event", "event": {"type": "thinking_delta", "delta": {"thinking": "plan"}}},
+        {"type": "stream_event", "event": {"type": "content_block_delta", "delta": {"text": "part"}}},
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "final",
+            "usage": {
+                "input_tokens": 2,
+                "cache_creation_input_tokens": 10,
+                "cache_read_input_tokens": 20,
+                "output_tokens": 3,
+            },
+        },
+    ]
+    stdout = "\n".join(json.dumps(item) for item in payloads)
+
+    with patch(
+        "agent.claude_cli_client.subprocess.run",
+    ) as mock_run:
+        mock_run.return_value = _Proc(returncode=0, stdout=stdout, stderr="")
+        response = client.chat.completions.create(
+            model="claude-opus-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    _assert_safe_stateless_cmd(mock_run.call_args.args[0])
+    message = response.choices[0].message
+    assert message.content == "final"
+    assert message.reasoning == "plan"
+    assert response.usage.prompt_tokens == 32
+    assert response.usage.completion_tokens == 3
+    assert response.usage.total_tokens == 35
+    assert response.usage.prompt_tokens_details.cached_tokens == 20
+
+
+def test_tool_call_text_is_returned_to_hermes_loop():
+    client = ClaudeCLIClient(command="claude")
+    tool_text = json.dumps(
+        {
+            "id": "call_1",
+            "function": {"name": "shell", "arguments": {"cmd": "pwd"}},
+        }
+    )
+    stdout = _stdout(f"Need a tool.\n<tool_call>{tool_text}</tool_call>")
+
+    with patch(
+        "agent.claude_cli_client.subprocess.run",
+    ) as mock_run:
+        mock_run.return_value = _Proc(returncode=0, stdout=stdout, stderr="")
+        response = client.chat.completions.create(
+            model="claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "run pwd"}],
+        )
+
+    _assert_safe_stateless_cmd(mock_run.call_args.args[0])
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content == "Need a tool."
+    assert choice.message.tool_calls[0].id == "call_1"
+    assert choice.message.tool_calls[0].function.name == "shell"
+    assert json.loads(choice.message.tool_calls[0].function.arguments) == {"cmd": "pwd"}
+
+
+def test_large_transcript_is_sent_via_stdin_not_argv():
+    client = ClaudeCLIClient(command="claude")
+    large_content = "large transcript chunk " * 20000
+    large_content_core = large_content.strip()
+
+    def _run(cmd, **kwargs):
+        _assert_safe_stateless_cmd(cmd)
+        argv_text = "\n".join(cmd)
+        assert large_content_core not in argv_text
+        stdin_text = _stdin_text(kwargs)
+        assert large_content_core in stdin_text
+        assert len(kwargs["input"]) > len(large_content)
+        return _Proc(returncode=0, stdout=_stdout("OK"), stderr="")
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=_run):
+        response = client.chat.completions.create(
+            model="claude-sonnet-4.6",
+            messages=[
+                {"role": "system", "content": "System guidance"},
+                {"role": "user", "content": large_content},
+            ],
+        )
+
+    assert response.choices[0].message.content == "OK"

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -13,7 +13,7 @@ Tests exercise the real ``_apply_session_model_override()`` and
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -82,6 +82,69 @@ def _make_runner():
 
 class TestApplySessionModelOverride:
     """Verify _apply_session_model_override replaces config defaults."""
+
+    def test_resolve_session_runtime_uses_persisted_override_after_restart(self):
+        runner = _make_runner()
+        sk = build_session_key(_make_source())
+        runner.session_store.get_session_model_override = MagicMock(return_value={
+            "model": "gpt-5.4",
+            "provider": "copilot-acp",
+            "base_url": "acp://copilot",
+            "api_mode": "chat_completions",
+        })
+
+        with patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={
+                "provider": "openai-codex",
+                "api_key": "***",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_mode": "codex_responses",
+            },
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "copilot-acp",
+                "api_key": "copilot-acp",
+                "base_url": "acp://copilot",
+                "api_mode": "chat_completions",
+                "command": "copilot",
+                "args": ["--acp", "--stdio"],
+            },
+        ):
+            model, rt = runner._resolve_session_agent_runtime(
+                session_key=sk,
+                user_config={"model": {"default": "gpt-5.4-mini"}},
+            )
+
+        assert model == "gpt-5.4"
+        assert rt["provider"] == "copilot-acp"
+        assert rt["api_key"] == "copilot-acp"
+        assert rt["base_url"] == "acp://copilot"
+        assert runner._session_model_overrides[sk]["model"] == "gpt-5.4"
+
+    def test_persist_session_model_override_updates_session_store(self):
+        runner = _make_runner()
+        sk = build_session_key(_make_source())
+        runner.session_store.set_session_model_override = MagicMock(return_value=True)
+
+        runner._persist_session_model_override(
+            sk,
+            model="gpt-5.4",
+            provider="copilot-acp",
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            api_mode="chat_completions",
+        )
+
+        assert runner._session_model_overrides[sk]["provider"] == "copilot-acp"
+        runner.session_store.set_session_model_override.assert_called_once_with(
+            sk,
+            model="gpt-5.4",
+            provider="copilot-acp",
+            base_url="acp://copilot",
+            api_mode="chat_completions",
+        )
 
     def test_override_replaces_all_fields(self):
         runner = _make_runner()

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -465,6 +465,64 @@ class TestSessionStoreRewriteTranscript:
         assert reloaded == []
 
 
+class TestSessionStoreModelOverridePersistence:
+    def test_roundtrip_preserves_session_model_override(self, tmp_path):
+        config = GatewayConfig()
+        sessions_dir = tmp_path / "sessions"
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="c1",
+            chat_type="group",
+            user_id="u1",
+            user_name="tester",
+        )
+
+        store = SessionStore(sessions_dir=sessions_dir, config=config)
+        entry = store.get_or_create_session(source)
+        assert store.set_session_model_override(
+            entry.session_key,
+            model="gpt-5.4",
+            provider="copilot-acp",
+            base_url="acp://copilot",
+            api_mode="chat_completions",
+        )
+
+        reloaded = SessionStore(sessions_dir=sessions_dir, config=config)
+        override = reloaded.get_session_model_override(entry.session_key)
+
+        assert override == {
+            "model": "gpt-5.4",
+            "provider": "copilot-acp",
+            "base_url": "acp://copilot",
+            "api_mode": "chat_completions",
+        }
+
+    def test_clear_session_model_override_persists_after_reload(self, tmp_path):
+        config = GatewayConfig()
+        sessions_dir = tmp_path / "sessions"
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="c1",
+            chat_type="group",
+            user_id="u1",
+            user_name="tester",
+        )
+
+        store = SessionStore(sessions_dir=sessions_dir, config=config)
+        entry = store.get_or_create_session(source)
+        assert store.set_session_model_override(
+            entry.session_key,
+            model="gpt-5.4",
+            provider="copilot-acp",
+            base_url="acp://copilot",
+            api_mode="chat_completions",
+        )
+        assert store.clear_session_model_override(entry.session_key)
+
+        reloaded = SessionStore(sessions_dir=sessions_dir, config=config)
+        assert reloaded.get_session_model_override(entry.session_key) is None
+
+
 class TestLoadTranscriptCorruptLines:
     """Regression: corrupt JSONL lines (e.g. from mid-write crash) must be
     skipped instead of crashing the entire transcript load.  GH-1193."""

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -53,6 +53,7 @@ def _make_runner():
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = session_entry
     runner.session_store.reset_session.return_value = session_entry
+    runner.session_store.clear_session_model_override = MagicMock(return_value=True)
     runner.session_store._entries = {session_key: session_entry}
     runner.session_store._generate_session_key.return_value = session_key
     runner._running_agents = {}
@@ -88,6 +89,7 @@ async def test_new_command_clears_session_model_override():
     assert session_key not in runner._session_model_overrides
     assert session_key not in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
+    runner.session_store.clear_session_model_override.assert_called_once_with(session_key)
 
 
 @pytest.mark.asyncio
@@ -103,6 +105,27 @@ async def test_new_command_no_override_is_noop():
 
     assert session_key not in runner._session_model_overrides
     assert session_key not in runner._session_reasoning_overrides
+    runner.session_store.clear_session_model_override.assert_called_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_reset_alias_clears_persisted_session_model_override():
+    """/reset must clear the persisted model override for the current session."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-4o",
+        "provider": "openai",
+        "api_key": "***",
+        "base_url": "",
+        "api_mode": "openai",
+    }
+
+    await runner._handle_reset_command(_make_event("/reset"))
+
+    assert session_key not in runner._session_model_overrides
+    runner.session_store.clear_session_model_override.assert_called_once_with(session_key)
 
 
 @pytest.mark.asyncio
@@ -115,7 +138,7 @@ async def test_new_command_only_clears_own_session():
     runner._session_model_overrides[session_key] = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
@@ -124,7 +147,7 @@ async def test_new_command_only_clears_own_session():
         "provider": "anthropic",
         "api_key": "***",
         "base_url": "",
-        "api_mode": "anthropic",
+        "api_mode": "chat_completions",
     }
     runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
     runner._session_reasoning_overrides[other_key] = {"enabled": True, "effort": "low"}
@@ -139,3 +162,4 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
     assert other_key in runner._pending_model_notes
+    runner.session_store.clear_session_model_override.assert_called_once_with(session_key)

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-cli", "Claude CLI", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -120,6 +121,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["claude-cli"].inference_base_url == "claude-cli://local"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["stepfun"].inference_base_url == STEPFUN_STEP_PLAN_INTL_BASE_URL
@@ -155,6 +157,7 @@ PROVIDER_ENV_VARS = (
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
+    "HERMES_CLAUDE_CLI_COMMAND", "HERMES_CLAUDE_CLI_ARGS", "CLAUDE_CLI_BASE_URL",
 )
 
 
@@ -245,6 +248,10 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_claude_cli(self):
+        assert resolve_provider("claude-cli") == "claude-cli"
+        assert resolve_provider("claude-code-cli") == "claude-cli"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -384,6 +391,18 @@ class TestApiKeyProviderStatus:
         assert status["args"] == ["--acp", "--stdio", "--debug"]
         assert status["base_url"] == "acp://copilot"
 
+    def test_claude_cli_status_detects_local_cli(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_external_process_provider_status("claude-cli")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["command"] == "claude"
+        assert status["resolved_command"] == "/opt/bin/claude"
+        assert status["args"] == []
+        assert status["base_url"] == "claude-cli://local"
+
     def test_get_auth_status_dispatches_to_external_process(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
 
@@ -391,6 +410,14 @@ class TestApiKeyProviderStatus:
 
         assert status["configured"] is True
         assert status["provider"] == "copilot-acp"
+
+    def test_get_auth_status_dispatches_to_claude_cli(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_auth_status("claude-cli")
+
+        assert status["configured"] is True
+        assert status["provider"] == "claude-cli"
 
     def test_non_api_key_provider(self):
         status = get_api_key_provider_status("nous")
@@ -465,6 +492,18 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "acp://copilot"
         assert creds["command"] == "/usr/local/bin/copilot"
         assert creds["args"] == ["--acp", "--stdio"]
+        assert creds["source"] == "process"
+
+    def test_resolve_claude_cli_with_local_cli(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("claude-cli")
+
+        assert creds["provider"] == "claude-cli"
+        assert creds["api_key"] == "claude-cli"
+        assert creds["base_url"] == "claude-cli://local"
+        assert creds["command"] == "/usr/local/bin/claude"
+        assert creds["args"] == []
         assert creds["source"] == "process"
 
     def test_resolve_kimi_with_key(self, monkeypatch):
@@ -687,6 +726,21 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_claude_cli_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+        monkeypatch.setenv("HERMES_CLAUDE_CLI_ARGS", "--verbose")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="claude-cli")
+
+        assert result["provider"] == "claude-cli"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "claude-cli"
+        assert result["base_url"] == "claude-cli://local"
+        assert result["command"] == "/usr/local/bin/claude"
+        assert result["args"] == []
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_codex_cli_model_picker.py
+++ b/tests/hermes_cli/test_codex_cli_model_picker.py
@@ -133,6 +133,20 @@ def test_claude_code_file_detected_by_model_picker(claude_code_only_env):
     assert anthropic["total_models"] > 0
 
 
+def test_claude_cli_detected_by_model_picker(monkeypatch, claude_code_only_env):
+    """claude-cli should appear as a separate picker option when Claude CLI is installed and Claude Code creds exist."""
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+    providers = list_authenticated_providers(
+        current_provider="claude-cli",
+        max_models=10,
+    )
+    slugs = [p["slug"] for p in providers]
+    assert "claude-cli" in slugs, f"claude-cli not found in /model picker providers: {slugs}"
+
+
 def test_no_codex_when_no_credentials(tmp_path, monkeypatch):
     """openai-codex should NOT appear when no credentials exist anywhere."""
     hermes_home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -142,6 +142,14 @@ class TestCopilotModelNormalization:
         """Copilot ACP shares the same API expectations as HTTP Copilot."""
         assert normalize_model_for_provider(model, "copilot-acp") == expected
 
+    @pytest.mark.parametrize("model,expected", [
+        ("anthropic/claude-sonnet-4.6", "claude-sonnet-4.6"),
+        ("claude-sonnet-4-6",           "claude-sonnet-4.6"),
+        ("claude-opus-4-6",             "claude-opus-4.6"),
+    ])
+    def test_claude_cli_normalization(self, model, expected):
+        assert normalize_model_for_provider(model, "claude-cli") == expected
+
     def test_openai_codex_still_strips_openai_prefix(self):
         """Regression: openai-codex must still strip the openai/ prefix."""
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -167,7 +167,7 @@ class TestProviderPersistsAfterModelSave:
             "hermes_cli.auth.resolve_external_process_provider_credentials",
             return_value={
                 "provider": "copilot-acp",
-                "api_key": "copilot-acp",
+                "api_key": "***",
                 "base_url": "acp://copilot",
                 "command": "/usr/local/bin/copilot",
                 "args": ["--acp", "--stdio"],
@@ -177,7 +177,7 @@ class TestProviderPersistsAfterModelSave:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={
                 "provider": "copilot",
-                "api_key": "gh-cli-token",
+                "api_key": "***",
                 "base_url": "https://api.githubcopilot.com",
                 "source": "gh auth token",
             },
@@ -213,7 +213,48 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("default") == "gpt-5.4"
         assert model.get("api_mode") == "chat_completions"
 
+    def test_claude_cli_provider_saved_when_selected(self, config_home):
+        """_model_flow_claude_cli should persist separate provider/base_url/model together."""
+        from hermes_cli.main import _model_flow_claude_cli
+        from hermes_cli.config import load_config
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            return_value={
+                "resolved_command": "/usr/local/bin/claude",
+                "command": "claude",
+                "base_url": "claude-cli://local",
+            },
+        ), patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "claude-cli",
+                "api_key": "claude-cli",
+                "base_url": "claude-cli://local",
+                "command": "/usr/local/bin/claude",
+                "args": [],
+                "source": "process",
+            },
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="claude-sonnet-4.6",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ):
+            _model_flow_claude_cli(load_config(), "old-model")
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict), f"model should be dict, got {type(model)}"
+        assert model.get("provider") == "claude-cli"
+        assert model.get("base_url") == "claude-cli://local"
+        assert model.get("default") == "claude-sonnet-4.6"
+        assert model.get("api_mode") == "chat_completions"
+
     def test_opencode_go_models_are_selectable_and_persist_normalized(self, config_home, monkeypatch):
+
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -174,6 +174,7 @@ class TestProviderLabel:
         assert provider_label("stepfun") == "StepFun Step Plan"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("claude-cli") == "Claude CLI"
         assert provider_label("auto") == "Auto"
 
     def test_unknown_provider_preserves_original_name(self):
@@ -245,6 +246,11 @@ class TestProviderModelIds:
         assert "gemini-3.1-pro-preview" in ids
         assert "copilot-acp" not in ids
         assert "claude-opus-4.6" not in ids
+
+    def test_claude_cli_uses_curated_claude_models(self):
+        ids = provider_model_ids("claude-cli")
+        assert "claude-opus-4.6" in ids
+        assert "claude-sonnet-4.6" in ids
 
 
 # -- fetch_api_models --------------------------------------------------------

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3924,6 +3924,125 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_uses_claude_cli_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="claude-cli",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+            acp_command="/usr/local/bin/claude",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    mock_openai.assert_not_called()
+    mock_claude_client.assert_called_once()
+    assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "claude-cli"
+    assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_claude_client.call_args.kwargs["args"] == []
+
+
+def test_aiagent_does_not_bind_claude_cli_runtime_state_from_session_db():
+    session_db = MagicMock()
+    session_db.get_session.return_value = {
+        "model_config": json.dumps(
+            {
+                "runtime_state": {
+                    "claude-cli": {
+                        "claude_session_id": "11111111-1111-1111-1111-111111111111",
+                        "synced_message_count": 7,
+                    }
+                }
+            }
+        )
+    }
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        cli_client.export_session_state.return_value = {
+            "claude_session_id": "11111111-1111-1111-1111-111111111111",
+            "synced_message_count": 7,
+        }
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="claude-cli",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+            session_id="session-123",
+            session_db=session_db,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    cli_client.export_session_state.assert_not_called()
+    assert "hermes_session_id" not in agent._client_kwargs
+    assert "session_state" not in agent._client_kwargs
+
+
+def test_switch_model_to_claude_cli_does_not_restore_backend_session_state():
+    agent = object.__new__(AIAgent)
+    agent.provider = "claude-cli"
+    agent.session_id = "session-123"
+    agent.model = "claude-haiku"
+    agent.base_url = "claude-cli://local"
+    agent.api_key = "claude-cli"
+    agent.api_mode = "chat_completions"
+    agent.acp_command = "/usr/local/bin/claude"
+    agent.acp_args = []
+    agent.client = MagicMock()
+    agent.client.export_session_state.return_value = {
+        "claude_session_id": "22222222-2222-2222-2222-222222222222",
+        "synced_message_count": 5,
+    }
+    agent._client_kwargs = {
+        "base_url": "claude-cli://local",
+        "api_key": "claude-cli",
+        "session_state": {"claude_session_id": "stale"},
+    }
+    agent._session_db = None
+    agent._transport_cache = {}
+    agent._config_context_length = None
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent.context_compressor = None
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+
+    with patch("run_agent.get_provider_request_timeout", return_value=None):
+        agent.switch_model(
+            new_model="claude-sonnet-4.6",
+            new_provider="claude-cli",
+            api_key="claude-cli",
+            base_url="claude-cli://local",
+            api_mode="chat_completions",
+        )
+
+    created_kwargs = agent._create_openai_client.call_args.args[0]
+    assert created_kwargs["command"] == "/usr/local/bin/claude"
+    assert created_kwargs["args"] == []
+    assert "hermes_session_id" not in created_kwargs
+    assert "session_state" not in created_kwargs
+    assert "session_state" not in agent._primary_runtime["client_kwargs"]
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):
@@ -4160,6 +4279,15 @@ class TestStreamingApiCall:
         callback.assert_any_call("Hel")
         callback.assert_any_call("lo ")
         callback.assert_any_call("World")
+
+    def test_non_streaming_response_object_falls_back_cleanly(self, agent):
+        resp = _mock_response(content="PINEAPPLE", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        recovered = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert recovered is resp
+        assert recovered.choices[0].message.content == "PINEAPPLE"
 
     def test_tool_call_accumulation(self, agent):
         # Per OpenAI streaming spec, function names are delivered atomically


### PR DESCRIPTION
Cleaned up substantially and recombined into one review branch.

## Scope
- Persist gateway session-scoped `/model` overrides on `SessionEntry`
- Restore persisted model/provider/base_url/api_mode overrides after gateway restart
- Clear persisted overrides on `/new` and `/reset`
- Add a `claude-cli` provider lane backed by the local `claude` command
- Use Claude CLI only as a stateless auth/inference transport
- Send the full Hermes transcript every turn; Hermes remains the orchestrator for tools, logging, budget, and turn state

## Guardrails
- No `--permission-mode bypassPermissions`
- No `--resume` or `--session-id`
- No backend Claude session persistence or runtime-state sync
- No arbitrary `HERMES_CLAUDE_CLI_ARGS`; only `HERMES_CLAUDE_CLI_COMMAND` is supported

## Tests
`UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/gateway/test_session.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_model_reset.py tests/agent/test_claude_cli_client.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_codex_cli_model_picker.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_model_validation.py tests/run_agent/test_run_agent.py -q`

Result: 668 passed.
