### PR TITLE
docs: remove dead papers.md link from saelens references

### DIFF
--- a/optional-skills/mlops/saelens/references/README.md
+++ b/optional-skills/mlops/saelens/references/README.md
@@ -6,7 +6,6 @@ This directory contains comprehensive reference materials for SAELens.
 
 - [api.md](api.md) - Complete API reference for SAE, TrainingSAE, and configuration classes
 - [tutorials.md](tutorials.md) - Step-by-step tutorials for training and analyzing SAEs
-- [papers.md](papers.md) - Key research papers on sparse autoencoders
 
 ## Quick Links
 


### PR DESCRIPTION
## Summary
- remove dead `papers.md` entry from `optional-skills/mlops/saelens/references/README.md`
- keep existing valid entries unchanged

## Why
Issue #14562 reported that `README.md` links to `papers.md`, but that file does not exist in `optional-skills/mlops/saelens/references/`.

## Validation
- confirmed `papers.md` link is removed from the reference index
- docs-only change (no runtime/code behavior changes)

Closes #14562