### PR TITLE
docs: fix broken nix-setup anchor for container-aware CLI

### DIFF
--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -122,7 +122,9 @@ services.hermes-agent.environmentFiles = [ "/var/lib/hermes/env" ];
 Setting `addToSystemPackages = true` does two things: puts the `hermes` CLI on your system PATH **and** sets `HERMES_HOME` system-wide so the interactive CLI shares state (sessions, skills, cron) with the gateway service. Without it, running `hermes` in your shell creates a separate `~/.hermes/` directory.
 :::
 
-:::info Container-aware CLI
+### Container-aware CLI
+
+:::info
 When `container.enable = true` and `addToSystemPackages = true`, **every** `hermes` command on the host automatically routes into the managed container. This means your interactive CLI session runs inside the same environment as the gateway service — with access to all container-installed packages and tools.
 
 - The routing is transparent: `hermes chat`, `hermes sessions list`, `hermes version`, etc. all exec into the container under the hood


### PR DESCRIPTION
## Summary
- fix broken in-page anchor on `website/docs/getting-started/nix-setup.md`
- add a real heading `### Container-aware CLI` so the existing link target `#container-aware-cli` resolves
- keep the existing `:::info` content unchanged

## Why
The troubleshooting table links to `[Container-aware CLI](#container-aware-cli)`, but the section previously used only an admonition title (`:::info Container-aware CLI`) which does not generate that heading anchor.

## Validation
Built docs locally from `website/`:
- `npm ci`
- `npm run build`

Result:
- broken anchor warning for `/docs/getting-started/nix-setup#container-aware-cli` is gone
- unrelated existing warning remains in `/docs/user-guide/docker` (`./api-server.md`)

Closes #14595