### PR TITLE
fix: preserve thinking signatures for apimart anthropic passthrough (clean)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -323,6 +323,32 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     return True  # Any other endpoint is a third-party proxy
 
 
+def _supports_anthropic_signature_validation(base_url: str | None) -> bool:
+    """Return True when endpoint validates Anthropic thinking signatures.
+
+    Most third-party Anthropic-compatible endpoints cannot validate Anthropic's
+    proprietary thinking signatures, so Hermes strips thinking blocks before
+    replay. Some providers (e.g. API gateways backed by native Bedrock/Claude
+    validation) *do* require valid signatures and will reject unsigned/stripped
+    payloads with 400 errors like "signature: Field required".
+
+    For those endpoints we should preserve the same signature-safe behavior used
+    for direct Anthropic: keep only last signed thinking/redacted_thinking block.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return True  # Direct Anthropic API
+    normalized = normalized.rstrip("/").lower()
+    if "anthropic.com" in normalized:
+        return True
+
+    # Known third-party gateway that enforces Anthropic signature validation.
+    if "apimart.ai" in normalized:
+        return True
+
+    return False
+
+
 def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     """Return True for Kimi's /coding endpoint that requires claude-code UA."""
     normalized = _normalize_base_url_text(base_url)
@@ -1319,8 +1345,8 @@ def convert_messages_to_anthropic(
     # 3. Strip cache_control from thinking/redacted_thinking blocks —
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
-    _is_third_party = _is_third_party_anthropic_endpoint(base_url)
     _is_kimi = _is_kimi_coding_endpoint(base_url)
+    _preserve_signed_thinking = _supports_anthropic_signature_validation(base_url)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -1344,25 +1370,26 @@ def convert_messages_to_anthropic(
                     new_content.append(b)
                     continue
                 if b.get("signature") or b.get("data"):
-                    # Anthropic-signed block — Kimi can't validate, strip
+                    # Anthropic-signed block — Kimi can't validate, strip.
                     continue
                 # Unsigned thinking (synthesised from reasoning_content) —
                 # keep it: Kimi needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _is_third_party or idx != last_assistant_idx:
-            # Third-party endpoint: strip ALL thinking blocks from every
-            # assistant message — signatures are Anthropic-proprietary.
-            # Direct Anthropic: strip from non-latest assistant messages only.
+        elif (not _preserve_signed_thinking) or idx != last_assistant_idx:
+            # Endpoints without Anthropic signature validation: strip ALL
+            # thinking blocks to avoid third-party 400 errors.
+            # Signature-validating endpoints (Anthropic, apimart passthrough):
+            # strip from non-latest assistant messages only.
             stripped = [
                 b for b in m["content"]
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
         else:
-            # Latest assistant on direct Anthropic: keep signed thinking
-            # blocks for reasoning continuity; downgrade unsigned ones to
-            # plain text.
+            # Latest assistant on signature-validating endpoints: keep signed
+            # thinking blocks for reasoning continuity; downgrade unsigned ones
+            # to plain text.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -11,6 +11,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_oauth_token,
     _refresh_oauth_token,
+    _supports_anthropic_signature_validation,
     _to_plain_data,
     _write_claude_code_credentials,
     build_anthropic_client,
@@ -1608,6 +1609,53 @@ class TestThinkingBlockSignatureManagement:
         ]
         assert len(last_thinking) == 1
         assert last_thinking[0]["signature"] == "sig_3"
+
+    def test_non_signature_validating_third_party_strips_all_thinking(self):
+        """Generic third-party endpoints should strip every thinking block."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "thought", "signature": "sig_1"},
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        _, result = convert_messages_to_anthropic(messages, base_url="https://custom.api.com/v1")
+        assistant = next(m for m in result if m["role"] == "assistant")
+        assert not any(
+            isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking")
+            for b in assistant["content"]
+        )
+
+    def test_apimart_keeps_signed_last_thinking_for_signature_validation(self):
+        """Apimart passthrough validates signatures, so keep latest signed block."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "latest", "signature": "sig_keep"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages, base_url="https://api.apimart.ai/v1")
+        blocks = result[0]["content"]
+        thinking = [b for b in blocks if isinstance(b, dict) and b.get("type") == "thinking"]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_keep"
+
+
+class TestSignatureValidationEndpointDetection:
+    def test_direct_anthropic_supports_signature_validation(self):
+        assert _supports_anthropic_signature_validation("https://api.anthropic.com") is True
+
+    def test_apimart_supports_signature_validation(self):
+        assert _supports_anthropic_signature_validation("https://api.apimart.ai/v1") is True
+
+    def test_generic_third_party_does_not_support_signature_validation(self):
+        assert _supports_anthropic_signature_validation("https://custom.example.com") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `_supports_anthropic_signature_validation(base_url)` and treat `api.apimart.ai` as signature-validating
- preserve latest signed thinking/redacted_thinking blocks for signature-validating endpoints
- keep existing strip-all behavior for generic third-party endpoints and keep Kimi special-case behavior
- add regression tests for endpoint detection and apimart behavior

## Verification
- `pytest tests/agent/test_anthropic_adapter.py -k "apimart or SignatureValidationEndpointDetection or non_signature_validating_third_party"`
- live two-turn call against apimart `claude-sonnet-4-6-thinking` with reasoning_details replay succeeded (no 400 `signature: Field required`)