### PR TITLE
feat(agent): add PLATFORM_HINTS for matrix, mattermost, and feishu

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -370,6 +370,32 @@ PLATFORM_HINTS = {
         "MEDIA:/absolute/path/to/file in your response. Images (.jpg, .png, "
         ".heic) appear as photos and other files arrive as attachments."
     ),
+    "mattermost": (
+        "You are in a Mattermost workspace communicating with your user. "
+        "Mattermost renders standard Markdown — headings, bold, italic, code "
+        "blocks, and tables all work. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are uploaded as photo "
+        "attachments, audio and video as file attachments. "
+        "Image URLs in markdown format ![alt](url) are rendered as inline previews automatically."
+    ),
+    "matrix": (
+        "You are in a Matrix room communicating with your user. "
+        "Matrix renders Markdown — bold, italic, code blocks, and links work; "
+        "the adapter converts your Markdown to HTML for rich display. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are sent as inline photos, "
+        "audio (.ogg, .mp3) as voice/audio messages, video (.mp4) inline, "
+        "and other files as downloadable attachments."
+    ),
+    "feishu": (
+        "You are in a Feishu (Lark) workspace communicating with your user. "
+        "Feishu renders Markdown in messages — bold, italic, code blocks, and "
+        "links are supported. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are uploaded and displayed "
+        "inline, audio files as voice messages, and other files as attachments."
+    ),
     "weixin": (
         "You are on Weixin/WeChat. Markdown formatting is supported, so you may use it when "
         "it improves readability, but keep the message compact and chat-friendly. You can send media files natively: "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -807,6 +807,23 @@ class TestPromptBuilderConstants:
         # check that this test is calibrated correctly).
         assert "include MEDIA:" in PLATFORM_HINTS["telegram"]
 
+    def test_platform_hints_mattermost(self):
+        hint = PLATFORM_HINTS["mattermost"]
+        assert "Mattermost" in hint
+        assert "MEDIA:" in hint
+        assert "Markdown" in hint
+
+    def test_platform_hints_matrix(self):
+        hint = PLATFORM_HINTS["matrix"]
+        assert "Matrix" in hint
+        assert "MEDIA:" in hint
+        assert "Markdown" in hint
+
+    def test_platform_hints_feishu(self):
+        hint = PLATFORM_HINTS["feishu"]
+        assert "Feishu" in hint
+        assert "MEDIA:" in hint
+
 
 # =========================================================================
 # Environment hints

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -823,6 +823,7 @@ class TestPromptBuilderConstants:
         hint = PLATFORM_HINTS["feishu"]
         assert "Feishu" in hint
         assert "MEDIA:" in hint
+        assert "Markdown" in hint
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

- Adds `PLATFORM_HINTS` entries for **Matrix**, **Mattermost**, and **Feishu** in `agent/prompt_builder.py`
- Adds corresponding tests in `tests/agent/test_prompt_builder.py`

Salvaged from #7370 by @Rutimka — resolved merge conflicts (wecom was already on main with a more detailed hint, so it was excluded).

## Background

These three platform adapters fully implement media delivery (`send_image`, `send_image_file`, `send_document`, `send_voice`, `send_video`) but were missing from `PLATFORM_HINTS`. Without a hint, agents running on these platforms have no context about:
- Which platform they are on
- Whether Markdown renders
- How to send media files via `MEDIA:/path/to/file`

**Verified on a live Matrix session**: the current system prompt (27KB) contains **zero** `MEDIA:` mentions and **zero** platform identity when running on Matrix. The agent literally doesn't know it's on Matrix. This explains user reports of poor formatting and confusion about file delivery capabilities.

Closes the platform hints gap identified in #4531. Supersedes #7370.

| Platform | Markdown | MEDIA: support |
|---|---|---|
| matrix | converted to HTML | images, audio, video, documents |
| mattermost | standard Markdown | images, audio, video, documents |
| feishu | subset | images, audio, documents |

## Test plan

- [x] `uv run pytest tests/agent/test_prompt_builder.py::TestPromptBuilderConstants` — 6 passed
- [x] Verified injection path: `run_agent.py:4206-4208` looks up `PLATFORM_HINTS[platform_key]` where `platform_key` comes from `source.platform.value` (= `"matrix"` for Matrix sessions)
- [x] Verified current Matrix session has no platform hint (checked session JSON in running container)
- [x] Verified Matrix adapter supports all claimed media types (`matrix.py:927-971`)