### PR TITLE
fix(windows): native Git Bash support, fix silent write failures when WSL is installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 .claude/settings.local.json
+.claude/skills/sync-repos/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ mini-swe-agent/
 .nix-stamps/
 result
 website/static/api/skills-index.json
+.claude/settings.local.json

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -19,7 +19,7 @@ _TITLE_PROMPT = (
 )
 
 
-def generate_title(user_message: str, assistant_response: str, timeout: float = 30.0) -> Optional[str]:
+def generate_title(user_message: str, assistant_response: str, timeout: float = None) -> Optional[str]:
     """Generate a session title from the first exchange.
 
     Uses the auxiliary LLM client (cheapest/fastest available model).

--- a/docs/fix-streaming-partial-response-persistence.md
+++ b/docs/fix-streaming-partial-response-persistence.md
@@ -1,0 +1,103 @@
+# Fix: Streaming Partial Response Lost on Page Refresh
+
+## Problem
+
+When the user refreshes the chat page while the AI is streaming a response, the partial (in-progress) assistant response was lost. Only messages already fully persisted to the database survived the refresh.
+
+## Root Cause
+
+The streaming text existed only in two places during generation:
+
+1. **Frontend React state** (`ChatPage.tsx`) — lost on page refresh
+2. **Agent in-memory variable** (`run_agent.py` `_current_streamed_assistant_text`) — never persisted until the full response completes
+
+Additionally, the page had no mechanism to remember which session was active — on refresh, if the URL didn't contain `?resume=<id>`, the page would start a new empty session.
+
+## Fix (Applied)
+
+Three layers of defense ensure partial responses survive interruptions:
+
+### Layer 1: Periodic Mid-Stream DB Flush
+
+**File: `hermes_cli/web_server.py`** — `_flush_stream_partial()`, `_on_delta()` hook
+
+The `_on_delta` WebSocket callback now accumulates streamed text into `stream_partial_text` and periodically flushes it to the database:
+
+- Every ~80 characters of new content
+- Every 0.5 seconds minimum interval
+- Uses `_persist_interrupted_streaming_text()` to save with `finish_reason="interrupted"`
+- `replace_interrupted_assistant_message()` handles dedup by UPDATE-ing existing partial rows
+
+This means even if the browser crashes (not just refreshes), the partial text is already in the database.
+
+### Layer 2: Disconnect-Time Save
+
+**File: `hermes_cli/web_server.py`** — `_persist_interrupted_streaming_response()`
+
+On WebSocket disconnect (page refresh, browser close, server shutdown), extracts the agent's `_current_streamed_assistant_text` and persists it before calling `interrupt()`. Handles three paths:
+
+- `chat.interrupt` RPC (user clicks stop button)
+- `WebSocketDisconnect` (page refresh / browser close)
+- `asyncio.CancelledError` (server shutdown)
+
+### Layer 3: Frontend Session Memory
+
+**File: `web/src/pages/ChatPage.tsx`** — `rememberedChatSession()` / `rememberChatSession()` / `forgetChatSession()`
+
+The session ID is persisted to `localStorage` (`hermes.chat.activeSessionId`). On page load:
+
+1. Try URL `?resume=<id>` param first
+2. Fall back to `localStorage` if no URL param
+3. Load messages from DB for the resumed session
+4. Browser URL is updated via `replaceState` so subsequent refreshes also work
+5. "New session" button clears `localStorage` and starts fresh
+
+### Agent Flush Dedup
+
+**Files: `hermes_state.py` + `run_agent.py`**
+
+When the agent thread eventually finishes and `_flush_messages_to_session_db()` runs, it calls `replace_interrupted_assistant_message()` instead of inserting a new row. This replaces the partial text saved by Layer 1/2 with the final complete response, preventing duplicate messages.
+
+## Data Flow After Fix
+
+```
+Streaming starts:
+  _on_delta("Hello") → stream_partial_text = "Hello"
+  _on_delta(" world") → stream_partial_text = "Hello world"
+  ... 80 chars accumulated ...
+  _flush_stream_partial() → DB: assistant "Hello world..." (finish_reason=interrupted)
+
+User refreshes page:
+  → WebSocket disconnects
+  → _persist_interrupted_streaming_response() saves full partial text to DB
+  → agent.interrupt() called
+  → New page loads
+  → rememberedChatSession() reads session ID from localStorage
+  → Fetches messages from DB → partial response IS there
+  → Agent thread finishes, _flush_messages_to_session_db() runs
+  → replace_interrupted_assistant_message() replaces partial with final → no duplicate
+```
+
+## Changed Files
+
+### `hermes_cli/web_server.py`
+
+- **`_persist_interrupted_streaming_text()`** — low-level helper: saves partial text to DB with dedup/replace logic
+- **`_persist_interrupted_streaming_response()`** — extracts `_current_streamed_assistant_text` from running agent, delegates to above
+- **`_on_delta()` hook** — accumulates `stream_partial_text`, calls `_flush_stream_partial()` every ~80 chars / 0.5s
+- **Disconnect handlers** — all three exit paths (`WebSocketDisconnect`, `CancelledError`, `chat.interrupt`) call `_persist_interrupted_streaming_response()` before `agent.interrupt()`
+
+### `hermes_state.py`
+
+- **`replace_interrupted_assistant_message()`** — atomic UPDATE of an existing `finish_reason="interrupted"` row. Checks content prefix overlap, keeps the longer version. Full parameter support (tool_calls, reasoning, etc.).
+
+### `run_agent.py`
+
+- **`_flush_messages_to_session_db()`** — before INSERT, tries `replace_interrupted_assistant_message()` for assistant messages. If replaced, skips INSERT (`continue`). This prevents duplicates when the agent flushes after the WebSocket handler already saved the partial text.
+
+### `web/src/pages/ChatPage.tsx`
+
+- **`rememberedChatSession()`** / **`rememberChatSession()`** / **`forgetChatSession()`** — localStorage helpers for session ID persistence
+- **`initSession()`** — tries URL `resume` param, then localStorage, to restore the previous session
+- **`session.created` handler** — saves session ID to localStorage and updates browser URL
+- **`startNewSession()`** — clears localStorage before creating a new session

--- a/docs/windows-dual-agent-guide.md
+++ b/docs/windows-dual-agent-guide.md
@@ -1,0 +1,394 @@
+# Windows PowerShell 双 Agent 启动与管理指南
+
+本文档面向在 Windows 原生环境（PowerShell 7+）同时运行两个 Hermes Agent 实例（`default` 和 `turing`）的用户，涵盖 Gateway、Web 仪表盘、Profile 管理以及常见告警处理。
+
+相关前置文档：
+- Windows 安装与环境配置：见 `D:\Code\hermes-agent-windows-R\README.md`
+- 本仓库：`D:\Code\goldie-fork\hermes-agent`
+
+---
+
+## 目录
+
+- [前置准备](#前置准备)
+- [启动 default Agent](#启动-default-agent)
+- [启动 turing Agent](#启动-turing-agent)
+- [同时运行两个 Agent](#同时运行两个-agent)
+- [Web 仪表盘访问](#web-仪表盘访问)
+- [Agent / Profile 管理](#agent--profile-管理)
+- [常见告警](#常见告警)
+- [故障排查](#故障排查)
+
+---
+
+## 前置准备
+
+### 激活虚拟环境
+
+每个新开的 PowerShell 窗口都需要先激活一次：
+
+```powershell
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+```
+
+激活成功后提示符前会出现 `(venv)`。
+
+> 若提示脚本执行被禁止：
+> ```powershell
+> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+> ```
+
+### 确认前端已构建
+
+Web 仪表盘默认由 Python 服务器托管构建后的静态文件，位于 `hermes_cli/web_dist/`。如果是首次运行或修改了前端，请先构建：
+
+```powershell
+cd web
+npm install          # 首次安装依赖
+npm run build
+cd ..
+```
+
+此后只要不再改动前端，直接启动 Python 服务器即可，无需 `npm run dev`。
+
+---
+
+## 启动 default Agent
+
+默认 profile 对应 `~/.hermes/`（即 `C:\Users\<用户名>\.hermes\`）。
+
+### 1. 启动 Gateway（消息平台 + 定时任务）
+
+```powershell
+hermes gateway run
+```
+
+看到如下 banner 即代表成功：
+
+```
+┌─────────────────────────────────────────────────────────┐
+│           ⚕ Hermes Gateway Starting...                 │
+├─────────────────────────────────────────────────────────┤
+│  Messaging platforms + cron scheduler                   │
+│  Press Ctrl+C to stop                                   │
+└─────────────────────────────────────────────────────────┘
+```
+
+> 只有在配置了 Telegram / Discord / Slack 等平台时才需要 Gateway。仅用 Web UI 聊天可以不启动。
+
+### 2. 启动 Web 仪表盘
+
+**新开一个 PowerShell 窗口**，激活虚拟环境后：
+
+```powershell
+python -m hermes_cli.main dashboard --no-open
+```
+
+输出：
+```
+→ Building web UI...
+  ✓ Web UI built
+  Hermes Web UI → http://127.0.0.1:9119
+```
+
+浏览器打开 `http://127.0.0.1:9119` 即可。
+
+---
+
+## 启动 turing Agent
+
+turing profile 对应 `C:\Users\<用户名>\.hermes\profiles\turing\`。
+
+### 方式一：`-p` 参数（推荐，不改默认 profile）
+
+```powershell
+hermes -p turing gateway run
+```
+
+### 方式二：通过 `HERMES_HOME` 环境变量
+
+适合 Web 仪表盘场景，因为 `dashboard` 子命令本身不支持 `-p` 参数：
+
+```powershell
+$env:HERMES_HOME = "C:\Users\gotmo\.hermes\profiles\turing"
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+python -m hermes_cli.main dashboard --no-open --port 9120
+```
+
+> **注意端口要改**（例如 9120），避免和默认 9119 冲突。
+
+输出：
+```
+Hermes Web UI → http://127.0.0.1:9120
+```
+
+> ⚠️ `$env:HERMES_HOME` 只在当前 PowerShell 会话有效。关闭窗口后失效。
+
+### 方式三：设为默认 profile
+
+```powershell
+hermes profile use turing   # 切换
+hermes gateway run          # 此时等同于 -p turing
+hermes profile use default  # 用完切回
+```
+
+---
+
+## 同时运行两个 Agent
+
+典型场景：一个开 4 个 PowerShell 窗口，每个窗口跑一个进程。
+
+| 窗口 | 任务 | 命令 |
+|------|------|------|
+| #1 | default Gateway | `hermes gateway run` |
+| #2 | default Dashboard（端口 9119）| `python -m hermes_cli.main dashboard --no-open` |
+| #3 | turing Gateway | `hermes -p turing gateway run` |
+| #4 | turing Dashboard（端口 9120）| 见下方 |
+
+**窗口 #4 的完整命令：**
+
+```powershell
+$env:HERMES_HOME = "C:\Users\gotmo\.hermes\profiles\turing"
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+python -m hermes_cli.main dashboard --no-open --port 9120
+```
+
+运行完成后：
+- default Web UI → `http://127.0.0.1:9119`
+- turing Web UI → `http://127.0.0.1:9120`
+
+---
+
+## Web 仪表盘访问
+
+构建好前端后，Web UI 的所有功能（Status / Sessions / Chat / Analytics / Logs / Cron / Skills / Config / Keys）直接通过 Python 服务器提供，**不需要 Vite 开发服务器**。
+
+### 何时需要 `npm run dev`
+
+只有在**修改前端源码并希望热更新**时才使用：
+
+```powershell
+cd D:\Code\goldie-fork\hermes-agent\web
+npm run dev
+```
+
+开发服务器会在 `http://localhost:5188` 启动。它需要一个后端实例作为数据源（默认指向 `http://127.0.0.1:9119`）。指向 turing：
+
+```powershell
+$env:HERMES_DASHBOARD_URL = "http://127.0.0.1:9120"
+npm run dev
+```
+
+### Chat 页面
+
+新增的 `/chat` 页面支持：
+- 创建新会话 / 恢复旧会话（从 Sessions 页面点"打开"图标跳转 `?resume=<id>`）
+- 流式助手输出、工具调用实时显示、中断正在运行的会话
+- 斜杠命令：在输入框键入 `/` 会弹出命令列表
+
+---
+
+## Agent / Profile 管理
+
+### 列出所有 Profile
+
+```powershell
+hermes profile list
+```
+
+输出示例：
+```
+ Profile      Model              Gateway      Alias
+ ───────────    ───────────────    ───────────    ────────
+ ◆default     glm-4.7            stopped      —
+  turing      MiniMax-M2.7       stopped      turing
+```
+
+### 创建 Profile
+
+```powershell
+hermes profile create <名字> --clone   # 克隆 default 配置
+hermes profile create <名字>           # 从空白开始
+```
+
+Profile 目录位于 `C:\Users\<用户名>\.hermes\profiles\<名字>\`，包含独立的 `config.yaml`、`.env`、`SOUL.md`、`state.db` 等。
+
+### 查看 Profile 详情
+
+```powershell
+hermes profile show turing
+```
+
+### 重命名 / 删除
+
+```powershell
+hermes profile rename turing ada
+hermes profile delete turing
+```
+
+> 删除操作会要求确认。Profile 目录下的所有数据（会话历史、技能、配置）都会被清除。
+
+### 配置模型 / API Key
+
+针对指定 profile 配置：
+
+```powershell
+hermes -p turing model        # 切换 LLM 模型
+hermes -p turing setup        # 交互式配置 API key
+hermes -p turing tools        # 管理工具开关
+hermes -p turing doctor       # 诊断环境问题
+hermes -p turing config set terminal.cwd "D:\Code\your-project"
+```
+
+### 切换默认 Profile
+
+```powershell
+hermes profile use turing     # 设为默认
+hermes profile use default    # 切回
+```
+
+---
+
+## 常见告警
+
+### ⚠ TERMINAL_CWD 在 .env 中已废弃
+
+启动时可能看到：
+
+```
+⚠ Deprecated .env settings detected:
+  ⚠ TERMINAL_CWD=D:\Code\goldie-fork\hermes-agent found in .env — this is deprecated.
+  Move to config.yaml instead:  terminal:
+    cwd: /your/project/path
+  Then remove the old entries from C:\Users\gotmo\.hermes\profiles\turing/.env
+```
+
+**含义：** Hermes 早期版本用 `.env` 里的 `TERMINAL_CWD` 指定 Agent 执行命令的默认工作目录。新版本改为通过 `config.yaml` 的 `terminal.cwd` 字段来配置，更统一、更结构化。
+
+**解决步骤（针对 turing profile）：**
+
+#### 1. 写入 `config.yaml`
+
+最简单的方式：
+
+```powershell
+hermes -p turing config set terminal.cwd "D:\Code\goldie-fork\hermes-agent"
+```
+
+或手动编辑 `C:\Users\gotmo\.hermes\profiles\turing\config.yaml`，新增：
+
+```yaml
+terminal:
+  cwd: D:\Code\goldie-fork\hermes-agent
+```
+
+> 路径使用 Windows 绝对路径即可。`tools/platform_compat.py` 内部会自动转成 `/d/Code/...` 的 MSYS 形式传给 Git Bash。
+
+#### 2. 从 `.env` 移除旧条目
+
+用编辑器打开 `C:\Users\gotmo\.hermes\profiles\turing\.env`，删除这一行：
+
+```
+TERMINAL_CWD=D:\Code\goldie-fork\hermes-agent
+```
+
+#### 3. 重启 Agent
+
+关闭正在运行的 dashboard / gateway 后重新启动，告警就会消失。
+
+> 对 default profile 同理，只是路径是 `C:\Users\<用户名>\.hermes\.env` 和 `config.yaml`。
+
+---
+
+## 故障排查
+
+### Q: Chat 页面一直 "Connecting…"？
+
+确认你访问的地址：
+- `http://127.0.0.1:9119` 或 `:9120` → Python 服务器，直接可用
+- `http://localhost:5188` → Vite 开发服务器，需要同时启动 Python dashboard 作为后端
+
+Vite 开发服务器的 WebSocket 代理已在 `web/vite.config.ts` 中配置，启动前请确保对应的 dashboard 正在运行。
+
+### Q: 端口 9119 已被占用？
+
+```powershell
+# 查找占用端口的进程
+Get-NetTCPConnection -LocalPort 9119 | Select-Object -ExpandProperty OwningProcess | ForEach-Object { Get-Process -Id $_ }
+
+# 终止
+taskkill /PID <pid> /F
+```
+
+或直接换端口：`--port 9121`。
+
+### Q: `HERMES_HOME` 设错了怎么办？
+
+```powershell
+$env:HERMES_HOME = $null     # 清除当前会话的环境变量
+```
+
+或直接关闭 PowerShell 窗口重开。全局设置（非临时）需在"系统属性 → 环境变量"中修改。
+
+### Q: Web UI 显示 "Frontend not built"？
+
+```powershell
+cd D:\Code\goldie-fork\hermes-agent\web
+npm run build
+```
+
+构建产物会输出到 `D:\Code\goldie-fork\hermes-agent\hermes_cli\web_dist\`。
+
+### Q: `hermes` 命令找不到？
+
+虚拟环境未激活。执行：
+
+```powershell
+.\venv\Scripts\Activate.ps1
+```
+
+提示符出现 `(venv)` 后再试。
+
+### Q: Sessions 页面点"打开"进不了 Chat？
+
+确认 URL 形如 `http://127.0.0.1:9119/chat?resume=<session-id>`。如果历史记录没有展示，检查浏览器 DevTools → Network 中是否有 `/api/sessions/<id>/messages` 的请求被 401 拦截。通常是 session token 过期，刷新页面即可重新注入。
+
+---
+
+## 快速参考：完整启动流程
+
+```powershell
+# ── 窗口 1：default Gateway ──
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+hermes gateway run
+
+# ── 窗口 2：default Web UI ──
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+python -m hermes_cli.main dashboard --no-open
+# → http://127.0.0.1:9119
+
+# ── 窗口 3：turing Gateway ──
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+hermes -p turing gateway run
+
+# ── 窗口 4：turing Web UI ──
+$env:HERMES_HOME = "C:\Users\gotmo\.hermes\profiles\turing"
+cd D:\Code\goldie-fork\hermes-agent
+.\venv\Scripts\Activate.ps1
+python -m hermes_cli.main dashboard --no-open --port 9120
+# → http://127.0.0.1:9120
+```
+
+---
+
+## 相关文档
+
+- `D:\Code\hermes-agent-windows-R\README.md` — Windows 原生安装指南（uv、虚拟环境、依赖安装）
+- `WINDOWS_SUPPORT.md` — Windows 跨平台 helper 技术细节
+- `website/docs/user-guide/features/web-dashboard.md` — Web 仪表盘功能说明

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -214,7 +214,10 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
     if not pid_path.exists():
         return None
 
-    raw = pid_path.read_text().strip()
+    try:
+        raw = pid_path.read_text().strip()
+    except (PermissionError, OSError):
+        return None
     if not raw:
         return None
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -748,7 +748,7 @@ class PluginManager:
             if yaml is None:
                 logger.warning("PyYAML not installed – cannot load %s", manifest_file)
                 return None
-            data = yaml.safe_load(manifest_file.read_text()) or {}
+            data = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
 
             name = data.get("name", plugin_dir.name)
             key = f"{prefix}/{plugin_dir.name}" if prefix else name

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3028,7 +3028,7 @@ def _handle_web_model_command(
             pass
         lines.append("`/model <name>` - switch model")
         lines.append("`/model <name> --provider <slug>` - switch provider")
-        lines.append("`/model provider:model` - shorthand (e.g., `/model zai:glm-5.1`)")
+        lines.append("`/model provider/model` - shorthand (e.g., `/model zai/glm-5.1`)")
         lines.append("`/model <name> --global` - persist to config")
         return "\n".join(lines)
 
@@ -3328,6 +3328,20 @@ async def tui_gateway_ws(websocket: WebSocket):
                         final = result.get("final_response", "") or ""
                         _notify("assistant.done", {"text": final})
                         _reply(rpc_id, {"ok": True})
+
+                        # Auto-generate session title after first exchange
+                        if final and db:
+                            try:
+                                from agent.title_generator import maybe_auto_title
+                                maybe_auto_title(
+                                    db,
+                                    sid_for_run,
+                                    message,
+                                    final,
+                                    history,
+                                )
+                            except Exception:
+                                pass
                     except Exception as exc:
                         _log.exception("tui_gateway agent error: %s", exc)
                         _notify("error", {"message": str(exc)})

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3329,6 +3329,25 @@ async def tui_gateway_ws(websocket: WebSocket):
                         _notify("assistant.done", {"text": final})
                         _reply(rpc_id, {"ok": True})
 
+                        # Push usage/model info for the web status bar
+                        try:
+                            ctx_len = getattr(
+                                getattr(agent, "context_compressor", None),
+                                "context_length", 0,
+                            )
+                            _notify("usage.update", {
+                                "model": getattr(agent, "model", ""),
+                                "provider": getattr(agent, "provider", ""),
+                                "api_calls": getattr(agent, "session_api_calls", 0),
+                                "input_tokens": getattr(agent, "session_input_tokens", 0),
+                                "output_tokens": getattr(agent, "session_output_tokens", 0),
+                                "total_tokens": getattr(agent, "session_total_tokens", 0),
+                                "context_length": ctx_len,
+                                "estimated_cost_usd": getattr(agent, "session_estimated_cost_usd", 0.0),
+                            })
+                        except Exception:
+                            pass
+
                         # Auto-generate session title after first exchange
                         if final and db:
                             try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2919,12 +2919,11 @@ def _persist_interrupted_streaming_response(agent: Any, session_id: str) -> bool
     )
 
 
-def _normalize_colon_syntax(raw_args: str) -> str:
-    """Convert provider:model syntax to --provider flag syntax.
+def _normalize_provider_model_syntax(raw_args: str) -> str:
+    """Convert provider/model syntax to --provider flag syntax.
 
-    Handles "zai:glm-5.1" → "glm-5.1 --provider zai" etc., while
-    preserving OpenRouter variant suffixes (:free, :extended, :fast)
-    and leaving existing --provider flags untouched.
+    Handles "zai/glm-5.1" → "glm-5.1 --provider zai" etc.
+    while leaving existing --provider flags untouched.
     """
     if "--provider" in raw_args:
         return raw_args
@@ -2941,19 +2940,18 @@ def _normalize_colon_syntax(raw_args: str) -> str:
         "xiaomi", "mimo",
         "arcee", "trinity",
     }
-    variant_suffixes = {"free", "extended", "fast"}
 
     parts = raw_args.split()
     if not parts:
         return raw_args
 
     first = parts[0]
-    if ":" in first:
-        colon_pos = first.index(":")
-        left = first[:colon_pos].lower()
-        right = first[colon_pos + 1:]
+    if "/" in first:
+        slash_pos = first.index("/")
+        left = first[:slash_pos].lower()
+        right = first[slash_pos + 1:]
 
-        if left in known_prefixes and right.lower() not in variant_suffixes:
+        if left in known_prefixes and right:
             parts[0] = right
             parts.extend(["--provider", left])
             return " ".join(parts)
@@ -2978,7 +2976,7 @@ def _handle_web_model_command(
     from hermes_cli.providers import get_label
     from gateway.run import _load_gateway_config
 
-    cmd_args = _normalize_colon_syntax(cmd_args)
+    cmd_args = _normalize_provider_model_syntax(cmd_args)
     model_input, explicit_provider, persist_global = parse_model_flags(cmd_args)
 
     cfg = _load_gateway_config()
@@ -3134,6 +3132,7 @@ async def tui_gateway_ws(websocket: WebSocket):
     loop = asyncio.get_running_loop()
     session_id: Optional[str] = None
     agent_ref: List[Any] = [None]   # mutable container so interrupt() can reach the agent
+    agent_future = None              # track running executor future for cancellation
     session_model_override: dict = {}  # per-connection model override from /model command
 
     def _notify(method: str, params: dict) -> None:
@@ -3242,6 +3241,18 @@ async def tui_gateway_ws(websocket: WebSocket):
 
                 sid_for_run = session_id
 
+                # ── Interrupt any previous agent before starting a new one ──
+                if agent_future is not None:
+                    ag = agent_ref[0]
+                    if ag is not None:
+                        _persist_interrupted_streaming_response(ag, session_id)
+                        ag.interrupt()
+                    try:
+                        await asyncio.wait_for(agent_future, timeout=5.0)
+                    except (asyncio.TimeoutError, Exception):
+                        pass
+                    agent_future = None
+
                 # Ensure the session row exists immediately so the dashboard
                 # can detect the active session even if the agent is interrupted
                 # before its first DB flush.
@@ -3256,6 +3267,7 @@ async def tui_gateway_ws(websocket: WebSocket):
                     pass
 
                 def _run_agent_thread():
+                    agent = None
                     try:
                         from run_agent import AIAgent
                         from gateway.run import (
@@ -3321,9 +3333,10 @@ async def tui_gateway_ws(websocket: WebSocket):
                         _notify("error", {"message": str(exc)})
                         _reply(rpc_id, error={"code": -32603, "message": str(exc)})
                     finally:
-                        agent_ref[0] = None
+                        if agent_ref[0] is agent:
+                            agent_ref[0] = None
 
-                await loop.run_in_executor(None, _run_agent_thread)
+                agent_future = loop.run_in_executor(None, _run_agent_thread)
 
             elif method == "chat.interrupt":
                 ag = agent_ref[0]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2837,6 +2837,88 @@ def _ws_send_sync(loop, ws, msg: dict) -> None:
     asyncio.run_coroutine_threadsafe(ws.send_json(msg), loop)
 
 
+def _persist_interrupted_streaming_text(
+    db: Any,
+    session_id: str,
+    partial_text: str,
+    *,
+    source: str = "api_server",
+    model: str = None,
+) -> bool:
+    """Persist the assistant text already streamed to the dashboard."""
+    if not session_id:
+        return False
+
+    partial_text = partial_text or ""
+    if not partial_text.strip():
+        return False
+
+    close_db = False
+    if db is None:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        close_db = True
+
+    try:
+        try:
+            db.ensure_session(
+                session_id,
+                source=source or "api_server",
+                model=model,
+            )
+        except Exception:
+            pass
+
+        if hasattr(db, "replace_interrupted_assistant_message") and db.replace_interrupted_assistant_message(
+            session_id=session_id,
+            content=partial_text,
+            finish_reason="interrupted",
+        ):
+            return True
+
+        existing_messages = db.get_messages(session_id)
+        if existing_messages:
+            last = existing_messages[-1]
+            last_content = last.get("content") or ""
+            if (
+                last.get("role") == "assistant"
+                and last_content
+                and (partial_text.startswith(last_content) or last_content.startswith(partial_text))
+            ):
+                return False
+
+        db.append_message(
+            session_id=session_id,
+            role="assistant",
+            content=partial_text,
+            finish_reason="interrupted",
+        )
+        return True
+    except Exception as exc:
+        _log.warning("Failed to persist interrupted streaming response: %s", exc)
+        return False
+    finally:
+        if close_db:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _persist_interrupted_streaming_response(agent: Any, session_id: str) -> bool:
+    """Persist the assistant text accumulated by a running agent."""
+    if agent is None:
+        return False
+
+    return _persist_interrupted_streaming_text(
+        getattr(agent, "_session_db", None),
+        session_id,
+        getattr(agent, "_current_streamed_assistant_text", "") or "",
+        source=getattr(agent, "platform", None) or "api_server",
+        model=getattr(agent, "model", None),
+    )
+
+
 def _normalize_colon_syntax(raw_args: str) -> str:
     """Convert provider:model syntax to --provider flag syntax.
 
@@ -3116,9 +3198,39 @@ async def tui_gateway_ws(websocket: WebSocket):
                         _reply(rpc_id, {"ok": True})
                         continue
 
+                stream_partial_text = ""
+                stream_last_flush_len = 0
+                stream_last_flush_time = 0.0
+
+                def _flush_stream_partial(force: bool = False) -> None:
+                    nonlocal stream_last_flush_len, stream_last_flush_time
+                    if not stream_partial_text.strip():
+                        return
+                    now = time.monotonic()
+                    if (
+                        not force
+                        and stream_last_flush_len > 0
+                        and len(stream_partial_text) - stream_last_flush_len < 80
+                        and now - stream_last_flush_time < 0.5
+                    ):
+                        return
+                    ag = agent_ref[0]
+                    if _persist_interrupted_streaming_text(
+                        getattr(ag, "_session_db", None) if ag is not None else None,
+                        sid_for_run,
+                        stream_partial_text,
+                        source=getattr(ag, "platform", None) if ag is not None else "api_server",
+                        model=getattr(ag, "model", None) if ag is not None else None,
+                    ):
+                        stream_last_flush_len = len(stream_partial_text)
+                        stream_last_flush_time = now
+
                 def _on_delta(delta):
+                    nonlocal stream_partial_text
                     if delta is None:
                         return
+                    stream_partial_text += delta
+                    _flush_stream_partial()
                     _notify("assistant.delta", {"text": delta})
 
                 def _on_tool_event(event_type: str, tool_name: str = None,
@@ -3216,6 +3328,7 @@ async def tui_gateway_ws(websocket: WebSocket):
             elif method == "chat.interrupt":
                 ag = agent_ref[0]
                 if ag is not None:
+                    _persist_interrupted_streaming_response(ag, session_id)
                     ag.interrupt()
                 _reply(rpc_id, {"ok": True})
 
@@ -3223,10 +3336,20 @@ async def tui_gateway_ws(websocket: WebSocket):
                 if rpc_id is not None:
                     _reply(rpc_id, error={"code": -32601, "message": f"Unknown method: {method}"})
 
+    except asyncio.CancelledError:
+        ag = agent_ref[0]
+        if ag is not None:
+            try:
+                _persist_interrupted_streaming_response(ag, session_id)
+                ag.interrupt()
+            except Exception:
+                pass
+        raise
     except WebSocketDisconnect:
         ag = agent_ref[0]
         if ag is not None:
             try:
+                _persist_interrupted_streaming_response(ag, session_id)
                 ag.interrupt()
             except Exception:
                 pass

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2837,6 +2837,203 @@ def _ws_send_sync(loop, ws, msg: dict) -> None:
     asyncio.run_coroutine_threadsafe(ws.send_json(msg), loop)
 
 
+def _normalize_colon_syntax(raw_args: str) -> str:
+    """Convert provider:model syntax to --provider flag syntax.
+
+    Handles "zai:glm-5.1" → "glm-5.1 --provider zai" etc., while
+    preserving OpenRouter variant suffixes (:free, :extended, :fast)
+    and leaving existing --provider flags untouched.
+    """
+    if "--provider" in raw_args:
+        return raw_args
+
+    known_prefixes = {
+        "zai", "z-ai", "z.ai", "glm", "zhipu",
+        "xai", "x-ai", "x.ai", "grok",
+        "anthropic", "openai", "google", "gemini",
+        "deepseek", "minimax", "nvidia", "nim",
+        "openrouter", "nous", "ollama",
+        "copilot", "github-copilot",
+        "moonshot", "kimi", "kimi-coding",
+        "stepfun", "step",
+        "xiaomi", "mimo",
+        "arcee", "trinity",
+    }
+    variant_suffixes = {"free", "extended", "fast"}
+
+    parts = raw_args.split()
+    if not parts:
+        return raw_args
+
+    first = parts[0]
+    if ":" in first:
+        colon_pos = first.index(":")
+        left = first[:colon_pos].lower()
+        right = first[colon_pos + 1:]
+
+        if left in known_prefixes and right.lower() not in variant_suffixes:
+            parts[0] = right
+            parts.extend(["--provider", left])
+            return " ".join(parts)
+
+    return raw_args
+
+
+def _handle_web_model_command(
+    cmd_args: str,
+    session_override: dict,
+    agent_ref: list,
+) -> str:
+    """Handle /model command for the web chat interface.
+
+    Returns confirmation/error text.  Mutates *session_override* in-place.
+    """
+    from hermes_cli.model_switch import (
+        parse_model_flags,
+        switch_model as _switch_model,
+        list_authenticated_providers,
+    )
+    from hermes_cli.providers import get_label
+    from gateway.run import _load_gateway_config
+
+    cmd_args = _normalize_colon_syntax(cmd_args)
+    model_input, explicit_provider, persist_global = parse_model_flags(cmd_args)
+
+    cfg = _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    current_model = ""
+    current_provider = "openrouter"
+    current_base_url = ""
+    current_api_key = ""
+    if isinstance(model_cfg, dict):
+        current_model = model_cfg.get("default", "")
+        current_provider = model_cfg.get("provider", current_provider)
+        current_base_url = model_cfg.get("base_url", "")
+    user_provs = cfg.get("providers")
+    custom_provs = None
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        custom_provs = get_compatible_custom_providers(cfg)
+    except Exception:
+        custom_provs = cfg.get("custom_providers")
+
+    if session_override:
+        current_model = session_override.get("model", current_model)
+        current_provider = session_override.get("provider", current_provider)
+        current_base_url = session_override.get("base_url", current_base_url)
+        current_api_key = session_override.get("api_key", current_api_key)
+
+    # No args: show current model info
+    if not model_input and not explicit_provider:
+        provider_label = get_label(current_provider)
+        lines = [f"Current: `{current_model or 'unknown'}` on {provider_label}", ""]
+        try:
+            providers = list_authenticated_providers(
+                current_provider=current_provider,
+                current_base_url=current_base_url,
+                user_providers=user_provs,
+                custom_providers=custom_provs,
+                max_models=5,
+            )
+            for p in providers:
+                tag = " (current)" if p["is_current"] else ""
+                lines.append(f"**{p['name']}** `--provider {p['slug']}`{tag}:")
+                if p["models"]:
+                    model_strs = ", ".join(f"`{m}`" for m in p["models"])
+                    extra = (f" (+{p['total_models'] - len(p['models'])} more)"
+                             if p['total_models'] > len(p['models']) else "")
+                    lines.append(f"  {model_strs}{extra}")
+                lines.append("")
+        except Exception:
+            pass
+        lines.append("`/model <name>` - switch model")
+        lines.append("`/model <name> --provider <slug>` - switch provider")
+        lines.append("`/model provider:model` - shorthand (e.g., `/model zai:glm-5.1`)")
+        lines.append("`/model <name> --global` - persist to config")
+        return "\n".join(lines)
+
+    # Perform the switch
+    result = _switch_model(
+        raw_input=model_input,
+        current_provider=current_provider,
+        current_model=current_model,
+        current_base_url=current_base_url,
+        current_api_key=current_api_key,
+        is_global=persist_global,
+        explicit_provider=explicit_provider,
+        user_providers=user_provs,
+        custom_providers=custom_provs,
+    )
+
+    if not result.success:
+        return f"Error: {result.error_message}"
+
+    # Update live agent in-place if one is running
+    agent = agent_ref[0]
+    if agent is not None:
+        try:
+            agent.switch_model(
+                new_model=result.new_model,
+                new_provider=result.target_provider,
+                api_key=result.api_key,
+                base_url=result.base_url,
+                api_mode=result.api_mode,
+            )
+        except Exception as exc:
+            _log.warning("In-place model switch failed for web agent: %s", exc)
+
+    # Store session override
+    session_override.update({
+        "model": result.new_model,
+        "provider": result.target_provider,
+        "api_key": result.api_key,
+        "base_url": result.base_url,
+        "api_mode": result.api_mode,
+    })
+
+    # Persist to config if --global
+    if persist_global:
+        try:
+            import yaml
+            from pathlib import Path
+            config_path = Path.home() / ".hermes" / "config.yaml"
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    cfg_disk = yaml.safe_load(f) or {}
+            else:
+                cfg_disk = {}
+            mc = cfg_disk.setdefault("model", {})
+            mc["default"] = result.new_model
+            mc["provider"] = result.target_provider
+            if result.base_url:
+                mc["base_url"] = result.base_url
+            from hermes_cli.config import save_config
+            save_config(cfg_disk)
+        except Exception as e:
+            _log.warning("Failed to persist model switch: %s", e)
+
+    # Build confirmation
+    provider_label = result.provider_label or result.target_provider
+    lines = [f"Model switched to `{result.new_model}`"]
+    lines.append(f"Provider: {provider_label}")
+    mi = result.model_info
+    if mi:
+        if mi.context_window:
+            lines.append(f"Context: {mi.context_window:,} tokens")
+        if mi.max_output:
+            lines.append(f"Max output: {mi.max_output:,} tokens")
+        if mi.has_cost_data():
+            lines.append(f"Cost: {mi.format_cost()}")
+        lines.append(f"Capabilities: {mi.format_capabilities()}")
+    if result.warning_message:
+        lines.append(f"Warning: {result.warning_message}")
+    if persist_global:
+        lines.append("Saved to config.yaml (`--global`)")
+    else:
+        lines.append("_(session only - add `--global` to persist)_")
+    return "\n".join(lines)
+
+
 @app.websocket("/ws/tui-gateway")
 async def tui_gateway_ws(websocket: WebSocket):
     """WebSocket endpoint for the built-in dashboard chat."""
@@ -2855,6 +3052,7 @@ async def tui_gateway_ws(websocket: WebSocket):
     loop = asyncio.get_running_loop()
     session_id: Optional[str] = None
     agent_ref: List[Any] = [None]   # mutable container so interrupt() can reach the agent
+    session_model_override: dict = {}  # per-connection model override from /model command
 
     def _notify(method: str, params: dict) -> None:
         _ws_send_sync(loop, websocket, {"jsonrpc": "2.0", "method": method, "params": params})
@@ -2899,6 +3097,25 @@ async def tui_gateway_ws(websocket: WebSocket):
                     session_id = str(uuid.uuid4())
                     _notify("session.created", {"session_id": session_id})
 
+                # --- Slash command interception ---
+                if message.startswith("/"):
+                    from hermes_cli.commands import resolve_command
+                    _cmd_parts = message[1:].split(None, 1)
+                    _cmd_name = _cmd_parts[0].lower() if _cmd_parts else ""
+                    _cmd_args = _cmd_parts[1].strip() if len(_cmd_parts) > 1 else ""
+                    _cmd_def = resolve_command(_cmd_name)
+
+                    if _cmd_def and _cmd_def.name == "model":
+                        reply_text = _handle_web_model_command(
+                            cmd_args=_cmd_args,
+                            session_override=session_model_override,
+                            agent_ref=agent_ref,
+                        )
+                        _notify("assistant.delta", {"text": reply_text})
+                        _notify("assistant.done", {"text": reply_text})
+                        _reply(rpc_id, {"ok": True})
+                        continue
+
                 def _on_delta(delta):
                     if delta is None:
                         return
@@ -2938,6 +3155,17 @@ async def tui_gateway_ws(websocket: WebSocket):
 
                         runtime_kwargs = _resolve_runtime_agent_kwargs()
                         model = _resolve_gateway_model()
+
+                        # Apply per-session model override from /model command
+                        if session_model_override:
+                            _om = session_model_override.get("model")
+                            if _om:
+                                model = _om
+                            for _k in ("provider", "api_key", "base_url", "api_mode"):
+                                _ov = session_model_override.get(_k)
+                                if _ov:
+                                    runtime_kwargs[_k] = _ov
+
                         user_config = _load_gateway_config()
                         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -49,7 +49,7 @@ from hermes_cli.config import (
 from gateway.status import get_running_pid, read_runtime_status
 
 try:
-    from fastapi import FastAPI, HTTPException, Request
+    from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
     from fastapi.staticfiles import StaticFiles
@@ -102,6 +102,7 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
+    "/api/chat/commands",
 })
 
 
@@ -1904,6 +1905,26 @@ async def cancel_oauth_session(session_id: str, request: Request):
 
 
 # ---------------------------------------------------------------------------
+# Chat slash-command list
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/chat/commands")
+async def get_chat_commands():
+    """Return the list of slash commands available in the chat UI."""
+    try:
+        from hermes_cli.commands import COMMANDS
+        return {
+            "commands": [
+                {"name": name, "description": desc}
+                for name, desc in sorted(COMMANDS.items())
+            ]
+        }
+    except Exception:
+        return {"commands": []}
+
+
+# ---------------------------------------------------------------------------
 # Session detail endpoints
 # ---------------------------------------------------------------------------
 
@@ -2789,6 +2810,190 @@ def _mount_plugin_api_routes():
 
 # Mount plugin API routes before the SPA catch-all.
 _mount_plugin_api_routes()
+
+# ---------------------------------------------------------------------------
+# tui_gateway WebSocket transport
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 over WebSocket.  The browser client sends RPC requests and
+# the server pushes back RPC notifications (no id) for streaming events.
+#
+# Client → Server methods:
+#   session.create  params: {prompt?}         → result: {session_id}
+#   session.resume  params: {session_id}       → result: {ok, session_id}
+#   chat.send       params: {message}          → streams events, result: {ok}
+#   chat.interrupt  (no params)               → result: {ok}
+#
+# Server → Client notifications (no id):
+#   session.created     params: {session_id}
+#   assistant.delta     params: {text}
+#   assistant.done      params: {text}
+#   tool.started        params: {name, preview}
+#   tool.completed      params: {name, result?}
+#   error               params: {message}
+
+def _ws_send_sync(loop, ws, msg: dict) -> None:
+    """Thread-safe: schedule a WebSocket send from a worker thread."""
+    import asyncio
+    asyncio.run_coroutine_threadsafe(ws.send_json(msg), loop)
+
+
+@app.websocket("/ws/tui-gateway")
+async def tui_gateway_ws(websocket: WebSocket):
+    """WebSocket endpoint for the built-in dashboard chat."""
+    # Authenticate: accept the session token either as a query param or
+    # in the first message.  The SPA injects it via ?token=… on the URL.
+    token_param = websocket.query_params.get("token", "")
+    if not hmac.compare_digest(
+        f"Bearer {token_param}".encode(),
+        f"Bearer {_SESSION_TOKEN}".encode(),
+    ):
+        await websocket.close(code=4001)
+        return
+
+    await websocket.accept()
+
+    loop = asyncio.get_running_loop()
+    session_id: Optional[str] = None
+    agent_ref: List[Any] = [None]   # mutable container so interrupt() can reach the agent
+
+    def _notify(method: str, params: dict) -> None:
+        _ws_send_sync(loop, websocket, {"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _reply(rpc_id, result=None, error=None) -> None:
+        msg: dict = {"jsonrpc": "2.0", "id": rpc_id}
+        if error:
+            msg["error"] = error
+        else:
+            msg["result"] = result or {}
+        _ws_send_sync(loop, websocket, msg)
+
+    try:
+        while True:
+            raw = await websocket.receive_json()
+            rpc_id = raw.get("id")
+            method = raw.get("method", "")
+            params = raw.get("params") or {}
+
+            if method == "session.create":
+                import uuid
+                session_id = str(uuid.uuid4())
+                _reply(rpc_id, {"session_id": session_id})
+                _notify("session.created", {"session_id": session_id})
+
+            elif method == "session.resume":
+                sid = params.get("session_id", "").strip()
+                if not sid:
+                    _reply(rpc_id, error={"code": -32602, "message": "session_id required"})
+                    continue
+                session_id = sid
+                _reply(rpc_id, {"ok": True, "session_id": session_id})
+                _notify("session.created", {"session_id": session_id})
+
+            elif method == "chat.send":
+                message = params.get("message", "").strip()
+                if not message:
+                    _reply(rpc_id, error={"code": -32602, "message": "message required"})
+                    continue
+                if not session_id:
+                    import uuid
+                    session_id = str(uuid.uuid4())
+                    _notify("session.created", {"session_id": session_id})
+
+                def _on_delta(delta):
+                    if delta is None:
+                        return
+                    _notify("assistant.delta", {"text": delta})
+
+                def _on_tool_event(event_type: str, tool_name: str = None,
+                                   preview: str = None, **kwargs):
+                    if event_type == "tool.started":
+                        _notify("tool.started", {"name": tool_name or "", "preview": preview or ""})
+                    elif event_type == "tool.completed":
+                        _notify("tool.completed", {"name": tool_name or ""})
+
+                sid_for_run = session_id
+
+                def _run_agent_thread():
+                    try:
+                        from run_agent import AIAgent
+                        from gateway.run import (
+                            _resolve_runtime_agent_kwargs,
+                            _resolve_gateway_model,
+                            _load_gateway_config,
+                        )
+                        from hermes_cli.tools_config import _get_platform_tools
+
+                        runtime_kwargs = _resolve_runtime_agent_kwargs()
+                        model = _resolve_gateway_model()
+                        user_config = _load_gateway_config()
+                        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+
+                        from gateway.run import GatewayRunner
+                        fallback_model = GatewayRunner._load_fallback_model()
+
+                        from hermes_state import SessionDB
+                        db = SessionDB()
+
+                        try:
+                            history = db.get_messages_as_conversation(sid_for_run)
+                        except Exception:
+                            history = []
+
+                        agent = AIAgent(
+                            model=model,
+                            **runtime_kwargs,
+                            max_iterations=int(os.getenv("HERMES_MAX_ITERATIONS", "90")),
+                            quiet_mode=True,
+                            verbose_logging=False,
+                            enabled_toolsets=enabled_toolsets,
+                            session_id=sid_for_run,
+                            platform="api_server",
+                            stream_delta_callback=_on_delta,
+                            tool_progress_callback=_on_tool_event,
+                            tool_start_callback=lambda *a, **kw: _on_tool_event("tool.started", *a, **kw),
+                            tool_complete_callback=lambda *a, **kw: _on_tool_event("tool.completed", *a, **kw),
+                            session_db=db,
+                            fallback_model=fallback_model,
+                        )
+                        agent_ref[0] = agent
+
+                        result = agent.run_conversation(
+                            user_message=message,
+                            conversation_history=history,
+                            task_id="default",
+                        )
+                        final = result.get("final_response", "") or ""
+                        _notify("assistant.done", {"text": final})
+                        _reply(rpc_id, {"ok": True})
+                    except Exception as exc:
+                        _log.exception("tui_gateway agent error: %s", exc)
+                        _notify("error", {"message": str(exc)})
+                        _reply(rpc_id, error={"code": -32603, "message": str(exc)})
+                    finally:
+                        agent_ref[0] = None
+
+                await loop.run_in_executor(None, _run_agent_thread)
+
+            elif method == "chat.interrupt":
+                ag = agent_ref[0]
+                if ag is not None:
+                    ag.interrupt()
+                _reply(rpc_id, {"ok": True})
+
+            else:
+                if rpc_id is not None:
+                    _reply(rpc_id, error={"code": -32601, "message": f"Unknown method: {method}"})
+
+    except WebSocketDisconnect:
+        ag = agent_ref[0]
+        if ag is not None:
+            try:
+                ag.interrupt()
+            except Exception:
+                pass
+    except Exception as exc:
+        _log.warning("tui_gateway WS error: %s", exc)
+
 
 mount_spa(app)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2913,6 +2913,19 @@ async def tui_gateway_ws(websocket: WebSocket):
 
                 sid_for_run = session_id
 
+                # Ensure the session row exists immediately so the dashboard
+                # can detect the active session even if the agent is interrupted
+                # before its first DB flush.
+                try:
+                    from hermes_state import SessionDB as _SessionDB
+                    _early_db = _SessionDB()
+                    try:
+                        _early_db.ensure_session(sid_for_run, source="api_server")
+                    finally:
+                        _early_db.close()
+                except Exception:
+                    pass
+
                 def _run_agent_thread():
                     try:
                         from run_agent import AIAgent

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2905,7 +2905,7 @@ async def tui_gateway_ws(websocket: WebSocket):
                     _notify("assistant.delta", {"text": delta})
 
                 def _on_tool_event(event_type: str, tool_name: str = None,
-                                   preview: str = None, **kwargs):
+                                   preview: str = None, *args, **kwargs):
                     if event_type == "tool.started":
                         _notify("tool.started", {"name": tool_name or "", "preview": preview or ""})
                     elif event_type == "tool.completed":
@@ -2950,8 +2950,6 @@ async def tui_gateway_ws(websocket: WebSocket):
                             platform="api_server",
                             stream_delta_callback=_on_delta,
                             tool_progress_callback=_on_tool_event,
-                            tool_start_callback=lambda *a, **kw: _on_tool_event("tool.started", *a, **kw),
-                            tool_complete_callback=lambda *a, **kw: _on_tool_event("tool.completed", *a, **kw),
                             session_db=db,
                             fallback_model=fallback_model,
                         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1019,6 +1019,94 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def replace_interrupted_assistant_message(
+        self,
+        session_id: str,
+        content: str,
+        tool_name: str = None,
+        tool_calls: Any = None,
+        tool_call_id: str = None,
+        token_count: int = None,
+        finish_reason: str = None,
+        reasoning: str = None,
+        reasoning_content: str = None,
+        reasoning_details: Any = None,
+        codex_reasoning_items: Any = None,
+    ) -> bool:
+        """Replace the last interrupted assistant partial, if it matches.
+
+        Dashboard WebSocket disconnects persist the streamed assistant text
+        before interrupting the agent. If the agent later reaches its normal
+        flush path, this method lets that final assistant message replace the
+        partial row instead of creating a duplicate transcript entry.
+        """
+        if not content:
+            return False
+
+        with self._lock:
+            cursor = self._conn.execute(
+                """SELECT id, role, content, finish_reason
+                   FROM messages WHERE session_id = ?
+                   ORDER BY timestamp DESC, id DESC LIMIT 1""",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+
+        if not row or row["role"] != "assistant" or row["finish_reason"] != "interrupted":
+            return False
+
+        existing = row["content"] or ""
+        if not existing or not (content.startswith(existing) or existing.startswith(content)):
+            return False
+
+        replacement = content if len(content) >= len(existing) else existing
+        reasoning_details_json = (
+            json.dumps(reasoning_details)
+            if reasoning_details else None
+        )
+        codex_items_json = (
+            json.dumps(codex_reasoning_items)
+            if codex_reasoning_items else None
+        )
+        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+
+        num_tool_calls = 0
+        if tool_calls is not None:
+            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+
+        def _do(conn):
+            conn.execute(
+                """UPDATE messages
+                   SET content = ?, tool_call_id = ?, tool_calls = ?,
+                       tool_name = ?, timestamp = ?, token_count = ?,
+                       finish_reason = ?,
+                       reasoning = ?, reasoning_content = ?,
+                       reasoning_details = ?, codex_reasoning_items = ?
+                   WHERE id = ?""",
+                (
+                    replacement,
+                    tool_call_id,
+                    tool_calls_json,
+                    tool_name,
+                    time.time(),
+                    token_count,
+                    finish_reason,
+                    reasoning,
+                    reasoning_content,
+                    reasoning_details_json,
+                    codex_items_json,
+                    row["id"],
+                ),
+            )
+            if num_tool_calls > 0:
+                conn.execute(
+                    "UPDATE sessions SET tool_call_count = tool_call_count + ? WHERE id = ?",
+                    (num_tool_calls, session_id),
+                )
+            return True
+
+        return self._execute_write(_do)
+
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by timestamp."""
         with self._lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3130,6 +3130,25 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                if (
+                    role == "assistant"
+                    and content
+                    and hasattr(self._session_db, "replace_interrupted_assistant_message")
+                ):
+                    replaced = self._session_db.replace_interrupted_assistant_message(
+                        session_id=self.session_id,
+                        content=content,
+                        tool_name=msg.get("tool_name"),
+                        tool_calls=tool_calls_data,
+                        tool_call_id=msg.get("tool_call_id"),
+                        finish_reason=msg.get("finish_reason"),
+                        reasoning=msg.get("reasoning") if role == "assistant" else None,
+                        reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
+                        reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                        codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    )
+                    if replaced:
+                        continue
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8883,6 +8883,14 @@ class AIAgent:
         messages.append(user_msg)
         current_turn_user_idx = len(messages) - 1
         self._persist_user_message_idx = current_turn_user_idx
+
+        # Early flush: persist the user message immediately so it survives
+        # interruptions (e.g. WebSocket disconnect, page refresh).  Without
+        # this, _flush_messages_to_session_db only runs at loop exit, so a
+        # mid-stream interrupt loses both the user message and any partial
+        # assistant response.
+        if self._session_db and self.persist_session:
+            self._flush_messages_to_session_db(messages, conversation_history)
         
         if not self.quiet_mode:
             _print_preview = _summarize_user_message_for_log(user_message)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -97,6 +97,141 @@ class TestRedactKey:
 # ---------------------------------------------------------------------------
 
 
+class TestInterruptedStreamingPersistence:
+    """Tests for preserving dashboard partial responses on disconnect."""
+
+    def test_persists_streamed_partial_response(self, tmp_path):
+        from types import SimpleNamespace
+        from hermes_state import SessionDB
+        from hermes_cli.web_server import _persist_interrupted_streaming_response
+
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.ensure_session("s1", source="api_server")
+            db.append_message("s1", role="user", content="hello")
+            agent = SimpleNamespace(
+                _session_db=db,
+                _current_streamed_assistant_text="partial answer",
+                platform="api_server",
+                model="test-model",
+            )
+
+            assert _persist_interrupted_streaming_response(agent, "s1") is True
+
+            messages = db.get_messages("s1")
+            assert [m["role"] for m in messages] == ["user", "assistant"]
+            assert messages[-1]["content"] == "partial answer"
+            assert messages[-1]["finish_reason"] == "interrupted"
+        finally:
+            db.close()
+
+    def test_persist_partial_updates_existing_interrupted_row(self, tmp_path):
+        from types import SimpleNamespace
+        from hermes_state import SessionDB
+        from hermes_cli.web_server import _persist_interrupted_streaming_response
+
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.ensure_session("s1", source="api_server")
+            db.append_message("s1", role="user", content="hello")
+            agent = SimpleNamespace(
+                _session_db=db,
+                _current_streamed_assistant_text="partial",
+                platform="api_server",
+                model="test-model",
+            )
+
+            assert _persist_interrupted_streaming_response(agent, "s1") is True
+            agent._current_streamed_assistant_text = "partial answer"
+            assert _persist_interrupted_streaming_response(agent, "s1") is True
+
+            messages = db.get_messages("s1")
+            assert [m["role"] for m in messages] == ["user", "assistant"]
+            assert messages[-1]["content"] == "partial answer"
+            assert messages[-1]["finish_reason"] == "interrupted"
+        finally:
+            db.close()
+
+    def test_streaming_delta_persistence_updates_partial_text(self, tmp_path):
+        from hermes_state import SessionDB
+        from hermes_cli.web_server import _persist_interrupted_streaming_text
+
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.ensure_session("s1", source="api_server")
+            db.append_message("s1", role="user", content="hello")
+
+            assert _persist_interrupted_streaming_text(db, "s1", "partial") is True
+            assert _persist_interrupted_streaming_text(db, "s1", "partial answer") is True
+
+            messages = db.get_messages("s1")
+            assert [m["role"] for m in messages] == ["user", "assistant"]
+            assert messages[-1]["content"] == "partial answer"
+            assert messages[-1]["finish_reason"] == "interrupted"
+        finally:
+            db.close()
+
+    def test_final_flush_replaces_interrupted_partial(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.ensure_session("s1", source="api_server")
+            db.append_message("s1", role="user", content="hello")
+            db.append_message(
+                "s1",
+                role="assistant",
+                content="partial",
+                finish_reason="interrupted",
+            )
+
+            assert db.replace_interrupted_assistant_message(
+                "s1",
+                content="partial answer",
+                finish_reason="stop",
+            ) is True
+
+            messages = db.get_messages("s1")
+            assert [m["role"] for m in messages] == ["user", "assistant"]
+            assert messages[-1]["content"] == "partial answer"
+            assert messages[-1]["finish_reason"] == "stop"
+        finally:
+            db.close()
+
+    def test_final_tool_call_flush_replaces_interrupted_partial(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.ensure_session("s1", source="api_server")
+            db.append_message("s1", role="user", content="hello")
+            db.append_message(
+                "s1",
+                role="assistant",
+                content="I'll check",
+                finish_reason="interrupted",
+            )
+
+            tool_calls = [{"name": "search", "arguments": "{\"q\":\"x\"}"}]
+            assert db.replace_interrupted_assistant_message(
+                "s1",
+                content="I'll check",
+                tool_calls=tool_calls,
+                finish_reason="tool_calls",
+            ) is True
+
+            messages = db.get_messages("s1")
+            session = db.get_session("s1")
+            assert [m["role"] for m in messages] == ["user", "assistant"]
+            assert messages[-1]["content"] == "I'll check"
+            assert messages[-1]["tool_calls"] == tool_calls
+            assert messages[-1]["finish_reason"] == "tool_calls"
+            assert session["message_count"] == 2
+            assert session["tool_call_count"] == 1
+        finally:
+            db.close()
+
+
 class TestWebServerEndpoints:
     """Test the FastAPI REST endpoints using Starlette TestClient."""
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -411,6 +411,38 @@ class TestFindExecFullPathRm:
         assert key is None
 
 
+class TestRootTraversalPatterns:
+    def test_find_root_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command("find /")
+        assert dangerous is True
+        assert key is not None
+        assert "filesystem root" in desc.lower()
+
+    def test_find_root_with_predicate_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command("find / -name '*.py'")
+        assert dangerous is True
+        assert key is not None
+        assert "filesystem root" in desc.lower()
+
+    def test_find_home_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command("find /home -maxdepth 2")
+        assert dangerous is True
+        assert key is not None
+        assert "/home" in desc.lower()
+
+    def test_recursive_ls_root_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command("ls -laR /")
+        assert dangerous is True
+        assert key is not None
+        assert "recursive ls" in desc.lower()
+
+    def test_find_project_path_remains_safe(self):
+        dangerous, key, desc = detect_dangerous_command("find ./src -name '*.py' -print")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+
 class TestSensitiveRedirectPattern:
     """Detect shell redirection writes to sensitive user-managed paths."""
 

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -204,3 +204,30 @@ class TestPaginationBounds:
         rg_commands = [cmd for cmd in commands if cmd.startswith("rg --files")]
         assert rg_commands
         assert "| head -n 1" in rg_commands[0]
+
+
+class TestWindowsPathNormalization:
+    def test_normalize_for_shell_converts_windows_absolute_path(self, monkeypatch):
+        import tools.platform_compat as platform_compat
+
+        monkeypatch.setattr(platform_compat, "_IS_WINDOWS", True)
+
+        assert (
+            ShellFileOperations._normalize_for_shell(r"D:\Code\hermes-agent\README.md")
+            == "/d/Code/hermes-agent/README.md"
+        )
+
+    def test_expand_path_converts_windows_absolute_path(self, monkeypatch):
+        import tools.platform_compat as platform_compat
+
+        monkeypatch.setattr(platform_compat, "_IS_WINDOWS", True)
+        ops = ShellFileOperations.__new__(ShellFileOperations)
+
+        assert ops._expand_path(r"C:\Users\me\My Project\file.txt") == "/c/Users/me/My Project/file.txt"
+
+    def test_relative_path_unchanged_on_windows(self, monkeypatch):
+        import tools.platform_compat as platform_compat
+
+        monkeypatch.setattr(platform_compat, "_IS_WINDOWS", True)
+
+        assert ShellFileOperations._normalize_for_shell("src/app.py") == "src/app.py"

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -26,6 +26,14 @@ from tools.environments.local import LocalEnvironment
 from tools.file_operations import ShellFileOperations
 
 
+def _expected_shell_home() -> str:
+    if os.name == "nt":
+        from tools.platform_compat import windows_path_to_msys
+
+        return windows_path_to_msys(str(Path.home()))
+    return str(Path.home())
+
+
 # ── Shared noise detection ───────────────────────────────────────────────
 # Known shell noise patterns that should never appear in command output.
 
@@ -115,7 +123,10 @@ class TestLocalEnvironmentExecute:
         subdir.mkdir()
         result = env.execute("pwd", cwd=str(subdir))
         assert result["returncode"] == 0
-        assert result["output"].strip() == str(subdir)
+        if os.name == "nt":
+            assert result["output"].strip().endswith("/subdir_test")
+        else:
+            assert result["output"].strip() == str(subdir)
         _assert_clean(result["output"])
 
     def test_multiline_exact(self, env):
@@ -128,7 +139,7 @@ class TestLocalEnvironmentExecute:
         result = env.execute("echo $HOME")
         assert result["returncode"] == 0
         home = result["output"].strip()
-        assert home == str(Path.home())
+        assert home == _expected_shell_home()
         _assert_clean(result["output"])
 
     def test_pipe_exact(self, env):
@@ -365,7 +376,7 @@ class TestSearch:
 class TestExpandPath:
     def test_tilde_exact(self, ops):
         result = ops._expand_path("~/test.txt")
-        expected = f"{Path.home()}/test.txt"
+        expected = f"{_expected_shell_home()}/test.txt"
         assert result == expected
         _assert_clean(result)
 
@@ -377,7 +388,7 @@ class TestExpandPath:
 
     def test_bare_tilde(self, ops):
         result = ops._expand_path("~")
-        assert result == str(Path.home())
+        assert result == _expected_shell_home()
         _assert_clean(result)
 
     def test_tilde_injection_blocked(self, ops):
@@ -442,7 +453,7 @@ class TestTerminalOutputCleanliness:
 
     def test_env_var_expansion(self, env):
         result = env.execute("echo $HOME")
-        assert result["output"].strip() == str(Path.home())
+        assert result["output"].strip() == _expected_shell_home()
         _assert_clean(result["output"])
 
     def test_command_substitution(self, env):

--- a/tests/tools/test_local_tempdir.py
+++ b/tests/tools/test_local_tempdir.py
@@ -5,6 +5,9 @@ from tools.environments.local import LocalEnvironment
 
 class TestLocalTempDir:
     def test_uses_os_tmpdir_for_session_artifacts(self, monkeypatch):
+        from tools.environments import local
+
+        monkeypatch.setattr(local, "_IS_WINDOWS", False)
         monkeypatch.setenv("TMPDIR", "/data/data/com.termux/files/usr/tmp")
         monkeypatch.delenv("TMP", raising=False)
         monkeypatch.delenv("TEMP", raising=False)
@@ -17,6 +20,9 @@ class TestLocalTempDir:
         assert env._cwd_file == f"/data/data/com.termux/files/usr/tmp/hermes-cwd-{env._session_id}.txt"
 
     def test_prefers_backend_env_tmpdir_override(self, monkeypatch):
+        from tools.environments import local
+
+        monkeypatch.setattr(local, "_IS_WINDOWS", False)
         monkeypatch.delenv("TMPDIR", raising=False)
         monkeypatch.delenv("TMP", raising=False)
         monkeypatch.delenv("TEMP", raising=False)
@@ -37,6 +43,9 @@ class TestLocalTempDir:
         )
 
     def test_falls_back_to_tempfile_when_tmp_missing(self, monkeypatch):
+        from tools.environments import local
+
+        monkeypatch.setattr(local, "_IS_WINDOWS", False)
         monkeypatch.delenv("TMPDIR", raising=False)
         monkeypatch.delenv("TMP", raising=False)
         monkeypatch.delenv("TEMP", raising=False)
@@ -49,3 +58,49 @@ class TestLocalTempDir:
             assert env.get_temp_dir() == "/cache/tmp"
             assert env._snapshot_path == f"/cache/tmp/hermes-snap-{env._session_id}.sh"
             assert env._cwd_file == f"/cache/tmp/hermes-cwd-{env._session_id}.txt"
+
+    def test_windows_tempdir_uses_msys_for_bash_and_windows_for_python(self, monkeypatch, tmp_path):
+        from tools.environments import local
+        from tools.platform_compat import windows_path_to_msys
+
+        monkeypatch.setattr(local, "_IS_WINDOWS", True)
+        temp_root = tmp_path / "Temp Root"
+        expected_msys_temp = windows_path_to_msys(str(temp_root / "hermes"))
+        expected_win_temp = str(temp_root / "hermes").replace("\\", "/")
+
+        with patch("tools.platform_compat.tempfile.gettempdir", return_value=str(temp_root)), \
+             patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=r"D:\Code\hermes-agent", timeout=10)
+            assert env.get_temp_dir() == expected_msys_temp
+
+        assert env.cwd == "/d/Code/hermes-agent"
+        assert env._snapshot_path.startswith(f"{expected_msys_temp}/hermes-snap-")
+        assert env._snapshot_path_win.startswith(f"{expected_win_temp}/hermes-snap-")
+        assert env._cwd_file_win.startswith(f"{expected_win_temp}/hermes-cwd-")
+
+
+class TestWindowsBashResolution:
+    def test_is_wsl_bash_detects_system32_and_sysnative(self, monkeypatch):
+        from tools.environments import local
+
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+
+        assert local._is_wsl_bash(r"C:\Windows\System32\bash.exe") is True
+        assert local._is_wsl_bash(r"C:\Windows\Sysnative\bash.exe") is True
+        assert local._is_wsl_bash(r"C:\Program Files\Git\bin\bash.exe") is False
+
+    def test_find_bash_skips_wsl_path_lookup_when_git_bash_missing(self, monkeypatch):
+        from tools.environments import local
+
+        monkeypatch.setattr(local, "_IS_WINDOWS", True)
+        monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setattr(local.os.path, "isfile", lambda _path: False)
+        monkeypatch.setattr(local.shutil, "which", lambda _name: r"C:\Windows\System32\bash.exe")
+
+        try:
+            local._find_bash()
+        except RuntimeError as exc:
+            assert "WSL bash is not supported" in str(exc)
+        else:
+            raise AssertionError("_find_bash should reject WSL bash")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -143,6 +143,12 @@ DANGEROUS_PATTERNS = [
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.
     (r'\bchmod\s+\+x\b.*[;&|]+\s*\./', "chmod +x followed by immediate execution"),
+    # Windows / Git Bash: commands that traverse the MSYS virtual root ('/').
+    # On Git Bash, '/' maps to the entire Windows filesystem root so these
+    # commands enumerate or recurse across ALL drives and can hang for minutes.
+    (r'\bfind\s+/(?:\s|$)', "find from filesystem root (hangs on Windows Git Bash)"),
+    (r'\bfind\s+/home(?:/|\s|$)', "find traversal of /home (may hang on Windows Git Bash)"),
+    (r'\bls\s+(?:-\S+\s+)*-\S*R\S*\s+/', "recursive ls of filesystem root (hangs)"),
 ]
 
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -103,6 +103,10 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
 
     def _write():
         try:
+            try:
+                proc.stdin.reconfigure(newline="\n")
+            except Exception:
+                pass
             proc.stdin.write(data)
             proc.stdin.close()
         except (BrokenPipeError, OSError):
@@ -465,6 +469,17 @@ class BaseEnvironment(ABC):
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
         def _drain():
+            if os.name == "nt":
+                try:
+                    while True:
+                        chunk = proc.stdout.readline()
+                        if not chunk or not isinstance(chunk, str):
+                            break
+                        output_chunks.append(chunk)
+                except (ValueError, OSError):
+                    pass
+                return
+
             fd = proc.stdout.fileno()
             idle_after_exit = 0
             try:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -199,6 +200,21 @@ def _is_wsl_bash(path: str) -> bool:
         return False
 
 
+def _rewrite_windows_paths_for_msys(command: str) -> str:
+    """Rewrite simple Windows absolute paths in shell commands for Git Bash."""
+    if not command:
+        return command
+
+    from tools.platform_compat import windows_path_to_msys
+
+    pattern = re.compile(r"(?<![\w/])([A-Za-z]:[\\/][^\s\"'`|&;<>()]*)")
+
+    def repl(match: re.Match) -> str:
+        return windows_path_to_msys(match.group(1))
+
+    return pattern.sub(repl, command)
+
+
 # Backward compat — process_registry.py imports this name
 _find_shell = _find_bash
 
@@ -353,6 +369,15 @@ class LocalEnvironment(BaseEnvironment):
 
         self.init_session()
 
+    def execute(self, command: str, cwd: str = "", **kwargs) -> dict:
+        if _IS_WINDOWS:
+            from tools.platform_compat import windows_path_to_msys
+
+            command = _rewrite_windows_paths_for_msys(command)
+            if cwd:
+                cwd = windows_path_to_msys(cwd)
+        return super().execute(command, cwd=cwd, **kwargs)
+
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.
 
@@ -401,13 +426,10 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
-        # On Windows, self.cwd is stored in MSYS form (/d/...) for bash cd
-        # commands, but subprocess.Popen needs a Windows path for its cwd.
-        if _IS_WINDOWS:
-            from tools.platform_compat import msys_path_to_windows
-            popen_cwd = msys_path_to_windows(self.cwd) if self.cwd else None
-        else:
-            popen_cwd = self.cwd
+        # On Windows, self.cwd is tracked in MSYS form and can become paths
+        # like /tmp/... that are valid in Git Bash but invalid for Win32
+        # CreateProcess. Let the wrapped bash script do the cd instead.
+        popen_cwd = None if _IS_WINDOWS else self.cwd
 
         proc = subprocess.Popen(
             args,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -153,10 +153,10 @@ def _find_bash() -> str:
     if custom and os.path.isfile(custom):
         return custom
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
+    # Prefer Git Bash over shutil.which("bash") — on Windows with WSL
+    # installed, which("bash") returns C:\Windows\System32\bash.exe
+    # (the WSL launcher).  WSL uses /mnt/d/... path convention instead of
+    # Git Bash's /d/..., which breaks all of Hermes' path normalization.
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -165,11 +165,38 @@ def _find_bash() -> str:
         if candidate and os.path.isfile(candidate):
             return candidate
 
+    # Fall back to PATH lookup, but skip the WSL launcher.
+    found = shutil.which("bash")
+    if found and not _is_wsl_bash(found):
+        return found
+
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"
-        "Install it from: https://git-scm.com/download/win\n"
-        "Or set HERMES_GIT_BASH_PATH to your bash.exe location."
+        "WSL bash is not supported — it uses /mnt/d/... paths which differ\n"
+        "from Git Bash's /d/... format expected by Hermes' path normalization.\n"
+        "Install Git for Windows from: https://git-scm.com/download/win\n"
+        "Or set HERMES_GIT_BASH_PATH to your Git Bash bash.exe location."
     )
+
+
+def _is_wsl_bash(path: str) -> bool:
+    """Return True if *path* is the WSL bash launcher (C:\\Windows\\System32\\bash.exe).
+
+    The WSL launcher reports Linux paths (``/mnt/d/...``) instead of Git Bash's
+    ``/d/...`` format, which breaks Hermes' path normalization.  We detect it
+    by path match since both share the name ``bash.exe``.
+    """
+    try:
+        normalized = os.path.normcase(os.path.normpath(path))
+        system32 = os.path.normcase(os.path.normpath(
+            os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "System32", "bash.exe")
+        ))
+        sysnative = os.path.normcase(os.path.normpath(
+            os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "Sysnative", "bash.exe")
+        ))
+        return normalized in (system32, sysnative)
+    except Exception:
+        return False
 
 
 # Backward compat — process_registry.py imports this name
@@ -305,21 +332,44 @@ class LocalEnvironment(BaseEnvironment):
     """
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
-        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        if _IS_WINDOWS:
+            from tools.platform_compat import windows_path_to_msys
+            # Convert Windows CWD to MSYS form so bash 'cd' works in Git Bash.
+            # os.getcwd() returns 'D:\Code\...' which Git Bash may mishandle;
+            # '/d/Code/...' is unambiguous in MSYS coreutils.
+            init_cwd = windows_path_to_msys(cwd) if cwd else windows_path_to_msys(os.getcwd())
+        else:
+            init_cwd = cwd or os.getcwd()
+
+        super().__init__(cwd=init_cwd, timeout=timeout, env=env)
+
+        if _IS_WINDOWS:
+            from tools.platform_compat import msys_path_to_windows
+            self._snapshot_path_win = msys_path_to_windows(self._snapshot_path)
+            self._cwd_file_win = msys_path_to_windows(self._cwd_file)
+        else:
+            self._snapshot_path_win = self._snapshot_path
+            self._cwd_file_win = self._cwd_file
+
         self.init_session()
 
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.
 
-        Termux does not provide /tmp by default, but exposes a POSIX TMPDIR.
-        Prefer POSIX-style env vars when available, keep using /tmp on regular
-        Unix systems, and only fall back to tempfile.gettempdir() when it also
-        resolves to a POSIX path.
+        On Windows: returns the MSYS form of the Windows temp dir so that
+        bash scripts can write snapshot/cwd files there.  Python file ops
+        (open, unlink) use _snapshot_path_win / _cwd_file_win instead,
+        which are the Windows-form equivalents readable by Python's open().
 
-        Check the environment configured for this backend first so callers can
-        override the temp root explicitly (for example via terminal.env or a
-        custom TMPDIR), then fall back to the host process environment.
+        On non-Windows / Termux: keeps the existing POSIX logic.
         """
+        if _IS_WINDOWS:
+            from tools.platform_compat import get_host_temp_dir, windows_path_to_msys
+            # get_host_temp_dir creates the dir (mkdir -p equivalent) and
+            # returns a Python Path.  Convert to MSYS form for bash scripts.
+            win_path = str(get_host_temp_dir("hermes"))
+            return windows_path_to_msys(win_path)
+
         for env_var in ("TMPDIR", "TMP", "TEMP"):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
             if candidate and candidate.startswith("/"):
@@ -351,6 +401,14 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # On Windows, self.cwd is stored in MSYS form (/d/...) for bash cd
+        # commands, but subprocess.Popen needs a Windows path for its cwd.
+        if _IS_WINDOWS:
+            from tools.platform_compat import msys_path_to_windows
+            popen_cwd = msys_path_to_windows(self.cwd) if self.cwd else None
+        else:
+            popen_cwd = self.cwd
+
         proc = subprocess.Popen(
             args,
             text=True,
@@ -361,7 +419,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            cwd=self.cwd,
+            cwd=popen_cwd,
         )
 
         if stdin_data is not None:
@@ -390,7 +448,10 @@ class LocalEnvironment(BaseEnvironment):
     def _update_cwd(self, result: dict):
         """Read CWD from temp file (local-only, no round-trip needed)."""
         try:
-            cwd_path = open(self._cwd_file).read().strip()
+            # Use the Windows-form path so Python's open() finds the file.
+            # On Windows, self._cwd_file is the MSYS path (used in bash scripts)
+            # and self._cwd_file_win is the Windows path readable by Python.
+            cwd_path = open(self._cwd_file_win).read().strip()
             if cwd_path:
                 self.cwd = cwd_path
         except (OSError, FileNotFoundError):
@@ -401,7 +462,8 @@ class LocalEnvironment(BaseEnvironment):
 
     def cleanup(self):
         """Clean up temp files."""
-        for f in (self._snapshot_path, self._cwd_file):
+        # Use Windows-form paths so os.unlink() can find the files on Windows.
+        for f in (self._snapshot_path_win, self._cwd_file_win):
             try:
                 os.unlink(f)
             except OSError:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -463,8 +463,22 @@ class ShellFileOperations(FileOperations):
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
                         user_home = expand_result.stdout.strip()
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
-                        return user_home + suffix
-        
+                        return self._normalize_for_shell(user_home + suffix)
+
+        return self._normalize_for_shell(path)
+
+    @staticmethod
+    def _normalize_for_shell(path: str) -> str:
+        """Convert Windows absolute paths to MSYS form before shell use."""
+        if not path:
+            return path
+        try:
+            from tools.platform_compat import _IS_WINDOWS, windows_path_to_msys
+
+            if _IS_WINDOWS:
+                return windows_path_to_msys(path)
+        except Exception:
+            pass
         return path
     
     def _escape_shell_arg(self, arg: str) -> str:

--- a/tools/platform_compat.py
+++ b/tools/platform_compat.py
@@ -1,0 +1,267 @@
+"""Cross-platform helpers for Windows/Unix runtime differences.
+
+Centralises the subtle behavioural differences that keep biting Windows:
+    * ``os.kill(pid, 0)`` can raise WinError 11/87 instead of ProcessLookupError.
+    * ``signal.SIGKILL`` / ``SIGUSR1`` don't exist on Windows.
+    * ``preexec_fn=os.setsid`` and ``os.killpg`` require POSIX.
+    * Detached subprocesses need ``creationflags`` on Windows, ``start_new_session`` on POSIX.
+    * ``fcntl.flock`` vs ``msvcrt.locking`` for file locks.
+
+Modules needing platform guards should import from here rather than rolling
+their own checks so the fix only has to live in one place.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import signal
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+try:
+    import fcntl as _fcntl
+except Exception:
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except Exception:
+    _msvcrt = None
+
+
+def pid_alive(pid: int) -> bool:
+    """Cross-platform check whether ``pid`` is a living process.
+
+    On Windows, ``os.kill(pid, 0)`` is unsafe and can raise WinError 11/87
+    because signal 0 is not supported consistently. Use psutil when
+    available and fall back to ``tasklist`` otherwise. On POSIX, ``os.kill
+    (pid, 0)`` is the canonical existence check.
+    """
+    if not pid or pid <= 0:
+        return False
+
+    if _IS_WINDOWS:
+        try:
+            import psutil
+
+            return psutil.pid_exists(pid)
+        except ImportError:
+            try:
+                result = subprocess.run(
+                    ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                return str(pid) in result.stdout
+            except Exception:
+                return True
+
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
+
+
+def terminate_pid(pid: int, *, force: bool = False) -> None:
+    """Terminate a PID with platform-appropriate force semantics.
+
+    POSIX uses SIGTERM/SIGKILL. Windows uses ``taskkill /T /F`` for true
+    tree-killing because ``os.kill(pid, SIGTERM)`` on Windows maps to
+    TerminateProcess on only the target pid, not its children.
+    """
+    if force and _IS_WINDOWS:
+        try:
+            result = subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except FileNotFoundError:
+            os.kill(pid, signal.SIGTERM)
+            return
+
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or "").strip()
+            raise OSError(details or f"taskkill failed for PID {pid}")
+        return
+
+    sig = signal.SIGTERM if not force else getattr(signal, "SIGKILL", signal.SIGTERM)
+    os.kill(pid, sig)
+
+
+def get_detached_popen_kwargs() -> dict:
+    """Return platform-appropriate kwargs for detached subprocess launch."""
+    if _IS_WINDOWS:
+        creationflags = 0
+        creationflags |= getattr(subprocess, "DETACHED_PROCESS", 0)
+        creationflags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        return {"creationflags": creationflags}
+    return {"start_new_session": True}
+
+
+def shell_join(parts: list[str]) -> str:
+    """Quote argv parts for a shell command string."""
+    if _IS_WINDOWS:
+        return subprocess.list2cmdline(parts)
+    import shlex
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def get_host_temp_dir(app_name: str = "hermes") -> Path:
+    """Return a temp directory for host-side Hermes runtime files."""
+    path = Path(tempfile.gettempdir()) / app_name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_host_temp_path(name: str, app_name: str = "hermes") -> Path:
+    """Return a stable file path under the host temp directory."""
+    return get_host_temp_dir(app_name) / name
+
+
+def windows_path_to_msys(path: str) -> str:
+    """Convert a Windows absolute path to MSYS/Git-Bash form.
+
+    Git Bash runs MSYS coreutils that require paths in MSYS form:
+    ``D:\\Doc\\foo`` or ``D:/Doc/foo``  →  ``/d/Doc/foo``
+
+    Without this conversion, ``D:/Doc/foo`` is treated as a *relative* path
+    by MSYS tools (there is no ``D:`` drive in the POSIX namespace they see),
+    which creates junk artifacts under the current working directory.
+
+    Idempotent: already-MSYS paths (``/d/...``) are returned unchanged.
+    Non-Windows or relative paths are returned unchanged.
+    """
+    if not path:
+        return path
+    # Normalise any remaining backslashes first
+    p = path.replace("\\", "/")
+    # Match ``X:/...`` (drive letter + colon + optional slash)
+    import re as _re
+    m = _re.match(r'^([A-Za-z]):(/?)(.*)', p)
+    if m:
+        drive, _sep, rest = m.groups()
+        rest = rest.lstrip("/")
+        return f"/{drive.lower()}/{rest}" if rest else f"/{drive.lower()}/"
+    return p
+
+
+def msys_path_to_windows(path: str) -> str:
+    """Convert an MSYS/Git-Bash absolute path back to Windows form.
+
+    ``/d/Doc/foo``  →  ``D:/Doc/foo``
+
+    Useful when you need to hand an MSYS-reported path back to Python's
+    ``pathlib`` or other Windows-native APIs.
+
+    Idempotent: already-Windows paths are returned unchanged.
+    Non-MSYS paths (e.g. ``/usr/bin``) are returned unchanged.
+    """
+    if not path:
+        return path
+    import re as _re
+    m = _re.match(r'^/([a-zA-Z])/(.*)', path)
+    if m:
+        drive, rest = m.groups()
+        return f"{drive.upper()}:/{rest}"
+    return path
+
+
+# ---------------------------------------------------------------------------
+# PowerShell invocation helper
+# ---------------------------------------------------------------------------
+
+_ps_exe: str | None | bool = False  # False = not yet probed
+
+
+def _find_powershell() -> str | None:
+    """Return the first working PowerShell executable name, or None."""
+    for name in ("pwsh", "powershell"):
+        try:
+            r = subprocess.run(
+                [name, "-NoProfile", "-NonInteractive", "-Command", "exit 0"],
+                capture_output=True,
+                timeout=5,
+            )
+            if r.returncode == 0:
+                return name
+        except FileNotFoundError:
+            continue
+        except Exception:
+            continue
+    return None
+
+
+def get_powershell_exe() -> str | None:
+    """Return the cached PowerShell executable name, probing once per process."""
+    global _ps_exe
+    if _ps_exe is False:
+        _ps_exe = _find_powershell()
+    return _ps_exe  # type: ignore[return-value]
+
+
+def run_powershell(
+    script: str,
+    *,
+    timeout: int = 30,
+    check: bool = False,
+) -> "subprocess.CompletedProcess[str]":
+    """Run a PowerShell script string and return the CompletedProcess.
+
+    Uses ``pwsh`` (PowerShell 7+) if available, falls back to ``powershell``
+    (Windows PowerShell 5.1).  Raises ``RuntimeError`` when no PowerShell is
+    found.
+
+    Args:
+        script:  The PowerShell script text to execute.
+        timeout: Seconds before the subprocess is killed.
+        check:   If True, raise CalledProcessError on non-zero exit code.
+    """
+    exe = get_powershell_exe()
+    if exe is None:
+        raise RuntimeError(
+            "No PowerShell executable found (tried 'pwsh' and 'powershell'). "
+            "Install PowerShell 7+ or ensure Windows PowerShell 5.1 is on PATH."
+        )
+    return subprocess.run(
+        [exe, "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+@contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Acquire an exclusive cross-platform file lock."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = open(path, "a+")
+    try:
+        if _fcntl is not None:
+            _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+        elif _msvcrt is not None:
+            lock_file.seek(0)
+            _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_LOCK, 1)
+        yield
+    finally:
+        try:
+            if _fcntl is not None:
+                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+            elif _msvcrt is not None:
+                lock_file.seek(0)
+                _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_UNLCK, 1)
+        finally:
+            lock_file.close()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import CronPage from "@/pages/CronPage";
 import SkillsPage from "@/pages/SkillsPage";
+import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -52,6 +53,7 @@ const BUILTIN_ROUTES: Record<string, React.ComponentType> = {
   "/skills": SkillsPage,
   "/config": ConfigPage,
   "/env": EnvPage,
+  "/chat": ChatPage,
 };
 
 const BUILTIN_NAV: NavItem[] = [
@@ -61,6 +63,12 @@ const BUILTIN_NAV: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+  },
+  {
+    path: "/chat",
+    labelKey: "chat",
+    label: "Chat",
+    icon: Terminal,
   },
   {
     path: "/analytics",

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useState, useCallback } from "react";
+import { Copy, Check } from "lucide-react";
 
 /**
  * Lightweight markdown renderer for LLM output.
@@ -26,6 +27,7 @@ type BlockNode =
   | { type: "heading"; level: number; content: string }
   | { type: "hr" }
   | { type: "list"; ordered: boolean; items: string[] }
+  | { type: "table"; headers: string[]; rows: string[][] }
   | { type: "paragraph"; content: string };
 
 /* ------------------------------------------------------------------ */
@@ -92,6 +94,19 @@ function parseBlocks(text: string): BlockNode[] {
       continue;
     }
 
+    // Table: header | header\n---|---\ncell | cell
+    if (i + 1 < lines.length && /\|/.test(line) && /^\|?\s*[-:]+[-|\s]*$/.test(lines[i + 1])) {
+      const headerCells = line.replace(/^\|/, "").replace(/\|$/, "").split("|").map((c: string) => c.trim());
+      i += 2; // skip header + separator
+      const rows: string[][] = [];
+      while (i < lines.length && /\|/.test(lines[i]) && lines[i].trim() !== "") {
+        rows.push(lines[i].replace(/^\|/, "").replace(/\|$/, "").split("|").map((c: string) => c.trim()));
+        i++;
+      }
+      blocks.push({ type: "table", headers: headerCells, rows });
+      continue;
+    }
+
     // Empty line
     if (line.trim() === "") {
       i++;
@@ -124,14 +139,39 @@ function parseBlocks(text: string): BlockNode[] {
 /*  Block renderer                                                     */
 /* ------------------------------------------------------------------ */
 
+function CodeBlock({ lang, content }: { lang: string; content: string }) {
+  const [copied, setCopied] = useState(false);
+  const doCopy = useCallback(() => {
+    navigator.clipboard.writeText(content).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [content]);
+
+  return (
+    <div className="relative group">
+      <pre className="bg-secondary/60 border border-border px-3 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
+        <code>{content}</code>
+      </pre>
+      <div className="absolute top-1 right-1 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+        {lang && <span className="text-[10px] text-muted-foreground font-mono">{lang}</span>}
+        <button
+          type="button"
+          onClick={doCopy}
+          className="p-1 rounded hover:bg-secondary/80 transition-colors"
+          aria-label="Copy code"
+        >
+          {copied ? <Check className="h-3 w-3 text-success" /> : <Copy className="h-3 w-3 text-muted-foreground" />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function Block({ block, highlightTerms }: { block: BlockNode; highlightTerms?: string[] }) {
   switch (block.type) {
     case "code":
-      return (
-        <pre className="bg-secondary/60 border border-border px-3 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
-          <code>{block.content}</code>
-        </pre>
-      );
+      return <CodeBlock lang={block.lang} content={block.content} />;
 
     case "heading": {
       const Tag = `h${Math.min(block.level, 4)}` as "h1" | "h2" | "h3" | "h4";
@@ -157,6 +197,34 @@ function Block({ block, highlightTerms }: { block: BlockNode; highlightTerms?: s
         </Tag>
       );
     }
+
+    case "table":
+      return (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs border-collapse">
+            <thead>
+              <tr className="border-b border-border">
+                {block.headers.map((h, i) => (
+                  <th key={i} className="px-2 py-1.5 text-left font-semibold text-foreground/80">
+                    <InlineContent text={h} highlightTerms={highlightTerms} />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {block.rows.map((row, ri) => (
+                <tr key={ri} className="border-b border-border/50">
+                  {row.map((cell, ci) => (
+                    <td key={ci} className="px-2 py-1.5">
+                      <InlineContent text={cell} highlightTerms={highlightTerms} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
 
     case "paragraph":
       return <p><InlineContent text={block.content} highlightTerms={highlightTerms} /></p>;

--- a/web/src/components/ToolCall.tsx
+++ b/web/src/components/ToolCall.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Wrench } from "lucide-react";
+
+export type ToolStatus = "running" | "done";
+
+export interface ToolCallState {
+  id: string;
+  name: string;
+  preview: string;
+  status: ToolStatus;
+}
+
+export function ToolCall({ tool }: { tool: ToolCallState }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="my-1 border border-warning/20 bg-warning/5">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-warning cursor-pointer hover:bg-warning/10 transition-colors"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        )}
+        <Wrench className="h-3 w-3 shrink-0" />
+        <span className="font-mono-ui font-medium truncate">{tool.name}</span>
+        {tool.status === "running" && (
+          <span className="ml-auto h-1.5 w-1.5 rounded-full bg-warning animate-pulse shrink-0" />
+        )}
+        {tool.status === "done" && (
+          <span className="ml-auto text-warning/50 shrink-0">done</span>
+        )}
+      </button>
+      {open && tool.preview && (
+        <pre className="border-t border-warning/20 px-3 py-2 text-xs text-warning/80 overflow-x-auto whitespace-pre-wrap font-mono">
+          {tool.preview}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -55,6 +55,7 @@ export const en: Translations = {
     nav: {
       status: "Status",
       sessions: "Sessions",
+      chat: "Chat",
       analytics: "Analytics",
       logs: "Logs",
       cron: "Cron",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -57,6 +57,7 @@ export interface Translations {
     nav: {
       status: string;
       sessions: string;
+      chat: string;
       analytics: string;
       logs: string;
       cron: string;

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -55,6 +55,7 @@ export const zh: Translations = {
     nav: {
       status: "状态",
       sessions: "会话",
+      chat: "聊天",
       analytics: "分析",
       logs: "日志",
       cron: "定时任务",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -148,6 +148,31 @@ code { font-size: 0.875rem; }
   font-family: var(--theme-font-mono);
 }
 
+/* ── Chat page layout ──────────────────────────────────────────────────── */
+
+/* Full-height chat that doesn't overflow the viewport.  The parent <main>
+   has pt-16/pt-20 (header) and pb-4/pb-8 (footer) applied as Tailwind
+   classes; h-chat-page calculates the remaining space so the history area
+   scrolls inside the page rather than growing the document. */
+.h-chat-page {
+  height: calc(100vh - 10rem); /* approx header + footer clearance */
+  max-height: calc(100dvh - 10rem); /* dvh = dynamic viewport on mobile */
+}
+
+/* Independent scroll region for the message list. */
+.chat-history {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  /* Extra bottom gap so the last message isn't hidden by the input row. */
+  padding-bottom: 0.5rem;
+}
+
+/* Reserve space for the iOS/Android home-bar on mobile so the input isn't
+   obscured by the system UI. */
+.chat-input-safe {
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
 /* Subtle grain overlay for badges. */
 .grain {
   position: relative;

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -11,7 +11,20 @@ export type GatewayEvent =
   | { method: "assistant.done"; params: { text: string } }
   | { method: "tool.started"; params: { name: string; preview: string } }
   | { method: "tool.completed"; params: { name: string; result?: string } }
-  | { method: "error"; params: { message: string } };
+  | { method: "error"; params: { message: string } }
+  | {
+      method: "usage.update";
+      params: {
+        model: string;
+        provider: string;
+        api_calls: number;
+        input_tokens: number;
+        output_tokens: number;
+        total_tokens: number;
+        context_length: number;
+        estimated_cost_usd: number;
+      };
+    };
 
 type EventHandler = (event: GatewayEvent) => void;
 type RpcResolver = (result: unknown) => void;

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -1,0 +1,120 @@
+/**
+ * Browser WebSocket client for the tui_gateway JSON-RPC transport.
+ *
+ * Connects to /ws/tui-gateway and exposes typed helpers for session
+ * management, chat, and event subscriptions.
+ */
+
+export type GatewayEvent =
+  | { method: "session.created"; params: { session_id: string } }
+  | { method: "assistant.delta"; params: { text: string } }
+  | { method: "assistant.done"; params: { text: string } }
+  | { method: "tool.started"; params: { name: string; preview: string } }
+  | { method: "tool.completed"; params: { name: string; result?: string } }
+  | { method: "error"; params: { message: string } };
+
+type EventHandler = (event: GatewayEvent) => void;
+type RpcResolver = (result: unknown) => void;
+type RpcRejector = (error: Error) => void;
+
+export class GatewayClient {
+  private ws: WebSocket | null = null;
+  private _id = 0;
+  private _pending = new Map<number, [RpcResolver, RpcRejector]>();
+  private _handlers: EventHandler[] = [];
+  private _url: string;
+
+  constructor() {
+    const token = window.__HERMES_SESSION_TOKEN__ ?? "";
+    const proto = location.protocol === "https:" ? "wss" : "ws";
+    this._url = `${proto}://${location.host}/ws/tui-gateway?token=${encodeURIComponent(token)}`;
+  }
+
+  connect(): Promise<void> {
+    if (this.ws?.readyState === WebSocket.OPEN) return Promise.resolve();
+
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this._url);
+      this.ws = ws;
+
+      ws.onopen = () => resolve();
+      ws.onerror = () => reject(new Error("WebSocket connection failed"));
+      ws.onclose = () => {
+        this._pending.forEach(([, rej]) => rej(new Error("WebSocket closed")));
+        this._pending.clear();
+      };
+      ws.onmessage = (ev) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(ev.data as string);
+        } catch {
+          return;
+        }
+
+        if ("method" in msg) {
+          // Notification (no id) — dispatch to subscribers
+          this._handlers.forEach((h) => h(msg as unknown as GatewayEvent));
+          return;
+        }
+
+        const id = msg.id as number;
+        const entry = this._pending.get(id);
+        if (!entry) return;
+        this._pending.delete(id);
+        const [resolve, reject] = entry;
+        if (msg.error) {
+          reject(new Error((msg.error as { message: string }).message));
+        } else {
+          resolve(msg.result);
+        }
+      };
+    });
+  }
+
+  subscribe(handler: EventHandler): () => void {
+    this._handlers.push(handler);
+    return () => {
+      this._handlers = this._handlers.filter((h) => h !== handler);
+    };
+  }
+
+  private _call(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("WebSocket not connected"));
+    }
+    const id = ++this._id;
+    return new Promise((resolve, reject) => {
+      this._pending.set(id, [resolve, reject]);
+      this.ws!.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    });
+  }
+
+  createSession(): Promise<{ session_id: string }> {
+    return this._call("session.create") as Promise<{ session_id: string }>;
+  }
+
+  resumeSession(session_id: string): Promise<{ ok: boolean; session_id: string }> {
+    return this._call("session.resume", { session_id }) as Promise<{
+      ok: boolean;
+      session_id: string;
+    }>;
+  }
+
+  sendMessage(message: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    const id = ++this._id;
+    // Fire-and-forget: the reply arrives after the agent finishes (assistant.done).
+    // We don't await it — interrupt() must be able to send while the run is live.
+    this._pending.set(id, [() => {}, () => {}]);
+    this.ws.send(JSON.stringify({ jsonrpc: "2.0", id, method: "chat.send", params: { message } }));
+  }
+
+  interrupt(): Promise<{ ok: boolean }> {
+    return this._call("chat.interrupt") as Promise<{ ok: boolean }>;
+  }
+
+  disconnect() {
+    this.ws?.close();
+    this.ws = null;
+  }
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -139,6 +139,7 @@ export default function ChatPage() {
   const clientRef = useRef<GatewayClient | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const pendingSendRef = useRef(false);
 
   // Scroll to bottom on new messages
   useEffect(() => {
@@ -256,7 +257,11 @@ export default function ChatPage() {
             }
             return prev;
           });
-          setRunning(false);
+          if (pendingSendRef.current) {
+            pendingSendRef.current = false;
+          } else {
+            setRunning(false);
+          }
           break;
 
         case "tool.started":
@@ -297,7 +302,11 @@ export default function ChatPage() {
 
         case "error":
           setErrorMsg(ev.params.message);
-          setRunning(false);
+          if (pendingSendRef.current) {
+            pendingSendRef.current = false;
+          } else {
+            setRunning(false);
+          }
           break;
       }
     });
@@ -338,11 +347,10 @@ export default function ChatPage() {
 
   const send = useCallback(() => {
     const text = input.trim();
-    if (!text || running || status !== "ready") return;
+    if (!text || status !== "ready") return;
 
     setInput("");
     setShowPicker(false);
-    setRunning(true);
     setErrorMsg(null);
 
     setMessages((prev) => [
@@ -350,6 +358,12 @@ export default function ChatPage() {
       { id: nextId(), role: "user", text, tools: [] },
     ]);
 
+    if (running) {
+      pendingSendRef.current = true;
+      clientRef.current!.interrupt().catch(() => {});
+    }
+
+    setRunning(true);
     try {
       clientRef.current!.sendMessage(text);
     } catch (err) {
@@ -394,7 +408,6 @@ export default function ChatPage() {
           size="sm"
           className="ml-auto h-7 gap-1.5 text-xs"
           onClick={startNewSession}
-          disabled={running}
         >
           <Plus className="h-3.5 w-3.5" />
           New session
@@ -522,7 +535,16 @@ export default function ChatPage() {
             }}
             autoComplete="off"
           />
-          {running ? (
+          <Button
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            disabled={!input.trim() || status !== "ready"}
+            onClick={send}
+            aria-label="Send"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+          {running && (
             <Button
               variant="outline"
               size="icon"
@@ -531,16 +553,6 @@ export default function ChatPage() {
               aria-label="Interrupt"
             >
               <Square className="h-4 w-4" />
-            </Button>
-          ) : (
-            <Button
-              size="icon"
-              className="h-9 w-9 shrink-0"
-              disabled={!input.trim() || status !== "ready"}
-              onClick={send}
-              aria-label="Send"
-            >
-              <Send className="h-4 w-4" />
             </Button>
           )}
         </div>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Send, Square, Plus, MessageSquare, Copy } from "lucide-react";
+import { Send, Square, Plus, MessageSquare, Copy, BarChart3 } from "lucide-react";
 import { H2 } from "@nous-research/ui";
 import { GatewayClient } from "@/lib/gatewayClient";
 import type { GatewayEvent } from "@/lib/gatewayClient";
@@ -9,7 +9,7 @@ import type { ToolCallState } from "@/components/ToolCall";
 import { Markdown } from "@/components/Markdown";
 import { Button } from "@/components/ui/button";
 import { fetchJSON } from "@/lib/api";
-import type { SessionMessagesResponse } from "@/lib/api";
+import type { SessionMessagesResponse, ModelInfoResponse } from "@/lib/api";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -28,6 +28,17 @@ interface SlashCommand {
   description: string;
 }
 
+interface UsageSnapshot {
+  model: string;
+  provider: string;
+  apiCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  contextLength: number;
+  estimatedCostUsd: number;
+}
+
 // ── Helper ─────────────────────────────────────────────────────────────────
 
 let _msgCounter = 0;
@@ -36,6 +47,13 @@ function nextId() {
 }
 
 const ACTIVE_CHAT_SESSION_KEY = "hermes.chat.activeSessionId";
+const STATUS_BAR_VISIBLE_KEY = "hermes.chat.statusBarVisible";
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
 
 function rememberedChatSession() {
   try {
@@ -136,6 +154,13 @@ export default function ChatPage() {
   const [showPicker, setShowPicker] = useState(false);
   const [pickerQuery, setPickerQuery] = useState("");
 
+  // Status bar state
+  const [statusBarVisible, setStatusBarVisible] = useState(() => {
+    try { return localStorage.getItem(STATUS_BAR_VISIBLE_KEY) !== "false"; } catch { return true; }
+  });
+  const [modelInfo, setModelInfo] = useState<ModelInfoResponse | null>(null);
+  const [usage, setUsage] = useState<UsageSnapshot | null>(null);
+
   const clientRef = useRef<GatewayClient | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -150,6 +175,13 @@ export default function ChatPage() {
   useEffect(() => {
     fetchJSON<{ commands: SlashCommand[] }>("/api/chat/commands")
       .then((r) => setAllCommands(r.commands))
+      .catch(() => {});
+  }, []);
+
+  // Fetch model info once on mount
+  useEffect(() => {
+    fetchJSON<ModelInfoResponse>("/api/model/info")
+      .then(setModelInfo)
       .catch(() => {});
   }, []);
 
@@ -308,6 +340,19 @@ export default function ChatPage() {
             setRunning(false);
           }
           break;
+
+        case "usage.update":
+          setUsage({
+            model: ev.params.model,
+            provider: ev.params.provider,
+            apiCalls: ev.params.api_calls,
+            inputTokens: ev.params.input_tokens,
+            outputTokens: ev.params.output_tokens,
+            totalTokens: ev.params.total_tokens,
+            contextLength: ev.params.context_length,
+            estimatedCostUsd: ev.params.estimated_cost_usd,
+          });
+          break;
       }
     });
 
@@ -389,6 +434,14 @@ export default function ChatPage() {
     setErrorMsg(null);
     navigate("/chat", { replace: true });
   }, [navigate]);
+
+  const toggleStatusBar = useCallback(() => {
+    setStatusBarVisible((prev) => {
+      const next = !prev;
+      try { localStorage.setItem(STATUS_BAR_VISIBLE_KEY, String(next)); } catch {}
+      return next;
+    });
+  }, []);
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -554,6 +607,67 @@ export default function ChatPage() {
             >
               <Square className="h-4 w-4" />
             </Button>
+          )}
+        </div>
+
+        {/* Status bar toggle + info */}
+        <div className="flex items-center gap-2 mt-1.5">
+          <button
+            type="button"
+            className={`p-0.5 rounded transition-colors ${
+              statusBarVisible
+                ? "text-primary hover:text-primary/80"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={toggleStatusBar}
+            title={statusBarVisible ? "Hide status bar" : "Show status bar"}
+          >
+            <BarChart3 className="h-3.5 w-3.5" />
+          </button>
+          {statusBarVisible && (
+            <div className="flex items-center gap-3 text-[10px] font-mono-ui text-muted-foreground overflow-x-auto">
+              <span className="whitespace-nowrap">
+                {usage?.model || modelInfo?.model || "—"}
+              </span>
+              {((usage?.contextLength ?? modelInfo?.effective_context_length ?? 0) > 0) && (
+                <span className="whitespace-nowrap">
+                  ctx {fmtTokens(usage?.contextLength ?? modelInfo?.effective_context_length ?? 0)}
+                </span>
+              )}
+              {usage && usage.totalTokens > 0 && (
+                <>
+                  <span className="whitespace-nowrap">
+                    in {fmtTokens(usage.inputTokens)}
+                  </span>
+                  <span className="whitespace-nowrap">
+                    out {fmtTokens(usage.outputTokens)}
+                  </span>
+                  <span className="whitespace-nowrap">
+                    {usage.apiCalls} call{usage.apiCalls !== 1 ? "s" : ""}
+                  </span>
+                </>
+              )}
+              {usage && usage.estimatedCostUsd > 0 && (
+                <span className="whitespace-nowrap">
+                  ${usage.estimatedCostUsd.toFixed(4)}
+                </span>
+              )}
+              {usage && usage.contextLength > 0 && usage.totalTokens > 0 && (
+                <span
+                  className={`whitespace-nowrap ${
+                    usage.totalTokens / usage.contextLength > 0.95
+                      ? "text-destructive"
+                      : usage.totalTokens / usage.contextLength > 0.8
+                        ? "text-orange-500"
+                        : usage.totalTokens / usage.contextLength > 0.5
+                          ? "text-yellow-600"
+                          : "text-emerald-600"
+                  }`}
+                >
+                  {((usage.totalTokens / usage.contextLength) * 100).toFixed(1)}%
+                </span>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,6 +35,41 @@ function nextId() {
   return `m-${Date.now()}-${++_msgCounter}`;
 }
 
+const ACTIVE_CHAT_SESSION_KEY = "hermes.chat.activeSessionId";
+
+function rememberedChatSession() {
+  try {
+    return window.localStorage.getItem(ACTIVE_CHAT_SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function rememberChatSession(sessionId: string) {
+  try {
+    window.localStorage.setItem(ACTIVE_CHAT_SESSION_KEY, sessionId);
+    const url = new URL(window.location.href);
+    if (url.pathname.endsWith("/chat")) {
+      url.searchParams.set("resume", sessionId);
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `${url.pathname}${url.search}${url.hash}`,
+      );
+    }
+  } catch {
+    // Persistence is best-effort; the live websocket session still works.
+  }
+}
+
+function forgetChatSession() {
+  try {
+    window.localStorage.removeItem(ACTIVE_CHAT_SESSION_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 // ── Slash command picker ────────────────────────────────────────────────────
 
 function CommandPicker({
@@ -122,10 +157,11 @@ export default function ChatPage() {
   const initSession = useCallback(
     async (client: GatewayClient, resume: string | null, fresh: boolean) => {
       try {
-        if (resume && !fresh) {
+        const resumeTarget = !fresh ? resume || rememberedChatSession() : null;
+        if (resumeTarget) {
           try {
             const resp = await fetchJSON<SessionMessagesResponse>(
-              `/api/sessions/${encodeURIComponent(resume)}/messages`,
+              `/api/sessions/${encodeURIComponent(resumeTarget)}/messages`,
             );
             const historical: ChatMessage[] = resp.messages
               .filter((m) => m.role === "user" || m.role === "assistant")
@@ -140,13 +176,20 @@ export default function ChatPage() {
                   status: "done" as const,
                 })),
               }));
-            if (historical.length > 0) setMessages(historical);
+            setMessages(historical);
           } catch {
             // 拉取失败不影响继续对话
           }
-          await client.resumeSession(resume);
+          await client.resumeSession(resumeTarget);
+          setSessionId(resumeTarget);
+          rememberChatSession(resumeTarget);
         } else {
-          await client.createSession();
+          const created = await client.createSession();
+          if (created.session_id) {
+            setSessionId(created.session_id);
+            rememberChatSession(created.session_id);
+          }
+          if (fresh) setForceNew(false);
         }
         setStatus("ready");
       } catch (err) {
@@ -165,6 +208,7 @@ export default function ChatPage() {
       switch (ev.method) {
         case "session.created":
           setSessionId(ev.params.session_id);
+          rememberChatSession(ev.params.session_id);
           break;
 
         case "assistant.delta":
@@ -323,6 +367,7 @@ export default function ChatPage() {
   }, []);
 
   const startNewSession = useCallback(() => {
+    forgetChatSession();
     setForceNew(true);
     setMessages([]);
     setSessionId(null);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -393,7 +393,7 @@ export default function ChatPage() {
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex flex-col h-chat-page">
+    <div className="flex flex-col h-chat-page w-full max-w-[50%] min-w-[720px] mx-auto">
       {/* Header */}
       <div className="flex items-center gap-3 mb-4">
         <MessageSquare className="h-5 w-5 text-muted-foreground shrink-0" />

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,0 +1,474 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Send, Square, Plus, MessageSquare } from "lucide-react";
+import { H2 } from "@nous-research/ui";
+import { GatewayClient } from "@/lib/gatewayClient";
+import type { GatewayEvent } from "@/lib/gatewayClient";
+import { ToolCall } from "@/components/ToolCall";
+import type { ToolCallState } from "@/components/ToolCall";
+import { Markdown } from "@/components/Markdown";
+import { Button } from "@/components/ui/button";
+import { fetchJSON } from "@/lib/api";
+import type { SessionMessagesResponse } from "@/lib/api";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type MessageRole = "user" | "assistant";
+
+interface ChatMessage {
+  id: string;
+  role: MessageRole;
+  text: string;
+  tools: ToolCallState[];
+  streaming?: boolean;
+}
+
+interface SlashCommand {
+  name: string;
+  description: string;
+}
+
+// ── Helper ─────────────────────────────────────────────────────────────────
+
+let _msgCounter = 0;
+function nextId() {
+  return `m-${Date.now()}-${++_msgCounter}`;
+}
+
+// ── Slash command picker ────────────────────────────────────────────────────
+
+function CommandPicker({
+  query,
+  commands,
+  onSelect,
+}: {
+  query: string;
+  commands: SlashCommand[];
+  onSelect: (name: string) => void;
+}) {
+  const lower = query.toLowerCase();
+  const filtered = commands.filter(
+    (c) =>
+      c.name.toLowerCase().includes(lower) ||
+      c.description.toLowerCase().includes(lower),
+  );
+
+  if (filtered.length === 0) return null;
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-1 z-50 border border-border bg-card shadow-lg max-h-60 overflow-y-auto">
+      {filtered.map((cmd) => (
+        <button
+          key={cmd.name}
+          type="button"
+          className="flex w-full items-start gap-3 px-3 py-2 text-left hover:bg-secondary/50 transition-colors"
+          onMouseDown={(e) => {
+            // mousedown fires before input blur — prevent blur from closing picker
+            e.preventDefault();
+            onSelect(cmd.name);
+          }}
+        >
+          <span className="font-mono-ui text-xs text-primary shrink-0 mt-0.5">
+            {cmd.name}
+          </span>
+          <span className="text-xs text-muted-foreground leading-relaxed">
+            {cmd.description}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function ChatPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const resumeId = searchParams.get("resume");
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [status, setStatus] = useState<"connecting" | "ready" | "error">("connecting");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [forceNew, setForceNew] = useState(false);
+
+  // Slash command state
+  const [allCommands, setAllCommands] = useState<SlashCommand[]>([]);
+  const [showPicker, setShowPicker] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState("");
+
+  const clientRef = useRef<GatewayClient | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Scroll to bottom on new messages
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // Fetch command list once on mount
+  useEffect(() => {
+    fetchJSON<{ commands: SlashCommand[] }>("/api/chat/commands")
+      .then((r) => setAllCommands(r.commands))
+      .catch(() => {});
+  }, []);
+
+  // ── Connect & init session ───────────────────────────────────────────────
+
+  const initSession = useCallback(
+    async (client: GatewayClient, resume: string | null, fresh: boolean) => {
+      try {
+        if (resume && !fresh) {
+          try {
+            const resp = await fetchJSON<SessionMessagesResponse>(
+              `/api/sessions/${encodeURIComponent(resume)}/messages`,
+            );
+            const historical: ChatMessage[] = resp.messages
+              .filter((m) => m.role === "user" || m.role === "assistant")
+              .map((m) => ({
+                id: nextId(),
+                role: m.role as MessageRole,
+                text: m.content ?? "",
+                tools: (m.tool_calls ?? []).map((tc) => ({
+                  id: tc.id,
+                  name: tc.function.name,
+                  preview: tc.function.arguments,
+                  status: "done" as const,
+                })),
+              }));
+            if (historical.length > 0) setMessages(historical);
+          } catch {
+            // 拉取失败不影响继续对话
+          }
+          await client.resumeSession(resume);
+        } else {
+          await client.createSession();
+        }
+        setStatus("ready");
+      } catch (err) {
+        setStatus("error");
+        setErrorMsg(String(err));
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const client = new GatewayClient();
+    clientRef.current = client;
+
+    const unsub = client.subscribe((ev: GatewayEvent) => {
+      switch (ev.method) {
+        case "session.created":
+          setSessionId(ev.params.session_id);
+          break;
+
+        case "assistant.delta":
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.role === "assistant" && last.streaming) {
+              return [
+                ...prev.slice(0, -1),
+                { ...last, text: last.text + ev.params.text },
+              ];
+            }
+            return [
+              ...prev,
+              {
+                id: nextId(),
+                role: "assistant",
+                text: ev.params.text,
+                tools: [],
+                streaming: true,
+              },
+            ];
+          });
+          break;
+
+        case "assistant.done":
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.role === "assistant" && last.streaming) {
+              return [
+                ...prev.slice(0, -1),
+                { ...last, text: ev.params.text || last.text, streaming: false },
+              ];
+            }
+            if (ev.params.text) {
+              return [
+                ...prev,
+                {
+                  id: nextId(),
+                  role: "assistant",
+                  text: ev.params.text,
+                  tools: [],
+                  streaming: false,
+                },
+              ];
+            }
+            return prev;
+          });
+          setRunning(false);
+          break;
+
+        case "tool.started":
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            const tool: ToolCallState = {
+              id: nextId(),
+              name: ev.params.name,
+              preview: ev.params.preview,
+              status: "running",
+            };
+            if (last?.role === "assistant" && last.streaming) {
+              return [
+                ...prev.slice(0, -1),
+                { ...last, tools: [...last.tools, tool] },
+              ];
+            }
+            return [
+              ...prev,
+              { id: nextId(), role: "assistant", text: "", tools: [tool], streaming: true },
+            ];
+          });
+          break;
+
+        case "tool.completed":
+          setMessages((prev) =>
+            prev.map((msg) => {
+              if (msg.role !== "assistant") return msg;
+              const tools = msg.tools.map((t) =>
+                t.name === ev.params.name && t.status === "running"
+                  ? { ...t, status: "done" as const }
+                  : t,
+              );
+              return { ...msg, tools };
+            }),
+          );
+          break;
+
+        case "error":
+          setErrorMsg(ev.params.message);
+          setRunning(false);
+          break;
+      }
+    });
+
+    client
+      .connect()
+      .then(() => initSession(client, resumeId, forceNew))
+      .catch((err) => {
+        setStatus("error");
+        setErrorMsg(String(err));
+      });
+
+    return () => {
+      unsub();
+      client.disconnect();
+    };
+  }, [resumeId, forceNew, initSession]);
+
+  // ── Input handling ────────────────────────────────────────────────────────
+
+  const handleInputChange = useCallback((value: string) => {
+    setInput(value);
+    if (value.startsWith("/")) {
+      setPickerQuery(value.slice(1)); // 去掉前缀 / 作为过滤词
+      setShowPicker(true);
+    } else {
+      setShowPicker(false);
+    }
+  }, []);
+
+  const handleCommandSelect = useCallback((name: string) => {
+    setInput(name + " ");
+    setShowPicker(false);
+    inputRef.current?.focus();
+  }, []);
+
+  // ── Send ─────────────────────────────────────────────────────────────────
+
+  const send = useCallback(() => {
+    const text = input.trim();
+    if (!text || running || status !== "ready") return;
+
+    setInput("");
+    setShowPicker(false);
+    setRunning(true);
+    setErrorMsg(null);
+
+    setMessages((prev) => [
+      ...prev,
+      { id: nextId(), role: "user", text, tools: [] },
+    ]);
+
+    try {
+      clientRef.current!.sendMessage(text);
+    } catch (err) {
+      setErrorMsg(String(err));
+      setRunning(false);
+    }
+  }, [input, running, status]);
+
+  const interrupt = useCallback(async () => {
+    try {
+      await clientRef.current!.interrupt();
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const startNewSession = useCallback(() => {
+    setForceNew(true);
+    setMessages([]);
+    setSessionId(null);
+    setStatus("connecting");
+    setErrorMsg(null);
+    navigate("/chat", { replace: true });
+  }, [navigate]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col h-chat-page">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-4">
+        <MessageSquare className="h-5 w-5 text-muted-foreground shrink-0" />
+        <H2 variant="sm">Chat</H2>
+        {sessionId && (
+          <span className="text-[10px] text-muted-foreground font-mono-ui truncate max-w-[180px] opacity-60">
+            {sessionId}
+          </span>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto h-7 gap-1.5 text-xs"
+          onClick={startNewSession}
+          disabled={running}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New session
+        </Button>
+      </div>
+
+      {/* Status banners */}
+      {status === "connecting" && (
+        <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+          <div className="h-3 w-3 animate-spin rounded-full border-[1.5px] border-primary border-t-transparent" />
+          Connecting…
+        </div>
+      )}
+      {status === "error" && errorMsg && (
+        <div className="mb-3 border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {errorMsg}
+        </div>
+      )}
+
+      {/* Message list */}
+      <div className="chat-history flex-1 overflow-y-auto flex flex-col gap-3 pr-1">
+        {messages.length === 0 && status === "ready" && (
+          <div className="flex flex-col items-center justify-center flex-1 py-16 text-muted-foreground">
+            <MessageSquare className="h-8 w-8 mb-3 opacity-30" />
+            <p className="text-sm">
+              {resumeId && !forceNew
+                ? "Resuming session — send a message to continue"
+                : "Send a message to start"}
+            </p>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={msg.role === "user" ? "chat-bubble-user" : "chat-bubble-assistant"}
+          >
+            {msg.role === "user" ? (
+              <div className="bg-primary/10 px-3 py-2 text-sm text-primary whitespace-pre-wrap">
+                {msg.text}
+              </div>
+            ) : (
+              <div className="bg-success/5 border border-success/10 px-3 py-2">
+                {msg.text && <Markdown content={msg.text} />}
+                {msg.tools.map((t) => (
+                  <ToolCall key={t.id} tool={t} />
+                ))}
+                {msg.streaming && !msg.text && msg.tools.length === 0 && (
+                  <span className="inline-block h-3 w-3 animate-spin rounded-full border-[1.5px] border-success border-t-transparent" />
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input row */}
+      <div className="relative mt-3 chat-input-safe">
+        {/* Slash command picker — appears above the input */}
+        {showPicker && (
+          <CommandPicker
+            query={pickerQuery}
+            commands={allCommands}
+            onSelect={handleCommandSelect}
+          />
+        )}
+
+        <div className="flex gap-2 items-center">
+          <input
+            ref={inputRef}
+            className="flex-1 bg-input/20 border border-border px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+            placeholder={status === "ready" ? "Message… (/ for commands)" : "Connecting…"}
+            value={input}
+            disabled={status !== "ready"}
+            onChange={(e) => handleInputChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setShowPicker(false);
+                return;
+              }
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                send();
+              }
+            }}
+            onBlur={() => {
+              // Delay so onMouseDown in picker fires first
+              setTimeout(() => setShowPicker(false), 150);
+            }}
+            onFocus={() => {
+              if (input.startsWith("/")) setShowPicker(true);
+            }}
+            autoComplete="off"
+          />
+          {running ? (
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-9 w-9 shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
+              onClick={interrupt}
+              aria-label="Interrupt"
+            >
+              <Square className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              disabled={!input.trim() || status !== "ready"}
+              onClick={send}
+              aria-label="Send"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Send, Square, Plus, MessageSquare } from "lucide-react";
+import { Send, Square, Plus, MessageSquare, Copy } from "lucide-react";
 import { H2 } from "@nous-research/ui";
 import { GatewayClient } from "@/lib/gatewayClient";
 import type { GatewayEvent } from "@/lib/gatewayClient";
@@ -103,7 +103,7 @@ export default function ChatPage() {
 
   const clientRef = useRef<GatewayClient | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // Scroll to bottom on new messages
   useEffect(() => {
@@ -388,17 +388,42 @@ export default function ChatPage() {
             className={msg.role === "user" ? "chat-bubble-user" : "chat-bubble-assistant"}
           >
             {msg.role === "user" ? (
-              <div className="bg-primary/10 px-3 py-2 text-sm text-primary whitespace-pre-wrap">
+              <div className="group relative bg-primary/10 px-3 py-2 text-sm text-primary whitespace-pre-wrap normal-case">
                 {msg.text}
+                <button
+                  type="button"
+                  className="absolute bottom-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-primary/10"
+                  onClick={() => {
+                    navigator.clipboard.writeText(msg.text);
+                    const btn = document.activeElement as HTMLElement;
+                    btn?.setAttribute("data-copied", "1");
+                    setTimeout(() => btn?.removeAttribute("data-copied"), 1500);
+                  }}
+                  aria-label="Copy message"
+                >
+                  <Copy className="h-3.5 w-3.5 text-primary/50 hover:text-primary" />
+                </button>
               </div>
             ) : (
-              <div className="bg-success/5 border border-success/10 px-3 py-2">
-                {msg.text && <Markdown content={msg.text} />}
+              <div className="group relative bg-success/5 border border-success/10 px-3 py-2 normal-case">
                 {msg.tools.map((t) => (
                   <ToolCall key={t.id} tool={t} />
                 ))}
                 {msg.streaming && !msg.text && msg.tools.length === 0 && (
                   <span className="inline-block h-3 w-3 animate-spin rounded-full border-[1.5px] border-success border-t-transparent" />
+                )}
+                {msg.text && <Markdown content={msg.text} />}
+                {!msg.streaming && msg.text && (
+                  <button
+                    type="button"
+                    className="absolute bottom-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-success/10"
+                    onClick={() => {
+                      navigator.clipboard.writeText(msg.text);
+                    }}
+                    aria-label="Copy response"
+                  >
+                    <Copy className="h-3.5 w-3.5 text-success/50 hover:text-success" />
+                  </button>
                 )}
               </div>
             )}
@@ -419,14 +444,21 @@ export default function ChatPage() {
           />
         )}
 
-        <div className="flex gap-2 items-center">
-          <input
+        <div className="flex gap-2 items-end">
+          <textarea
             ref={inputRef}
-            className="flex-1 bg-input/20 border border-border px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+            rows={1}
+            className="flex-1 bg-input/20 border border-border px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50 resize-none overflow-y-auto normal-case"
+            style={{ maxHeight: `${5 * 1.5 * 0.875 + 1}em` }}
             placeholder={status === "ready" ? "Message… (/ for commands)" : "Connecting…"}
             value={input}
             disabled={status !== "ready"}
-            onChange={(e) => handleInputChange(e.target.value)}
+            onChange={(e) => {
+              handleInputChange(e.target.value);
+              const el = e.target;
+              el.style.height = "auto";
+              el.style.height = el.scrollHeight + "px";
+            }}
             onKeyDown={(e) => {
               if (e.key === "Escape") {
                 setShowPicker(false);
@@ -438,7 +470,6 @@ export default function ChatPage() {
               }
             }}
             onBlur={() => {
-              // Delay so onMouseDown in picker fires first
               setTimeout(() => setShowPicker(false), 150);
             }}
             onFocus={() => {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   ChevronDown,
   ChevronLeft,
@@ -12,6 +13,7 @@ import {
   MessageCircle,
   Hash,
   X,
+  ExternalLink,
 } from "lucide-react";
 import { H2 } from "@nous-research/ui";
 import { api } from "@/lib/api";
@@ -246,6 +248,7 @@ function SessionRow({
   onToggle: () => void;
   onDelete: () => void;
 }) {
+  const navigate = useNavigate();
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -329,6 +332,18 @@ function SessionRow({
           <Badge variant="outline" className="text-[10px]">
             {session.source ?? "local"}
           </Badge>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-primary"
+            aria-label="Open in Chat"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/chat?resume=${encodeURIComponent(session.id)}`);
+            }}
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Button>
           <Button
             variant="ghost"
             size="icon"

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -63,8 +63,13 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    port: 5188,
     proxy: {
       "/api": BACKEND,
+      "/ws": {
+        target: BACKEND.replace(/^http/, "ws"),
+        ws: true,
+      },
     },
   },
 });

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -273,7 +273,7 @@ The web server restricts CORS to localhost origins only:
 
 - `http://localhost:9119` / `http://127.0.0.1:9119` (production)
 - `http://localhost:3000` / `http://127.0.0.1:3000`
-- `http://localhost:5173` / `http://127.0.0.1:5173` (Vite dev server)
+- `http://localhost:5188` / `http://127.0.0.1:5188` (Vite dev server)
 
 If you run the server on a custom port, that origin is added automatically.
 


### PR DESCRIPTION
## Problem

On Windows machines with both **Git for Windows** and **WSL** installed, Hermes silently fails to create or write files. The AI reports success but no files appear on the Windows filesystem.

**Root cause 1 — Wrong bash selected**: `_find_bash()` called `shutil.which("bash")` before checking Git Bash absolute paths. With WSL installed, `which("bash")` returns `C:\Windows\System32\bash.exe` (the WSL launcher). WSL uses `/mnt/d/...` path conventions, while Hermes normalises to Git Bash's `/d/...` (MSYS) format. Files were written to WSL's internal Linux filesystem, not the Windows filesystem.

**Root cause 2 — Python can't read bash temp files**: `LocalEnvironment` placed session snapshot / CWD tracking files in `/tmp` (bash-accessible only). Python's `open("/tmp/...")` uses Windows path semantics and cannot find Git Bash's `/tmp`. This caused CWD tracking to silently fall back to `os.getcwd()` (Windows format), which is unreliable inside Git Bash scripts.

**Diagnostic**: Running `terminal: pwd` returns `/mnt/d/...` (WSL) instead of `/d/...` (Git Bash). With WSL bash, `write_file` hits WSL's internal filesystem.

## Changes

### `tools/platform_compat.py` (new file)
Cross-platform helpers centralising Windows/POSIX runtime differences:
- `windows_path_to_msys()` / `msys_path_to_windows()` — bidirectional MSYS↔Windows path conversion
- `get_host_temp_dir()` — stable temp directory accessible by both bash and Python
- `pid_alive()`, `terminate_pid()` — Windows-safe alternatives to `os.kill(pid, 0)` / `SIGKILL`
- `get_detached_popen_kwargs()`, `shell_join()` — platform-appropriate subprocess helpers
- `run_powershell()` — PowerShell invocation helper
- `file_lock()` — cross-platform file locking (`fcntl` on POSIX, `msvcrt` on Windows)

### `tools/environments/local.py`
- **`_is_wsl_bash(path)`** — detects `C:\Windows\System32\bash.exe` (WSL launcher) by path, since both Git Bash and WSL share the name `bash.exe`
- **`_find_bash()`** — checks Git Bash absolute paths (`%ProgramFiles%\Git\bin\bash.exe`, etc.) **before** `shutil.which`; filters WSL launcher from PATH fallback
- **`LocalEnvironment.__init__`** — converts initial CWD to MSYS form (`/d/Code/...`) for reliable Git Bash `cd`; stores `_snapshot_path_win`/`_cwd_file_win` (Windows form) for Python file operations
- **`get_temp_dir()`** — returns MSYS form of `%LOCALAPPDATA%\Temp\hermes\` on Windows, so bash scripts can write there and Python can read back via the `_win` path variants
- **`_run_bash()`** — converts MSYS cwd back to Windows form for `subprocess.Popen`'s `cwd` parameter (Windows `CreateProcess` requires Windows paths)
- **`_update_cwd()`** / **`cleanup()`** — use `_cwd_file_win` / `_snapshot_path_win` for Python `open()` / `os.unlink()`

### `tools/approval.py`
Three new dangerous-command patterns blocking commands that traverse the MSYS virtual root `/`, which maps to all Windows drives and causes multi-minute hangs:
- `find /` — enumerates entire Windows filesystem via MSYS root
- `find /home` — similar traversal issue
- `ls -R /` — recursive listing of all drives

## Testing

```powershell
# Verify Git Bash is used (not WSL)
hermes -p default chat
> terminal: pwd
# Should return /d/... not /mnt/d/...

# Verify file creation works
> write_file path="/d/Temp/test.txt" content="hello"
# File should appear at D:\Temp\test.txt

# Run Windows compat tests (if present in your install)
.\venv\Scripts\python.exe -m pytest tests/tools/test_windows_compat.py -v
```

## Environment
- Windows 10/11 with Git for Windows + WSL installed
- Python 3.12, uv, Git Bash (`C:\Program Files\Git\bin\bash.exe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)