### PR TITLE
fix(hints): load all hint files per directory, not just the first

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -202,8 +202,6 @@ class SubdirectoryHintTracker:
                     except ValueError:
                         pass  # keep absolute
                 found_hints.append((rel_path, content))
-                # First match wins per directory (like startup loading)
-                break
             except Exception as exc:
                 logger.debug("Could not read %s: %s", hint_path, exc)
 

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -232,3 +232,55 @@ class TestPermissionErrorHandling:
             )
             # Result may be None (backend skipped) — the key point is no crash
             assert result is None or isinstance(result, str)
+
+
+class TestMultipleHintFilesInDirectory:
+    """Regression tests for #14537 — all hint files in a directory should be loaded."""
+
+    def test_loads_all_hint_files_in_directory(self, tmp_path):
+        """Both AGENTS.md and .cursorrules in the same dir must both be loaded."""
+        wd = tmp_path / "workspace"
+        wd.mkdir()
+        pkg = wd / "pkg"
+        pkg.mkdir()
+        (pkg / "AGENTS.md").write_text("agents rules")
+        (pkg / ".cursorrules").write_text("cursor rules")
+
+        tracker = SubdirectoryHintTracker(str(wd))
+        result = tracker._load_hints_for_directory(pkg)
+
+        assert result is not None
+        assert "agents rules" in result
+        assert "cursor rules" in result
+
+    def test_first_hit_does_not_suppress_subsequent_files(self, tmp_path):
+        """Removing the break means every matching file is appended, not just the first."""
+        wd = tmp_path / "workspace"
+        wd.mkdir()
+        sub = wd / "lib"
+        sub.mkdir()
+
+        # AGENTS.md and .cursorrules are both in _HINT_FILENAMES and are distinct filenames
+        (sub / "AGENTS.md").write_text("content of AGENTS.md")
+        (sub / ".cursorrules").write_text("content of .cursorrules")
+
+        tracker = SubdirectoryHintTracker(str(wd))
+        result = tracker._load_hints_for_directory(sub)
+
+        assert result is not None
+        assert "content of AGENTS.md" in result, "AGENTS.md content missing"
+        assert "content of .cursorrules" in result, ".cursorrules content missing"
+
+    def test_single_hint_file_still_works(self, tmp_path):
+        """Regression guard — a directory with only one hint file still returns it."""
+        wd = tmp_path / "workspace"
+        wd.mkdir()
+        sub = wd / "only-one"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("sole agent rule")
+
+        tracker = SubdirectoryHintTracker(str(wd))
+        result = tracker._load_hints_for_directory(sub)
+
+        assert result is not None
+        assert "sole agent rule" in result


### PR DESCRIPTION
## Problem

Closes #14537

`SubdirectoryHintTracker._load_hints_for_directory()` contains an unconditional `break` at the end of the per-filename try block. This stops the loop after the first matching file, silently dropping any other hint files in the same directory (e.g. `AGENTS.md` + `.cursorrules`).

The module docstring and issue description both state that **all** matching hint files should be loaded.

## Root Cause

```python
# agent/subdirectory_hints.py  (before)
found_hints.append((rel_path, content))
# First match wins per directory (like startup loading)
break  # ← stops after first file
```

## Fix

Remove the `break`. The `found_hints` list and the `sections`-building code below the loop already handle multiple entries correctly — only the early exit was wrong.

```python
# after
found_hints.append((rel_path, content))
# (no break — continue to next filename)
```

## Minimal Reproduction (from issue)

```python
import tempfile
from pathlib import Path
from agent.subdirectory_hints import SubdirectoryHintTracker

with tempfile.TemporaryDirectory() as td:
    wd = Path(td)
    sub = wd / 'pkg'
    sub.mkdir()
    (sub / 'AGENTS.md').write_text('agents rules')
    (sub / '.cursorrules').write_text('cursor rules')

    tracker = SubdirectoryHintTracker(str(wd))
    result = tracker._load_hints_for_directory(sub)
    print(result)
```

**Before:** only `agents rules` (cursor rules silently dropped)
**After:** both `agents rules` and `cursor rules`

## Tests Added

- `test_loads_all_hint_files_in_directory` — AGENTS.md + .cursorrules both appear in result
- `test_first_hit_does_not_suppress_subsequent_files` — two distinct hint files both loaded
- `test_single_hint_file_still_works` — regression guard for single-file directories