### PR TITLE
fix(qqbot): notify gateway via _set_fatal_error when reconnect loop exhausts

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -484,6 +484,13 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        logger.error("[%s] Max reconnect attempts reached (4008 rate-limit)", self._log_tag)
+                        self._set_fatal_error(
+                            "qq_reconnect_exhausted",
+                            "Max reconnect attempts reached (4008 rate-limit)",
+                            retryable=False,
+                        )
+                        await self._notify_fatal_error()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -537,6 +544,12 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        self._set_fatal_error(
+                            "qq_reconnect_exhausted",
+                            "Max reconnect attempts reached (QQCloseError)",
+                            retryable=False,
+                        )
+                        await self._notify_fatal_error()
                         return
 
             except Exception as exc:
@@ -548,6 +561,12 @@ class QQAdapter(BasePlatformAdapter):
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
+                    self._set_fatal_error(
+                        "qq_reconnect_exhausted",
+                        "Max reconnect attempts reached",
+                        retryable=False,
+                    )
+                    await self._notify_fatal_error()
                     return
 
                 if await self._reconnect(backoff_idx):

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -582,3 +582,102 @@ class TestWaitForReconnection:
         assert not result.success
         assert result.retryable is True
         assert "Not connected" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _listen_loop — reconnect exhaustion notifies gateway via _set_fatal_error
+# ---------------------------------------------------------------------------
+
+class TestListenLoopReconnectExhaustion:
+    """Verify _listen_loop calls _set_fatal_error + _notify_fatal_error on all exhaustion paths."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+        adapter._notify_fatal_error = mock.AsyncMock()
+        return adapter
+
+    def test_exception_path_sets_fatal_error(self):
+        """Exception branch: exhausted backoff marks adapter as fatal and notifies gateway."""
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._mark_disconnected = mock.MagicMock()
+        adapter._fail_pending = mock.MagicMock()
+
+        call_count = 0
+
+        async def _raise_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("persistent network failure")
+            adapter._running = False
+
+        adapter._read_events = _raise_once
+        adapter._reconnect = mock.AsyncMock(return_value=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.MAX_RECONNECT_ATTEMPTS", 0):
+            asyncio.run(adapter._listen_loop())
+
+        assert adapter.has_fatal_error
+        assert adapter._fatal_error_code == "qq_reconnect_exhausted"
+        assert adapter._fatal_error_retryable is False
+        adapter._notify_fatal_error.assert_awaited_once()
+
+    def test_qqcloseerror_path_sets_fatal_error(self):
+        """QQCloseError branch: exhausted backoff marks adapter as fatal and notifies gateway."""
+        from gateway.platforms.qqbot.adapter import QQCloseError
+
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._mark_disconnected = mock.MagicMock()
+        adapter._fail_pending = mock.MagicMock()
+
+        call_count = 0
+
+        async def _raise_close():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise QQCloseError(1006, "abnormal closure")
+            adapter._running = False
+
+        adapter._read_events = _raise_close
+        adapter._reconnect = mock.AsyncMock(return_value=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.MAX_RECONNECT_ATTEMPTS", 1):
+            asyncio.run(adapter._listen_loop())
+
+        assert adapter.has_fatal_error
+        assert adapter._fatal_error_code == "qq_reconnect_exhausted"
+        assert adapter._fatal_error_retryable is False
+        adapter._notify_fatal_error.assert_awaited_once()
+
+    def test_rate_limit_4008_path_sets_fatal_error(self):
+        """4008 rate-limit branch: exhausted backoff marks adapter as fatal and notifies gateway."""
+        from gateway.platforms.qqbot.adapter import QQCloseError
+
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._mark_disconnected = mock.MagicMock()
+        adapter._fail_pending = mock.MagicMock()
+
+        call_count = 0
+
+        async def _raise_rate_limit():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise QQCloseError(4008, "rate limited")
+            adapter._running = False
+
+        adapter._read_events = _raise_rate_limit
+        adapter._reconnect = mock.AsyncMock(return_value=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.MAX_RECONNECT_ATTEMPTS", 0):
+            asyncio.run(adapter._listen_loop())
+
+        assert adapter.has_fatal_error
+        assert adapter._fatal_error_code == "qq_reconnect_exhausted"
+        assert adapter._fatal_error_retryable is False
+        adapter._notify_fatal_error.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

\`_listen_loop()\` in \`gateway/platforms/qqbot/adapter.py\` has three paths where \`MAX_RECONNECT_ATTEMPTS\` is reached and the loop exits via \`return\` — but none of them call \`_set_fatal_error()\` or \`_notify_fatal_error()\`. The gateway runner keeps the platform state as the last \`_mark_connected()\` value (connected), while the adapter is silently dead. Because the gateway process itself does not exit, \`systemd Restart=on-failure\` never fires.

Three exhaustion paths are affected:
- **4008 rate-limit branch** — bare \`return\` with no \`logger.error\`, no \`_set_fatal_error()\`, no \`_notify_fatal_error()\`
- **QQCloseError general branch** — has \`logger.error\` but no \`_set_fatal_error()\` or \`_notify_fatal_error()\`
- **Exception branch** — has \`logger.error\` but no \`_set_fatal_error()\` or \`_notify_fatal_error()\`

Fix: add \`_set_fatal_error("qq_reconnect_exhausted", ..., retryable=False)\` followed by \`await self._notify_fatal_error()\` to all three paths. \`_set_fatal_error()\` alone only writes to the status file — \`_notify_fatal_error()\` is required to invoke the GatewayRunner's \`_handle_adapter_fatal_error\` handler, which disconnects the adapter and triggers \`systemd Restart=on-failure\`. This matches the pattern already used in the Telegram adapter (\`gateway/platforms/telegram.py\` lines 366, 460).

## Related Issue

Fixes #14539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- \`gateway/platforms/qqbot/adapter.py\`: add \`_set_fatal_error()\` + \`await _notify_fatal_error()\` before each of the three \`return\` points in \`_listen_loop()\` (+18 lines)
- \`tests/gateway/test_qqbot.py\`: add \`TestListenLoopReconnectExhaustion\` with one test per exhaustion path, each asserting both \`has_fatal_error\` and \`_notify_fatal_error\` was awaited (+100 lines)

## How to Test

Requires a live QQ Bot setup. Unit tests cover all three paths:

\`\`\`bash
pytest tests/gateway/test_qqbot.py::TestListenLoopReconnectExhaustion -v
\`\`\`

All 3 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run \`pytest tests/gateway/test_qqbot.py -v\` and pre-existing failures are unrelated to this change (they require \`pytest-asyncio\` which is in dev deps)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated \`cli-config.yaml.example\` — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A