### PR TITLE
docs(rl-training): link Atropos, Tinker, and wandb (salvage #7727)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -402,6 +402,7 @@ AUTHOR_MAP = {
     "curtis992250@gmail.com": "TaroballzChen",
     "92638503+Lind3ey@users.noreply.github.com": "Lind3ey",
     "1352808998@qq.com": "phpoh",
+    "caliberoviv@gmail.com": "vivganes",
 }
 
 

--- a/website/docs/user-guide/features/rl-training.md
+++ b/website/docs/user-guide/features/rl-training.md
@@ -12,8 +12,8 @@ Hermes Agent includes an integrated RL (Reinforcement Learning) training pipelin
 
 The RL training system consists of three components:
 
-1. **Atropos** — A trajectory API server that coordinates environment interactions, manages rollout groups, and computes advantages
-2. **Tinker** — A training service that handles model weights, LoRA training, sampling/inference, and optimizer steps
+1. **[Atropos](https://github.com/NousResearch/atropos)** — A trajectory API server that coordinates environment interactions, manages rollout groups, and computes advantages
+2. **[Tinker](https://thinkingmachines.ai/tinker/)** — A training service that handles model weights, LoRA training, sampling/inference, and optimizer steps
 3. **Environments** — Python classes that define tasks, scoring, and reward functions (e.g., GSM8K math problems)
 
 The agent can discover environments, configure training parameters, launch training runs, and monitor metrics — all through a set of `rl_*` tools.
@@ -24,7 +24,7 @@ RL training requires:
 
 - **Python >= 3.11** (Tinker package requirement)
 - **TINKER_API_KEY** — API key for the Tinker training service
-- **WANDB_API_KEY** — API key for Weights & Biases metrics tracking
+- **WANDB_API_KEY** — API key for [Weights & Biases](https://wandb.ai/) metrics tracking
 - The `tinker-atropos` submodule (at `tinker-atropos/` relative to the Hermes root)
 
 ```bash


### PR DESCRIPTION
Salvages #7727 by @vivganes onto current main.

The RL training user guide named Atropos, Tinker, and Weights and Biases as prerequisites but did not link to any of them. Adds markdown links so readers can jump directly to the upstream docs.

Closes #7727. Author attribution preserved via cherry-pick.