### PR TITLE
fix(model_metadata): recognize Venice.ai camelCase context keys

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -204,12 +204,14 @@ _CONTEXT_LENGTH_KEYS = (
     "n_ctx_train",
     "n_ctx",
     "ctx_size",
+    "availableContextTokens",  # Venice.ai model_spec field
 )
 
 _MAX_COMPLETION_KEYS = (
     "max_completion_tokens",
     "max_output_tokens",
     "max_tokens",
+    "maxCompletionTokens",  # Venice.ai model_spec field
 )
 
 # Local server hostnames / address patterns

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -376,6 +376,30 @@ class TestGetModelContextLength:
         assert result == 200000
 
 
+class TestExtractContextLengthCamelCase:
+    """Venice.ai returns camelCase keys (availableContextTokens, maxCompletionTokens)
+    nested inside a model_spec object. _extract_context_length must find them.
+
+    Regression test for the bug where all Venice models were capped at the 128K
+    fallback because the key-matching tuples used only snake_case names.
+    """
+
+    def test_extracts_available_context_tokens_from_nested_model_spec(self):
+        from agent.model_metadata import _extract_context_length, _extract_max_completion_tokens
+
+        venice_model = {
+            "id": "claude-opus-4-7",
+            "model_spec": {
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {"supportsVision": True},
+            },
+        }
+
+        assert _extract_context_length(venice_model) == 1000000
+        assert _extract_max_completion_tokens(venice_model) == 128000
+
+
 # =========================================================================
 # _strip_provider_prefix — Ollama model:tag vs provider:model
 # =========================================================================


### PR DESCRIPTION
## Summary

Venice.ai users were silently capped at 128K context on every model, including ones that support 200K, 256K, 1M, and even 2M tokens (GLM 5, Claude Opus 4.x via Venice, Grok 4.20, Gemini 3 Pro, Qwen 3.6 Plus, etc.).

## Root cause

Venice's `/api/v1/models` endpoint returns per-model specs using **camelCase keys nested inside a `model_spec` object**:

```json
{
  "id": "claude-opus-4-7",
  "model_spec": {
    "availableContextTokens": 1000000,
    "maxCompletionTokens": 128000,
    ...
  }
}
```

`fetch_endpoint_model_metadata` calls `_extract_context_length` / `_extract_max_completion_tokens`, which walk all nested dicts but only match keys in `_CONTEXT_LENGTH_KEYS` / `_MAX_COMPLETION_KEYS`. Neither tuple included `availableContextTokens` or `maxCompletionTokens`, so the values were silently dropped. With no endpoint metadata and no models.dev entry, resolution fell all the way through to the 128K default (`DEFAULT_FALLBACK_CONTEXT`) at step 9.

## Fix

Two-line addition to the extractor key tuples. Keys are matched case-insensitively by `_extract_first_int`, and the existing nested-dict walker already handles the `model_spec` wrapping, so no other changes are required.

Deliberately **not** adding `api.venice.ai` to `_URL_TO_PROVIDER`. Venice's own `/models` is the authoritative source of context limits — treating it as an unknown custom endpoint (step 2 of resolution) is the correct path. Promoting it to a "known" provider would *skip* endpoint metadata and then find nothing in models.dev, regressing to 128K.

## Verification

End-to-end against the live Venice API:

| Model | Before | After |
|---|---|---|
| `claude-opus-4-7` | 128,000 | **1,000,000** |
| `grok-4-20` | 128,000 | **2,000,000** |
| `zai-org-glm-5` | 128,000 | **198,000** |
| `qwen3-coder-480b-a35b-instruct-turbo` | 128,000 | **256,000** |
| `venice-uncensored-1-2` | 128,000 | 128,000 (unchanged — correct) |

Regression test added: `TestExtractContextLengthCamelCase::test_extracts_available_context_tokens_from_nested_model_spec`. Full suite passes (`tests/agent/test_model_metadata.py`: 81 passed).

## Config context

Works with either schema — no user-side changes required:

```yaml
providers:
  venice:
    name: Venice AI
    api: https://api.venice.ai/api/v1
    key_env: VENICE_API_KEY
    transport: openai_chat
```
