### PR TITLE
fix: preserve thinking signatures for apimart anthropic passthrough

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -266,6 +266,32 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     return True  # Any other endpoint is a third-party proxy
 
 
+def _supports_anthropic_signature_validation(base_url: str | None) -> bool:
+    """Return True when endpoint validates Anthropic thinking signatures.
+
+    Most third-party Anthropic-compatible endpoints cannot validate Anthropic's
+    proprietary thinking signatures, so Hermes strips thinking blocks before
+    replay. Some providers (e.g. API gateways backed by native Bedrock/Claude
+    validation) *do* require valid signatures and will reject unsigned/stripped
+    payloads with 400 errors like "signature: Field required".
+
+    For those endpoints we should preserve the same signature-safe behavior used
+    for direct Anthropic: keep only last signed thinking/redacted_thinking block.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return True  # Direct Anthropic API
+    normalized = normalized.rstrip("/").lower()
+    if "anthropic.com" in normalized:
+        return True
+
+    # Known third-party gateway that enforces Anthropic signature validation.
+    if "apimart.ai" in normalized:
+        return True
+
+    return False
+
+
 def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     """Return True for Kimi's /coding endpoint that requires claude-code UA."""
     normalized = _normalize_base_url_text(base_url)
@@ -1237,7 +1263,7 @@ def convert_messages_to_anthropic(
     # 3. Strip cache_control from thinking/redacted_thinking blocks —
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
-    _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+    _preserve_signed_thinking = _supports_anthropic_signature_validation(base_url)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -1249,19 +1275,20 @@ def convert_messages_to_anthropic(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _is_third_party or idx != last_assistant_idx:
-            # Third-party endpoint: strip ALL thinking blocks from every
-            # assistant message — signatures are Anthropic-proprietary.
-            # Direct Anthropic: strip from non-latest assistant messages only.
+        if (not _preserve_signed_thinking) or idx != last_assistant_idx:
+            # Endpoints without Anthropic signature validation: strip ALL
+            # thinking blocks to avoid third-party 400 errors.
+            # Signature-validating endpoints (Anthropic, apimart passthrough):
+            # strip from non-latest assistant messages only.
             stripped = [
                 b for b in m["content"]
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
         else:
-            # Latest assistant on direct Anthropic: keep signed thinking
-            # blocks for reasoning continuity; downgrade unsigned ones to
-            # plain text.
+            # Latest assistant on signature-validating endpoints: keep signed
+            # thinking blocks for reasoning continuity; downgrade unsigned ones
+            # to plain text.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4972,6 +4972,21 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    def _status_total_tokens(self, session_entry: "SessionEntry") -> int:
+        """Return total tokens for /status, preferring SQLite session stats."""
+        if self._session_db:
+            try:
+                row = self._session_db.get_session(session_entry.session_id)
+            except Exception:
+                row = None
+            if row:
+                input_tokens = int(row.get("input_tokens") or 0)
+                output_tokens = int(row.get("output_tokens") or 0)
+                cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+                cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+                return input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+        return int(getattr(session_entry, "total_tokens", 0) or 0)
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
@@ -4990,6 +5005,8 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        total_tokens = self._status_total_tokens(session_entry)
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -5000,7 +5017,7 @@ class GatewayRunner:
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
+            f"**Tokens:** {total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4911,6 +4911,21 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    def _status_total_tokens(self, session_entry: "SessionEntry") -> int:
+        """Return total tokens for /status, preferring SQLite session stats."""
+        if self._session_db:
+            try:
+                row = self._session_db.get_session(session_entry.session_id)
+            except Exception:
+                row = None
+            if row:
+                input_tokens = int(row.get("input_tokens") or 0)
+                output_tokens = int(row.get("output_tokens") or 0)
+                cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+                cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+                return input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+        return int(getattr(session_entry, "total_tokens", 0) or 0)
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
@@ -4929,6 +4944,8 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        total_tokens = self._status_total_tokens(session_entry)
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -4939,7 +4956,7 @@ class GatewayRunner:
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
+            f"**Tokens:** {total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -11,6 +11,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_oauth_token,
     _refresh_oauth_token,
+    _supports_anthropic_signature_validation,
     _to_plain_data,
     _write_claude_code_credentials,
     build_anthropic_client,
@@ -1608,6 +1609,53 @@ class TestThinkingBlockSignatureManagement:
         ]
         assert len(last_thinking) == 1
         assert last_thinking[0]["signature"] == "sig_3"
+
+    def test_non_signature_validating_third_party_strips_all_thinking(self):
+        """Generic third-party endpoints should strip every thinking block."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "thought", "signature": "sig_1"},
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        _, result = convert_messages_to_anthropic(messages, base_url="https://custom.api.com/v1")
+        assistant = next(m for m in result if m["role"] == "assistant")
+        assert not any(
+            isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking")
+            for b in assistant["content"]
+        )
+
+    def test_apimart_keeps_signed_last_thinking_for_signature_validation(self):
+        """Apimart passthrough validates signatures, so keep latest signed block."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "latest", "signature": "sig_keep"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages, base_url="https://api.apimart.ai/v1")
+        blocks = result[0]["content"]
+        thinking = [b for b in blocks if isinstance(b, dict) and b.get("type") == "thinking"]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_keep"
+
+
+class TestSignatureValidationEndpointDetection:
+    def test_direct_anthropic_supports_signature_validation(self):
+        assert _supports_anthropic_signature_validation("https://api.anthropic.com") is True
+
+    def test_apimart_supports_signature_validation(self):
+        assert _supports_anthropic_signature_validation("https://api.apimart.ai/v1") is True
+
+    def test_generic_third_party_does_not_support_signature_validation(self):
+        assert _supports_anthropic_signature_validation("https://custom.example.com") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -54,6 +54,7 @@ def _make_runner(session_entry: SessionEntry):
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._session_db = MagicMock()
+    runner._session_db.get_session.return_value = None
     runner._session_db.get_session_title.return_value = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -111,6 +112,31 @@ async def test_status_command_includes_session_title_when_present():
 
     assert "**Session ID:** `sess-1`" in result
     assert "**Title:** My titled session" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_sqlite_token_counts_over_session_store_entry():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session.return_value = {
+        "id": "sess-1",
+        "input_tokens": 120,
+        "output_tokens": 45,
+        "cache_read_tokens": 30,
+        "cache_write_tokens": 5,
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 200" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `_supports_anthropic_signature_validation(base_url)` and treat `api.apimart.ai` as signature-validating
- preserve latest signed thinking/redacted_thinking blocks for signature-validating endpoints
- keep existing strip-all behavior for generic third-party endpoints
- add regression tests for endpoint detection and apimart behavior

## Verification
- `pytest tests/agent/test_anthropic_adapter.py`
- live two-turn call against apimart `claude-sonnet-4-6-thinking` with reasoning_details replay succeeded (no 400 `signature: Field required`)