### PR TITLE
fix: discover standalone plugin CLI commands

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7662,19 +7662,32 @@ Examples:
     # Plugins provide a register_cli(subparser) function that builds their
     # own argparse tree.  No hardcoded plugin commands in main.py.
     # =========================================================================
+    plugin_cli_commands = {}
+    try:
+        from hermes_cli.plugins import get_plugin_cli_commands
+
+        plugin_cli_commands.update(get_plugin_cli_commands())
+    except Exception as _exc:
+        logging.getLogger(__name__).debug(
+            "General plugin CLI discovery failed: %s", _exc
+        )
+
     try:
         from plugins.memory import discover_plugin_cli_commands
 
         for cmd_info in discover_plugin_cli_commands():
-            plugin_parser = subparsers.add_parser(
-                cmd_info["name"],
-                help=cmd_info["help"],
-                description=cmd_info.get("description", ""),
-                formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
-            )
-            cmd_info["setup_fn"](plugin_parser)
+            plugin_cli_commands.setdefault(cmd_info["name"], cmd_info)
     except Exception as _exc:
-        logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
+        logging.getLogger(__name__).debug("Memory plugin CLI discovery failed: %s", _exc)
+
+    for cmd_info in plugin_cli_commands.values():
+        plugin_parser = subparsers.add_parser(
+            cmd_info["name"],
+            help=cmd_info["help"],
+            description=cmd_info.get("description", ""),
+            formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
+        )
+        cmd_info["setup_fn"](plugin_parser)
 
     # =========================================================================
     # memory command

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1076,6 +1076,16 @@ def get_plugin_commands() -> Dict[str, dict]:
     return _ensure_plugins_discovered()._plugin_commands
 
 
+def get_plugin_cli_commands() -> Dict[str, dict]:
+    """Return plugin-registered top-level CLI commands.
+
+    The returned dict maps command name to the metadata captured by
+    ``PluginContext.register_cli_command()``: ``help``, ``description``,
+    ``setup_fn``, ``handler_fn``, and ``plugin``.
+    """
+    return _ensure_plugins_discovered()._cli_commands
+
+
 def get_plugin_toolsets() -> List[tuple]:
     """Return plugin toolsets as ``(key, label, description)`` tuples.
 

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -20,6 +20,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    get_plugin_cli_commands,
 )
 
 
@@ -61,6 +62,44 @@ class TestRegisterCliCommand:
         ctx, mgr = self._make_ctx()
         ctx.register_cli_command("nocb", "test", MagicMock())
         assert mgr._cli_commands["nocb"]["handler_fn"] is None
+
+
+class TestGeneralPluginCliDiscovery:
+    def test_discovers_enabled_standalone_plugin_cli_commands(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        plugins_dir = hermes_home / "plugins"
+        plugin_dir = plugins_dir / "a2a"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: a2a\ndescription: Test A2A plugin\nversion: 0.1.0\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    def setup(parser):\n"
+            "        parser.add_argument('action')\n"
+            "    def handle(args):\n"
+            "        return args.action\n"
+            "    ctx.register_cli_command(\n"
+            "        name='a2a',\n"
+            "        help='Operate A2A',\n"
+            "        setup_fn=setup,\n"
+            "        handler_fn=handle,\n"
+            "        description='A2A plugin command',\n"
+            "    )\n"
+        )
+        (hermes_home / "config.yaml").write_text("plugins:\n  enabled:\n    - a2a\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.plugins as plugin_module
+
+        monkeypatch.setattr(plugin_module, "_plugin_manager", None)
+        commands = get_plugin_cli_commands()
+
+        assert "a2a" in commands
+        assert commands["a2a"]["help"] == "Operate A2A"
+        assert commands["a2a"]["plugin"] == "a2a"
+        assert callable(commands["a2a"]["setup_fn"])
+        assert callable(commands["a2a"]["handler_fn"])
 
 
 # ── Memory plugin CLI discovery ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- register top-level CLI commands from enabled standalone plugins
- preserve existing memory-plugin CLI discovery and merge both command sources
- add a regression test covering an enabled standalone plugin command (`a2a`)

## Verification
- `pytest tests/hermes_cli/test_plugin_cli_registration.py -q`
- `pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py -q`
- `source venv/bin/activate && hermes a2a status`
