### PR TITLE
fix(honcho): auto-enable honcho toolset when configured (rebased)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -607,6 +607,18 @@ def _get_platform_tools(
                 enabled_toolsets.add(pts)
             # else: known but not in config = user disabled it
 
+    # Honcho toolset: auto-enable when configured, similar to plugins.
+    # Honcho is not in CONFIGURABLE_TOOLSETS (it is enabled via `hermes honcho setup`),
+    # so it would be silently dropped when platform_toolsets is explicitly configured.
+    if "honcho" not in enabled_toolsets:
+        try:
+            from honcho_integration.client import HonchoClientConfig
+            hcfg = HonchoClientConfig.from_global_config()
+            if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
+                enabled_toolsets.add("honcho")
+        except Exception:
+            pass  # honcho not installed or not configured — skip silently
+
     # Preserve any explicit non-configurable toolset entries (for example,
     # custom toolsets or MCP server names saved in platform_toolsets).
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}


### PR DESCRIPTION
## Problem

Rebased version of #4553.

After running `hermes tools` to customize toolsets, `platform_toolsets` becomes an explicit dict and honcho is silently dropped from the active toolset — even if the user previously ran `hermes honcho setup`.

## Root Cause

Honcho is not in `CONFIGURABLE_TOOLSETS` (it is configured via `hermes honcho setup`), so it is not included when toolsets are resolved from an explicit config.

## Fix

Added a guard in `_get_platform_tools()` that checks for a valid `HonchoClientConfig` and auto-adds honcho to the enabled set, mirroring the existing auto-enable logic for plugins. Import is guarded in try/except — no breakage if honcho is not installed.

```python
if "honcho" not in enabled_toolsets:
    try:
        from honcho_integration.client import HonchoClientConfig
        hcfg = HonchoClientConfig.from_global_config()
        if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
            enabled_toolsets.add("honcho")
    except Exception:
        pass
```

## Changes

| File | Change |
|------|--------|
| `hermes_cli/tools_config.py` | Honcho auto-enable guard (12 lines) |

Supersedes #4553.