### PR TITLE
fix(skills): preserve modes during atomic writes

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,6 +1,8 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import os
+import stat
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -12,6 +14,7 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _atomic_write_text,
     _find_skill,
     _resolve_skill_dir,
     _create_skill,
@@ -57,6 +60,25 @@ description: Updated description.
 
 Step 1: Do the new thing.
 """
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteText:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are platform-specific")
+    def test_preserves_existing_file_mode(self, tmp_path):
+        skill_md = tmp_path / "shared-skill" / "SKILL.md"
+        skill_md.parent.mkdir()
+        skill_md.write_text("old", encoding="utf-8")
+        os.chmod(skill_md, 0o660)
+
+        _atomic_write_text(skill_md, "new")
+
+        assert skill_md.read_text(encoding="utf-8") == "new"
+        assert stat.S_IMODE(skill_md.stat().st_mode) == 0o660
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1,7 +1,11 @@
 """Tests for tools/skills_sync.py — manifest-based skill seeding and updating."""
 
+import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from tools.skills_sync import (
     _get_bundled_dir,
@@ -47,6 +51,18 @@ class TestReadWriteManifest:
         lines = manifest_file.read_text().strip().splitlines()
         names = [line.split(":")[0] for line in lines]
         assert names == ["alpha", "middle", "zebra"]
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are platform-specific")
+    def test_write_manifest_preserves_existing_file_mode(self, tmp_path):
+        manifest_file = tmp_path / ".bundled_manifest"
+        manifest_file.write_text("old-skill:oldhash\n", encoding="utf-8")
+        os.chmod(manifest_file, 0o660)
+
+        with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            _write_manifest({"new-skill": "newhash"})
+
+        assert manifest_file.read_text(encoding="utf-8") == "new-skill:newhash\n"
+        assert stat.S_IMODE(manifest_file.stat().st_mode) == 0o660
 
     def test_read_v1_manifest_migration(self, tmp_path):
         """v1 format (plain names, no hashes) should be read with empty hashes."""

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -37,6 +37,7 @@ import logging
 import os
 import re
 import shutil
+import stat
 import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
@@ -265,6 +266,16 @@ def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Pat
     return target, None
 
 
+def _replacement_file_mode(file_path: Path) -> int:
+    """Return the mode an atomic replacement should leave on disk."""
+    try:
+        return stat.S_IMODE(file_path.stat().st_mode)
+    except OSError:
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        return 0o666 & ~current_umask
+
+
 def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -> None:
     """
     Atomically write text content to a file.
@@ -279,6 +290,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
         encoding: Text encoding (default: utf-8)
     """
     file_path.parent.mkdir(parents=True, exist_ok=True)
+    replacement_mode = _replacement_file_mode(file_path)
     fd, temp_path = tempfile.mkstemp(
         dir=str(file_path.parent),
         prefix=f".{file_path.name}.tmp.",
@@ -287,6 +299,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
     try:
         with os.fdopen(fd, "w", encoding=encoding) as f:
             f.write(content)
+        os.chmod(temp_path, replacement_mode)
         os.replace(temp_path, file_path)
     except Exception:
         # Clean up temp file on error

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -25,6 +25,7 @@ import hashlib
 import logging
 import os
 import shutil
+import stat
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Tuple
@@ -35,6 +36,16 @@ logger = logging.getLogger(__name__)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
+
+
+def _replacement_file_mode(file_path: Path) -> int:
+    """Return the mode an atomic replacement should leave on disk."""
+    try:
+        return stat.S_IMODE(file_path.stat().st_mode)
+    except OSError:
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        return 0o666 & ~current_umask
 
 
 def _get_bundled_dir() -> Path:
@@ -86,6 +97,7 @@ def _write_manifest(entries: Dict[str, str]):
 
     MANIFEST_FILE.parent.mkdir(parents=True, exist_ok=True)
     data = "\n".join(f"{name}:{hash_val}" for name, hash_val in sorted(entries.items())) + "\n"
+    replacement_mode = _replacement_file_mode(MANIFEST_FILE)
 
     try:
         fd, tmp_path = tempfile.mkstemp(
@@ -98,6 +110,7 @@ def _write_manifest(entries: Dict[str, str]):
                 f.write(data)
                 f.flush()
                 os.fsync(f.fileno())
+            os.chmod(tmp_path, replacement_mode)
             os.replace(tmp_path, MANIFEST_FILE)
         except BaseException:
             try:


### PR DESCRIPTION
## Summary

Fixes #14181.

This preserves file permissions when Hermes rewrites skill runtime files through atomic temp-file replacement.

## Root cause

`tempfile.mkstemp()` creates replacement files as `0600`. Both `skill_manage` writes and bundled skill manifest writes then used `os.replace()` directly, so existing group-readable/group-writable files could be silently recreated as owner-private files in managed/shared deployments.

## Fix

- Preserve the existing target file mode before replacing `SKILL.md` or `.bundled_manifest`.
- For new files, apply the process umask-derived default file mode instead of leaving the `mkstemp()` default.
- Add regressions for `skill_manage` atomic writes and `skills_sync` manifest writes preserving `0660` files.

## Validation

- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skill_manager_tool.py::TestAtomicWriteText::test_preserves_existing_file_mode tests/tools/test_skills_sync.py::TestReadWriteManifest::test_write_manifest_preserves_existing_file_mode -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skills_sync.py -q --tb=short`
- `git diff --check`
