### PR TITLE
fix(agent): exclude ssl.SSLError from is_local_validation_error to prevent non-retryable abort

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 import os
 import random
 import re
+import ssl
 import sys
 import tempfile
 import time
@@ -10681,6 +10682,14 @@ class AIAgent:
                     is_local_validation_error = (
                         isinstance(api_error, (ValueError, TypeError))
                         and not isinstance(api_error, UnicodeEncodeError)
+                        # ssl.SSLError (and its subclass SSLCertVerificationError)
+                        # inherits from OSError *and* ValueError via Python MRO,
+                        # so the isinstance(ValueError) check above would
+                        # misclassify a TLS transport failure as a local
+                        # programming bug and abort without retrying.  Exclude
+                        # ssl.SSLError explicitly so the error classifier's
+                        # retryable=True mapping takes effect instead.
+                        and not isinstance(api_error, ssl.SSLError)
                     )
                     is_client_error = (
                         is_local_validation_error


### PR DESCRIPTION
## Problem

Fixes #14367.

`ssl.SSLError` (and its subclass `ssl.SSLCertVerificationError`) inherits from **both** `OSError` **and** `ValueError` via Python's MRO:

```
ssl.SSLCertVerificationError
  └─ ssl.SSLError
       ├─ OSError
       └─ (via adapter) ValueError
```

The `is_local_validation_error` check at run_agent.py ~line 10681:

```python
is_local_validation_error = (
    isinstance(api_error, (ValueError, TypeError))
    and not isinstance(api_error, UnicodeEncodeError)
)
```

…catches `ssl.SSLCertVerificationError` as a `ValueError`, marking it non-retryable and triggering an immediate abort.

The error classifier already maps `SSLCertVerificationError` to `FailoverReason.timeout, retryable=True` (its type name appears in `_TRANSPORT_ERROR_TYPES`), but the inline `isinstance` guard overrides that mapping before the classifier result is checked.

**Result:** A TLS transport error causes an unnecessary session abort instead of retrying or failing over to a backup provider.

## Fix

Add `ssl.SSLError` to the exclusion list alongside the existing `UnicodeEncodeError` carve-out, and import `ssl` at the top of `run_agent.py`:

```python
import ssl
# …
is_local_validation_error = (
    isinstance(api_error, (ValueError, TypeError))
    and not isinstance(api_error, UnicodeEncodeError)
    and not isinstance(api_error, ssl.SSLError)   # ← new
)
```

## Verification

```python
import ssl
e = ssl.SSLCertVerificationError("certificate verify failed")

# Before fix:
isinstance(e, (ValueError, TypeError))  # True  → flagged as programming bug

# After fix:
is_local = (
    isinstance(e, (ValueError, TypeError))
    and not isinstance(e, UnicodeEncodeError)
    and not isinstance(e, ssl.SSLError)
)
assert is_local is False  # ✅ falls through to classifier's retryable path
```