### PR TITLE
fix(tui): respect agent.max_turns config for iteration limit

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2008,3 +2008,130 @@ def test_prompt_submit_skips_auto_title_when_response_empty(monkeypatch):
         )
 
     mock_title.assert_not_called()
+
+
+# ── max_iterations config reading ─────────────────────────────────────
+
+
+def _setup_make_agent_mocks(monkeypatch, cfg):
+    """Common mock setup for _make_agent max_iterations tests."""
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(
+        server, "_resolve_startup_runtime",
+        lambda: ("test-model", None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        server, "_load_tool_progress_mode", lambda: "off"
+    )
+    monkeypatch.setattr(
+        server, "_load_reasoning_config", lambda: None
+    )
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_agent_cbs", lambda sid: {})
+
+
+def test_make_agent_reads_agent_max_turns(monkeypatch):
+    """_make_agent() reads max_iterations from agent.max_turns in config."""
+    _setup_make_agent_mocks(monkeypatch, {"agent": {"max_turns": 200}})
+
+    with patch("run_agent.AIAgent") as MockAgent:
+        server._make_agent("sid1", "key1")
+        _, kwargs = MockAgent.call_args
+        assert kwargs["max_iterations"] == 200
+
+
+def test_make_agent_falls_back_to_root_max_turns(monkeypatch):
+    """Without agent.max_turns, fall back to root-level max_turns."""
+    _setup_make_agent_mocks(monkeypatch, {"max_turns": 150})
+
+    with patch("run_agent.AIAgent") as MockAgent:
+        server._make_agent("sid1", "key1")
+        _, kwargs = MockAgent.call_args
+        assert kwargs["max_iterations"] == 150
+
+
+def test_make_agent_defaults_to_90(monkeypatch):
+    """With no max_turns anywhere, default to 90."""
+    _setup_make_agent_mocks(monkeypatch, {})
+
+    with patch("run_agent.AIAgent") as MockAgent:
+        server._make_agent("sid1", "key1")
+        _, kwargs = MockAgent.call_args
+        assert kwargs["max_iterations"] == 90
+
+
+def test_make_agent_agent_max_turns_takes_priority(monkeypatch):
+    """agent.max_turns takes priority over root-level max_turns."""
+    _setup_make_agent_mocks(
+        monkeypatch, {"agent": {"max_turns": 500}, "max_turns": 100}
+    )
+
+    with patch("run_agent.AIAgent") as MockAgent:
+        server._make_agent("sid1", "key1")
+        _, kwargs = MockAgent.call_args
+        assert kwargs["max_iterations"] == 500
+
+
+class _FakeAgentForBackground:
+    """Minimal stub with the attributes _background_agent_kwargs reads."""
+    base_url = None
+    api_key = None
+    provider = None
+    api_mode = None
+    acp_command = None
+    acp_args = None
+    model = "test-model"
+    enabled_toolsets = None
+    ephemeral_system_prompt = None
+    providers_allowed = None
+    providers_ignored = None
+    providers_order = None
+    provider_sort = None
+    provider_require_parameters = False
+    provider_data_collection = None
+    reasoning_config = None
+    service_tier = None
+    request_overrides = {}
+    _fallback_model = None
+
+
+def test_background_agent_kwargs_reads_agent_max_turns(monkeypatch):
+    """_background_agent_kwargs() reads max_iterations from agent.max_turns."""
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"max_turns": 300}}
+    )
+
+    kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
+    assert kwargs["max_iterations"] == 300
+
+
+def test_background_agent_kwargs_defaults_to_25(monkeypatch):
+    """With no max_turns, _background_agent_kwargs defaults to 25."""
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
+    assert kwargs["max_iterations"] == 25
+
+
+def test_background_agent_kwargs_falls_back_to_root_max_turns(monkeypatch):
+    """Without agent.max_turns, _background_agent_kwargs falls back to root max_turns."""
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"max_turns": 50}
+    )
+
+    kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
+    assert kwargs["max_iterations"] == 50

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1291,7 +1291,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
         "model": getattr(agent, "model", None) or _resolve_model(),
-        "max_iterations": int(cfg.get("max_turns", 25) or 25),
+        "max_iterations": int(cfg.get("agent", {}).get("max_turns") or cfg.get("max_turns") or 25),
         "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
         or _load_enabled_toolsets(),
         "quiet_mode": True,
@@ -1347,7 +1347,10 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     cfg = _load_cfg()
-    system_prompt = ((cfg.get("agent") or {}).get("system_prompt", "") or "").strip()
+    agent_cfg = cfg.get("agent") or {}
+    # Priority: agent.max_turns > root max_turns (backwards compat) > default 90
+    max_iterations = int(agent_cfg.get("max_turns") or cfg.get("max_turns") or 90)
+    system_prompt = (agent_cfg.get("system_prompt", "") or "").strip()
     model, requested_provider = _resolve_startup_runtime()
     runtime = resolve_runtime_provider(
         requested=requested_provider,
@@ -1355,6 +1358,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
     )
     return AIAgent(
         model=model,
+        max_iterations=max_iterations,
         provider=runtime.get("provider"),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
@@ -4411,7 +4415,7 @@ def _(rid, params: dict) -> dict:
             {
                 "title": "Agent",
                 "rows": [
-                    ["Max Turns", str(cfg.get("max_turns", 25))],
+                    ["Max Turns", str(cfg.get("agent", {}).get("max_turns") or cfg.get("max_turns") or 90)],
                     ["Toolsets", ", ".join(cfg.get("enabled_toolsets", [])) or "all"],
                     ["Verbose", str(cfg.get("verbose", False))],
                 ],


### PR DESCRIPTION
## What does this PR do?

The TUI gateway (`tui_gateway/server.py`) ignores the `agent.max_turns` config setting. Agents always hit hardcoded iteration limits (90 for main sessions, 25 for background tasks) regardless of what the user configured in `~/.hermes/config.yaml`.

The CLI (`cli.py` lines 1942-1949) reads `agent.max_turns` correctly. The TUI gateway diverged — it was never wired to the nested config path. Three sites were broken:

1. **`_make_agent()`** — never passes `max_iterations` to `AIAgent`, so the constructor always uses its default of 90.
2. **`_background_agent_kwargs()`** — reads `cfg.get("max_turns", 25)` from the root level, but the canonical config path is `agent.max_turns` (nested under `agent:`). The root-level key is always absent, so background agents always get 25.
3. **`config.show` RPC endpoint** — same wrong key, plus wrong default (shows 25 instead of 90). No frontend caller currently, but the data should be correct.

All three sites now use the same priority chain as CLI: `agent.max_turns` (nested) → `max_turns` (root, backwards compat) → default.

## Related Issue

None filed yet — bug discovered during local configuration debugging.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tui_gateway/server.py`** — 3 sites fixed:
  - `_make_agent()` (~line 1150): Extract `agent_cfg`, read `max_turns` with fallback chain, pass as `max_iterations` to `AIAgent`. Default 90.
  - `_background_agent_kwargs()` (~line 1092): `cfg.get("max_turns", 25)` → `cfg.get("agent", {}).get("max_turns") or cfg.get("max_turns") or 25`. Default 25.
  - `config.show` RPC endpoint (~line 3750): Same fix, default corrected from 25 to 90.

- **`tests/test_tui_gateway_server.py`** — 7 new tests:
  - `test_make_agent_reads_agent_max_turns` — `agent.max_turns: 200` → `max_iterations=200`
  - `test_make_agent_falls_back_to_root_max_turns` — root `max_turns: 150` → `150`
  - `test_make_agent_defaults_to_90` — no config → default `90`
  - `test_make_agent_agent_max_turns_takes_priority` — both present → nested wins
  - `test_background_agent_kwargs_reads_agent_max_turns` — `agent.max_turns: 300` → `300`
  - `test_background_agent_kwargs_defaults_to_25` — no config → default `25`
  - `test_background_agent_kwargs_falls_back_to_root_max_turns` — root `max_turns: 50` → `50`

## How to Test

1. Set `agent.max_turns: 200` in `~/.hermes/config.yaml`
2. Start the TUI: `hermes --tui`
3. `config.show` RPC now returns correct `agent.max_turns` with proper fallback (previously returned 25 from wrong key)
4. Use the agent for a multi-tool task — it should respect the 200-iteration limit instead of hitting 90
5. Run tests: `pytest tests/test_tui_gateway_server.py -v` — 59 pass (52 existing + 7 new)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
