### PR TITLE
fix: restore memory setup picker defaults

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -20,6 +20,7 @@ from hermes_constants import get_hermes_home
 # Curses-based interactive picker (same pattern as hermes tools)
 # ---------------------------------------------------------------------------
 
+
 def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -> int:
     """Interactive single-select with arrow keys.
 
@@ -27,12 +28,12 @@ def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -
     Returns selected index, or default on escape/quit.
     """
     from hermes_cli.curses_ui import curses_radiolist
+
     # Format (label, desc) tuples into display strings
-    display_items = [
-        f"{label}  {desc}" if desc else label
-        for label, desc in items
-    ]
-    return curses_radiolist(title, display_items, selected=default, cancel_returns=default)
+    display_items = [f"{label}  {desc}" if desc else label for label, desc in items]
+    return curses_radiolist(
+        title, display_items, selected=default, cancel_returns=default
+    )
 
 
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
@@ -56,6 +57,7 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
+
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
@@ -70,6 +72,7 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         import yaml
+
         with open(yaml_path, encoding="utf-8") as f:
             meta = yaml.safe_load(f) or {}
     except Exception:
@@ -102,6 +105,7 @@ def _install_dependencies(provider_name: str) -> None:
     print(f"\n  Installing dependencies: {', '.join(missing)}")
 
     import shutil
+
     uv_path = shutil.which("uv")
     if not uv_path:
         print(f"  ⚠ uv not found — cannot install dependencies")
@@ -111,8 +115,10 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         subprocess.run(
-            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + missing,
-            check=True, timeout=120,
+            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"]
+            + missing,
+            check=True,
+            timeout=120,
             capture_output=True,
         )
         print(f"  ✓ Installed {', '.join(missing)}")
@@ -121,10 +127,14 @@ def _install_dependencies(provider_name: str) -> None:
         stderr = (e.stderr or b"").decode()[:200]
         if stderr:
             print(f"    {stderr}")
-        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
+        print(
+            f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}"
+        )
     except Exception as e:
         print(f"  ⚠ Install failed: {e}")
-        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
+        print(
+            f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}"
+        )
 
     # Also show external dependencies (non-pip) if any
     ext_deps = meta.get("external_dependencies", [])
@@ -150,6 +160,7 @@ def _get_available_providers() -> list:
     """
     try:
         from plugins.memory import discover_memory_providers, load_memory_provider
+
         raw = discover_memory_providers()
     except Exception:
         raw = []
@@ -163,7 +174,11 @@ def _get_available_providers() -> list:
         except Exception:
             continue
 
-        schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+        schema = (
+            provider.get_config_schema()
+            if hasattr(provider, "get_config_schema")
+            else []
+        )
         has_secrets = any(f.get("secret") for f in schema)
         has_non_secrets = any(not f.get("secret") for f in schema)
         if has_secrets and has_non_secrets:
@@ -182,6 +197,7 @@ def _get_available_providers() -> list:
 # ---------------------------------------------------------------------------
 # Setup wizard
 # ---------------------------------------------------------------------------
+
 
 def cmd_setup_provider(provider_name: str) -> None:
     """Run memory setup for a specific provider, skipping the picker."""
@@ -224,6 +240,9 @@ def cmd_setup(args) -> None:
     from hermes_cli.config import load_config, save_config
 
     providers = _get_available_providers()
+    config = load_config()
+    if not isinstance(config.get("memory"), dict):
+        config["memory"] = {}
 
     if not providers:
         print("\n  No memory provider plugins detected.")
@@ -237,11 +256,14 @@ def cmd_setup(args) -> None:
     items.append(("Built-in only", "— MEMORY.md / USER.md (default)"))
 
     builtin_idx = len(items) - 1
-    selected = _curses_select("Memory provider setup", items, default=builtin_idx)
-
-    config = load_config()
-    if not isinstance(config.get("memory"), dict):
-        config["memory"] = {}
+    default_idx = builtin_idx
+    saved_provider = config["memory"].get("provider")
+    if saved_provider:
+        for idx, (name, _, _) in enumerate(providers):
+            if name == saved_provider:
+                default_idx = idx
+                break
+    selected = _curses_select("Memory provider setup", items, default=default_idx)
 
     # Built-in only
     if selected >= len(providers) or selected < 0:
@@ -263,7 +285,9 @@ def cmd_setup(args) -> None:
         provider.post_setup(hermes_home, config)
         return
 
-    schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+    schema = (
+        provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+    )
 
     provider_config = config["memory"].get(name, {})
     if not isinstance(provider_config, dict):
@@ -312,7 +336,9 @@ def cmd_setup(args) -> None:
                 existing = os.environ.get(env_var, "") if env_var else ""
                 if existing:
                     masked = f"...{existing[-4:]}" if len(existing) > 4 else "set"
-                    val = _prompt(f"{desc} (current: {masked}, blank to keep)", secret=True)
+                    val = _prompt(
+                        f"{desc} (current: {masked}, blank to keep)", secret=True
+                    )
                 else:
                     hint = f"  Get yours at {url}" if url else ""
                     if hint:
@@ -324,7 +350,9 @@ def cmd_setup(args) -> None:
                 # Regular text prompt
                 current = provider_config.get(key)
                 effective_default = current or default
-                val = _prompt(desc, default=str(effective_default) if effective_default else None)
+                val = _prompt(
+                    desc, default=str(effective_default) if effective_default else None
+                )
                 if val:
                     provider_config[key] = val
                     # Also write to .env if this field has an env_var
@@ -391,6 +419,7 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
 # Status
 # ---------------------------------------------------------------------------
 
+
 def cmd_status(args) -> None:
     """Show current memory provider config."""
     from hermes_cli.config import load_config
@@ -420,7 +449,11 @@ def cmd_status(args) -> None:
                         print(f"  Status:    available ✓")
                     else:
                         print(f"  Status:    not available ✗")
-                        schema = p.get_config_schema() if hasattr(p, "get_config_schema") else []
+                        schema = (
+                            p.get_config_schema()
+                            if hasattr(p, "get_config_schema")
+                            else []
+                        )
                         # Check all fields that have env_var (both secret and non-secret)
                         required_fields = [f for f in schema if f.get("env_var")]
                         if required_fields:
@@ -437,7 +470,9 @@ def cmd_status(args) -> None:
                     break
         else:
             print(f"\n  Plugin:    NOT installed ✗")
-            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
+            print(
+                f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/"
+            )
 
     providers = _get_available_providers()
     if providers:
@@ -452,6 +487,7 @@ def cmd_status(args) -> None:
 # ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
+
 
 def memory_command(args) -> None:
     """Route memory subcommands."""

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -19,6 +19,7 @@ from hermes_constants import get_hermes_home
 # Curses-based interactive picker (same pattern as hermes tools)
 # ---------------------------------------------------------------------------
 
+
 def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -> int:
     """Interactive single-select with arrow keys.
 
@@ -26,12 +27,12 @@ def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -
     Returns selected index, or default on escape/quit.
     """
     from hermes_cli.curses_ui import curses_radiolist
+
     # Format (label, desc) tuples into display strings
-    display_items = [
-        f"{label}  {desc}" if desc else label
-        for label, desc in items
-    ]
-    return curses_radiolist(title, display_items, selected=default, cancel_returns=default)
+    display_items = [f"{label}  {desc}" if desc else label for label, desc in items]
+    return curses_radiolist(
+        title, display_items, selected=default, cancel_returns=default
+    )
 
 
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
@@ -55,6 +56,7 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
+
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
@@ -69,6 +71,7 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         import yaml
+
         with open(yaml_path) as f:
             meta = yaml.safe_load(f) or {}
     except Exception:
@@ -101,6 +104,7 @@ def _install_dependencies(provider_name: str) -> None:
     print(f"\n  Installing dependencies: {', '.join(missing)}")
 
     import shutil
+
     uv_path = shutil.which("uv")
     if not uv_path:
         print(f"  ⚠ uv not found — cannot install dependencies")
@@ -110,8 +114,10 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         subprocess.run(
-            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + missing,
-            check=True, timeout=120,
+            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"]
+            + missing,
+            check=True,
+            timeout=120,
             capture_output=True,
         )
         print(f"  ✓ Installed {', '.join(missing)}")
@@ -120,10 +126,14 @@ def _install_dependencies(provider_name: str) -> None:
         stderr = (e.stderr or b"").decode()[:200]
         if stderr:
             print(f"    {stderr}")
-        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
+        print(
+            f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}"
+        )
     except Exception as e:
         print(f"  ⚠ Install failed: {e}")
-        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
+        print(
+            f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}"
+        )
 
     # Also show external dependencies (non-pip) if any
     ext_deps = meta.get("external_dependencies", [])
@@ -133,9 +143,7 @@ def _install_dependencies(provider_name: str) -> None:
         install_cmd = dep.get("install", "")
         if check_cmd:
             try:
-                subprocess.run(
-                    check_cmd, shell=True, capture_output=True, timeout=5
-                )
+                subprocess.run(check_cmd, shell=True, capture_output=True, timeout=5)
             except Exception:
                 if install_cmd:
                     print(f"\n  ⚠ '{dep_name}' not found. Install with:")
@@ -149,6 +157,7 @@ def _get_available_providers() -> list:
     """
     try:
         from plugins.memory import discover_memory_providers, load_memory_provider
+
         raw = discover_memory_providers()
     except Exception:
         raw = []
@@ -162,7 +171,11 @@ def _get_available_providers() -> list:
         except Exception:
             continue
 
-        schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+        schema = (
+            provider.get_config_schema()
+            if hasattr(provider, "get_config_schema")
+            else []
+        )
         has_secrets = any(f.get("secret") for f in schema)
         has_non_secrets = any(not f.get("secret") for f in schema)
         if has_secrets and has_non_secrets:
@@ -181,6 +194,7 @@ def _get_available_providers() -> list:
 # ---------------------------------------------------------------------------
 # Setup wizard
 # ---------------------------------------------------------------------------
+
 
 def cmd_setup_provider(provider_name: str) -> None:
     """Run memory setup for a specific provider, skipping the picker."""
@@ -223,6 +237,9 @@ def cmd_setup(args) -> None:
     from hermes_cli.config import load_config, save_config
 
     providers = _get_available_providers()
+    config = load_config()
+    if not isinstance(config.get("memory"), dict):
+        config["memory"] = {}
 
     if not providers:
         print("\n  No memory provider plugins detected.")
@@ -236,11 +253,14 @@ def cmd_setup(args) -> None:
     items.append(("Built-in only", "— MEMORY.md / USER.md (default)"))
 
     builtin_idx = len(items) - 1
-    selected = _curses_select("Memory provider setup", items, default=builtin_idx)
-
-    config = load_config()
-    if not isinstance(config.get("memory"), dict):
-        config["memory"] = {}
+    default_idx = builtin_idx
+    saved_provider = config["memory"].get("provider")
+    if saved_provider:
+        for idx, (name, _, _) in enumerate(providers):
+            if name == saved_provider:
+                default_idx = idx
+                break
+    selected = _curses_select("Memory provider setup", items, default=default_idx)
 
     # Built-in only
     if selected >= len(providers) or selected < 0:
@@ -262,7 +282,9 @@ def cmd_setup(args) -> None:
         provider.post_setup(hermes_home, config)
         return
 
-    schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+    schema = (
+        provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+    )
 
     provider_config = config["memory"].get(name, {})
     if not isinstance(provider_config, dict):
@@ -311,7 +333,9 @@ def cmd_setup(args) -> None:
                 existing = os.environ.get(env_var, "") if env_var else ""
                 if existing:
                     masked = f"...{existing[-4:]}" if len(existing) > 4 else "set"
-                    val = _prompt(f"{desc} (current: {masked}, blank to keep)", secret=True)
+                    val = _prompt(
+                        f"{desc} (current: {masked}, blank to keep)", secret=True
+                    )
                 else:
                     hint = f"  Get yours at {url}" if url else ""
                     if hint:
@@ -323,7 +347,9 @@ def cmd_setup(args) -> None:
                 # Regular text prompt
                 current = provider_config.get(key)
                 effective_default = current or default
-                val = _prompt(desc, default=str(effective_default) if effective_default else None)
+                val = _prompt(
+                    desc, default=str(effective_default) if effective_default else None
+                )
                 if val:
                     provider_config[key] = val
                     # Also write to .env if this field has an env_var
@@ -384,6 +410,7 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
 # Status
 # ---------------------------------------------------------------------------
 
+
 def cmd_status(args) -> None:
     """Show current memory provider config."""
     from hermes_cli.config import load_config
@@ -413,7 +440,11 @@ def cmd_status(args) -> None:
                         print(f"  Status:    available ✓")
                     else:
                         print(f"  Status:    not available ✗")
-                        schema = p.get_config_schema() if hasattr(p, "get_config_schema") else []
+                        schema = (
+                            p.get_config_schema()
+                            if hasattr(p, "get_config_schema")
+                            else []
+                        )
                         # Check all fields that have env_var (both secret and non-secret)
                         required_fields = [f for f in schema if f.get("env_var")]
                         if required_fields:
@@ -430,7 +461,9 @@ def cmd_status(args) -> None:
                     break
         else:
             print(f"\n  Plugin:    NOT installed ✗")
-            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
+            print(
+                f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/"
+            )
 
     providers = _get_available_providers()
     if providers:
@@ -445,6 +478,7 @@ def cmd_status(args) -> None:
 # ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
+
 
 def memory_command(args) -> None:
     """Route memory subcommands."""

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,0 +1,43 @@
+from argparse import Namespace
+
+
+def _picker_default(monkeypatch, config):
+    import hermes_cli.config as config_module
+    import hermes_cli.memory_setup as memory_setup
+
+    providers = [
+        ("mem0", "requires API key", object()),
+        ("hindsight", "local", object()),
+    ]
+    selected_defaults = []
+
+    def fake_select(title, items, default=0):
+        selected_defaults.append(default)
+        return len(providers)
+
+    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: providers)
+    monkeypatch.setattr(memory_setup, "_curses_select", fake_select)
+    monkeypatch.setattr(config_module, "load_config", lambda: config)
+    monkeypatch.setattr(config_module, "save_config", lambda cfg: None)
+
+    memory_setup.cmd_setup(Namespace())
+
+    return selected_defaults[0]
+
+
+def test_saved_provider_defaults_to_saved_provider_index(monkeypatch):
+    default = _picker_default(monkeypatch, {"memory": {"provider": "hindsight"}})
+
+    assert default == 1
+
+
+def test_unknown_saved_provider_defaults_to_builtin_index(monkeypatch):
+    default = _picker_default(monkeypatch, {"memory": {"provider": "unknown"}})
+
+    assert default == 2
+
+
+def test_malformed_memory_config_defaults_to_builtin_index(monkeypatch):
+    default = _picker_default(monkeypatch, {"memory": "broken"})
+
+    assert default == 2


### PR DESCRIPTION
## Summary
- default `hermes memory setup` to the currently configured provider when it is still discoverable
- keep falling back to `Built-in only` for unknown or malformed memory config
- add focused regression coverage for saved-provider and fallback default selection behavior

## Behavior Change
Before this change, reopening `hermes memory setup` always highlighted `Built-in only`, even when a plugin provider was already configured and still available.

After this change, the picker defaults to the saved provider when Hermes can still discover it. If the saved config is unknown or malformed, the picker still safely falls back to `Built-in only`.

## Test Plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_memory_setup.py`

Fixes #12990
