### PR TITLE
fix(api-server): bind container API host for published ports

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -46,17 +46,34 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from hermes_constants import is_container
 
 logger = logging.getLogger(__name__)
 
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
+CONTAINER_DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+
+
+def _resolve_default_host(explicit_host: Any, *, api_key: str) -> str:
+    """Choose the API server bind host when the user did not set one.
+
+    In Docker/Podman, a loopback-only bind makes ``-p 8642:8642`` appear
+    broken from the host. When an API key is configured, default to a
+    container-friendly bind so the mapped port is actually reachable.
+    """
+    host = str(explicit_host or "").strip()
+    if host:
+        return host
+    if api_key and is_container():
+        return CONTAINER_DEFAULT_HOST
+    return DEFAULT_HOST
 
 
 def _normalize_chat_content(
@@ -569,9 +586,12 @@ class APIServerAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
-        self._host: str = extra.get("host", os.getenv("API_SERVER_HOST", DEFAULT_HOST))
-        self._port: int = int(extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))))
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
+        self._host: str = _resolve_default_host(
+            extra.get("host", os.getenv("API_SERVER_HOST", "")),
+            api_key=self._api_key,
+        )
+        self._port: int = int(extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))))
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -240,6 +240,18 @@ class TestAdapterInit:
             "http://127.0.0.1:3000",
         )
 
+    def test_container_with_key_defaults_to_network_bind(self):
+        config = PlatformConfig(enabled=True, extra={"key": "sk-test"})
+        with patch("gateway.platforms.api_server.is_container", return_value=True):
+            adapter = APIServerAdapter(config)
+        assert adapter._host == "0.0.0.0"
+
+    def test_container_without_key_keeps_loopback_default(self):
+        config = PlatformConfig(enabled=True)
+        with patch("gateway.platforms.api_server.is_container", return_value=True):
+            adapter = APIServerAdapter(config)
+        assert adapter._host == "127.0.0.1"
+
 
 # ---------------------------------------------------------------------------
 # Auth checking

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -36,10 +36,12 @@ docker run -d \
   --restart unless-stopped \
   -v ~/.hermes:/opt/data \
   -p 8642:8642 \
+  -e API_SERVER_KEY="$(openssl rand -hex 32)" \
   nousresearch/hermes-agent gateway run
 ```
 
 Port 8642 exposes the gateway's [OpenAI-compatible API server](./api-server.md) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
+When `API_SERVER_KEY` is set, the containerized API server binds to `0.0.0.0` by default so the published port is reachable from the host. Set `API_SERVER_HOST` explicitly if you want a different bind address.
 
 Opening any port on an internet facing machine is a security risk. You should not do it unless you understand the risks.
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -282,7 +282,7 @@ The default bind address (`127.0.0.1`) is for local-only use. Browser access is 
 |----------|---------|-------------|
 | `API_SERVER_ENABLED` | `false` | Enable the API server |
 | `API_SERVER_PORT` | `8642` | HTTP server port |
-| `API_SERVER_HOST` | `127.0.0.1` | Bind address (localhost only by default) |
+| `API_SERVER_HOST` | `127.0.0.1` | Bind address (localhost only by default; inside Docker/Podman with `API_SERVER_KEY`, defaults to `0.0.0.0` so published ports work) |
 | `API_SERVER_KEY` | _(none)_ | Bearer token for auth |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |


### PR DESCRIPTION
## Summary

Fixes #14585.

When Hermes runs inside Docker/Podman, the API server used to keep its normal
loopback default (`127.0.0.1`) even when an `API_SERVER_KEY` was configured.
That made `-p 8642:8642` look broken from the host because the containerized
server never bound a reachable interface.

This change:

- keeps the normal local-only default on native hosts
- defaults the API server to `0.0.0.0` only for container runs with an API key
- preserves any explicit `API_SERVER_HOST` override
- documents the container-specific default in the Docker and API server docs

## Testing

- `python3 -m pytest -o addopts='' tests/gateway/test_api_server.py -q -k 'test_default_config or test_custom_config_from_extra or test_config_from_env or test_container_with_key_defaults_to_network_bind or test_container_without_key_keeps_loopback_default or test_env_override_port_and_host'`

## Notes

- I also ran the full `tests/gateway/test_api_server.py` file locally, but this
  environment already has unrelated auth-path failures in that suite, so I kept
  the reported verification scoped to the adapter-init paths touched here.
