### PR TITLE
fix(ssh): send skill env passthrough variables

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -66,6 +66,81 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
+    def _bare_env(self):
+        env = SSHEnvironment.__new__(SSHEnvironment)
+        env.control_socket = "/tmp/hermes-ssh-test.sock"
+        env.host = "h"
+        env.user = "u"
+        env.port = 22
+        env.key_path = ""
+        return env
+
+    def test_send_env_flags_are_added_when_requested(self):
+        env = self._bare_env()
+        cmd = env._build_ssh_command(send_env_keys=["NEXTCLOUD_URL", "NEXTCLOUD_USER"])
+
+        assert "SendEnv=NEXTCLOUD_URL" in cmd
+        assert "SendEnv=NEXTCLOUD_USER" in cmd
+
+    def test_run_bash_forwards_allowed_env_without_provider_keys(self, monkeypatch):
+        import tools.env_passthrough as env_passthrough
+
+        env = self._bare_env()
+        monkeypatch.setenv("NEXTCLOUD_URL", "https://next.example")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-forward")
+        monkeypatch.setattr(
+            env_passthrough,
+            "get_all_passthrough",
+            lambda: frozenset({"NEXTCLOUD_URL", "OPENAI_API_KEY"}),
+        )
+
+        captured = {}
+
+        def _fake_popen(cmd, stdin_data=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["stdin_data"] = stdin_data
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        monkeypatch.setattr(ssh_env, "_popen_bash", _fake_popen)
+
+        env._run_bash("echo ok")
+
+        assert "SendEnv=NEXTCLOUD_URL" in captured["cmd"]
+        assert "SendEnv=OPENAI_API_KEY" not in captured["cmd"]
+        assert captured["kwargs"]["env"]["NEXTCLOUD_URL"] == "https://next.example"
+        assert captured["kwargs"]["env"]["OPENAI_API_KEY"] == "sk-should-not-forward"
+
+    def test_run_bash_uses_hermes_env_file_values_for_send_env(self, monkeypatch):
+        import tools.env_passthrough as env_passthrough
+
+        env = self._bare_env()
+        monkeypatch.delenv("NEXTCLOUD_URL", raising=False)
+        monkeypatch.setattr(
+            env_passthrough,
+            "get_all_passthrough",
+            lambda: frozenset({"NEXTCLOUD_URL"}),
+        )
+        monkeypatch.setattr(
+            ssh_env,
+            "_load_hermes_env_vars",
+            lambda: {"NEXTCLOUD_URL": "https://next.from-env-file"},
+        )
+
+        captured = {}
+
+        def _fake_popen(cmd, stdin_data=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        monkeypatch.setattr(ssh_env, "_popen_bash", _fake_popen)
+
+        env._run_bash("echo ok")
+
+        assert "SendEnv=NEXTCLOUD_URL" in captured["cmd"]
+        assert captured["kwargs"]["env"]["NEXTCLOUD_URL"] == "https://next.from-env-file"
+
 
 class TestControlSocketPath:
     """Regression tests for issue #11840.

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -29,6 +29,16 @@ def _ensure_ssh_available() -> None:
         )
 
 
+def _load_hermes_env_vars() -> dict[str, str]:
+    """Load ~/.hermes/.env values without failing SSH command execution."""
+    try:
+        from hermes_cli.config import load_env
+
+        return load_env() or {}
+    except Exception:
+        return {}
+
+
 class SSHEnvironment(BaseEnvironment):
     """Run commands on a remote machine over SSH.
 
@@ -76,7 +86,11 @@ class SSHEnvironment(BaseEnvironment):
 
         self.init_session()
 
-    def _build_ssh_command(self, extra_args: list | None = None) -> list:
+    def _build_ssh_command(
+        self,
+        extra_args: list | None = None,
+        send_env_keys: list[str] | None = None,
+    ) -> list:
         cmd = ["ssh"]
         cmd.extend(["-o", f"ControlPath={self.control_socket}"])
         cmd.extend(["-o", "ControlMaster=auto"])
@@ -84,6 +98,8 @@ class SSHEnvironment(BaseEnvironment):
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])
+        for key in send_env_keys or []:
+            cmd.extend(["-o", f"SendEnv={key}"])
         if self.port != 22:
             cmd.extend(["-p", str(self.port)])
         if self.key_path:
@@ -257,17 +273,48 @@ class SSHEnvironment(BaseEnvironment):
     # Execution
     # ------------------------------------------------------------------
 
+    def _get_passthrough_env(self) -> tuple[list[str], dict[str, str] | None]:
+        """Return SSH SendEnv keys and a child env containing their values."""
+        try:
+            from tools.env_passthrough import get_all_passthrough
+            from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+            passthrough_keys = set(get_all_passthrough()) - _HERMES_PROVIDER_ENV_BLOCKLIST
+        except Exception:
+            passthrough_keys = set()
+
+        if not passthrough_keys:
+            return [], None
+
+        child_env = dict(os.environ)
+        hermes_env = _load_hermes_env_vars()
+        send_env_keys: list[str] = []
+        for key in sorted(passthrough_keys):
+            value = child_env.get(key)
+            if value is None:
+                value = hermes_env.get(key)
+            if value is None:
+                continue
+            child_env[key] = value
+            send_env_keys.append(key)
+
+        if not send_env_keys:
+            return [], None
+        return send_env_keys, child_env
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
-        cmd = self._build_ssh_command()
+        send_env_keys, child_env = self._get_passthrough_env()
+        cmd = self._build_ssh_command(send_env_keys=send_env_keys)
         if login:
             cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
         else:
             cmd.extend(["bash", "-c", shlex.quote(cmd_string)])
 
-        return _popen_bash(cmd, stdin_data)
+        popen_kwargs = {"env": child_env} if child_env is not None else {}
+        return _popen_bash(cmd, stdin_data, **popen_kwargs)
 
     def cleanup(self):
         if self._sync_manager:


### PR DESCRIPTION
## Summary

Fixes #14091.

This makes the SSH terminal backend forward skill/config allowlisted environment variables into remote SSH sessions via OpenSSH `SendEnv`.

## Root cause

Skill readiness can register `required_environment_variables` through `tools.env_passthrough`, and local/Docker/code-execution paths already consult that allowlist. The SSH backend, however, only launched `ssh ... bash -c ...` and never asked OpenSSH to send the allowlisted variables, so remote `terminal` / `execute_code` sessions could not see them even when the local Hermes process or `~/.hermes/.env` had the values.

## Fix

- Resolve the current passthrough allowlist for each SSH shell invocation.
- Filter out Hermes provider credentials using the existing provider credential blocklist.
- Populate the child `ssh` process environment from `os.environ`, falling back to Hermes `.env` values.
- Add `-o SendEnv=<KEY>` only for allowlisted keys that have values.
- Add regressions for explicit SendEnv flags, provider-key filtering, and `.env` fallback values.

This intentionally uses `SendEnv` instead of embedding secret values into the remote shell command string; SSH servers still need the corresponding `AcceptEnv` configuration, matching the issue reproduction.

## Validation

- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_ssh_environment.py::TestBuildSSHCommand::test_send_env_flags_are_added_when_requested tests/tools/test_ssh_environment.py::TestBuildSSHCommand::test_run_bash_forwards_allowed_env_without_provider_keys tests/tools/test_ssh_environment.py::TestBuildSSHCommand::test_run_bash_uses_hermes_env_file_values_for_send_env -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_ssh_environment.py tests/tools/test_env_passthrough.py -q --tb=short`
- `git diff --check`

Note: the full SSH test file still emits pre-existing `PytestUnhandledThreadExceptionWarning` warnings from its mocked `stdout` object in unrelated constructor tests; the new targeted tests avoid that warning and pass cleanly.
