### PR TITLE
fix(session): mark resumed CLI sessions active before next message

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3495,14 +3495,9 @@ class HermesCLI:
             )
             return False
 
-        # Re-open the session (clear ended_at so it's active again)
+        # Re-open the session (clear ended_at and refresh activity so UIs see it as live)
         try:
-            self._session_db._conn.execute(
-                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
-                "WHERE id = ?",
-                (self.session_id,),
-            )
-            self._session_db._conn.commit()
+            self._session_db.reopen_session(self.session_id)
         except Exception:
             pass
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -66,6 +66,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     pricing_version TEXT,
     title TEXT,
     api_call_count INTEGER DEFAULT 0,
+    last_active_at REAL,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -347,8 +348,7 @@ class SessionDB:
                 cursor.execute("UPDATE schema_version SET version = 7")
             if current_version < 8:
                 # v8: add api_call_count column to sessions — tracks the number
-                # of individual LLM API calls made within a session (as opposed
-                # to the session count itself).
+                # of update_token_counts() calls for richer session analytics.
                 try:
                     cursor.execute(
                         'ALTER TABLE sessions ADD COLUMN "api_call_count" INTEGER DEFAULT 0'
@@ -356,9 +356,22 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 8")
+            if current_version < 9:
+                # v9: track explicit session reactivation time so resumed CLI
+                # sessions surface as active before the next user message lands.
+                try:
+                    cursor.execute(
+                        'ALTER TABLE sessions ADD COLUMN "last_active_at" REAL'
+                    )
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute(
+                    "UPDATE sessions SET last_active_at = COALESCE(last_active_at, started_at)"
+                )
+                cursor.execute("UPDATE schema_version SET version = 9")
 
-        # Unique title index — always ensure it exists (safe to run after migrations
-        # since the title column is guaranteed to exist at this point)
+            self._conn.commit()
+
         try:
             cursor.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
@@ -391,10 +404,11 @@ class SessionDB:
     ) -> str:
         """Create a new session record. Returns the session_id."""
         def _do(conn):
+            now = time.time()
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, last_active_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -403,7 +417,8 @@ class SessionDB:
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
-                    time.time(),
+                    now,
+                    now,
                 ),
             )
         self._execute_write(_do)
@@ -428,11 +443,11 @@ class SessionDB:
         self._execute_write(_do)
 
     def reopen_session(self, session_id: str) -> None:
-        """Clear ended_at/end_reason so a session can be resumed."""
+        """Clear ended_at/end_reason and refresh activity for resumed sessions."""
         def _do(conn):
             conn.execute(
-                "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
-                (session_id,),
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL, last_active_at = ? WHERE id = ?",
+                (time.time(), session_id),
             )
         self._execute_write(_do)
 
@@ -842,9 +857,9 @@ class SessionDB:
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
-                COALESCE(
-                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
-                    s.started_at
+                MAX(
+                    COALESCE((SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id), 0),
+                    COALESCE(s.last_active_at, s.started_at)
                 ) AS last_active
             FROM sessions s
             {where_sql}
@@ -917,9 +932,9 @@ class SessionDB:
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
-                COALESCE(
-                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
-                    s.started_at
+                MAX(
+                    COALESCE((SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id), 0),
+                    COALESCE(s.last_active_at, s.started_at)
                 ) AS last_active
             FROM sessions s
             WHERE s.id = ?

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -559,19 +559,13 @@ class TestPreloadResumedSession:
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"id": "reopen_session", "title": None}
         mock_db.get_messages_as_conversation.return_value = messages
-        mock_conn = MagicMock()
-        mock_db._conn = mock_conn
         cli._session_db = mock_db
 
         buf = StringIO()
         cli.console.file = buf
         cli._preload_resumed_session()
 
-        # Should have executed UPDATE to clear ended_at
-        mock_conn.execute.assert_called_once()
-        call_args = mock_conn.execute.call_args
-        assert "ended_at = NULL" in call_args[0][0]
-        mock_conn.commit.assert_called_once()
+        mock_db.reopen_session.assert_called_once_with("reopen_session")
 
     def test_singular_user_message_grammar(self):
         """1 user message should say 'message' not 'messages'."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1173,7 +1173,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 8
+        assert version == 9
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1229,12 +1229,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v8
+        # Open with SessionDB — should migrate to v9
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 8
+        assert cursor.fetchone()[0] == 9
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1246,6 +1246,12 @@ class TestSchemaInit:
             "SELECT api_call_count FROM sessions WHERE id = 'existing'"
         )
         assert cursor.fetchone()[0] == 0
+
+        # Verify last_active_at was backfilled from started_at for existing rows
+        cursor = migrated_db._conn.execute(
+            "SELECT last_active_at FROM sessions WHERE id = 'existing'"
+        )
+        assert cursor.fetchone()[0] == 1000.0
 
         # Verify we can set title on migrated session
         assert migrated_db.set_session_title("existing", "Migrated Title") is True
@@ -1437,6 +1443,23 @@ class TestListSessionsRich:
         sessions = db.list_sessions_rich()
         # No messages, so last_active falls back to started_at
         assert sessions[0]["last_active"] == sessions[0]["started_at"]
+
+    def test_reopen_session_refreshes_last_active_over_old_messages(self, db):
+        import time
+
+        db.create_session("s1", "cli")
+        db.append_message("s1", "user", "Hello")
+        sessions = db.list_sessions_rich()
+        previous_last_active = sessions[0]["last_active"]
+
+        time.sleep(0.01)
+        db.end_session("s1", end_reason="user_exit")
+        time.sleep(0.01)
+        db.reopen_session("s1")
+
+        refreshed = db.list_sessions_rich()[0]
+        assert refreshed["ended_at"] is None
+        assert refreshed["last_active"] > previous_last_active
 
     def test_rich_list_includes_title(self, db):
         db.create_session("s1", "cli")


### PR DESCRIPTION
## Summary
- route `--session` resume through `SessionDB.reopen_session()` instead of an ad-hoc SQL update
- persist an explicit `last_active_at` timestamp for resumed sessions
- use that timestamp when computing rich session activity so the Web UI marks resumed sessions as live before the next user message

## Root cause
`hermes --session <id>` reopened the session by only clearing `ended_at`/`end_reason`. For sessions with existing history, `list_sessions_rich()` derived `last_active` from the latest message timestamp, which stayed stale until the next turn. That made resumed CLI sessions look inactive in the Web UI.

## Fix
- add `last_active_at` to `sessions` with a migration/backfill from `started_at`
- update `reopen_session()` to refresh `last_active_at`
- make the rich-session queries use the newer of message activity and explicit resume activity
- reuse `reopen_session()` in the CLI `--session` preload path

## Regression coverage
- add a SessionDB regression test proving `reopen_session()` refreshes `last_active` even when the session already has older messages
- update the CLI resume test to assert `--session` goes through `reopen_session()`
- extend schema migration coverage for the new `last_active_at` backfill

## Testing
- `scripts/run_tests.sh tests/test_hermes_state.py::TestListSessionsRich::test_reopen_session_refreshes_last_active_over_old_messages tests/cli/test_resume_display.py::TestPreloadResumedSession::test_reopens_session_in_db`
- `scripts/run_tests.sh tests/test_hermes_state.py tests/cli/test_resume_display.py`

Closes #14501
