### PR TITLE
fix(skills): follow symlinks when discovering SKILL.md

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -255,6 +255,40 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
 
+    def test_discovers_symlinked_skill_directory(self, tmp_path):
+        """Regression: Path.rglob() does not recurse into symlinked dirs by
+        default (recurse_symlinks=False, and the kwarg is Py 3.13+ only), so
+        a skill installed as ``~/.hermes/skills/my-skill -> /path/to/repo``
+        was silently invisible to skills_list/skill_view.
+        """
+        external = tmp_path / "external"
+        external.mkdir()
+        _make_skill(external, "linked-skill")
+
+        skills_home = tmp_path / "skills"
+        skills_home.mkdir()
+        _make_skill(skills_home, "real-skill")
+        os.symlink(external / "linked-skill", skills_home / "linked-skill")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_home):
+            skills = _find_all_skills()
+
+        names = {s["name"] for s in skills}
+        assert "real-skill" in names
+        assert "linked-skill" in names
+
+    def test_symlink_cycle_terminates(self, tmp_path):
+        """A symlink loop under the skills dir must not hang discovery."""
+        skills_home = tmp_path / "skills"
+        skills_home.mkdir()
+        _make_skill(skills_home, "real-skill")
+        os.symlink(skills_home, skills_home / "loop")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_home):
+            skills = _find_all_skills()
+
+        assert "real-skill" in {s["name"] for s in skills}
+
 
 # ---------------------------------------------------------------------------
 # skills_list

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -521,6 +521,29 @@ def _get_session_platform() -> str:
         return ""
 
 
+def _iter_skill_md(scan_dir: Path, filename: str = "SKILL.md"):
+    """Yield ``filename`` paths under ``scan_dir``, following symlinked dirs.
+
+    ``Path.rglob`` defaults to ``recurse_symlinks=False`` (and the kwarg is
+    Py 3.13+ only), so a skill installed as ``~/.hermes/skills/my-skill ->
+    /path/to/repo/skill`` would otherwise be silently invisible to
+    ``skills_list``/``skill_view``. A ``realpath``-based visited set guards
+    against symlink cycles on all supported Python versions (3.11+).
+    """
+    visited: Set[str] = set()
+    for root, dirs, files in os.walk(scan_dir, followlinks=True):
+        try:
+            real = os.path.realpath(root)
+        except OSError:
+            real = root
+        if real in visited:
+            dirs[:] = []
+            continue
+        visited.add(real)
+        if filename in files:
+            yield Path(root) / filename
+
+
 def _is_skill_disabled(name: str, platform: str = None) -> bool:
     """Check if a skill is disabled in config.
 
@@ -569,7 +592,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
-        for skill_md in scan_dir.rglob("SKILL.md"):
+        for skill_md in _iter_skill_md(scan_dir):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
 
@@ -926,7 +949,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         # Search by directory name across all dirs
         if not skill_md:
             for search_dir in all_dirs:
-                for found_skill_md in search_dir.rglob("SKILL.md"):
+                for found_skill_md in _iter_skill_md(search_dir):
                     if found_skill_md.parent.name == name:
                         skill_dir = found_skill_md.parent
                         skill_md = found_skill_md
@@ -937,7 +960,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         # Legacy: flat .md files
         if not skill_md:
             for search_dir in all_dirs:
-                for found_md in search_dir.rglob(f"{name}.md"):
+                for found_md in _iter_skill_md(search_dir, f"{name}.md"):
                     if found_md.name != "SKILL.md":
                         skill_md = found_md
                         break


### PR DESCRIPTION
## What & Why

A skill installed as a symlink, e.g.

```
~/.hermes/skills/my-skill -> /path/to/repo/skill
```

(a supported dev workflow per `CONTRIBUTING.md` — users iterate on a repo-local skill and link it into `~/.hermes/skills/` while they work) was silently invisible to `skills_list` and `skill_view`.

Root cause: discovery uses `Path.rglob("SKILL.md")`, which defaults to `recurse_symlinks=False`. The `recurse_symlinks` kwarg is also Python 3.13+ only, so we can't simply flip it given `pyproject.toml`'s `requires-python = ">=3.11"`. Net effect: the `SKILL.md` inside a symlinked target is never yielded, and the skill is dropped from the agent's view without any error or warning.

## Reproduction

```bash
mkdir -p /tmp/my-skill
cat > /tmp/my-skill/SKILL.md <<'MD'
---
name: my-skill
description: demo
---
# Body
MD
ln -s /tmp/my-skill ~/.hermes/skills/my-skill
hermes chat -q "List your skills"
# Before this PR: my-skill is missing.
# After this PR:  my-skill shows up.
```

## Fix

A small private helper `_iter_skill_md` in `tools/skills_tool.py` walks with `os.walk(..., followlinks=True)` plus a `realpath`-based visited set (cycle guard). The three `rglob("SKILL.md")` / `rglob(f"{name}.md")` call sites in that file (one in `_find_all_skills`, two in `skill_view`) become one-liners over the helper.

Scope is intentionally limited to **one production file** — the file that powers the user-observable skill-discovery flow (`_find_all_skills` → `skills_list`, `skill_view`). Other secondary call sites (`tools/skill_manager_tool.py`, `hermes_cli/dump.py`, `hermes_cli/profiles.py`) have the same underlying issue and can follow in a separate PR if maintainers prefer that split.

Design notes:
- `os.walk(followlinks=True)` chosen over `Path.rglob(recurse_symlinks=True)` because the latter is Py 3.13+ only.
- Cycle guard via `os.path.realpath` visited set — a user can easily create a loop with `ln -s ~/.hermes/skills ~/.hermes/skills/loop`, and without the guard `os.walk` would spin forever.
- No behavior change for non-symlinked setups (the default, bundled skill layout).

## Tests

Two new regression tests in `tests/tools/test_skills_tool.py::TestFindAllSkills`:

- `test_discovers_symlinked_skill_directory` — creates `skills_home/linked-skill -> external/linked-skill` and asserts `_find_all_skills()` returns it alongside a real-dir skill.
- `test_symlink_cycle_terminates` — creates `skills_home/loop -> skills_home` and asserts discovery terminates instead of hanging.

Full `tests/tools/test_skills_tool.py` suite (74 tests) passes locally on macOS / Python 3.11.

## Platforms tested

- macOS (darwin 23.4.0), Python 3.11

## Diff size

```
 tests/tools/test_skills_tool.py | 34 ++++++++++++++++++++++++++++++++++
 tools/skills_tool.py            | 26 +++++++++++++++++++++++---
 2 files changed, 57 insertions(+), 3 deletions(-)
```