### PR TITLE
fix(gateway): refresh installed systemd unit on in-process restart; make generator deterministic across user contexts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1862,6 +1862,15 @@ class GatewayRunner:
         task.add_done_callback(self._background_tasks.discard)
         return True
 
+    def _refresh_installed_unit_before_service_restart(self) -> bool:
+        """Best-effort refresh of the installed systemd unit before exit-75 restart."""
+        from hermes_cli.gateway import _detect_installed_unit_scope, refresh_systemd_unit_if_needed
+
+        scope = _detect_installed_unit_scope()
+        if scope is None:
+            return False
+        return refresh_systemd_unit_if_needed(system=scope)
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -2626,6 +2635,10 @@ class GatewayRunner:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
             if self._restart_requested and self._restart_via_service:
+                try:
+                    self._refresh_installed_unit_before_service_restart()
+                except Exception:
+                    logger.debug("Pre-restart unit refresh failed", exc_info=True)
                 self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import logging
 import os
 import shutil
 import signal
@@ -14,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+
+logger = logging.getLogger(__name__)
 
 from gateway.status import terminate_pid
 from gateway.restart import (
@@ -1315,15 +1318,37 @@ def systemd_unit_is_current(system: bool = False) -> bool:
 def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     """Rewrite the installed systemd unit when the generated definition has changed."""
     unit_path = get_systemd_unit_path(system=system)
-    if not unit_path.exists() or systemd_unit_is_current(system=system):
+    is_current = systemd_unit_is_current(system=system) if unit_path.exists() else False
+    if not unit_path.exists() or is_current:
         return False
 
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    unit_path.write_text(generate_systemd_unit(system=system, run_as_user=expected_user), encoding="utf-8")
-    _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
+    rendered_unit = generate_systemd_unit(system=system, run_as_user=expected_user)
+    remedy = f"{'sudo ' if system else ''}hermes gateway install --force{' --system' if system else ''}"
+    try:
+        unit_path.write_text(rendered_unit, encoding="utf-8")
+        _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
+    except (PermissionError, OSError, subprocess.CalledProcessError) as exc:
+        msg = (
+            f"Cannot refresh {_service_scope_label(system)} gateway unit at {unit_path} ({exc}). "
+            f"Run: {remedy} to update it."
+        )
+        logger.warning(msg)
+        print(f"⚠ {msg}", file=sys.stderr, flush=True)
+        return False
     print(f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install")
     return True
 
+
+def _detect_installed_unit_scope() -> bool | None:
+    """Return the installed systemd scope when exactly one gateway unit exists."""
+    system_exists = get_systemd_unit_path(system=True).exists()
+    user_exists = get_systemd_unit_path(system=False).exists()
+    if system_exists and not user_exists:
+        return True
+    if user_exists and not system_exists:
+        return False
+    return None
 
 
 def _print_linger_enable_warning(username: str, detail: str | None = None) -> None:
@@ -1388,7 +1413,7 @@ def _ensure_linger_enabled() -> None:
 def _select_systemd_scope(system: bool = False) -> bool:
     if system:
         return True
-    return get_systemd_unit_path(system=True).exists() and not get_systemd_unit_path(system=False).exists()
+    return _detect_installed_unit_scope() is True
 
 
 def _get_restart_drain_timeout() -> float:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1129,6 +1129,14 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     return [p for p in candidates if p not in path_entries and Path(p).exists()]
 
 
+def _bundled_node_bin_dir(home: Path) -> str | None:
+    """Return the bundled Hermes node bin dir for *home* when present."""
+    bundled_node = home / ".hermes" / "node" / "bin" / "node"
+    if bundled_node.exists():
+        return str(bundled_node.parent)
+    return None
+
+
 def _remap_path_for_user(path: str, target_home_dir: str) -> str:
     """Remap *path* from the current user's home to *target_home_dir*.
 
@@ -1190,12 +1198,6 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
 
     path_entries = [venv_bin, node_bin]
-    resolved_node = shutil.which("node")
-    if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
-        if resolved_node_dir not in path_entries:
-            path_entries.append(resolved_node_dir)
-
     common_bin_paths = ["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
     restart_timeout = max(60, int(_get_restart_drain_timeout() or 0))
 
@@ -1212,6 +1214,9 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         venv_bin = _remap_path_for_user(venv_bin, home_dir)
         node_bin = _remap_path_for_user(node_bin, home_dir)
         path_entries = [_remap_path_for_user(p, home_dir) for p in path_entries]
+        bundled_node_dir = _bundled_node_bin_dir(Path(home_dir))
+        if bundled_node_dir and bundled_node_dir not in path_entries:
+            path_entries.append(bundled_node_dir)
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(common_bin_paths)
         sane_path = ":".join(path_entries)
@@ -1250,6 +1255,9 @@ WantedBy=multi-user.target
 
     hermes_home = str(get_hermes_home().resolve())
     profile_arg = _profile_arg(hermes_home)
+    bundled_node_dir = _bundled_node_bin_dir(Path.home())
+    if bundled_node_dir and bundled_node_dir not in path_entries:
+        path_entries.append(bundled_node_dir)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(common_bin_paths)
     sane_path = ":".join(path_entries)

--- a/tests/gateway/test_inprocess_restart_refresh.py
+++ b/tests/gateway/test_inprocess_restart_refresh.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_stop_impl_refreshes_unit_before_service_restart_exit_code(monkeypatch):
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+
+    calls = []
+
+    def fake_refresh():
+        calls.append(runner._exit_code)
+
+    monkeypatch.setattr(
+        runner,
+        "_refresh_installed_unit_before_service_restart",
+        fake_refresh,
+        raising=False,
+    )
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop(restart=True, service_restart=True)
+
+    assert calls == [None]
+    assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_stop_impl_swallows_refresh_exception(monkeypatch):
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+
+    calls = []
+
+    def boom():
+        calls.append("called")
+        raise RuntimeError("refresh failed")
+
+    monkeypatch.setattr(
+        runner,
+        "_refresh_installed_unit_before_service_restart",
+        boom,
+        raising=False,
+    )
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop(restart=True, service_restart=True)
+
+    assert calls == ["called"]
+    assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,7 +1,11 @@
 """Tests for gateway service management helpers."""
 
+import builtins
+import logging
 import os
 import pwd
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -81,6 +85,107 @@ class TestSystemdServiceRefresh:
             ["systemctl", "--user", "daemon-reload"],
             ["systemctl", "--user", "reload-or-restart", gateway_cli.get_service_name()],
         ]
+
+    def test_systemd_restart_system_scope_refreshes_outdated_unit(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: True)
+        monkeypatch.setattr(gateway_cli, "_require_root_for_system_service", lambda action: None)
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "updated unit\n")
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.systemd_restart(system=True)
+
+        assert unit_path.read_text(encoding="utf-8") == "updated unit\n"
+        assert calls[:2] == [
+            ["systemctl", "daemon-reload"],
+            ["systemctl", "reload-or-restart", gateway_cli.get_service_name()],
+        ]
+
+    def test_refresh_logs_warning_on_permission_error(self, tmp_path, monkeypatch, caplog, capsys):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "updated unit\n")
+
+        def fake_write_text(self, data, encoding=None):
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr(type(unit_path), "write_text", fake_write_text, raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.gateway"):
+            result = gateway_cli.refresh_systemd_unit_if_needed(system=True)
+
+        assert result is False
+        assert any(
+            "Cannot refresh system gateway unit" in record.message
+            and "sudo hermes gateway install --force --system" in record.message
+            for record in caplog.records
+        )
+        err = capsys.readouterr().err
+        assert "Cannot refresh system gateway unit" in err
+        assert "sudo hermes gateway install --force --system" in err
+
+    def test_refresh_permission_error_prints_to_stderr_and_flushes(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "updated unit\n")
+
+        def fake_write_text(self, data, encoding=None):
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr(type(unit_path), "write_text", fake_write_text, raising=False)
+
+        print_calls = []
+
+        def fake_print(*args, **kwargs):
+            print_calls.append((args, kwargs))
+
+        monkeypatch.setattr(builtins, "print", fake_print)
+
+        result = gateway_cli.refresh_systemd_unit_if_needed(system=True)
+
+        assert result is False
+        assert print_calls
+        args, kwargs = print_calls[-1]
+        assert args == ("⚠ Cannot refresh system gateway unit at " f"{unit_path} (permission denied). Run: sudo hermes gateway install --force --system to update it.",)
+        assert kwargs.get("file") is sys.stderr
+        assert kwargs.get("flush") is True
+
+    def test_refresh_logs_warning_on_daemon_reload_failure(self, tmp_path, monkeypatch, caplog):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "updated unit\n")
+
+        def fake_run_systemctl(args, system=False, check=True, timeout=30):
+            raise subprocess.CalledProcessError(returncode=1, cmd=["systemctl", *args])
+
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.gateway"):
+            result = gateway_cli.refresh_systemd_unit_if_needed(system=True)
+
+        assert result is False
+        assert any(
+            "Cannot refresh system gateway unit" in record.message
+            and "sudo hermes gateway install --force --system" in record.message
+            for record in caplog.records
+        )
 
 
 class TestGeneratedSystemdUnits:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -198,12 +198,43 @@ class TestGeneratedSystemdUnits:
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "TimeoutStopSec=60" in unit
 
-    def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
+    def test_generate_systemd_unit_deterministic_across_user_contexts(self, monkeypatch, tmp_path):
+        current_home = tmp_path / "root"
+        current_home.mkdir()
+        (current_home / ".hermes").mkdir()
 
-        unit = gateway_cli.generate_systemd_unit(system=False)
+        target_home = tmp_path / "home" / "hermes"
+        bundled_node = target_home / ".hermes" / "node" / "bin" / "node"
+        bundled_node.parent.mkdir(parents=True)
+        bundled_node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        bundled_node.chmod(0o755)
 
-        assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
+        shim_dir = tmp_path / "node-shim"
+        shim_dir.mkdir()
+        shim_node = shim_dir / "node"
+        shim_node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        shim_node.chmod(0o755)
+
+        empty_dir = tmp_path / "empty-path"
+        empty_dir.mkdir()
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: current_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: current_home / ".hermes")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("hermes", "hermes", str(target_home)),
+        )
+
+        monkeypatch.setenv("PATH", str(shim_dir))
+        with_node_on_caller_path = gateway_cli.generate_systemd_unit(system=True, run_as_user="hermes")
+
+        monkeypatch.setenv("PATH", str(empty_dir))
+        without_node_on_caller_path = gateway_cli.generate_systemd_unit(system=True, run_as_user="hermes")
+
+        assert with_node_on_caller_path == without_node_on_caller_path
+        assert str(bundled_node.parent) in with_node_on_caller_path
+        assert str(shim_dir) not in with_node_on_caller_path
 
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=True)


### PR DESCRIPTION
## Summary

Fix two related gateway/systemd issues:

1. **In-process service restarts did not refresh the installed systemd unit.**
   `/restart`, `SIGUSR1`, `/update`, and other in-process restart paths exited
   with status `75` so systemd would respawn the gateway, but they never called
   `refresh_systemd_unit_if_needed(...)`. If the installed unit was stale, it
   stayed stale indefinitely unless an operator manually ran a root-level CLI
   restart/install.

2. **Systemd unit generation was not deterministic across user contexts.**
   `generate_systemd_unit(...)` used `shutil.which("node")`, so the generated
   unit could vary depending on the caller's `PATH`. As a result,
   `systemd_unit_is_current(...)` could disagree between `root` and `hermes`,
   causing false `"Installed gateway service definition is outdated"` warnings
   immediately after a successful refresh.

## Changes

### `gateway/run.py`
- Add `_refresh_installed_unit_before_service_restart()`.
- Call it from the in-process service-restart path in `_stop_impl` before
  setting exit code `75`.
- Keep restart behavior best-effort: refresh failures never block restart.

### `hermes_cli/gateway.py`
- Harden `refresh_systemd_unit_if_needed(...)` to catch:
  - `PermissionError`
  - `OSError`
  - `subprocess.CalledProcessError`
- On failure, emit an operator-visible warning with remediation guidance:
  - log warning
  - flushed `stderr` warning
  - `sudo hermes gateway install --force --system` hint
- Extract `_detect_installed_unit_scope()` so the runner can refresh the
  installed scope without duplicating CLI scope-selection logic.
- Make `generate_systemd_unit(...)` deterministic by replacing
  `shutil.which("node")` with a direct bundled-node existence check:
  - system scope: target user's `~/.hermes/node/bin/node`
  - user scope: current user's `~/.hermes/node/bin/node`

## Tests

Added/updated coverage for:

- system-scope restart refreshing an outdated installed unit
- permission-error warning behavior
- daemon-reload failure warning behavior
- in-process restart refreshing the installed unit before exit `75`
- in-process restart swallowing refresh exceptions
- deterministic unit generation across different caller `PATH` values

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh -v`
- [x] `pytest tests/gateway/test_inprocess_restart_refresh.py -v`
- [x] `pytest tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits::test_generate_systemd_unit_deterministic_across_user_contexts -v`

## Live evidence

### In-process restart path (non-root, actual bug path)

Triggered via `SIGUSR1` as the `hermes` user. Observed in journald:

```text
⚠ Cannot refresh system gateway unit at /etc/systemd/system/hermes-gateway.service ([Errno 13] Permission denied: '/etc/systemd/system/hermes-gateway.service'). Run: sudo hermes gateway install --force --system to update it.
```

This confirms:
- the in-process restart path now attempts the refresh
- lack of permission is surfaced clearly to the operator
- restart still proceeds normally

### Root CLI refresh path

Before:
```text
2026-04-19 15:31:48 /etc/systemd/system/hermes-gateway.service
```

Command:
```bash
sudo hermes gateway restart --system
```

Observed output:
```text
↻ Updated gateway system service definition to match the current Hermes install
✓ System service restarted
```

After:
```text
2026-04-23 11:07:55 /etc/systemd/system/hermes-gateway.service
```

Service state:
```text
$ systemctl is-active hermes-gateway
active
```

Verification under the same context that performed the refresh:
`hermes gateway status` as `root` no longer reports the installed unit as outdated.

### Determinism issue validation

After the successful root refresh, `hermes gateway status` as the `hermes` user
still reported the unit as outdated. Diffing installed vs regenerated unit
showed the only mismatch was PATH content caused by caller-dependent node
resolution:

```diff
-Environment="PATH=...:/home/hermes/.hermes/node/bin:/home/hermes/.local/bin:..."
+Environment="PATH=...:/home/hermes/.local/bin:..."
```

This PR fixes that by making bundled-node inclusion depend only on filesystem
state under the target user's home, not on the invoking user's `PATH`.

## Notes

This PR intentionally does **not** add a privileged escalation path for
non-root system-unit rewrites. Non-root in-process restarts still cannot rewrite
`/etc/systemd/system/...`, but they now fail transparently and guide the
operator to the documented root-level repair path.

Co-authored-by: Keira (Hermes Agent) <keira@hermes.agent.local>
