### PR TITLE
fix(skills): reject unsupported custom taps

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -838,7 +838,12 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
         if not repo:
             c.print("[bold red]Error:[/] Repo required. Usage: hermes skills tap add owner/repo\n")
             return
-        if mgr.add(repo):
+        try:
+            added = mgr.add(repo)
+        except ValueError as exc:
+            c.print(f"[bold red]Error:[/] {exc}\n")
+            return
+        if added:
             c.print(f"[bold green]Added tap:[/] {repo}\n")
         else:
             c.print(f"[yellow]Tap already exists:[/] {repo}\n")

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_tap, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -77,6 +77,13 @@ def _capture_check(monkeypatch, results, name=None) -> str:
     console = Console(file=sink, force_terminal=False, color_system=None)
     monkeypatch.setattr(hub, "check_for_skill_updates", lambda **_kwargs: results)
     do_check(name=name, console=console)
+    return sink.getvalue()
+
+
+def _capture_tap(action: str, repo: str = "") -> str:
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_tap(action=action, repo=repo, console=console)
     return sink.getvalue()
 
 
@@ -179,6 +186,13 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_do_tap_add_rejects_self_hosted_git_repo(hub_env):
+    output = _capture_tap("add", "git@git.rccchina.com:crawl/spider-skills.git")
+
+    assert "generic/self-hosted git URLs are not supported yet" in output
+    assert not (hub_env / "taps.json").exists()
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -23,6 +23,7 @@ from tools.skills_hub import (
     create_source_router,
     unified_search,
     append_audit_log,
+    _normalize_github_tap_repo,
     _skill_meta_to_dict,
     quarantine_bundle,
 )
@@ -861,6 +862,17 @@ class TestHubLockFile:
 
 
 class TestTapsManager:
+    def test_normalize_github_tap_repo_accepts_owner_repo(self):
+        assert _normalize_github_tap_repo("owner/repo") == "owner/repo"
+
+    def test_normalize_github_tap_repo_accepts_github_urls(self):
+        assert _normalize_github_tap_repo("https://github.com/owner/repo.git") == "owner/repo"
+        assert _normalize_github_tap_repo("git@github.com:owner/repo.git") == "owner/repo"
+
+    def test_normalize_github_tap_repo_rejects_self_hosted_git(self):
+        with pytest.raises(ValueError, match="generic/self-hosted git URLs"):
+            _normalize_github_tap_repo("git@git.rccchina.com:crawl/spider-skills.git")
+
     def test_load_missing_file(self, tmp_path):
         mgr = TapsManager(path=tmp_path / "taps.json")
         assert mgr.load() == []
@@ -885,6 +897,11 @@ class TestTapsManager:
         taps = mgr.load()
         assert len(taps) == 1
         assert taps[0]["repo"] == "owner/repo"
+
+    def test_add_normalizes_github_url(self, tmp_path):
+        mgr = TapsManager(path=tmp_path / "taps.json")
+        assert mgr.add("https://github.com/owner/repo.git") is True
+        assert mgr.load()[0]["repo"] == "owner/repo"
 
     def test_add_duplicate_tap(self, tmp_path):
         mgr = TapsManager(path=tmp_path / "taps.json")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2441,6 +2441,42 @@ class HubLockFile:
 # Taps management
 # ---------------------------------------------------------------------------
 
+_GITHUB_TAP_REPO_RE = re.compile(
+    r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+)
+
+
+def _normalize_github_tap_repo(repo: str) -> str:
+    """Normalize tap repo input to owner/repo for the GitHub API backend."""
+    raw = (repo or "").strip()
+    if not raw:
+        raise ValueError("Repo required. Use owner/repo or https://github.com/owner/repo.")
+
+    if _GITHUB_TAP_REPO_RE.fullmatch(raw):
+        return raw
+
+    if raw.startswith("git@github.com:"):
+        path = raw.split(":", 1)[1].removesuffix(".git").strip("/")
+        if _GITHUB_TAP_REPO_RE.fullmatch(path):
+            return path
+
+    parsed = urlparse(raw)
+    if parsed.scheme in {"http", "https"} and parsed.netloc.lower() in {"github.com", "www.github.com"}:
+        parts = [part for part in parsed.path.strip("/").split("/") if part]
+        if len(parts) == 2:
+            owner, name = parts
+            name = name.removesuffix(".git")
+            normalized = f"{owner}/{name}"
+            if _GITHUB_TAP_REPO_RE.fullmatch(normalized):
+                return normalized
+
+    raise ValueError(
+        "Custom skill taps currently support GitHub repositories via the "
+        "GitHub Contents API. Use owner/repo or https://github.com/owner/repo; "
+        "generic/self-hosted git URLs are not supported yet."
+    )
+
+
 class TapsManager:
     """Manages the taps.json file — custom GitHub repo sources."""
 
@@ -2462,6 +2498,7 @@ class TapsManager:
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
+        repo = _normalize_github_tap_repo(repo)
         taps = self.load()
         if any(t["repo"] == repo for t in taps):
             return False


### PR DESCRIPTION
## Summary

Fixes #14290.

This prevents `hermes skills tap add` from accepting custom git repositories that the current skills hub backend cannot actually search, inspect, or install from.

## Root cause

`TapsManager.add()` persisted arbitrary `repo` strings, but `GitHubSource` later treats taps as `owner/repo` GitHub repositories and resolves them through the GitHub Contents API. A self-hosted SSH git URL could therefore be accepted successfully, then silently produce no results during `skills search` / `inspect` / `install`.

## Fix

- Normalize supported GitHub tap inputs to `owner/repo`.
- Accept `owner/repo`, `https://github.com/owner/repo(.git)`, and `git@github.com:owner/repo.git`.
- Reject generic or self-hosted git URLs with an actionable error explaining that generic git taps are not supported yet.
- Have the CLI print that validation error instead of writing an unusable tap entry.

This is intentionally the minimal compatibility fix. Generic git tap support would need a separate clone/cache/index implementation rather than the current GitHub API-backed source adapter.

## Validation

- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skills_hub.py::TestTapsManager::test_normalize_github_tap_repo_accepts_owner_repo tests/tools/test_skills_hub.py::TestTapsManager::test_normalize_github_tap_repo_accepts_github_urls tests/tools/test_skills_hub.py::TestTapsManager::test_normalize_github_tap_repo_rejects_self_hosted_git tests/tools/test_skills_hub.py::TestTapsManager::test_add_new_tap tests/tools/test_skills_hub.py::TestTapsManager::test_add_normalizes_github_url tests/hermes_cli/test_skills_hub.py::test_do_tap_add_rejects_self_hosted_git_repo -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skills_hub.py -k 'TapsManager or CreateSourceRouter or UnifiedSearchDedup' -q --tb=short`
- `/Users/stephenyu/Documents/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_skills_hub.py -k 'tap or do_install_scans_with_resolved_identifier or do_list or do_check or do_update' -q --tb=short`
- `git diff --check`
