### PR TITLE
fix(cron): guard against non-dict result from run_conversation (salvage #9437)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -972,6 +972,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"— last activity: {_last_desc}"
             )
 
+        # Guard against non-dict returns from run_conversation under error conditions
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
+            )
+
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -393,6 +393,7 @@ AUTHOR_MAP = {
     "brett@brettbrewer.com": "minorgod",
     "67779267+wenhao7@users.noreply.github.com": "wenhao7",
     "git@yzx9.xyz": "yzx9",
+    "nilesh@cloudgeni.us": "lvnilesh",
 }
 
 


### PR DESCRIPTION
Salvages #9437 by @lvnilesh onto current main.

`run_job()` in `cron/scheduler.py` assumes `result` from `agent.run_conversation` is always a dict, but under error conditions it can return a string or None. Subsequent `.get("final_response", "")` then raises `AttributeError` which surfaces as an opaque crash to the user instead of a clear "the agent returned an unexpected shape" signal.

One small isinstance guard raises a descriptive RuntimeError with the actual type + repr so cron logs show what went wrong.

Closes #9437. Author attribution preserved via cherry-pick.