### PR TITLE
fix(config): preserve list-format models in custom_providers normalize (#13509)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2055,6 +2055,14 @@ def _normalize_custom_provider_entry(
     models = entry.get("models")
     if isinstance(models, dict) and models:
         normalized["models"] = models
+    elif isinstance(models, list) and models:
+        # Hand-edited configs (and older Hermes versions) write ``models`` as
+        # a plain list of model ids. Preserve them by converting to the dict
+        # shape downstream code expects; otherwise normalize silently drops
+        # the list and /model shows the provider with (0) models.
+        normalized["models"] = {
+            str(m): {} for m in models if isinstance(m, str) and m.strip()
+        }
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,7 @@ AUTHOR_MAP = {
     "teknium1@gmail.com": "teknium1",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "343873859@qq.com": "DrStrangerUJN",
     # contributors (from noreply pattern)
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",
     "snreynolds2506@gmail.com": "snreynolds",

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -135,3 +135,48 @@ class TestNormalizeCustomProviderEntry:
         }
         result = _normalize_custom_provider_entry(entry, provider_key="")
         assert result is None
+
+    def test_models_list_converted_to_dict(self):
+        """List-format models should be preserved as an empty-value dict so
+        /model picks them up instead of showing the provider with (0) models."""
+        entry = {
+            "name": "tencent-coding-plan",
+            "base_url": "https://api.lkeap.cloud.tencent.com/coding/v3",
+            "models": ["glm-5", "kimi-k2.5", "minimax-m2.5"],
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["models"] == {"glm-5": {}, "kimi-k2.5": {}, "minimax-m2.5": {}}
+
+    def test_models_dict_preserved(self):
+        """Dict-format models should pass through unchanged."""
+        entry = {
+            "name": "acme",
+            "base_url": "https://api.example.com/v1",
+            "models": {"gpt-foo": {"context_length": 32000}},
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["models"] == {"gpt-foo": {"context_length": 32000}}
+
+    def test_models_list_filters_empty_and_non_string(self):
+        """List entries that are empty strings or non-strings are skipped."""
+        entry = {
+            "name": "acme",
+            "base_url": "https://api.example.com/v1",
+            "models": ["valid", "", None, 42, "  ", "also-valid"],
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["models"] == {"valid": {}, "also-valid": {}}
+
+    def test_models_empty_list_omitted(self):
+        """Empty list (falsy) should not produce a models key."""
+        entry = {
+            "name": "acme",
+            "base_url": "https://api.example.com/v1",
+            "models": [],
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert "models" not in result


### PR DESCRIPTION
## Summary
`custom_providers:` entries with `models:` as a plain list now surface in the `/model` picker. Previously the normalize pass silently dropped list-format `models`, so configs using the hand-edited/legacy shape showed `provider (0)` in Telegram/Discord and the CLI even though the underlying picker logic handles lists fine.

Salvaged from #13509 by @DrStrangerUJN.

## Root cause
`_normalize_custom_provider_entry` in `hermes_cli/config.py` only preserved `models` when it was a `dict`. Downstream the picker reads through `get_compatible_custom_providers(cfg)` → `list_authenticated_providers()`, so a list-format `models:` was gone by the time the picker looked.

## Changes
- `hermes_cli/config.py`: list-format `models:` is converted to the empty-value dict shape (`{model_id: {}}`) the pipeline already expects. Dict entries pass through unchanged. Non-string / empty / whitespace entries are filtered out.
- `tests/hermes_cli/test_provider_config_validation.py`: 4 new tests (list→dict conversion, dict passthrough, filter empties/non-strings, empty-list omission).
- `scripts/release.py`: AUTHOR_MAP entry for @DrStrangerUJN.

## Validation
E2E with the exact config from #13509:
```yaml
custom_providers:
- name: tencent-coding-plan
  base_url: https://api.lkeap.cloud.tencent.com/coding/v3
  api_key: sk-...
  api_mode: chat_completions
  models:
  - glm-5
  - kimi-k2.5
  - minimax-m2.5
```

| | Before | After |
|---|---|---|
| Picker row | `tencent-coding-plan (0)` | `tencent-coding-plan (3)` |
| Models surfaced | `[]` | `[glm-5, kimi-k2.5, minimax-m2.5]` |

Targeted tests: `tests/hermes_cli/test_provider_config_validation.py` — 16/16 passing (12 existing + 4 new).

Also closes #11017 (duplicate report) and supersedes #12045 (different fix for the same bug, worse shape handling).

Closes #13509
Closes #11017