### PR TITLE
fix(transports): drop malformed tool_call.arguments before outbound request

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -4,10 +4,14 @@ Delegates to the existing adapter functions in agent/anthropic_adapter.py.
 This transport owns format conversion and normalization — NOT client lifecycle.
 """
 
+import json
+import logging
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse
+
+logger = logging.getLogger(__name__)
 
 
 class AnthropicTransport(ProviderTransport):
@@ -22,15 +26,119 @@ class AnthropicTransport(ProviderTransport):
         return "anthropic_messages"
 
     def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
-        """Convert OpenAI messages to Anthropic (system, messages) tuple.
+        """Sanitize malformed tool_calls then convert to Anthropic format.
+
+        Pre-pass (before handing off to the adapter):
+            Drop any assistant tool_call whose arguments string fails json.loads.
+            Remove tool_calls key entirely if all are dropped (strict providers
+            reject tool_calls:[]).  Inject placeholder content if the message
+            would otherwise be empty.  Strip orphan tool messages whose
+            tool_call_id no longer matches a surviving tool_call.
+
+        Then delegates to convert_messages_to_anthropic which performs
+        Anthropic-specific format conversion (system extraction, tool_use
+        blocks, thinking signatures, orphan tool_use/tool_result cleanup).
 
         kwargs:
             base_url: Optional[str] — affects thinking signature handling.
         """
-        from agent.anthropic_adapter import convert_messages_to_anthropic
+        import copy
+
+        # ── Pre-pass: drop malformed tool_calls ──────────────────────────────
+        has_malformed = False
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            tool_calls = msg.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function")
+                if not isinstance(fn, dict):
+                    continue
+                args = fn.get("arguments")
+                if not isinstance(args, str) or not args:
+                    continue
+                try:
+                    json.loads(args)
+                except json.JSONDecodeError:
+                    has_malformed = True
+                    break
+            if has_malformed:
+                break
+
+        if has_malformed:
+            messages = copy.deepcopy(messages)
+            dropped_tc = 0
+            surviving_ids: set = set()
+
+            for msg in messages:
+                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                    continue
+                tool_calls = msg.get("tool_calls")
+                if not isinstance(tool_calls, list):
+                    continue
+
+                good: list = []
+                for tc in tool_calls:
+                    if not isinstance(tc, dict):
+                        good.append(tc)
+                        continue
+                    fn = tc.get("function")
+                    if not isinstance(fn, dict):
+                        good.append(tc)
+                        continue
+                    args = fn.get("arguments")
+                    if not isinstance(args, str) or not args:
+                        good.append(tc)
+                        surviving_ids.add(tc.get("id"))
+                        continue
+                    try:
+                        json.loads(args)
+                        good.append(tc)
+                        surviving_ids.add(tc.get("id"))
+                    except json.JSONDecodeError:
+                        dropped_tc += 1
+
+                if good:
+                    msg["tool_calls"] = good
+                else:
+                    msg.pop("tool_calls", None)
+                    if not msg.get("content"):
+                        msg["content"] = "(tool call dropped — malformed arguments)"
+
+            # Strip orphan tool messages whose tool_call_id lost its assistant counterpart.
+            filtered: list = []
+            dropped_tool_msgs = 0
+            for m in messages:
+                if (
+                    isinstance(m, dict)
+                    and m.get("role") == "tool"
+                    and m.get("tool_call_id") not in surviving_ids
+                ):
+                    dropped_tool_msgs += 1
+                else:
+                    filtered.append(m)
+            messages = filtered
+
+            if dropped_tc or dropped_tool_msgs:
+                logger.warning(
+                    "Dropped %d malformed tool_call(s) and %d orphan tool message(s) "
+                    "from conversation history before sending to provider.",
+                    dropped_tc,
+                    dropped_tool_msgs,
+                )
+
+        # ── Delegate to adapter for Anthropic format conversion ───────────────
+        # Import is deferred to method level to match original behaviour and
+        # avoid circular-import risk at module load time.  Tests that need to
+        # mock this call should patch 'agent.anthropic_adapter.convert_messages_to_anthropic'.
+        from agent.anthropic_adapter import convert_messages_to_anthropic as _convert
 
         base_url = kwargs.get("base_url")
-        return convert_messages_to_anthropic(messages, base_url=base_url)
+        return _convert(messages, base_url=base_url)
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Anthropic input_schema format."""

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,7 +10,11 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import json
+import logging
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -28,12 +32,111 @@ class ChatCompletionsTransport(ProviderTransport):
         return "chat_completions"
 
     def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> List[Dict[str, Any]]:
-        """Messages are already in OpenAI format — sanitize Codex leaks only.
+        """Messages are already in OpenAI format — sanitize Codex leaks and malformed tool_calls.
 
-        Strips Codex Responses API fields (``codex_reasoning_items`` on the
-        message, ``call_id``/``response_item_id`` on tool_calls) that strict
-        chat-completions providers reject with 400/422.
+        Pass 1 (malformed tool_call sanitization):
+            For each assistant message whose tool_calls list contains entries
+            with unparseable JSON arguments, drop those entries.  If all
+            tool_calls are dropped, remove the key entirely (strict providers
+            reject tool_calls:[]).  If the message ends up with no content and
+            no tool_calls, inject a placeholder so the message is not empty.
+            Then strip orphan tool messages (role=="tool") whose tool_call_id
+            no longer matches any surviving assistant tool_call id.
+
+        Pass 2 (Codex-leak sanitization):
+            Strips Codex Responses API fields (``codex_reasoning_items`` on the
+            message, ``call_id``/``response_item_id`` on tool_calls) that strict
+            chat-completions providers reject with 400/422.
         """
+        # ── Pass 1: drop malformed tool_calls ────────────────────────────────
+        # First scan: detect any malformed entries so we only mutate when needed.
+        has_malformed = False
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            tool_calls = msg.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function")
+                if not isinstance(fn, dict):
+                    continue
+                args = fn.get("arguments")
+                if not isinstance(args, str) or not args:
+                    continue  # empty string or non-string — not malformed per spec
+                try:
+                    json.loads(args)
+                except json.JSONDecodeError:
+                    has_malformed = True
+                    break
+            if has_malformed:
+                break
+
+        if has_malformed:
+            messages = copy.deepcopy(messages)
+            dropped_tc = 0
+            surviving_ids: set = set()
+
+            for msg in messages:
+                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                    continue
+                tool_calls = msg.get("tool_calls")
+                if not isinstance(tool_calls, list):
+                    continue
+
+                good: list = []
+                for tc in tool_calls:
+                    if not isinstance(tc, dict):
+                        good.append(tc)
+                        continue
+                    fn = tc.get("function")
+                    if not isinstance(fn, dict):
+                        good.append(tc)
+                        continue
+                    args = fn.get("arguments")
+                    if not isinstance(args, str) or not args:
+                        good.append(tc)
+                        surviving_ids.add(tc.get("id"))
+                        continue
+                    try:
+                        json.loads(args)
+                        good.append(tc)
+                        surviving_ids.add(tc.get("id"))
+                    except json.JSONDecodeError:
+                        dropped_tc += 1
+
+                if good:
+                    msg["tool_calls"] = good
+                else:
+                    msg.pop("tool_calls", None)
+                    if not msg.get("content"):
+                        msg["content"] = "(tool call dropped — malformed arguments)"
+
+            # Strip orphan tool messages whose tool_call_id lost its assistant counterpart.
+            filtered: list = []
+            dropped_tool_msgs = 0
+            for m in messages:
+                if (
+                    isinstance(m, dict)
+                    and m.get("role") == "tool"
+                    and m.get("tool_call_id") not in surviving_ids
+                ):
+                    dropped_tool_msgs += 1
+                else:
+                    filtered.append(m)
+            messages = filtered
+
+            if dropped_tc or dropped_tool_msgs:
+                logger.warning(
+                    "Dropped %d malformed tool_call(s) and %d orphan tool message(s) "
+                    "from conversation history before sending to provider.",
+                    dropped_tc,
+                    dropped_tool_msgs,
+                )
+
+        # ── Pass 2: Codex-leak sanitization ──────────────────────────────────
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):

--- a/tests/agent/transports/test_anthropic.py
+++ b/tests/agent/transports/test_anthropic.py
@@ -1,0 +1,244 @@
+"""Tests for AnthropicTransport.
+
+Focused on the malformed tool_call sanitization pre-pass added to
+convert_messages.  The adapter-level conversion (convert_messages_to_anthropic)
+has its own test suite; these tests exercise the transport entrypoint guard
+using a lightweight mock that short-circuits the real adapter.
+"""
+
+import copy
+from unittest.mock import patch
+
+import pytest
+
+from agent.transports import get_transport
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.anthropic  # noqa: F401
+    return get_transport("anthropic_messages")
+
+
+def _fake_adapter(messages, base_url=None):
+    """Minimal stand-in for convert_messages_to_anthropic.
+
+    Returns (system, messages) like the real adapter but with no conversion,
+    so tests can inspect the sanitized OpenAI-format messages directly.
+    """
+    system = None
+    body = []
+    for m in messages:
+        if m.get("role") == "system":
+            system = m.get("content", "")
+        else:
+            body.append(m)
+    return system, body
+
+
+class TestAnthropicMalformedToolCallSanitization:
+    """Mirror of TestMalformedToolCallSanitization for the Anthropic transport.
+
+    The sanitization logic is identical to chat_completions.py; the transport
+    just runs it before delegating to the adapter.
+    """
+
+    # ── Case 1: mixed valid + malformed ──────────────────────────────────────
+
+    def test_malformed_dropped_valid_preserved(self, transport):
+        """One malformed + one valid tool_call: malformed dropped, valid kept."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": '{"path": "~/.hermes/file.py", "old_string": "    # Anthropic think',
+                        },
+                    },
+                    {
+                        "id": "call_good",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "ls"}',
+                        },
+                    },
+                ],
+            }
+        ]
+        with patch(
+            "agent.anthropic_adapter.convert_messages_to_anthropic",
+            side_effect=_fake_adapter,
+        ):
+            _system, body = transport.convert_messages(msgs)
+
+        assert len(body) == 1
+        msg = body[0]
+        tool_calls = msg["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["id"] == "call_good"
+        # Original not mutated
+        assert len(msgs[0]["tool_calls"]) == 2
+    # ── Case 2: all malformed + orphan tool result ────────────────────────────
+
+    def test_all_malformed_and_orphan_tool_stripped(self, transport):
+        """Only malformed tool_call + orphan tool result: both removed, placeholder injected."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": '{"path": "~/.hermes/file.py", "old_string": "    # Anthropic think',
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_bad",
+                "content": "ok",
+            },
+        ]
+        with patch(
+            "agent.anthropic_adapter.convert_messages_to_anthropic",
+            side_effect=_fake_adapter,
+        ):
+            _system, body = transport.convert_messages(msgs)
+
+        # Only the assistant message; orphan tool msg stripped
+        assert len(body) == 1
+        msg = body[0]
+        assert "tool_calls" not in msg
+        assert msg["content"] == "(tool call dropped — malformed arguments)"
+
+    # ── Case 3: well-formed tool_calls — no deepcopy, adapter called once ────
+
+    def test_well_formed_unchanged(self, transport):
+        """Well-formed tool_calls pass through without mutation."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_ok",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "pwd"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        original_ids = [tc["id"] for tc in msgs[0]["tool_calls"]]
+
+        with patch(
+            "agent.anthropic_adapter.convert_messages_to_anthropic",
+            side_effect=_fake_adapter,
+        ):
+            _system, body = transport.convert_messages(msgs)
+
+        assert [tc["id"] for tc in body[0]["tool_calls"]] == original_ids
+
+    # ── Case 4: empty arguments string — not malformed ───────────────────────
+
+    def test_empty_arguments_string_not_malformed(self, transport):
+        """arguments='' is not treated as malformed; message passes through."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_empty",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": "",
+                        },
+                    }
+                ],
+            }
+        ]
+        with patch(
+            "agent.anthropic_adapter.convert_messages_to_anthropic",
+            side_effect=_fake_adapter,
+        ):
+            _system, body = transport.convert_messages(msgs)
+
+        assert body[0]["tool_calls"][0]["function"]["arguments"] == ""
+
+    # ── Extra: surviving tool result preserved ───────────────────────────────
+
+    def test_surviving_tool_result_kept(self, transport):
+        """Orphan from dropped call removed; tool msg for surviving call kept."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"name": "patch", "arguments": '{"truncated":'},
+                    },
+                    {
+                        "id": "call_good",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command": "ls"}'},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_bad", "content": "err"},
+            {"role": "tool", "tool_call_id": "call_good", "content": "file.py"},
+        ]
+        with patch(
+            "agent.anthropic_adapter.convert_messages_to_anthropic",
+            side_effect=_fake_adapter,
+        ):
+            _system, body = transport.convert_messages(msgs)
+
+        # 1 assistant + 1 surviving tool msg
+        assert len(body) == 2
+        assert body[1]["tool_call_id"] == "call_good"
+
+    # ── Warning emitted on drop ───────────────────────────────────────────────
+
+    def test_warning_logged_on_drop(self, transport, caplog):
+        """logger.warning is emitted exactly once when a drop occurs."""
+        import logging
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"name": "patch", "arguments": '{"broken":'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_bad", "content": "n/a"},
+        ]
+        with patch(
+            "agent.anthropic_adapter.convert_messages_to_anthropic",
+            side_effect=_fake_adapter,
+        ):
+            with caplog.at_level(logging.WARNING, logger="agent.transports.anthropic"):
+                transport.convert_messages(msgs)
+
+        assert any("malformed tool_call" in r.message for r in caplog.records)
+        assert any("orphan tool message" in r.message for r in caplog.records)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -332,6 +332,169 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"reasoning_content": "detailed scratchpad"}
 
 
+class TestMalformedToolCallSanitization:
+    """Tests for the malformed tool_call pre-pass in convert_messages."""
+
+    # ── Case 1: mixed valid + malformed ──────────────────────────────────────
+
+    def test_malformed_dropped_valid_preserved(self, transport):
+        """Assistant message with one malformed and one valid tool_call.
+        Malformed is dropped; valid is kept; message retains both content and
+        surviving tool_call.
+        """
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": '{"path": "~/.hermes/file.py", "old_string": "    # Anthropic think',
+                        },
+                    },
+                    {
+                        "id": "call_good",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "ls"}',
+                        },
+                    },
+                ],
+            }
+        ]
+        result = transport.convert_messages(msgs)
+        assert len(result) == 1
+        msg = result[0]
+        tool_calls = msg["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["id"] == "call_good"
+        # Original not mutated (deepcopy-on-demand)
+        assert len(msgs[0]["tool_calls"]) == 2
+
+    # ── Case 2: all malformed + orphan tool result ────────────────────────────
+
+    def test_all_malformed_and_orphan_tool_stripped(self, transport):
+        """Assistant message with only a malformed tool_call plus a following
+        tool result message.  Both should be cleaned up: tool_calls removed,
+        orphan tool message stripped, placeholder content injected.
+        """
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": '{"path": "~/.hermes/file.py", "old_string": "    # Anthropic think',
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_bad",
+                "content": "ok",
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        # Only the assistant message should remain
+        assert len(result) == 1
+        msg = result[0]
+        assert "tool_calls" not in msg
+        assert msg["content"] == "(tool call dropped — malformed arguments)"
+
+    # ── Case 3: well-formed tool_calls — identity, no deepcopy ───────────────
+
+    def test_well_formed_unchanged_and_not_copied(self, transport):
+        """Assistant message with valid tool_calls returns same list object
+        (no deepcopy — no mutation needed).
+        """
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_ok",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "pwd"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        result = transport.convert_messages(msgs)
+        assert result is msgs  # identity — no copy
+        assert result[0]["tool_calls"][0]["id"] == "call_ok"
+
+    # ── Case 4: empty arguments string — not malformed ───────────────────────
+
+    def test_empty_arguments_string_not_malformed(self, transport):
+        """tool_call with arguments='' is treated as not malformed per spec.
+        The message passes through unchanged (identity — no deepcopy).
+        """
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_empty",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": "",
+                        },
+                    }
+                ],
+            }
+        ]
+        result = transport.convert_messages(msgs)
+        assert result is msgs
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == ""
+
+    # ── Extra: surviving tool result preserved ───────────────────────────────
+
+    def test_surviving_tool_result_kept(self, transport):
+        """When one tool_call is malformed and one is valid, only the orphan
+        tool message for the dropped call is removed; the tool message for the
+        surviving call stays.
+        """
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"name": "patch", "arguments": '{"truncated":'},
+                    },
+                    {
+                        "id": "call_good",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command": "ls"}'},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_bad", "content": "err"},
+            {"role": "tool", "tool_call_id": "call_good", "content": "file.py"},
+        ]
+        result = transport.convert_messages(msgs)
+        # 1 assistant + 1 surviving tool msg
+        assert len(result) == 2
+        assert result[1]["tool_call_id"] == "call_good"
+
+
 class TestChatCompletionsCacheStats:
 
     def test_no_usage(self, transport):


### PR DESCRIPTION
## Problem

A truncated streamed assistant response can save a `tool_call` with non-JSON `function.arguments` to conversation history. On the next turn, Anthropic-compatible proxies (LiteLLM in particular) reject the outbound request with `400 Failed to parse tool call arguments`, and because the bad message is pinned in history, every retry and the direct-Anthropic fallback fail the same way. See #14443.

## Fix

Add a pre-pass to `ChatCompletionsTransport.convert_messages` and `AnthropicTransport.convert_messages` that:

1. Scans every assistant message's `tool_calls` and `json.loads()` each `function.arguments` string.
2. Drops any entry that fails to parse. If all are dropped, the `tool_calls` key is removed entirely (strict providers reject `tool_calls: []`).
3. Injects a placeholder `content` if the message would otherwise be empty.
4. Strips orphan `tool` messages whose `tool_call_id` no longer has a surviving counterpart.
5. Emits a single `logger.warning` per call if anything was dropped.
6. Short-circuits with no mutation and no deepcopy when nothing is malformed.

The sanitization is symmetrical across both transports so the behavior is independent of which provider we're talking to. The existing `anthropic_adapter.convert_messages_to_anthropic` adapter-level guard is left untouched — this adds a transport-level safety net that protects providers we hit via the chat-completions path (LiteLLM, OpenRouter routing to Anthropic, etc.).

## Design choice: drop vs. repair

We drop malformed tool_calls rather than repairing arguments to `{}`. A `{}`-arg tool call (e.g. a `patch` with no `path`/`old_string`) would execute a garbage action or surface a confusing downstream error. Dropping removes the bad call entirely; the model re-attempts on the next turn with whatever context it still has.

## Tests

- `tests/agent/transports/test_chat_completions.py::TestMalformedToolCallSanitization` — 5 cases
- `tests/agent/transports/test_anthropic.py::TestAnthropicMalformedToolCallSanitization` — 6 cases (including warning log assertion)

Coverage: mixed valid/malformed, all-malformed with orphan tool result, all-clean identity (verifies no deepcopy), empty-string arguments treated as clean (not malformed), surviving-tool-result preservation, `logger.warning` emission.

Full suite: `pytest tests/agent/transports/` — **130 passed, 0 regressions**.

## Files changed

- `agent/transports/chat_completions.py` — +113 lines (pre-pass + module logger)
- `agent/transports/anthropic.py` — +114 lines (pre-pass + module logger)
- `tests/agent/transports/test_chat_completions.py` — +163 lines (new test class)
- `tests/agent/transports/test_anthropic.py` — new file, 244 lines

No changes to `run_agent.py`, `error_classifier.py`, or `anthropic_adapter.py`.

## Non-goals

- Not changing the retry loop in `run_agent.py` — once the bad message is cleaned out of the outbound request, the existing retry logic works.
- Not adding a new `FailoverReason` for this class of error — prevention at the outbound boundary is simpler and covers more cases than post-hoc classification.
