### PR TITLE
fix(cron): freeze threaded origin delivery to explicit targets

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 from tools.cronjob_tools import (
+    _freeze_thread_sensitive_origin_delivery,
     _scan_cron_prompt,
     check_cronjob_requirements,
     cronjob,
@@ -98,6 +99,22 @@ class TestCronjobRequirements:
         assert check_cronjob_requirements() is False
 
 
+class TestFreezeThreadSensitiveOriginDelivery:
+    def test_freezes_discord_thread_origin_to_explicit_target(self):
+        result = _freeze_thread_sensitive_origin_delivery(
+            "origin",
+            {"platform": "discord", "chat_id": "1493169190197268510", "thread_id": "1496085239917973644"},
+        )
+        assert result == "discord:1493169190197268510:1496085239917973644"
+
+    def test_leaves_non_thread_origin_unchanged(self):
+        result = _freeze_thread_sensitive_origin_delivery(
+            "origin",
+            {"platform": "discord", "chat_id": "1493169190197268510", "thread_id": None},
+        )
+        assert result == "origin"
+
+
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)
     def _setup_cron_dir(self, tmp_path, monkeypatch):
@@ -121,6 +138,43 @@ class TestUnifiedCronjobTool:
         assert listing["count"] == 1
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
+
+    def test_create_freezes_threaded_origin_delivery(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.cronjob_tools._origin_from_env",
+            lambda: {
+                "platform": "discord",
+                "chat_id": "1493169190197268510",
+                "thread_id": "1496085239917973644",
+            },
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                deliver="origin",
+            )
+        )
+        assert created["success"] is True
+        assert created["deliver"] == "discord:1493169190197268510:1496085239917973644"
+
+    def test_update_origin_delivery_freezes_threaded_target(self, monkeypatch):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h", deliver="local"))
+        job_id = created["job_id"]
+        monkeypatch.setattr(
+            "tools.cronjob_tools._origin_from_env",
+            lambda: {
+                "platform": "discord",
+                "chat_id": "1493169190197268510",
+                "thread_id": "1496085239917973644",
+            },
+        )
+
+        updated = json.loads(cronjob(action="update", job_id=job_id, deliver="origin"))
+        assert updated["success"] is True
+        assert updated["job"]["deliver"] == "discord:1493169190197268510:1496085239917973644"
 
     def test_pause_and_resume(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -114,6 +114,13 @@ class TestFreezeThreadSensitiveOriginDelivery:
         )
         assert result == "origin"
 
+    def test_normalizes_plain_origin_variants_when_not_freezing(self):
+        result = _freeze_thread_sensitive_origin_delivery(
+            " Origin ",
+            {"platform": "discord", "chat_id": "1493169190197268510", "thread_id": None},
+        )
+        assert result == "origin"
+
 
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -121,6 +121,13 @@ class TestFreezeThreadSensitiveOriginDelivery:
         )
         assert result == "origin"
 
+    def test_keeps_explicit_thread_target_unchanged(self):
+        result = _freeze_thread_sensitive_origin_delivery(
+            "discord:1493169190197268510:1496085239917973644",
+            {"platform": "discord", "chat_id": "1493169190197268510", "thread_id": "1496085239917973644"},
+        )
+        assert result == "discord:1493169190197268510:1496085239917973644"
+
 
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -98,6 +98,26 @@ def _repeat_display(job: Dict[str, Any]) -> str:
     return f"{completed}/{times}" if completed else f"{times} times"
 
 
+def _freeze_thread_sensitive_origin_delivery(
+    deliver: Optional[str],
+    origin: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    normalized = (deliver or "").strip().lower() if isinstance(deliver, str) else deliver
+    if normalized not in (None, "", "origin"):
+        return deliver
+    if not origin:
+        return deliver
+
+    platform = str(origin.get("platform") or "").strip().lower()
+    chat_id = str(origin.get("chat_id") or "").strip()
+    thread_id = str(origin.get("thread_id") or "").strip()
+    if not (platform and chat_id and thread_id):
+        return deliver
+    if platform not in {"discord", "telegram"}:
+        return deliver
+    return f"{platform}:{chat_id}:{thread_id}"
+
+
 def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
     if skills is None:
         raw_items = [skill] if skill else []
@@ -278,13 +298,16 @@ def cronjob(
                             success=False,
                         )
 
+            origin = _origin_from_env()
+            effective_deliver = _freeze_thread_sensitive_origin_delivery(deliver, origin)
+
             job = create_job(
                 prompt=prompt or "",
                 schedule=schedule,
                 name=name,
                 repeat=repeat,
-                deliver=deliver,
-                origin=_origin_from_env(),
+                deliver=effective_deliver,
+                origin=origin,
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
@@ -364,7 +387,8 @@ def cronjob(
             if name is not None:
                 updates["name"] = name
             if deliver is not None:
-                updates["deliver"] = deliver
+                current_origin = _origin_from_env() or job.get("origin")
+                updates["deliver"] = _freeze_thread_sensitive_origin_delivery(deliver, current_origin)
             if skills is not None or skill is not None:
                 canonical_skills = _canonical_skills(skill, skills)
                 updates["skills"] = canonical_skills

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -105,16 +105,18 @@ def _freeze_thread_sensitive_origin_delivery(
     normalized = (deliver or "").strip().lower() if isinstance(deliver, str) else deliver
     if normalized not in (None, "", "origin"):
         return deliver
+
+    canonical_deliver = "origin" if normalized in ("", "origin") else deliver
     if not origin:
-        return deliver
+        return canonical_deliver
 
     platform = str(origin.get("platform") or "").strip().lower()
     chat_id = str(origin.get("chat_id") or "").strip()
     thread_id = str(origin.get("thread_id") or "").strip()
     if not (platform and chat_id and thread_id):
-        return deliver
+        return canonical_deliver
     if platform not in {"discord", "telegram"}:
-        return deliver
+        return canonical_deliver
     return f"{platform}:{chat_id}:{thread_id}"
 
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a cron delivery reliability issue for **thread-based chats**.

Today, when a cron job is created from inside a Discord or Telegram thread with `deliver="origin"`, Hermes may preserve only the abstract `origin` token instead of the concrete thread destination. That is convenient at creation time, but it is too ambiguous for a delayed job that runs later in a different execution context.

In practice, that means a follow-up that was clearly intended to return to **the exact original thread** can lose that thread-specific routing information and fall back to a broader channel target. For users relying on scheduled reminders, check-ins, or delayed reports, that breaks continuity and makes the automation feel unreliable.

This PR fixes that by resolving thread-sensitive `origin` deliveries into an explicit persisted target — `platform:chat_id:thread_id` — **when Hermes already has complete origin metadata available**. The change is intentionally conservative: if Hermes does not know the full thread destination, behavior remains unchanged.

## Why this PR should be merged

### 1. It fixes a real user-facing reliability problem
This is not a cosmetic cleanup. It addresses a failure mode where scheduled follow-ups can land in the wrong place even though the user clearly initiated them from a specific thread.

### 2. It preserves the existing user-facing workflow
Users can still say “deliver to origin.” This PR does **not** make the interface more complex. It only makes the stored routing data more explicit in the cases where the original intent is already known.

### 3. The scope is narrow and low-risk
The fix is deliberately small:
- it only touches cron delivery target normalization
- it only upgrades `origin` when the origin is clearly thread-scoped
- it leaves non-threaded and non-supported-platform cases alone

### 4. It adds regression coverage for the exact edge case
The PR includes focused tests for both create/update flows and for the thread-sensitive normalization behavior itself, so the bug is less likely to regress later.

## Related Issue

N/A — prepared from a focused upstream contribution worktree for a thread-routing reliability bug observed during real Discord cron follow-up workflows.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Code changes
- Added `_freeze_thread_sensitive_origin_delivery()` in `tools/cronjob_tools.py`
- Freeze `deliver="origin"` into an explicit `discord:chat_id:thread_id` or `telegram:chat_id:thread_id` target when full origin metadata is present
- Apply the same normalization during both **cron job creation** and **cron job update**

### Safety / compatibility behavior
- Leave non-threaded `origin` unchanged
- Leave already-explicit delivery targets unchanged
- Leave unsupported or incomplete origin metadata unchanged

### Test coverage
Added regression tests in `tests/tools/test_cronjob_tools.py` for:
- Discord thread origin freezing
- non-threaded `origin` pass-through
- normalization of loose `origin` variants like `" Origin "`
- preserving already-explicit thread targets
- create/update persistence of the frozen thread target

## Why this approach

I chose to resolve the delivery target **at create/update time** rather than later at execution time because that is the point where Hermes still has the best access to the original thread context.

By freezing the destination early, the scheduler no longer depends on later execution context to reconstruct a thread-specific route. That keeps the behavior deterministic and makes delayed delivery more robust.

Just as importantly, this avoids a broader redesign of cron delivery semantics. The fix stays close to the existing model and changes only what is necessary to preserve the original intent.

## How to Test

1. Run the focused cronjob tool tests:
   ```bash
   python3 -m pytest -q -o addopts='' tests/tools/test_cronjob_tools.py
   ```
2. Confirm the new regression cases pass, especially the ones covering thread-sensitive `origin` freezing.
3. Review `tools/cronjob_tools.py` and verify the expected behavior:
   - threaded Discord/Telegram origins become explicit persisted targets
   - non-threaded `origin` remains `origin`
   - already-explicit delivery targets are left untouched

## Verification

Focused verification output:

```text
31 passed in 0.08s
```

## Risks

This PR intentionally changes how Hermes persists a subset of `origin` deliveries, so the main risk would be over-eager normalization.

That is why the implementation is intentionally strict:
- it requires platform + chat_id + thread_id
- it only applies to thread-sensitive platforms
- it preserves the previous behavior everywhere else

So the expected risk surface is small and well-bounded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
