### PR TITLE
fix(gateway): recover stale pid files and release evicted clients

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8809,10 +8809,25 @@ class GatewayRunner:
 
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc)."""
+        entry = None
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                entry = self._agent_cache.pop(session_key, None)
+        else:
+            entry = self._agent_cache.pop(session_key, None)
+
+        agent = entry[0] if isinstance(entry, tuple) and entry else entry
+        if agent is None:
+            return
+
+        t = threading.Thread(
+            target=self._release_evicted_agent_soft,
+            args=(agent,),
+            daemon=True,
+            name=f"agent-evict-{session_key[:24]}",
+        )
+        t.start()
 
     def _release_evicted_agent_soft(self, agent: Any) -> None:
         """Soft cleanup for cache-evicted agents — preserves session tool state.
@@ -11127,7 +11142,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Telegram polling, Discord gateway sockets, etc. The loser exits
     # cleanly before touching any external service.
     import atexit
-    from gateway.status import write_pid_file, remove_pid_file, get_running_pid
+    from gateway.status import (
+        write_pid_file,
+        remove_pid_file,
+        get_running_pid,
+        force_remove_pid_file,
+    )
     _current_pid = get_running_pid()
     if _current_pid is not None and _current_pid != os.getpid():
         logger.error(
@@ -11143,11 +11163,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     try:
         write_pid_file()
     except FileExistsError:
-        release_gateway_runtime_lock()
-        logger.error(
-            "PID file race lost to another gateway instance. Exiting."
+        logger.warning(
+            "Gateway PID file already existed after claiming the runtime lock; "
+            "removing the stale file and retrying once."
         )
-        return False
+        force_remove_pid_file()
+        try:
+            write_pid_file()
+        except FileExistsError:
+            release_gateway_runtime_lock()
+            logger.error(
+                "PID file still exists after stale-file recovery. Exiting."
+            )
+            return False
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -456,6 +456,19 @@ def remove_pid_file() -> None:
         pass
 
 
+def force_remove_pid_file() -> None:
+    """Remove the gateway PID file regardless of the recorded PID.
+
+    Safe only for recovery paths that already proved no sibling gateway owns
+    this HERMES_HOME anymore, such as startup after the runtime lock has been
+    claimed successfully.
+    """
+    try:
+        _get_pid_path().unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
 def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, Any]] = None) -> tuple[bool, Optional[dict[str, Any]]]:
     """Acquire a machine-local lock keyed by scope + identity.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -190,6 +190,32 @@ class TestAgentCacheLifecycle:
             assert "session-A" not in runner._agent_cache
             assert "session-B" in runner._agent_cache
 
+    def test_evict_triggers_soft_release(self, monkeypatch):
+        """Direct cache eviction should release provider clients asynchronously."""
+        runner = _make_runner()
+        agent = MagicMock()
+        released: list = []
+
+        class _ImmediateThread:
+            def __init__(self, *args, **kwargs):
+                self._target = kwargs["target"]
+                self._args = kwargs.get("args", ())
+
+            def start(self):
+                self._target(*self._args)
+
+        monkeypatch.setattr("gateway.run.threading.Thread", _ImmediateThread)
+        runner._release_evicted_agent_soft = lambda a: released.append(a)
+
+        with runner._agent_cache_lock:
+            runner._agent_cache["session-A"] = (agent, "sig-A")
+
+        runner._evict_cached_agent("session-A")
+
+        assert released == [agent]
+        with runner._agent_cache_lock:
+            assert "session-A" not in runner._agent_cache
+
     def test_reasoning_config_updates_in_place(self):
         """Reasoning config can be set on a cached agent without eviction."""
         from run_agent import AIAgent

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from unittest.mock import AsyncMock
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -331,6 +332,43 @@ async def test_start_gateway_replace_clears_marker_on_permission_denied(
     assert ok is False
     # Marker must NOT be left behind
     assert not (tmp_path / ".gateway-takeover.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_recovers_from_stale_pid_file_after_lock(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _CleanExitRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = True
+            self.exit_reason = None
+            self.adapters = {}
+
+        async def start(self):
+            return True
+
+        async def stop(self):
+            return None
+
+    pid_path = tmp_path / "gateway.pid"
+    pid_path.write_text(json.dumps({"pid": 999999, "start_time": 1}), encoding="utf-8")
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _CleanExitRunner)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is True
+    record = json.loads(pid_path.read_text(encoding="utf-8"))
+    assert record["pid"] != 999999
 
 
 def test_runner_warns_when_docker_gateway_lacks_explicit_output_mount(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## Summary
- recover startup when a stale `gateway.pid` is still present after the runtime lock is acquired
- release provider clients when `_evict_cached_agent()` drops a cached agent
- add regression coverage for both recovery paths

## Testing
- `python3 -m pytest -o addopts='' -q tests/gateway/test_agent_cache.py -k 'evict' tests/gateway/test_runner_startup_failures.py -k 'stale_pid or start_gateway'`
- `python3 -m pytest -o addopts='' -q tests/tools/test_zombie_process_cleanup.py -k 'evict_does_not_call_close' tests/gateway/test_session_model_reset.py -k 'evict'`

Closes #14598
