### PR TITLE
fix(gateway): merge restart resume transcript tail

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1220,6 +1220,13 @@ class SessionStore:
                                 session_id, line[:120],
                             )
 
+        if self._is_resume_pending_session_id(session_id):
+            return self._merge_resume_pending_transcript(
+                session_id,
+                jsonl_messages,
+                db_messages,
+            )
+
         # Prefer whichever source has more messages.
         #
         # Background: when a session pre-dates SQLite storage (or when the DB
@@ -1240,6 +1247,87 @@ class SessionStore:
             return jsonl_messages
 
         return db_messages
+
+    def _is_resume_pending_session_id(self, session_id: str) -> bool:
+        """Return True when a live SessionEntry is waiting for restart resume."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return any(
+                entry.session_id == session_id and entry.resume_pending
+                for entry in self._entries.values()
+            )
+
+    @staticmethod
+    def _message_identity(message: Dict[str, Any]) -> str:
+        """Canonicalize the fields that identify the visible conversation turn."""
+        comparable = {
+            "role": message.get("role"),
+            "content": message.get("content"),
+            "tool_call_id": message.get("tool_call_id"),
+            "tool_calls": message.get("tool_calls"),
+            "tool_name": message.get("tool_name"),
+        }
+        return json.dumps(comparable, sort_keys=True, ensure_ascii=False, default=str)
+
+    @classmethod
+    def _merge_resume_pending_transcript(
+        cls,
+        session_id: str,
+        jsonl_messages: List[Dict[str, Any]],
+        db_messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Merge restart-resume transcripts without dropping an interrupted tail.
+
+        Normal sessions keep the legacy "longer source wins" behavior above.
+        Resume-pending sessions are different: SQLite may contain the newest
+        interrupted messages while JSONL still has the longer pre-restart
+        history.  Preserve JSONL history, then append only the SQLite suffix
+        that is not already represented.
+        """
+        if not jsonl_messages:
+            return db_messages
+        if not db_messages:
+            return jsonl_messages
+
+        jsonl_ids = [cls._message_identity(msg) for msg in jsonl_messages]
+        db_ids = [cls._message_identity(msg) for msg in db_messages]
+
+        if cls._contains_contiguous_subsequence(jsonl_ids, db_ids):
+            return jsonl_messages
+        if cls._contains_contiguous_subsequence(db_ids, jsonl_ids):
+            return db_messages
+
+        max_overlap = min(len(jsonl_ids), len(db_ids))
+        overlap = 0
+        for size in range(max_overlap, 0, -1):
+            if jsonl_ids[-size:] == db_ids[:size]:
+                overlap = size
+                break
+
+        merged = jsonl_messages + db_messages[overlap:]
+        logger.debug(
+            "Session %s: merged resume-pending transcript from JSONL (%d) "
+            "and SQLite (%d) with %d-message overlap -> %d messages",
+            session_id, len(jsonl_messages), len(db_messages),
+            overlap, len(merged),
+        )
+        return merged
+
+    @staticmethod
+    def _contains_contiguous_subsequence(
+        haystack: List[str],
+        needle: List[str],
+    ) -> bool:
+        """Return True if *needle* appears contiguously inside *haystack*."""
+        if not needle:
+            return True
+        if len(needle) > len(haystack):
+            return False
+        limit = len(haystack) - len(needle) + 1
+        for start in range(limit):
+            if haystack[start:start + len(needle)] == needle:
+                return True
+        return False
 
 
 def build_session_context(

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -586,6 +586,73 @@ class TestLoadTranscriptPreferLongerSource:
         # Should be the SQLite version (equal count → prefers SQLite)
         assert result[0]["content"] == "db-q"
 
+    def test_resume_pending_merges_newer_sqlite_tail(self, store_with_db):
+        """Restart resume must not drop SQLite-only interrupted-turn messages."""
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="resume-chat",
+            chat_type="group",
+            user_id="u1",
+        )
+        entry = store_with_db.get_or_create_session(source)
+        sid = entry.session_id
+
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            store_with_db.append_to_transcript(
+                sid, {"role": role, "content": f"old-jsonl-{i}"}, skip_db=True,
+            )
+
+        store_with_db._db.append_message(
+            session_id=sid,
+            role="user",
+            content="start long interrupted task",
+        )
+        store_with_db._db.append_message(
+            session_id=sid,
+            role="assistant",
+            content="working on interrupted task",
+        )
+        store_with_db.mark_resume_pending(entry.session_key)
+
+        result = store_with_db.load_transcript(sid)
+
+        assert [msg["content"] for msg in result] == [
+            "old-jsonl-0",
+            "old-jsonl-1",
+            "old-jsonl-2",
+            "old-jsonl-3",
+            "old-jsonl-4",
+            "old-jsonl-5",
+            "start long interrupted task",
+            "working on interrupted task",
+        ]
+
+    def test_resume_pending_does_not_duplicate_sqlite_tail_already_in_jsonl(
+        self,
+        store_with_db,
+    ):
+        """Already synchronized JSONL/SQLite transcripts should stay unchanged."""
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="resume-chat-synced",
+            chat_type="group",
+            user_id="u1",
+        )
+        entry = store_with_db.get_or_create_session(source)
+        sid = entry.session_id
+
+        for msg in [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]:
+            store_with_db.append_to_transcript(sid, msg)
+        store_with_db.mark_resume_pending(entry.session_key)
+
+        result = store_with_db.load_transcript(sid)
+
+        assert [msg["content"] for msg in result] == ["hello", "hi"]
+
 
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""


### PR DESCRIPTION
## Summary
- Fixes #13121.
- Keeps the existing longer-source transcript fallback for normal sessions.
- For `resume_pending` sessions, merges JSONL history with SQLite-only interrupted-turn tail messages so restart recovery does not silently drop the newest pre-restart context.
- Avoids duplicating SQLite messages already present in JSONL.

## Root cause
`SessionStore.load_transcript()` chose whichever transcript source had more messages. That protects legacy JSONL-heavy sessions, but during gateway restart recovery SQLite can contain the newest interrupted-turn messages while JSONL remains longer but stale. The longer-source rule could therefore discard the immediate pre-restart context.

## Validation
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_session.py::TestLoadTranscriptPreferLongerSource tests/gateway/test_restart_resume_pending.py -q --tb=short` -> `38 passed`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_session.py -q --tb=short` -> `65 passed`
- `git diff --check`