### PR TITLE
docs: remove dead links in flash-attention optional skill

### DIFF
--- a/optional-skills/mlops/flash-attention/SKILL.md
+++ b/optional-skills/mlops/flash-attention/SKILL.md
@@ -345,10 +345,6 @@ Flash Attention uses float16/bfloat16 for speed. Float32 not supported.
 
 **Performance benchmarks**: See [references/benchmarks.md](references/benchmarks.md) for detailed speed and memory comparisons across GPUs and sequence lengths.
 
-**Algorithm details**: See [references/algorithm.md](references/algorithm.md) for tiling strategy, recomputation, and IO complexity analysis.
-
-**Advanced features**: See [references/advanced-features.md](references/advanced-features.md) for rotary embeddings, ALiBi, paged KV cache, and custom attention masks.
-
 ## Hardware requirements
 
 - **GPU**: NVIDIA Ampere+ (A100, A10, A30) or AMD MI200+


### PR DESCRIPTION
## Summary
- remove two dead reference links from `optional-skills/mlops/flash-attention/SKILL.md`
  - `references/algorithm.md`
  - `references/advanced-features.md`
- keep existing valid references (`benchmarks.md`, `transformers-integration.md`) unchanged

## Why
Issue #14563 reported that `SKILL.md` linked to files that do not exist in `optional-skills/mlops/flash-attention/references/`, which creates broken documentation flow.

## Validation
- verified referenced files in `SKILL.md` now resolve to existing files only
- no code/runtime changes (docs-only)

Closes #14563