### PR TITLE
docs(cron): clarify default model/provider behavior for scheduled jobs (salvage #5787)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -391,6 +391,7 @@ AUTHOR_MAP = {
     "l973401489@126.com": "zhouxiaoya12",
     "373119611@qq.com": "roytian1217",
     "brett@brettbrewer.com": "minorgod",
+    "67779267+wenhao7@users.noreply.github.com": "wenhao7",
 }
 
 

--- a/website/docs/guides/daily-briefing-bot.md
+++ b/website/docs/guides/daily-briefing-bot.md
@@ -90,6 +90,8 @@ Try different prompts until you get output you love. Add instructions like "use 
 
 Now let's schedule this to run automatically every morning. You can do this in two ways.
 
+Before creating cron jobs, ensure Hermes has a default model and provider configured globally. If you want a specific job to use different values, set explicit per-job model/provider overrides when creating it.
+
 ### Option A: Natural Language (in chat)
 
 Just tell Hermes what you want:

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -338,6 +338,8 @@ For `update`, pass `skills=[]` to remove all attached skills.
 
 Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`.
 
+Jobs may store `model` and `provider` as `null`. When those fields are omitted, Hermes resolves them at execution time from the global configuration. They only appear in the job record when a per-job override is set.
+
 The storage uses atomic file writes so interrupted writes do not leave a partially written job file behind.
 
 ## Self-contained prompts still matter


### PR DESCRIPTION
Salvages #5787 by @wenhao7 onto current main.

Two doc additions:
- `website/docs/guides/daily-briefing-bot.md`: note that Hermes needs a default model/provider configured before creating cron jobs, unless a per-job override is set
- `website/docs/user-guide/features/cron.md`: explain that jobs with `model: null` / `provider: null` resolve at runtime from global config

New users often got confused when they'd set up a cron job before configuring their default provider.

Closes #5787. Author attribution preserved via cherry-pick.