### PR TITLE
fix: add document extensions to MEDIA: path extraction regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1318,7 +1318,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|xlsx?|docx?|pdf|pptx|txt|csv|json|xml|zip|rar|7z)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Summary

Fix `BasePlatformAdapter.extract_media()` to correctly extract `MEDIA:` tags containing document file paths (xlsx, docx, pdf, pptx, etc.).

## Problem

The regex pattern only matched image/video/audio extensions, causing document paths to be truncated during extraction.

## Solution

Extend the media pattern regex to include common document extensions: xlsx?, docx?, pdf, pptx, txt, csv, json, xml, zip, rar, 7z.

## Testing

Verified that extract_media() now correctly extracts full document paths, and confirmed successful WeChat file delivery of xlsx files.