### PR TITLE
fix(agent): load all subdirectory hint files

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -202,8 +202,6 @@ class SubdirectoryHintTracker:
                     except ValueError:
                         pass  # keep absolute
                 found_hints.append((rel_path, content))
-                # First match wins per directory (like startup loading)
-                break
             except Exception as exc:
                 logger.debug("Could not read %s: %s", hint_path, exc)
 

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -162,6 +162,24 @@ class TestSubdirectoryHintTracker:
         assert "Subdirectory context discovered:" in result
         assert "AGENTS.md" in result
 
+    def test_loads_all_supported_hint_files_in_same_directory(self, tmp_path):
+        """A directory with multiple supported hint files should surface all of them."""
+        sub = tmp_path / "pkg"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Agent rules")
+        (sub / ".cursorrules").write_text("Cursor rules")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(sub / "module.py")}
+        )
+
+        assert result is not None
+        assert "Agent rules" in result
+        assert "Cursor rules" in result
+        assert "pkg/AGENTS.md" in result
+        assert "pkg/.cursorrules" in result
+
     def test_truncation_of_large_hints(self, tmp_path):
         """Hint files over the limit are truncated."""
         sub = tmp_path / "bigdir"


### PR DESCRIPTION
## Summary
- load every supported hint file found in a newly visited subdirectory instead of stopping at the first match
- preserve existing formatting and truncation behavior for each discovered hint file
- add a regression test covering a directory that contains both `AGENTS.md` and `.cursorrules`

## Testing
- `python3 -m pytest -o addopts='' tests/agent/test_subdirectory_hints.py -q`

## Issue
- closes #14537
