### PR TITLE
﻿fix(cron): #13288 inherit runtime provider defaults on job create

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -231,3 +231,63 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         assert updated["job"]["skills"] == []
         assert updated["job"]["skill"] is None
+
+    def test_create_inherits_runtime_provider_when_missing(self, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        def _fake_runtime_provider(**kwargs):
+            return {
+                "provider": "custom",
+                "base_url": "https://gateway.example/v1/",
+                "api_key": "dummy",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _fake_runtime_provider,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Provider Inheritance",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["provider"] == "custom"
+        assert created["job"]["base_url"] == "https://gateway.example/v1"
+
+    def test_create_preserves_explicit_provider_and_base_url(self, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        def _fake_runtime_provider(**kwargs):
+            return {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "dummy",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _fake_runtime_provider,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Provider Explicit",
+                provider="custom",
+                base_url="https://keep.me/v1/",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["provider"] == "custom"
+        assert created["job"]["base_url"] == "https://keep.me/v1"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -150,6 +150,43 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _resolve_create_runtime_defaults(
+    *,
+    provider: Optional[str],
+    base_url: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Best-effort runtime defaults for cron create.
+
+    Gateway-created jobs may omit provider/base_url. Resolve the active runtime
+    settings so persisted jobs execute with the same provider selection as the
+    current session. Explicit user values always win.
+    """
+    resolved_provider = _normalize_optional_job_value(provider)
+    resolved_base_url = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+    if resolved_provider and resolved_base_url:
+        return resolved_provider, resolved_base_url
+
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=resolved_provider,
+            explicit_base_url=resolved_base_url,
+        )
+    except Exception as exc:
+        logger.debug("cron create: runtime provider resolution unavailable: %s", exc)
+        return resolved_provider, resolved_base_url
+
+    if not resolved_provider:
+        resolved_provider = _normalize_optional_job_value(runtime.get("provider"))
+    if not resolved_base_url:
+        resolved_base_url = _normalize_optional_job_value(
+            runtime.get("base_url"),
+            strip_trailing_slash=True,
+        )
+    return resolved_provider, resolved_base_url
+
+
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
@@ -259,6 +296,11 @@ def cronjob(
                 if script_error:
                     return tool_error(script_error, success=False)
 
+            resolved_provider, resolved_base_url = _resolve_create_runtime_defaults(
+                provider=provider,
+                base_url=base_url,
+            )
+
             job = create_job(
                 prompt=prompt or "",
                 schedule=schedule,
@@ -268,8 +310,8 @@ def cronjob(
                 origin=_origin_from_env(),
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
-                provider=_normalize_optional_job_value(provider),
-                base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                provider=resolved_provider,
+                base_url=resolved_base_url,
                 script=_normalize_optional_job_value(script),
             )
             return json.dumps(


### PR DESCRIPTION
## What does this PR do?

This PR fixes cron jobs created from gateway sessions (for example Weixin) inheriting an invalid legacy provider at execution time.
When `provider` or `base_url` is omitted on `cronjob(action="create")`, the tool now resolves runtime defaults from the active session and persists them into the job.

## Related Issue

Fixes #13288

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/cronjob_tools.py` to resolve runtime defaults for cron create when `provider`/`base_url` are not explicitly passed.
- Preserved explicit `provider` and `base_url` values when users provide them.
- Kept runtime-resolution failures non-fatal to preserve existing behavior in constrained environments.
- Added regressions in `tests/tools/test_cronjob_tools.py` for gateway-session inheritance and explicit-override preservation.

## How to Test

1. Run `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/tools/test_cronjob_tools.py -q`
2. Verify new tests pass:
   - `test_create_inherits_runtime_provider_when_missing`
   - `test_create_preserves_explicit_provider_and_base_url`
3. Optionally create a cron job from a gateway session without explicit provider/base_url and confirm the stored job fields inherit runtime provider settings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 (Git Bash/PowerShell with uv-managed Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/tools/test_cronjob_tools.py -q` -> `27 passed`
