### PR TITLE
fix(gateway): enumerate Discord forum channels

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -120,7 +120,7 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
                 "type": "channel",
             })
         # Forum channels (type 15) — creating a message auto-spawns a thread post.
-        forums = getattr(guild, "forum_channels", None) or []
+        forums = getattr(guild, "forums", None) or []
         for ch in forums:
             channels.append({
                 "id": str(ch.id),


### PR DESCRIPTION
## Summary
- Read Discord forum parent channels from `Guild.forums` when building the gateway channel directory.
- Restores forum parent entries for channel listing and name resolution with current `discord.py` versions.

## Verification
- `git grep -n 'forum_channels' -- .` returns no tracked references
- `git diff --check`
- `python -m py_compile gateway/channel_directory.py`

Full test suite not run; this is a surgical compatibility fix.