### PR TITLE
fix(tools): enforce ACP transport overrides in delegate_task child agents (salvage #8256)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -397,6 +397,7 @@ AUTHOR_MAP = {
     "63502660+azhengbot@users.noreply.github.com": "azhengbot",
     "sharvil.saxena@gmail.com": "sharziki",
     "yuanhe@minimaxi.com": "RyanLee-Dev",
+    "curtis992250@gmail.com": "TaroballzChen",
 }
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -922,6 +922,12 @@ def _build_child_agent(
         else (getattr(parent_agent, "acp_args", []) or [])
     )
 
+    if override_acp_command:
+        # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
+        # so run_agent.py initializes the CopilotACPClient.
+        effective_provider = "copilot-acp"
+        effective_api_mode = "chat_completions"
+
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning


### PR DESCRIPTION
Salvages #8256 by @TaroballzChen onto current main.

When a delegate_task tasks-list entry specifies `acp_command` (e.g. `"claude"` to route a subagent through Claude Code via ACP), `_build_child_agent` resolved effective credentials from the parent and ignored the fact that an ACP-transport override requires `provider="copilot-acp"` so `run_agent.py` initializes `CopilotACPClient`. Without this, the child agent inherited the parent's provider and hit the wrong transport code path.

6-line guard: when `override_acp_command` is set, force `effective_provider="copilot-acp"` and `effective_api_mode="chat_completions"`.

Closes #8256. Author attribution preserved via cherry-pick.