### PR TITLE
fix: reorder fuzzy match strategies so indentation_flexible is not dead code

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -148,3 +148,44 @@ class TestStrategyNameSurfaced:
         assert count == 0
         assert strategy is None
         assert err is not None
+
+
+class TestIndentationFlexibleOrdering:
+    """Tests for the strategy reordering: indentation_flexible (lstrip) now
+    runs before line_trimmed (strip), giving each strategy a unique catch zone."""
+
+    def test_indentation_flexible_used_for_leading_whitespace_only(self):
+        """When only leading whitespace differs, indentation_flexible should match
+        (it is now tried before line_trimmed)."""
+        content = "    def foo():\n        pass"
+        # Pattern has no leading whitespace — only indentation differs
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "def foo():\n    pass", "def bar():\n    return 1"
+        )
+        assert count == 1
+        assert strategy == "indentation_flexible"
+        assert "bar" in new
+
+    def test_line_trimmed_still_catches_trailing_whitespace(self):
+        """line_trimmed (strip) still matches when trailing whitespace differs,
+        which indentation_flexible (lstrip) would miss."""
+        # Content has trailing spaces that pattern doesn't
+        content = "hello world  \nfoo bar  "
+        pattern = "hello world\nfoo bar"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, pattern, "replaced"
+        )
+        assert count == 1
+        assert strategy == "line_trimmed"
+
+    def test_indentation_flexible_not_dead_code(self):
+        """Verify indentation_flexible actually contributes matches that
+        exact and whitespace_normalized miss."""
+        # Content uses tabs, pattern uses spaces — only lstrip can normalize this
+        content = "\tx = 1\n\ty = 2"
+        pattern = "x = 1\ny = 2"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, pattern, "replaced"
+        )
+        assert count == 1
+        assert strategy == "indentation_flexible"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -6,15 +6,16 @@ Implements a multi-strategy matching chain to robustly find and replace text,
 accommodating variations in whitespace, indentation, and escaping common
 in LLM-generated code.
 
-The 8-strategy chain (inspired by OpenCode), tried in order:
+The 9-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
-2. Line-trimmed - Strip leading/trailing whitespace per line
+2. Indentation flexible - Ignore leading whitespace only (lstrip)
 3. Whitespace normalized - Collapse multiple spaces/tabs to single space
-4. Indentation flexible - Ignore indentation differences entirely
+4. Line-trimmed - Strip leading and trailing whitespace per line
 5. Escape normalized - Convert \\n literals to actual newlines
 6. Trimmed boundary - Trim first/last line whitespace only
-7. Block anchor - Match first+last lines, use similarity for middle
-8. Context-aware - 50% line similarity threshold
+7. Unicode normalized - Normalize smart quotes, dashes, etc.
+8. Block anchor - Match first+last lines, use similarity for middle
+9. Context-aware - 50% line similarity threshold
 
 Multi-occurrence matching is handled via the replace_all flag.
 
@@ -72,9 +73,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
         ("exact", _strategy_exact),
-        ("line_trimmed", _strategy_line_trimmed),
-        ("whitespace_normalized", _strategy_whitespace_normalized),
         ("indentation_flexible", _strategy_indentation_flexible),
+        ("whitespace_normalized", _strategy_whitespace_normalized),
+        ("line_trimmed", _strategy_line_trimmed),
         ("escape_normalized", _strategy_escape_normalized),
         ("trimmed_boundary", _strategy_trimmed_boundary),
         ("unicode_normalized", _strategy_unicode_normalized),
@@ -143,7 +144,7 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
 
 def _strategy_line_trimmed(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 2: Match with line-by-line whitespace trimming.
+    Strategy 4: Match with line-by-line whitespace trimming.
     
     Strips leading/trailing whitespace from each line before matching.
     """
@@ -163,7 +164,7 @@ def _strategy_line_trimmed(content: str, pattern: str) -> List[Tuple[int, int]]:
 
 def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 3: Collapse multiple whitespace to single space.
+    Strategy 3: Collapse runs of whitespace to single space.
     """
     def normalize(s):
         # Collapse multiple spaces/tabs to single space, preserve newlines
@@ -184,7 +185,7 @@ def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[in
 
 def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 4: Ignore indentation differences entirely.
+    Strategy 2: Ignore leading indentation differences (lstrip-only).
     
     Strips all leading whitespace from lines before matching.
     """
@@ -200,7 +201,7 @@ def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int
 
 def _strategy_escape_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 5: Convert escape sequences to actual characters.
+    Strategy 5: Convert literal escape sequences to actual characters.
     
     Handles \\n -> newline, \\t -> tab, etc.
     """
@@ -219,7 +220,7 @@ def _strategy_escape_normalized(content: str, pattern: str) -> List[Tuple[int, i
 
 def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 6: Trim whitespace from first and last lines only.
+    Strategy 6: Trim first/last line boundary whitespace only.
     
     Useful when the pattern boundaries have whitespace differences.
     """
@@ -310,7 +311,7 @@ def _map_positions_norm_to_orig(
 
 
 def _strategy_unicode_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
-    """Strategy 7: Unicode normalisation.
+    """Strategy 7: Unicode normalisation (smart quotes, dashes, etc.).
 
     Normalises smart quotes, em/en-dashes, ellipsis, and non-breaking spaces
     to their ASCII equivalents in both *content* and *pattern*, then runs
@@ -398,7 +399,7 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
 
 def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 9: Line-by-line similarity with 50% threshold.
+    Strategy 9: Line-by-line similarity with 80% per-line / 50% block threshold.
     
     Finds blocks where at least 50% of lines have high similarity.
     """


### PR DESCRIPTION
## What

Reorder the fuzzy matching strategy chain in `tools/fuzzy_match.py` so that `indentation_flexible` (strategy 2, uses `lstrip()`) runs **before** `line_trimmed` (strategy 4, uses `strip()`).

## Why

In the previous ordering, `line_trimmed` was tried before `indentation_flexible`. Since `str.strip()` is a strict superset of `str.lstrip()` (it removes both leading **and** trailing whitespace, while `lstrip` only removes leading), any content that matched after `lstrip` normalization would also match after `strip` normalization.

**This made `indentation_flexible` dead code** — it could never contribute a match because `line_trimmed` would always match first (or fail, in which case `indentation_flexible` was guaranteed to fail too).

## How

Swapped the order so:

| # | Strategy | Normalization | Catch zone |
|---|----------|--------------|------------|
| 2 | `indentation_flexible` | `lstrip()` | Indentation-only differences (preserves trailing whitespace precision) |
| 4 | `line_trimmed` | `strip()` | Indentation + trailing whitespace differences (more aggressive fallback) |

Now each strategy has a unique contribution to the matching chain.

Also updated the module docstring to reflect the correct 9-strategy count (was listed as 8, missing `unicode_normalized`).

## Before vs After

```
# Before: indentation_flexible was never reached
content = "    def foo():\n        pass"
pattern = "def foo():\n    pass"
# line_trimmed matches (strip handles both leading+trailing)
# indentation_flexible is dead code

# After: indentation_flexible matches first (more precise)
# Same content/pattern now matches via indentation_flexible
# line_trimmed still available as fallback for trailing whitespace diffs
```

## Testing

- All 16 existing tests pass ✓
- Added 3 new tests in `TestIndentationFlexibleOrdering`:
  - `test_indentation_flexible_used_for_leading_whitespace_only` — verifies strategy is now reachable
  - `test_line_trimmed_still_catches_trailing_whitespace` — verifies fallback still works
  - `test_indentation_flexible_not_dead_code` — verifies unique contribution with tab indentation

Closes #14497