### PR TITLE
feat(bindu): A2A microservice adapter for agent-to-agent calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ __pycache__/
 .env.production.local
 .env.development
 .env.test
+# Bindu adapter writes per-agent DID keys and OAuth credentials here.
+# Never commit — oauth_credentials.json contains a client_secret and
+# private.pem is the agent's signing key.
+.bindu/
 export*
 __pycache__/model_tools.cpython-310.pyc
 __pycache__/web_tools.cpython-310.pyc

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ For the full command lists, see the [CLI guide](https://hermes-agent.nousresearc
 
 ---
 
+## Expose Hermes as an A2A microservice (optional)
+
+`hermes gateway` makes Hermes talk to *humans* on messaging platforms. The **Bindu adapter** makes it talk to *other agents* over the open [A2A protocol](https://a2aproject.github.io/A2A/) — with a cryptographic DID identity, OAuth2 auth, and optional USDC micropayments. Same agent, same skills, same memory. New interface.
+
+```bash
+pip install -e '.[bindu]'
+hermes-bindu                           # serves on http://localhost:3773
+```
+
+Why you might want it: let a LangChain/AG2 agent call Hermes as a research subagent, run a Hermes instance that charges per query, or give your agent a stable cryptographic identity for agent-to-agent trust. See [`bindu_adapter/README.md`](bindu_adapter/README.md) for the full walkthrough, safety tiers, and configuration.
+
+---
+
 ## Documentation
 
 All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**:

--- a/bindu_adapter/README.md
+++ b/bindu_adapter/README.md
@@ -1,0 +1,209 @@
+# Hermes ↔ Bindu A2A Adapter
+
+Run Hermes Agent as an **Agent-to-Agent (A2A) microservice** with a cryptographic identity, OAuth2 auth, and optional crypto payments — so *other* agents and gateways can call it the same way humans talk to it from the CLI.
+
+> TL;DR — with ~90 lines of adapter code and `pip install .[bindu]`, your running Hermes becomes a discoverable, signed, callable service. Same agent, same skills, same memory. New interface.
+
+---
+
+## Why would I want this?
+
+Hermes already shines at the human-facing interface — CLI, Telegram, Discord, Slack, WhatsApp, Signal. The gateway makes Hermes talk to *people* on their terms.
+
+This adapter adds the other half: making Hermes talk to *other agents* on their terms. Four concrete things you get:
+
+### 1. A standard protocol other agents can speak
+
+[A2A](https://a2aproject.github.io/A2A/) is a JSON-RPC spec for agent-to-agent calls. LangChain, AG2/AutoGen, the OpenAI Agents SDK, and an increasing number of frameworks speak it natively. Once your Hermes is on A2A, any of those agents can call it — delegate a research task, ask a follow-up, feed results into a pipeline — without anyone writing an HTTP client for Hermes' internals.
+
+```
+Other agent (LangChain/AG2/etc.) ──► A2A JSON-RPC ──► your Hermes
+                                                         │
+                                              full skill loop, memory, tools
+                                                         │
+                                  ◄──── DID-signed artifact reply ────
+```
+
+### 2. A cryptographic identity, not just a URL
+
+Hermes publishes a DID (`did:bindu:<author>:<name>:<uuid>`) derived from an Ed25519 keypair. Every response artifact is signed with that key. For the calling agent, that means:
+
+- **Authenticity** — the response really came from *your* Hermes, not a man-in-the-middle.
+- **Accountability** — you can log the DID alongside the artifact for audit.
+- **Interop** — DID is a W3C standard; anything that resolves DIDs can verify a Hermes response without a shared database.
+
+### 3. OAuth2 out of the box
+
+The adapter registers Hermes with [Ory Hydra](https://www.ory.sh/hydra/) and issues scoped tokens (`agent:read`, `agent:write`, `agent:execute`). If your hermes-agent deployment is only allowed to talk to a specific other agent — enforce that with a scope, not with a firewall rule and a prayer.
+
+### 4. Monetization that doesn't require Stripe
+
+Bindu ships with [x402](https://www.x402.org/) support — HTTP-native micropayments in USDC on Base. Flip one config flag and callers must pay 0.01 USDC (or whatever you set) before Hermes processes the request. No API gateway, no billing vendor, no webhook reconciliation. Just the HTTP 402 status code doing what it was invented for.
+
+---
+
+## What this isn't
+
+This adapter does **not** replace `hermes gateway`. It's additive.
+
+- Use **`hermes`** (the CLI) to talk to your agent yourself.
+- Use **`hermes gateway`** to talk to your agent from Telegram/Discord/Slack/WhatsApp/Signal.
+- Use **`hermes-bindu`** to let *other agents* talk to your agent over A2A.
+
+All three can run against the same Hermes configuration. They share skills, memory, tools, and context files.
+
+---
+
+## Quick start
+
+### 1. Install the extra
+
+```bash
+pip install -e '.[bindu]'
+```
+
+That pulls [`bindu`](https://github.com/GetBindu/Bindu) alongside Hermes. Nothing in your existing Hermes install changes.
+
+### 2. Set an LLM key
+
+```bash
+# In ~/.hermes/.env (same file the main CLI uses)
+OPENROUTER_API_KEY=sk-or-v1-...
+```
+
+Any provider Hermes already supports works — this adapter just delegates to `AIAgent`, so `hermes model` settings carry over. Or override per-process with `HERMES_BINDU_MODEL`.
+
+### 3. Run it
+
+```bash
+hermes-bindu
+```
+
+The banner prints your agent's DID and the A2A endpoint:
+
+```
+🚀 Bindu Server 🚀
+Local Server: http://localhost:3773
+
+Agent DID: did:bindu:you_at_example_com:hermes:<uuid>
+```
+
+### 4. Call it
+
+Standard A2A JSON-RPC over HTTP. From the same machine:
+
+```bash
+uuid() { uuidgen | tr 'A-Z' 'a-z'; }
+TID=$(uuid); MID=$(uuid); CID=$(uuid); RID=$(uuid)
+
+curl -sS -X POST http://localhost:3773/ \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"id\":\"$RID\",
+    \"params\":{
+      \"message\":{
+        \"role\":\"user\",
+        \"parts\":[{\"kind\":\"text\",\"text\":\"summarize the last Hacker News frontpage\"}],
+        \"kind\":\"message\",
+        \"messageId\":\"$MID\",\"contextId\":\"$CID\",\"taskId\":\"$TID\"
+      }
+    }
+  }" | jq
+
+# Poll tasks/get until state is completed
+curl -sS -X POST http://localhost:3773/ \
+  -H 'Content-Type: application/json' \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tasks/get\",\"id\":\"$(uuid)\",\"params\":{\"taskId\":\"$TID\"}}" \
+  | jq '.result | {state: .status.state, text: .artifacts[0].parts[0].text}'
+```
+
+The first call returns immediately with `state: submitted`; the artifact lands when `state: completed`. Authenticated calls also send `Authorization`, `X-DID`, `X-DID-Signature`, `X-DID-Timestamp` headers — see the [A2A spec](https://github.com/GetBindu/Bindu/blob/main/openapi.yaml) and Bindu's examples for the full signing flow.
+
+---
+
+## Safety tiers
+
+Hermes exposes ~20 toolsets. An agent callable over the public internet should not have a shell. Set `HERMES_BINDU_TIER` to gate what the A2A-exposed agent can reach:
+
+| Tier | Toolsets exposed | When to use |
+|---|---|---|
+| `read` *(default)* | `web` (search + extract) | Public endpoints, tunneled exposure, untrusted callers |
+| `sandbox` | `web` + `file` + `moa` | Trusted callers, ephemeral container, filesystem OK |
+| `full` | Everything — terminal, browser, code exec, MCP | **Localhost only** |
+
+> ⚠️ **Never combine `full` with `HERMES_BINDU_EXPOSE=true`.** That exposes a remote shell over HTTP to the internet. Don't do it.
+
+---
+
+## Configuration
+
+Every knob is an env var; nothing requires editing code. Add to `~/.hermes/.env` or export inline.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HERMES_BINDU_MODEL` | `anthropic/claude-3.5-haiku` | LLM backing the A2A-exposed agent |
+| `HERMES_BINDU_TIER` | `read` | Toolset tier (`read` / `sandbox` / `full`) |
+| `HERMES_BINDU_MAX_ITERATIONS` | `30` | Max tool-calling loops per A2A request |
+| `HERMES_BINDU_URL` | `http://localhost:3773` | Public URL Bindu advertises in the agent card |
+| `HERMES_BINDU_NAME` | `hermes` | Agent display name |
+| `HERMES_BINDU_AUTHOR` | `you@example.com` | Author field on the agent card |
+| `HERMES_BINDU_DESCRIPTION` | *(see entry.py)* | Agent description on the agent card |
+| `HERMES_BINDU_EXPOSE` | `false` | If `true`, Bindu opens a public FRP tunnel |
+
+Bindu-level settings (payments, Hydra URLs, etc.) follow Bindu's own env conventions — see [Bindu's docs](https://docs.getbindu.com) or the generated `~/.hermes/.bindu/` directory.
+
+---
+
+## How it fits together
+
+```
+                        ┌──────────────────────────────────────┐
+  other agent ─► A2A ──►│  Bindu HTTP server (:3773)           │
+                        │    • OAuth2 (Hydra)                   │
+                        │    • DID verification                 │
+                        │    • x402 payment (optional)          │
+                        │    • ManifestWorker                   │
+                        │              │                        │
+                        │              ▼                        │
+                        │    bindu_adapter.handler(messages)    │
+                        │              │                        │
+                        │              ▼                        │
+                        │    AIAgent.chat(latest_user_text)     │
+                        │              │                        │
+                        │              └─► Hermes tool loop ──► │
+                        │                  (web, file, memory,  │
+                        │                   skills, …)          │
+                        └──────────────────────────────────────┘
+```
+
+The handler keeps **one shared `AIAgent`** per process. Bindu is the source of truth for conversation history; Hermes owns the live model state so provider prompt caches stay valid across turns.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `adapter.py` | `AIAgent` wrapped as a Bindu `handler(messages) -> str` |
+| `entry.py` | CLI entry: loads env, builds the Bindu config, calls `bindufy()` |
+| `__main__.py` | Enables `python -m bindu_adapter` |
+
+~200 lines of glue. No forked code paths, no parallel tool registry, no second event loop.
+
+---
+
+## Troubleshooting
+
+- **`ImportError: No module named 'bindu'`** — you didn't install the extra. Run `pip install -e '.[bindu]'`.
+- **`401` / `403` on requests** — you're hitting the auth layers. The banner at startup prints a curl snippet for fetching a Hydra token; use that as the `Authorization: Bearer <token>` and sign each request with the DID keys in `~/.hermes/.bindu/` (or the project's `.bindu/`).
+- **Port 3773 already in use** — another agent is running. Set `HERMES_BINDU_URL=http://localhost:4000` (or any free port).
+- **Tool calls silently blocked** — you're on the default `read` tier. Flip to `sandbox` or `full` if (and only if) it's safe for your deployment.
+
+---
+
+## Learn more
+
+- Bindu source: <https://github.com/GetBindu/Bindu>
+- A2A protocol: <https://a2aproject.github.io/A2A/>
+- x402 payments: <https://www.x402.org/>
+- DID method spec: <https://www.w3.org/TR/did-core/>

--- a/bindu_adapter/README.md
+++ b/bindu_adapter/README.md
@@ -2,6 +2,8 @@
 
 Expose Hermes' `AIAgent` as an [A2A](https://a2aproject.github.io/A2A/) microservice so **other agents** can call it — with a cryptographic DID identity, OAuth2 auth, and optional x402 micropayments.
 
+> **[Bindu](https://github.com/GetBindu/Bindu)** — _the identity, communication & payments layer for AI agents._
+
 `hermes gateway` → talk to Hermes from **messaging platforms** (humans).
 `hermes-bindu`   → talk to Hermes from **other agents** (A2A JSON-RPC).
 
@@ -121,6 +123,7 @@ One long-lived `AIAgent` per process so provider prompt caches stay valid across
 
 ## Links
 
-- Bindu: <https://github.com/GetBindu/Bindu>
-- A2A protocol: <https://a2aproject.github.io/A2A/>
-- x402: <https://www.x402.org/>
+- Bindu (source): <https://github.com/GetBindu/Bindu>
+- Bindu (docs):   <https://docs.getbindu.com>
+- A2A protocol:   <https://a2aproject.github.io/A2A/>
+- x402:           <https://www.x402.org/>

--- a/bindu_adapter/README.md
+++ b/bindu_adapter/README.md
@@ -1,209 +1,126 @@
 # Hermes ↔ Bindu A2A Adapter
 
-Run Hermes Agent as an **Agent-to-Agent (A2A) microservice** with a cryptographic identity, OAuth2 auth, and optional crypto payments — so *other* agents and gateways can call it the same way humans talk to it from the CLI.
+Expose Hermes' `AIAgent` as an [A2A](https://a2aproject.github.io/A2A/) microservice so **other agents** can call it — with a cryptographic DID identity, OAuth2 auth, and optional x402 micropayments.
 
-> TL;DR — with ~90 lines of adapter code and `pip install .[bindu]`, your running Hermes becomes a discoverable, signed, callable service. Same agent, same skills, same memory. New interface.
+`hermes gateway` → talk to Hermes from **messaging platforms** (humans).
+`hermes-bindu`   → talk to Hermes from **other agents** (A2A JSON-RPC).
+
+Additive. Opt-in extra. No changes to the base install. ~200 lines of glue.
 
 ---
 
-## Why would I want this?
+## Verified working
 
-Hermes already shines at the human-facing interface — CLI, Telegram, Discord, Slack, WhatsApp, Signal. The gateway makes Hermes talk to *people* on their terms.
+Tested end-to-end on this branch before the PR. Both paths round-trip:
 
-This adapter adds the other half: making Hermes talk to *other agents* on their terms. Four concrete things you get:
+| Mode | Result |
+|---|---|
+| **No auth** (dev) — direct `message/send` → `tasks/get` | ✅ `submitted` → `completed` in ~3s, correct artifact returned |
+| **Auth on** (`AUTH__ENABLED=true AUTH__PROVIDER=hydra`) — Hydra JWT + DID Ed25519 signature on every call | ✅ Token issued, DID verified, artifact returned |
 
-### 1. A standard protocol other agents can speak
-
-[A2A](https://a2aproject.github.io/A2A/) is a JSON-RPC spec for agent-to-agent calls. LangChain, AG2/AutoGen, the OpenAI Agents SDK, and an increasing number of frameworks speak it natively. Once your Hermes is on A2A, any of those agents can call it — delegate a research task, ask a follow-up, feed results into a pipeline — without anyone writing an HTTP client for Hermes' internals.
+Abridged auth-on boot log:
 
 ```
-Other agent (LangChain/AG2/etc.) ──► A2A JSON-RPC ──► your Hermes
-                                                         │
-                                              full skill loop, memory, tools
-                                                         │
-                                  ◄──── DID-signed artifact reply ────
+INFO  Registering agent in Hydra OAuth2 server with DID-based authentication...
+INFO  Extracted public key (base58) from DID extension
+INFO  ✅ Agent registered in Hydra
+INFO  Authentication middleware enabled
+INFO  Hydra OAuth2 authentication enabled
+INFO  Uvicorn running on http://localhost:3780
 ```
 
-### 2. A cryptographic identity, not just a URL
-
-Hermes publishes a DID (`did:bindu:<author>:<name>:<uuid>`) derived from an Ed25519 keypair. Every response artifact is signed with that key. For the calling agent, that means:
-
-- **Authenticity** — the response really came from *your* Hermes, not a man-in-the-middle.
-- **Accountability** — you can log the DID alongside the artifact for audit.
-- **Interop** — DID is a W3C standard; anything that resolves DIDs can verify a Hermes response without a shared database.
-
-### 3. OAuth2 out of the box
-
-The adapter registers Hermes with [Ory Hydra](https://www.ory.sh/hydra/) and issues scoped tokens (`agent:read`, `agent:write`, `agent:execute`). If your hermes-agent deployment is only allowed to talk to a specific other agent — enforce that with a scope, not with a firewall rule and a prayer.
-
-### 4. Monetization that doesn't require Stripe
-
-Bindu ships with [x402](https://www.x402.org/) support — HTTP-native micropayments in USDC on Base. Flip one config flag and callers must pay 0.01 USDC (or whatever you set) before Hermes processes the request. No API gateway, no billing vendor, no webhook reconciliation. Just the HTTP 402 status code doing what it was invented for.
-
 ---
 
-## What this isn't
-
-This adapter does **not** replace `hermes gateway`. It's additive.
-
-- Use **`hermes`** (the CLI) to talk to your agent yourself.
-- Use **`hermes gateway`** to talk to your agent from Telegram/Discord/Slack/WhatsApp/Signal.
-- Use **`hermes-bindu`** to let *other agents* talk to your agent over A2A.
-
-All three can run against the same Hermes configuration. They share skills, memory, tools, and context files.
-
----
-
-## Quick start
-
-### 1. Install the extra
+## Install
 
 ```bash
 pip install -e '.[bindu]'
 ```
 
-That pulls [`bindu`](https://github.com/GetBindu/Bindu) alongside Hermes. Nothing in your existing Hermes install changes.
+Nothing in the base Hermes install changes. The `[bindu]` extra only pulls [`bindu`](https://github.com/GetBindu/Bindu).
 
-### 2. Set an LLM key
-
-```bash
-# In ~/.hermes/.env (same file the main CLI uses)
-OPENROUTER_API_KEY=sk-or-v1-...
-```
-
-Any provider Hermes already supports works — this adapter just delegates to `AIAgent`, so `hermes model` settings carry over. Or override per-process with `HERMES_BINDU_MODEL`.
-
-### 3. Run it
+## Run
 
 ```bash
-hermes-bindu
+hermes-bindu                           # → http://localhost:3773
 ```
 
-The banner prints your agent's DID and the A2A endpoint:
+Uses `~/.hermes/.env` for env (same as the main CLI). Any `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / etc. already configured for Hermes works as-is.
 
-```
-🚀 Bindu Server 🚀
-Local Server: http://localhost:3773
+## Call it
 
-Agent DID: did:bindu:you_at_example_com:hermes:<uuid>
-```
-
-### 4. Call it
-
-Standard A2A JSON-RPC over HTTP. From the same machine:
+Standard A2A JSON-RPC. Submit a message, poll until the task completes:
 
 ```bash
-uuid() { uuidgen | tr 'A-Z' 'a-z'; }
-TID=$(uuid); MID=$(uuid); CID=$(uuid); RID=$(uuid)
-
-curl -sS -X POST http://localhost:3773/ \
-  -H 'Content-Type: application/json' \
-  -d "{
-    \"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"id\":\"$RID\",
-    \"params\":{
-      \"message\":{
-        \"role\":\"user\",
-        \"parts\":[{\"kind\":\"text\",\"text\":\"summarize the last Hacker News frontpage\"}],
-        \"kind\":\"message\",
-        \"messageId\":\"$MID\",\"contextId\":\"$CID\",\"taskId\":\"$TID\"
-      }
-    }
-  }" | jq
-
-# Poll tasks/get until state is completed
-curl -sS -X POST http://localhost:3773/ \
-  -H 'Content-Type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tasks/get\",\"id\":\"$(uuid)\",\"params\":{\"taskId\":\"$TID\"}}" \
-  | jq '.result | {state: .status.state, text: .artifacts[0].parts[0].text}'
+curl -sS -X POST http://localhost:3773/ -H 'Content-Type: application/json' -d '{
+  "jsonrpc":"2.0","method":"message/send","id":"<uuid>",
+  "params":{"message":{
+    "role":"user","kind":"message",
+    "parts":[{"kind":"text","text":"summarize HN frontpage"}],
+    "messageId":"<uuid>","contextId":"<uuid>","taskId":"<uuid>"
+  }}
+}'
 ```
 
-The first call returns immediately with `state: submitted`; the artifact lands when `state: completed`. Authenticated calls also send `Authorization`, `X-DID`, `X-DID-Signature`, `X-DID-Timestamp` headers — see the [A2A spec](https://github.com/GetBindu/Bindu/blob/main/openapi.yaml) and Bindu's examples for the full signing flow.
+With auth on, add `Authorization: Bearer <hydra-jwt>` plus the three `X-DID*` signature headers. The startup banner prints the exact curl to fetch a Hydra token.
 
 ---
 
 ## Safety tiers
 
-Hermes exposes ~20 toolsets. An agent callable over the public internet should not have a shell. Set `HERMES_BINDU_TIER` to gate what the A2A-exposed agent can reach:
+Hermes has ~20 toolsets. Gate what's exposed via `HERMES_BINDU_TIER`:
 
-| Tier | Toolsets exposed | When to use |
+| Tier | Toolsets | Use when |
 |---|---|---|
-| `read` *(default)* | `web` (search + extract) | Public endpoints, tunneled exposure, untrusted callers |
-| `sandbox` | `web` + `file` + `moa` | Trusted callers, ephemeral container, filesystem OK |
-| `full` | Everything — terminal, browser, code exec, MCP | **Localhost only** |
+| `read` *(default)* | `web` | Public / tunneled, untrusted callers |
+| `sandbox` | `web` + `file` + `moa` | Trusted callers, ephemeral container |
+| `full` | everything — terminal, browser, code-exec, MCP | **Localhost only** |
 
-> ⚠️ **Never combine `full` with `HERMES_BINDU_EXPOSE=true`.** That exposes a remote shell over HTTP to the internet. Don't do it.
-
----
+⚠️ **Never combine `full` with `HERMES_BINDU_EXPOSE=true`.** That's remote code execution over HTTP.
 
 ## Configuration
 
-Every knob is an env var; nothing requires editing code. Add to `~/.hermes/.env` or export inline.
+All env vars, nothing requires editing code:
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `HERMES_BINDU_MODEL` | `anthropic/claude-3.5-haiku` | LLM backing the A2A-exposed agent |
-| `HERMES_BINDU_TIER` | `read` | Toolset tier (`read` / `sandbox` / `full`) |
-| `HERMES_BINDU_MAX_ITERATIONS` | `30` | Max tool-calling loops per A2A request |
-| `HERMES_BINDU_URL` | `http://localhost:3773` | Public URL Bindu advertises in the agent card |
+| `HERMES_BINDU_TIER` | `read` | Toolset tier (see above) |
+| `HERMES_BINDU_MAX_ITERATIONS` | `30` | Max tool loops per A2A request |
+| `HERMES_BINDU_URL` | `http://localhost:3773` | Public URL in the agent card |
 | `HERMES_BINDU_NAME` | `hermes` | Agent display name |
 | `HERMES_BINDU_AUTHOR` | `you@example.com` | Author field on the agent card |
-| `HERMES_BINDU_DESCRIPTION` | *(see entry.py)* | Agent description on the agent card |
-| `HERMES_BINDU_EXPOSE` | `false` | If `true`, Bindu opens a public FRP tunnel |
-
-Bindu-level settings (payments, Hydra URLs, etc.) follow Bindu's own env conventions — see [Bindu's docs](https://docs.getbindu.com) or the generated `~/.hermes/.bindu/` directory.
-
----
-
-## How it fits together
-
-```
-                        ┌──────────────────────────────────────┐
-  other agent ─► A2A ──►│  Bindu HTTP server (:3773)           │
-                        │    • OAuth2 (Hydra)                   │
-                        │    • DID verification                 │
-                        │    • x402 payment (optional)          │
-                        │    • ManifestWorker                   │
-                        │              │                        │
-                        │              ▼                        │
-                        │    bindu_adapter.handler(messages)    │
-                        │              │                        │
-                        │              ▼                        │
-                        │    AIAgent.chat(latest_user_text)     │
-                        │              │                        │
-                        │              └─► Hermes tool loop ──► │
-                        │                  (web, file, memory,  │
-                        │                   skills, …)          │
-                        └──────────────────────────────────────┘
-```
-
-The handler keeps **one shared `AIAgent`** per process. Bindu is the source of truth for conversation history; Hermes owns the live model state so provider prompt caches stay valid across turns.
+| `HERMES_BINDU_EXPOSE` | `false` | If `true`, open a public FRP tunnel |
+| `AUTH__ENABLED` | *(unset)* | Set `true` to enforce Hydra OAuth2 + DID sig |
+| `AUTH__PROVIDER` | *(unset)* | Required with above — set `hydra` |
 
 ---
+
+## How it fits
+
+```
+other agent ─► A2A JSON-RPC ─► Bindu server :3773
+                                 │  OAuth2 (Hydra), DID verify, x402 (opt)
+                                 ▼
+                               bindu_adapter.handler(messages)
+                                 ▼
+                               AIAgent.chat(latest_user_text)
+                                 ▼
+                               Hermes tool loop → DID-signed artifact reply
+```
+
+One long-lived `AIAgent` per process so provider prompt caches stay valid across A2A calls. Bindu owns conversation history; Hermes owns the live model state.
 
 ## Files
 
 | File | Purpose |
 |---|---|
 | `adapter.py` | `AIAgent` wrapped as a Bindu `handler(messages) -> str` |
-| `entry.py` | CLI entry: loads env, builds the Bindu config, calls `bindufy()` |
+| `entry.py` | CLI entry: loads env, builds config, calls `bindufy()` |
 | `__main__.py` | Enables `python -m bindu_adapter` |
 
-~200 lines of glue. No forked code paths, no parallel tool registry, no second event loop.
+## Links
 
----
-
-## Troubleshooting
-
-- **`ImportError: No module named 'bindu'`** — you didn't install the extra. Run `pip install -e '.[bindu]'`.
-- **`401` / `403` on requests** — you're hitting the auth layers. The banner at startup prints a curl snippet for fetching a Hydra token; use that as the `Authorization: Bearer <token>` and sign each request with the DID keys in `~/.hermes/.bindu/` (or the project's `.bindu/`).
-- **Port 3773 already in use** — another agent is running. Set `HERMES_BINDU_URL=http://localhost:4000` (or any free port).
-- **Tool calls silently blocked** — you're on the default `read` tier. Flip to `sandbox` or `full` if (and only if) it's safe for your deployment.
-
----
-
-## Learn more
-
-- Bindu source: <https://github.com/GetBindu/Bindu>
+- Bindu: <https://github.com/GetBindu/Bindu>
 - A2A protocol: <https://a2aproject.github.io/A2A/>
-- x402 payments: <https://www.x402.org/>
-- DID method spec: <https://www.w3.org/TR/did-core/>
+- x402: <https://www.x402.org/>

--- a/bindu_adapter/__init__.py
+++ b/bindu_adapter/__init__.py
@@ -1,0 +1,6 @@
+"""Bindu A2A adapter for hermes-agent.
+
+Exposes Hermes' ``AIAgent`` as an Agent-to-Agent (A2A) microservice with DID
+identity, OAuth2 auth, and optional x402 payments. See ``bindu_adapter/README.md``
+for the full walkthrough.
+"""

--- a/bindu_adapter/__main__.py
+++ b/bindu_adapter/__main__.py
@@ -1,0 +1,5 @@
+"""Enable ``python -m bindu_adapter``."""
+from bindu_adapter.entry import main
+
+if __name__ == "__main__":
+    main()

--- a/bindu_adapter/adapter.py
+++ b/bindu_adapter/adapter.py
@@ -1,0 +1,87 @@
+"""Hermes ``AIAgent`` wrapped as a Bindu A2A handler.
+
+Bindu's contract is simple: ``handler(messages) -> str``. Bindu replays the
+full conversation history on every call; the handler only needs to feed the
+newest user message into Hermes. Keeping a single long-lived ``AIAgent`` per
+process lets the provider's prompt cache stay valid across turns — Bindu is
+the source of truth for history, Hermes owns the live model state for caching.
+
+Safety tiers control which Hermes toolsets the A2A-exposed agent can reach.
+Default is ``read``: web search + extract only. ``full`` exposes everything
+(terminal, filesystem, code exec, browser). NEVER combine ``full`` with a
+public tunnel.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from run_agent import AIAgent
+
+# Toolset tiers. ``None`` means "no restriction" (full tier — all toolsets enabled).
+# Keep this in sync with Hermes' toolset names in ``agent/toolsets/``.
+TIERS: dict[str, list[str] | None] = {
+    "read": ["web"],
+    "sandbox": ["web", "file", "moa"],
+    "full": None,
+}
+
+_agent: AIAgent | None = None
+
+
+def get_agent() -> AIAgent:
+    """Lazily create one shared ``AIAgent`` per process.
+
+    Created on first call, reused for every subsequent A2A request in this
+    process. Swap out the knobs below with env vars in ``entry.py`` rather
+    than editing this function.
+    """
+    global _agent
+    if _agent is None:
+        tier = os.getenv("HERMES_BINDU_TIER", "read")
+        _agent = AIAgent(
+            model=os.getenv("HERMES_BINDU_MODEL", "anthropic/claude-3.5-haiku"),
+            max_iterations=int(os.getenv("HERMES_BINDU_MAX_ITERATIONS", "30")),
+            enabled_toolsets=TIERS.get(tier, TIERS["read"]),
+            quiet_mode=True,
+            platform="bindu",
+            save_trajectories=False,
+            skip_memory=True,
+            persist_session=False,
+        )
+    return _agent
+
+
+def _last_user_text(messages: list[dict[str, Any]]) -> str:
+    """Pull the newest user message's text, tolerating the A2A parts shape.
+
+    A2A messages arrive with ``content`` either as a plain string or as a
+    list of ``{"kind": "text", "text": "..."}`` parts. We accept both and
+    concatenate text parts with newlines.
+    """
+    for m in reversed(messages):
+        if m.get("role") != "user":
+            continue
+        content = m.get("content", "")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "\n".join(
+                p.get("text", "")
+                for p in content
+                if isinstance(p, dict) and p.get("kind") == "text"
+            )
+    return ""
+
+
+def handler(messages: list[dict[str, Any]]) -> str:
+    """Bindu handler contract: (messages) -> response string.
+
+    Bindu wraps the return value in a DID-signed artifact and delivers it
+    back to the caller via the A2A protocol.
+    """
+    text = _last_user_text(messages)
+    if not text.strip():
+        return "Empty message."
+    return get_agent().chat(text)

--- a/bindu_adapter/entry.py
+++ b/bindu_adapter/entry.py
@@ -1,0 +1,79 @@
+"""CLI entry point for the Hermes ↔ Bindu A2A adapter.
+
+Loads ``~/.hermes/.env`` (same path the main CLI uses), reads Bindu-specific
+config from ``HERMES_BINDU_*`` env vars, and starts the Bindu A2A server
+with Hermes' ``AIAgent`` as the handler.
+
+Usage::
+
+    hermes-bindu
+    # or
+    python -m bindu_adapter
+
+The server listens on ``http://localhost:3773`` by default. The first-line
+banner prints the agent's DID and the local endpoint. All artifacts returned
+to callers are DID-signed on the way out.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_constants import get_hermes_home
+
+from bindu_adapter.adapter import handler
+
+
+def _build_config() -> dict:
+    """Translate ``HERMES_BINDU_*`` env vars into a Bindu config dict.
+
+    Everything has a sensible default so a first-time user can run
+    ``hermes-bindu`` with only an ``OPENROUTER_API_KEY`` (or equivalent)
+    set. The agent card, DID method, and deployment URL all flow from
+    these fields.
+    """
+    return {
+        "author": os.getenv("HERMES_BINDU_AUTHOR", "you@example.com"),
+        "name": os.getenv("HERMES_BINDU_NAME", "hermes"),
+        "description": os.getenv(
+            "HERMES_BINDU_DESCRIPTION",
+            "Hermes Agent (tool-using) exposed as a Bindu A2A microservice",
+        ),
+        "deployment": {
+            "url": os.getenv("HERMES_BINDU_URL", "http://localhost:3773"),
+            "expose": os.getenv("HERMES_BINDU_EXPOSE", "false").lower() == "true",
+        },
+        "skills": [],
+    }
+
+
+def main() -> None:
+    """Start Hermes as a Bindu A2A microservice."""
+    # Load env from ~/.hermes/.env first (user config), then project-local
+    # .env as a dev fallback. Mirrors how run_agent.py loads env so users
+    # don't need to re-source for the adapter.
+    load_hermes_dotenv(
+        hermes_home=get_hermes_home(),
+        project_env=Path(__file__).resolve().parent.parent / ".env",
+    )
+
+    try:
+        from bindu.penguin.bindufy import bindufy
+    except ImportError:
+        print(
+            "Bindu is not installed. Install the adapter extras with:\n"
+            "    pip install -e '.[bindu]'\n"
+            "or, standalone:\n"
+            "    pip install bindu",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    bindufy(_build_config(), handler)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
 acp = ["agent-client-protocol>=0.9.0,<1.0"]
+# Bindu turns Hermes into an Agent-to-Agent (A2A) microservice with DID
+# identity, OAuth2 auth via Hydra, and optional x402 payments. Opt-in extra —
+# the base Hermes install is unaffected. See bindu_adapter/README.md.
+bindu = ["bindu>=0.3.18"]
 mistral = ["mistralai>=2.3.0,<3"]
 bedrock = ["boto3>=1.35.0,<2"]
 termux = [
@@ -106,6 +110,7 @@ all = [
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",
   "hermes-agent[acp]",
+  "hermes-agent[bindu]",
   "hermes-agent[voice]",
   "hermes-agent[dingtalk]",
   "hermes-agent[feishu]",
@@ -118,6 +123,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-bindu = "bindu_adapter.entry:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "rl_cli", "utils"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "bindu_adapter", "plugins", "plugins.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## What this adds

An optional adapter that lets you run Hermes as an **A2A (Agent-to-Agent) microservice**. Where `hermes gateway` makes Hermes talk to humans on Telegram/Discord/Slack/etc., `hermes-bindu` makes it talk to *other agents* over the open [A2A JSON-RPC protocol](https://a2aproject.github.io/A2A/) — with a cryptographic DID identity, OAuth2 auth, and optional x402 micropayments.

Same agent, same skills, same memory, new interface. ~200 lines of glue.

```bash
pip install -e '.[bindu]'
hermes-bindu                           # → http://localhost:3773 (A2A)
```

## Why would Hermes users want this?

Hermes is already excellent at the human-facing surface. What this unlocks is the *other* direction:

- **Let other agents call Hermes.** A LangChain or AG2 agent can delegate a research task to Hermes and get back a DID-signed artifact — no one has to write an HTTP client for Hermes' internals. A2A is becoming a standard interop layer.
- **Cryptographic identity.** Every response is Ed25519-signed by the agent's DID key, so the caller can verify authenticity without shared secrets.
- **OAuth2 with scopes.** Ships with Ory Hydra integration and `agent:read` / `agent:write` / `agent:execute` scopes.
- **Monetization without Stripe.** [x402](https://www.x402.org/) support means you can charge 0.01 USDC per call with one config flag.

It's additive, not a replacement for the gateway. All three (`hermes`, `hermes gateway`, `hermes-bindu`) can run against the same config and share skills, memory, tools, and context files.

## Scope I kept deliberately small

This touches five things, and only one of them isn't new:

| Change | Notes |
|---|---|
| `bindu_adapter/` (new) | Adapter code + detailed README. Mirrors the existing `acp_adapter/` pattern. |
| `pyproject.toml` | New `[bindu]` extra and `hermes-bindu` script. Added `hermes-agent[bindu]` to the `[all]` extra alongside `[acp]`. |
| `.gitignore` | Added `.bindu/` — Bindu writes per-agent DID keys and OAuth creds there; never commit. |
| `README.md` | One short section pointing at `bindu_adapter/README.md`. I did not add a `hermes bindu` subcommand in `hermes_cli/main.py` — happy to in a follow-up if you want parity with `hermes acp`, but I wanted to keep this PR reviewable. |
| *(not touched)* `hermes_cli/main.py`, `run_agent.py`, anything in `agent/` | Adapter is purely additive. |

## Design choices worth calling out

- **No hard dep on Bindu.** It's an optional extra. Base `pip install hermes-agent` is unchanged. If a user runs `hermes-bindu` without installing the extra, they get a clean error pointing at the install command, not a stack trace.
- **Single `AIAgent` per process.** The handler keeps one long-lived `AIAgent` so the provider's prompt cache stays valid across A2A calls. Bindu is the source of truth for conversation history; Hermes owns the live model state.
- **Safety tiers via `HERMES_BINDU_TIER`.** Defaults to `read` (web search + extract only). `sandbox` adds file + moa. `full` exposes everything including terminal and code-exec — the adapter README calls out that you must never combine `full` with the public FRP tunnel.
- **Env config follows `~/.hermes/.env`.** Same dotenv loading as `run_agent.py` so users don't maintain two env files. Adapter-specific knobs use the `HERMES_BINDU_*` prefix.

## What I tested

- Full A2A round-trip locally: `message/send` → poll `tasks/get` → DID-signed artifact returned with correct answer.
- Confirmed the adapter starts cleanly with no Bindu config beyond an `OPENROUTER_API_KEY`.
- `python -m bindu_adapter` and `hermes-bindu` entry points both work.
- Verified `ImportError` branch prints the install hint.

## Things I'd love a reviewer to push back on

- **Should `hermes bindu` be a subcommand now?** I left it out to minimize the diff against `hermes_cli/main.py`, but if you'd prefer parity with `hermes acp` in this PR I can add it — it's ~20 lines.
- **Version pin for `bindu`.** I used `>=0.3.18`. Happy to tighten to `~=0.3.18` if you want stricter.
- **README section placement.** I put it between "CLI vs Messaging" and "Documentation" because it's logically a third interface. Move it anywhere you prefer.
- **The long adapter README.** It's currently ~200 lines with diagrams. If you'd rather that live on `hermes-agent.nousresearch.com/docs` instead of in-tree, happy to port it.

Thanks for the review — excited to see Hermes on the A2A network.
