### PR TITLE
fix: normalize provider alias in list_provider_models (salvage #13313)

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -418,6 +418,9 @@ def list_provider_models(provider: str) -> List[str]:
 
     Returns an empty list if the provider is unknown or has no data.
     """
+    from hermes_cli.models import normalize_provider
+    provider = normalize_provider(provider) or provider
+    
     models = _get_provider_models(provider)
     if models is None:
         return []

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -388,6 +388,7 @@ AUTHOR_MAP = {
     "216480837+isaachuangGMICLOUD@users.noreply.github.com": "isaachuangGMICLOUD",
     "nukuom976228@gmail.com": "hsy5571616",
     "11462216+Nan93@users.noreply.github.com": "Nan93",
+    "l973401489@126.com": "zhouxiaoya12",
 }
 
 


### PR DESCRIPTION
Salvages #13313 by @zhouxiaoya12 onto current main.

`list_provider_models(provider)` in `agent/models_dev.py` looked up provider data by exact-match key. Users passing an alias (e.g. `copilot` vs `github-copilot`, `kimi` vs `kimi-for-coding`) got an empty list even though the provider was configured. Adding `normalize_provider(provider) or provider` at the top aligns with how `hermes_cli/models.py` already resolves aliases. Lazy import avoids the circular dep (`hermes_cli/models.py` already imports from `agent/models_dev` lazily at lines 1636, 2341).

Closes #13313. Author attribution preserved via cherry-pick.