### PR TITLE
feat: add OMX and open-spec telegram slash commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31,6 +31,11 @@ from datetime import datetime
 from typing import Dict, Optional, Any, List
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
+from hermes_cli.external_slash_commands import (
+    build_external_exec_argv,
+    build_external_prompt_message,
+    resolve_external_slash_command,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -3683,6 +3688,42 @@ class GatewayRunner:
                 else:
                     return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
 
+        # External OMX/Open Spec slash commands
+        if command:
+            external_command = resolve_external_slash_command(command)
+            if external_command:
+                user_args = event.get_command_args().strip()
+                if external_command.kind == "prompt":
+                    msg = build_external_prompt_message(
+                        external_command,
+                        user_args,
+                        task_id=_quick_key,
+                    )
+                    if not msg:
+                        return f"Failed to load `/{external_command.name}`."
+                    event.text = msg
+                    command = None
+                    canonical = None
+                elif external_command.kind == "exec":
+                    argv = build_external_exec_argv(external_command, user_args)
+                    if not argv:
+                        return f"Failed to build `/{external_command.name}` command invocation."
+                    try:
+                        proc = await asyncio.create_subprocess_exec(
+                            *argv,
+                            stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.PIPE,
+                        )
+                        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
+                        output = (stdout or stderr).decode().strip()
+                        return output if output else "Command returned no output."
+                    except asyncio.TimeoutError:
+                        return "External command timed out (60s)."
+                    except Exception as e:
+                        return f"External command error: {e}"
+                else:
+                    return f"Unsupported external command type: {external_command.kind}"
+
         # Plugin-registered slash commands
         if command:
             try:
@@ -5317,7 +5358,7 @@ class GatewayRunner:
         else:
             requested_page = 1
 
-        # Build combined entry list: built-in commands + skill commands
+        # Build combined entry list: built-in commands + skill commands + external commands
         entries = list(gateway_help_lines())
         try:
             from agent.skill_commands import get_skill_commands
@@ -5328,6 +5369,16 @@ class GatewayRunner:
                 for cmd in sorted(skill_cmds):
                     desc = skill_cmds[cmd].get("description", "").strip() or "Skill command"
                     entries.append(f"`{cmd}` — {desc}")
+        except Exception:
+            pass
+        try:
+            from hermes_cli.external_slash_commands import list_external_slash_commands
+            external_cmds = list_external_slash_commands()
+            if external_cmds:
+                entries.append("")
+                entries.append("🧩 **External OMX / Open Spec Commands**:")
+                for cmd in external_cmds:
+                    entries.append(f"`/{cmd.name}` — {cmd.description or 'External command'}")
         except Exception:
             pass
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -192,6 +192,15 @@ def _build_command_lookup() -> dict[str, CommandDef]:
 _COMMAND_LOOKUP: dict[str, CommandDef] = _build_command_lookup()
 
 
+def resolve_external_slash_command(name: str | None):
+    """Resolve an external OMX/Open Spec slash command if available."""
+    try:
+        from hermes_cli.external_slash_commands import resolve_external_slash_command as _resolve
+    except Exception:
+        return None
+    return _resolve(name)
+
+
 def resolve_command(name: str) -> CommandDef | None:
     """Resolve a command name or alias to its CommandDef.
 
@@ -304,7 +313,12 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     ACTIVE_SESSION_BYPASS_COMMANDS remains the subset of commands with
     explicit Level-2 handlers; the rest fall through to the catch-all.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    if not command_name:
+        return False
+    return (
+        resolve_command(command_name) is not None
+        or resolve_external_slash_command(command_name) is not None
+    )
 
 
 def _resolve_config_gates() -> set[str]:
@@ -567,6 +581,42 @@ def _collect_gateway_skill_entries(
     return all_entries[:max_slots], hidden_count
 
 
+def collect_external_telegram_commands(
+    max_slots: int,
+    reserved_names: set[str],
+) -> tuple[list[tuple[str, str, str]], int]:
+    """Collect externally-discovered OMX/Open Spec commands for Telegram."""
+    try:
+        from hermes_cli.external_slash_commands import list_external_slash_commands
+    except Exception:
+        return [], 0
+
+    pairs: list[tuple[str, str, str]] = []
+    for cmd in list_external_slash_commands():
+        name = _sanitize_telegram_name(cmd.name)
+        if not name:
+            continue
+        desc = cmd.description or "External command"
+        if len(desc) > 40:
+            desc = desc[:37] + "..."
+        pairs.append((name, desc, cmd.name))
+
+    clamped = _clamp_command_names([(n, d) for n, d, _ in pairs], reserved_names)
+    kept_names = {name for name, _ in clamped}
+    reserved_names.update(kept_names)
+
+    kept: list[tuple[str, str, str]] = []
+    for name, desc, original in pairs:
+        if name in kept_names:
+            kept.append((name, desc, original))
+            kept_names.remove(name)
+            if len(kept) >= max_slots:
+                break
+
+    hidden_count = max(0, len(pairs) - len(kept))
+    return kept[:max_slots], hidden_count
+
+
 # ---------------------------------------------------------------------------
 # Platform-specific wrappers
 # ---------------------------------------------------------------------------
@@ -602,7 +652,14 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     )
     # Drop the cmd_key — Telegram only needs (name, desc) pairs.
     all_commands.extend((n, d) for n, d, _k in entries)
-    return all_commands[:max_commands], hidden_count
+
+    remaining_slots = max(0, max_commands - len(all_commands))
+    external_entries, hidden_external = collect_external_telegram_commands(
+        max_slots=remaining_slots,
+        reserved_names=reserved_names,
+    )
+    all_commands.extend((n, d) for n, d, _k in external_entries)
+    return all_commands[:max_commands], hidden_count + hidden_external
 
 
 def discord_skill_commands(

--- a/hermes_cli/external_slash_commands.py
+++ b/hermes_cli/external_slash_commands.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import functools
+import re
+import shlex
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class ExternalSlashCommand:
+    name: str
+    description: str
+    kind: str  # 'prompt' | 'exec'
+    source: str
+    prompt_path: str | None = None
+    binary: str | None = None
+    argv: tuple[str, ...] = ()
+
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+_OMX_SKILL_REF_RE = re.compile(r"\$([a-z0-9][a-z0-9-]*)")
+_SPECKIT_REF_RE = re.compile(r"(?<![a-z0-9_-])/?(speckit(?:\.[a-z0-9_-]+)+)")
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_frontmatter(text: str) -> dict:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    if yaml is None:
+        return {}
+    try:
+        data = yaml.safe_load(match.group(1)) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _description_from_file(path: Path, fallback: str) -> str:
+    try:
+        meta = _parse_frontmatter(_read_text(path))
+    except Exception:
+        return fallback
+    desc = str(meta.get("description") or "").strip()
+    return desc or fallback
+
+
+def _find_omx_root() -> Path | None:
+    omx_path = shutil.which("omx")
+    if not omx_path:
+        return None
+    resolved = Path(omx_path).expanduser().resolve()
+    for parent in (resolved.parent, *resolved.parents):
+        if (parent / "skills").is_dir():
+            return parent
+    return None
+
+
+def _find_specify_root() -> Path | None:
+    specify_path = shutil.which("specify")
+    if not specify_path:
+        return None
+    resolved = Path(specify_path).expanduser().resolve()
+    for parent in (resolved.parent, *resolved.parents):
+        matches = sorted(parent.glob("lib/python*/site-packages/specify_cli"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _parse_omx_help_subcommands(help_text: str) -> list[str]:
+    commands: list[str] = []
+    seen: set[str] = set()
+    for line in help_text.splitlines():
+        match = re.match(r"^\s*omx(?:\s+([a-z][a-z0-9-]*))?(?:\s|$)", line)
+        if not match:
+            continue
+        subcommand = match.group(1)
+        if not subcommand or subcommand in seen:
+            continue
+        seen.add(subcommand)
+        commands.append(subcommand)
+    return commands
+
+
+def _parse_specify_help_subcommands(help_text: str) -> list[str]:
+    commands: list[str] = []
+    seen: set[str] = set()
+    for line in help_text.splitlines():
+        match = re.match(r"^\s*[│|]\s*([a-z][a-z0-9-]*)\s{2,}", line)
+        if not match:
+            continue
+        subcommand = match.group(1)
+        if subcommand in seen:
+            continue
+        seen.add(subcommand)
+        commands.append(subcommand)
+    return commands
+
+
+def _run_help(argv: list[str]) -> str:
+    import subprocess
+
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=15, check=False)
+    except Exception:
+        return ""
+    return proc.stdout or proc.stderr or ""
+
+
+def _specify_prompt_slug(path: Path, root: Path) -> str | None:
+    rel = path.relative_to(root)
+    parts = rel.parts
+    stem = path.stem
+    if parts[:2] == ("core_pack", "commands"):
+        return stem
+    if len(parts) >= 5 and parts[:3] == ("core_pack", "extensions", parts[2]) and parts[3] == "commands":
+        tokens = stem.split(".")
+        if tokens and tokens[0] == "speckit":
+            tokens = tokens[1:]
+        return "-".join(tokens)
+    if len(parts) >= 6 and parts[:3] == ("core_pack", "presets", parts[2]) and parts[3] == "commands":
+        preset = parts[2]
+        tokens = stem.split(".")
+        if tokens and tokens[0] == "speckit":
+            tokens = tokens[1:]
+        return "-".join([preset, *tokens])
+    return None
+
+
+def _iter_prompt_files(specify_root: Path) -> Iterable[tuple[str, Path]]:
+    for path in sorted(specify_root.rglob("commands/*.md")):
+        slug = _specify_prompt_slug(path, specify_root)
+        if slug:
+            yield slug, path
+
+
+def _discover_omx_skill_commands(commands: dict[str, ExternalSlashCommand]) -> None:
+    root = _find_omx_root()
+    if not root:
+        return
+    skills_dir = root / "skills"
+    for skill_file in sorted(skills_dir.glob("*/SKILL.md")):
+        skill_name = skill_file.parent.name
+        command_name = f"omx-{skill_name}"
+        commands[command_name] = ExternalSlashCommand(
+            name=command_name,
+            description=_description_from_file(skill_file, f"OMX skill {skill_name}"),
+            kind="prompt",
+            source="omx-skill",
+            prompt_path=str(skill_file),
+        )
+
+
+def _discover_omx_cli_commands(commands: dict[str, ExternalSlashCommand]) -> None:
+    binary = shutil.which("omx")
+    if not binary:
+        return
+    commands.setdefault(
+        "omx-cli",
+        ExternalSlashCommand(
+            name="omx-cli",
+            description="Run the OMX CLI",
+            kind="exec",
+            source="omx-cli",
+            binary=binary,
+        ),
+    )
+    for subcommand in _parse_omx_help_subcommands(_run_help([binary, "--help"])):
+        name = f"omx-cli-{subcommand}"
+        commands[name] = ExternalSlashCommand(
+            name=name,
+            description=f"Run `omx {subcommand}`",
+            kind="exec",
+            source="omx-cli",
+            binary=binary,
+            argv=(subcommand,),
+        )
+
+
+def _discover_specify_prompt_commands(commands: dict[str, ExternalSlashCommand]) -> None:
+    root = _find_specify_root()
+    if not root:
+        return
+    for slug, path in _iter_prompt_files(root):
+        name = f"open-spec-{slug}"
+        commands[name] = ExternalSlashCommand(
+            name=name,
+            description=_description_from_file(path, f"Open Spec command {slug}"),
+            kind="prompt",
+            source="open-spec-command",
+            prompt_path=str(path),
+        )
+
+
+def _discover_specify_cli_commands(commands: dict[str, ExternalSlashCommand]) -> None:
+    binary = shutil.which("specify")
+    if not binary:
+        return
+    commands.setdefault(
+        "open-spec-cli",
+        ExternalSlashCommand(
+            name="open-spec-cli",
+            description="Run the Open Spec CLI",
+            kind="exec",
+            source="open-spec-cli",
+            binary=binary,
+        ),
+    )
+    for subcommand in _parse_specify_help_subcommands(_run_help([binary, "--help"])):
+        name = f"open-spec-cli-{subcommand}"
+        commands[name] = ExternalSlashCommand(
+            name=name,
+            description=f"Run `specify {subcommand}`",
+            kind="exec",
+            source="open-spec-cli",
+            binary=binary,
+            argv=(subcommand,),
+        )
+
+
+@functools.lru_cache(maxsize=1)
+def _discover_external_slash_commands() -> dict[str, ExternalSlashCommand]:
+    commands: dict[str, ExternalSlashCommand] = {}
+    _discover_omx_skill_commands(commands)
+    _discover_omx_cli_commands(commands)
+    _discover_specify_prompt_commands(commands)
+    _discover_specify_cli_commands(commands)
+    return commands
+
+
+def invalidate_external_slash_commands_cache() -> None:
+    _discover_external_slash_commands.cache_clear()
+
+
+def list_external_slash_commands() -> list[ExternalSlashCommand]:
+    return [
+        _discover_external_slash_commands()[key]
+        for key in sorted(_discover_external_slash_commands())
+    ]
+
+
+def resolve_external_slash_command(command: str | None) -> ExternalSlashCommand | None:
+    if not command:
+        return None
+    normalized = command.strip().lower().lstrip("/").replace("_", "-")
+    if not normalized:
+        return None
+    return _discover_external_slash_commands().get(normalized)
+
+
+def _rewrite_omx_skill_content(content: str) -> str:
+    known_skill_refs = {
+        cmd.name.removeprefix("omx-")
+        for cmd in list_external_slash_commands()
+        if cmd.source == "omx-skill"
+    }
+
+    def _replace(match: re.Match[str]) -> str:
+        skill_name = match.group(1)
+        if skill_name in known_skill_refs:
+            return f"/omx-{skill_name}"
+        return match.group(0)
+
+    return _OMX_SKILL_REF_RE.sub(_replace, content)
+
+
+def _rewrite_open_spec_content(content: str) -> str:
+    alias_map: dict[str, str] = {}
+    for cmd in list_external_slash_commands():
+        if cmd.source != "open-spec-command":
+            continue
+        slug = cmd.name.removeprefix("open-spec-")
+        if slug.startswith("lean-"):
+            alias_map[f"speckit.{slug.removeprefix('lean-')}"] = cmd.name
+        else:
+            alias_map[f"speckit.{slug.replace('-', '.')}"] = cmd.name
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        mapped = alias_map.get(key)
+        if not mapped:
+            return match.group(0)
+        return f"/{mapped}"
+
+    return _SPECKIT_REF_RE.sub(_replace, content)
+
+
+def build_external_prompt_message(command: ExternalSlashCommand, user_instruction: str, task_id: str | None = None) -> str | None:
+    if command.kind != "prompt" or not command.prompt_path:
+        return None
+
+    from agent.skill_commands import _build_skill_message
+
+    path = Path(command.prompt_path)
+    try:
+        raw = _read_text(path)
+    except Exception:
+        return None
+
+    content = raw
+    if command.source == "omx-skill":
+        content = _rewrite_omx_skill_content(content)
+    elif command.source == "open-spec-command":
+        content = _rewrite_open_spec_content(content)
+        content = content.replace("$ARGUMENTS", user_instruction)
+        content = content.replace("{{ARGUMENTS}}", user_instruction)
+        content = content.replace("{ARGS}", user_instruction)
+
+    activation_note = (
+        f'[SYSTEM: The user has invoked the external slash command "{command.name}", '
+        "indicating they want you to follow its loaded instructions.]"
+    )
+    loaded = {
+        "content": content,
+        "raw_content": raw,
+        "name": command.name,
+    }
+    return _build_skill_message(
+        loaded,
+        path.parent,
+        activation_note,
+        user_instruction=user_instruction,
+        session_id=task_id,
+    )
+
+
+def build_external_exec_argv(command: ExternalSlashCommand, user_instruction: str) -> list[str] | None:
+    if command.kind != "exec" or not command.binary:
+        return None
+    extra_args = shlex.split(user_instruction) if user_instruction else []
+    return [command.binary, *command.argv, *extra_args]

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -200,3 +200,40 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_external_prompt_command_rewrites_to_agent_message(self, monkeypatch):
+        from gateway.run import GatewayRunner
+        from hermes_cli.external_slash_commands import ExternalSlashCommand
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {}}
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        runner._pending_messages = {}
+        runner._busy_ack_ts = {}
+        runner._draining = False
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._handle_message_with_agent = AsyncMock(return_value="agent ok")
+
+        monkeypatch.setattr(
+            "gateway.run.resolve_external_slash_command",
+            lambda command: ExternalSlashCommand(
+                name="omx-deep-interview",
+                description="OMX deep interview",
+                kind="prompt",
+                source="omx-skill",
+                prompt_path="/tmp/deep-interview.md",
+            ) if command in {"omx_deep_interview", "omx-deep-interview"} else None,
+        )
+        monkeypatch.setattr(
+            "gateway.run.build_external_prompt_message",
+            lambda command, user_instruction, task_id=None: f"PROMPT::{command.name}::{user_instruction}::{task_id}",
+        )
+
+        event = self._make_event("omx_deep_interview", "improve auth flow")
+        result = await runner._handle_message(event)
+
+        assert result == "agent ok"
+        assert event.text.startswith("PROMPT::omx-deep-interview::improve auth flow::agent:main:telegram:dm:123")
+        runner._handle_message_with_agent.assert_awaited_once()

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -343,6 +343,24 @@ class TestAllResolvableCommandsBypassGuard:
         # A file path split on whitespace: '/path/to/file.py' -> 'path/to/file.py'
         assert should_bypass_active_session("path/to/file.py") is False
 
+    def test_should_bypass_returns_true_for_external_commands(self, monkeypatch):
+        from hermes_cli.commands import should_bypass_active_session
+        from hermes_cli.external_slash_commands import ExternalSlashCommand
+
+        monkeypatch.setattr(
+            "hermes_cli.commands.resolve_external_slash_command",
+            lambda command: ExternalSlashCommand(
+                name="omx-deep-interview",
+                description="OMX deep interview",
+                kind="prompt",
+                source="omx-skill",
+                prompt_path="/tmp/deep-interview.md",
+            ) if command in {"omx-deep-interview", "omx_deep_interview"} else None,
+        )
+
+        assert should_bypass_active_session("omx-deep-interview") is True
+        assert should_bypass_active_session("omx_deep_interview") is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: non-bypass messages still get queued

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -231,6 +231,25 @@ class TestTelegramBotCommands:
                 assert tg_name not in names
 
 
+class TestTelegramMenuCommands:
+    def test_includes_external_slash_commands(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.commands.collect_external_telegram_commands",
+            lambda max_slots, reserved_names: (
+                [
+                    ("omx_deep_interview", "OMX deep interview", "omx-deep-interview"),
+                    ("open_spec_specify", "Open Spec specify", "open-spec-specify"),
+                ],
+                0,
+            ),
+        )
+
+        names = {name for name, _ in telegram_menu_commands(max_commands=100)}
+
+        assert "omx_deep_interview" in names
+        assert "open_spec_specify" in names
+
+
 class TestSlackSubcommandMap:
     def test_returns_dict(self):
         mapping = slack_subcommand_map()


### PR DESCRIPTION
## Summary
- add dynamic Telegram slash-command bridging for OMX and Open Spec prompt and CLI commands
- expose discovered external commands in slash-command listings and Telegram menu overflow slots
- allow external slash commands to bypass the active-session queue like built-in commands

## Test Plan
- pytest -q tests/cli/test_quick_commands.py tests/hermes_cli/test_commands.py tests/gateway/test_command_bypass_active_session.py
