### PR TITLE
feat(gateway): add /list command to browse recent sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3565,6 +3565,9 @@ class GatewayRunner:
         if canonical == "profile":
             return await self._handle_profile_command(event)
 
+        if canonical == "list":
+            return await self._handle_list_command(event)
+
         if canonical == "status":
             return await self._handle_status_command(event)
 
@@ -5080,6 +5083,96 @@ class GatewayRunner:
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ])
+
+        return "\n".join(lines)
+
+    async def _handle_list_command(self, event: MessageEvent) -> str:
+        """Handle /list command — list recent sessions."""
+        from datetime import datetime
+
+        raw_args = event.get_command_args().strip()
+        show_all = "-a" in raw_args
+        raw_args = raw_args.replace("-a", "").strip()
+        try:
+            limit = int(raw_args) if raw_args else 10
+        except ValueError:
+            return "Usage: `/list [limit]` or `/list -a`"
+
+        limit = max(1, min(limit, 50))
+
+        source = event.source
+        current_session_id = None
+        try:
+            current_session_id = self.session_store.get_or_create_session(source).session_id
+        except Exception:
+            pass
+
+        sessions = []
+        if self._session_db:
+            try:
+                sessions = self._session_db.list_sessions_rich(limit=limit)
+            except Exception as e:
+                logger.warning("Failed to list sessions: %s", e)
+
+        if not sessions:
+            return "No sessions found."
+
+        def _format_time(ts):
+            if not ts:
+                return ""
+            dt = datetime.fromtimestamp(ts)
+            return dt.strftime("%Y-%m-%d  %H:%M")
+
+        def _format_tokens(n):
+            if not n:
+                return ""
+            if n >= 1_000_000:
+                return f"{n / 1_000_000:.1f}M"
+            if n >= 1_000:
+                return f"{n / 1_000:.0f}K"
+            return str(n)
+
+        if show_all:
+            titled = sessions
+            section_label = "All Sessions"
+        else:
+            titled = [s for s in sessions if s.get("title")]
+            section_label = "Sessions"
+
+        titled.sort(key=lambda s: s.get("last_active", 0) or 0, reverse=True)
+
+        lines = [section_label, ""]
+
+        if not titled:
+            if show_all:
+                lines.append("No sessions found.")
+            else:
+                lines.append("No named sessions yet.")
+                lines.append("Use /title <name> to name your current session.")
+            return "\n".join(lines)
+
+        for s in titled:
+            sid = s.get("id", "")
+            is_current = sid == (current_session_id or "")
+            name = s["title"] if s.get("title") else sid[:12]
+
+            t = _format_time(s.get("last_active"))
+            tok = _format_tokens((s.get("input_tokens", 0) or 0) + (s.get("output_tokens", 0) or 0))
+
+            meta_parts = [p for p in [t, tok] if p]
+            meta = "  \u2014  ".join(meta_parts) if meta_parts else ""
+
+            if is_current:
+                lines.append(f"**{name}**")
+                if meta:
+                    lines.append(f"  {meta}  \u00b7  current")
+            else:
+                lines.append(f"{name}")
+                if meta:
+                    lines.append(f"  {meta}")
+            lines.append("")
+
+        lines.append("/resume <name>  \u00b7  /list <n>  \u00b7  /list -a")
 
         return "\n".join(lines)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -94,6 +94,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session"),
+    CommandDef("list", "List recent sessions", "Session",
+               gateway_only=True, args_hint="[limit]"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),


### PR DESCRIPTION
Add a `/list` gateway command to browse recent sessions directly from Telegram, Discord, or any connected platform.

## Features
- **Default view** — shows only named sessions (unnamed cannot be resumed)
- **Optional limit** — `/list 20`
- **Show all** — `/list -a` includes unnamed and cron sessions
- **Current session marker** — bold with `current` label
- **Sorting** — newest first, compact token counts (K/M)

## Design
- Uses `list_sessions_rich()` replacing deprecated `list_sessions()`
- Hides untitled sessions by default since `/resume` requires explicit titles
- No emojis, clean typography
- Read-only, no data modification

## Testing
- All existing tests pass (113/113)
- Manual verification on Telegram

## Files
- `gateway/run.py` (+93)
- `hermes_cli/commands.py` (+2)