### PR TITLE
fix(docker): repair config.yaml permissions on startup (salvage #10027)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,6 +58,13 @@ if [ ! -f "$HERMES_HOME/config.yaml" ]; then
     cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
 fi
 
+# Ensure the main config file remains accessible to the hermes runtime user
+# even if it was edited on the host after initial ownership setup.
+if [ -f "$HERMES_HOME/config.yaml" ]; then
+    chown hermes:hermes "$HERMES_HOME/config.yaml"
+    chmod 640 "$HERMES_HOME/config.yaml"
+fi
+
 # SOUL.md
 if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
     cp "$INSTALL_DIR/docker/SOUL.md" "$HERMES_HOME/SOUL.md"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -404,6 +404,7 @@ AUTHOR_MAP = {
     "1352808998@qq.com": "phpoh",
     "caliberoviv@gmail.com": "vivganes",
     "michaelfackerell@gmail.com": "MikeFac",
+    "18024642@qq.com": "GuyCui",
 }
 
 


### PR DESCRIPTION
Salvages #10027 by @GuyCui onto current main.

`docker/entrypoint.sh` only chowned `/config.yaml` on the first-run path where it copied the template. If a user edited the host-mounted config from outside the container (common when troubleshooting), ownership flipped to the host UID and the hermes runtime user could no longer read it. Adds a 7-line guard block that runs AFTER the template-copy step: if config.yaml exists, chown it back to `hermes:hermes` and chmod 640, regardless of first-run state.

Closes #10027. Author attribution preserved via cherry-pick.