### PR TITLE
fix(feishu): format_message on streaming edits to strip leading newlines (salvage #8254)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1700,6 +1700,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -399,6 +399,7 @@ AUTHOR_MAP = {
     "sharvil.saxena@gmail.com": "sharziki",
     "yuanhe@minimaxi.com": "RyanLee-Dev",
     "curtis992250@gmail.com": "TaroballzChen",
+    "92638503+Lind3ey@users.noreply.github.com": "Lind3ey",
 }
 
 


### PR DESCRIPTION
Salvages #8254 by @Lind3ey onto current main.

Feishu adapter's `send_message` passes content through `self.format_message()` to strip trailing newlines and MEDIA/skill marker artifacts, but `edit_message` (used during streaming updates) skipped the step — so each chunk-append caused a fresh leading blank line to appear in the Feishu UI.

One-line fix: call `content = self.format_message(content)` at the top of `edit_message`, matching what `send_message` already does.

## Attribution note
Original commit used an unlinked corporate email (`hongjie.li@huaxinjushu.com`), re-authored to @Lind3ey's GitHub noreply email so the contribution attributes to their profile.

Closes #8254.