### PR TITLE
fix(send_message): pass media_files to _send_feishu in _send_to_platform

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -500,6 +500,23 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu: special handling for media attachments ---
+    if platform == Platform.FEISHU:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-Telegram/Discord platforms ---
     if media_files and not message.strip():
         return {
@@ -535,8 +552,6 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_homeassistant(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
-        elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Problem

The `send_message` tool silently drops media attachments when targeting Feishu/Lark.

When `_send_to_platform()` routes to Feishu, it calls `_send_feishu()` without passing the `media_files` parameter:

```python
# Before (line 538-539)
elif platform == Platform.FEISHU:
    result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
    # ↑ media_files not passed — media silently dropped
```

This affects all other platforms (Telegram, Discord, Matrix, Weixin) correctly pass `media_files` in their respective branches.

## Fix

Pass `media_files` to `_send_feishu()`, following the same pattern as Telegram/Discord/Matrix — media is only attached to the final chunk when a message is split:

```python
# After
elif platform == Platform.FEISHU:
    is_last = (chunk is chunks[-1])
    result = await _send_feishu(
        pconfig, chat_id, chunk,
        media_files=media_files if is_last else [],
        thread_id=thread_id,
    )
```

## Notes

- The `_send_feishu()` function already fully supports media (images, video, voice, documents) via the FeishuAdapter methods — it just wasn't being called with the parameter.
- Normal agent responses using `MEDIA:` syntax were unaffected because they go through `BasePlatformAdapter.extract_media()` in the gateway main loop, bypassing `_send_to_platform()` entirely.
- Lint check passed (syntax ok, no issues).