### PR TITLE
fix: avoid reusing Weixin sessions across event loops

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1982,7 +1982,15 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    current_loop = asyncio.get_running_loop()
+    live_session_loop = getattr(send_session, "_loop", None)
+    can_reuse_live_adapter = (
+        live_adapter is not None
+        and send_session is not None
+        and not send_session.closed
+        and live_session_loop is current_loop
+    )
+    if can_reuse_live_adapter:
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -308,6 +308,61 @@ class TestWeixinSendMessageIntegration:
             media_files=[("/tmp/demo.png", False)],
         )
 
+    @patch("gateway.platforms.weixin.ContextTokenStore.restore")
+    @patch("gateway.platforms.weixin.WeixinAdapter.send", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin.aiohttp.ClientSession")
+    def test_send_weixin_direct_ignores_live_adapter_bound_to_different_loop(
+        self,
+        client_session_mock,
+        adapter_send_mock,
+        restore_mock,
+    ):
+        class _SessionContext:
+            def __init__(self):
+                self.closed = False
+                self._loop = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class _ForeignSession:
+            def __init__(self):
+                self.closed = False
+                self._loop = object()
+
+        class _LiveAdapter:
+            def __init__(self):
+                self._send_session = _ForeignSession()
+                self.send = AsyncMock(side_effect=AssertionError("should not reuse live adapter across loops"))
+                self.send_image_file = AsyncMock()
+                self.send_document = AsyncMock()
+
+            def format_message(self, content):
+                return content
+
+        session_ctx = _SessionContext()
+        client_session_mock.return_value = session_ctx
+        adapter_send_mock.return_value = SendResult(success=True, message_id="fallback-msg")
+
+        live_adapter = _LiveAdapter()
+        with patch.dict(weixin._LIVE_ADAPTERS, {"test-token": live_adapter}, clear=True):
+            result = asyncio.run(
+                weixin.send_weixin_direct(
+                    extra={"account_id": "acct"},
+                    token="test-token",
+                    chat_id="wxid_test123",
+                    message="hello",
+                )
+            )
+
+        assert result["success"] is True
+        adapter_send_mock.assert_awaited_once()
+        live_adapter.send.assert_not_called()
+        restore_mock.assert_called_once_with("acct")
+
 
 class TestWeixinChunkDelivery:
     def _connected_adapter(self) -> WeixinAdapter:


### PR DESCRIPTION
## Summary
- prevent `send_weixin_direct()` from reusing a live Weixin adapter unless its aiohttp session belongs to the current event loop
- fall back to a fresh one-shot `aiohttp.ClientSession` when the cached live adapter is bound to a different loop
- add a regression test covering the cross-loop fallback path

## Root cause
When cron delivery hit the Weixin fallback path after an initial send failure, it could reuse a live adapter/session created by the long-running gateway loop. If that session belonged to a different asyncio event loop than the current cron delivery context, aiohttp could fail with:

`Timeout context manager should be used inside a task`

That turned one recoverable Weixin send failure into a second Hermes-side delivery failure.

## Fix
Gate live-adapter reuse on loop affinity:
- read the current running loop with `asyncio.get_running_loop()`
- inspect the live session loop
- reuse the live adapter only when the session is open **and** belongs to the current loop
- otherwise, skip reuse and send through a fresh one-shot session

## Verification
- added regression test: `test_send_weixin_direct_ignores_live_adapter_bound_to_different_loop`
- ran `python -m pytest tests/gateway/test_weixin.py -q -o 'addopts='`
- result: `43 passed`
- manually re-ran the affected cron job and confirmed the delivery error was cleared in the cron job state

## Notes
This fixes the Hermes fallback bug. It does not change the upstream iLink error behavior itself; it prevents the fallback path from failing for an unrelated cross-event-loop reason.