### PR TITLE
fix(agent): exclude ssl.SSLError from local validation error check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 import os
 import random
 import re
+import ssl
 import sys
 import tempfile
 import time
@@ -10680,7 +10681,7 @@ class AIAgent:
                     # errors (ValueError, TypeError) are programming bugs.
                     is_local_validation_error = (
                         isinstance(api_error, (ValueError, TypeError))
-                        and not isinstance(api_error, UnicodeEncodeError)
+                        and not isinstance(api_error, (UnicodeEncodeError, ssl.SSLError))  # ssl.SSLError subclasses ValueError via OSError — transport error, not a programming bug
                     )
                     is_client_error = (
                         is_local_validation_error

--- a/tests/run_agent/test_14367_ssl_local_validation.py
+++ b/tests/run_agent/test_14367_ssl_local_validation.py
@@ -1,0 +1,77 @@
+"""Tests for #14367 — ssl.SSLCertVerificationError mis-classified as local validation error.
+
+ssl.SSLCertVerificationError inherits from SSLError → OSError → ValueError.
+The is_local_validation_error guard in run_agent.py caught it via isinstance(e, ValueError)
+and triggered a non-retryable abort, even though the error classifier returns retryable=True
+for all OSError subclasses (transport heuristic, step 7).
+
+Fix: add ssl.SSLError to the exclusion tuple alongside UnicodeEncodeError.
+"""
+
+import ssl
+
+
+# ── Helper: replicate the fixed guard from run_agent.py ───────────────────
+
+def _is_local_validation_error(api_error: BaseException) -> bool:
+    """Mirror of the is_local_validation_error check in run_agent.py."""
+    return (
+        isinstance(api_error, (ValueError, TypeError))
+        and not isinstance(api_error, (UnicodeEncodeError, ssl.SSLError))
+    )
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+class TestSSLErrorNotLocalValidation:
+    """ssl.SSLError and its subclasses must not be treated as local
+    validation errors — they are transport errors and should be retried."""
+
+    def test_ssl_cert_verification_error_is_not_local(self):
+        """SSLCertVerificationError (the reported bug case) should not be
+        classified as a local validation error."""
+        e = ssl.SSLCertVerificationError("certificate verify failed: self-signed certificate")
+        assert not _is_local_validation_error(e)
+
+    def test_ssl_error_base_is_not_local(self):
+        """ssl.SSLError itself (parent of all SSL errors) should not be
+        classified as a local validation error."""
+        e = ssl.SSLError("unknown SSL error")
+        assert not _is_local_validation_error(e)
+
+    def test_ssl_cert_verification_error_is_value_error_via_mro(self):
+        """Confirm the MRO bug exists: SSLCertVerificationError IS a ValueError,
+        which is why the pre-fix guard misfired."""
+        e = ssl.SSLCertVerificationError("cert error")
+        assert isinstance(e, ValueError), (
+            "Prerequisite: SSLCertVerificationError must subclass ValueError via MRO"
+        )
+
+
+class TestExistingExclusionsPreserved:
+    """Existing exclusions (UnicodeEncodeError) must remain effective."""
+
+    def test_unicode_encode_error_is_not_local(self):
+        """Pre-existing: UnicodeEncodeError should not be a local validation error."""
+        e = UnicodeEncodeError("utf-8", "x", 0, 1, "invalid char")
+        assert not _is_local_validation_error(e)
+
+
+class TestValueErrorAndTypeErrorStillLocal:
+    """Plain ValueError and TypeError remain local validation errors — the fix
+    must not weaken detection of real programming bugs."""
+
+    def test_plain_value_error_is_local(self):
+        e = ValueError("unexpected keyword argument 'stream_options'")
+        assert _is_local_validation_error(e)
+
+    def test_plain_type_error_is_local(self):
+        e = TypeError("got an unexpected keyword argument 'stream_options'")
+        assert _is_local_validation_error(e)
+
+    def test_json_decode_error_is_still_local(self):
+        """json.JSONDecodeError is a ValueError subclass — still local until
+        #14366 lands its own exclusion."""
+        import json
+        e = json.JSONDecodeError("Expecting value", "doc", 0)
+        assert _is_local_validation_error(e)


### PR DESCRIPTION
## What does this PR do?

`ssl.SSLCertVerificationError` inherits from `SSLError → OSError → ValueError`. The `is_local_validation_error` guard in `run_agent.py` caught it via `isinstance(api_error, ValueError)` and triggered a **non-retryable abort** — even though the error classifier already returns `retryable=True` for all `OSError` subclasses (transport heuristic, step 7).

The inline `isinstance` check fires before `classified.retryable` is consulted, so the classifier's correct verdict is overridden. Fix: add `ssl.SSLError` to the exclusion tuple alongside the existing `UnicodeEncodeError`, mirroring the same pattern already in place.

## Related Issue

Fixes #14367

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: add `import ssl` (stdlib, no new dependency); extend exclusion tuple to `(UnicodeEncodeError, ssl.SSLError)` with inline comment explaining the MRO
- `tests/run_agent/test_14367_ssl_local_validation.py`: new test file covering the reported case (`SSLCertVerificationError`), the parent class (`ssl.SSLError`), the MRO prerequisite, the preserved `UnicodeEncodeError` exclusion, and regression checks that plain `ValueError`/`TypeError` remain local errors

## How to Test

1. Confirm the MRO that caused the bug:
   ```python
   import ssl
   e = ssl.SSLCertVerificationError("cert error")
   print(isinstance(e, ValueError))  # True — this was the root cause
   ```
2. Run the new tests:
   ```bash
   pytest tests/run_agent/test_14367_ssl_local_validation.py -v
   ```
3. All 7 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A