### PR TITLE
fix(skills): search custom taps when index is enabled

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1039,6 +1039,26 @@ class TestUnifiedSearchDedup:
         results = unified_search("query", [failing, ok])
         assert len(results) == 1
 
+    def test_custom_tap_github_search_not_skipped_when_index_available(self):
+        index = self._make_source("hermes-index", [])
+        index.is_available = True
+
+        github = self._make_source("github", [
+            SkillMeta(
+                name="my-fancy-skill",
+                description="custom tap skill",
+                source="github",
+                identifier="owner/repo/skills/my-fancy-skill",
+                trust_level="community",
+            )
+        ])
+        github.has_extra_taps = True
+
+        results = unified_search("my-fancy-skill", [index, github])
+
+        assert [r.name for r in results] == ["my-fancy-skill"]
+        github.search.assert_called_once_with("my-fancy-skill", limit=50)
+
 
 # ---------------------------------------------------------------------------
 # append_audit_log

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -294,6 +294,7 @@ class GitHubSource(SkillSource):
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
         self.auth = auth
         self.taps = list(self.DEFAULT_TAPS)
+        self.has_extra_taps = bool(extra_taps)
         if extra_taps:
             self.taps.extend(extra_taps)
         # Per-instance cache: repo -> (default_branch, tree_entries)
@@ -2988,9 +2989,12 @@ def parallel_search_sources(
         sid = src.source_id()
         if source_filter != "all" and sid != source_filter and sid != "official":
             continue
-        # Skip external API sources when the index covers them
+        # Skip external API sources when the index covers them. GitHub taps are
+        # not mirrored into the centralized index, so keep GitHub search enabled
+        # when the user has configured extra taps.
         if _index_available and sid in _api_source_ids:
-            continue
+            if sid != "github" or not getattr(src, "has_extra_taps", False):
+                continue
         active.append(src)
 
     all_results: List[SkillMeta] = []


### PR DESCRIPTION
## Summary
- keep GitHub tap search active when users have configured custom taps, even if the centralized Hermes index is available
- add a regression test covering the indexed-search path with a custom GitHub tap

## Root cause
- `parallel_search_sources()` skips API-backed sources whenever the centralized index is available
- the centralized index does not include user-configured GitHub taps
- as a result, `github` search was skipped entirely for default `hermes skills search`, even though `--source github` still worked

## Fix
- track whether `GitHubSource` was created with extra taps
- only skip indexed GitHub search when there are no user-configured taps to search

## Regression coverage
- added `test_custom_tap_github_search_not_skipped_when_index_available`
- this reproduces the previous indexed-search path and asserts the tapped GitHub source is still queried

## Testing
- `scripts/run_tests.sh tests/tools/test_skills_hub.py -k custom_tap_github_search_not_skipped_when_index_available`
- `scripts/run_tests.sh tests/tools/test_skills_hub.py tests/cli/test_cli_loading_indicator.py`

Closes #14466
