### PR TITLE
fix(nix): make workingDirectory writable in systemd service (salvage #12775)

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -777,7 +777,10 @@ HERMES_NIX_ENV_EOF
             NoNewPrivileges = true;
             ProtectSystem = "strict";
             ProtectHome = false;
-            ReadWritePaths = [ cfg.stateDir ];
+            ReadWritePaths = [
+              cfg.stateDir
+              cfg.workingDirectory
+            ];
             PrivateTmp = true;
           };
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -392,6 +392,7 @@ AUTHOR_MAP = {
     "373119611@qq.com": "roytian1217",
     "brett@brettbrewer.com": "minorgod",
     "67779267+wenhao7@users.noreply.github.com": "wenhao7",
+    "git@yzx9.xyz": "yzx9",
 }
 
 


### PR DESCRIPTION
Salvages #12775 by @yzx9 onto current main.

The NixOS module set `ProtectSystem = "strict"` on the hermes-agent systemd service, which requires every writable path to be explicitly listed in `ReadWritePaths`. Only `cfg.stateDir` was listed, so users who configured a `workingDirectory` outside `stateDir` (e.g. `/var/lib/hermes-work`) hit permission-denied errors when the service tried to write there.

Fix: add `cfg.workingDirectory` to `ReadWritePaths`. When workingDirectory is a subpath of stateDir (the common case), the extra entry is a harmless no-op.

Closes #12775. Author attribution preserved via cherry-pick.