### PR TITLE
delegate_task: default to slim results with traceability; keep detailed mode for debugging

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -288,6 +288,57 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    def _normalize_threshold_tokens_override(
+        self,
+        threshold_tokens_override: Optional[int],
+    ) -> Optional[int]:
+        """Validate an absolute compression threshold override."""
+        if threshold_tokens_override is None:
+            return None
+        try:
+            value = int(threshold_tokens_override)
+        except (TypeError, ValueError):
+            return None
+        if value <= 0:
+            return None
+        return value
+
+    def _recompute_threshold_budget(self) -> None:
+        """Recalculate the active threshold and derived tail budget."""
+        override = getattr(self, "threshold_tokens_override", None)
+        if override is None:
+            threshold_tokens = max(
+                int(self.context_length * self.threshold_percent),
+                MINIMUM_CONTEXT_LENGTH,
+            )
+        else:
+            threshold_tokens = override
+            if self.context_length and threshold_tokens > self.context_length:
+                threshold_tokens = self.context_length
+        self.threshold_tokens = threshold_tokens
+        self.tail_token_budget = int(self.threshold_tokens * self.summary_target_ratio)
+
+    def set_threshold_tokens_override(
+        self,
+        threshold_tokens_override: Optional[int],
+        *,
+        update_percent: bool = False,
+    ) -> None:
+        """Persist a session-scoped absolute threshold and refresh budgets."""
+        normalized = self._normalize_threshold_tokens_override(
+            threshold_tokens_override
+        )
+        if normalized is None:
+            self.threshold_tokens_override = None
+            self._recompute_threshold_budget()
+            return
+        if self.context_length and normalized > self.context_length:
+            normalized = self.context_length
+        self.threshold_tokens_override = normalized
+        if update_percent and self.context_length:
+            self.threshold_percent = normalized / self.context_length
+        self._recompute_threshold_budget()
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()
@@ -313,10 +364,7 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        self._recompute_threshold_budget()
 
     def __init__(
         self,
@@ -332,6 +380,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        threshold_tokens_override: int | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -339,6 +388,9 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.threshold_percent = threshold_percent
+        self.threshold_tokens_override = self._normalize_threshold_tokens_override(
+            threshold_tokens_override
+        )
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
@@ -349,19 +401,10 @@ class ContextCompressor(ContextEngine):
             config_context_length=config_context_length,
             provider=provider,
         )
-        # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
+        self._recompute_threshold_budget()
         self.max_summary_tokens = min(
             int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -594,6 +594,17 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
     return None
 
 
+def _format_verbose_tool_progress(tool_name: str, args: dict, preview_len: int) -> str:
+    """Render verbose gateway tool progress while preserving per-tool emoji."""
+    from agent.display import get_tool_emoji
+
+    emoji = get_tool_emoji(tool_name, default="⚙️")
+    args_str = json.dumps(args, ensure_ascii=False, default=str)
+    if preview_len > 0 and len(args_str) > preview_len:
+        args_str = args_str[:preview_len - 3] + "..."
+    return f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -9339,8 +9350,28 @@ class GatewayRunner:
             if not progress_queue or not _run_still_current():
                 return
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
-            if event_type not in ("tool.started",):
+            # Surface a compact subset of progress events in gateway chats.
+            if event_type not in ("tool.started", "subagent.complete"):
+                return
+
+            if event_type == "subagent.complete":
+                try:
+                    from tools.delegate_tool import _subagent_progress_message
+
+                    msg = _subagent_progress_message(
+                        event_type,
+                        tool_name=tool_name,
+                        preview=preview,
+                        args=args,
+                        **kwargs,
+                    )
+                except Exception:
+                    msg = None
+                if not msg:
+                    return
+                progress_queue.put(msg)
+                last_progress_msg[0] = msg
+                repeat_count[0] = 0
                 return
 
             # "new" mode: only report when tool changes
@@ -9349,40 +9380,29 @@ class GatewayRunner:
             last_tool[0] = tool_name
             
             # Build progress message with primary argument preview
-            from agent.display import get_tool_emoji
-            emoji = get_tool_emoji(tool_name, default="⚙️")
+            from tools.delegate_tool import _subagent_progress_message
+
+            msg = _subagent_progress_message(
+                event_type,
+                tool_name=tool_name,
+                preview=preview,
+                args=args,
+                **kwargs,
+            )
+            if msg is None:
+                return
             
             # Verbose mode: show detailed arguments, respects tool_preview_length
             if progress_mode == "verbose":
                 if args:
                     from agent.display import get_tool_preview_max_len
                     _pl = get_tool_preview_max_len()
-                    args_str = json.dumps(args, ensure_ascii=False, default=str)
                     # When tool_preview_length is 0 (default), don't truncate
                     # in verbose mode — the user explicitly asked for full
                     # detail.  Platform message-length limits handle the rest.
-                    if _pl > 0 and len(args_str) > _pl:
-                        args_str = args_str[:_pl - 3] + "..."
-                    msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
-                elif preview:
-                    msg = f"{emoji} {tool_name}: \"{preview}\""
-                else:
-                    msg = f"{emoji} {tool_name}..."
+                    msg = _format_verbose_tool_progress(tool_name, args, _pl)
                 progress_queue.put(msg)
                 return
-            
-            # "all" / "new" modes: short preview, respects tool_preview_length
-            # config (defaults to 40 chars when unset to keep gateway messages
-            # compact — unlike CLI spinners, these persist as permanent messages).
-            if preview:
-                from agent.display import get_tool_preview_max_len
-                _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
-                if len(preview) > _cap:
-                    preview = preview[:_cap - 3] + "..."
-                msg = f"{emoji} {tool_name}: \"{preview}\""
-            else:
-                msg = f"{emoji} {tool_name}..."
             
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same

--- a/run_agent.py
+++ b/run_agent.py
@@ -35,6 +35,7 @@ import sys
 import tempfile
 import time
 import threading
+from collections import deque
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
@@ -976,6 +977,7 @@ class AIAgent:
         self._delegate_depth = 0        # 0 = top-level agent, incremented for children
         self._active_children = []      # Running child AIAgents (for interrupt propagation)
         self._active_children_lock = threading.Lock()
+        self._reset_delegate_soft_guardrails()
         
         # Store OpenRouter provider preferences
         self.providers_allowed = providers_allowed
@@ -1558,6 +1560,26 @@ class AIAgent:
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        compression_threshold_tokens = _compression_cfg.get("threshold_tokens")
+        if compression_threshold_tokens is not None:
+            try:
+                compression_threshold_tokens = int(compression_threshold_tokens)
+                if compression_threshold_tokens <= 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid compression.threshold_tokens in config.yaml: %r — "
+                    "must be a positive integer. Falling back to percentage-based threshold.",
+                    compression_threshold_tokens,
+                )
+                print(
+                    f"\n⚠ Invalid compression.threshold_tokens in config.yaml: {compression_threshold_tokens!r}\n"
+                    f"  Must be a positive integer.\n"
+                    f"  Falling back to percentage-based compression threshold.\n",
+                    file=sys.stderr,
+                )
+                compression_threshold_tokens = None
+        self._compression_threshold_tokens_config = compression_threshold_tokens
 
         # Read optional explicit context_length override for the auxiliary
         # compression model. Custom endpoints often cannot report this via
@@ -1714,6 +1736,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                threshold_tokens_override=compression_threshold_tokens,
             )
         self.compression_enabled = compression_enabled
 
@@ -1802,7 +1825,16 @@ class AIAgent:
 
         if not self.quiet_mode:
             if compression_enabled:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                if getattr(self.context_compressor, "threshold_tokens_override", None) is not None:
+                    print(
+                        f"📊 Context limit: {self.context_compressor.context_length:,} tokens "
+                        f"(compress at custom threshold {self.context_compressor.threshold_tokens:,})"
+                    )
+                else:
+                    print(
+                        f"📊 Context limit: {self.context_compressor.context_length:,} tokens "
+                        f"(compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})"
+                    )
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 
@@ -2234,11 +2266,15 @@ class AIAgent:
                 # so the new threshold is always >= 64K.
                 old_threshold = threshold
                 new_threshold = aux_context
-                self.context_compressor.threshold_tokens = new_threshold
-                # Keep threshold_percent in sync so future main-model
-                # context_length changes (update_model) re-derive from a
-                # sensible number rather than the original too-high value.
                 main_ctx = self.context_compressor.context_length
+                _set_threshold_override = getattr(
+                    self.context_compressor,
+                    "set_threshold_tokens_override",
+                    None,
+                )
+                if callable(_set_threshold_override):
+                    _set_threshold_override(new_threshold, update_percent=True)
+                self.context_compressor.threshold_tokens = new_threshold
                 if main_ctx:
                     self.context_compressor.threshold_percent = (
                         new_threshold / main_ctx
@@ -4322,6 +4358,93 @@ class AIAgent:
             delegate_count - max_children, max_children,
         )
         return truncated
+
+    def _reset_delegate_soft_guardrails(self) -> None:
+        """Reset per-run delegate cadence state.
+
+        Soft guardrails should accumulate across rounds within one top-level
+        run_conversation() call, but not leak into the next user request.
+        """
+        self._delegate_call_timestamps = deque()
+        self._delegate_consecutive_rounds = 0
+        self._delegate_guardrail_last_notice_ts = 0.0
+
+    def _apply_delegate_soft_guardrails(self, tool_calls: list) -> list:
+        """Soft-limit repeated delegation bursts across rounds.
+
+        This is intentionally gentler than the per-turn concurrency cap:
+        - warn when delegation is becoming the dominant strategy
+        - queue a steer/checkpoint reminder for the next iteration
+        - when multiple delegate_task calls are present, keep only the first
+          one so the model must regroup before fanning out again
+
+        Non-delegate calls are preserved.
+        """
+        delegate_calls = [tc for tc in tool_calls if tc.function.name == "delegate_task"]
+        if not delegate_calls:
+            self._delegate_consecutive_rounds = 0
+            return tool_calls
+
+        timestamps = getattr(self, "_delegate_call_timestamps", None)
+        if timestamps is None:
+            timestamps = deque()
+            self._delegate_call_timestamps = timestamps
+        elif not isinstance(timestamps, deque):
+            timestamps = deque(timestamps)
+            self._delegate_call_timestamps = timestamps
+        now = time.monotonic()
+        window_seconds = 60.0
+        max_calls_per_window = 6
+        max_consecutive_rounds = 3
+        while timestamps and (now - timestamps[0]) > window_seconds:
+            timestamps.popleft()
+        for _ in delegate_calls:
+            timestamps.append(now)
+
+        self._delegate_consecutive_rounds = (
+            getattr(self, "_delegate_consecutive_rounds", 0) + 1
+        )
+        window_count = len(timestamps)
+        triggered = (
+            window_count > max_calls_per_window
+            or self._delegate_consecutive_rounds >= max_consecutive_rounds
+        )
+        if not triggered:
+            return tool_calls
+
+        notice = (
+            "Delegation soft guardrail triggered: repeated delegate_task usage "
+            f"({window_count} calls in the last {int(window_seconds)}s; "
+            f"{self._delegate_consecutive_rounds} consecutive delegate-heavy rounds). "
+            "Checkpoint now: summarize findings, decisions, and acceptance criteria; "
+            "if more delegation is still needed, prefer one broader delegate_task next turn."
+        )
+        last_notice_ts = float(getattr(self, "_delegate_guardrail_last_notice_ts", 0.0) or 0.0)
+        if now - last_notice_ts >= 5.0:
+            self._delegate_guardrail_last_notice_ts = now
+            self._emit_status(notice)
+        try:
+            self.steer(notice)
+        except Exception:
+            logger.debug("Failed to enqueue delegation guardrail steer", exc_info=True)
+
+        if len(delegate_calls) <= 1:
+            return tool_calls
+
+        trimmed = []
+        kept_delegate = False
+        for tc in tool_calls:
+            if tc.function.name != "delegate_task":
+                trimmed.append(tc)
+                continue
+            if not kept_delegate:
+                trimmed.append(tc)
+                kept_delegate = True
+        logger.warning(
+            "Soft guardrail reduced delegate_task fan-out from %d call(s) to 1 for this turn",
+            len(delegate_calls),
+        )
+        return trimmed
 
     @staticmethod
     def _deduplicate_tool_calls(tool_calls: list) -> list:
@@ -8720,6 +8843,9 @@ class AIAgent:
         
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
+        # Delegate soft-guardrail cadence is also per top-level user request,
+        # not a sticky cross-request counter on a reused AIAgent instance.
+        self._reset_delegate_soft_guardrails()
         self._invalid_tool_retries = 0
         self._invalid_json_retries = 0
         self._empty_content_retries = 0
@@ -11242,6 +11368,9 @@ class AIAgent:
 
                     # ── Post-call guardrails ──────────────────────────
                     assistant_message.tool_calls = self._cap_delegate_task_calls(
+                        assistant_message.tool_calls
+                    )
+                    assistant_message.tool_calls = self._apply_delegate_soft_guardrails(
                         assistant_message.tool_calls
                     )
                     assistant_message.tool_calls = self._deduplicate_tool_calls(

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -685,6 +685,34 @@ class TestSummaryTargetRatio:
         # 50% of 200K = 100K, which is above the 64K floor
         assert c.threshold_tokens == 100_000
 
+    def test_explicit_threshold_tokens_override_is_honored(self):
+        """An explicit absolute threshold should override the percentage rule."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_050_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                threshold_percent=0.40,
+                threshold_tokens_override=180_000,
+            )
+        assert c.threshold_percent == 0.40
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 180_000
+        assert c.tail_token_budget == int(180_000 * c.summary_target_ratio)
+
+    def test_explicit_threshold_tokens_override_survives_model_update(self):
+        """Absolute thresholds should persist across model switches/fallbacks."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_050_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                threshold_percent=0.40,
+                threshold_tokens_override=180_000,
+            )
+        c.update_model("fallback-model", 400_000)
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 180_000
+        assert c.tail_token_budget == int(180_000 * c.summary_target_ratio)
+
     def test_default_protect_last_n_is_20(self):
         """Default protect_last_n should be 20."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):

--- a/tests/gateway/test_progress_format.py
+++ b/tests/gateway/test_progress_format.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from gateway.run import _format_verbose_tool_progress
+
+
+def test_format_verbose_tool_progress_uses_tool_emoji():
+    with patch("agent.display.get_tool_emoji", return_value="🔍"):
+        msg = _format_verbose_tool_progress("web_search", {"query": "btc"}, preview_len=0)
+
+    assert msg.startswith("🔍 web_search(")
+    assert '"query": "btc"' in msg
+
+
+def test_format_verbose_tool_progress_truncates_when_preview_len_positive():
+    with patch("agent.display.get_tool_emoji", return_value="💻"):
+        msg = _format_verbose_tool_progress("terminal", {"command": "x" * 80}, preview_len=30)
+
+    assert msg.startswith("💻 terminal(")
+    assert msg.endswith("...")

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -7,6 +7,7 @@ Covers three static methods on AIAgent (inspired by PR #1321 — @alireza78a):
 """
 
 import types
+from unittest.mock import MagicMock
 
 from run_agent import AIAgent
 from tools.delegate_tool import _get_max_concurrent_children
@@ -166,6 +167,66 @@ class TestCapDelegateTaskCalls:
         assert len(out) == len(expected)
         for i, (actual, exp) in enumerate(zip(out, expected)):
             assert actual is exp, f"mismatch at index {i}"
+
+
+class TestDelegateSoftGuardrails:
+
+    @staticmethod
+    def _make_agent_stub():
+        agent = object.__new__(AIAgent)
+        agent._delegate_call_timestamps = []
+        agent._delegate_consecutive_rounds = 0
+        agent._delegate_guardrail_last_notice_ts = 0.0
+        agent._emit_status = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        return agent
+
+    def test_reset_delegate_soft_guardrails_clears_all_state(self):
+        agent = self._make_agent_stub()
+        agent._delegate_call_timestamps = [1.0, 2.0]
+        agent._delegate_consecutive_rounds = 5
+        agent._delegate_guardrail_last_notice_ts = 123.4
+
+        AIAgent._reset_delegate_soft_guardrails(agent)
+
+        assert list(agent._delegate_call_timestamps) == []
+        assert agent._delegate_consecutive_rounds == 0
+        assert agent._delegate_guardrail_last_notice_ts == 0.0
+
+    def test_no_delegate_calls_reset_consecutive_counter(self):
+        agent = self._make_agent_stub()
+        agent._delegate_consecutive_rounds = 4
+        tcs = [make_tc("terminal"), make_tc("web_search")]
+        out = agent._apply_delegate_soft_guardrails(tcs)
+        assert out is tcs
+        assert agent._delegate_consecutive_rounds == 0
+        agent._emit_status.assert_not_called()
+        agent.steer.assert_not_called()
+
+    def test_triggered_by_consecutive_rounds_keeps_one_delegate(self):
+        agent = self._make_agent_stub()
+        agent._delegate_call_timestamps = [0.0, 0.0]
+        agent._delegate_consecutive_rounds = 2
+        tcs = [make_tc("delegate_task", '{"goal":"a"}'), make_tc("terminal"), make_tc("delegate_task", '{"goal":"b"}')]
+        out = agent._apply_delegate_soft_guardrails(tcs)
+        names = [tc.function.name for tc in out]
+        assert names.count("delegate_task") == 1
+        assert "terminal" in names
+        agent._emit_status.assert_called_once()
+        agent.steer.assert_called_once()
+        assert agent._delegate_consecutive_rounds == 3
+
+    def test_triggered_by_window_with_single_delegate_warns_without_trimming(self):
+        import time
+
+        agent = self._make_agent_stub()
+        now = time.monotonic()
+        agent._delegate_call_timestamps = [now] * 6
+        tcs = [make_tc("delegate_task", '{"goal":"only"}'), make_tc("read_file")]
+        out = agent._apply_delegate_soft_guardrails(tcs)
+        assert out is tcs
+        agent._emit_status.assert_called_once()
+        agent.steer.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -40,6 +40,38 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     return agent
 
 
+@patch.object(AIAgent, "_check_compression_model_feasibility", return_value=None)
+@patch("agent.context_compressor.get_model_context_length", return_value=1_050_000)
+def test_init_reads_compression_threshold_tokens_override(mock_ctx_len, _mock_feasibility):
+    """config.yaml compression.threshold_tokens should override the percentage threshold."""
+    cfg = {
+        "compression": {
+            "threshold": 0.40,
+            "threshold_tokens": 180_000,
+        },
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider="openai-codex",
+            model="gpt-5.4",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._compression_threshold_tokens_config == 180_000
+    assert agent.context_compressor.threshold_tokens_override == 180_000
+    assert agent.context_compressor.threshold_tokens == 180_000
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=131_072)
 def test_switch_model_preserves_config_context_length(mock_ctx_len):
     """When switching models, config_context_length should be passed to get_model_context_length."""
@@ -72,3 +104,24 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_switch_model_preserves_threshold_tokens_override(mock_ctx_len):
+    """Absolute compression thresholds should survive switch_model()."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent.context_compressor = ContextCompressor(
+        model="primary-model",
+        threshold_percent=0.50,
+        threshold_tokens_override=80_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-primary",
+        provider="openrouter",
+        quiet_mode=True,
+    )
+
+    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+
+    assert agent.context_compressor.model == "new-model"
+    assert agent.context_compressor.threshold_tokens_override == 80_000
+    assert agent.context_compressor.threshold_tokens == 80_000

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -58,6 +58,31 @@ def _make_mock_parent(depth=0):
     return parent
 
 
+_DEFAULT_TEST_DELEGATION_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "command": None,
+    "args": None,
+}
+
+
+class _DelegateCredentialPatchMixin:
+    def setUp(self):
+        super().setUp()
+        self._delegate_cred_patcher = patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value=dict(_DEFAULT_TEST_DELEGATION_CREDS),
+        )
+        self._delegate_cred_patcher.start()
+
+    def tearDown(self):
+        self._delegate_cred_patcher.stop()
+        super().tearDown()
+
+
 class TestDelegateRequirements(unittest.TestCase):
     def test_always_available(self):
         self.assertTrue(check_delegate_requirements())
@@ -70,6 +95,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
+        self.assertIn("detail_level", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
 
@@ -105,7 +131,7 @@ class TestStripBlockedTools(unittest.TestCase):
         self.assertEqual(result, [])
 
 
-class TestDelegateTask(unittest.TestCase):
+class TestDelegateTask(_DelegateCredentialPatchMixin, unittest.TestCase):
     def test_no_parent_agent(self):
         result = json.loads(delegate_task(goal="test"))
         self.assertIn("error", result)
@@ -306,7 +332,7 @@ class TestDelegateTask(unittest.TestCase):
         parent.tool_progress_callback.assert_not_called()
 
 
-class TestToolNamePreservation(unittest.TestCase):
+class TestToolNamePreservation(_DelegateCredentialPatchMixin, unittest.TestCase):
     """Verify _last_resolved_tool_names is restored after subagent runs."""
 
     def test_global_tool_names_restored_after_delegation(self):
@@ -402,16 +428,16 @@ class TestToolNamePreservation(unittest.TestCase):
         self.assertEqual(captured["saved"], expected_tools)
 
 
-class TestDelegateObservability(unittest.TestCase):
+class TestDelegateObservability(_DelegateCredentialPatchMixin, unittest.TestCase):
     """Tests for enriched metadata returned by _run_single_child."""
 
-    def test_observability_fields_present(self):
-        """Completed child should return tool_trace, tokens, model, exit_reason."""
+    def test_observability_fields_require_detailed_mode(self):
         parent = _make_mock_parent(depth=0)
 
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
             mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_id = "child-session-1"
             mock_child.session_prompt_tokens = 5000
             mock_child.session_completion_tokens = 1200
             mock_child.run_conversation.return_value = {
@@ -430,10 +456,33 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test observability", parent_agent=parent))
-            entry = result["results"][0]
+            slim = json.loads(delegate_task(goal="Test observability", parent_agent=parent))
+            slim_entry = slim["results"][0]
+            self.assertEqual(slim_entry["exit_reason"], "completed")
+            self.assertEqual(slim_entry["duration_seconds"] >= 0, True)
+            self.assertTrue(slim_entry["delegation_id"].startswith("deleg-"))
+            self.assertEqual(slim_entry["child_session_id"], "child-session-1")
+            self.assertEqual(slim_entry["child_role"], "leaf")
+            self.assertEqual(slim_entry["depth"], 1)
+            self.assertNotIn("model", slim_entry)
+            self.assertNotIn("tokens", slim_entry)
+            self.assertNotIn("tool_trace", slim_entry)
+            self.assertNotIn("api_calls", slim_entry)
+
+            detailed = json.loads(
+                delegate_task(
+                    goal="Test observability",
+                    detail_level="detailed",
+                    parent_agent=parent,
+                )
+            )
+            entry = detailed["results"][0]
 
             # Core observability fields
+            self.assertTrue(entry["delegation_id"].startswith("deleg-"))
+            self.assertEqual(entry["child_session_id"], "child-session-1")
+            self.assertEqual(entry["child_role"], "leaf")
+            self.assertEqual(entry["depth"], 1)
             self.assertEqual(entry["model"], "claude-sonnet-4-6")
             self.assertEqual(entry["exit_reason"], "completed")
             self.assertEqual(entry["tokens"]["input"], 5000)
@@ -447,7 +496,7 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertEqual(entry["tool_trace"][0]["status"], "ok")
 
     def test_tool_trace_detects_error(self):
-        """Tool results containing 'error' should be marked as error status."""
+
         parent = _make_mock_parent(depth=0)
 
         with patch("run_agent.AIAgent") as MockAgent:
@@ -469,7 +518,13 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test error trace", parent_agent=parent))
+            result = json.loads(
+                delegate_task(
+                    goal="Test error trace",
+                    detail_level="detailed",
+                    parent_agent=parent,
+                )
+            )
             trace = result["results"][0]["tool_trace"]
             self.assertEqual(trace[0]["status"], "error")
 
@@ -501,7 +556,13 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test parallel", parent_agent=parent))
+            result = json.loads(
+                delegate_task(
+                    goal="Test parallel",
+                    detail_level="detailed",
+                    parent_agent=parent,
+                )
+            )
             trace = result["results"][0]["tool_trace"]
 
             # All three tool calls should have results
@@ -540,7 +601,12 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test interrupt", parent_agent=parent))
+            result = json.loads(
+                delegate_task(
+                    goal="Test interrupt",
+                    parent_agent=parent,
+                )
+            )
             self.assertEqual(result["results"][0]["exit_reason"], "interrupted")
 
     def test_exit_reason_max_iterations(self):
@@ -561,7 +627,12 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test max iter", parent_agent=parent))
+            result = json.loads(
+                delegate_task(
+                    goal="Test max iter",
+                    parent_agent=parent,
+                )
+            )
             self.assertEqual(result["results"][0]["exit_reason"], "max_iterations")
 
 
@@ -1160,7 +1231,40 @@ class TestChildCredentialLeasing(unittest.TestCase):
         )
 
         self.assertEqual(result["status"], "error")
+        self.assertEqual(result["exit_reason"], "error")
         child._credential_pool.release_lease.assert_called_once_with("cred-a")
+
+
+class TestDelegateBatchFallbackExitReasons(_DelegateCredentialPatchMixin, unittest.TestCase):
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_fabricated_error_entry_includes_exit_reason(self, mock_run):
+        parent = _make_mock_parent()
+
+        def _side_effect(*args, **kwargs):
+            goal = kwargs.get("goal")
+            if goal == "boom":
+                raise RuntimeError("batch exploded")
+            return {
+                "task_index": kwargs["task_index"],
+                "status": "completed",
+                "summary": "ok",
+                "exit_reason": "completed",
+                "api_calls": 1,
+                "duration_seconds": 0.1,
+            }
+
+        mock_run.side_effect = _side_effect
+
+        result = json.loads(
+            delegate_task(
+                tasks=[{"goal": "boom"}, {"goal": "ok"}],
+                parent_agent=parent,
+            )
+        )
+
+        self.assertEqual(result["results"][0]["status"], "error")
+        self.assertEqual(result["results"][0]["exit_reason"], "error")
+        self.assertIn("batch exploded", result["results"][0]["error"])
 
 
 class TestDelegateHeartbeat(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -67,6 +67,20 @@ _SUBAGENT_TOOLSETS = sorted(
 _TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
+_DEFAULT_DETAIL_LEVEL = "slim"
+_DETAIL_LEVELS = frozenset({"slim", "detailed"})
+_DETAILED_RESULT_FIELDS = (
+    "api_calls",
+    "model",
+    "tokens",
+    "tool_trace",
+)
+_TRACEABILITY_FIELDS = (
+    "delegation_id",
+    "child_session_id",
+    "child_role",
+    "depth",
+)
 MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected unless max_spawn_depth raised.
 # Configurable depth cap consulted by _get_max_spawn_depth; MAX_DEPTH
 # stays as the default fallback and is still the symbol tests import.
@@ -261,6 +275,99 @@ def _normalize_role(r: Optional[str]) -> str:
         return r_norm
     logger.warning("Unknown delegate_task role=%r, coercing to 'leaf'", r)
     return "leaf"
+
+
+def _normalize_detail_level(detail_level: Optional[str]) -> str:
+    """Return the public delegate_task result detail level.
+
+    Defaults to ``slim`` to reduce parent-context growth, but accepts
+    ``detailed`` for the legacy rich payload with tool traces and token stats.
+    Unknown values degrade to the default with a warning.
+    """
+    if detail_level is None or not str(detail_level).strip():
+        return _DEFAULT_DETAIL_LEVEL
+    normalized = str(detail_level).strip().lower()
+    if normalized in _DETAIL_LEVELS:
+        return normalized
+    logger.warning(
+        "Unknown delegate_task detail_level=%r, coercing to %r",
+        detail_level,
+        _DEFAULT_DETAIL_LEVEL,
+    )
+    return _DEFAULT_DETAIL_LEVEL
+
+
+def _public_delegate_entry(entry: Dict[str, Any], detail_level: str) -> Dict[str, Any]:
+    """Strip internal-only and optional heavy fields from a child result entry."""
+    public = dict(entry)
+    public.pop("_child_role", None)
+    if detail_level != "detailed":
+        for field in _DETAILED_RESULT_FIELDS:
+            public.pop(field, None)
+    return public
+
+
+def _delegate_trace_fields(child) -> Dict[str, Any]:
+    """Return lightweight per-child traceability metadata for parent payloads."""
+    fields: Dict[str, Any] = {}
+    delegation_id = getattr(child, "_delegation_id", None)
+    if isinstance(delegation_id, str) and delegation_id:
+        fields["delegation_id"] = delegation_id
+    child_session_id = getattr(child, "session_id", None)
+    if isinstance(child_session_id, str) and child_session_id:
+        fields["child_session_id"] = child_session_id
+    child_role = getattr(child, "_delegate_role", None)
+    if isinstance(child_role, str) and child_role:
+        fields["child_role"] = child_role
+    depth = getattr(child, "_delegate_depth", None)
+    if isinstance(depth, int):
+        fields["depth"] = depth
+    return fields
+
+
+def _subagent_progress_message(
+    event_type: str,
+    tool_name: Optional[str] = None,
+    preview: Optional[str] = None,
+    args: Optional[dict] = None,
+    **kwargs,
+) -> Optional[str]:
+    """Return a compact gateway progress line for supported subagent/tool events."""
+    from agent.display import get_tool_emoji
+
+    if event_type == "tool.started":
+        emoji = get_tool_emoji(tool_name, default="⚙️")
+        if preview:
+            from agent.display import get_tool_preview_max_len
+
+            _pl = get_tool_preview_max_len()
+            _cap = _pl if _pl > 0 else 40
+            if len(preview) > _cap:
+                preview = preview[:_cap - 3] + "..."
+            return f"{emoji} {tool_name}: \"{preview}\""
+        return f"{emoji} {tool_name}..."
+
+    if event_type == "subagent.complete":
+        idx = kwargs.get("task_index")
+        status = str(kwargs.get("status") or "completed")
+        summary = str(kwargs.get("summary") or kwargs.get("preview") or "").strip()
+        duration = kwargs.get("duration_seconds")
+        status_icon = "✓" if status == "completed" else "✗"
+        label = f"subagent {idx}" if idx is not None else "subagent"
+        tail = []
+        if duration not in (None, ""):
+            try:
+                tail.append(f"{float(duration):.1f}s")
+            except (TypeError, ValueError):
+                pass
+        if summary:
+            if len(summary) > 120:
+                summary = summary[:117] + "..."
+            tail.append(summary)
+        suffix = f": {' — '.join(tail)}" if tail else ""
+        return f"{status_icon} {label} {status}{suffix}"
+
+    return None
 
 
 def _get_max_concurrent_children() -> int:
@@ -584,6 +691,7 @@ def _build_child_progress_callback(
     depth: Optional[int] = None,
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    delegation_id: Optional[str] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -592,7 +700,7 @@ def _build_child_progress_callback(
       Gateway: batches tool names and relays to parent's progress callback
 
     The identity kwargs (``subagent_id``, ``parent_id``, ``depth``, ``model``,
-    ``toolsets``) are threaded into every relayed event so the TUI can
+    ``toolsets``, ``delegation_id``) are threaded into every relayed event so the TUI can
     reconstruct the live spawn tree and route per-branch controls (kill,
     pause) back by ``subagent_id``.  All are optional for backward compat —
     older callers that ignore them still produce a flat list on the TUI.
@@ -631,6 +739,8 @@ def _build_child_progress_callback(
             kw["model"] = model
         if toolsets is not None:
             kw["toolsets"] = list(toolsets)
+        if delegation_id is not None:
+            kw["delegation_id"] = delegation_id
         kw["tool_count"] = _tool_count[0]
         return kw
 
@@ -781,6 +891,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    delegation_id: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -881,12 +992,13 @@ def _build_child_agent(
         task_index,
         goal,
         parent_agent,
-        task_count,
+        task_count=task_count,
         subagent_id=subagent_id,
-        parent_id=parent_subagent_id,
+        parent_id=(parent_subagent_id if isinstance(parent_subagent_id, str) else None),
         depth=tui_depth,
-        model=effective_model_for_cb,
-        toolsets=child_toolsets,
+        model=effective_model_for_cb if isinstance(effective_model_for_cb, str) else None,
+        toolsets=list(child_toolsets),
+        delegation_id=delegation_id,
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
@@ -977,6 +1089,7 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    child._delegation_id = delegation_id
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -1219,6 +1332,7 @@ def _run_single_child(
                 "exit_reason": "timeout" if is_timeout else "error",
                 "api_calls": 0,
                 "duration_seconds": duration,
+                **_delegate_trace_fields(child),
                 "_child_role": getattr(child, "_delegate_role", None),
             }
         finally:
@@ -1316,6 +1430,7 @@ def _run_single_child(
                 ),
             },
             "tool_trace": tool_trace,
+            **_delegate_trace_fields(child),
             # Captured before the finally block calls child.close() so the
             # parent thread can fire subagent_stop with the correct role.
             # Stripped before the dict is serialised back to the model.
@@ -1405,6 +1520,7 @@ def _run_single_child(
             "files_read": _files_read,
             "files_written": _files_written,
             "output_tail": _output_tail,
+            **_delegate_trace_fields(child),
         }
         if _cost_usd is not None:
             try:
@@ -1439,8 +1555,10 @@ def _run_single_child(
             "status": "error",
             "summary": None,
             "error": str(exc),
+            "exit_reason": "error",
             "api_calls": 0,
             "duration_seconds": duration,
+            **_delegate_trace_fields(child),
             "_child_role": getattr(child, "_delegate_role", None),
         }
 
@@ -1502,6 +1620,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    detail_level: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1532,6 +1651,10 @@ def delegate_task(
 
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+    public_detail_level = _normalize_detail_level(detail_level)
+
+    import uuid as _uuid
+    delegation_id = f"deleg-{_uuid.uuid4().hex[:10]}"
 
     # Depth limit — configurable via delegation.max_spawn_depth,
     # default 2 for parity with the original MAX_DEPTH constant.
@@ -1637,6 +1760,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                delegation_id=delegation_id,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -1693,8 +1817,10 @@ def delegate_task(
                                     "status": "error",
                                     "summary": None,
                                     "error": str(exc),
+                                    "exit_reason": "error",
                                     "api_calls": 0,
                                     "duration_seconds": 0,
+                                    **_delegate_trace_fields(_child_by_index.get(idx)),
                                     "_child_role": getattr(
                                         _child_by_index.get(idx), "_delegate_role", None
                                     ),
@@ -1705,8 +1831,10 @@ def delegate_task(
                                 "status": "interrupted",
                                 "summary": None,
                                 "error": "Parent agent interrupted — child did not finish in time",
+                                "exit_reason": "interrupted",
                                 "api_calls": 0,
                                 "duration_seconds": 0,
+                                **_delegate_trace_fields(_child_by_index.get(idx)),
                                 "_child_role": getattr(
                                     _child_by_index.get(idx), "_delegate_role", None
                                 ),
@@ -1730,8 +1858,10 @@ def delegate_task(
                             "status": "error",
                             "summary": None,
                             "error": str(exc),
+                            "exit_reason": "error",
                             "api_calls": 0,
                             "duration_seconds": 0,
+                            **_delegate_trace_fields(_child_by_index.get(idx)),
                             "_child_role": getattr(
                                 _child_by_index.get(idx), "_delegate_role", None
                             ),
@@ -1822,10 +1952,13 @@ def delegate_task(
             logger.debug("subagent_stop hook invocation failed", exc_info=True)
 
     total_duration = round(time.monotonic() - overall_start, 2)
+    public_results = [
+        _public_delegate_entry(entry, public_detail_level) for entry in results
+    ]
 
     return json.dumps(
         {
-            "results": results,
+            "results": public_results,
             "total_duration_seconds": total_duration,
         },
         ensure_ascii=False,
@@ -2018,7 +2151,9 @@ DELEGATE_TASK_SCHEMA = {
         "(default 2) and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
+        "- Results are always returned as an array, one entry per task. Default detail_level='slim' returns only the"
+        " fields most useful for parent decisions; use detail_level='detailed' when you explicitly need metrics,"
+        " token counts, model info, or tool traces."
     ),
     "parameters": {
         "type": "object",
@@ -2112,6 +2247,15 @@ DELEGATE_TASK_SCHEMA = {
                     "delegation.orchestrator_enabled=false."
                 ),
             },
+            "detail_level": {
+                "type": "string",
+                "enum": ["slim", "detailed"],
+                "description": (
+                    "Public result payload size. 'slim' (default) keeps parent-context usage low while preserving status,"
+                    " summary, duration, and exit_reason. 'detailed' restores metrics like api_calls, model, tokens, and"
+                    " tool_trace for debugging or instrumentation."
+                ),
+            },
             "acp_command": {
                 "type": "string",
                 "description": (
@@ -2151,6 +2295,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        detail_level=args.get("detail_level"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Why
`delegate_task` responses were carrying high-volume metadata by default, which bloats the parent conversation during delegation-heavy runs.

One of the main goals of this change is to **save main-window context budget**, so Hermes can:
- keep more of the active task in a single session,
- trigger automatic compression less often,
- and stay effective on longer same-window workflows before context quality degrades.

## What changed
- `delegate_task` now defaults to `detail_level="slim"`.
- Added explicit `detail_level` modes:
  - `slim` (default): compact parent-facing payload
  - `detailed`: rich payload for debugging and instrumentation
- Added lightweight traceability fields so parent workflows remain auditable without pulling back heavy child traces.

## Why this is safe
Slim mode keeps the signals needed for normal parent decisions and control flow, while removing only heavy debug fields.
If richer diagnostics are needed, callers can opt into `detail_level="detailed"`.

This is meant to improve context efficiency **without sacrificing usability**: the parent still gets the information needed to orchestrate work, decide next steps, and trace child execution.

## Signals still available in slim mode
Each result still includes:
- `task_index`
- `status`
- `summary`
- `exit_reason`
- `duration_seconds`
- `error` (when applicable)
- traceability: `delegation_id`, `child_session_id`, `child_role`, `depth`

Slim mode removes only:
- `api_calls`
- `model`
- `tokens`
- `tool_trace`

## Other changes in this PR
- Added soft delegation guardrails to reduce repeated delegate fan-out bursts.
- Preserved absolute `compression.threshold_tokens` overrides across model switches, with regression coverage.
- Kept gateway progress usable by preserving per-tool emoji formatting and surfacing compact `subagent.complete` progress lines.
- Updated relevant skill guidance to reflect the slim-vs-detailed behavior.

## Testing
- `scripts/run_tests.sh tests/tools/test_delegate.py`
- `scripts/run_tests.sh tests/run_agent/test_agent_guardrails.py`
- `scripts/run_tests.sh tests/agent/test_context_compressor.py tests/run_agent/test_switch_model_context.py`
- `scripts/run_tests.sh tests/gateway/test_progress_format.py`
