### PR TITLE
fix(wecom): strip @mention prefix in group chats for slash commands (salvage #13896)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -508,6 +508,11 @@ class WeComAdapter(BasePlatformAdapter):
         self._remember_chat_req_id(chat_id, self._payload_req_id(payload))
 
         text, reply_text = self._extract_text(body)
+        # Strip leading @mention in group chats so slash commands like
+        # "@BotName /approve" are correctly recognized as "/approve".
+        # Mirrors what the Telegram adapter does (re.sub @botname).
+        if is_group and text:
+            text = re.sub(r"^@\S+\s*", "", text).strip()
         media_urls, media_types = await self._extract_media(body)
         message_type = self._derive_message_type(body, text, media_types)
         has_reply_context = bool(reply_text and (text or media_urls))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -389,6 +389,7 @@ AUTHOR_MAP = {
     "nukuom976228@gmail.com": "hsy5571616",
     "11462216+Nan93@users.noreply.github.com": "Nan93",
     "l973401489@126.com": "zhouxiaoya12",
+    "373119611@qq.com": "roytian1217",
 }
 
 


### PR DESCRIPTION
Salvages #13896 by @roytian1217 onto current main.

In WeChat Work (wecom) group chats, the webhook fires only when the bot is mentioned — so every group message arrives as `@BotName <actual text>`. Slash commands like `@BotName /approve` therefore never matched the `startswith("/")` check and fell through to the LLM instead of executing. Mirrors the Telegram adapter's `re.sub("^@\\\S+\\\s*", "", text)` normalization.

Scoped to `is_group and text` so 1:1 DMs and empty messages are untouched.

Closes #13896. Author attribution preserved via cherry-pick.