### PR TITLE
docs(agent): remove stale BuiltinMemoryProvider references from memory module docstrings

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1,17 +1,14 @@
-"""MemoryManager — orchestrates the built-in memory provider plus at most
-ONE external plugin memory provider.
+"""MemoryManager — orchestrates memory providers for the agent.
 
 Single integration point in run_agent.py. Replaces scattered per-backend
 code with one manager that delegates to registered providers.
 
-The BuiltinMemoryProvider is always registered first and cannot be removed.
-Only ONE external (non-builtin) provider is allowed at a time — attempting
-to register a second external provider is rejected with a warning.  This
+Only ONE external plugin provider is allowed at a time — attempting to
+register a second external provider is rejected with a warning.  This
 prevents tool schema bloat and conflicting memory backends.
 
 Usage in run_agent.py:
     self._memory_manager = MemoryManager()
-    self._memory_manager.add_provider(BuiltinMemoryProvider(...))
     # Only ONE of these:
     self._memory_manager.add_provider(plugin_provider)
 

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -1,17 +1,16 @@
 """Abstract base class for pluggable memory providers.
 
-Memory providers give the agent persistent recall across sessions. One
-external provider is active at a time alongside the always-on built-in
-memory (MEMORY.md / USER.md). The MemoryManager enforces this limit.
+Memory providers give the agent persistent recall across sessions.
+The MemoryManager enforces a one-external-provider limit to prevent
+tool schema bloat and conflicting memory backends.
 
-Built-in memory is always active as the first provider and cannot be removed.
-External providers (Honcho, Hindsight, Mem0, etc.) are additive — they never
-disable the built-in store. Only one external provider runs at a time to
-prevent tool schema bloat and conflicting memory backends.
+External providers (Honcho, Hindsight, Mem0, etc.) are registered
+and managed via MemoryManager. Only one external provider runs at a
+time.
 
 Registration:
-  1. Built-in: BuiltinMemoryProvider — always present, not removable.
-  2. Plugins: Ship in plugins/memory/<name>/, activated by memory.provider config.
+  Plugins ship in plugins/memory/<name>/ and are activated via
+  the memory.provider config key.
 
 Lifecycle (called by MemoryManager, wired in run_agent.py):
   initialize()          — connect, create resources, warm up


### PR DESCRIPTION
## Problem

Fixes #14402.

`agent/memory_manager.py` and `agent/memory_provider.py` contain stale docstring references to `BuiltinMemoryProvider` — a class that no longer exists in the repository. This causes confusion for contributors who:

1. Read the example usage in `memory_manager.py` and try `add_provider(BuiltinMemoryProvider(...))` → `ImportError`
2. See `memory_provider.py` claiming `BuiltinMemoryProvider — always present, not removable` and look for it in the codebase → not found

**Verification:** The regression test `test_memory_user_id.py::TestMemoryManagerUserIdThreading` already passes without any `BuiltinMemoryProvider` reference — it uses `RecordingProvider` instances directly. All 5 tests in that class pass on current `main`.

## Fix

Update both docstrings to reflect the actual current architecture:
- `MemoryManager` accepts external plugin providers only (one at a time)
- No mention of `BuiltinMemoryProvider` since it doesn't exist
- Example code in `memory_manager.py` updated to remove the phantom `add_provider(BuiltinMemoryProvider(...))` call

## Testing

```
python3 -m pytest tests/agent/test_memory_user_id.py::TestMemoryManagerUserIdThreading -v
# 5 passed
```