### PR TITLE
fix(agent): scope subdirectory hint discovery to workspace - closes #14471

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -158,13 +158,27 @@ class SubdirectoryHintTracker:
             self._add_path_candidate(token, candidates)
 
     def _is_valid_subdir(self, path: Path) -> bool:
-        """Check if path is a valid directory to scan for hints."""
+        """Check if path is a valid directory to scan for hints.
+
+        Only allows directories inside the configured working_dir to prevent
+        unrelated instruction files from being injected into the agent context
+        (e.g., an AGENTS.md from a completely different project).
+        """
         try:
             if not path.is_dir():
                 return False
         except OSError:
             return False
         if path in self._loaded_dirs:
+            return False
+        # Scope to workspace — only scan directories inside working_dir
+        try:
+            path.relative_to(self.working_dir)
+        except ValueError:
+            logger.debug(
+                "Skipping subdirectory hint for %s: outside working_dir %s",
+                path, self.working_dir,
+            )
             return False
         return True
 


### PR DESCRIPTION
## Fix: Scope subdirectory hint discovery to workspace directory

### Bug
Closes #14471

Hermes has a second project-context injection path beyond the normal startup cwd-based prompt assembly. Post-tool-call path discovery can append context from nearby AGENTS.md, CLAUDE.md, or .cursorrules files based on tool arguments — even from directories completely outside the intended workspace.

This breaks workspace isolation expectations and can cause:
- Unexpected instruction contamination
- Profile/agent behavior drift
- Hard-to-debug prompt pollution
- Cross-project leakage of local instruction files

### Root Cause
In `agent/subdirectory_hints.py`, `SubdirectoryHintTracker._is_valid_subdir()` only checks:
1. Is the path a directory?
2. Has it already been loaded?

It does **not** check whether the directory is inside the configured `working_dir`. This means any tool call that touches a file in an unrelated directory can trigger hint discovery there.

### Fix
Add a workspace boundary check in `_is_valid_subdir()` using `Path.relative_to()`. Only directories inside `working_dir` are scanned for hint files:

```python
def _is_valid_subdir(self, path: Path) -> bool:
    # ... existing checks ...
    # Scope to workspace — only scan directories inside working_dir
    try:
        path.relative_to(self.working_dir)
    except ValueError:
        logger.debug(
            "Skipping subdirectory hint for %s: outside working_dir %s",
            path, self.working_dir,
        )
        return False
    return True
```

### Impact
- Prevents injection of unrelated AGENTS.md/CLAUDE.md/.cursorrules from outside the workspace
- Minimal change (15 lines added, 1 line modified)
- No behavioral change for directories inside the workspace
- Debug logging when a directory is skipped (for troubleshooting)
