### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap (salvage #7501)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -396,6 +396,7 @@ AUTHOR_MAP = {
     "nilesh@cloudgeni.us": "lvnilesh",
     "63502660+azhengbot@users.noreply.github.com": "azhengbot",
     "sharvil.saxena@gmail.com": "sharziki",
+    "yuanhe@minimaxi.com": "RyanLee-Dev",
 }
 
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -289,6 +289,7 @@ class GitHubSource(SkillSource):
         {"repo": "anthropics/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
         {"repo": "garrytan/gstack", "path": ""},
+        {"repo": "MiniMax-AI/cli", "path": "skill/"},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):


### PR DESCRIPTION
Salvages #7501 by @RyanLee-Dev (MiniMax) onto current main.

Adds `MiniMax-AI/cli` to the `GitHubSource.DEFAULT_TAPS` list in `tools/skills_hub.py`, alongside the existing openai/skills, anthropics/skills, VoltAgent/awesome-agent-skills, and garrytan/gstack entries. MiniMax-AI/cli (1.5k+ stars) hosts skills for MiniMax's text/image/video/speech/music APIs — legitimate ecosystem contribution in the same shape as other vendor skill taps we ship.

Closes #7501. Author attribution preserved via cherry-pick.