### PR TITLE
fix(gateway): preserve legacy voice off suppression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -821,14 +821,26 @@ class GatewayRunner:
         if not isinstance(data, dict):
             return {}
 
+        legacy_prefix = "legacy:"
         valid_modes = {"off", "voice_only", "all"}
         result = {}
         for chat_id, mode in data.items():
             if mode not in valid_modes:
                 continue
             key = str(chat_id)
-            # Skip legacy unprefixed keys (warn and skip)
+            # Legacy keys have no platform namespace. Preserve only "off"
+            # because it is a conservative auto-TTS suppression state; enabling
+            # voice replies for an unknown platform would recreate #12542.
             if ":" not in key:
+                if mode == "off":
+                    result[f"{legacy_prefix}{key}"] = "off"
+                    logger.warning(
+                        "Preserving legacy unprefixed /voice off key %r as "
+                        "auto-TTS suppression until a platform-specific /voice "
+                        "setting is saved.",
+                        key,
+                    )
+                    continue
                 logger.warning(
                     "Skipping legacy unprefixed voice mode key %r during migration. "
                     "Re-enable voice mode on that chat to rebuild the prefixed key.",
@@ -867,9 +879,23 @@ class GatewayRunner:
             return
         disabled_chats.clear()
         prefix = f"{platform.value}:"
+        platform_modes = {
+            key[len(prefix):]: mode
+            for key, mode in self._voice_mode.items()
+            if key.startswith(prefix)
+        }
         disabled_chats.update(
-            key[len(prefix):] for key, mode in self._voice_mode.items()
-            if mode == "off" and key.startswith(prefix)
+            chat_id for chat_id, mode in platform_modes.items()
+            if mode == "off"
+        )
+        legacy_prefix = "legacy:"
+        disabled_chats.update(
+            key[len(legacy_prefix):] for key, mode in self._voice_mode.items()
+            if (
+                mode == "off"
+                and key.startswith(legacy_prefix)
+                and key[len(legacy_prefix):] not in platform_modes
+            )
         )
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:

--- a/tests/gateway/test_voice_mode_platform_isolation.py
+++ b/tests/gateway/test_voice_mode_platform_isolation.py
@@ -65,16 +65,17 @@ class TestVoiceModePlatformIsolation:
 class TestLegacyKeyMigration:
     """Test migration of legacy unprefixed keys in _load_voice_modes."""
 
-    def test_load_voice_modes_skips_legacy_keys(self):
-        """_load_voice_modes skips keys without ':' prefix and logs a warning."""
+    def test_load_voice_modes_preserves_legacy_off_only(self):
+        """Legacy off keys remain as conservative auto-TTS suppression."""
         runner = _make_runner()
 
         # Simulate legacy persisted data with unprefixed keys
         legacy_data = {
             "123": "all",
             "456": "voice_only",
+            "789": "off",
             # Also includes a properly prefixed key (from after the fix)
-            "telegram:789": "off",
+            "telegram:999": "off",
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -88,12 +89,15 @@ class TestLegacyKeyMigration:
             # Legacy keys without ':' should be skipped
             assert "123" not in result
             assert "456" not in result
+            # Legacy off is preserved without assuming a platform.
+            assert result.get("legacy:789") == "off"
             # Prefixed key should be preserved
-            assert result.get("telegram:789") == "off"
+            assert result.get("telegram:999") == "off"
             # Warning should be logged for each legacy key
             assert mock_logger.warning.called
             warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
             assert any("Skipping legacy unprefixed voice mode key" in str(c) for c in warning_calls)
+            assert any("Preserving legacy unprefixed /voice off key" in str(c) for c in warning_calls)
 
     def test_load_voice_modes_preserves_prefixed_keys(self):
         """_load_voice_modes correctly loads platform-prefixed keys."""
@@ -162,6 +166,35 @@ class TestSyncVoiceModeStateToAdapter:
 
         # Only telegram:123 should be in disabled_chats (mode="off" for telegram)
         assert mock_adapter._auto_tts_disabled_chats == {"123"}
+
+    def test_sync_restores_legacy_off_for_any_platform(self):
+        """Legacy off suppresses auto-TTS until a platform-specific state exists."""
+        runner = _make_runner()
+        runner._voice_mode = {"legacy:123": "off"}
+
+        mock_adapter = MagicMock()
+        mock_adapter.platform = Platform.TELEGRAM
+        mock_adapter._auto_tts_disabled_chats = set()
+
+        runner._sync_voice_mode_state_to_adapter(mock_adapter)
+
+        assert mock_adapter._auto_tts_disabled_chats == {"123"}
+
+    def test_sync_platform_state_overrides_legacy_off(self):
+        """An explicit post-migration platform state supersedes legacy off."""
+        runner = _make_runner()
+        runner._voice_mode = {
+            "legacy:123": "off",
+            "telegram:123": "voice_only",
+        }
+
+        mock_adapter = MagicMock()
+        mock_adapter.platform = Platform.TELEGRAM
+        mock_adapter._auto_tts_disabled_chats = set()
+
+        runner._sync_voice_mode_state_to_adapter(mock_adapter)
+
+        assert mock_adapter._auto_tts_disabled_chats == set()
 
     def test_sync_clears_existing_state(self):
         """_sync_voice_mode_state_to_adapter clears existing disabled_chats first."""


### PR DESCRIPTION
## Summary

Fixes #14025.

This preserves legacy `/voice off` auto-TTS suppression after the platform-key migration without reintroducing cross-platform voice-mode collisions.

## Root cause

After #12542, `_load_voice_modes()` skipped all legacy unprefixed voice-mode keys. That was safe for old `all` / `voice_only` entries because enabling voice for an unknown platform can collide, but it also dropped old `off` entries. Since adapter auto-TTS suppression is rebuilt only from persisted `off` state, a Telegram chat that had `/voice off` before upgrade could receive one unwanted voice reply until `/voice off` was run again.

## Fix

- Preserve legacy unprefixed `off` entries as internal `legacy:<chat_id>` suppression markers.
- Continue skipping legacy unprefixed `all` and `voice_only` entries.
- During adapter sync, apply legacy suppression only when that platform does not already have an explicit platform-prefixed state for the chat.
- Add regressions for legacy `off` loading, runtime suppression restore, and platform-specific override behavior.

## Validation

- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_voice_mode_platform_isolation.py::TestLegacyKeyMigration::test_load_voice_modes_preserves_legacy_off_only tests/gateway/test_voice_mode_platform_isolation.py::TestSyncVoiceModeStateToAdapter::test_sync_restores_legacy_off_for_any_platform tests/gateway/test_voice_mode_platform_isolation.py::TestSyncVoiceModeStateToAdapter::test_sync_platform_state_overrides_legacy_off tests/gateway/test_voice_command.py::TestHandleVoiceCommand::test_restart_restores_voice_off_state -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_voice_mode_platform_isolation.py tests/gateway/test_voice_command.py -q --tb=short`
- `git diff --check`
