### PR TITLE
feat(stt): add xAI Grok STT provider

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -995,3 +995,259 @@ class TestTranscribeAudioMistralDispatch:
             transcribe_audio(sample_ogg, model="voxtral-mini-2602")
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
+
+
+# ============================================================================
+# _transcribe_xai
+# ============================================================================
+
+
+@pytest.fixture
+def mock_xai_http_module():
+    """Inject a fake tools.xai_http module for testing."""
+    fake_module = MagicMock()
+    fake_module.hermes_xai_user_agent = MagicMock(return_value="hermes-xai/test")
+    with patch.dict("sys.modules", {"tools.xai_http": fake_module}):
+        yield fake_module
+
+
+class TestTranscribeXAI:
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_xai
+        result = _transcribe_xai("/tmp/test.ogg", "grok-stt")
+        assert result["success"] is False
+        assert "XAI_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "text": "bonjour le monde",
+            "language": "fr",
+            "duration": 3.2,
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_xai
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is True
+        assert result["transcript"] == "bonjour le monde"
+        assert result["provider"] == "xai"
+
+    def test_whitespace_stripped(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "  hello world  \n"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_xai
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["transcript"] == "hello world"
+
+    def test_api_error_returns_failure(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"error": {"message": "Invalid audio format"}}
+        mock_response.text = '{"error": {"message": "Invalid audio format"}}'
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_xai
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is False
+        assert "HTTP 400" in result["error"]
+        assert "Invalid audio format" in result["error"]
+
+    def test_empty_transcript_returns_failure(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "   "}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_xai
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is False
+        assert "empty transcript" in result["error"]
+
+    def test_permission_error(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("builtins.open", side_effect=PermissionError("denied")):
+            from tools.transcription_tools import _transcribe_xai
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is False
+        assert "Permission denied" in result["error"]
+
+    def test_network_error_returns_failure(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", side_effect=ConnectionError("timeout")):
+            from tools.transcription_tools import _transcribe_xai
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is False
+        assert "timeout" in result["error"]
+
+    def test_sends_language_and_format(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test", "language": "fr", "duration": 1.0}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_xai
+            _transcribe_xai(sample_ogg, "grok-stt")
+
+        call_kwargs = mock_post.call_args
+        data = call_kwargs.kwargs.get("data", call_kwargs[1].get("data", {}))
+        assert data.get("language") == "fr"
+        assert data.get("format") == "true"
+
+    def test_custom_base_url(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        monkeypatch.setenv("XAI_STT_BASE_URL", "https://custom.x.ai/v1")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test", "language": "en", "duration": 1.0}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_xai
+            _transcribe_xai(sample_ogg, "grok-stt")
+
+        call_args = mock_post.call_args
+        url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
+        assert "custom.x.ai" in url
+
+    def test_diarize_sent_when_configured(self, monkeypatch, sample_ogg, mock_xai_http_module):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test", "language": "fr", "duration": 1.0}
+
+        config = {"xai": {"diarize": True}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_xai
+            _transcribe_xai(sample_ogg, "grok-stt")
+
+        data = mock_post.call_args.kwargs.get("data", mock_post.call_args[1].get("data", {}))
+        assert data.get("diarize") == "true"
+
+
+# ============================================================================
+# _get_provider — xAI
+# ============================================================================
+
+class TestGetProviderXAI:
+    """xAI-specific provider selection tests."""
+
+    def test_xai_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "xai-test")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "xai"}) == "xai"
+
+    def test_xai_explicit_no_key_returns_none(self, monkeypatch):
+        """Explicit xai with no key returns none — no cross-provider fallback."""
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "xai"}) == "none"
+
+    def test_auto_detect_xai_after_mistral(self, monkeypatch):
+        """Auto-detect: xai is tried after mistral when all above are unavailable."""
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        monkeypatch.setenv("XAI_API_KEY", "xai-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.transcription_tools._HAS_MISTRAL", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "xai"
+
+    def test_auto_detect_mistral_preferred_over_xai(self, monkeypatch):
+        """Auto-detect: mistral is preferred over xai."""
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        monkeypatch.setenv("XAI_API_KEY", "xai-test")
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.transcription_tools._HAS_MISTRAL", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "mistral"
+
+    def test_auto_detect_no_key_returns_none(self, monkeypatch):
+        """Auto-detect: xai skipped when no key is set."""
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.transcription_tools._HAS_MISTRAL", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "none"
+
+
+# ============================================================================
+# transcribe_audio — xAI dispatch
+# ============================================================================
+
+class TestTranscribeAudioXAIDispatch:
+    def test_dispatches_to_xai(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "xai"}), \
+             patch("tools.transcription_tools._get_provider", return_value="xai"), \
+             patch("tools.transcription_tools._transcribe_xai",
+                   return_value={"success": True, "transcript": "hi", "provider": "xai"}) as mock_xai:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "xai"
+        mock_xai.assert_called_once()
+
+    def test_model_default_is_grok_stt(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "xai"}), \
+             patch("tools.transcription_tools._get_provider", return_value="xai"), \
+             patch("tools.transcription_tools._transcribe_xai",
+                   return_value={"success": True, "transcript": "hi"}) as mock_xai:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_xai.call_args[0][1] == "grok-stt"
+
+    def test_model_override_passed_to_xai(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="xai"), \
+             patch("tools.transcription_tools._transcribe_xai",
+                   return_value={"success": True, "transcript": "hi"}) as mock_xai:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="custom-stt")
+
+        assert mock_xai.call_args[0][1] == "custom-stt"

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1109,6 +1109,9 @@ class TestTranscribeXAI:
 
     def test_sends_language_and_format(self, monkeypatch, sample_ogg, mock_xai_http_module):
         monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        # Explicitly set language via env to exercise the override chain
+        # (config > env > DEFAULT_LOCAL_STT_LANGUAGE)
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "fr")
 
         mock_response = MagicMock()
         mock_response.status_code = 200

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,15 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with six providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
+  - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
+    Inverse Text Normalization, diarization, 26 languages.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -73,6 +76,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
+XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -242,6 +246,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "xai":
+            if os.getenv("XAI_API_KEY"):
+                return "xai"
+            logger.warning(
+                "STT provider 'xai' configured but XAI_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
@@ -259,6 +271,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_MISTRAL and os.getenv("MISTRAL_API_KEY"):
         logger.info("No local STT available, using Mistral Voxtral Transcribe API")
         return "mistral"
+    if os.getenv("XAI_API_KEY"):
+        logger.info("No local STT available, using xAI Grok STT API")
+        return "xai"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -574,6 +589,103 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: xAI (Grok STT API)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using xAI Grok STT API.
+
+    Uses the ``POST /v1/stt`` REST endpoint with multipart/form-data.
+    Supports Inverse Text Normalization, diarization, and word-level timestamps.
+    Requires ``XAI_API_KEY`` environment variable.
+    """
+    api_key = os.getenv("XAI_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "XAI_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    xai_config = stt_config.get("xai", {})
+    base_url = str(
+        xai_config.get("base_url")
+        or os.getenv("XAI_STT_BASE_URL")
+        or XAI_STT_BASE_URL
+    ).strip().rstrip("/")
+    language = str(
+        xai_config.get("language")
+        or os.getenv("HERMES_LOCAL_STT_LANGUAGE")
+        or "fr"
+    ).strip()
+    use_format = is_truthy_value(xai_config.get("format", True), default=True)
+    use_diarize = is_truthy_value(xai_config.get("diarize", False), default=False)
+
+    try:
+        import requests
+        from tools.xai_http import hermes_xai_user_agent
+
+        data: Dict[str, str] = {}
+        if language:
+            data["language"] = language
+        if use_format:
+            data["format"] = "true"
+        if use_diarize:
+            data["diarize"] = "true"
+
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                f"{base_url}/stt",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": hermes_xai_user_agent(),
+                },
+                files={
+                    "file": (Path(file_path).name, audio_file),
+                },
+                data=data,
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"xAI STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = result.get("text", "").strip()
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "xAI STT returned empty transcript",
+            }
+
+        logger.info(
+            "Transcribed %s via xAI Grok STT (lang=%s, %.1fs audio, %d chars)",
+            Path(file_path).name,
+            result.get("language", language),
+            result.get("duration", 0),
+            len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "xai"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("xAI STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"xAI STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -641,6 +753,12 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "xai":
+        xai_cfg = stt_config.get("xai", {})
+        # xAI Grok STT doesn't use a model parameter — pass through for logging
+        model_name = model or "grok-stt"
+        return _transcribe_xai(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -649,7 +767,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -10,7 +10,7 @@ Provides speech-to-text transcription with six providers:
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
-    Inverse Text Normalization, diarization, 26 languages.
+    Inverse Text Normalization, diarization, 21 languages.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -256,7 +256,7 @@ def _get_provider(stt_config: dict) -> str:
 
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
+    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai -
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -614,10 +614,12 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
     language = str(
         xai_config.get("language")
         or os.getenv("HERMES_LOCAL_STT_LANGUAGE")
-        or "fr"
+        or DEFAULT_LOCAL_STT_LANGUAGE
     ).strip()
-    use_format = is_truthy_value(xai_config.get("format", True), default=True)
-    use_diarize = is_truthy_value(xai_config.get("diarize", False), default=False)
+    # .get("format", True) already defaults to True when the key is absent;
+    # is_truthy_value only normalizes truthy/falsy strings from config.
+    use_format = is_truthy_value(xai_config.get("format", True))
+    use_diarize = is_truthy_value(xai_config.get("diarize", False))
 
     try:
         import requests


### PR DESCRIPTION
Salvage of #12120 onto current main (709 commits behind).

Adds xAI as a 6th STT provider using POST /v1/stt with multipart/form-data.

## Changes
- `tools/transcription_tools.py`: `_transcribe_xai()` + dispatch branch + auto-detect chain entry (+120 lines)
- `tests/tools/test_transcription_tools.py`: 17 new unit tests (+256 lines)

## Note on architecture
STT has no pluggable provider ABC — providers live as `_transcribe_<name>` functions with if/elif dispatch in `transcribe_audio()`. This PR correctly follows the existing convention (same shape as mistral/openai/groq).

## Validation
- py_compile OK
- 89/89 tests pass (72 existing + 17 new)

Original author @Julientalbot preserved via cherry-pick. Closes #12120.