### PR TITLE
fix(copilot-acp): raise NotImplementedError on stream=True to prevent SimpleNamespace iteration crash

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -320,8 +320,18 @@ class CopilotACPClient:
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
+        stream: bool = False,
         **_: Any,
     ) -> Any:
+        if stream:
+            # The copilot-acp backend communicates over a subprocess stdio
+            # JSON-RPC channel and does not support incremental chunk delivery.
+            # Raising here triggers the agent loop's existing "stream not
+            # supported" recovery path (run_agent.py _interruptible_streaming_-
+            # api_call), which sets _disable_streaming=True and retries the
+            # same request without streaming so the conversation continues
+            # uninterrupted.
+            raise NotImplementedError("stream not supported for copilot-acp provider")
         prompt_text = _format_messages_as_prompt(
             messages or [],
             model=model,


### PR DESCRIPTION
## Problem

Fixes #14437.

When using the `copilot-acp` provider, any request crashes with:

```
RuntimeError: 'types.SimpleNamespace' object is not iterable
```

**Root cause:** The agent loop calls `.chat.completions.create(stream=True)` by default (via `_interruptible_streaming_api_call`). The copilot-acp provider's `_create_chat_completion` accepted `**_` and silently ignored the `stream` kwarg, returning a `SimpleNamespace` response object directly. The streaming loop then did:

```python
for chunk in stream:  # stream is a SimpleNamespace, not an iterator
```

…crashing immediately with the `not iterable` error before any response was delivered.

## Fix

Add `stream` as an explicit keyword argument in `_create_chat_completion` and raise `NotImplementedError("stream not supported for copilot-acp provider")` when `True`.

The error message matches the pattern the agent loop already checks in `_interruptible_streaming_api_call`:

```python
_is_stream_unsupported = (
    "stream" in _err_lower
    and "not supported" in _err_lower
)
if _is_stream_unsupported:
    self._disable_streaming = True  # retries without streaming
```

This means on the **first request** Hermes auto-detects that copilot-acp doesn't support streaming, disables it for the session, and retries — so the conversation continues uninterrupted with no user intervention needed.

## Testing

```python
from agent.copilot_acp_client import CopilotACPClient
import pytest

client = CopilotACPClient(acp_command="echo")

# stream=False (default) — should NOT raise
# (will fail to connect to echo, but won't crash on iteration)

# stream=True — should raise NotImplementedError with correct message
try:
    client.chat.completions.create(
        model="copilot",
        messages=[{"role": "user", "content": "hi"}],
        stream=True,
    )
    assert False, "Should have raised"
except NotImplementedError as e:
    assert "stream not supported" in str(e).lower()
```