### PR TITLE
fix(resume): accept unique truncated title prefixes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -697,7 +697,12 @@ class SessionDB:
         If not, searches for "title #N" variants and returns the latest one.
         If the exact title exists AND numbered variants exist, returns the
         latest numbered variant (the most recent continuation).
+        If neither exists, accepts a unique title prefix so users can resume
+        from titles copied out of width-limited session lists.
         """
+        if not title or not title.strip():
+            return None
+
         # First try exact match
         exact = self.get_session_by_title(title)
 
@@ -717,6 +722,19 @@ class SessionDB:
             return numbered[0]["id"]
         elif exact:
             return exact["id"]
+
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT id FROM sessions "
+                "WHERE title LIKE ? ESCAPE '\\' "
+                "ORDER BY started_at DESC "
+                "LIMIT 2",
+                (f"{escaped}%",),
+            )
+            prefix_matches = cursor.fetchall()
+
+        if len(prefix_matches) == 1:
+            return prefix_matches[0]["id"]
         return None
 
     def get_next_title_in_lineage(self, base_title: str) -> str:
@@ -1588,4 +1606,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1335,6 +1335,27 @@ class TestTitleLineage:
     def test_resolve_nonexistent_title(self, db):
         assert db.resolve_session_by_title("nonexistent") is None
 
+    def test_resolve_blank_title_returns_none(self, db):
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "my project")
+
+        assert db.resolve_session_by_title("") is None
+        assert db.resolve_session_by_title("   ") is None
+
+    def test_resolve_unique_title_prefix_from_truncated_display(self, db):
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "Salvage BytePlus Volcengine PR With Fixes")
+
+        assert db.resolve_session_by_title("Salvage BytePlus Volcengine PR") == "s1"
+
+    def test_resolve_ambiguous_title_prefix_returns_none(self, db):
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "Salvage BytePlus Volcengine PR With Fixes")
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "Salvage BytePlus Volcengine PR Review")
+
+        assert db.resolve_session_by_title("Salvage BytePlus Volcengine PR") is None
+
     def test_next_title_no_existing(self, db):
         """With no existing sessions, base title is returned as-is."""
         assert db.get_next_title_in_lineage("my project") == "my project"
@@ -1911,4 +1932,3 @@ class TestAutoMaintenance:
         assert marker is not None
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
-


### PR DESCRIPTION
## Summary

Fixes #14082.

This lets `/resume <title>` recover sessions when the user copies the width-limited title shown by the recent-session list.

## Root cause

`/resume` tells users they can resume by session ID or title, but the recent-session table truncates titles. The resolver only accepted exact title matches (plus lineage suffixes), so copying the displayed title prefix failed with `Session not found`.

## Fix

- Preserve the existing exact-title and numbered-lineage behavior.
- If exact/lineage resolution fails, accept a unique title prefix.
- Keep ambiguous prefixes unresolved so Hermes does not jump to the wrong session.
- Guard blank title input so it cannot prefix-match arbitrary sessions.

## Validation

- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/test_hermes_state.py::TestTitleLineage::test_resolve_blank_title_returns_none tests/test_hermes_state.py::TestTitleLineage::test_resolve_unique_title_prefix_from_truncated_display tests/test_hermes_state.py::TestTitleLineage::test_resolve_ambiguous_title_prefix_returns_none tests/test_hermes_state.py::TestTitleLineage::test_resolve_exact_title tests/test_hermes_state.py::TestTitleLineage::test_resolve_returns_latest_numbered tests/test_hermes_state.py::TestTitleSqlWildcards::test_resolve_title_with_percent tests/test_hermes_state.py::TestTitleSqlWildcards::test_resolve_title_with_underscore -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/test_hermes_state.py -q --tb=short`
- `git diff --check`
