### PR TITLE
fix(agent): accept emoji sign-offs as natural endings

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -35,6 +35,7 @@ import sys
 import tempfile
 import time
 import threading
+import unicodedata
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
@@ -2605,6 +2606,21 @@ class AIAgent:
         return content
 
     @staticmethod
+    def _get_terminal_response_char(content: str) -> str:
+        """Return the last visible response character, ignoring emoji joiners/modifiers."""
+        stripped = content.rstrip()
+        while stripped:
+            last_char = stripped[-1]
+            if last_char in ("\u200d", "\ufe0e", "\ufe0f"):
+                stripped = stripped[:-1]
+                continue
+            if 0x1F3FB <= ord(last_char) <= 0x1F3FF:
+                stripped = stripped[:-1]
+                continue
+            return last_char
+        return ""
+
+    @staticmethod
     def _has_natural_response_ending(content: str) -> bool:
         """Heuristic: does visible assistant text look intentionally finished?"""
         if not content:
@@ -2614,7 +2630,13 @@ class AIAgent:
             return False
         if stripped.endswith("```"):
             return True
-        return stripped[-1] in '.!?:)"\']}。！？：）】」』》'
+        terminal_char = AIAgent._get_terminal_response_char(stripped)
+        if not terminal_char:
+            return False
+        return (
+            terminal_char in '.!?:…)"\']}。！？：）】」』》'
+            or unicodedata.category(terminal_char) == "So"
+        )
 
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2667,6 +2667,39 @@ class TestRunConversation:
             == "Based on the search results, the best next step is to update the config."
         )
 
+    def test_ollama_glm_stop_with_emoji_signoff_does_not_continue(self, agent):
+        """Emoji sign-offs should count as a natural response ending."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        complete_stop = _mock_response(
+            content="Based on the search results, the best next step is to update the config 💛",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [tool_turn, complete_stop]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert (
+            result["final_response"]
+            == "Based on the search results, the best next step is to update the config 💛"
+        )
+
     def test_non_ollama_stop_without_terminal_boundary_does_not_continue(self, agent):
         """The stop->length workaround should stay scoped to Ollama/GLM backends."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
- treat emoji sign-offs as natural response endings for the Ollama/GLM stop-to-length heuristic
- ignore trailing emoji joiners and modifiers before checking the terminal visible character
- add a regression test covering a tool-using GLM reply that ends with `💛`

## Testing
- python3 -m pytest -o addopts='' tests/run_agent/test_run_agent.py -q -k 'ollama_glm_stop or non_ollama_stop_without_terminal_boundary'

Closes #14572
