### PR TITLE
feat(xai): add video generation tool — generate/edit/extend via xAI grok-imagine-video

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,20 +106,13 @@ def _codex_curated_models() -> list[str]:
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
-# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
-# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
-# or retires a model, the disk cache picks it up on the next refresh and the
-# fallback here only matters until that refresh lands.
+# install, offline first run, etc.). Keep this list conservative: it should
+# not advertise models scheduled for May 15, 2026 retirement.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
 ]
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -55,6 +55,8 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("x_search",        "🐦 X/Twitter Search (xAI)",    "x_search"),
+    ("video_gen",       "🎬 Video Generation (xAI)",    "video_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -83,7 +83,10 @@ CONFIGURABLE_TOOLSETS = [
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video",
+    "video_gen",
+}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -59,6 +59,8 @@ CONFIGURABLE_TOOLSETS = [
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("x_search",        "🐦 X/Twitter Search (xAI)",    "x_search"),
+    ("video_gen",       "🎬 Video Generation (xAI)",    "video_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -318,6 +318,7 @@ class TestBuiltinDiscovery:
             "tools.todo_tool",
             "tools.tts_tool",
             "tools.vision_tools",
+            "tools.video_generation_tool",
             "tools.web_tools",
             "tools.yuanbao_tools",
         }

--- a/tests/tools/test_video_generation_tool.py
+++ b/tests/tools/test_video_generation_tool.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Tests for tools/video_generation_tool.py."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure XAI_API_KEY is set for all tests."""
+    monkeypatch.setenv("XAI_API_KEY", "test-key-12345")
+
+
+# ---------------------------------------------------------------------------
+# check_video_generation_requirements
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRequirements:
+    def test_returns_true_with_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "sk-xxx")
+        from tools.video_generation_tool import check_video_generation_requirements
+        assert check_video_generation_requirements() is True
+
+    def test_returns_false_without_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.video_generation_tool import check_video_generation_requirements
+        assert check_video_generation_requirements() is False
+
+    def test_returns_false_empty_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "   ")
+        from tools.video_generation_tool import check_video_generation_requirements
+        assert check_video_generation_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeOperation:
+    def test_default(self):
+        from tools.video_generation_tool import _normalize_operation
+        assert _normalize_operation(None) == "generate"
+        assert _normalize_operation("") == "generate"
+
+    def test_valid_operations(self):
+        from tools.video_generation_tool import _normalize_operation
+        assert _normalize_operation("generate") == "generate"
+        assert _normalize_operation("edit") == "edit"
+        assert _normalize_operation("extend") == "extend"
+
+    def test_case_insensitive(self):
+        from tools.video_generation_tool import _normalize_operation
+        assert _normalize_operation("Generate") == "generate"
+        assert _normalize_operation("EDIT") == "edit"
+
+    def test_invalid_raises(self):
+        from tools.video_generation_tool import _normalize_operation
+        with pytest.raises(ValueError, match="operation must be"):
+            _normalize_operation("invalid")
+
+
+class TestNormalizeDuration:
+    def test_default_generate(self):
+        from tools.video_generation_tool import _normalize_duration
+        assert _normalize_duration(None, "generate") == 8
+
+    def test_default_extend(self):
+        from tools.video_generation_tool import _normalize_duration
+        assert _normalize_duration(None, "extend") == 6
+
+    def test_clamps_max_generate(self):
+        from tools.video_generation_tool import _normalize_duration
+        assert _normalize_duration(100, "generate") == 15
+
+    def test_clamps_max_extend(self):
+        from tools.video_generation_tool import _normalize_duration
+        assert _normalize_duration(100, "extend") == 10
+
+    def test_clamps_min(self):
+        from tools.video_generation_tool import _normalize_duration
+        assert _normalize_duration(0, "generate") == 1
+
+
+class TestNormalizeAspectRatio:
+    def test_default(self):
+        from tools.video_generation_tool import _normalize_aspect_ratio
+        assert _normalize_aspect_ratio(None) == "16:9"
+
+    def test_valid(self):
+        from tools.video_generation_tool import _normalize_aspect_ratio
+        assert _normalize_aspect_ratio("1:1") == "1:1"
+        assert _normalize_aspect_ratio("9:16") == "9:16"
+
+    def test_invalid_raises(self):
+        from tools.video_generation_tool import _normalize_aspect_ratio
+        with pytest.raises(ValueError, match="aspect_ratio must be"):
+            _normalize_aspect_ratio("21:9")
+
+
+class TestNormalizeResolution:
+    def test_default(self):
+        from tools.video_generation_tool import _normalize_resolution
+        assert _normalize_resolution(None) == "720p"
+
+    def test_valid(self):
+        from tools.video_generation_tool import _normalize_resolution
+        assert _normalize_resolution("480p") == "480p"
+        assert _normalize_resolution("720p") == "720p"
+
+    def test_invalid_raises(self):
+        from tools.video_generation_tool import _normalize_resolution
+        with pytest.raises(ValueError, match="resolution must be"):
+            _normalize_resolution("1080p")
+
+
+class TestNormalizeSize:
+    def test_none(self):
+        from tools.video_generation_tool import _normalize_size
+        assert _normalize_size(None) is None
+        assert _normalize_size("") is None
+
+    def test_valid(self):
+        from tools.video_generation_tool import _normalize_size
+        assert _normalize_size("1280x720") == "1280x720"
+
+    def test_invalid_raises(self):
+        from tools.video_generation_tool import _normalize_size
+        with pytest.raises(ValueError, match="size must be"):
+            _normalize_size("1920x1080p")
+
+
+class TestNormalizeReferenceImages:
+    def test_empty(self):
+        from tools.video_generation_tool import _normalize_reference_images
+        assert _normalize_reference_images(None) == []
+        assert _normalize_reference_images([]) == []
+
+    def test_strips_whitespace(self):
+        from tools.video_generation_tool import _normalize_reference_images
+        result = _normalize_reference_images([" https://example.com/img.png "])
+        assert result == ["https://example.com/img.png"]
+
+    def test_max_5(self):
+        from tools.video_generation_tool import _normalize_reference_images
+        images = [f"https://example.com/{i}.png" for i in range(10)]
+        result = _normalize_reference_images(images)
+        assert len(result) == 5
+
+    def test_skips_non_strings(self):
+        from tools.video_generation_tool import _normalize_reference_images
+        result = _normalize_reference_images(["https://ok.png", 123, None, ""])
+        assert result == ["https://ok.png"]
+
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+
+
+class TestXaiHeaders:
+    def test_returns_headers(self):
+        from tools.video_generation_tool import _xai_headers
+        headers = _xai_headers()
+        assert "Bearer test-key-12345" in headers["Authorization"]
+        assert "application/json" in headers["Content-Type"]
+        assert "Hermes-Agent" in headers["User-Agent"]
+
+    def test_raises_without_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.video_generation_tool import _xai_headers
+        with pytest.raises(ValueError, match="XAI_API_KEY not set"):
+            _xai_headers()
+
+
+# ---------------------------------------------------------------------------
+# video_generate_tool (async main function)
+# ---------------------------------------------------------------------------
+
+
+class TestVideoGenerateTool:
+    @pytest.mark.asyncio
+    async def test_missing_prompt_for_generate(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="", operation="generate")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "prompt or image_url" in parsed["error"]
+
+    @pytest.mark.asyncio
+    async def test_edit_requires_video_url(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test", operation="edit")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "video_url" in parsed["error"]
+
+    @pytest.mark.asyncio
+    async def test_extend_requires_video_url(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test", operation="extend")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "video_url" in parsed["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_operation(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test", operation="invalid")
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    @pytest.mark.asyncio
+    async def test_invalid_aspect_ratio(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test", aspect_ratio="21:9")
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    @pytest.mark.asyncio
+    async def test_invalid_resolution(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test", resolution="4k")
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    @pytest.mark.asyncio
+    async def test_timeout_too_low(self):
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test", timeout_seconds=5)
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from tools.video_generation_tool import video_generate_tool
+        result = await video_generate_tool(prompt="test")
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    @pytest.mark.asyncio
+    async def test_successful_generation(self):
+        """Test successful video generation with mocked httpx."""
+        from tools.video_generation_tool import video_generate_tool
+
+        # Mock submit response
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json = MagicMock(return_value={"id": "job-123"})
+
+        # Mock poll response (done)
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json = MagicMock(return_value={
+            "status": "done",
+            "video": {"url": "https://xai.video/result.mp4"},
+            "model": "grok-imagine-video",
+        })
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=submit_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            result = await video_generate_tool(
+                prompt="A cat playing piano",
+                timeout_seconds=30,
+                poll_interval_seconds=1,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "done"
+        assert parsed["video_url"] == "https://xai.video/result.mp4"
+        assert parsed["tool"] == "video_generate"
+
+    @pytest.mark.asyncio
+    async def test_failed_generation(self):
+        """Test failed video generation."""
+        from tools.video_generation_tool import video_generate_tool
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json = MagicMock(return_value={"id": "job-456"})
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json = MagicMock(return_value={
+            "status": "failed",
+            "error": {"message": "Content policy violation"},
+        })
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=submit_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            result = await video_generate_tool(
+                prompt="test",
+                timeout_seconds=30,
+                poll_interval_seconds=1,
+            )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Content policy" in parsed["error"]
+
+    @pytest.mark.asyncio
+    async def test_submit_auth_error(self):
+        """Test auth error on submit (no retry)."""
+        import httpx as httpx_lib
+        from tools.video_generation_tool import video_generate_tool
+
+        error_resp = MagicMock()
+        error_resp.status_code = 401
+        error_resp.text = "Unauthorized"
+        error_resp.json = MagicMock(return_value={"error": {"message": "Invalid API key"}})
+        error_resp.raise_for_status = MagicMock(
+            side_effect=httpx_lib.HTTPStatusError("401", request=MagicMock(), response=error_resp)
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=error_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            result = await video_generate_tool(prompt="test")
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    @pytest.mark.asyncio
+    async def test_image_to_video(self):
+        """Test image-to-video generation."""
+        from tools.video_generation_tool import video_generate_tool
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json = MagicMock(return_value={"id": "job-789"})
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json = MagicMock(return_value={
+            "status": "done",
+            "video": {"url": "https://xai.video/img2vid.mp4"},
+        })
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=submit_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            result = await video_generate_tool(
+                image_url="https://example.com/cat.png",
+                timeout_seconds=30,
+                poll_interval_seconds=1,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "done"
+        assert parsed["video_url"] == "https://xai.video/img2vid.mp4"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from tools.video_generation_tool import _get_model
+        assert _get_model() == "grok-imagine-video"
+
+    def test_default_timeout(self):
+        from tools.video_generation_tool import _get_timeout
+        assert _get_timeout() == 240
+
+    def test_default_poll_interval(self):
+        from tools.video_generation_tool import _get_poll_interval
+        assert _get_poll_interval() == 5
+
+    def test_custom_config(self):
+        with patch("tools.video_generation_tool._load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "model": "grok-video-fast",
+                "timeout_seconds": 120,
+                "poll_interval_seconds": 2,
+            }
+            from tools.video_generation_tool import _get_model, _get_timeout, _get_poll_interval
+            assert _get_model() == "grok-video-fast"
+            assert _get_timeout() == 120
+            assert _get_poll_interval() == 2

--- a/tests/tools/test_video_generation_tool.py
+++ b/tests/tools/test_video_generation_tool.py
@@ -152,11 +152,11 @@ class TestNormalizeReferenceImages:
         result = _normalize_reference_images([" https://example.com/img.png "])
         assert result == ["https://example.com/img.png"]
 
-    def test_max_5(self):
+    def test_max_7(self):
         from tools.video_generation_tool import _normalize_reference_images
         images = [f"https://example.com/{i}.png" for i in range(10)]
         result = _normalize_reference_images(images)
-        assert len(result) == 5
+        assert len(result) == 7
 
     def test_skips_non_strings(self):
         from tools.video_generation_tool import _normalize_reference_images
@@ -259,7 +259,7 @@ class TestVideoGenerateTool:
         submit_resp = MagicMock()
         submit_resp.status_code = 200
         submit_resp.raise_for_status = MagicMock()
-        submit_resp.json = MagicMock(return_value={"id": "job-123"})
+        submit_resp.json = MagicMock(return_value={"request_id": "req-123"})
 
         # Mock poll response (done)
         poll_resp = MagicMock()
@@ -288,6 +288,14 @@ class TestVideoGenerateTool:
         assert parsed["status"] == "done"
         assert parsed["video_url"] == "https://xai.video/result.mp4"
         assert parsed["tool"] == "video_generate"
+        post_url = mock_client.post.call_args.args[0]
+        post_body = mock_client.post.call_args.kwargs["json"]
+        poll_url = mock_client.get.call_args.args[0]
+        assert post_url.endswith("/videos/generations")
+        assert poll_url.endswith("/videos/req-123")
+        assert post_body["prompt"] == "A cat playing piano"
+        assert post_body["resolution"] == "720p"
+        assert "operation" not in post_body
 
     @pytest.mark.asyncio
     async def test_failed_generation(self):
@@ -297,7 +305,7 @@ class TestVideoGenerateTool:
         submit_resp = MagicMock()
         submit_resp.status_code = 200
         submit_resp.raise_for_status = MagicMock()
-        submit_resp.json = MagicMock(return_value={"id": "job-456"})
+        submit_resp.json = MagicMock(return_value={"request_id": "req-456"})
 
         poll_resp = MagicMock()
         poll_resp.status_code = 200
@@ -357,7 +365,7 @@ class TestVideoGenerateTool:
         submit_resp = MagicMock()
         submit_resp.status_code = 200
         submit_resp.raise_for_status = MagicMock()
-        submit_resp.json = MagicMock(return_value={"id": "job-789"})
+        submit_resp.json = MagicMock(return_value={"request_id": "req-789"})
 
         poll_resp = MagicMock()
         poll_resp.status_code = 200
@@ -383,6 +391,123 @@ class TestVideoGenerateTool:
         parsed = json.loads(result)
         assert parsed["status"] == "done"
         assert parsed["video_url"] == "https://xai.video/img2vid.mp4"
+        post_body = mock_client.post.call_args.kwargs["json"]
+        assert post_body["image"] == {"url": "https://example.com/cat.png"}
+        assert "image_url" not in post_body
+
+    @pytest.mark.asyncio
+    async def test_edit_uses_official_endpoint_and_video_url(self):
+        """Test video edit request shape."""
+        from tools.video_generation_tool import video_generate_tool
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json = MagicMock(return_value={"request_id": "edit-1"})
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json = MagicMock(return_value={
+            "status": "done",
+            "video": {"url": "https://xai.video/edit.mp4"},
+        })
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=submit_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            await video_generate_tool(
+                prompt="Add sunglasses",
+                operation="edit",
+                video_url="https://example.com/source.mp4",
+                timeout_seconds=30,
+                poll_interval_seconds=1,
+            )
+
+        post_url = mock_client.post.call_args.args[0]
+        post_body = mock_client.post.call_args.kwargs["json"]
+        assert post_url.endswith("/videos/edits")
+        assert post_body["video_url"] == "https://example.com/source.mp4"
+
+    @pytest.mark.asyncio
+    async def test_extend_uses_official_endpoint_and_video_object(self):
+        """Test video extension request shape."""
+        from tools.video_generation_tool import video_generate_tool
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json = MagicMock(return_value={"request_id": "extend-1"})
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json = MagicMock(return_value={
+            "status": "done",
+            "video": {"url": "https://xai.video/extend.mp4"},
+        })
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=submit_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            await video_generate_tool(
+                prompt="Pan left",
+                operation="extend",
+                video_url="https://example.com/source.mp4",
+                timeout_seconds=30,
+                poll_interval_seconds=1,
+            )
+
+        post_url = mock_client.post.call_args.args[0]
+        post_body = mock_client.post.call_args.kwargs["json"]
+        assert post_url.endswith("/videos/extensions")
+        assert post_body["video"] == {"url": "https://example.com/source.mp4"}
+
+    @pytest.mark.asyncio
+    async def test_reference_images_are_url_objects(self):
+        """Test reference-to-video request shape."""
+        from tools.video_generation_tool import video_generate_tool
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json = MagicMock(return_value={"request_id": "ref-1"})
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json = MagicMock(return_value={
+            "status": "done",
+            "video": {"url": "https://xai.video/ref.mp4"},
+        })
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=submit_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tools.video_generation_tool.httpx.AsyncClient", return_value=mock_client):
+            await video_generate_tool(
+                prompt="Use the reference",
+                reference_images=["https://example.com/a.png", "https://example.com/b.png"],
+                timeout_seconds=30,
+                poll_interval_seconds=1,
+            )
+
+        post_body = mock_client.post.call_args.kwargs["json"]
+        assert post_body["reference_images"] == [
+            {"url": "https://example.com/a.png"},
+            {"url": "https://example.com/b.png"},
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+Video Generation Tool — Generate videos via xAI's grok-imagine-video API.
+
+Supports text-to-video, image-to-video, video editing, and video extension.
+Uses async submit + polling pattern.
+
+Requires ``XAI_API_KEY`` in ``~/.hermes/.env``.
+
+Configuration (optional, in config.yaml)::
+
+    video_generation:
+      model: grok-imagine-video     # default
+      timeout_seconds: 240          # default
+      poll_interval_seconds: 5      # default
+
+Usage::
+
+    from tools.video_generation_tool import video_generate_tool, check_video_generation_requirements
+
+    result = await video_generate_tool(prompt="A cat playing piano")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_MODEL = "grok-imagine-video"
+DEFAULT_OPERATION = "generate"
+DEFAULT_DURATION = 8
+DEFAULT_ASPECT_RATIO = "16:9"
+DEFAULT_RESOLUTION = "720p"
+DEFAULT_TIMEOUT_SECONDS = 240
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
+VALID_RESOLUTIONS = {"480p", "720p"}
+VALID_SIZES = {"848x480", "1696x960", "1280x720", "1920x1080"}
+VALID_OPERATIONS = {"generate", "edit", "extend"}
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_base_url() -> str:
+    return (os.getenv("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        return load_config().get("video_generation", {})
+    except Exception:
+        return {}
+
+
+def _get_model() -> str:
+    return (_load_config().get("model") or DEFAULT_MODEL).strip()
+
+
+def _get_timeout() -> int:
+    raw = _load_config().get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    try:
+        return max(30, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+
+
+def _get_poll_interval() -> int:
+    raw = _load_config().get("poll_interval_seconds", DEFAULT_POLL_INTERVAL_SECONDS)
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_POLL_INTERVAL_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Requirement check
+# ---------------------------------------------------------------------------
+
+
+def check_video_generation_requirements() -> bool:
+    """Return True if XAI_API_KEY is set."""
+    return bool(os.getenv("XAI_API_KEY", "").strip())
+
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+
+
+def _xai_headers() -> Dict[str, str]:
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("XAI_API_KEY not set")
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize_operation(operation: Optional[str]) -> str:
+    op = (operation or DEFAULT_OPERATION).strip().lower()
+    if op not in VALID_OPERATIONS:
+        raise ValueError(f"operation must be one of {sorted(VALID_OPERATIONS)}")
+    return op
+
+
+def _normalize_duration(duration: Optional[int], operation: str) -> int:
+    if duration is None:
+        return 6 if operation == "extend" else DEFAULT_DURATION
+    try:
+        d = int(duration)
+    except (TypeError, ValueError):
+        return DEFAULT_DURATION
+    if operation == "extend":
+        return max(1, min(d, 10))
+    return max(1, min(d, 15))
+
+
+def _normalize_aspect_ratio(ar: Optional[str]) -> str:
+    normalized = (ar or DEFAULT_ASPECT_RATIO).strip()
+    if normalized not in VALID_ASPECT_RATIOS:
+        raise ValueError(f"aspect_ratio must be one of {sorted(VALID_ASPECT_RATIOS)}")
+    return normalized
+
+
+def _normalize_resolution(res: Optional[str]) -> str:
+    normalized = (res or DEFAULT_RESOLUTION).strip().lower()
+    if normalized not in VALID_RESOLUTIONS:
+        raise ValueError(f"resolution must be one of {sorted(VALID_RESOLUTIONS)}")
+    return normalized
+
+
+def _normalize_size(size: Optional[str]) -> Optional[str]:
+    if not size:
+        return None
+    normalized = size.strip().lower()
+    if normalized not in VALID_SIZES:
+        raise ValueError(f"size must be one of {sorted(VALID_SIZES)}")
+    return normalized
+
+
+def _normalize_reference_images(
+    images: Optional[List[str]],
+) -> List[str]:
+    if not images:
+        return []
+    cleaned: List[str] = []
+    for img in images:
+        if isinstance(img, str) and img.strip():
+            cleaned.append(img.strip())
+    return cleaned[:5]  # max 5 reference images
+
+
+# ---------------------------------------------------------------------------
+# Main tool function
+# ---------------------------------------------------------------------------
+
+
+async def video_generate_tool(
+    prompt: str = "",
+    operation: str = DEFAULT_OPERATION,
+    duration: Optional[int] = None,
+    aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    resolution: str = DEFAULT_RESOLUTION,
+    size: Optional[str] = None,
+    video_url: Optional[str] = None,
+    image_url: Optional[str] = None,
+    reference_images: Optional[List[str]] = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
+) -> str:
+    """Generate, edit, or extend a video using xAI's grok-imagine-video.
+
+    Returns JSON with ``video_url``, ``status``, and metadata.
+    """
+    # Validate inputs
+    try:
+        normalized_op = _normalize_operation(operation)
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    if normalized_op in ("edit", "extend") and not video_url:
+        return tool_error(f"operation '{normalized_op}' requires video_url")
+
+    if normalized_op == "generate" and not prompt and not image_url:
+        return tool_error("generate requires prompt or image_url")
+
+    try:
+        normalized_duration = _normalize_duration(duration, normalized_op)
+        normalized_ar = _normalize_aspect_ratio(aspect_ratio)
+        normalized_res = _normalize_resolution(resolution)
+        normalized_size = _normalize_size(size)
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    ref_images = _normalize_reference_images(reference_images)
+
+    if timeout_seconds < 30:
+        return tool_error("timeout_seconds must be at least 30")
+    if poll_interval_seconds < 1:
+        return tool_error("poll_interval_seconds must be at least 1")
+
+    # Build submit body
+    submit_body: Dict[str, Any] = {
+        "model": _get_model(),
+        "operation": normalized_op,
+    }
+
+    if prompt:
+        submit_body["prompt"] = prompt.strip()
+    if image_url and normalized_op == "generate":
+        submit_body["image_url"] = image_url.strip()
+    if video_url and normalized_op in ("edit", "extend"):
+        submit_body["video_url"] = video_url.strip()
+    if ref_images:
+        submit_body["reference_images"] = ref_images
+
+    # Duration for generate/extend
+    if normalized_op in ("generate", "extend"):
+        submit_body["duration"] = normalized_duration
+
+    # Aspect ratio + resolution for generate
+    if normalized_op == "generate":
+        submit_body["aspect_ratio"] = normalized_ar
+        submit_body["resolution"] = normalized_res
+        if normalized_size:
+            submit_body["size"] = normalized_size
+
+    try:
+        headers = _xai_headers()
+    except ValueError as exc:
+        return tool_error(str(exc))
+    base_url = _get_base_url()
+
+    async with httpx.AsyncClient() as client:
+        # Step 1: Submit generation request
+        try:
+            submit_response = await client.post(
+                f"{base_url}/video/generate",
+                headers=headers,
+                json=submit_body,
+                timeout=30,
+            )
+            submit_response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            try:
+                err_msg = exc.response.json().get("error", {}).get("message", exc.response.text[:300])
+            except Exception:
+                err_msg = exc.response.text[:300]
+            logger.error("video_gen submit failed (%d): %s", status, err_msg)
+            if status in (400, 401, 403):
+                return tool_error(f"Video generation auth error ({status}): {err_msg}")
+            return tool_error(f"Video generation submit failed ({status}): {err_msg}")
+        except httpx.TimeoutException:
+            return tool_error("Video generation submit timed out")
+        except httpx.ConnectError as exc:
+            return tool_error(f"Video generation connection error: {exc}")
+
+        submit_payload = submit_response.json()
+        job_id = submit_payload.get("id") or submit_payload.get("job_id")
+        if not job_id:
+            return tool_error("Video generation: no job ID returned")
+
+        logger.info("video_gen submitted: job_id=%s, op=%s", job_id, normalized_op)
+
+        # Step 2: Poll for completion
+        elapsed = 0
+        last_status = "queued"
+
+        while elapsed < timeout_seconds:
+            await asyncio.sleep(poll_interval_seconds)
+            elapsed += poll_interval_seconds
+
+            try:
+                status_response = await client.get(
+                    f"{base_url}/video/generate/{job_id}",
+                    headers=headers,
+                    timeout=15,
+                )
+                status_response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                logger.warning("video_gen poll failed: %s", exc)
+                continue
+            except httpx.TimeoutException:
+                logger.warning("video_gen poll timeout at %ds", elapsed)
+                continue
+
+            status_payload = status_response.json()
+            last_status = (status_payload.get("status") or "").lower()
+
+            if last_status == "done":
+                video = status_payload.get("video") or {}
+                video_url_result = video.get("url") or status_payload.get("video_url", "")
+
+                result = {
+                    "tool": "video_generate",
+                    "status": "done",
+                    "video_url": video_url_result,
+                    "duration": normalized_duration,
+                    "operation": normalized_op,
+                    "model": status_payload.get("model", _get_model()),
+                    "usage": status_payload.get("usage"),
+                }
+
+                logger.info(
+                    "video_gen completed: job_id=%s, url=%s",
+                    job_id, video_url_result[:100] if video_url_result else "none",
+                )
+
+                return json.dumps(result, ensure_ascii=False)
+
+            if last_status in {"failed", "error", "expired", "cancelled"}:
+                err_msg = (
+                    status_payload.get("error", {}).get("message")
+                    or status_payload.get("message")
+                    or f"Video generation ended with status '{last_status}'"
+                )
+                logger.error("video_gen failed: job_id=%s, status=%s", job_id, last_status)
+                return tool_error(f"Video generation {last_status}: {err_msg}")
+
+            logger.debug("video_gen status: %s (%ds elapsed)", last_status, elapsed)
+
+        # Timeout
+        return tool_error(
+            f"Video generation timed out after {timeout_seconds}s (status: {last_status})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool schema
+# ---------------------------------------------------------------------------
+
+VIDEO_GENERATE_SCHEMA = {
+    "name": "video_generate",
+    "description": (
+        "Generate, edit, or extend short videos with xAI grok-imagine-video. "
+        "Supports text-to-video, image-to-video, reference-image-guided generation, "
+        "native video edits, and native video extensions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Describe the video to generate, edit, or extend. "
+                    "Optional only for image-to-video where the image alone is the instruction."
+                ),
+            },
+            "operation": {
+                "type": "string",
+                "enum": sorted(VALID_OPERATIONS),
+                "description": (
+                    "Video mode: 'generate' for new videos, 'edit' to modify existing, "
+                    "'extend' to continue an existing video."
+                ),
+                "default": DEFAULT_OPERATION,
+            },
+            "duration": {
+                "type": "integer",
+                "description": (
+                    "Duration in seconds. Generate: 1-15s. Extend: 1-10s. "
+                    "Edit retains source duration."
+                ),
+                "default": DEFAULT_DURATION,
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": sorted(VALID_ASPECT_RATIOS),
+                "description": "Output aspect ratio for generate mode.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+            "resolution": {
+                "type": "string",
+                "enum": sorted(VALID_RESOLUTIONS),
+                "description": "Output resolution for generate mode.",
+                "default": DEFAULT_RESOLUTION,
+            },
+            "size": {
+                "type": "string",
+                "enum": sorted(VALID_SIZES),
+                "description": "Optional explicit output size for generate mode.",
+            },
+            "video_url": {
+                "type": "string",
+                "description": "Required for edit and extend modes. Source video URL.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Optional source image URL for image-to-video generation.",
+            },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional reference image URLs to guide generation (max 5).",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handler + registration
+# ---------------------------------------------------------------------------
+
+
+async def _handle_video_generate(args: Dict[str, Any], **kw: Any) -> str:
+    return await video_generate_tool(
+        prompt=args.get("prompt", ""),
+        operation=args.get("operation", DEFAULT_OPERATION),
+        duration=args.get("duration"),
+        aspect_ratio=args.get("aspect_ratio", DEFAULT_ASPECT_RATIO),
+        resolution=args.get("resolution", DEFAULT_RESOLUTION),
+        size=args.get("size"),
+        video_url=args.get("video_url"),
+        image_url=args.get("image_url"),
+        reference_images=args.get("reference_images"),
+    )
+
+
+registry.register(
+    name="video_generate",
+    toolset="video_gen",
+    schema=VIDEO_GENERATE_SCHEMA,
+    handler=_handle_video_generate,
+    check_fn=check_video_generation_requirements,
+    requires_env=["XAI_API_KEY"],
+    is_async=True,
+    emoji="🎬",
+)

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -3,7 +3,8 @@
 Video Generation Tool — Generate videos via xAI's grok-imagine-video API.
 
 Supports text-to-video, image-to-video, video editing, and video extension.
-Uses async submit + polling pattern.
+Uses the async submit + polling pattern:
+POST /v1/videos/generations|edits|extensions, then GET /v1/videos/{request_id}.
 
 Requires ``XAI_API_KEY`` in ``~/.hermes/.env``.
 
@@ -53,6 +54,11 @@ VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
 VALID_RESOLUTIONS = {"480p", "720p"}
 VALID_SIZES = {"848x480", "1696x960", "1280x720", "1920x1080"}
 VALID_OPERATIONS = {"generate", "edit", "extend"}
+OPERATION_ENDPOINTS = {
+    "generate": "generations",
+    "edit": "edits",
+    "extend": "extensions",
+}
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -173,7 +179,7 @@ def _normalize_reference_images(
     for img in images:
         if isinstance(img, str) and img.strip():
             cleaned.append(img.strip())
-    return cleaned[:5]  # max 5 reference images
+    return cleaned[:7]  # xAI allows up to 7 reference images
 
 
 # ---------------------------------------------------------------------------
@@ -228,17 +234,18 @@ async def video_generate_tool(
     # Build submit body
     submit_body: Dict[str, Any] = {
         "model": _get_model(),
-        "operation": normalized_op,
     }
 
     if prompt:
         submit_body["prompt"] = prompt.strip()
     if image_url and normalized_op == "generate":
-        submit_body["image_url"] = image_url.strip()
-    if video_url and normalized_op in ("edit", "extend"):
+        submit_body["image"] = {"url": image_url.strip()}
+    if video_url and normalized_op == "edit":
         submit_body["video_url"] = video_url.strip()
+    if video_url and normalized_op == "extend":
+        submit_body["video"] = {"url": video_url.strip()}
     if ref_images:
-        submit_body["reference_images"] = ref_images
+        submit_body["reference_images"] = [{"url": img} for img in ref_images]
 
     # Duration for generate/extend
     if normalized_op in ("generate", "extend"):
@@ -261,7 +268,7 @@ async def video_generate_tool(
         # Step 1: Submit generation request
         try:
             submit_response = await client.post(
-                f"{base_url}/video/generate",
+                f"{base_url}/videos/{OPERATION_ENDPOINTS[normalized_op]}",
                 headers=headers,
                 json=submit_body,
                 timeout=30,
@@ -283,11 +290,11 @@ async def video_generate_tool(
             return tool_error(f"Video generation connection error: {exc}")
 
         submit_payload = submit_response.json()
-        job_id = submit_payload.get("id") or submit_payload.get("job_id")
-        if not job_id:
-            return tool_error("Video generation: no job ID returned")
+        request_id = submit_payload.get("request_id")
+        if not request_id:
+            return tool_error("Video generation: no request_id returned")
 
-        logger.info("video_gen submitted: job_id=%s, op=%s", job_id, normalized_op)
+        logger.info("video_gen submitted: request_id=%s, op=%s", request_id, normalized_op)
 
         # Step 2: Poll for completion
         elapsed = 0
@@ -299,7 +306,7 @@ async def video_generate_tool(
 
             try:
                 status_response = await client.get(
-                    f"{base_url}/video/generate/{job_id}",
+                    f"{base_url}/videos/{request_id}",
                     headers=headers,
                     timeout=15,
                 )
@@ -329,8 +336,8 @@ async def video_generate_tool(
                 }
 
                 logger.info(
-                    "video_gen completed: job_id=%s, url=%s",
-                    job_id, video_url_result[:100] if video_url_result else "none",
+                    "video_gen completed: request_id=%s, url=%s",
+                    request_id, video_url_result[:100] if video_url_result else "none",
                 )
 
                 return json.dumps(result, ensure_ascii=False)
@@ -341,7 +348,7 @@ async def video_generate_tool(
                     or status_payload.get("message")
                     or f"Video generation ended with status '{last_status}'"
                 )
-                logger.error("video_gen failed: job_id=%s, status=%s", job_id, last_status)
+                logger.error("video_gen failed: request_id=%s, status=%s", request_id, last_status)
                 return tool_error(f"Video generation {last_status}: {err_msg}")
 
             logger.debug("video_gen status: %s (%ds elapsed)", last_status, elapsed)

--- a/toolsets.py
+++ b/toolsets.py
@@ -60,6 +60,10 @@ _HERMES_CORE_TOOLS = [
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # X/Twitter search via xAI (gated on XAI_API_KEY via check_fn)
+    "x_search",
+    # Video generation via xAI (gated on XAI_API_KEY via check_fn)
+    "video_generate",
 ]
 
 
@@ -90,13 +94,25 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-    
+
+    "x_search": {
+        "description": "Search X (Twitter) posts and profiles via xAI native search",
+        "tools": ["x_search"],
+        "includes": []
+    },
+
+    "video_gen": {
+        "description": "Generate, edit, or extend videos via xAI grok-imagine-video",
+        "tools": ["video_generate"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
         "includes": []
     },
-    
+
     "moa": {
         "description": "Advanced reasoning and problem-solving tools",
         "tools": ["mixture_of_agents"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Video generation via xAI (gated on XAI_API_KEY via check_fn)
+    "video_generate",
 ]
 
 
@@ -117,12 +119,18 @@ TOOLSETS = {
         "includes": []
     },
 
+    "video_gen": {
+        "description": "Generate, edit, or extend videos via xAI grok-imagine-video",
+        "tools": ["video_generate"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
         "includes": []
     },
-    
+
     "moa": {
         "description": "Advanced reasoning and problem-solving tools",
         "tools": ["mixture_of_agents"],

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -82,6 +82,7 @@ Or in-session:
 | `vision` | `vision_analyze` | Image analysis via vision-capable models. |
 | `video` | `video_analyze` | Video analysis and understanding tools (opt-in, not in the default toolset — add explicitly via `--toolsets`). |
 | `web` | `web_extract`, `web_search` | Web search and page content extraction. |
+| `video_gen` | `video_generate` | Generate, edit, or extend video via xAI Grok Imagine Video. Requires `XAI_API_KEY`; opt-in for new installs. |
 | `yuanbao` | `yb_query_group_info`, `yb_query_group_members`, `yb_search_sticker`, `yb_send_dm`, `yb_send_sticker` | Yuanbao DM/group actions and sticker search. Registered only on `hermes-yuanbao`. |
 
 ## Platform Toolsets


### PR DESCRIPTION
## What does this PR do?

Add a new async `video_generate` tool that generates, edits, or extends videos using xAI's grok-imagine-video API. Uses submit + polling pattern for async video generation.

## Changes

- **`tools/video_generation_tool.py`** (~450 LOC): Self-contained async tool implementation
  - Uses xAI `/video/generate` endpoint with async httpx polling
  - Supports three operations: `generate`, `edit`, `extend`
  - Text-to-video, image-to-video, reference-image-guided generation
  - Configurable duration (1-15s generate, 1-10s extend)
  - Aspect ratio (7 options), resolution (480p/720p), explicit size
  - Timeout and poll interval configurable via `config.yaml` under `video_generation:`
  - Shared `xai_http.py` for User-Agent header

- **`tests/tools/test_video_generation_tool.py`** (~400 LOC): 43 unit tests
  - Requirements check (with/without/empty API key)
  - Input normalization: operation, duration, aspect_ratio, resolution, size, reference_images
  - Headers verification
  - Async main function: missing prompt, edit/extend requires video_url, invalid operation/aspect_ratio/resolution, timeout too low, missing API key
  - Successful generation, failed generation, auth error, image-to-video
  - Config defaults and overrides

- **`toolsets.py`**: Add `video_generate` to `_HERMES_CORE_TOOLS` and `video_gen` toolset
- **`hermes_cli/tools_config.py`**: Add `video_gen` to `CONFIGURABLE_TOOLSETS`

## How to Test

Requires `XAI_API_KEY` set in `~/.hermes/.env`. Get one at https://console.x.ai/

```bash
# Unit tests (43 tests)
python -m pytest tests/tools/test_video_generation_tool.py -v

# Live API test (takes ~30-60 seconds for video generation)
source ~/.hermes/.env
python3 -c "
import asyncio, sys; sys.path.insert(0, '.')
from tools.video_generation_tool import video_generate_tool
result = asyncio.run(video_generate_tool(prompt='A cat playing piano', duration=5))
print(result[:300])
"
```

## Design Decisions

- **Async pattern**: Video generation is async (submit + poll), uses httpx.AsyncClient
- **One tool, one file**: Follows the same pattern as STT (#14473), TTS (#10783), and x_search (#14541)
- **Atomic PR**: video_gen only — image_gen xAI backend will follow in a separate PR
- **Config-driven**: Model, timeout, poll_interval configurable via `config.yaml`
- **Three operations**: generate (text/image-to-video), edit (modify existing), extend (continue existing)
