### PR TITLE
[codex] Prevent long-context probe collapse

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -85,10 +85,15 @@ _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
 
-# Descending tiers for context length probing when the model is unknown.
-# We start at 128K (a safe default for most modern models) and step down
-# on context-length errors until one works.
+# Descending tiers for context length probing after a provider reports that the
+# current request is too large without giving a parseable limit. Keep long
+# context tiers here so known large-window models degrade gradually instead of
+# collapsing straight to the conservative unknown-model fallback.
 CONTEXT_PROBE_TIERS = [
+    1_050_000,
+    400_000,
+    272_000,
+    200_000,
     128_000,
     64_000,
     32_000,
@@ -96,8 +101,10 @@ CONTEXT_PROBE_TIERS = [
     8_000,
 ]
 
-# Default context length when no detection method succeeds.
-DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
+# Default context length when no detection method succeeds. Unknown models
+# should still start conservatively even though probe-down tiers include
+# larger windows for known long-context models.
+DEFAULT_FALLBACK_CONTEXT = 128_000
 
 # Minimum context length required to run Hermes Agent.  Models with fewer
 # tokens cannot maintain enough working memory for tool-calling workflows.

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -218,9 +218,11 @@ class TestGetModelContextLength:
         assert get_model_context_length("anthropic/claude-sonnet-4") == 200000
 
     @patch("agent.model_metadata.fetch_model_metadata")
-    def test_unknown_model_returns_first_probe_tier(self, mock_fetch):
+    def test_unknown_model_returns_default_fallback_context(self, mock_fetch):
         mock_fetch.return_value = {}
-        assert get_model_context_length("unknown/never-heard-of-this") == CONTEXT_PROBE_TIERS[0]
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+
+        assert get_model_context_length("unknown/never-heard-of-this") == DEFAULT_FALLBACK_CONTEXT
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_partial_match_in_defaults(self, mock_fetch):
@@ -268,9 +270,11 @@ class TestGetModelContextLength:
         cache_file = tmp_path / "cache.yaml"
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length("custom/model", "http://local", 32768)
-            # No base_url → cache skipped → falls to probe tier
+            # No base_url -> cache skipped -> falls to conservative default
             result = get_model_context_length("custom/model")
-            assert result == CONTEXT_PROBE_TIERS[0]
+            from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+
+            assert result == DEFAULT_FALLBACK_CONTEXT
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
@@ -300,7 +304,9 @@ class TestGetModelContextLength:
             api_key="test-key",
         )
 
-        assert result == CONTEXT_PROBE_TIERS[0]
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+
+        assert result == DEFAULT_FALLBACK_CONTEXT
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
@@ -551,8 +557,8 @@ class TestContextProbeTiers:
         for i in range(len(CONTEXT_PROBE_TIERS) - 1):
             assert CONTEXT_PROBE_TIERS[i] > CONTEXT_PROBE_TIERS[i + 1]
 
-    def test_first_tier_is_128k(self):
-        assert CONTEXT_PROBE_TIERS[0] == 128_000
+    def test_first_tier_is_large_context(self):
+        assert CONTEXT_PROBE_TIERS[0] == 1_050_000
 
     def test_last_tier_is_8k(self):
         assert CONTEXT_PROBE_TIERS[-1] == 8_000
@@ -578,8 +584,21 @@ class TestGetNextProbeTier:
         assert get_next_probe_tier(100_000) == 64_000
 
     def test_above_max_tier(self):
-        """Value above 128K should return 128K."""
-        assert get_next_probe_tier(500_000) == 128_000
+        """Value above known long-context tiers should step down gradually."""
+        assert get_next_probe_tier(1_100_000) == 1_050_000
+
+    def test_gpt54_context_steps_down_to_intermediate_tier(self):
+        """GPT-5.4 overflow should not collapse from 1.05M directly to 128K."""
+        assert get_next_probe_tier(1_050_000) == 400_000
+        assert get_next_probe_tier(400_000) == 272_000
+        assert get_next_probe_tier(272_000) == 200_000
+        assert get_next_probe_tier(200_000) == 128_000
+
+    def test_default_fallback_stays_safe_for_unknown_models(self):
+        """Unknown models should still begin at the conservative 128K fallback."""
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+
+        assert DEFAULT_FALLBACK_CONTEXT == 128_000
 
     def test_zero_returns_none(self):
         assert get_next_probe_tier(0) is None

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -541,9 +541,9 @@ class TestGetModelContextLengthLocalFallback:
 
         mock_save.assert_called_once_with("omnicoder-9b", "http://localhost:11434/v1", 131072)
 
-    def test_local_endpoint_server_returns_none_falls_back_to_2m(self):
-        """When local server returns None, still falls back to 2M probe tier."""
-        from agent.model_metadata import get_model_context_length, CONTEXT_PROBE_TIERS
+    def test_local_endpoint_server_returns_none_falls_back_to_default_context(self):
+        """When local server returns None, still falls back to conservative default."""
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT, get_model_context_length
 
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
@@ -552,7 +552,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata._query_local_context_length", return_value=None):
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
-        assert result == CONTEXT_PROBE_TIERS[0]
+        assert result == DEFAULT_FALLBACK_CONTEXT
 
     def test_non_local_endpoint_does_not_query_local_server(self):
         """For non-local endpoints, _query_local_context_length is not called."""


### PR DESCRIPTION
## Summary

Fixes long-context probe-down behavior so known large-window models do not collapse directly to the conservative unknown-model fallback.

- Adds intermediate probe tiers above 128K: 1,050,000, 400,000, 272,000, and 200,000 tokens.
- Keeps `DEFAULT_FALLBACK_CONTEXT` fixed at 128K for truly unknown models/endpoints.
- Updates model metadata tests to distinguish unknown-model fallback from provider error probe-down tiers.

## Root cause

`CONTEXT_PROBE_TIERS[0]` served two different meanings: the default when context detection fails, and the next probe size when a provider reports that a known request is too large without a parseable limit.

That made Hermes fall straight from a known long-context model window to 128K whenever the provider error did not include a usable context limit.

## Evidence

Observed failure from the report screenshot:

```text
Provider: openai-codex Model: gpt-5.4
Endpoint: https://chatgpt.com/backend-api/codex
Error: Your input exceeds the context window of this model.
Context: 492 msgs, ~285,378 tokens
Context length exceeded - stepping down: 1,050,000 -> 128,000 tokens
Context too large (~285,378 tokens) - compressing (1/3)...
gpt-5.4 270K/128K ... 100%
```

The problematic jump is the direct `1,050,000 -> 128,000` step even though the request was only about 285K tokens.

## Validation

```text
./venv/bin/python -m pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py tests/test_ctx_halving_fix.py -q
128 passed in 3.79s
```

Also checked before commit:

```text
git diff --check
# no output
```

## Notes

I did not run a live OpenAI/GPT-5.4 overflow call; this PR covers the fallback/probe selection logic with focused regression tests.