### PR TITLE
fix: preserve dots in model names for custom providers with anthropic_messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6785,34 +6785,27 @@ class AIAgent:
 
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
-        Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
-        AWS Bedrock uses dotted inference-profile IDs
-        (e.g. ``global.anthropic.claude-opus-4-7``,
-        ``us.anthropic.claude-sonnet-4-5-20250929-v1:0``) and rejects
-        the hyphenated form with
-        ``HTTP 400 The provided model identifier is invalid``.
-        Regression for #11976; mirrors the opencode-go fix for #5211
-        (commit f77be22c), which extended this same allowlist."""
-        if (getattr(self, "provider", "") or "").lower() in {
-            "alibaba", "minimax", "minimax-cn",
-            "opencode-go", "opencode-zen",
-            "zai", "bedrock",
-        }:
-            return True
+
+        Only the native Anthropic API (provider="anthropic" or base_url pointing at
+        api.anthropic.com) needs dots converted to hyphens — OpenRouter-style aliases
+        like ``claude-sonnet-4.6`` must become ``claude-sonnet-4-6`` for the official
+        SDK.  Every other provider (custom proxies, MiniMax, ZAI, Bedrock, etc.)
+        receives the model name exactly as configured by the user.
+
+        This reverses the earlier allowlist approach: instead of enumerating every
+        third-party provider that needs preservation, we default to *preserving* and
+        only normalize for the one provider that explicitly requires it.
+        """
+        provider = (getattr(self, "provider", "") or "").lower()
         base = (getattr(self, "base_url", "") or "").lower()
-        return (
-            "dashscope" in base
-            or "aliyuncs" in base
-            or "minimax" in base
-            or "opencode.ai/zen/" in base
-            or "bigmodel.cn" in base
-            # AWS Bedrock runtime endpoints — defense-in-depth when
-            # ``provider`` is unset but ``base_url`` still names Bedrock.
-            or "bedrock-runtime." in base
-        )
+
+        # Native Anthropic is the only case that needs dot→hyphen normalization.
+        if provider == "anthropic" or base_url_host_matches(base, "api.anthropic.com"):
+            return False
+
+        # Everything else (custom, minimax, zai, bedrock, dashscope, etc.) preserves
+        # the user's model name verbatim.
+        return True
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -276,6 +276,18 @@ class TestMinimaxPreserveDots:
         from run_agent import AIAgent
         assert AIAgent._anthropic_preserve_dots(agent) is False
 
+    def test_custom_provider_with_proxy_preserves_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="custom", base_url="https://coding.onlyservice.io/")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_custom_provider_with_anthropic_does_not_preserve_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="custom", base_url="https://api.anthropic.com")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
     def test_opencode_zen_provider_preserves_dots(self):
         from types import SimpleNamespace
         agent = SimpleNamespace(provider="opencode-zen", base_url="")


### PR DESCRIPTION
## Summary

Fixes model name dot-to-hyphen conversion for custom providers using `api_mode: anthropic_messages`.

## Problem

When using a custom provider (e.g., a proxy service) with `api_mode: anthropic_messages`, model names containing dots (e.g., `kimi-k2.6`) are converted to hyphens (`kimi-k2-6`). This causes the proxy provider to return HTTP 503 because it does not recognize the transformed model name.

## Root Cause

The `_anthropic_preserve_dots()` method used a hardcoded allowlist of providers and base URLs that should preserve dots. This approach doesn't scale — every new third-party proxy needs an upstream code change.

## Solution

**Reversed the logic**: Instead of maintaining an allowlist of providers that preserve dots, we now only normalize dots for the **native Anthropic API** (`provider="anthropic"` or `base_url=api.anthropic.com`). All other providers receive the model name exactly as configured by the user.

This is a **breaking change** in behavior for the allowlist, but it's the correct long-term approach:
- Users configure `kimi-k2.6` → hermes sends `kimi-k2.6` (not `kimi-k2-6`)
- Users configure `anthropic.claude-opus-4-7` → hermes sends `anthropic.claude-opus-4-7`
- Only `provider="anthropic"` gets `claude-sonnet-4.6` → `claude-sonnet-4-6`

## Changes

- `run_agent.py`: Replaced allowlist with denylist — only native Anthropic normalizes dots
- `tests/agent/test_minimax_provider.py`: Added 2 unit tests for custom provider behavior

## Testing

- All `TestMinimaxPreserveDots` tests pass (14/14)
- Full `test_minimax_provider.py` suite: 42/43 pass (1 pre-existing failure unrelated to this change)

## Related Issues

- Closes #14575 (duplicate of #13953)
- Supersedes the allowlist approach discussed in #13953

## Notes

This PR takes a different approach than #13953 (which proposed a `model.preserve_dots` config option). Instead of adding configuration complexity, we default to **preserving** the user's model name and only normalize for the one provider that explicitly requires it (native Anthropic). This is simpler and more intuitive.
