### PR TITLE
fix(streaming): handle Anthropic client in stale stream detector

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6177,17 +6177,28 @@ class AIAgent:
                     f"Reconnecting..."
                 )
                 try:
-                    rc = request_client_holder.get("client")
-                    if rc is not None:
-                        self._close_request_openai_client(rc, reason="stale_stream_kill")
+                    if self.api_mode == "anthropic_messages":
+                        from agent.anthropic_adapter import build_anthropic_client
+
+                        self._anthropic_client.close()
+                        self._anthropic_client = build_anthropic_client(
+                            self._anthropic_api_key,
+                            getattr(self, "_anthropic_base_url", None),
+                            timeout=get_provider_request_timeout(self.provider, self.model),
+                        )
+                    else:
+                        rc = request_client_holder.get("client")
+                        if rc is not None:
+                            self._close_request_openai_client(rc, reason="stale_stream_kill")
                 except Exception:
                     pass
                 # Rebuild the primary client too — its connection pool
                 # may hold dead sockets from the same provider outage.
-                try:
-                    self._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
-                except Exception:
-                    pass
+                if self.api_mode != "anthropic_messages":
+                    try:
+                        self._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                    except Exception:
+                        pass
                 # Reset the timer so we don't kill repeatedly while
                 # the inner thread processes the closure.
                 last_chunk_time["t"] = time.time()


### PR DESCRIPTION
## Summary

The streaming stale detector in `_run_streaming_api_call()` does not handle the `anthropic_messages` api_mode. When the stale timeout fires, the code attempts to close `request_client_holder["client"]` — but for Anthropic, this holder is always `None` (the Anthropic SDK manages its own transport internally). As a result, the stale connection is never actually closed and no fresh connection is ever established.

## Root Cause

Three connection-reset sites exist in the streaming path:

| Location | Purpose | Has Anthropic branch? |
|----------|---------|----------------------|
| ~line 5235 | Non-streaming stale detector | ✅ |
| ~line 6179 | **Streaming stale detector** | ❌ **Missing** |
| ~line 6199 | Interrupt handler | ✅ |

The streaming stale detector was copied from the OpenAI path without being extended to cover Anthropic.

## Symptom

When the agent is running on the `anthropic_messages` api_mode and a stream stalls (e.g. due to an SSE keep-alive with no real chunks), the stale detector fires and emits `"⚠️ No response from provider... Reconnecting..."` — but the underlying Anthropic client is never closed. The inner `_call_anthropic()` thread keeps waiting on the same dead stream. Each subsequent detector tick emits another status message while doing nothing, leaving the agent stuck until the stream eventually errors out on its own.

## Fix

Mirror the pattern already used by the non-streaming stale detector (~line 5235) and the interrupt handler (~line 6199): branch on `self.api_mode` and call `self._anthropic_client.close()` + rebuild via `build_anthropic_client()` for the Anthropic path, keeping the existing OpenAI path unchanged. Guard `_replace_primary_openai_client()` to the non-Anthropic path only, since it operates on the OpenAI connection pool.

## Testing

- `python -m py_compile run_agent.py` passes
- `pytest tests/agent/ -q` — 1735 passed, 1 skipped. The 1 pre-existing failure (`test_minimax_provider.py::TestMinimaxSwitchModelCredentialGuard`) reproduces identically on the unmodified upstream `run_agent.py`, confirming it is unrelated to this change.
- Tested on macOS (Apple Silicon) with `anthropic_messages` api_mode via direct Anthropic API key
- Existing OpenAI/chat-completions path behavior is unchanged
