### PR TITLE
docs: rename _api_call_with_interrupt → _interruptible_api_call references (salvage #8997)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -394,6 +394,7 @@ AUTHOR_MAP = {
     "67779267+wenhao7@users.noreply.github.com": "wenhao7",
     "git@yzx9.xyz": "yzx9",
     "nilesh@cloudgeni.us": "lvnilesh",
+    "63502660+azhengbot@users.noreply.github.com": "azhengbot",
 }
 
 

--- a/website/docs/developer-guide/adding-providers.md
+++ b/website/docs/developer-guide/adding-providers.md
@@ -253,7 +253,7 @@ Search for `api_mode` and audit every switch point. At minimum, verify:
 - `__init__` chooses the new `api_mode`
 - client construction works for the provider
 - `_build_api_kwargs()` knows how to format requests
-- `_api_call_with_interrupt()` dispatches to the right client call
+- `_interruptible_api_call()` dispatches to the right client call
 - interrupt / client rebuild paths work
 - response validation accepts the provider's shape
 - finish-reason extraction is correct

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -72,7 +72,7 @@ run_conversation()
      - anthropic_messages: convert via anthropic_adapter.py
   6. Inject ephemeral prompt layers (budget warnings, context pressure)
   7. Apply prompt caching markers if on Anthropic
-  8. Make interruptible API call (_api_call_with_interrupt)
+  8. Make interruptible API call (_interruptible_api_call)
   9. Parse response:
      - If tool_calls: execute them, append results, loop back to step 5
      - If text response: persist session, flush memory if needed, return
@@ -105,7 +105,7 @@ Providers validate these sequences and will reject malformed histories.
 
 ## Interruptible API Calls
 
-API requests are wrapped in `_api_call_with_interrupt()` which runs the actual HTTP call in a background thread while monitoring an interrupt event:
+API requests are wrapped in `_interruptible_api_call()` which runs the actual HTTP call in a background thread while monitoring an interrupt event:
 
 ```text
 ┌────────────────────────────────────────────────────┐


### PR DESCRIPTION
Salvages #8997 by @azhengbot onto current main.

`run_agent.py` renamed the helper from `_api_call_with_interrupt` to `_interruptible_api_call` at some point, but two developer-guide pages (`agent-loop.md` + `adding-providers.md`) still referenced the old name. Contributors landing on those docs would grep the codebase and find nothing. Both pages now use the current name.

Two-commit cherry-pick.

Closes #8997. Author attribution preserved via cherry-pick.