### PR TITLE
fix: sanitize broken tool_call arguments before storing in message history

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11183,8 +11183,18 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}⚠️  Injecting recovery tool results for invalid JSON...")
                             self._invalid_json_retries = 0  # Reset for next attempt
                             
-                            # Append the assistant message with its (broken) tool_calls
+                            # Append the assistant message, sanitizing broken tool_call arguments
+                            # so they don't poison the message history with invalid JSON.
+                            # (strict APIs like Copilot validate all historical tool_calls)
                             recovery_assistant = self._build_assistant_message(assistant_message, finish_reason)
+                            for tc_dict in recovery_assistant.get("tool_calls") or []:
+                                raw = tc_dict.get("function", {}).get("arguments", "")
+                                try:
+                                    json.loads(raw)
+                                except (json.JSONDecodeError, TypeError):
+                                    tc_dict["function"]["arguments"] = _repair_tool_call_arguments(
+                                        raw, tc_dict.get("function", {}).get("name", "?"),
+                                    )
                             messages.append(recovery_assistant)
                             
                             # Respond with tool error results for each tool call


### PR DESCRIPTION
## Problem

When a model generates invalid JSON in tool call arguments 3 times in a row, the recovery path (`run_agent.py:11186`) appends the assistant message with its **broken** `tool_calls` directly into the message history:

```python
# Before this fix:
recovery_assistant = self._build_assistant_message(assistant_message, finish_reason)
messages.append(recovery_assistant)  # broken JSON stored permanently
```

These poisoned entries then cause **HTTP 400 "Invalid JSON format in tool call arguments"** errors — especially after context compression brings them back into the API request. Strict APIs like GitHub Copilot (`api.githubcopilot.com`) validate ALL historical `tool_calls` and reject the entire request.

## Root Cause

The existing `_repair_tool_call_arguments()` function (introduced recently) already sanitizes tool call arguments at **read time** (when building `api_messages` for the API call). However, the recovery code path writes broken arguments into the message history **before** that sanitization runs.

This means:
1. Broken JSON persists in session state (`.db` files)
2. Every subsequent API call must repair the same broken entries
3. If `_repair_tool_call_arguments()` can't fix an edge case, the session is permanently poisoned

## Fix

Reuse the existing `_repair_tool_call_arguments()` helper to sanitize arguments at **write time** — when storing the recovery message — so broken JSON never enters the message history.

```python
recovery_assistant = self._build_assistant_message(assistant_message, finish_reason)
for tc_dict in recovery_assistant.get("tool_calls") or []:
    raw = tc_dict.get("function", {}).get("arguments", "")
    try:
        json.loads(raw)
    except (json.JSONDecodeError, TypeError):
        tc_dict["function"]["arguments"] = _repair_tool_call_arguments(
            raw, tc_dict.get("function", {}).get("name", "?"),
        )
messages.append(recovery_assistant)
```

## Impact

- **11 lines changed** in `run_agent.py`
- No new dependencies
- Defense-in-depth: fixes data at the source rather than patching it on every read
- Especially helps users on strict API providers (GitHub Copilot, Mistral, Fireworks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)