### PR TITLE
fix: thread-safe IterationBudget.used, _SafeWriter.fileno guard, browser temp file leak

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -147,7 +147,10 @@ class _SafeWriter:
             pass
 
     def fileno(self):
-        return self._inner.fileno()
+        try:
+            return self._inner.fileno()
+        except (OSError, ValueError):
+            return -1  # Sentinel: stream is closed/broken
 
     def isatty(self):
         try:
@@ -203,7 +206,8 @@ class IterationBudget:
 
     @property
     def used(self) -> int:
-        return self._used
+        with self._lock:
+            return self._used
 
     @property
     def remaining(self) -> int:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1123,6 +1123,12 @@ def _run_browser_command(
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+            # Clean up temp files even on timeout to prevent accumulation
+            for p in (stdout_path, stderr_path):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
             logger.warning("browser '%s' timed out after %ds (task=%s, socket_dir=%s)",
                            command, timeout, task_id, task_socket_dir)
             return {"success": False, "error": f"Command timed out after {timeout} seconds"}


### PR DESCRIPTION
## Fix: Three defensive hardening fixes for thread safety and resource cleanup

This PR addresses three bugs discovered through code analysis:

### 1. `IterationBudget.used` — data race on `_used` (run_agent.py:204)

**Bug:** The `used` property reads `self._used` without acquiring the lock, while `consume()` and `refund()` modify it under the lock, and the sibling property `remaining()` also acquires the lock. This is a data race — concurrent callers (parallel tool execution, subagent delegation) can see stale values.

**Fix:** Acquire `self._lock` before reading `self._used`, matching the thread-safety contract documented in the class docstring.

### 2. `_SafeWriter.fileno()` — unhandled exception on broken streams (run_agent.py:149)

**Bug:** `_SafeWriter` wraps `write()`, `flush()`, and `isatty()` in `try/except (OSError, ValueError)`, but `fileno()` delegates directly to the inner stream without protection. When stdout/stderr is closed (daemon mode, Docker, subagent teardown), any library calling `sys.stdout.fileno()` (prompt_toolkit, Rich, colorama) crashes with an unhandled exception.

**Fix:** Wrap `fileno()` in the same `try/except` pattern, returning `-1` as a sentinel for closed/broken streams.

### 3. Browser tool temp file leak on timeout (browser_tool.py:1123)

**Bug:** `_run_browser_command()` creates `_stdout_*` and `_stderr_*` temp files before spawning the subprocess. When the subprocess times out, the `TimeoutExpired` handler returns early without reaching the cleanup block at the end of the function. Over many timeouts, orphaned temp files accumulate in the agent-browser socket directory.

**Fix:** Add temp file cleanup (`os.unlink`) in the `TimeoutExpired` handler before the early return.
