### PR TITLE
fix(cli): guard file-drop detector against ENAMETOOLONG

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1366,7 +1366,15 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
     except Exception:
         resolved = path
 
-    if not resolved.exists() or not resolved.is_file():
+    # stat() can raise OSError when a path component exceeds the filesystem's
+    # NAME_MAX (e.g. ENAMETOOLONG / Errno 63 on macOS when a multi-paragraph
+    # prompt starting with "/" is tested as a candidate path). Treat any stat
+    # failure as "not a file" rather than letting it bubble up and crash the
+    # input loop.
+    try:
+        if not resolved.exists() or not resolved.is_file():
+            return None
+    except OSError:
         return None
     return resolved
 

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -219,3 +219,24 @@ class TestEdgeCases:
         result = _detect_file_drop(str(link))
         assert result is not None
         assert result["is_image"] is True
+
+    def test_long_slash_prefixed_prompt_does_not_raise(self):
+        """Regression: a long multi-paragraph prompt starting with ``/`` used to
+        crash the input loop with OSError(ENAMETOOLONG) on macOS because the
+        space-walk fallback in ``_detect_file_drop`` would try an oversized
+        prefix as a candidate path and ``Path.exists()`` raised instead of
+        returning False. Must return ``None`` cleanly instead of propagating.
+        """
+        # Simulates the user typing a slash command followed by a long,
+        # multi-paragraph body — the exact shape that reproduced the bug.
+        long_prompt = (
+            "/some-skill " + ("lorem ipsum dolor sit amet consectetur "
+            "adipiscing elit sed do eiusmod tempor incididunt ut labore "
+            "et dolore magna aliqua ut enim ad minim veniam quis nostrud "
+            "exercitation ullamco laboris nisi ut aliquip ex ea commodo "
+            "consequat duis aute irure dolor in reprehenderit in voluptate.")
+        )
+        # The basename of this candidate is well over any mainstream FS's
+        # NAME_MAX (255 bytes), which is what used to raise ENAMETOOLONG.
+        assert len(long_prompt) > 255
+        assert _detect_file_drop(long_prompt) is None


### PR DESCRIPTION
## Summary

`_resolve_attachment_path()` in `cli.py` wraps `Path.resolve()` in `try/except` but leaves the subsequent `.exists()` / `.is_file()` calls unguarded. On macOS (APFS, HFS+) and any filesystem with `NAME_MAX <= 255 bytes`, `stat()` raises `OSError(Errno 63, 'File name too long')` when a path component exceeds the limit — and `pathlib`'s `exists()` / `is_file()` propagate that instead of returning `False`.

This crashes the entire input loop whenever a user types a slash command followed by a long multi-paragraph message, because the space-walking fallback in `_detect_file_drop()` iterates `reversed(space_positions)` and starts by testing **the largest prefix of the input** as a candidate path. For a 300+ byte message, the very first candidate blows past `NAME_MAX` and the `OSError` bubbles all the way up.

## Reproduction

Type or paste any slash command followed by a long (>255 byte) message body into the CLI, e.g.:

```
/some-skill lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
```

Before this patch:
```
OSError: [Errno 63] File name too long: '/some-skill lorem ipsum dolor sit amet, ...'
```

## Fix

Wrap the `.exists()` / `.is_file()` calls in `try/except OSError` and treat any failure as "not a file", matching the existing treatment of `Path.resolve()` a few lines above. Surgical: one function, one block. No behavior change for valid paths.

## Test

Adds a regression test in `tests/cli/test_cli_file_drop.py` using the exact input shape that reproduced the crash.

Verified:
- **Without the fix**: the new test fails with `OSError: [Errno 63] File name too long`.
- **With the fix**: 34/34 tests in `tests/cli/test_cli_file_drop.py` pass.

## Notes

Not a length check — the detector still walks every space position as before. This change only prevents the loop from crashing when a candidate trips `NAME_MAX`. A length pre-filter would be a performance optimization; correctness is handled by the guard.
