### PR TITLE
fix(status): catch OSError in os.kill(pid, 0) for Windows compatibility (salvage #12490)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -496,7 +496,8 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except (ProcessLookupError, PermissionError, OSError):
+                # Windows raises OSError with WinError 87 for invalid pid check
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -742,6 +743,10 @@ def get_running_pid(
             # rather than deleting the PID file as "stale".
             if _record_looks_like_gateway(record):
                 return pid
+            continue
+        except OSError:
+            # Windows raises OSError with WinError 87 for an invalid pid
+            # (process is definitely gone). Treat as "process doesn't exist".
             continue
 
         recorded_start = record.get("start_time")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -401,6 +401,7 @@ AUTHOR_MAP = {
     "yuanhe@minimaxi.com": "RyanLee-Dev",
     "curtis992250@gmail.com": "TaroballzChen",
     "92638503+Lind3ey@users.noreply.github.com": "Lind3ey",
+    "1352808998@qq.com": "phpoh",
 }
 
 


### PR DESCRIPTION
Salvages #12490 by @phpoh onto current main.

On Windows, `os.kill(nonexistent_pid, 0)` raises `OSError` with WinError 87 instead of `ProcessLookupError`. Two sites in `gateway/status.py` caught only `(ProcessLookupError, PermissionError)` — any invalid PID check crashed on Windows, preventing gateway startup whenever a stale PID file survived.

**Applied:**
- `acquire_scoped_lock` (line ~499): widened except to include `OSError` alongside the existing tuple
- `get_running_pid` (line ~737): added a separate `except OSError: continue` clause AFTER `except PermissionError:` so PermissionError (an OSError subclass) still gets its dedicated branch first

The PR's original patch didn't apply cleanly because main refactored `get_running_pid` to iterate over primary/fallback records with a per-iteration try/except block. Functionally equivalent to @phpoh's original.

Closes #12490. Author attribution preserved via `--author=`.