### PR TITLE
feat(xai): add x_search tool — search X via xAI Responses API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,20 +106,13 @@ def _codex_curated_models() -> list[str]:
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
-# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
-# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
-# or retires a model, the disk cache picks it up on the next refresh and the
-# fallback here only matters until that refresh lands.
+# install, offline first run, etc.). Keep this list conservative: it should
+# not advertise models scheduled for May 15, 2026 retirement.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
 ]
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -55,6 +55,7 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("x_search",        "🐦 X/Twitter Search (xAI)",    "x_search"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -52,6 +52,7 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
 # These map to keys in toolsets.py TOOLSETS dict.
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
+    ("x_search",        "🐦 X (Twitter) Search",       "x_search"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -52,7 +52,7 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
 # These map to keys in toolsets.py TOOLSETS dict.
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
-    ("x_search",        "🐦 X (Twitter) Search",       "x_search"),
+    ("x_search",        "🐦 X/Twitter Search (xAI)",    "x_search"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -319,6 +319,7 @@ class TestBuiltinDiscovery:
             "tools.tts_tool",
             "tools.vision_tools",
             "tools.web_tools",
+            "tools.x_search_tool",
             "tools.yuanbao_tools",
         }
 

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -1,0 +1,207 @@
+import json
+import requests
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"{self.status_code} Client Error")
+            err.response = self
+            raise err
+
+    def json(self):
+        return self._payload
+
+
+def test_x_search_posts_responses_request(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+    from hermes_cli import __version__
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "output_text": "People on X are discussing xAI's latest launch.",
+                "citations": [{"url": "https://x.com/example/status/1", "title": "Example post"}],
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        x_search_tool(
+            query="What are people saying about xAI on X?",
+            allowed_x_handles=["xai", "@grok"],
+            from_date="2026-04-01",
+            to_date="2026-04-10",
+            enable_image_understanding=True,
+        )
+    )
+
+    tool_def = captured["json"]["tools"][0]
+    assert captured["url"] == "https://api.x.ai/v1/responses"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["model"] == "grok-4.20-reasoning"
+    assert captured["json"]["store"] is False
+    assert tool_def["type"] == "x_search"
+    assert tool_def["allowed_x_handles"] == ["xai", "grok"]
+    assert tool_def["from_date"] == "2026-04-01"
+    assert tool_def["to_date"] == "2026-04-10"
+    assert tool_def["enable_image_understanding"] is True
+    assert result["success"] is True
+    assert result["answer"] == "People on X are discussing xAI's latest launch."
+
+
+def test_x_search_rejects_conflicting_handle_filters(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(
+        x_search_tool(
+            query="latest xAI discussion",
+            allowed_x_handles=["xai"],
+            excluded_x_handles=["grok"],
+        )
+    )
+
+    assert result["error"] == "allowed_x_handles and excluded_x_handles cannot be used together"
+
+
+def test_x_search_extracts_inline_url_citations(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "xAI posted an update on X.",
+                                "annotations": [
+                                    {
+                                        "type": "url_citation",
+                                        "url": "https://x.com/xai/status/123",
+                                        "title": "xAI update",
+                                        "start_index": 0,
+                                        "end_index": 3,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="latest post from xai"))
+
+    assert result["success"] is True
+    assert result["answer"] == "xAI posted an update on X."
+    assert result["inline_citations"] == [
+        {
+            "url": "https://x.com/xai/status/123",
+            "title": "xAI update",
+            "start_index": 0,
+            "end_index": 3,
+        }
+    ]
+
+
+def test_x_search_returns_structured_http_error(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    class _FailingResponse:
+        status_code = 403
+        text = '{"code":"forbidden","error":"x_search is not enabled for this model"}'
+
+        def json(self):
+            return {
+                "code": "forbidden",
+                "error": "x_search is not enabled for this model",
+            }
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(x_search_tool(query="latest xai discussion"))
+
+    assert result["success"] is False
+    assert result["provider"] == "xai"
+    assert result["tool"] == "x_search"
+    assert result["error_type"] == "HTTPError"
+    assert result["error"] == "forbidden: x_search is not enabled for this model"
+
+
+def test_x_search_retries_read_timeout_then_succeeds(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ReadTimeout("timed out")
+        return _FakeResponse(
+            {
+                "output_text": "Recovered after retry.",
+                "citations": [],
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.x_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(x_search_tool(query="grok xai"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after retry."
+
+
+def test_x_search_retries_5xx_then_succeeds(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResponse(
+                {"code": "Internal error", "error": "Service temporarily unavailable."},
+                status_code=500,
+            )
+        return _FakeResponse({"output_text": "Recovered after 5xx retry."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.x_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(x_search_tool(query="grok xai"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after 5xx retry."

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Tests for tools/x_search_tool.py."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure XAI_API_KEY is set for all tests."""
+    monkeypatch.setenv("XAI_API_KEY", "test-key-12345")
+
+
+@pytest.fixture()
+def mock_post():
+    """Patch requests.post for x_search calls."""
+    with patch("tools.x_search_tool.requests.post") as m:
+        yield m
+
+
+def _make_response(
+    text: str = "Test result",
+    citations: list | None = None,
+    status_code: int = 200,
+) -> MagicMock:
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import requests
+        http_err = requests.HTTPError(response=resp)
+        resp.raise_for_status.side_effect = http_err
+        resp.json.return_value = {
+            "error": {"message": f"HTTP {status_code}"}
+        }
+        return resp
+
+    output_items = []
+    content_blocks = [{"type": "output_text", "text": text}]
+    if citations:
+        content_blocks[0]["annotations"] = [
+            {"type": "url_citation", **c} for c in citations
+        ]
+    output_items.append({"type": "message", "content": content_blocks})
+    resp.json.return_value = {"output": output_items}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# check_x_search_requirements
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRequirements:
+    def test_returns_true_with_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "sk-xxx")
+        from tools.x_search_tool import check_x_search_requirements
+        assert check_x_search_requirements() is True
+
+    def test_returns_false_without_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.x_search_tool import check_x_search_requirements
+        assert check_x_search_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# _normalize_handles
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeHandles:
+    def test_strips_at_prefix(self):
+        from tools.x_search_tool import _normalize_handles
+        result = _normalize_handles(["@elonmusk", "@xaboratory"], "test")
+        assert result == ["elonmusk", "xaboratory"]
+
+    def test_deduplicates(self):
+        from tools.x_search_tool import _normalize_handles
+        result = _normalize_handles(["@a", "a", "@a"], "test")
+        assert result == ["a"]
+
+    def test_empty_input(self):
+        from tools.x_search_tool import _normalize_handles
+        assert _normalize_handles(None, "test") == []
+        assert _normalize_handles([], "test") == []
+
+    def test_max_handles(self):
+        from tools.x_search_tool import _normalize_handles, MAX_HANDLES
+        handles = [f"@user{i}" for i in range(MAX_HANDLES + 5)]
+        result = _normalize_handles(handles, "test")
+        assert len(result) == MAX_HANDLES
+
+    def test_skips_non_strings(self):
+        from tools.x_search_tool import _normalize_handles
+        result = _normalize_handles(["@valid", 123, None, "@ok"], "test")
+        assert result == ["valid", "ok"]
+
+
+# ---------------------------------------------------------------------------
+# _extract_response_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponseText:
+    def test_from_output_text(self):
+        from tools.x_search_tool import _extract_response_text
+        payload = {"output_text": "Hello world"}
+        assert _extract_response_text(payload) == "Hello world"
+
+    def test_from_output_items(self):
+        from tools.x_search_tool import _extract_response_text
+        payload = {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Found it"}],
+                }
+            ]
+        }
+        assert _extract_response_text(payload) == "Found it"
+
+    def test_empty(self):
+        from tools.x_search_tool import _extract_response_text
+        assert _extract_response_text({}) == ""
+        assert _extract_response_text({"output": []}) == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_citations
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCitations:
+    def test_extracts_url_citations(self):
+        from tools.x_search_tool import _extract_citations
+        payload = {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "result",
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://x.com/user/status/123",
+                                    "title": "Post",
+                                    "start_index": 0,
+                                    "end_index": 10,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        cites = _extract_citations(payload)
+        assert len(cites) == 1
+        assert cites[0]["url"] == "https://x.com/user/status/123"
+
+    def test_empty(self):
+        from tools.x_search_tool import _extract_citations
+        assert _extract_citations({}) == []
+        assert _extract_citations({"output": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# x_search_tool (main function)
+# ---------------------------------------------------------------------------
+
+
+class TestXSearchTool:
+    def test_missing_query(self):
+        from tools.x_search_tool import x_search_tool
+        result = x_search_tool(query="")
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.x_search_tool import x_search_tool
+        result = x_search_tool(query="test")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "XAI_API_KEY" in parsed.get("error", "")
+
+    def test_successful_search(self, mock_post):
+        mock_post.return_value = _make_response(
+            text="xAI announced Grok 4.3",
+            citations=[
+                {"url": "https://x.com/xai/status/1", "title": "xAI", "start_index": 0, "end_index": 5}
+            ],
+        )
+        from tools.x_search_tool import x_search_tool
+        result = x_search_tool(query="xAI Grok 4.3")
+        parsed = json.loads(result)
+        assert parsed["text"] == "xAI announced Grok 4.3"
+        assert parsed["citation_count"] == 1
+        assert parsed["tool"] == "x_search"
+        assert mock_post.call_count == 1
+
+    def test_handles_passed_to_payload(self, mock_post):
+        mock_post.return_value = _make_response(text="ok")
+        from tools.x_search_tool import x_search_tool
+        x_search_tool(
+            query="test",
+            allowed_x_handles=["@xaboratory"],
+            excluded_x_handles=["@spam"],
+        )
+        call_args = mock_post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        tool_def = payload["tools"][0]
+        assert tool_def["allowed_x_handles"] == ["xaboratory"]
+        assert tool_def["excluded_x_handles"] == ["spam"]
+
+    def test_date_filters_passed(self, mock_post):
+        mock_post.return_value = _make_response(text="ok")
+        from tools.x_search_tool import x_search_tool
+        x_search_tool(query="test", from_date="2026-01-01", to_date="2026-04-23")
+        call_args = mock_post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        tool_def = payload["tools"][0]
+        assert tool_def["from_date"] == "2026-01-01"
+        assert tool_def["to_date"] == "2026-04-23"
+
+    def test_auth_header(self, mock_post):
+        mock_post.return_value = _make_response(text="ok")
+        from tools.x_search_tool import x_search_tool
+        x_search_tool(query="test")
+        call_args = mock_post.call_args
+        headers = call_args.kwargs.get("headers") or call_args[1].get("headers")
+        assert "Bearer test-key-12345" in headers["Authorization"]
+        assert "Hermes-Agent" in headers["User-Agent"]
+
+    def test_retry_on_server_error(self, mock_post):
+        import requests as req_lib
+
+        # First call: server error
+        error_resp = MagicMock()
+        error_resp.status_code = 500
+        error_resp.text = "Internal Server Error"
+        error_resp.json.return_value = {"error": {"message": "Internal error"}}
+        http_err = req_lib.HTTPError(response=error_resp)
+
+        # Second call: success
+        ok_resp = _make_response(text="recovered")
+
+        call_count = [0]
+        def post_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                resp = MagicMock()
+                resp.status_code = 500
+                resp.raise_for_status.side_effect = http_err
+                resp.text = "Internal Server Error"
+                resp.json.return_value = {"error": {"message": "Internal error"}}
+                return resp
+            return ok_resp
+
+        mock_post.side_effect = post_side_effect
+
+        from tools.x_search_tool import x_search_tool
+        result = x_search_tool(query="test")
+        parsed = json.loads(result)
+        assert parsed["text"] == "recovered"
+        assert mock_post.call_count == 2
+
+    def test_no_retry_on_auth_error(self, mock_post):
+        import requests as req_lib
+        error_resp = MagicMock()
+        error_resp.status_code = 401
+        error_resp.text = "Unauthorized"
+        error_resp.json.return_value = {"error": {"message": "Unauthorized"}}
+        http_err = req_lib.HTTPError(response=error_resp)
+        error_resp.raise_for_status.side_effect = http_err
+        mock_post.return_value = error_resp
+
+        from tools.x_search_tool import x_search_tool
+        result = x_search_tool(query="test")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert mock_post.call_count == 1  # No retry
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from tools.x_search_tool import _get_model
+        assert _get_model() == "grok-4.20-reasoning"
+
+    def test_default_timeout(self):
+        from tools.x_search_tool import _get_timeout
+        assert _get_timeout() == 180
+
+    def test_default_retries(self):
+        from tools.x_search_tool import _get_retries
+        assert _get_retries() == 2
+
+    def test_custom_config(self, monkeypatch):
+        """Verify config.yaml overrides work by patching _load_config."""
+        with patch("tools.x_search_tool._load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "model": "grok-4-fast",
+                "timeout_seconds": 60,
+                "retries": 0,
+            }
+            from tools.x_search_tool import _get_model, _get_timeout, _get_retries
+            assert _get_model() == "grok-4-fast"
+            assert _get_timeout() == 60
+            assert _get_retries() == 0

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""
+X Search tool backed by xAI's built-in x_search Responses API tool.
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
+DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
+DEFAULT_X_SEARCH_RETRIES = 2
+MAX_HANDLES = 10
+
+
+def _get_xai_base_url() -> str:
+    return (os.getenv("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+
+
+def _load_x_search_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("x_search", {})
+    except Exception:
+        return {}
+
+
+def _get_x_search_model() -> str:
+    cfg = _load_x_search_config()
+    return (cfg.get("model") or DEFAULT_X_SEARCH_MODEL).strip()
+
+
+def _get_x_search_timeout_seconds() -> int:
+    cfg = _load_x_search_config()
+    raw_value = cfg.get("timeout_seconds", DEFAULT_X_SEARCH_TIMEOUT_SECONDS)
+    try:
+        return max(30, int(raw_value))
+    except Exception:
+        return DEFAULT_X_SEARCH_TIMEOUT_SECONDS
+
+
+def _get_x_search_retries() -> int:
+    cfg = _load_x_search_config()
+    raw_value = cfg.get("retries", DEFAULT_X_SEARCH_RETRIES)
+    try:
+        return max(0, int(raw_value))
+    except Exception:
+        return DEFAULT_X_SEARCH_RETRIES
+
+
+def check_x_search_requirements() -> bool:
+    return bool(os.getenv("XAI_API_KEY", "").strip())
+
+
+def _normalize_handles(handles: Optional[List[str]], field_name: str) -> List[str]:
+    cleaned = []
+    for handle in handles or []:
+        normalized = str(handle or "").strip().lstrip("@")
+        if normalized:
+            cleaned.append(normalized)
+    if len(cleaned) > MAX_HANDLES:
+        raise ValueError(f"{field_name} supports at most {MAX_HANDLES} handles")
+    return cleaned
+
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            ctype = content.get("type")
+            if ctype in ("output_text", "text"):
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    citations = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            for annotation in content.get("annotations", []) or []:
+                if annotation.get("type") != "url_citation":
+                    continue
+                citations.append(
+                    {
+                        "url": annotation.get("url", ""),
+                        "title": annotation.get("title", ""),
+                        "start_index": annotation.get("start_index"),
+                        "end_index": annotation.get("end_index"),
+                    }
+                )
+    return citations
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return str(exc)
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error = str(payload.get("error") or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    if text:
+        return text[:500]
+    return str(exc)
+
+
+def x_search_tool(
+    query: str,
+    allowed_x_handles: Optional[List[str]] = None,
+    excluded_x_handles: Optional[List[str]] = None,
+    from_date: str = "",
+    to_date: str = "",
+    enable_image_understanding: bool = False,
+    enable_video_understanding: bool = False,
+) -> str:
+    if not query or not query.strip():
+        return tool_error("query is required for x_search")
+
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        return tool_error("XAI_API_KEY is not set")
+
+    try:
+        allowed = _normalize_handles(allowed_x_handles, "allowed_x_handles")
+        excluded = _normalize_handles(excluded_x_handles, "excluded_x_handles")
+        if allowed and excluded:
+            return tool_error("allowed_x_handles and excluded_x_handles cannot be used together")
+
+        tool_def: Dict[str, Any] = {"type": "x_search"}
+        if allowed:
+            tool_def["allowed_x_handles"] = allowed
+        if excluded:
+            tool_def["excluded_x_handles"] = excluded
+        if from_date.strip():
+            tool_def["from_date"] = from_date.strip()
+        if to_date.strip():
+            tool_def["to_date"] = to_date.strip()
+        if enable_image_understanding:
+            tool_def["enable_image_understanding"] = True
+        if enable_video_understanding:
+            tool_def["enable_video_understanding"] = True
+
+        payload = {
+            "model": _get_x_search_model(),
+            "input": [
+                {
+                    "role": "user",
+                    "content": query.strip(),
+                }
+            ],
+            "tools": [tool_def],
+            "store": False,
+        }
+
+        timeout_seconds = _get_x_search_timeout_seconds()
+        max_retries = _get_x_search_retries()
+        response = None
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    f"{_get_xai_base_url()}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                status_code = getattr(getattr(e, "response", None), "status_code", None)
+                if status_code is None or status_code < 500 or attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "x_search upstream failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    _http_error_message(e),
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+            except (requests.ReadTimeout, requests.ConnectionError) as e:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "x_search transient failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+
+        if response is None:
+            raise RuntimeError("x_search request did not return a response")
+
+        data = response.json()
+
+        answer = _extract_response_text(data)
+        citations = list(data.get("citations") or [])
+        inline_citations = _extract_inline_citations(data)
+
+        return json.dumps(
+            {
+                "success": True,
+                "provider": "xai",
+                "tool": "x_search",
+                "model": payload["model"],
+                "query": query.strip(),
+                "answer": answer,
+                "citations": citations,
+                "inline_citations": inline_citations,
+            },
+            ensure_ascii=False,
+        )
+    except requests.HTTPError as e:
+        logger.error("x_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "x_search",
+                "error": _http_error_message(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except requests.ReadTimeout as e:
+        logger.error("x_search timed out: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "x_search",
+                "error": f"xAI x_search timed out after {_get_x_search_timeout_seconds()} seconds",
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("x_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "x_search",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+X_SEARCH_SCHEMA = {
+    "name": "x_search",
+    "description": "Search X (Twitter) posts, profiles, and threads using xAI's built-in X Search tool. Use this for current discussion, reactions, or claims on X rather than general web pages.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to look up on X.",
+            },
+            "allowed_x_handles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of X handles to include exclusively (max 10).",
+            },
+            "excluded_x_handles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of X handles to exclude (max 10).",
+            },
+            "from_date": {
+                "type": "string",
+                "description": "Optional start date in YYYY-MM-DD format.",
+            },
+            "to_date": {
+                "type": "string",
+                "description": "Optional end date in YYYY-MM-DD format.",
+            },
+            "enable_image_understanding": {
+                "type": "boolean",
+                "description": "Whether xAI should analyze images attached to matching X posts.",
+                "default": False,
+            },
+            "enable_video_understanding": {
+                "type": "boolean",
+                "description": "Whether xAI should analyze videos attached to matching X posts.",
+                "default": False,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def _handle_x_search(args, **kw):
+    return x_search_tool(
+        query=args.get("query", ""),
+        allowed_x_handles=args.get("allowed_x_handles"),
+        excluded_x_handles=args.get("excluded_x_handles"),
+        from_date=args.get("from_date", ""),
+        to_date=args.get("to_date", ""),
+        enable_image_understanding=bool(args.get("enable_image_understanding", False)),
+        enable_video_understanding=bool(args.get("enable_video_understanding", False)),
+    )
+
+
+registry.register(
+    name="x_search",
+    toolset="x_search",
+    schema=X_SEARCH_SCHEMA,
+    handler=_handle_x_search,
+    check_fn=check_x_search_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🐦",
+    max_result_size_chars=100_000,
+)

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+X Search Tool — Search X (Twitter) via xAI's native x_search Responses API.
+
+xAI is the only provider with native access to X/Twitter data.
+This tool uses the Responses API `x_search` built-in tool to search
+posts, profiles, and threads.
+
+Requires ``XAI_API_KEY`` in ``~/.hermes/.env``.
+
+Configuration (optional, in config.yaml)::
+
+    x_search:
+      model: grok-4.20-reasoning   # default
+      timeout_seconds: 180          # default
+      retries: 2                    # default
+
+Usage::
+
+    from tools.x_search_tool import x_search_tool, check_x_search_requirements
+
+    result = x_search_tool(query="latest news about Hermes Agent")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_MODEL = "grok-4.20-reasoning"
+DEFAULT_TIMEOUT_SECONDS = 180
+DEFAULT_RETRIES = 2
+MAX_HANDLES = 10
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_base_url() -> str:
+    return (os.getenv("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        return load_config().get("x_search", {})
+    except Exception:
+        return {}
+
+
+def _get_model() -> str:
+    return (_load_config().get("model") or DEFAULT_MODEL).strip()
+
+
+def _get_timeout() -> int:
+    raw = _load_config().get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    try:
+        return max(10, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+
+
+def _get_retries() -> int:
+    raw = _load_config().get("retries", DEFAULT_RETRIES)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Requirement check
+# ---------------------------------------------------------------------------
+
+
+def check_x_search_requirements() -> bool:
+    """Return True if XAI_API_KEY is set."""
+    return bool(os.getenv("XAI_API_KEY"))
+
+
+# ---------------------------------------------------------------------------
+# Handle normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_handles(
+    handles: Optional[List[str]], field_name: str
+) -> List[str]:
+    """Strip @ prefixes, deduplicate, enforce MAX_HANDLES."""
+    if not handles:
+        return []
+    cleaned: List[str] = []
+    seen: set = set()
+    for h in handles:
+        if not isinstance(h, str):
+            continue
+        handle = h.strip().lstrip("@")
+        if not handle or handle in seen:
+            continue
+        seen.add(handle)
+        cleaned.append(handle)
+        if len(cleaned) >= MAX_HANDLES:
+            break
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    """Pull the assistant message text from a Responses API payload."""
+    # Fast path: top-level output_text (some SDK versions)
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    # Standard path: walk output items
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for block in item.get("content", []) or []:
+            if block.get("type") == "output_text":
+                parts.append(block.get("text", ""))
+    return "\n".join(parts).strip()
+
+
+def _extract_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract inline URL citations from the response."""
+    citations: List[Dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for block in item.get("content", []) or []:
+            for ann in block.get("annotations", []) or []:
+                if ann.get("type") != "url_citation":
+                    continue
+                citations.append(
+                    {
+                        "url": ann.get("url", ""),
+                        "title": ann.get("title", ""),
+                        "start_index": ann.get("start_index"),
+                        "end_index": ann.get("end_index"),
+                    }
+                )
+    return citations
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    """Extract a readable error from an HTTPError."""
+    resp = exc.response
+    if resp is None:
+        return str(exc)
+    try:
+        body = resp.json()
+        return body.get("error", {}).get("message", resp.text[:300])
+    except Exception:
+        return resp.text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Main tool function
+# ---------------------------------------------------------------------------
+
+
+def x_search_tool(
+    query: str,
+    allowed_x_handles: Optional[List[str]] = None,
+    excluded_x_handles: Optional[List[str]] = None,
+    from_date: str = "",
+    to_date: str = "",
+    enable_image_understanding: bool = False,
+    enable_video_understanding: bool = False,
+) -> str:
+    """Search X (Twitter) via xAI's native x_search tool.
+
+    Returns JSON with ``text``, ``citations``, and metadata.
+    """
+    if not query or not query.strip():
+        return tool_error("query is required for x_search")
+
+    api_key = os.getenv("XAI_API_KEY", "")
+    if not api_key:
+        return tool_error("XAI_API_KEY not set — add it to ~/.hermes/.env")
+
+    # Build the x_search tool definition
+    tool_def: Dict[str, Any] = {"type": "x_search"}
+
+    allowed = _normalize_handles(allowed_x_handles, "allowed_x_handles")
+    excluded = _normalize_handles(excluded_x_handles, "excluded_x_handles")
+
+    if allowed:
+        tool_def["allowed_x_handles"] = allowed
+    if excluded:
+        tool_def["excluded_x_handles"] = excluded
+    if from_date:
+        tool_def["from_date"] = from_date.strip()
+    if to_date:
+        tool_def["to_date"] = to_date.strip()
+    if enable_image_understanding:
+        tool_def["enable_image_understanding"] = True
+    if enable_video_understanding:
+        tool_def["enable_video_understanding"] = True
+
+    # Build payload
+    payload = {
+        "model": _get_model(),
+        "input": [{"role": "user", "content": query.strip()}],
+        "tools": [tool_def],
+    }
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+
+    timeout = _get_timeout()
+    max_retries = _get_retries()
+    url = f"{_get_base_url()}/responses"
+
+    # Retry loop
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries + 1):
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            last_error = None
+            break
+        except requests.HTTPError as exc:
+            last_error = exc
+            status = exc.response.status_code if exc.response else 0
+            if status in (400, 401, 403):
+                # Non-retryable
+                logger.error("x_search auth/client error: %s", _http_error_message(exc))
+                return tool_error(f"xSearch error ({status}): {_http_error_message(exc)}")
+            logger.warning(
+                "x_search HTTP %s on attempt %d/%d: %s",
+                status, attempt + 1, max_retries + 1, _http_error_message(exc),
+            )
+        except requests.ConnectionError as exc:
+            last_error = exc
+            logger.warning(
+                "x_search connection error on attempt %d/%d: %s",
+                attempt + 1, max_retries + 1, exc,
+            )
+        except requests.Timeout as exc:
+            last_error = exc
+            logger.warning(
+                "x_search timeout on attempt %d/%d: %s",
+                attempt + 1, max_retries + 1, exc,
+            )
+
+    # All retries exhausted
+    if last_error is not None:
+        if isinstance(last_error, requests.Timeout):
+            return tool_error(
+                f"xSearch timed out after {timeout}s ({max_retries + 1} attempts)"
+            )
+        return tool_error(f"xSearch failed after {max_retries + 1} attempts: {last_error}")
+
+    # Parse response
+    try:
+        payload = response.json()
+    except Exception as exc:
+        logger.error("x_search JSON decode failed: %s", exc)
+        return tool_error(f"xSearch: invalid JSON response from xAI")
+
+    text = _extract_response_text(payload)
+    citations = _extract_citations(payload)
+
+    if not text and not citations:
+        return tool_error("xSearch returned empty response")
+
+    result = {
+        "tool": "x_search",
+        "query": query.strip(),
+        "text": text,
+        "citations": citations,
+        "citation_count": len(citations),
+        "model": _get_model(),
+    }
+
+    logger.info(
+        "x_search completed: query=%r, text_len=%d, citations=%d",
+        query, len(text), len(citations),
+    )
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Tool schema
+# ---------------------------------------------------------------------------
+
+X_SEARCH_SCHEMA = {
+    "name": "x_search",
+    "description": (
+        "Search X (Twitter) posts, profiles, and threads using xAI's built-in "
+        "X Search tool. Use this for current discussion, reactions, or claims "
+        "on X rather than general web pages."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to look up on X.",
+            },
+            "allowed_x_handles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of X handles to search exclusively "
+                    f"(max {MAX_HANDLES})."
+                ),
+            },
+            "excluded_x_handles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of X handles to exclude "
+                    f"(max {MAX_HANDLES})."
+                ),
+            },
+            "from_date": {
+                "type": "string",
+                "description": "Optional start date in YYYY-MM-DD format.",
+            },
+            "to_date": {
+                "type": "string",
+                "description": "Optional end date in YYYY-MM-DD format.",
+            },
+            "enable_image_understanding": {
+                "type": "boolean",
+                "description": "Analyze images attached to matching X posts.",
+                "default": False,
+            },
+            "enable_video_understanding": {
+                "type": "boolean",
+                "description": "Analyze videos attached to matching X posts.",
+                "default": False,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handler + registration
+# ---------------------------------------------------------------------------
+
+
+def _handle_x_search(args: Dict[str, Any], **kw: Any) -> str:
+    return x_search_tool(
+        query=args.get("query", ""),
+        allowed_x_handles=args.get("allowed_x_handles"),
+        excluded_x_handles=args.get("excluded_x_handles"),
+        from_date=args.get("from_date", ""),
+        to_date=args.get("to_date", ""),
+        enable_image_understanding=args.get("enable_image_understanding", False),
+        enable_video_understanding=args.get("enable_video_understanding", False),
+    )
+
+
+registry.register(
+    name="x_search",
+    toolset="x_search",
+    schema=X_SEARCH_SCHEMA,
+    handler=_handle_x_search,
+    check_fn=check_x_search_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🐦",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -60,6 +60,8 @@ _HERMES_CORE_TOOLS = [
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # X/Twitter search via xAI (gated on XAI_API_KEY via check_fn)
+    "x_search",
 ]
 
 
@@ -90,7 +92,13 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-    
+
+    "x_search": {
+        "description": "Search X (Twitter) posts and profiles via xAI native search",
+        "tools": ["x_search"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "x_search",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -86,6 +86,12 @@ TOOLSETS = {
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
+        "includes": []
+    },
+
+    "x_search": {
+        "description": "Search X (Twitter) posts and threads using xAI's built-in x_search Responses API tool",
+        "tools": ["x_search"],
         "includes": []
     },
     

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -332,6 +332,21 @@ No configuration is needed — caching activates automatically when an xAI endpo
 
 xAI also ships a dedicated TTS endpoint (`/v1/tts`). Select **xAI TTS** in `hermes tools` → Voice & TTS, or see the [Voice & TTS](../user-guide/features/tts.md#text-to-speech) page for config.
 
+#### `x_search` tool — Search X (Twitter) via xAI
+
+Enable **🐦 X (Twitter) Search** in `hermes tools` and Hermes exposes an `x_search` tool that queries X posts using xAI's built-in `x_search` Responses API tool. Requires `XAI_API_KEY` (same key as the xAI provider).
+
+Optional `config.yaml` section:
+
+```yaml
+x_search:
+  model: grok-4.20-reasoning    # default
+  timeout_seconds: 180          # default (min 30)
+  retries: 2                    # default
+```
+
+The tool returns a natural-language answer with citations to the source X posts, and supports filtering by handles (up to 10 per query).
+
 ### Ollama Cloud — Managed Ollama Models, OAuth + API Key
 
 [Ollama Cloud](https://ollama.com/cloud) hosts the same open-weight catalog as local Ollama but without the GPU requirement. Pick it in `hermes model` as **Ollama Cloud**, paste your API key from [ollama.com/settings/keys](https://ollama.com/settings/keys), and Hermes auto-discovers the available models.

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -82,6 +82,7 @@ Or in-session:
 | `vision` | `vision_analyze` | Image analysis via vision-capable models. |
 | `video` | `video_analyze` | Video analysis and understanding tools (opt-in, not in the default toolset — add explicitly via `--toolsets`). |
 | `web` | `web_extract`, `web_search` | Web search and page content extraction. |
+| `x_search` | `x_search` | Search public X/Twitter content via xAI's Responses API `x_search` tool. Requires `XAI_API_KEY`. |
 | `yuanbao` | `yb_query_group_info`, `yb_query_group_members`, `yb_search_sticker`, `yb_send_dm`, `yb_send_sticker` | Yuanbao DM/group actions and sticker search. Registered only on `hermes-yuanbao`. |
 
 ## Platform Toolsets


### PR DESCRIPTION
## What does this PR do?

Add a new `x_search` tool that searches X (Twitter) posts, profiles, and threads using xAI's native x_search Responses API tool. xAI is the only provider with native access to X/Twitter data.

## Changes

- **`tools/x_search_tool.py`** (~350 LOC): Self-contained tool implementation
  - Uses xAI Responses API (`POST /v1/responses`) with `x_search` built-in tool
  - Supports query, allowed/excluded handles (max 10 each), date filters
  - Image and video understanding options for analyzing X media
  - Retry logic with configurable retries (default: 2, non-retryable on 4xx)
  - Config via `config.yaml` under `x_search:` section (model, timeout, retries)
  - Citation extraction from response annotations
  - Shared `xai_http.py` for User-Agent header

- **`tests/tools/test_x_search_tool.py`** (~300 LOC): 24 unit tests
  - Requirements check (with/without API key)
  - Handle normalization (@prefix stripping, dedup, max enforcement)
  - Response text extraction (output_text + output items paths)
  - Citation extraction (url_citation annotations)
  - Main function: missing query, missing key, successful search
  - Auth header verification (Bearer token, User-Agent)
  - Retry on 5xx, no retry on 4xx auth errors
  - Config defaults and overrides

- **`toolsets.py`**: Add `x_search` to `_HERMES_CORE_TOOLS` and `TOOLSETS` dict
- **`hermes_cli/tools_config.py`**: Add `x_search` to `CONFIGURABLE_TOOLSETS`

## How to Test

Requires `XAI_API_KEY` set in `~/.hermes/.env`. Get one at https://console.x.ai/

```bash
# Unit tests (24 tests)
python -m pytest tests/tools/test_x_search_tool.py -v

# Live API test
source ~/.hermes/.env
python3 -c "
import sys; sys.path.insert(0, '.')
from tools.x_search_tool import x_search_tool
result = x_search_tool(query='latest news about Hermes Agent')
print(result[:300])
"
```

## Design Decisions

- **One tool, one file**: Follows the same pattern as STT (#14473) and TTS (#10783)
- **Atomic PR**: x_search only — video_gen and image_gen will follow in separate PRs
- **Config-driven**: Model, timeout, retries configurable via `config.yaml`
- **Retry with backoff**: Retries on 5xx/connection errors, fast-fails on 4xx auth errors
