### PR TITLE
fix: add encoding='utf-8', errors='replace' to subprocess.Popen

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1208,6 +1208,8 @@ def _run_browser_command(
                 stderr=stderr_fd,
                 stdin=subprocess.DEVNULL,
                 env=browser_env,
+                encoding='utf-8',
+                errors='replace',
             )
         finally:
             os.close(stdout_fd)


### PR DESCRIPTION
## Fix: Windows GBK encoding error in browser tool

**Problem:** On Windows, `subprocess.Popen` defaults to system encoding (GBK).
When reading browser command output from GitHub pages (UTF-8 content), Python
fails with:

```
'gbk' codec can't decode byte 0xa6 in position 1068: illegal multibyte sequence
```

**Solution:** Add `encoding='utf-8', errors='replace'` as kwargs to
`subprocess.Popen` in `_run_browser_command`.

**Files changed:** Only `tools/browser_tool.py` — adds two lines:
```python
proc = subprocess.Popen(
    ...,
    encoding='utf-8',   # NEW
    errors='replace',  # NEW
)
```

**Testing:** Verified on Windows — `browser_navigate` + `browser_console`
correctly return UTF-8 Chinese content from GitHub pages.