### PR TITLE
docs(docker): add in-container terminal hermes example (salvage #14118)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -390,6 +390,7 @@ AUTHOR_MAP = {
     "11462216+Nan93@users.noreply.github.com": "Nan93",
     "l973401489@126.com": "zhouxiaoya12",
     "373119611@qq.com": "roytian1217",
+    "brett@brettbrewer.com": "minorgod",
 }
 
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -78,6 +78,12 @@ docker run -it --rm \
   nousresearch/hermes-agent
 ```
 
+Or if you have already opened a terminal in your running container (via Docker Desktop for instance), just run:
+
+```sh
+/opt/hermes/.venv/bin/hermes
+```
+
 ## Persistent volumes
 
 The `/opt/data` volume is the single source of truth for all Hermes state. It maps to your host's `~/.hermes/` directory and contains:


### PR DESCRIPTION
Salvages #14118 by @minorgod onto current main.

Adds a snippet after the `docker run` example in `website/docs/user-guide/docker.md` for users who already have a shell open inside the running container (via Docker Desktop's exec-terminal UI, `docker exec`, etc.) — they can just run `/opt/hermes/.venv/bin/hermes` directly instead of re-exec-ing through docker.

Closes #14118. Author attribution preserved via cherry-pick.