### PR TITLE
fix: normalize imported session timestamps

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -198,8 +198,30 @@ from hermes_constants import AI_GATEWAY_BASE_URL, OPENROUTER_BASE_URL
 logger = logging.getLogger(__name__)
 
 
+def _coerce_timestamp(ts):
+    """Best-effort parse for epoch or ISO-8601 timestamps."""
+    if ts is None or ts == "":
+        return None
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        raw = ts.strip()
+        if not raw:
+            return None
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 def _relative_time(ts) -> str:
     """Format a timestamp as relative time (e.g., '2h ago', 'yesterday')."""
+    ts = _coerce_timestamp(ts)
     if not ts:
         return "?"
     delta = _time.time() - ts

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -899,8 +899,36 @@ def _termux_should_prefetch_update_check() -> bool:
     return os.environ.get("HERMES_TERMUX_PREFETCH_UPDATES") == "1"
 
 
+def _coerce_timestamp(ts):
+    """Best-effort parse for epoch or ISO-8601 timestamp values.
+
+    SessionDB normalizes legacy ISO TEXT timestamps at the source (v23
+    migration + import coercion), but rows written by older builds can
+    still reach the formatter before that migration has run. Defensive
+    coercion keeps `hermes sessions` from crashing on `time.time() - ts`.
+    """
+    if ts is None or ts == "":
+        return None
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        raw = ts.strip()
+        if not raw:
+            return None
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 def _relative_time(ts) -> str:
     """Format a timestamp as relative time (e.g., '2h ago', 'yesterday')."""
+    ts = _coerce_timestamp(ts)
     if not ts:
         return "?"
     delta = _time.time() - ts

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+from datetime import datetime
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
@@ -28,6 +29,32 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _normalize_timestamp(value: Any) -> Any:
+    """Best-effort normalization for legacy/imported timestamp values.
+
+    Session rows are supposed to store REAL epoch seconds, but imported data may
+    contain ISO-8601 strings. Normalize those on read so downstream callers can
+    safely compare/subtract timestamps without exploding.
+    """
+    if value is None or value == "":
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return value
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return value
+    return value
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
@@ -858,6 +885,9 @@ class SessionDB:
         sessions = []
         for row in rows:
             s = dict(row)
+            for key in ("started_at", "ended_at", "last_active"):
+                if key in s:
+                    s[key] = _normalize_timestamp(s.get(key))
             # Build the preview from the raw substring
             raw = s.pop("_preview_raw", "").strip()
             if raw:
@@ -930,6 +960,9 @@ class SessionDB:
         if not row:
             return None
         s = dict(row)
+        for key in ("started_at", "ended_at", "last_active"):
+            if key in s:
+                s[key] = _normalize_timestamp(s.get(key))
         raw = s.pop("_preview_raw", "").strip()
         if raw:
             text = raw[:60]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,6 +23,7 @@ import sqlite3
 import sys
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -152,7 +153,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -1948,6 +1949,34 @@ class SessionDB:
                         )
                 except sqlite3.OperationalError as exc:
                     logger.debug("v22 session_model_usage rebuild skipped: %s", exc)
+            if current_version < 23:
+                # v23: normalize legacy ISO-8601 TEXT timestamps to REAL epoch
+                # seconds. Sessions imported from external tools (e.g. the
+                # OpenClaw migration) could land with ISO strings in
+                # sessions.started_at/ended_at and messages.timestamp. TEXT
+                # values break SQL-level ORDER BY/MAX (TEXT sorts after REAL
+                # regardless of instant) and downstream arithmetic
+                # (``time.time() - ts`` TypeErrors in the CLI/dashboard).
+                # Normalizing once at the source fixes every reader — the
+                # rich list, the order_by_last_active CTE, list_cron_job_runs,
+                # and the dashboard's last_active subtraction — without
+                # per-row coercion on every read. strftime('%s') parses
+                # ISO-8601 (naive treated as UTC); non-parseable TEXT is
+                # left untouched rather than destroyed.
+                try:
+                    for _tbl, _cols in (
+                        ("sessions", ("started_at", "ended_at")),
+                        ("messages", ("timestamp",)),
+                    ):
+                        for _col in _cols:
+                            cursor.execute(
+                                f"UPDATE {_tbl} "
+                                f"SET {_col} = CAST(strftime('%s', {_col}) AS REAL) "
+                                f"WHERE typeof({_col}) = 'text' "
+                                f"AND strftime('%s', {_col}) IS NOT NULL"
+                            )
+                except sqlite3.OperationalError as exc:
+                    logger.debug("v23 timestamp normalization skipped: %s", exc)
             if current_version < SCHEMA_VERSION and fts_migrations_complete:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -4375,14 +4404,18 @@ class SessionDB:
             tool_calls = msg.get("tool_calls")
             message_timestamp = now_ts
             if msg.get("timestamp") is not None:
-                try:
-                    ts_value = msg.get("timestamp")
-                    if hasattr(ts_value, "timestamp"):
+                ts_value = msg.get("timestamp")
+                if hasattr(ts_value, "timestamp"):
+                    try:
                         message_timestamp = float(ts_value.timestamp())
+                    except (TypeError, ValueError, OSError):
+                        logger.debug("Ignoring invalid explicit message timestamp: %r", ts_value)
+                else:
+                    coerced = self._timestamp_or_none(ts_value)
+                    if coerced is not None:
+                        message_timestamp = coerced
                     else:
-                        message_timestamp = float(ts_value)
-                except (TypeError, ValueError):
-                    logger.debug("Ignoring invalid explicit message timestamp: %r", msg.get("timestamp"))
+                        logger.debug("Ignoring invalid explicit message timestamp: %r", ts_value)
             reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
             codex_reasoning_items = (
                 msg.get("codex_reasoning_items") if role == "assistant" else None
@@ -6220,6 +6253,36 @@ class SessionDB:
             return None
 
     @staticmethod
+    def _timestamp_or_none(value: Any) -> Optional[float]:
+        """Coerce an epoch number, numeric string, or ISO-8601 string to epoch seconds.
+
+        Import payloads produced by external exporters routinely carry ISO
+        strings; storing them as TEXT breaks SQL ordering and timestamp
+        arithmetic (see the v23 migration). Naive ISO strings are treated as
+        UTC to match SQLite's strftime('%s') used by that migration.
+        """
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                return None
+            try:
+                return float(raw)
+            except ValueError:
+                pass
+            try:
+                parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp()
+        return None
+
+    @staticmethod
     def _import_int_or_none(value: Any, field: str) -> Optional[int]:
         if value is None:
             return None
@@ -6435,7 +6498,7 @@ class SessionDB:
                     skipped_ids.append(session_id)
                     continue
 
-                started_at = self._float_or_none(raw.get("started_at"))
+                started_at = self._timestamp_or_none(raw.get("started_at"))
                 if started_at is None:
                     started_at = time.time()
                 archived = 1 if raw.get("archived") else 0
@@ -6470,7 +6533,7 @@ class SessionDB:
                         "model_config": raw.get("model_config"),
                         "system_prompt": raw.get("system_prompt"),
                         "started_at": started_at,
-                        "ended_at": self._float_or_none(raw.get("ended_at")),
+                        "ended_at": self._timestamp_or_none(raw.get("ended_at")),
                         "end_reason": raw.get("end_reason"),
                         "input_tokens": self._int_or_default(raw.get("input_tokens")),
                         "output_tokens": self._int_or_default(raw.get("output_tokens")),

--- a/tests/hermes_cli/test_relative_time.py
+++ b/tests/hermes_cli/test_relative_time.py
@@ -1,0 +1,10 @@
+import time
+
+from hermes_cli.main import _relative_time
+
+
+def test_relative_time_accepts_iso_timestamps():
+    ts = time.time() - 7200
+    iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(ts))
+
+    assert _relative_time(iso) == "2h ago"

--- a/tests/hermes_cli/test_relative_time.py
+++ b/tests/hermes_cli/test_relative_time.py
@@ -1,0 +1,27 @@
+"""_relative_time must tolerate legacy ISO-8601 timestamp strings.
+
+SessionDB normalizes timestamps at the source, but rows written by older
+builds can reach the formatter before the migration has run; the CLI list
+must degrade gracefully instead of raising TypeError.
+"""
+
+import time
+from datetime import datetime, timezone
+
+from hermes_cli.main import _relative_time
+
+
+def test_relative_time_accepts_iso_timestamps():
+    ts = time.time() - 7200
+    iso = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    assert _relative_time(iso) == "2h ago"
+
+
+def test_relative_time_accepts_epoch_strings():
+    ts = time.time() - 120
+    assert _relative_time(str(ts)) == "2m ago"
+
+
+def test_relative_time_unparseable_returns_placeholder():
+    assert _relative_time("not-a-timestamp") == "?"
+    assert _relative_time(None) == "?"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1438,6 +1438,22 @@ class TestListSessionsRich:
         # No messages, so last_active falls back to started_at
         assert sessions[0]["last_active"] == sessions[0]["started_at"]
 
+    def test_last_active_normalizes_legacy_iso_started_at(self, db):
+        db.create_session("legacy", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=? WHERE id=?",
+            ("2026-04-09T12:00:00", "2026-04-09T13:00:00", "legacy"),
+        )
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich()
+        legacy = next(s for s in sessions if s["id"] == "legacy")
+
+        assert isinstance(legacy["started_at"], float)
+        assert isinstance(legacy["ended_at"], float)
+        assert isinstance(legacy["last_active"], float)
+        assert legacy["last_active"] == legacy["started_at"]
+
     def test_rich_list_includes_title(self, db):
         db.create_session("s1", "cli")
         db.set_session_title("s1", "refactoring auth")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -6271,6 +6271,155 @@ class TestGetMessagesPagination:
 # Lone-surrogate persistence
 # =========================================================================
 
+class TestLegacyTimestampNormalization:
+    """Legacy/imported ISO-8601 TEXT timestamps must become REAL epoch seconds.
+
+    ISO TEXT in sessions.started_at / messages.timestamp breaks SQL-level
+    ORDER BY and MAX (TEXT sorts after REAL regardless of instant) and blows
+    up ``time.time() - ts`` arithmetic in the CLI and dashboard. The contract:
+    SessionDB normalizes at the source — a one-time v23 migration for existing
+    rows, plus coercion in import_sessions — so every reader sees numbers.
+    """
+
+    ISO_OLD = "2026-04-09T12:00:00+00:00"
+    ISO_OLD_EPOCH = 1775736000.0
+
+    def _reopen_with_downgraded_schema(self, db, tmp_path):
+        """Simulate a pre-v23 DB: plant legacy rows, mark schema v22, reopen."""
+        db._conn.execute("UPDATE schema_version SET version = 22")
+        db._conn.commit()
+        path = db.db_path
+        db.close()
+        return SessionDB(db_path=path)
+
+    def test_v23_migration_normalizes_session_and_message_timestamps(self, db, tmp_path):
+        db.create_session("legacy", "cli")
+        db.append_message("legacy", "user", "hello from the past")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=? WHERE id=?",
+            (self.ISO_OLD, "2026-04-09T13:00:00+00:00", "legacy"),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp=? WHERE session_id=?",
+            (self.ISO_OLD, "legacy"),
+        )
+        db._conn.commit()
+
+        migrated = self._reopen_with_downgraded_schema(db, tmp_path)
+        try:
+            row = migrated._conn.execute(
+                "SELECT started_at, ended_at, typeof(started_at) AS t1, "
+                "typeof(ended_at) AS t2 FROM sessions WHERE id='legacy'"
+            ).fetchone()
+            assert row["t1"] == "real"
+            assert row["t2"] == "real"
+            assert row["started_at"] == self.ISO_OLD_EPOCH
+
+            mrow = migrated._conn.execute(
+                "SELECT timestamp, typeof(timestamp) AS t "
+                "FROM messages WHERE session_id='legacy'"
+            ).fetchone()
+            assert mrow["t"] == "real"
+            assert mrow["timestamp"] == self.ISO_OLD_EPOCH
+        finally:
+            migrated.close()
+
+    def test_v23_migration_fixes_sql_ordering_against_numeric_rows(self, db, tmp_path):
+        # Legacy ISO row is OLDER than the numeric row, but TEXT sorts after
+        # REAL — so before normalization it would incorrectly sort first.
+        db.create_session("legacy-old", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?",
+            (self.ISO_OLD, "legacy-old"),
+        )
+        db._conn.commit()
+        db.create_session("numeric-new", "cli")
+
+        migrated = self._reopen_with_downgraded_schema(db, tmp_path)
+        try:
+            sessions = migrated.list_sessions_rich(order_by_last_active=True)
+            ids = [s["id"] for s in sessions]
+            assert ids.index("numeric-new") < ids.index("legacy-old")
+            # last_active must be numeric for downstream arithmetic.
+            for s in sessions:
+                assert isinstance(s["last_active"], float)
+                _ = time.time() - s["last_active"]
+        finally:
+            migrated.close()
+
+    def test_v23_migration_leaves_unparseable_text_untouched(self, db, tmp_path):
+        db.create_session("garbage", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?",
+            ("not-a-timestamp", "garbage"),
+        )
+        db._conn.commit()
+
+        migrated = self._reopen_with_downgraded_schema(db, tmp_path)
+        try:
+            row = migrated._conn.execute(
+                "SELECT started_at FROM sessions WHERE id='garbage'"
+            ).fetchone()
+            assert row["started_at"] == "not-a-timestamp"
+        finally:
+            migrated.close()
+
+    def test_import_sessions_coerces_iso_timestamps(self, db):
+        result = db.import_sessions(
+            [
+                {
+                    "id": "imported-iso",
+                    "source": "import",
+                    "started_at": self.ISO_OLD,
+                    "ended_at": "2026-04-09T13:00:00Z",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "imported message",
+                            "timestamp": self.ISO_OLD,
+                        }
+                    ],
+                }
+            ]
+        )
+        assert result["ok"] is True
+        assert result["imported"] == 1
+
+        row = db._conn.execute(
+            "SELECT started_at, ended_at, typeof(started_at) AS t1, "
+            "typeof(ended_at) AS t2 FROM sessions WHERE id='imported-iso'"
+        ).fetchone()
+        assert row["t1"] == "real"
+        assert row["t2"] == "real"
+        assert row["started_at"] == self.ISO_OLD_EPOCH
+
+        mrow = db._conn.execute(
+            "SELECT timestamp, typeof(timestamp) AS t "
+            "FROM messages WHERE session_id='imported-iso'"
+        ).fetchone()
+        assert mrow["t"] == "real"
+        assert mrow["timestamp"] == self.ISO_OLD_EPOCH
+
+    def test_cron_job_runs_last_active_stays_numeric(self, db):
+        sid = "cron_tsjob_00000001"
+        db.create_session(session_id=sid, source="cron")
+        db.append_message(sid, role="user", content="tick")
+        runs = db.list_cron_job_runs("tsjob")
+        assert len(runs) == 1
+        assert isinstance(runs[0]["last_active"], float)
+        _ = time.time() - runs[0]["last_active"]
+
+    def test_timestamp_or_none_contract(self):
+        assert SessionDB._timestamp_or_none(None) is None
+        assert SessionDB._timestamp_or_none("") is None
+        assert SessionDB._timestamp_or_none(1700000000) == 1700000000.0
+        assert SessionDB._timestamp_or_none("1700000000.5") == 1700000000.5
+        assert SessionDB._timestamp_or_none(self.ISO_OLD) == self.ISO_OLD_EPOCH
+        # Naive ISO is treated as UTC (matches the SQL migration).
+        assert SessionDB._timestamp_or_none("2026-04-09T12:00:00") == self.ISO_OLD_EPOCH
+        assert SessionDB._timestamp_or_none("garbage") is None
+
+
 class TestLoneSurrogatePersistence:
     """sqlite3 encodes bound str params as UTF-8 and raises UnicodeEncodeError
     on lone surrogates (U+D800..U+DFFF). Tool results scraped from the web can


### PR DESCRIPTION
## Summary
- normalize legacy/imported ISO-8601 session timestamps when reading SessionDB rows
- make CLI relative-time formatting accept epoch or ISO timestamps instead of crashing
- add regression coverage for imported-session rows and CLI formatting

## Problem
OpenClaw session imports can leave `sessions.started_at` as an ISO-8601 string like `2026-04-09T12:00:00`.

`SessionDB.list_sessions_rich()` surfaces that value as `last_active` when a session has no message timestamps to override it. The CLI then does:

- `hermes sessions list`
- `_relative_time(s.get("last_active"))`
- `time.time() - ts`

…which blows up with:

```text
TypeError: unsupported operand type(s) for -: 'float' and 'str'
```

This is easy to hit for imported history, especially OpenClaw migration data, and it breaks more than the pretty list output: anything that compares `last_active` numerically can trip over the same mixed-type row shape.

## Fix
Two layers of defense:

1. `hermes_state.py`
   - add `_normalize_timestamp()`
   - normalize `started_at`, `ended_at`, and `last_active` on read in `list_sessions_rich()` and `_get_session_rich_row()`

2. `hermes_cli/main.py`
   - add `_coerce_timestamp()`
   - make `_relative_time()` accept epoch floats, numeric strings, and ISO-8601 strings

The SessionDB normalization is the real fix; the CLI coercion is a belt-and-suspenders guard so imported legacy rows do not crater the UI.

## Why this matters
OpenClaw session import is already an active feature area (`#4112`, PR `#4120`). Even if future importers write clean `REAL` timestamps, existing migrated databases and any third-party import path can still leave legacy string values behind. The CLI should not faceplant on historical data.

## Tests
- added `test_last_active_normalizes_legacy_iso_started_at`
- added `tests/hermes_cli/test_relative_time.py`
- verified locally:
  - `python -m pytest tests/test_hermes_state.py -k 'last_active' -q -o 'addopts='`
  - `python -m pytest tests/hermes_cli/test_relative_time.py -q -o 'addopts='`
  - `python -m pytest tests/test_hermes_state.py tests/hermes_cli/test_relative_time.py -q -o 'addopts='`
- reproduced the original crash before the fix and verified `hermes sessions list` succeeds after it

## Repro before fix
```text
jeanclaude@JCvA:~$ hermes sessions list
...
TypeError: unsupported operand type(s) for -: 'float' and 'str'
```
