### PR TITLE
Add launch metadata capabilities

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -217,6 +217,96 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
         return []
 
 
+_LAUNCH_METADATA_ENV = "HERMES_FORGE_LAUNCH_METADATA"
+_LAUNCH_METADATA_DIAGNOSTICS_ENV = "HERMES_FORGE_LAUNCH_METADATA_DIAGNOSTICS"
+_LAUNCH_METADATA_FIELDS = (
+    "forgeSessionId",
+    "taskRunId",
+    "workspace",
+    "selectedFilePaths",
+    "attachmentPaths",
+    "imagePaths",
+    "windowsDesktopPathAlias",
+    "bridgeAvailability",
+    "cliSession",
+)
+
+
+def _emit_launch_metadata_diagnostic(payload: Dict[str, Any]) -> None:
+    if os.getenv(_LAUNCH_METADATA_DIAGNOSTICS_ENV) == "1":
+        print(
+            "launch_metadata: " + json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            file=sys.stderr,
+        )
+
+
+def _load_launch_metadata(file_path: str | None = None) -> tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+    """Load integration launch metadata as runtime metadata, never as chat history."""
+    source = "arg" if file_path else "env"
+    raw_path = (file_path or os.getenv(_LAUNCH_METADATA_ENV, "")).strip()
+    if not raw_path:
+        diagnostic = {
+            "supported": True,
+            "status": "absent",
+            "source": "none",
+            "fields": [],
+        }
+        _emit_launch_metadata_diagnostic(diagnostic)
+        return None, diagnostic
+
+    path_obj = Path(raw_path).expanduser()
+    try:
+        with open(path_obj, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except FileNotFoundError:
+        diagnostic = {
+            "supported": True,
+            "status": "error",
+            "source": source,
+            "path": str(path_obj),
+            "error": "metadata file not found",
+            "fields": [],
+        }
+        _emit_launch_metadata_diagnostic(diagnostic)
+        return None, diagnostic
+    except Exception as exc:
+        diagnostic = {
+            "supported": True,
+            "status": "error",
+            "source": source,
+            "path": str(path_obj),
+            "error": f"failed to read metadata: {exc}",
+            "fields": [],
+        }
+        _emit_launch_metadata_diagnostic(diagnostic)
+        return None, diagnostic
+
+    if not isinstance(raw, dict) or raw.get("version") != 1:
+        diagnostic = {
+            "supported": True,
+            "status": "error",
+            "source": source,
+            "path": str(path_obj),
+            "error": "unsupported launch metadata schema",
+            "fields": [],
+        }
+        _emit_launch_metadata_diagnostic(diagnostic)
+        return None, diagnostic
+
+    metadata = {field: raw.get(field) for field in _LAUNCH_METADATA_FIELDS if field in raw}
+    metadata["version"] = raw.get("version")
+    metadata["createdAt"] = raw.get("createdAt")
+    diagnostic = {
+        "supported": True,
+        "status": "loaded",
+        "source": source,
+        "path": str(path_obj),
+        "fields": [field for field in _LAUNCH_METADATA_FIELDS if field in raw],
+    }
+    _emit_launch_metadata_diagnostic(diagnostic)
+    return metadata, diagnostic
+
+
 def _parse_reasoning_config(effort: str) -> dict | None:
     """Parse a reasoning effort level into an OpenRouter reasoning config dict."""
     from hermes_constants import parse_reasoning_effort
@@ -1812,6 +1902,7 @@ class HermesCLI:
         resume: str = None,
         checkpoints: bool = False,
         pass_session_id: bool = False,
+        launch_metadata: str = None,
         ignore_rules: bool = False,
     ):
         """
@@ -1832,6 +1923,7 @@ class HermesCLI:
         # Initialize Rich console
         self.console = Console()
         self.config = CLI_CONFIG
+        self.launch_metadata, self.launch_metadata_diagnostic = _load_launch_metadata(launch_metadata)
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
@@ -10816,6 +10908,7 @@ def main(
     query: str = None,
     q: str = None,
     image: str = None,
+    launch_metadata: str = None,
     toolsets: str = None,
     skills: str | list[str] | tuple[str, ...] = None,
     model: str = None,
@@ -10844,6 +10937,7 @@ def main(
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
         image: Optional local image path to attach to a single query
+        launch_metadata: Optional JSON launch metadata sidecar (runtime metadata, not conversation history)
         toolsets: Comma-separated list of toolsets to enable (e.g., "web,terminal")
         skills: Comma-separated or repeated list of skills to preload for the session
         model: Model to use (default: anthropic/claude-opus-4-20250514)
@@ -10945,6 +11039,7 @@ def main(
         resume=resume,
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
+        launch_metadata=launch_metadata,
         ignore_rules=ignore_rules,
     )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -44,6 +44,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -1168,6 +1169,7 @@ def cmd_chat(args):
         "quiet": getattr(args, "quiet", False),
         "query": args.query,
         "image": getattr(args, "image", None),
+        "launch_metadata": getattr(args, "launch_metadata", None),
         "resume": getattr(args, "resume", None),
         "worktree": getattr(args, "worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
@@ -4412,6 +4414,32 @@ def cmd_version(args):
         pass
 
 
+def build_capabilities_payload() -> dict:
+    """Return stable machine-readable Hermes CLI capability metadata."""
+    return {
+        "schemaVersion": 1,
+        "cliName": "Hermes Agent",
+        "cliVersion": __version__,
+        "releaseDate": __release_date__,
+        "capabilities": {
+            "supportsLaunchMetadataArg": True,
+            "supportsLaunchMetadataEnv": True,
+            "supportsResume": True,
+        },
+    }
+
+
+def cmd_capabilities(args):
+    """Show machine-readable CLI capabilities."""
+    payload = build_capabilities_payload()
+    if getattr(args, "json", False):
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return
+    print(f"Hermes Agent v{payload['cliVersion']} capabilities")
+    for key, value in payload["capabilities"].items():
+        print(f"{key}: {value}")
+
+
 def cmd_uninstall(args):
     """Uninstall Hermes Agent."""
     _require_tty("uninstall")
@@ -6762,6 +6790,11 @@ For more help on a command:
         "--image", help="Optional local image path to attach to a single query"
     )
     chat_parser.add_argument(
+        "--launch-metadata",
+        default=argparse.SUPPRESS,
+        help="Optional JSON launch metadata sidecar for tool integrations (runtime metadata, not conversation history)",
+    )
+    chat_parser.add_argument(
         "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)"
     )
     chat_parser.add_argument(
@@ -8567,6 +8600,13 @@ Examples:
     version_parser.set_defaults(func=cmd_version)
 
     # =========================================================================
+    # capabilities command
+    # =========================================================================
+    capabilities_parser = subparsers.add_parser("capabilities", help="Show machine-readable CLI capabilities")
+    capabilities_parser.add_argument("--json", action="store_true", help="Output capabilities as JSON")
+    capabilities_parser.set_defaults(func=cmd_capabilities)
+
+    # =========================================================================
     # update command
     # =========================================================================
     update_parser = subparsers.add_parser(
@@ -8928,6 +8968,7 @@ Examples:
             ("toolsets", None),
             ("verbose", False),
             ("worktree", False),
+            ("launch_metadata", None),
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
@@ -8945,6 +8986,7 @@ Examples:
             ("resume", None),
             ("continue_last", None),
             ("worktree", False),
+            ("launch_metadata", None),
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)

--- a/tests/hermes_cli/test_launch_metadata_capabilities.py
+++ b/tests/hermes_cli/test_launch_metadata_capabilities.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import sys
+
+
+def test_capabilities_json_declares_launch_metadata_support():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "capabilities", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["schemaVersion"] == 1
+    assert payload["cliVersion"]
+    assert payload["capabilities"]["supportsLaunchMetadataArg"] is True
+    assert payload["capabilities"]["supportsLaunchMetadataEnv"] is True
+    assert payload["capabilities"]["supportsResume"] is True
+
+
+def test_chat_accepts_launch_metadata_flag():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "chat", "--launch-metadata", "metadata.json", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--launch-metadata" in result.stdout
+    assert "unrecognized arguments" not in result.stderr
+
+
+def test_launch_metadata_loader_reads_runtime_metadata_without_history(tmp_path, monkeypatch):
+    monkeypatch.syspath_prepend(str(tmp_path))
+    metadata = tmp_path / "launch.json"
+    metadata.write_text(json.dumps({
+        "version": 1,
+        "createdAt": "2026-04-23T00:00:00.000Z",
+        "forgeSessionId": "forge-session",
+        "taskRunId": "task-run",
+        "workspace": {"runtimePath": "/repo"},
+        "selectedFilePaths": [],
+        "attachmentPaths": [],
+        "imagePaths": [],
+        "bridgeAvailability": {"enabled": False, "available": False, "capabilities": []},
+        "cliSession": {"status": "fresh"},
+    }), encoding="utf-8")
+
+    import cli
+    loaded, diagnostic = cli._load_launch_metadata(str(metadata))
+
+    assert diagnostic["status"] == "loaded"
+    assert diagnostic["source"] == "arg"
+    assert loaded["forgeSessionId"] == "forge-session"
+    assert "workspace" in diagnostic["fields"]


### PR DESCRIPTION
## Summary

Adds a small machine-readable launch metadata capability surface for third-party integrations such as Hermes Forge:

- `hermes capabilities --json` reports stable CLI capabilities and version metadata.
- `hermes chat --launch-metadata <path>` accepts a JSON sidecar path without putting launch metadata into conversation history.
- `HERMES_FORGE_LAUNCH_METADATA` remains supported as an environment fallback.
- Launch metadata is loaded as runtime metadata on `HermesCLI`, not injected as user prompt, memory, or chat history.

## Why

Desktop/integration clients need a stable way to negotiate CLI capabilities and pass per-turn runtime metadata without scraping `--help` output or smuggling metadata through `--query`.

## Validation

- `python -m hermes_cli.main capabilities --json`
- `python -m hermes_cli.main chat --launch-metadata sample.json --help`
- `python -m compileall cli.py hermes_cli/main.py tests/hermes_cli/test_launch_metadata_capabilities.py`

Targeted pytest could not be run in this local shell because `pytest` is not installed in the active Python environment.
