### PR TITLE
fix: resolve 'Timeout context manager should be used inside a task' in Weixin send

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1980,33 +1980,11 @@ async def send_weixin_direct(
     token_store.restore(account_id)
     context_token = token_store.get(account_id, chat_id)
 
-    live_adapter = _LIVE_ADAPTERS.get(resolved_token)
-    send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
-        last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
-
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
-            else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
-
-        return {
-            "success": True,
-            "platform": "weixin",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id if last_result else None,
-            "context_token_used": bool(context_token),
-        }
-
+    # Always create a fresh session for send_weixin_direct.
+    # Reusing the live adapter's aiohttp session causes "Timeout context
+    # manager should be used inside a task" when this function runs on a
+    # different event loop than the gateway (e.g. via _run_async's thread
+    # pool path), because the session is bound to the gateway's loop.
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(

--- a/model_tools.py
+++ b/model_tools.py
@@ -119,16 +119,20 @@ def _run_async(coro):
             pool.shutdown(wait=False, cancel_futures=True)
 
     # If we're on a worker thread (e.g., parallel tool execution in
-    # delegate_task), use a per-thread persistent loop.  This avoids
-    # contention with the main thread's shared loop while keeping cached
-    # httpx/AsyncOpenAI clients bound to a live loop for the thread's
-    # lifetime — preventing "Event loop is closed" on GC cleanup.
+    # delegate_task), always use asyncio.run() so that a proper task
+    # context exists.  run_until_complete does NOT create a task, so
+    # asyncio.current_task() returns None — which breaks aiohttp's
+    # ClientTimeout context manager ("Timeout context manager should be
+    # used inside a task").
     if threading.current_thread() is not threading.main_thread():
-        worker_loop = _get_worker_loop()
-        return worker_loop.run_until_complete(coro)
+        return asyncio.run(coro)
 
-    tool_loop = _get_tool_loop()
-    return tool_loop.run_until_complete(coro)
+    # Main thread, no running loop — use asyncio.run() for proper task
+    # context (avoids "Timeout context manager should be used inside a
+    # task" with aiohttp >= 3.9).  The trade-off is that each call
+    # creates/destroys a loop, but this only applies to the CLI path
+    # where no running loop exists.
+    return asyncio.run(coro)
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

When the gateway is running and a Weixin user sends a message, the agent responds via `send_weixin_direct()` which tries to reuse the live adapter's `aiohttp.ClientSession` (bound to the gateway's event loop). However, `send_message` tool calls are dispatched via `_run_async()` which may run on a worker thread using `loop.run_until_complete()`.

`run_until_complete()` does **not** create a task, so `asyncio.current_task()` returns `None`. This causes `aiohttp.ClientTimeout.__enter__` to raise:

```
RuntimeError: Timeout context manager should be used inside a task
```

This breaks **all** Weixin send operations (text + media) from the `send_message` tool and cron delivery when the gateway is running.

Introduced by commit `5ca52bae` (split poll/send sessions, reuse live adapter).

## Fix

1. **`gateway/platforms/weixin.py`** — `send_weixin_direct()` always creates its own `aiohttp.ClientSession` instead of reusing the live adapter's session (which is bound to the gateway's event loop and may be on a different thread).

2. **`model_tools.py`** — `_run_async()` uses `asyncio.run()` instead of `run_until_complete()` for both worker-thread and main-thread fallback paths. `asyncio.run()` creates a proper task context, which `aiohttp >= 3.9` requires for `ClientTimeout`.

## Trade-off

Using `asyncio.run()` instead of a persistent loop means each call creates/destroys an event loop. The original persistent loop was introduced to prevent "Event loop is closed" errors with cached `httpx`/`AsyncOpenAI` clients (commit `7a427d7b`). If this becomes an issue again, an alternative fix would be to wrap the coroutine in `loop.create_task()` before `run_until_complete()`, e.g.:

```python
worker_loop = _get_worker_loop()
return worker_loop.run_until_complete(worker_loop.create_task(coro))
```

This preserves the persistent loop while still providing a task context.

## Verification

- Reproduced: all `send_message` calls to Weixin fail with timeout error when gateway is running
- Fixed: `send_weixin_direct()` creates its own session, `asyncio.run()` provides task context
- No impact on gateway's own send path (which runs on the gateway loop directly)