### PR TITLE
fix(browser): validate live Chrome CDP connect

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6618,17 +6618,39 @@ class HermesCLI:
             else:
                 print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")
 
-            os.environ["BROWSER_CDP_URL"] = cdp_url
+            try:
+                from tools.browser_tool import (
+                    _ensure_cdp_supervisor,  # type: ignore[import-not-found]
+                    _is_cdp_discovery_shorthand,
+                    _resolve_cdp_override,
+                )
+
+                resolved_cdp_url = _resolve_cdp_override(cdp_url)
+                if (
+                    _is_cdp_discovery_shorthand(cdp_url)
+                    and resolved_cdp_url == cdp_url
+                ):
+                    print()
+                    print("   ⚠ Chrome is listening, but Hermes could not resolve a usable CDP websocket")
+                    print("     Discovery endpoint /json/version did not expose webSocketDebuggerUrl.")
+                    print("     Use a full ws://.../devtools/browser/... endpoint, or launch Chrome")
+                    print("     with --remote-debugging-port and a non-default --user-data-dir.")
+                    return
+            except Exception as exc:
+                print()
+                print(f"   ⚠ Could not validate CDP endpoint {cdp_url}: {exc}")
+                return
+
+            os.environ["BROWSER_CDP_URL"] = resolved_cdp_url
             # Eagerly start the CDP supervisor so pending_dialogs + frame_tree
             # show up in the next browser_snapshot.  No-op if already started.
             try:
-                from tools.browser_tool import _ensure_cdp_supervisor  # type: ignore[import-not-found]
                 _ensure_cdp_supervisor("default")
             except Exception:
                 pass
             print()
             print("🌐 Browser connected to live Chrome via CDP")
-            print(f"   Endpoint: {cdp_url}")
+            print(f"   Endpoint: {resolved_cdp_url}")
             print()
 
             # Inject context message so the model knows

--- a/tests/test_cli_browser_connect.py
+++ b/tests/test_cli_browser_connect.py
@@ -19,6 +19,7 @@ def test_browser_connect_refuses_unresolved_discovery_endpoint(monkeypatch, caps
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
     monkeypatch.setattr("socket.socket", lambda *a, **kw: _FakeSocket())
     monkeypatch.setattr("tools.browser_tool.cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr("tools.browser_tool._ensure_cdp_supervisor", lambda _task_id: None)
     monkeypatch.setattr("tools.browser_tool._resolve_cdp_override", lambda url: url)
 
     cli._handle_browser_command("/browser connect http://127.0.0.1:9222")
@@ -33,10 +34,15 @@ def test_browser_connect_stores_resolved_websocket_endpoint(monkeypatch, capsys)
     from cli import HermesCLI
 
     resolved = "ws://127.0.0.1:9222/devtools/browser/abc123"
+    supervisor_starts = []
     cli = object.__new__(HermesCLI)
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
     monkeypatch.setattr("socket.socket", lambda *a, **kw: _FakeSocket())
     monkeypatch.setattr("tools.browser_tool.cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr(
+        "tools.browser_tool._ensure_cdp_supervisor",
+        lambda task_id: supervisor_starts.append(task_id),
+    )
     monkeypatch.setattr("tools.browser_tool._resolve_cdp_override", lambda url: resolved)
 
     cli._handle_browser_command("/browser connect http://127.0.0.1:9222")
@@ -45,3 +51,4 @@ def test_browser_connect_stores_resolved_websocket_endpoint(monkeypatch, capsys)
     assert "Browser connected to live Chrome via CDP" in output
     assert f"Endpoint: {resolved}" in output
     assert os.environ["BROWSER_CDP_URL"] == resolved
+    assert supervisor_starts == ["default"]

--- a/tests/test_cli_browser_connect.py
+++ b/tests/test_cli_browser_connect.py
@@ -1,0 +1,47 @@
+import os
+
+
+class _FakeSocket:
+    def settimeout(self, _timeout):
+        pass
+
+    def connect(self, _addr):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_browser_connect_refuses_unresolved_discovery_endpoint(monkeypatch, capsys):
+    from cli import HermesCLI
+
+    cli = object.__new__(HermesCLI)
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.setattr("socket.socket", lambda *a, **kw: _FakeSocket())
+    monkeypatch.setattr("tools.browser_tool.cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr("tools.browser_tool._resolve_cdp_override", lambda url: url)
+
+    cli._handle_browser_command("/browser connect http://127.0.0.1:9222")
+
+    output = capsys.readouterr().out
+    assert "could not resolve a usable CDP websocket" in output
+    assert "Browser connected to live Chrome via CDP" not in output
+    assert os.environ.get("BROWSER_CDP_URL") is None
+
+
+def test_browser_connect_stores_resolved_websocket_endpoint(monkeypatch, capsys):
+    from cli import HermesCLI
+
+    resolved = "ws://127.0.0.1:9222/devtools/browser/abc123"
+    cli = object.__new__(HermesCLI)
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.setattr("socket.socket", lambda *a, **kw: _FakeSocket())
+    monkeypatch.setattr("tools.browser_tool.cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr("tools.browser_tool._resolve_cdp_override", lambda url: resolved)
+
+    cli._handle_browser_command("/browser connect http://127.0.0.1:9222")
+
+    output = capsys.readouterr().out
+    assert "Browser connected to live Chrome via CDP" in output
+    assert f"Endpoint: {resolved}" in output
+    assert os.environ["BROWSER_CDP_URL"] == resolved

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -9,6 +9,19 @@ VERSION_URL = f"{HTTP_URL}/json/version"
 
 
 class TestResolveCdpOverride:
+    def test_identifies_discovery_shorthand_inputs(self):
+        from tools.browser_tool import _is_cdp_discovery_shorthand
+
+        assert _is_cdp_discovery_shorthand("http://localhost:9222")
+        assert _is_cdp_discovery_shorthand("http://localhost:9222/json/version")
+        assert _is_cdp_discovery_shorthand("ws://localhost:9222")
+        assert not _is_cdp_discovery_shorthand(
+            "ws://localhost:9222/devtools/browser/abc123"
+        )
+        assert not _is_cdp_discovery_shorthand(
+            "wss://connect.browserbase.example/session/abc123"
+        )
+
     def test_keeps_full_devtools_websocket_url(self):
         from tools.browser_tool import _resolve_cdp_override
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -260,6 +260,23 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     return raw
 
 
+def _is_cdp_discovery_shorthand(cdp_url: str) -> bool:
+    """Return True for CDP inputs that must resolve through /json/version."""
+    raw = (cdp_url or "").strip()
+    if not raw:
+        return False
+
+    lowered = raw.lower()
+    if "/devtools/browser/" in lowered:
+        return False
+    if lowered.startswith(("http://", "https://")):
+        return True
+    if lowered.startswith(("ws://", "wss://")):
+        host_and_path = raw.split("://", 1)[1].rstrip("/")
+        return "/" not in host_and_path
+    return False
+
+
 def _get_cdp_override() -> str:
     """Return a normalized CDP URL override, or empty string.
 


### PR DESCRIPTION
## Summary\n- Fixes #12912.\n- Makes /browser connect validate that discovery-style CDP inputs resolve to a concrete websocket before reporting success.\n- Stores the resolved websocket endpoint in BROWSER_CDP_URL instead of the ambiguous shorthand.\n- Leaves full websocket endpoints usable, but refuses misleading success when /json/version does not expose webSocketDebuggerUrl.\n\n## Root cause\n/browser connect checked only that a TCP port was open, then unconditionally set BROWSER_CDP_URL and printed a success message. Later browser tools still depend on CDP endpoint resolution, so Chrome modes where /json/version returns 404 could look connected while remaining unusable.\n\n## Tests\n- source /Users/stephenyu/Documents/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_browser_cdp_override.py tests/test_cli_browser_connect.py\n- source /Users/stephenyu/Documents/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_browser_homebrew_paths.py tests/tools/test_browser_hardening.py tests/tools/test_browser_ssrf_local.py\n- git diff --check