### PR TITLE
fix(config): expand ${ENV_VAR} placeholders in gateway config loading (#14457)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -486,13 +486,20 @@ def _platform_config_key(platform: "Platform") -> str:
 
 
 def _load_gateway_config() -> dict:
-    """Load and parse ~/.hermes/config.yaml, returning {} on any error."""
+    """Load and parse ~/.hermes/config.yaml, returning {} on any error.
+
+    Expands ``${ENV_VAR}`` placeholders so that callers always receive
+    runtime-ready values (matching the behaviour of
+    ``hermes_cli.config.load_config()``).
+    """
     try:
         config_path = _hermes_home / 'config.yaml'
         if config_path.exists():
             import yaml
             with open(config_path, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f) or {}
+                raw = yaml.safe_load(f) or {}
+            from hermes_cli.config import _expand_env_vars
+            return _expand_env_vars(raw)
     except Exception:
         logger.debug("Could not load gateway config from %s", _hermes_home / 'config.yaml')
     return {}
@@ -4192,6 +4199,8 @@ class GatewayRunner:
                     import yaml as _hyg_yaml
                     with open(_hyg_cfg_path, encoding="utf-8") as _hyg_f:
                         _hyg_data = _hyg_yaml.safe_load(_hyg_f) or {}
+                    from hermes_cli.config import _expand_env_vars
+                    _hyg_data = _expand_env_vars(_hyg_data)
 
                     # Resolve model name (same logic as run_sync)
                     _model_cfg = _hyg_data.get("model", {})
@@ -5447,6 +5456,8 @@ class GatewayRunner:
             if config_path.exists():
                 with open(config_path, encoding="utf-8") as f:
                     cfg = yaml.safe_load(f) or {}
+                from hermes_cli.config import _expand_env_vars
+                cfg = _expand_env_vars(cfg)
                 model_cfg = cfg.get("model", {})
                 if isinstance(model_cfg, dict):
                     current_model = model_cfg.get("default", "")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1999,12 +1999,18 @@ def _normalize_custom_provider_entry(
         )
 
     from urllib.parse import urlparse
+    import re as _re
 
     base_url = ""
     for url_key in ("base_url", "url", "api"):
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()
+            # Accept unresolved ${VAR} env-ref placeholders without URL
+            # validation — they will be expanded at runtime.
+            if _re.search(r"\${[^}]+}", candidate):
+                base_url = candidate
+                break
             parsed = urlparse(candidate)
             if parsed.scheme and parsed.netloc:
                 base_url = candidate

--- a/tests/gateway/test_gateway_env_expansion.py
+++ b/tests/gateway/test_gateway_env_expansion.py
@@ -1,0 +1,156 @@
+"""Tests for ${ENV_VAR} expansion in gateway config loading paths.
+
+Regression tests for #14457: custom_providers.base_url placeholders were
+validated before expansion because _load_gateway_config() returned raw
+YAML without calling _expand_env_vars().
+"""
+
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+class TestLoadGatewayConfigExpandsEnvVars:
+    """_load_gateway_config() must expand ${VAR} placeholders."""
+
+    def _write_config(self, tmp_path, content):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(textwrap.dedent(content))
+        return tmp_path
+
+    def test_base_url_placeholder_expanded(self, tmp_path, monkeypatch):
+        """${VAR} in custom_providers base_url must be expanded."""
+        self._write_config(tmp_path, """\
+            custom_providers:
+              - name: my-provider
+                base_url: ${TEST_PROVIDER_URL_14457}
+                key_env: TEST_KEY
+        """)
+        monkeypatch.setenv("TEST_PROVIDER_URL_14457", "https://api.example.com/v1")
+
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+        cfg = gw._load_gateway_config()
+        entry = cfg["custom_providers"][0]
+        assert entry["base_url"] == "https://api.example.com/v1"
+
+    def test_model_base_url_placeholder_expanded(self, tmp_path, monkeypatch):
+        """${VAR} in model.base_url must be expanded."""
+        self._write_config(tmp_path, """\
+            model:
+              provider: custom
+              default: gpt-4
+              base_url: ${TEST_MODEL_URL_14457}
+              api_key: ${TEST_MODEL_KEY_14457}
+        """)
+        monkeypatch.setenv("TEST_MODEL_URL_14457", "https://custom-api.example.com/v1")
+        monkeypatch.setenv("TEST_MODEL_KEY_14457", "sk-test-key-123")
+
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+        cfg = gw._load_gateway_config()
+        assert cfg["model"]["base_url"] == "https://custom-api.example.com/v1"
+        assert cfg["model"]["api_key"] == "sk-test-key-123"
+
+    def test_unresolved_var_kept_verbatim(self, tmp_path, monkeypatch):
+        """Unresolved ${VAR} should be kept as-is, not cause errors."""
+        self._write_config(tmp_path, """\
+            custom_providers:
+              - name: offline
+                base_url: ${UNSET_PROVIDER_URL_14457}
+        """)
+        monkeypatch.delenv("UNSET_PROVIDER_URL_14457", raising=False)
+
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+        cfg = gw._load_gateway_config()
+        assert cfg["custom_providers"][0]["base_url"] == "${UNSET_PROVIDER_URL_14457}"
+
+    def test_literal_values_unchanged(self, tmp_path, monkeypatch):
+        """Non-placeholder values must not be altered."""
+        self._write_config(tmp_path, """\
+            custom_providers:
+              - name: literal-provider
+                base_url: https://api.real.com/v1
+                key_env: MY_KEY
+        """)
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+        cfg = gw._load_gateway_config()
+        assert cfg["custom_providers"][0]["base_url"] == "https://api.real.com/v1"
+
+    def test_multiple_providers_all_expanded(self, tmp_path, monkeypatch):
+        """All providers in a multi-provider config must be expanded."""
+        self._write_config(tmp_path, """\
+            custom_providers:
+              - name: provider-a
+                base_url: ${TEST_URL_A_14457}
+                key_env: KEY_A
+              - name: provider-b
+                base_url: ${TEST_URL_B_14457}
+                key_env: KEY_B
+        """)
+        monkeypatch.setenv("TEST_URL_A_14457", "https://a.example.com/v1")
+        monkeypatch.setenv("TEST_URL_B_14457", "https://b.example.com/v1")
+
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+        cfg = gw._load_gateway_config()
+        assert cfg["custom_providers"][0]["base_url"] == "https://a.example.com/v1"
+        assert cfg["custom_providers"][1]["base_url"] == "https://b.example.com/v1"
+
+
+class TestGetCompatibleCustomProvidersWithEnvVars:
+    """get_compatible_custom_providers() must work with gateway-loaded config."""
+
+    def test_env_var_providers_are_found(self, tmp_path, monkeypatch):
+        """Providers with ${VAR} base_url must be returned after expansion."""
+        config = {
+            "custom_providers": [
+                {
+                    "name": "my-api",
+                    "base_url": "${TEST_CP_URL_14457}",
+                    "key_env": "MY_API_KEY",
+                },
+            ],
+        }
+        monkeypatch.setenv("TEST_CP_URL_14457", "https://my-api.example.com/v1")
+
+        from hermes_cli.config import _expand_env_vars, get_compatible_custom_providers
+
+        expanded = _expand_env_vars(config)
+        providers = get_compatible_custom_providers(expanded)
+        assert len(providers) == 1
+        assert providers[0]["base_url"] == "https://my-api.example.com/v1"
+        assert providers[0]["name"] == "my-api"
+
+    def test_unexpanded_base_url_not_rejected_as_invalid(self, monkeypatch):
+        """Unresolved ${VAR} in base_url must not be rejected by URL validation.
+
+        _normalize_custom_provider_entry() validates URLs with urlparse().
+        A literal '${VAR}' has no scheme/netloc and was rejected as invalid.
+        The fix: recognise env-ref patterns and pass them through unvalidated.
+        """
+        monkeypatch.delenv("NONEXISTENT_URL_VAR_14457", raising=False)
+        config = {
+            "custom_providers": [
+                {
+                    "name": "pending",
+                    "base_url": "${NONEXISTENT_URL_VAR_14457}",
+                },
+            ],
+        }
+        from hermes_cli.config import get_compatible_custom_providers
+
+        providers = get_compatible_custom_providers(config)
+        assert len(providers) == 1
+        assert providers[0]["base_url"] == "${NONEXISTENT_URL_VAR_14457}"


### PR DESCRIPTION
## Summary

- Gateway's `_load_gateway_config()` loaded `config.yaml` with `yaml.safe_load()` **without** calling `_expand_env_vars()`, so `custom_providers` entries with `base_url: ${MY_URL}` were passed to `_normalize_custom_provider_entry()` unexpanded
- `urlparse()` then rejected them as invalid URLs ("no scheme or host") and silently skipped the provider
- Two inline `yaml.safe_load()` sites in `GatewayRunner` (session-hygiene and `/model` command) had the same issue

## Changes

1. **`_load_gateway_config()`** now calls `_expand_env_vars()` before returning — fixes all 8+ call sites at once
2. **Two inline YAML loads** in `GatewayRunner` (session-hygiene context-length resolution + `/model` command provider listing) also expand after loading
3. **`_normalize_custom_provider_entry()`** recognises `${VAR}` patterns and defers URL validation so unresolved refs are passed through instead of rejected — defense-in-depth for any remaining raw-config paths

## Test plan

- [x] 7 new tests in `tests/gateway/test_gateway_env_expansion.py`:
  - `_load_gateway_config()` expands `${VAR}` in `custom_providers[].base_url`
  - `_load_gateway_config()` expands `${VAR}` in `model.base_url` and `model.api_key`
  - Unresolved `${VAR}` kept verbatim (not dropped or error)
  - Literal URLs unchanged
  - Multiple providers all expanded
  - `get_compatible_custom_providers()` works with expanded config
  - Unexpanded `${VAR}` in `base_url` not rejected by URL validation
- [x] All 80 existing config/validation/env-expansion tests pass
- [x] All 98 existing gateway config + runtime provider tests pass

Closes #14457