### PR TITLE
fix(tirith): guard against None tirith_path in security scanner (salvage #5766)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -403,6 +403,7 @@ AUTHOR_MAP = {
     "92638503+Lind3ey@users.noreply.github.com": "Lind3ey",
     "1352808998@qq.com": "phpoh",
     "caliberoviv@gmail.com": "vivganes",
+    "michaelfackerell@gmail.com": "MikeFac",
 }
 
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -631,6 +631,12 @@ def check_command_security(command: str) -> dict:
     timeout = cfg["tirith_timeout"]
     fail_open = cfg["tirith_fail_open"]
 
+    if tirith_path is None:
+        logger.warning("tirith path resolved to None; scanning disabled")
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith path unavailable"}
+        return {"action": "block", "findings": [], "summary": "tirith path unavailable (fail-closed)"}
+
     try:
         result = subprocess.run(
             [tirith_path, "check", "--json", "--non-interactive",


### PR DESCRIPTION
Salvages #5766 by @MikeFac onto current main.

`_resolve_tirith_path()` returns `None` when neither the configured binary nor the bundled one can be found. `check_command_security()` then passed `None` as `argv[0]` to `subprocess.run`, which crashes with an opaque `TypeError`. Adds an explicit guard that respects `fail_open`:

- `fail_open=True`: log a warning, allow the command (scanner unavailable shouldn't block agent work)
- `fail_open=False`: block with a clear `summary` so the user knows WHY

## Attribution note
Original commit used a Tailscale machine-derived email, re-authored to @MikeFac's public GitHub email (`michaelfackerell@gmail.com`) so the contribution attributes to their profile.

Closes #5766.