### PR TITLE
fix(skills_sync): don't poison manifest on new-skill collision + surface with reset hint

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -106,6 +106,7 @@ AUTHOR_MAP = {
     "134848055+UNLINEARITY@users.noreply.github.com": "UNLINEARITY",
     "ben.burtenshaw@gmail.com": "burtenshaw",
     "roopaknijhara@gmail.com": "rnijhara",
+    "josephzcan@gmail.com": "j0sephz",
     # contributors (manual mapping from git names)
     "ahmedsherif95@gmail.com": "asheriif",
     "liujinkun@bytedance.com": "liujinkun2025",

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -402,6 +402,64 @@ class TestSyncSkills:
 
         assert (user_skill / "SKILL.md").read_text() == "# User modified"
 
+    def test_collision_does_not_poison_manifest(self, tmp_path):
+        """Collision with an unmanifested user skill must NOT record bundled_hash.
+
+        Otherwise the next sync compares user_hash against the recorded
+        bundled_hash, finds a mismatch, and permanently flags the skill as
+        'user-modified' — even though the user never touched a bundled copy.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # Pre-existing user skill (e.g. from hub, custom, or leftover) that
+        # happens to share a name with a newly bundled skill.
+        user_skill = skills_dir / "category" / "new-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("# From hub — unrelated to bundled")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            sync_skills(quiet=True)
+
+        # User file must survive (existing invariant).
+        assert (user_skill / "SKILL.md").read_text() == (
+            "# From hub — unrelated to bundled"
+        )
+
+        # Manifest must NOT contain the skill — it was never synced from bundled.
+        with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            manifest = _read_manifest()
+        assert "new-skill" not in manifest, (
+            "Collision path wrote bundled_hash to the manifest even though "
+            "the on-disk copy is unrelated to bundled. This poisons update "
+            "detection: the next sync will mark the skill as 'user-modified'."
+        )
+
+    def test_collision_does_not_trigger_false_user_modified_on_resync(self, tmp_path):
+        """End-to-end: after a collision, a second sync must not flag user_modified.
+
+        Pre-fix bug: first sync wrote bundled_hash to the manifest; second
+        sync then diffed user_hash vs bundled_hash, mismatched, and shoved
+        the skill into the user_modified bucket forever.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        user_skill = skills_dir / "category" / "new-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("# From hub — unrelated to bundled")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            sync_skills(quiet=True)  # first sync: collision path
+            result2 = sync_skills(quiet=True)  # second sync: must not flag
+
+        assert "new-skill" not in result2["user_modified"], (
+            "Second sync after a collision falsely flagged the user's skill "
+            "as 'user-modified' — the manifest was poisoned on the first sync."
+        )
+
     def test_nonexistent_bundled_dir(self, tmp_path):
         with patch("tools.skills_sync._get_bundled_dir", return_value=tmp_path / "nope"):
             result = sync_skills(quiet=True)

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -460,6 +460,28 @@ class TestSyncSkills:
             "as 'user-modified' — the manifest was poisoned on the first sync."
         )
 
+    def test_collision_prints_reset_hint(self, tmp_path, capsys):
+        """Non-quiet sync must print a reset hint when a collision is skipped.
+
+        Silent skip hides the fact that a bundled skill shipped but was
+        shadowed by the user's local copy. The hint tells the user the
+        exact command to take the bundled version instead.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        user_skill = skills_dir / "category" / "new-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("# From hub — unrelated to bundled")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            sync_skills(quiet=False)
+
+        captured = capsys.readouterr().out
+        assert "new-skill" in captured
+        assert "hermes skills reset new-skill" in captured
+
     def test_nonexistent_bundled_dir(self, tmp_path):
         with patch("tools.skills_sync._get_bundled_dir", return_value=tmp_path / "nope"):
             result = sync_skills(quiet=True)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -206,9 +206,18 @@ def sync_skills(quiet: bool = False) -> dict:
             # ── New skill — never offered before ──
             try:
                 if dest.exists():
-                    # User already has a skill with the same name — don't overwrite
+                    # User already has a skill with the same name — don't overwrite.
+                    # Only baseline in the manifest when the on-disk copy is
+                    # byte-identical to bundled (e.g. a reset that re-syncs, or
+                    # a coincidentally identical install); that case is harmless
+                    # to track. If the copy differs (custom skill, hub-installed,
+                    # or user-edited) skip the manifest write: recording
+                    # bundled_hash there would poison update detection by making
+                    # user_hash != origin_hash read as "user-modified" on every
+                    # subsequent sync, permanently blocking bundled updates.
                     skipped += 1
-                    manifest[skill_name] = bundled_hash
+                    if _dir_hash(dest) == bundled_hash:
+                        manifest[skill_name] = bundled_hash
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copytree(skill_src, dest)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -218,6 +218,13 @@ def sync_skills(quiet: bool = False) -> dict:
                     skipped += 1
                     if _dir_hash(dest) == bundled_hash:
                         manifest[skill_name] = bundled_hash
+                    elif not quiet:
+                        print(
+                            f"  ⚠ {skill_name}: bundled version shipped but you "
+                            f"already have a local skill by this name — yours "
+                            f"was kept. Run `hermes skills reset {skill_name}` "
+                            f"to replace it with the bundled version."
+                        )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copytree(skill_src, dest)


### PR DESCRIPTION
Salvage of #14379 (@j0sephz) + warning follow-up.

## Summary
Fix the manifest-poisoning bug where a newly-bundled skill colliding with a pre-existing user skill (hub-installed, custom, leftover) permanently flagged the user's skill as `user_modified`, blocking all future bundled updates. Also surface the collision so users know a bundled version shipped and how to take it.

## Changes
- `tools/skills_sync.py`: on new-skill collision, only baseline `bundled_hash` in the manifest when the user's copy is byte-identical to bundled. Otherwise skip the manifest write entirely (prevents the false-positive `user_modified` flag on every subsequent sync).
- `tools/skills_sync.py`: on non-quiet sync, print a warning when a collision is skipped, telling the user `hermes skills reset <name>` will replace their copy with the bundled version.
- `tests/tools/test_skills_sync.py`: +3 tests (manifest-not-poisoned, no-false-user-modified-on-resync, warning printed).

## Attribution
- @j0sephz authored the core fix (`fix(skills_sync):` commit) — cherry-picked directly, authorship preserved.
- Follow-up commit adds the reset-hint warning per review feedback.
- AUTHOR_MAP entry added for `josephzcan@gmail.com`.

## Validation
- 45 / 45 tests in `tests/tools/test_skills_sync.py` pass (was 44; +1 for the warning).
- `reset_bundled_skill()` re-baseline flow preserved: after it deletes the user copy, the next `sync_skills()` call hits the `_dir_hash(dest) == bundled_hash` branch by construction and re-populates the manifest as before.

Closes #14379.