### PR TITLE
Fix WeCom media decryption for unpadded aeskey

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1005,7 +1005,8 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
-        key = base64.b64decode(aes_key)
+        normalized_aes_key = aes_key + "=" * (-len(aes_key) % 4)
+        key = base64.b64decode(normalized_aes_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -297,6 +297,24 @@ class TestMediaHelpers:
 
         assert decrypted == plaintext
 
+    def test_decrypt_file_bytes_accepts_unpadded_base64_key(self):
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from gateway.platforms.wecom import WeComAdapter
+
+        plaintext = b"wecom-secret"
+        key = os.urandom(32)
+        pad_len = 32 - (len(plaintext) % 32)
+        padded = plaintext + bytes([pad_len]) * pad_len
+        encryptor = Cipher(algorithms.AES(key), modes.CBC(key[:16])).encryptor()
+        encrypted = encryptor.update(padded) + encryptor.finalize()
+
+        decrypted = WeComAdapter._decrypt_file_bytes(
+            encrypted,
+            base64.b64encode(key).decode("ascii").rstrip("="),
+        )
+
+        assert decrypted == plaintext
+
     @pytest.mark.asyncio
     async def test_load_outbound_media_rejects_placeholder_path(self):
         from gateway.platforms.wecom import WeComAdapter
@@ -783,4 +801,3 @@ class TestWeComZombieSessionFix:
         adapter._send_request.assert_awaited_once()
         cmd = adapter._send_request.await_args.args[0]
         assert cmd == APP_CMD_SEND
-


### PR DESCRIPTION
## Summary

Fix WeCom inbound media decryption when the message `aeskey` is sent as an unpadded Base64 string.

## What changed

- Normalize inbound WeCom media `aeskey` before Base64 decoding
- Accept 43-character unpadded keys returned by WeCom media messages
- Add a regression test covering unpadded `aeskey`

## Why

In real WeCom bot traffic, inbound image media could fail with:

`Incorrect padding`

The adapter was decoding `aeskey` with `base64.b64decode(aes_key)` directly. Some WeCom media messages provide the AES key in unpadded Base64 form, so decoding fails before AES-CBC decryption begins.

This patch pads the key to a multiple of 4 before decoding, matching the behavior used by other WeCom implementations.

## Validation

Production validation:

- Verified against a real production failure where inbound WeCom image messages failed with `Incorrect padding`
- Confirmed the fix by successfully receiving, decrypting, caching, and analyzing a WeCom image after the change

Automated tests:

- `./.venv/bin/python -m pytest -q tests/gateway/test_wecom.py -k "decrypt_file_bytes"` -> `2 passed`
- `./.venv/bin/python -m pytest -q tests/gateway/test_wecom.py` -> `41 passed`