### PR TITLE
fix: sync Telegram topic titles with /title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -56,6 +56,26 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
         return None
 
 
+def generate_title_if_missing(
+    session_db,
+    session_id: str,
+    user_message: str,
+    assistant_response: str,
+) -> Optional[str]:
+    """Return a generated title only if the session does not already have one."""
+    if not session_db or not session_id:
+        return None
+
+    try:
+        existing = session_db.get_session_title(session_id)
+        if existing:
+            return None
+    except Exception:
+        return None
+
+    return generate_title(user_message, assistant_response)
+
+
 def auto_title_session(
     session_db,
     session_id: str,
@@ -70,18 +90,12 @@ def auto_title_session(
     - session already has a title (user-set or previously auto-generated)
     - title generation fails
     """
-    if not session_db or not session_id:
-        return
-
-    # Check if title already exists (user may have set one via /title before first response)
-    try:
-        existing = session_db.get_session_title(session_id)
-        if existing:
-            return
-    except Exception:
-        return
-
-    title = generate_title(user_message, assistant_response)
+    title = generate_title_if_missing(
+        session_db,
+        session_id,
+        user_message,
+        assistant_response,
+    )
     if not title:
         return
 
@@ -90,6 +104,12 @@ def auto_title_session(
         logger.debug("Auto-generated session title: %s", title)
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
+
+
+def should_auto_title(conversation_history: list) -> bool:
+    """Return whether this history is still early enough for auto-titling."""
+    user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
+    return user_msg_count <= 2
 
 
 def maybe_auto_title(
@@ -108,12 +128,7 @@ def maybe_auto_title(
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    # Count user messages in history to detect first exchange.
-    # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
-    user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
-    if user_msg_count > 2:
+    if not should_auto_title(conversation_history):
         return
 
     thread = threading.Thread(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1522,13 +1522,19 @@ class BasePlatformAdapter(ABC):
 
         ``generation`` lets callers tie the callback to a specific gateway run
         generation so stale runs cannot clear callbacks owned by a fresher run.
+        Multiple callbacks may be registered for the same session; matching
+        callbacks run in registration order.
         """
         if not session_key or not callable(callback):
             return
-        if generation is None:
-            self._post_delivery_callbacks[session_key] = callback
+        entry: Any = callback if generation is None else (int(generation), callback)
+        existing = self._post_delivery_callbacks.get(session_key)
+        if existing is None:
+            self._post_delivery_callbacks[session_key] = entry
+        elif isinstance(existing, list):
+            existing.append(entry)
         else:
-            self._post_delivery_callbacks[session_key] = (int(generation), callback)
+            self._post_delivery_callbacks[session_key] = [existing, entry]
 
     def pop_post_delivery_callback(
         self,
@@ -1536,22 +1542,46 @@ class BasePlatformAdapter(ABC):
         *,
         generation: int | None = None,
     ) -> Callable | None:
-        """Pop a deferred callback, optionally requiring generation ownership."""
+        """Pop deferred callbacks, optionally requiring generation ownership."""
         if not session_key:
             return None
         entry = self._post_delivery_callbacks.get(session_key)
         if entry is None:
             return None
-        if isinstance(entry, tuple) and len(entry) == 2:
-            entry_generation, callback = entry
-            if generation is not None and int(entry_generation) != int(generation):
-                return None
+
+        entries = entry if isinstance(entry, list) else [entry]
+        matched: list[Callable] = []
+        remaining: list[Any] = []
+
+        for item in entries:
+            if isinstance(item, tuple) and len(item) == 2:
+                entry_generation, callback = item
+                if generation is not None and int(entry_generation) != int(generation):
+                    remaining.append(item)
+                    continue
+                if callable(callback):
+                    matched.append(callback)
+                continue
+
+            if generation is not None:
+                remaining.append(item)
+                continue
+            if callable(item):
+                matched.append(item)
+
+        if remaining:
+            self._post_delivery_callbacks[session_key] = remaining if len(remaining) > 1 else remaining[0]
+        else:
             self._post_delivery_callbacks.pop(session_key, None)
-            return callback if callable(callback) else None
-        if generation is not None:
+
+        if not matched:
             return None
-        self._post_delivery_callbacks.pop(session_key, None)
-        return entry if callable(entry) else None
+
+        def _run_all() -> None:
+            for callback in matched:
+                callback()
+
+        return _run_all
 
     # ── Processing lifecycle hooks ──────────────────────────────────────────
     # Subclasses override these to react to message processing events

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1134,6 +1134,20 @@ class BasePlatformAdapter(ABC):
         Default is a no-op for platforms with one-shot typing indicators.
         """
         pass
+
+    async def update_thread_title(
+        self,
+        chat_id: str,
+        thread_id: str,
+        title: str,
+    ) -> bool:
+        """Rename a platform-specific thread/topic when supported.
+
+        Default implementation is a no-op so callers can optimistically try
+        to sync session titles to platform threads without special-casing
+        every adapter.
+        """
+        return False
     
     async def send_image(
         self,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -247,6 +247,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topics: Dict[str, int] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        # Runtime cache of topic titles keyed by "chat_id:thread_id".
+        # This lets /title-driven renames and Telegram service messages show up
+        # in Hermes context immediately without waiting for config changes.
+        self._thread_topic_titles: Dict[str, str] = {}
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
@@ -510,6 +514,57 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return None
 
+    def _cache_thread_topic_title(self, chat_id: str, thread_id: str, title: str) -> None:
+        """Remember the latest known title for a Telegram thread/topic."""
+        normalized = (title or "").strip()
+        if not normalized or not chat_id or not thread_id:
+            return
+        cache_key = f"{chat_id}:{thread_id}"
+        self._thread_topic_titles[cache_key] = normalized
+
+    def _get_cached_thread_topic_title(self, chat_id: str, thread_id: Optional[str]) -> Optional[str]:
+        if not chat_id or not thread_id:
+            return None
+        return self._thread_topic_titles.get(f"{chat_id}:{thread_id}")
+
+    async def update_thread_title(self, chat_id: str, thread_id: str, title: str) -> bool:
+        """Rename a Telegram forum topic / DM topic thread."""
+        if not self._bot or not chat_id or not thread_id:
+            return False
+        normalized = (title or "").strip()
+        if not normalized:
+            return False
+        try:
+            if str(thread_id) == self._GENERAL_TOPIC_THREAD_ID:
+                await self._bot.edit_general_forum_topic(
+                    chat_id=int(chat_id),
+                    name=normalized,
+                )
+            else:
+                await self._bot.edit_forum_topic(
+                    chat_id=int(chat_id),
+                    message_thread_id=int(thread_id),
+                    name=normalized,
+                )
+            self._cache_thread_topic_title(str(chat_id), str(thread_id), normalized)
+            logger.info(
+                "[%s] Renamed Telegram topic chat=%s thread=%s -> %s",
+                self.name,
+                chat_id,
+                thread_id,
+                normalized,
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                "[%s] Failed to rename Telegram topic chat=%s thread=%s: %s",
+                self.name,
+                chat_id,
+                thread_id,
+                e,
+            )
+            return False
+
     def _persist_dm_topic_thread_id(self, chat_id: int, topic_name: str, thread_id: int) -> None:
         """Save a newly created thread_id back into config.yaml so it persists across restarts."""
         try:
@@ -759,7 +814,11 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             self._app.add_handler(TelegramMessageHandler(
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
+                self._handle_media_message,
+            ))
+            self._app.add_handler(TelegramMessageHandler(
+                filters.StatusUpdate.FORUM_TOPIC_CREATED | filters.StatusUpdate.FORUM_TOPIC_EDITED,
+                self._handle_forum_topic_service_message,
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
@@ -2446,6 +2505,26 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = "\n".join(parts)
         await self.handle_message(event)
 
+    async def _handle_forum_topic_service_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Cache Telegram forum-topic create/edit service messages."""
+        message = getattr(update, "message", None)
+        if not message:
+            return
+        thread_id = getattr(message, "message_thread_id", None)
+        chat = getattr(message, "chat", None)
+        if thread_id is None or not chat:
+            return
+
+        if hasattr(message, "forum_topic_created") and message.forum_topic_created:
+            created_name = getattr(message.forum_topic_created, "name", None)
+            if created_name:
+                self._cache_thread_topic_title(str(chat.id), str(thread_id), created_name)
+
+        if hasattr(message, "forum_topic_edited") and message.forum_topic_edited:
+            edited_name = getattr(message.forum_topic_edited, "name", None)
+            if edited_name:
+                self._cache_thread_topic_title(str(chat.id), str(thread_id), edited_name)
+
     # ------------------------------------------------------------------
     # Text message aggregation (handles Telegram client-side splits)
     # ------------------------------------------------------------------
@@ -3019,6 +3098,22 @@ class TelegramAdapter(BasePlatformAdapter):
                             topic_skill = topic.get("skill")
                             break
                     break
+
+        cached_topic_title = self._get_cached_thread_topic_title(str(chat.id), thread_id_str)
+        if cached_topic_title:
+            chat_topic = cached_topic_title
+
+        if thread_id_str and hasattr(message, "forum_topic_created") and message.forum_topic_created:
+            created_name = message.forum_topic_created.name
+            if created_name:
+                self._cache_thread_topic_title(str(chat.id), thread_id_str, created_name)
+                chat_topic = created_name
+
+        if thread_id_str and hasattr(message, "forum_topic_edited") and message.forum_topic_edited:
+            edited_name = getattr(message.forum_topic_edited, "name", None)
+            if edited_name:
+                self._cache_thread_topic_title(str(chat.id), thread_id_str, edited_name)
+                chat_topic = edited_name
 
         # Build source
         source = self.build_source(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1028,6 +1028,169 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _track_background_task(self, task: asyncio.Task) -> asyncio.Task:
+        """Keep a background task alive until completion."""
+        background_tasks = getattr(self, "_background_tasks", None)
+        if isinstance(background_tasks, set):
+            background_tasks.add(task)
+            task.add_done_callback(background_tasks.discard)
+        return task
+
+    async def _sync_session_title_to_source(self, source: SessionSource, title: str) -> bool:
+        """Best-effort platform thread/topic title sync for a session title."""
+        if not source or not source.thread_id or not source.platform:
+            return False
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            return False
+        updater = getattr(adapter, "update_thread_title", None)
+        if not callable(updater):
+            return False
+        try:
+            return bool(await updater(source.chat_id, source.thread_id, title))
+        except Exception as e:
+            logger.debug("Session-title sync failed for %s thread %s: %s", source.platform, source.thread_id, e)
+            return False
+
+    def _schedule_session_title_sync_after_delivery(
+        self,
+        *,
+        session_key: Optional[str],
+        source: SessionSource,
+        title: str,
+        generation: int | None = None,
+    ) -> bool:
+        """Schedule platform title sync after the current response is delivered."""
+        if not session_key or not source or not source.thread_id or not source.platform:
+            return False
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            return False
+
+        def _after_delivery() -> None:
+            self._track_background_task(
+                asyncio.create_task(self._sync_session_title_to_source(source, title))
+            )
+
+        register = getattr(adapter, "register_post_delivery_callback", None)
+        if callable(register):
+            register(session_key, _after_delivery, generation=generation)
+            return True
+
+        post_callbacks = getattr(adapter, "_post_delivery_callbacks", None)
+        if isinstance(post_callbacks, dict):
+            post_callbacks[session_key] = _after_delivery
+            return True
+        return False
+
+    async def _apply_session_title(
+        self,
+        *,
+        session_id: str,
+        source: SessionSource,
+        title: str,
+        session_key: Optional[str] = None,
+        defer_thread_sync: bool = False,
+        sync_thread_now: bool = False,
+        only_if_missing: bool = False,
+        generation: int | None = None,
+    ) -> bool:
+        """Persist a session title and optionally propagate it to the source thread."""
+        if not self._session_db:
+            return False
+        if only_if_missing:
+            changed = self._session_db.set_session_title_if_missing(session_id, title)
+        else:
+            changed = self._session_db.set_session_title(session_id, title)
+        if not changed:
+            return False
+        if sync_thread_now:
+            await self._sync_session_title_to_source(source, title)
+        elif defer_thread_sync:
+            self._schedule_session_title_sync_after_delivery(
+                session_key=session_key,
+                source=source,
+                title=title,
+                generation=generation,
+            )
+        return True
+
+    async def _auto_title_gateway_session(
+        self,
+        *,
+        session_id: str,
+        session_key: Optional[str],
+        source: SessionSource,
+        user_message: str,
+        assistant_response: str,
+    ) -> None:
+        """Generate a missing title for a gateway session and sync it natively."""
+        if not self._session_db:
+            return
+        try:
+            from agent.title_generator import generate_title_if_missing
+
+            title = await asyncio.to_thread(
+                generate_title_if_missing,
+                self._session_db,
+                session_id,
+                user_message,
+                assistant_response,
+            )
+            if not title:
+                return
+            await self._apply_session_title(
+                session_id=session_id,
+                session_key=session_key,
+                source=source,
+                title=title,
+                sync_thread_now=True,
+                only_if_missing=True,
+            )
+        except Exception as e:
+            logger.debug("Gateway auto-title failed for %s: %s", session_id, e)
+
+    def _maybe_schedule_gateway_auto_title(
+        self,
+        *,
+        session_id: str,
+        session_key: Optional[str],
+        source: SessionSource,
+        user_message: str,
+        assistant_response: str,
+        conversation_history: list,
+        generation: int | None = None,
+    ) -> None:
+        """Run gateway auto-title after delivery when this is an early exchange."""
+        if not self._session_db or not session_id or not user_message or not assistant_response:
+            return
+        try:
+            from agent.title_generator import should_auto_title
+        except Exception:
+            return
+        if not should_auto_title(conversation_history):
+            return
+
+        def _launch() -> None:
+            self._track_background_task(
+                asyncio.create_task(
+                    self._auto_title_gateway_session(
+                        session_id=session_id,
+                        session_key=session_key,
+                        source=source,
+                        user_message=user_message,
+                        assistant_response=assistant_response,
+                    )
+                )
+            )
+
+        adapter = self.adapters.get(source.platform) if source and source.platform else None
+        register = getattr(adapter, "register_post_delivery_callback", None) if adapter else None
+        if session_key and callable(register):
+            register(session_key, _launch, generation=generation)
+        else:
+            _launch()
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -7063,17 +7226,14 @@ class GatewayRunner:
                 return "⚠️ Title is empty after cleanup. Please use printable characters."
             # Set the title
             try:
-                if self._session_db.set_session_title(session_id, sanitized):
-                    response = f"✏️ Session title set: **{sanitized}**"
-                    if source.platform == Platform.TELEGRAM and source.thread_id:
-                        adapter = self.adapters.get(source.platform)
-                        if adapter and await adapter.update_thread_title(
-                            source.chat_id,
-                            source.thread_id,
-                            sanitized,
-                        ):
-                            response += "\n🧵 Telegram topic renamed too."
-                    return response
+                if await self._apply_session_title(
+                    session_id=session_id,
+                    session_key=session_entry.session_key,
+                    source=source,
+                    title=sanitized,
+                    defer_thread_sync=True,
+                ):
+                    return f"✏️ Session title set: **{sanitized}**"
                 else:
                     return "Session not found in database."
             except ValueError as e:
@@ -10092,14 +10252,15 @@ class GatewayRunner:
             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:
                 try:
-                    from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    maybe_auto_title(
-                        self._session_db,
-                        effective_session_id,
-                        message,
-                        final_response,
-                        all_msgs,
+                    self._maybe_schedule_gateway_auto_title(
+                        session_id=effective_session_id,
+                        session_key=session_key,
+                        source=source,
+                        user_message=message,
+                        assistant_response=final_response,
+                        conversation_history=all_msgs,
+                        generation=run_generation,
                     )
                 except Exception:
                     pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7064,7 +7064,16 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
-                    return f"✏️ Session title set: **{sanitized}**"
+                    response = f"✏️ Session title set: **{sanitized}**"
+                    if source.platform == Platform.TELEGRAM and source.thread_id:
+                        adapter = self.adapters.get(source.platform)
+                        if adapter and await adapter.update_thread_title(
+                            source.chat_id,
+                            source.thread_id,
+                            sanitized,
+                        ):
+                            response += "\n🧵 Telegram topic renamed too."
+                    return response
                 else:
                     return "Session not found in database."
             except ValueError as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -641,6 +641,31 @@ class SessionDB:
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
+    def set_session_title_if_missing(self, session_id: str, title: str) -> bool:
+        """Atomically set a session title only when the current title is NULL."""
+        title = self.sanitize_title(title)
+        if not title:
+            return False
+
+        def _do(conn):
+            cursor = conn.execute(
+                "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                (title, session_id),
+            )
+            conflict = cursor.fetchone()
+            if conflict:
+                raise ValueError(
+                    f"Title '{title}' is already in use by session {conflict['id']}"
+                )
+            cursor = conn.execute(
+                "UPDATE sessions SET title = ? WHERE id = ? AND title IS NULL",
+                (title, session_id),
+            )
+            return cursor.rowcount
+
+        rowcount = self._execute_write(_do)
+        return rowcount > 0
+
     def get_session_title(self, session_id: str) -> Optional[str]:
         """Get the title for a session, or None."""
         with self._lock:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -7,6 +7,7 @@ import pytest
 
 from agent.title_generator import (
     generate_title,
+    generate_title_if_missing,
     auto_title_session,
     maybe_auto_title,
 )
@@ -89,19 +90,26 @@ class TestAutoTitleSession:
     def test_skips_if_no_session_db(self):
         auto_title_session(None, "sess-1", "hi", "hello")  # should not crash
 
-    def test_skips_if_title_exists(self):
+    def test_generate_title_if_missing_skips_if_title_exists(self):
         db = MagicMock()
         db.get_session_title.return_value = "Existing Title"
 
         with patch("agent.title_generator.generate_title") as gen:
-            auto_title_session(db, "sess-1", "hi", "hello")
+            assert generate_title_if_missing(db, "sess-1", "hi", "hello") is None
             gen.assert_not_called()
+
+    def test_generate_title_if_missing_returns_generated_title(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+
+        with patch("agent.title_generator.generate_title", return_value="New Title"):
+            assert generate_title_if_missing(db, "sess-1", "hi", "hello") == "New Title"
 
     def test_generates_and_sets_title(self):
         db = MagicMock()
         db.get_session_title.return_value = None
 
-        with patch("agent.title_generator.generate_title", return_value="New Title"):
+        with patch("agent.title_generator.generate_title_if_missing", return_value="New Title"):
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_session_title.assert_called_once_with("sess-1", "New Title")
 
@@ -109,7 +117,7 @@ class TestAutoTitleSession:
         db = MagicMock()
         db.get_session_title.return_value = None
 
-        with patch("agent.title_generator.generate_title", return_value=None):
+        with patch("agent.title_generator.generate_title_if_missing", return_value=None):
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_session_title.assert_not_called()
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -105,6 +105,14 @@ class TestAutoTitleSession:
         with patch("agent.title_generator.generate_title", return_value="New Title"):
             assert generate_title_if_missing(db, "sess-1", "hi", "hello") == "New Title"
 
+    def test_generate_title_if_missing_returns_none_on_lookup_error(self):
+        db = MagicMock()
+        db.get_session_title.side_effect = RuntimeError("db unavailable")
+
+        with patch("agent.title_generator.generate_title") as gen:
+            assert generate_title_if_missing(db, "sess-1", "hi", "hello") is None
+            gen.assert_not_called()
+
     def test_generates_and_sets_title(self):
         db = MagicMock()
         db.get_session_title.return_value = None
@@ -120,6 +128,14 @@ class TestAutoTitleSession:
         with patch("agent.title_generator.generate_title_if_missing", return_value=None):
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_session_title.assert_not_called()
+
+    def test_swallows_set_title_errors(self):
+        db = MagicMock()
+        db.set_session_title.side_effect = RuntimeError("write failed")
+
+        with patch("agent.title_generator.generate_title_if_missing", return_value="New Title"):
+            auto_title_session(db, "sess-1", "hi", "hello")
+            db.set_session_title.assert_called_once_with("sess-1", "New Title")
 
 
 class TestMaybeAutoTitle:

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -198,6 +198,71 @@ async def test_create_dm_topic_returns_none_without_bot():
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_update_thread_title_calls_edit_forum_topic_and_caches_name():
+    """Successful topic rename should hit Bot API and update runtime cache."""
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+
+    result = await adapter.update_thread_title("111", "222", "Indicative Topic")
+
+    assert result is True
+    adapter._bot.edit_forum_topic.assert_called_once_with(
+        chat_id=111,
+        message_thread_id=222,
+        name="Indicative Topic",
+    )
+    assert adapter._get_cached_thread_topic_title("111", "222") == "Indicative Topic"
+
+
+@pytest.mark.asyncio
+async def test_update_thread_title_uses_general_topic_api_for_thread_one():
+    """The General topic uses Telegram's separate rename API."""
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+
+    result = await adapter.update_thread_title("111", TelegramAdapter._GENERAL_TOPIC_THREAD_ID, "Lobby")
+
+    assert result is True
+    adapter._bot.edit_general_forum_topic.assert_called_once_with(
+        chat_id=111,
+        name="Lobby",
+    )
+    adapter._bot.edit_forum_topic.assert_not_called()
+    assert adapter._get_cached_thread_topic_title("111", TelegramAdapter._GENERAL_TOPIC_THREAD_ID) == "Lobby"
+
+
+@pytest.mark.asyncio
+async def test_update_thread_title_returns_false_on_api_error():
+    """Rename failures should be non-fatal and return False."""
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+    adapter._bot.edit_forum_topic.side_effect = Exception("boom")
+
+    result = await adapter.update_thread_title("111", "222", "Indicative Topic")
+
+    assert result is False
+    assert adapter._get_cached_thread_topic_title("111", "222") is None
+
+
+@pytest.mark.asyncio
+async def test_forum_topic_service_handler_caches_created_and_edited_names():
+    """Service messages should hot-update the runtime topic-title cache."""
+    adapter = _make_adapter()
+    update = SimpleNamespace(
+        message=SimpleNamespace(
+            chat=SimpleNamespace(id=111),
+            message_thread_id=222,
+            forum_topic_created=SimpleNamespace(name="Created Title"),
+            forum_topic_edited=SimpleNamespace(name="Edited Title"),
+        )
+    )
+
+    await adapter._handle_forum_topic_service_message(update, None)
+
+    assert adapter._get_cached_thread_topic_title("111", "222") == "Edited Title"
+
+
 # ── _persist_dm_topic_thread_id ──
 
 

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -245,6 +245,28 @@ async def test_update_thread_title_returns_false_on_api_error():
     assert adapter._get_cached_thread_topic_title("111", "222") is None
 
 
+def test_cache_thread_topic_title_ignores_incomplete_values():
+    """Empty title/chat/thread inputs should not populate the runtime cache."""
+    adapter = _make_adapter()
+
+    adapter._cache_thread_topic_title("111", "222", "")
+    adapter._cache_thread_topic_title("", "222", "Title")
+    adapter._cache_thread_topic_title("111", "", "Title")
+
+    assert adapter._thread_topic_titles == {}
+
+
+@pytest.mark.asyncio
+async def test_update_thread_title_returns_false_without_bot_or_title():
+    """Missing bot or blank title should short-circuit before any API call."""
+    adapter = _make_adapter()
+    assert await adapter.update_thread_title("111", "222", "Title") is False
+
+    adapter._bot = AsyncMock()
+    assert await adapter.update_thread_title("111", "222", "   ") is False
+    adapter._bot.edit_forum_topic.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_forum_topic_service_handler_caches_created_and_edited_names():
     """Service messages should hot-update the runtime topic-title cache."""
@@ -261,6 +283,24 @@ async def test_forum_topic_service_handler_caches_created_and_edited_names():
     await adapter._handle_forum_topic_service_message(update, None)
 
     assert adapter._get_cached_thread_topic_title("111", "222") == "Edited Title"
+
+
+@pytest.mark.asyncio
+async def test_forum_topic_service_handler_ignores_missing_message_or_context():
+    """Service handler should no-op when update lacks message/thread/chat context."""
+    adapter = _make_adapter()
+
+    await adapter._handle_forum_topic_service_message(SimpleNamespace(message=None), None)
+    await adapter._handle_forum_topic_service_message(
+        SimpleNamespace(message=SimpleNamespace(message_thread_id=None, chat=SimpleNamespace(id=111))),
+        None,
+    )
+    await adapter._handle_forum_topic_service_message(
+        SimpleNamespace(message=SimpleNamespace(message_thread_id=222, chat=None)),
+        None,
+    )
+
+    assert adapter._thread_topic_titles == {}
 
 
 # ── _persist_dm_topic_thread_id ──
@@ -594,6 +634,37 @@ def test_build_message_event_no_auto_skill_without_thread():
     event = adapter._build_message_event(msg, MessageType.TEXT)
 
     assert event.auto_skill is None
+
+
+def test_build_message_event_prefers_cached_thread_topic_title():
+    """Runtime-cached topic titles should flow into the built SessionSource."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    adapter._cache_thread_topic_title("111", "200", "Cached Topic")
+
+    msg = _make_mock_message(chat_id=111, thread_id=200)
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.source.chat_topic == "Cached Topic"
+
+
+def test_build_message_event_uses_topic_created_and_edited_service_names():
+    """Forum-topic service payloads should update the event topic name immediately."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_mock_message(
+        chat_id=111,
+        thread_id=300,
+        forum_topic_created=SimpleNamespace(name="Created Topic"),
+    )
+    msg.forum_topic_edited = SimpleNamespace(name="Edited Topic")
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.source.chat_topic == "Edited Topic"
+    assert adapter._get_cached_thread_topic_title("111", "300") == "Edited Topic"
 
 
 # ── _build_message_event: group_topics skill binding ──

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -783,6 +783,22 @@ async def test_base_processing_releases_post_delivery_callback_after_main_send()
 
 
 @pytest.mark.asyncio
+async def test_post_delivery_callbacks_compose_for_same_session():
+    """Multiple post-delivery callbacks for a session should all run."""
+    adapter = ProgressCaptureAdapter()
+    fired = []
+
+    adapter.register_post_delivery_callback("sess", lambda: fired.append("first"), generation=3)
+    adapter.register_post_delivery_callback("sess", lambda: fired.append("second"), generation=3)
+
+    callback = adapter.pop_post_delivery_callback("sess", generation=3)
+    assert callable(callback)
+    callback()
+
+    assert fired == ["first", "second"]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_drops_tool_progress_after_generation_invalidation(monkeypatch, tmp_path):
     import yaml
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -799,6 +799,43 @@ async def test_post_delivery_callbacks_compose_for_same_session():
 
 
 @pytest.mark.asyncio
+async def test_post_delivery_callbacks_append_to_existing_list_and_preserve_unmatched_generation():
+    """Generation filtering should leave unmatched callbacks queued for a later pop."""
+    adapter = ProgressCaptureAdapter()
+    fired = []
+
+    adapter.register_post_delivery_callback("sess", lambda: fired.append("first"), generation=3)
+    adapter.register_post_delivery_callback("sess", lambda: fired.append("second"), generation=3)
+    adapter.register_post_delivery_callback("sess", lambda: fired.append("third"), generation=4)
+
+    callback = adapter.pop_post_delivery_callback("sess", generation=3)
+    assert callable(callback)
+    callback()
+    assert fired == ["first", "second"]
+
+    callback = adapter.pop_post_delivery_callback("sess", generation=4)
+    assert callable(callback)
+    callback()
+    assert fired == ["first", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_post_delivery_callback_plain_entry_survives_generation_filtered_pop():
+    """A plain callback should remain queued when popping with a generation filter."""
+    adapter = ProgressCaptureAdapter()
+    fired = []
+
+    adapter.register_post_delivery_callback("sess", lambda: fired.append("plain"))
+
+    assert adapter.pop_post_delivery_callback("sess", generation=7) is None
+    callback = adapter.pop_post_delivery_callback("sess")
+    assert callable(callback)
+    callback()
+
+    assert fired == ["plain"]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_drops_tool_progress_after_generation_invalidation(monkeypatch, tmp_path):
     import yaml
 

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -1,9 +1,10 @@
-"""Tests for /title gateway slash command.
+"""Tests for gateway session-title flows.
 
-Tests the _handle_title_command handler (set/show session titles)
-across all gateway messenger platforms.
+Tests the /title handler plus native gateway session-title propagation
+for manual and auto-generated titles.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -33,6 +34,7 @@ def _make_runner(session_db=None):
     runner.adapters = {}
     runner._voice_mode = {}
     runner._session_db = session_db
+    runner._background_tasks = set()
 
     # Mock session_store that returns a session entry with a known session_id
     mock_session_entry = MagicMock()
@@ -72,7 +74,7 @@ class TestHandleTitleCommand:
 
     @pytest.mark.asyncio
     async def test_set_title_renames_telegram_topic_when_in_thread(self, tmp_path):
-        """Telegram /title should also rename the active topic thread when possible."""
+        """Telegram /title should schedule thread-title sync via the native callback path."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session("test_session_123", "telegram")
@@ -85,14 +87,18 @@ class TestHandleTitleCommand:
         event = _make_event(text="/title Indicative Topic", thread_id="470094")
         result = await runner._handle_title_command(event)
 
+        adapter.register_post_delivery_callback.assert_called_once()
+        callback = adapter.register_post_delivery_callback.call_args.args[1]
+        callback()
+        await asyncio.sleep(0)
         adapter.update_thread_title.assert_awaited_once_with("67890", "470094", "Indicative Topic")
-        assert "Telegram topic renamed too" in result
+        assert "Telegram topic renamed too" not in result
         assert db.get_session_title("test_session_123") == "Indicative Topic"
         db.close()
 
     @pytest.mark.asyncio
     async def test_set_title_renames_telegram_general_topic_when_thread_is_one(self, tmp_path):
-        """Telegram General topic thread_id=1 should still trigger a rename attempt."""
+        """Telegram General topic thread_id=1 should also use the deferred sync path."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session("test_session_123", "telegram")
@@ -105,8 +111,12 @@ class TestHandleTitleCommand:
         event = _make_event(text="/title Lobby", thread_id="1")
         result = await runner._handle_title_command(event)
 
+        adapter.register_post_delivery_callback.assert_called_once()
+        callback = adapter.register_post_delivery_callback.call_args.args[1]
+        callback()
+        await asyncio.sleep(0)
         adapter.update_thread_title.assert_awaited_once_with("67890", "1", "Lobby")
-        assert "Telegram topic renamed too" in result
+        assert "Telegram topic renamed too" not in result
         assert db.get_session_title("test_session_123") == "Lobby"
         db.close()
 
@@ -125,9 +135,89 @@ class TestHandleTitleCommand:
         event = _make_event(text="/title Plain Chat Title")
         result = await runner._handle_title_command(event)
 
-        adapter.update_thread_title.assert_not_called()
-        assert "Telegram topic renamed too" not in result
+        adapter.register_post_delivery_callback.assert_not_called()
         assert db.get_session_title("test_session_123") == "Plain Chat Title"
+        db.close()
+
+
+class TestGatewayAutoTitleSync:
+    @pytest.mark.asyncio
+    async def test_auto_title_flow_uses_same_session_title_path(self, tmp_path):
+        """Gateway auto-title should persist title and sync Telegram thread title."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = _make_event(thread_id="470094").source
+
+        with patch("agent.title_generator.generate_title_if_missing", return_value="Auto Topic"):
+            await runner._auto_title_gateway_session(
+                session_id="test_session_123",
+                session_key="telegram:12345:67890",
+                source=source,
+                user_message="hello",
+                assistant_response="hi there",
+            )
+
+        assert db.get_session_title("test_session_123") == "Auto Topic"
+        adapter.update_thread_title.assert_awaited_once_with("67890", "470094", "Auto Topic")
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_auto_title_skips_platform_sync_when_no_thread(self, tmp_path):
+        """Gateway auto-title without a thread should remain DB-only."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = _make_event().source
+
+        with patch("agent.title_generator.generate_title_if_missing", return_value="Auto Session"):
+            await runner._auto_title_gateway_session(
+                session_id="test_session_123",
+                session_key="telegram:12345:67890",
+                source=source,
+                user_message="hello",
+                assistant_response="hi there",
+            )
+
+        assert db.get_session_title("test_session_123") == "Auto Session"
+        adapter.update_thread_title.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_auto_title_skips_overwriting_existing_manual_title(self, tmp_path):
+        """Gateway auto-title should not clobber a title set while generation was in flight."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.set_session_title("test_session_123", "Manual Title")
+
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = _make_event(thread_id="470094").source
+
+        with patch("agent.title_generator.generate_title_if_missing", return_value="Auto Topic"):
+            await runner._auto_title_gateway_session(
+                session_id="test_session_123",
+                session_key="telegram:12345:67890",
+                source=source,
+                user_message="hello",
+                assistant_response="hi there",
+            )
+
+        assert db.get_session_title("test_session_123") == "Manual Title"
+        adapter.update_thread_title.assert_not_called()
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -4,8 +4,7 @@ Tests the _handle_title_command handler (set/show session titles)
 across all gateway messenger platforms.
 """
 
-import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -15,13 +14,14 @@ from gateway.session import SessionSource
 
 
 def _make_event(text="/title", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+                user_id="12345", chat_id="67890", thread_id=None):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
         user_name="testuser",
+        thread_id=thread_id,
     )
     return MessageEvent(text=text, source=source)
 
@@ -68,6 +68,66 @@ class TestHandleTitleCommand:
 
         # Verify in DB
         assert db.get_session_title("test_session_123") == "My Research Project"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_renames_telegram_topic_when_in_thread(self, tmp_path):
+        """Telegram /title should also rename the active topic thread when possible."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        event = _make_event(text="/title Indicative Topic", thread_id="470094")
+        result = await runner._handle_title_command(event)
+
+        adapter.update_thread_title.assert_awaited_once_with("67890", "470094", "Indicative Topic")
+        assert "Telegram topic renamed too" in result
+        assert db.get_session_title("test_session_123") == "Indicative Topic"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_renames_telegram_general_topic_when_thread_is_one(self, tmp_path):
+        """Telegram General topic thread_id=1 should still trigger a rename attempt."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        event = _make_event(text="/title Lobby", thread_id="1")
+        result = await runner._handle_title_command(event)
+
+        adapter.update_thread_title.assert_awaited_once_with("67890", "1", "Lobby")
+        assert "Telegram topic renamed too" in result
+        assert db.get_session_title("test_session_123") == "Lobby"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_skips_telegram_topic_rename_without_thread(self, tmp_path):
+        """Telegram chats without a thread_id keep the existing DB-only behavior."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        event = _make_event(text="/title Plain Chat Title")
+        result = await runner._handle_title_command(event)
+
+        adapter.update_thread_title.assert_not_called()
+        assert "Telegram topic renamed too" not in result
+        assert db.get_session_title("test_session_123") == "Plain Chat Title"
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -220,6 +220,116 @@ class TestGatewayAutoTitleSync:
         adapter.update_thread_title.assert_not_called()
         db.close()
 
+
+class TestGatewayTitleHelpers:
+    @pytest.mark.asyncio
+    async def test_sync_session_title_to_source_returns_false_without_adapter_or_updater(self):
+        runner = _make_runner()
+        source = _make_event(thread_id="470094").source
+
+        assert await runner._sync_session_title_to_source(source, "Title") is False
+
+        runner.adapters[Platform.TELEGRAM] = MagicMock()
+        assert await runner._sync_session_title_to_source(source, "Title") is False
+
+    @pytest.mark.asyncio
+    async def test_sync_session_title_to_source_handles_updater_errors(self):
+        runner = _make_runner()
+        source = _make_event(thread_id="470094").source
+        adapter = MagicMock()
+        adapter.update_thread_title = AsyncMock(side_effect=RuntimeError("boom"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        assert await runner._sync_session_title_to_source(source, "Title") is False
+
+    @pytest.mark.asyncio
+    async def test_schedule_session_title_sync_after_delivery_falls_back_to_adapter_dict(self):
+        runner = _make_runner()
+        source = _make_event(thread_id="470094").source
+        adapter = MagicMock()
+        adapter._post_delivery_callbacks = {}
+        del adapter.register_post_delivery_callback
+        adapter.update_thread_title = AsyncMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        scheduled = runner._schedule_session_title_sync_after_delivery(
+            session_key="telegram:12345:67890",
+            source=source,
+            title="Title",
+        )
+
+        assert scheduled is True
+        callback = adapter._post_delivery_callbacks["telegram:12345:67890"]
+        callback()
+        await asyncio.sleep(0)
+        adapter.update_thread_title.assert_awaited_once_with("67890", "470094", "Title")
+
+    @pytest.mark.asyncio
+    async def test_apply_session_title_uses_only_if_missing_path(self, tmp_path):
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        source = _make_event(thread_id="470094").source
+
+        changed = await runner._apply_session_title(
+            session_id="test_session_123",
+            source=source,
+            title="Initial",
+            only_if_missing=True,
+        )
+        unchanged = await runner._apply_session_title(
+            session_id="test_session_123",
+            source=source,
+            title="Second",
+            only_if_missing=True,
+        )
+
+        assert changed is True
+        assert unchanged is False
+        assert db.get_session_title("test_session_123") == "Initial"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_maybe_schedule_gateway_auto_title_registers_post_delivery_callback(self):
+        runner = _make_runner(session_db=MagicMock())
+        source = _make_event(thread_id="470094").source
+        adapter = MagicMock()
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        with patch("agent.title_generator.should_auto_title", return_value=True):
+            runner._maybe_schedule_gateway_auto_title(
+                session_id="test_session_123",
+                session_key="telegram:12345:67890",
+                source=source,
+                user_message="hello",
+                assistant_response="hi",
+                conversation_history=[{"role": "user", "content": "hello"}],
+                generation=5,
+            )
+
+        adapter.register_post_delivery_callback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_maybe_schedule_gateway_auto_title_launches_immediately_without_adapter_registration(self):
+        runner = _make_runner(session_db=MagicMock())
+        source = _make_event(thread_id="470094").source
+
+        with patch("agent.title_generator.should_auto_title", return_value=True), \
+             patch.object(runner, "_auto_title_gateway_session", AsyncMock()) as auto_title:
+            runner._maybe_schedule_gateway_auto_title(
+                session_id="test_session_123",
+                session_key=None,
+                source=source,
+                user_message="hello",
+                assistant_response="hi",
+                conversation_history=[{"role": "user", "content": "hello"}],
+            )
+            await asyncio.sleep(0)
+
+        auto_title.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_show_title_when_set(self, tmp_path):
         """Showing title when one is set returns the title."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -945,6 +945,7 @@ class TestSessionTitle:
 
     def test_set_title_nonexistent_session(self, db):
         assert db.set_session_title("nonexistent", "Title") is False
+        assert db.set_session_title_if_missing("nonexistent", "Title") is False
 
     def test_title_initially_none(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -958,6 +959,20 @@ class TestSessionTitle:
 
         session = db.get_session("s1")
         assert session["title"] == "Updated Title"
+
+    def test_set_title_if_missing_only_sets_once(self, db):
+        db.create_session(session_id="s1", source="cli")
+        assert db.set_session_title_if_missing("s1", "Initial Title") is True
+        assert db.set_session_title_if_missing("s1", "Ignored Title") is False
+        assert db.get_session("s1")["title"] == "Initial Title"
+
+    def test_set_title_if_missing_respects_uniqueness(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+        db.set_session_title("s1", "Taken")
+
+        with pytest.raises(ValueError, match="already in use"):
+            db.set_session_title_if_missing("s2", "Taken")
 
     def test_title_in_search_sessions(self, db):
         db.create_session(session_id="s1", source="cli")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -974,6 +974,12 @@ class TestSessionTitle:
         with pytest.raises(ValueError, match="already in use"):
             db.set_session_title_if_missing("s2", "Taken")
 
+    def test_set_title_if_missing_rejects_empty_title(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        assert db.set_session_title_if_missing("s1", "   ") is False
+        assert db.get_session("s1")["title"] is None
+
     def test_title_in_search_sessions(self, db):
         db.create_session(session_id="s1", source="cli")
         db.set_session_title("s1", "Debugging Auth")


### PR DESCRIPTION
## Summary
- rename Telegram topic threads when `/title` is used inside a Telegram topic
- support Telegram's separate general-topic rename API and cache topic-title changes
- add gateway and adapter tests covering thread renames and topic service updates

## Test Plan
- source venv/bin/activate && pytest -q tests/gateway/test_title_command.py tests/gateway/test_dm_topics.py