### PR TITLE
skills: add bundled agent-audit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
-| [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |
+| [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills, bundled agent-audit workflows |
 | [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) | Persistent memory, user profiles, best practices |
 | [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities |
 | [Cron Scheduling](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Scheduled tasks with platform delivery |

--- a/skills/software-development/agent-audit/SKILL.md
+++ b/skills/software-development/agent-audit/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: agent-audit
+description: >
+  Evidence-first audit workflow for agent runtimes, wrappers, memory layers,
+  tool routing, and delivery paths. Use when an agent becomes less reliable
+  than the base model, skips tools, leaks stale memory, or mutates otherwise
+  correct answers.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [agent-runtime, audit, diagnostics, reliability, tools, memory]
+    related_skills: [systematic-debugging, requesting-code-review, subagent-driven-development]
+---
+
+# Agent Audit
+
+Audit the agent system itself, not the user's domain task.
+
+Use this skill when an assistant, wrapper, gateway, CLI agent, browser agent,
+or long-running runtime:
+
+- behaves worse than the underlying model
+- skips required tools
+- reuses stale session or memory evidence
+- mutates correct answers during retries, formatting, or transport
+- hides repair, retry, recap, or summarization layers
+- gives confident operational answers without current evidence
+
+## Core rule
+
+Work evidence-first and JSON-first.
+
+Do not jump directly to prose conclusions. Build the structured artifacts first,
+then render the user-facing diagnosis from those artifacts.
+
+Required artifacts, in order:
+
+1. `agent_check_scope.json`
+2. `evidence_pack.json`
+3. `failure_map.json`
+4. `agent_check_report.json`
+
+## Audit target
+
+Inspect the full agent stack:
+
+1. system prompt and role shaping
+2. session history injection
+3. long-term memory retrieval
+4. summaries or distillation
+5. active recall or recap layers
+6. tool routing and selection
+7. tool execution
+8. tool-output interpretation
+9. answer shaping
+10. platform rendering or transport
+11. fallback or repair loops
+12. persistence and stale state
+
+## Required working style
+
+- Prefer direct evidence: code, config, logs, payloads, DB rows, screenshots, and tests.
+- Treat a clean current state as insufficient when the reported failure was historical.
+- Prefer code and configuration fixes over prompt-only fixes.
+- Be explicit about confidence and contradictory evidence.
+- Do not blame the base model unless wrapper layers have been falsified.
+
+## Artifact contracts
+
+Read these references before or during the audit:
+
+- `references/report-schema.json`
+- `references/rubric.md`
+- `references/playbooks.md`
+- `references/advanced-playbooks.md`
+- `references/example-report.json`
+- `references/trigger-prompts.md`
+
+### `agent_check_scope.json`
+
+Define:
+
+- target system
+- runtime entrypoints
+- channels or surfaces
+- model stack
+- time window of interest
+- known symptoms
+- suspected layers
+- layers to audit
+
+### `evidence_pack.json`
+
+Capture:
+
+- exact files and code locations
+- logs, payloads, DB rows, config files, and screenshots
+- whether each evidence item is current, historical, or mixed
+- missing evidence that blocks confidence
+
+### `failure_map.json`
+
+For each failure mode include:
+
+- severity
+- symptom
+- user impact
+- source layer
+- mechanism
+- root cause
+- evidence refs
+- confidence
+- recommended fix
+
+### `agent_check_report.json`
+
+Render the final structured report with:
+
+- executive verdict
+- severity-ranked findings
+- conflict map across layers
+- contamination paths
+- ordered fix plan
+
+## Standard playbooks
+
+Use the closest playbook from `references/playbooks.md`:
+
+- `wrapper-regression`
+- `memory-contamination`
+- `tool-discipline`
+- `rendering-transport`
+- `hidden-agent-layers`
+
+If the runtime is deeply compromised, use an advanced playbook from
+`references/advanced-playbooks.md`.
+
+## Recommended workflow
+
+1. Create the scope artifact.
+2. Gather direct evidence.
+3. Map failure modes.
+4. Build the final report from the structured artifacts.
+5. Present:
+   - severity-ranked findings first
+   - architecture diagnosis second
+   - ordered fix plan third
+
+## Output rules
+
+- Lead with findings, not compliments.
+- Do not hide uncertainty.
+- Do not improvise a new theory after producing the report.
+- If the main problem is wrapper design, say so directly.
+- If the user asks for JSON, provide `agent_check_report.json`.
+
+## Example prompt
+
+Use `agent-audit` to inspect this agent runtime for wrapper regression and
+tool-discipline failures. Focus on stale evidence reuse, hidden repair layers,
+and whether tool requirements are enforced in code or only described in prompts.
+Build the JSON artifacts first, then give severity-ranked findings and a fix order.

--- a/skills/software-development/agent-audit/references/advanced-playbooks.md
+++ b/skills/software-development/agent-audit/references/advanced-playbooks.md
@@ -1,0 +1,46 @@
+# Advanced Playbooks
+
+Use these when the target system is structurally compromised.
+
+## false-confidence
+
+Use when:
+
+- the agent sounds decisive while evidence is weak or missing
+- the wrapper adds confidence without adding truth
+
+## stale-evidence-replay
+
+Use when:
+
+- old outputs are repeated as if they were current
+- the agent reuses a prior status after the system changed
+
+## fake-agentic-depth
+
+Use when:
+
+- the system looks more agentic but gets less reliable
+- extra planning, recap, or orchestration layers degrade truthfulness
+
+## hidden-repair-brain
+
+Use when:
+
+- platform or fallback code silently spins up a second model pass
+- good answers become worse during repair or downgrade
+
+## memory-poisoning
+
+Use when:
+
+- assistant self-talk becomes durable knowledge
+- same-session facts teach the agent the wrong thing
+
+## protocol-decay
+
+Use when:
+
+- internal state is carried as prose instead of typed data
+- markdown becomes the protocol
+- intermediate layers keep paraphrasing each other

--- a/skills/software-development/agent-audit/references/example-report.json
+++ b/skills/software-development/agent-audit/references/example-report.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "agent-audit.report.v1",
+  "executive_verdict": {
+    "overall_health": "high_risk",
+    "primary_failure_mode": "stale same-session evidence is being reused as if it were current truth",
+    "most_urgent_fix": "enforce code-level fresh probes for operational queries"
+  },
+  "scope": {
+    "target_name": "Example Agent Runtime",
+    "entrypoints": ["cli", "slack adapter"],
+    "channels": ["slack", "cli"],
+    "model_stack": ["gpt-5.2", "memory-layer", "tool-router"],
+    "time_window": "historical incident window on 2026-04-15",
+    "layers_to_audit": [
+      "system_prompt",
+      "session_history",
+      "long_term_memory",
+      "distillation",
+      "active_recall",
+      "tool_selection",
+      "tool_execution",
+      "tool_interpretation",
+      "answer_shaping",
+      "platform_rendering",
+      "fallback_loops",
+      "persistence"
+    ]
+  },
+  "evidence_pack": [
+    {
+      "kind": "log",
+      "source": "runtime.log",
+      "location": "turn where the agent answered before using a required tool",
+      "summary": "The first reply claimed a system state without any current-turn probe.",
+      "time_scope": "historical"
+    },
+    {
+      "kind": "code",
+      "source": "runtime/tool-routing.py",
+      "location": "tool-gating path",
+      "summary": "Operational queries can complete without hard tool enforcement.",
+      "time_scope": "current"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Operational answers can bypass real inspection",
+      "symptom": "The agent gives confident system-state answers before tools run.",
+      "user_impact": "Users receive wrong operational facts with high confidence.",
+      "source_layer": "tool_selection",
+      "mechanism": "Tool usage is encouraged in prompt text but not always required by code.",
+      "root_cause": "Prompt-enforced discipline instead of code-enforced discipline.",
+      "evidence_refs": ["runtime.log:first_reply_without_tool", "tool-routing:gate"],
+      "confidence": 0.98,
+      "fix_type": "code",
+      "recommended_fix": "Introduce task classification plus mandatory probe execution before final answer generation."
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "session_history",
+      "to_layer": "tool_interpretation",
+      "conflict_type": "stale_state",
+      "note": "Old evidence is accepted as if it were fresh."
+    }
+  ],
+  "contamination_paths": [
+    {
+      "origin_layer": "session_history",
+      "affected_layer": "tool_selection",
+      "artifact": "stale operational observation",
+      "failure_mode": "stale_state",
+      "note": "A previous observation survives long enough to bias current-turn tool routing."
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "Force fresh probes for system-state queries",
+      "why_now": "It removes the most damaging correctness failure immediately.",
+      "expected_effect": "Wrong operational answers drop sharply."
+    }
+  ]
+}

--- a/skills/software-development/agent-audit/references/playbooks.md
+++ b/skills/software-development/agent-audit/references/playbooks.md
@@ -1,0 +1,75 @@
+# Playbooks
+
+Use one primary audit mode.
+
+## wrapper-regression
+
+Use when:
+
+- the base model seems strong, but the wrapped agent behaves much worse
+- users say the model is fine elsewhere, but this wrapper becomes unreliable
+
+Focus:
+
+- wrapper layering
+- duplicated context injection
+- hidden formatting or fallback layers
+- answer degradation after orchestration
+
+## memory-contamination
+
+Use when:
+
+- the agent drags old topics into new questions
+- the same session appears to teach itself bad facts
+- long-term memory and session history blur together
+
+Focus:
+
+- same-session artifact reentry
+- stale session reuse
+- weak memory admission criteria
+- aggressive distillation cadence
+
+## tool-discipline
+
+Use when:
+
+- the agent should have used a tool but did not
+- the wrong tool was selected
+- tool evidence was available but the conclusion drifted anyway
+
+Focus:
+
+- code-enforced vs prompt-enforced tool requirements
+- preflight probes
+- tool-call skip paths
+- stale evidence reuse
+
+## rendering-transport
+
+Use when:
+
+- the answer seems correct internally but broken in delivery
+- raw markdown leaks into cards or channel payloads
+- rendering or transport changes semantics
+
+Focus:
+
+- transport payload shape assumptions
+- deterministic fallback behavior
+- platform-layer mutations
+
+## hidden-agent-layers
+
+Use when:
+
+- repair, retry, summarize, or recap loops are hidden in the stack
+- unexpected second-pass model calls mutate outputs
+
+Focus:
+
+- hidden repair agents
+- recap or recall loops
+- maintenance-worker synthesis paths
+- transport repair prompts

--- a/skills/software-development/agent-audit/references/report-schema.json
+++ b/skills/software-development/agent-audit/references/report-schema.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "agent-audit.report.v1",
+  "executive_verdict": {
+    "overall_health": "critical | high_risk | unstable | acceptable | strong",
+    "primary_failure_mode": "string",
+    "most_urgent_fix": "string"
+  },
+  "scope": {
+    "target_name": "string",
+    "entrypoints": ["string"],
+    "channels": ["string"],
+    "model_stack": ["string"],
+    "time_window": "string",
+    "layers_to_audit": [
+      "system_prompt",
+      "session_history",
+      "long_term_memory",
+      "distillation",
+      "active_recall",
+      "tool_selection",
+      "tool_execution",
+      "tool_interpretation",
+      "answer_shaping",
+      "platform_rendering",
+      "fallback_loops",
+      "persistence"
+    ]
+  },
+  "evidence_pack": [
+    {
+      "kind": "code | log | db | config | screenshot | test",
+      "source": "string",
+      "location": "string",
+      "summary": "string",
+      "time_scope": "historical | current | mixed"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical | high | medium | low",
+      "title": "string",
+      "symptom": "string",
+      "user_impact": "string",
+      "source_layer": "string",
+      "mechanism": "string",
+      "root_cause": "string",
+      "evidence_refs": ["string"],
+      "confidence": 0.0,
+      "fix_type": "code | config | prompt_removal | architecture | data_cleanup",
+      "recommended_fix": "string"
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "string",
+      "to_layer": "string",
+      "conflict_type": "duplication | contradiction | stale_state | hidden_mutation | freeform_overwrite",
+      "note": "string"
+    }
+  ],
+  "contamination_paths": [
+    {
+      "origin_layer": "string",
+      "affected_layer": "string",
+      "artifact": "string",
+      "failure_mode": "string",
+      "note": "string"
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "string",
+      "why_now": "string",
+      "expected_effect": "string"
+    }
+  ]
+}

--- a/skills/software-development/agent-audit/references/rubric.md
+++ b/skills/software-development/agent-audit/references/rubric.md
@@ -1,0 +1,78 @@
+# Audit Rubric
+
+Use this rubric when producing `agent_check_report.json`.
+
+## 1. Context cleanliness
+
+Check:
+
+- Is the same information injected through multiple layers?
+- Are model-generated summaries fed back as context?
+- Is session history carrying stale facts forward?
+- Are current-session artifacts re-entering the same turn?
+
+## 2. Tool discipline
+
+Check:
+
+- Are tools merely available, or actually required in code?
+- Can the model skip tools and still answer?
+- Does the runtime bind final answers to current-turn evidence?
+
+## 3. Failure handling
+
+Check:
+
+- Does a send or render failure trigger another hidden agent?
+- Is there a deterministic fallback path?
+- Are failures visible and attributable?
+
+## 4. Memory admission
+
+Check:
+
+- Can assistant self-talk become long-term memory?
+- Are user corrections weighted more than assistant assertions?
+- Is there a stable-window or evidence gate before distillation?
+
+## 5. Answer shaping
+
+Check:
+
+- Is the final response derived from structured evidence?
+- Does formatting add noise or rewrap already-correct answers?
+- Does platform rendering leak raw markdown or transform meaning unpredictably?
+
+## 6. Hidden agent layers
+
+Check:
+
+- Are there hidden repair, retry, summarize, or recap agents?
+- Do these layers have explicit contracts and schemas?
+
+## 7. JSON vs freeform boundary
+
+Preferred:
+
+- internal planning and state should be structured
+- final rendering may be prose
+
+## Severity heuristics
+
+### critical
+
+- confidently wrong operational behavior
+- wrong actions or wrong system state with high confidence
+
+### high
+
+- repeated corruption of otherwise good evidence
+- memory or wrapper layers repeatedly steer answers off target
+
+### medium
+
+- correctness often survives, but the system is fragile or hard to trust
+
+### low
+
+- mostly maintainability or cosmetic concerns

--- a/skills/software-development/agent-audit/references/trigger-prompts.md
+++ b/skills/software-development/agent-audit/references/trigger-prompts.md
@@ -1,0 +1,11 @@
+# Trigger Prompts
+
+Use this skill when users ask:
+
+- Audit this agent runtime end to end
+- Why is this wrapped model worse than the base model?
+- Why does the assistant skip tools?
+- Why is memory polluting new turns?
+- Why do answers become worse after retries or formatting?
+- Diagnose hidden prompt conflicts in this assistant stack
+- Give me a severity-ranked audit of this agent wrapper

--- a/tests/skills/test_agent_audit_skill.py
+++ b/tests/skills/test_agent_audit_skill.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import json
+
+from agent.skill_utils import parse_frontmatter
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "software-development" / "agent-audit"
+
+
+def test_agent_audit_skill_frontmatter_and_references_are_parseable():
+    skill_text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    frontmatter, body = parse_frontmatter(skill_text)
+
+    assert frontmatter["name"] == "agent-audit"
+    assert "Evidence-first audit workflow" in frontmatter["description"]
+    assert "agent_check_scope.json" in body
+    assert "evidence_pack.json" in body
+    assert "failure_map.json" in body
+    assert "agent_check_report.json" in body
+    assert "references/report-schema.json" in body
+
+
+def test_agent_audit_report_schema_and_example_include_contamination_paths():
+    schema = json.loads((SKILL_DIR / "references" / "report-schema.json").read_text())
+    example = json.loads((SKILL_DIR / "references" / "example-report.json").read_text())
+
+    assert schema["schema_version"] == "agent-audit.report.v1"
+    assert example["schema_version"] == "agent-audit.report.v1"
+    assert "contamination_paths" in schema
+    assert "contamination_paths" in example
+    assert example["ordered_fix_plan"][0]["order"] == 1


### PR DESCRIPTION
## Summary
- add a bundled `agent-audit` skill under `skills/software-development/agent-audit/`
- include structured references for audit playbooks, advanced playbooks, rubric guidance, report schema, trigger prompts, and an example report
- add focused tests for the new skill's frontmatter and report contract
- mention bundled agent-audit workflows in the README skills-system row

## What this adds
This PR adds a Hermes-native skill for auditing agent runtimes themselves, rather than solving the user's domain task.

The skill is designed for cases like:
- wrapper regression
- tool-discipline failures
- stale memory contamination
- hidden repair or retry layers
- answer mutation during rendering or transport

The workflow asks the agent to build four structured artifacts before rendering a user-facing diagnosis:
1. `agent_check_scope.json`
2. `evidence_pack.json`
3. `failure_map.json`
4. `agent_check_report.json`

The bundled references provide a stable schema, playbooks, rubric, trigger prompts, and a concrete example report so audit output stays consistent instead of becoming freeform prose.

## Why this fits Hermes
Hermes already has a strong skills system and a self-improving agent loop. `agent-audit` gives users and contributors a repeatable way to inspect the wrapper, memory, tool-routing, and delivery layers when agent behavior regresses.

I kept this as a bundled skill instead of changing the core runtime, so it remains opt-in, easy to inspect, and aligned with the existing Skills Hub / bundled skills model.

## Verification
I ran the following locally:

```bash
cd /tmp/hermes-agent-feature && uv pip install -e '.[dev]'
cd /tmp/hermes-agent-feature && uv pip install ruff
cd /tmp/hermes-agent-feature && uv run pytest tests/skills/test_agent_audit_skill.py -q
cd /tmp/hermes-agent-feature && uv run pytest tests/test_packaging_metadata.py -q
cd /tmp/hermes-agent-feature && uv run ruff check tests/skills/test_agent_audit_skill.py
cd /tmp/hermes-agent-feature && uv run python -m py_compile tests/skills/test_agent_audit_skill.py agent/skill_utils.py
```

Results:
- `tests/skills/test_agent_audit_skill.py`: `2 passed`
- `tests/test_packaging_metadata.py`: `2 passed`
- `ruff`: all checks passed
- `py_compile`: passed
