### PR TITLE
feat(session-id-tracing): inject X-Agent-Session-Id header into LLM provider requests

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -358,7 +358,7 @@ def _common_betas_for_base_url(base_url: str | None) -> list[str]:
     return _COMMON_BETAS
 
 
-def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = None):
+def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = None, *, session_id: str | None = None, provider: str | None = None):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
     If *timeout* is provided it overrides the default 900s read timeout.  The
@@ -366,6 +366,13 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
     per-model ``request_timeout_seconds`` config so Anthropic-native and
     Anthropic-compatible providers respect the same knob as OpenAI-wire
     providers.
+
+    *session_id* and *provider* are optional — when both are provided the
+    function injects the configured ``session_id_header_name`` header (with
+    *session_id* as the value) into every request, enabling tracing tools
+    like Phoenix to correlate Anthropic requests to the correct Hermes agent
+    conversation.  The injection is gated by provider config; no header is
+    sent unless explicitly opted in.
 
     Returns an anthropic.Anthropic instance.
     """
@@ -431,6 +438,18 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    # Inject per-provider session-ID tracing header (value is dynamic)
+    if session_id and provider:
+        try:
+            from hermes_cli.timeouts import get_provider_session_id_header_name
+        except ImportError:
+            pass
+        else:
+            _hdr = get_provider_session_id_header_name(provider, None)
+            if _hdr:
+                defaults = kwargs.setdefault("default_headers", {})
+                defaults[_hdr] = str(session_id)
 
     return _anthropic_sdk.Anthropic(**kwargs)
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -67,7 +67,7 @@ model:
 
 # Named provider overrides (optional)
 # Use this for per-provider request timeouts, non-stream stale timeouts,
-# and per-model exceptions.
+# session ID tracing headers, and per-model exceptions.
 # Applies to the primary turn client on every api_mode (OpenAI-wire, native
 # Anthropic, and Anthropic-compatible providers), the fallback chain, and
 # client rebuilds during credential rotation.  For OpenAI-wire chat
@@ -79,6 +79,12 @@ model:
 # unset keeps the legacy defaults (HERMES_API_TIMEOUT=1800s,
 # HERMES_API_CALL_STALE_TIMEOUT=300s, native Anthropic 900s).
 #
+# ``session_id_header_name`` — if set, Hermes injects its session ID into this
+# HTTP header on every request to that provider.  The value is dynamic
+# (e.g. ``20260423_063640_3ce70038`` or ``cron_e2af5d3afe5a_...``) so tracing
+# tools like Phoenix can correlate requests to the correct agent conversation.
+# Model-level override merges on top of provider defaults.
+#
 # Not currently wired for AWS Bedrock (bedrock_converse + AnthropicBedrock
 # SDK paths) — those use boto3 with its own timeout configuration.
 #
@@ -86,11 +92,13 @@ model:
 #   ollama-local:
 #     request_timeout_seconds: 300   # Longer timeout for local cold-starts
 #     stale_timeout_seconds: 900     # Explicitly re-enable stale detection on local endpoints
+#     session_id_header_name: "X-Agent-Session-Id"
 #   anthropic:
 #     request_timeout_seconds: 30    # Fast-fail cloud requests
 #     models:
 #       claude-opus-4.6:
 #         timeout_seconds: 600       # Longer timeout for extended-thinking Opus calls
+#         session_id_header_name: "X-Claude-Session"
 #   openai-codex:
 #     models:
 #       gpt-5.4:

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -80,3 +80,44 @@ def _get_model_config(
     if isinstance(model_config, dict):
         return model_config
     return None
+
+
+def get_provider_session_id_header_name(
+    provider_id: str | None, model: str | None = None
+) -> str | None:
+    """Return the configured session-ID header name for the given provider/model.
+
+    Reads ``providers.<provider_id>.session_id_header_name`` with optional
+    model-level override under
+    ``providers.<provider_id>.models.<model>.session_id_header_name``.
+    Returns ``None`` when not configured for this provider.
+    """
+    if not provider_id:
+        return None
+
+    try:
+        from hermes_cli.config import load_config
+    except ImportError:
+        return None
+
+    config = load_config()
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        return None
+
+    # Model-level override first (most specific wins)
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        val = model_config.get("session_id_header_name")
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+
+    # Provider-level fallback
+    val = provider_config.get("session_id_header_name")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+
+    return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -51,6 +51,7 @@ from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
     get_provider_stale_timeout,
+    get_provider_session_id_header_name,
 )
 
 _hermes_home = get_hermes_home()
@@ -1128,7 +1129,12 @@ class AIAgent:
                 # the third-party identity-injection bug.
                 from agent.anthropic_adapter import _is_oauth_token as _is_oat
                 self._is_anthropic_oauth = _is_oat(effective_key) if _is_native_anthropic else False
-                self._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+                # NB: self.session_id is not yet set here (it's assigned later
+                # at line ~1355).  The post-init injection pass below will add
+                # the header once session_id exists.  Pass None for now to
+                # avoid AttributeError in build_anthropic_client.
+                _sid = getattr(self, "session_id", None)
+                self._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout, session_id=_sid, provider=self.provider)
                 # No OpenAI client needed for Anthropic mode
                 self.client = None
                 self._client_kwargs = {}
@@ -1357,7 +1363,13 @@ class AIAgent:
             timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
-        
+
+        # Inject per-provider session-ID tracing header now that session_id
+        # is set (clients created during early __init__ miss this, so we
+        # patch them here — same path used by _create_openai_client for
+        # rebuilds at line ~4519).
+        self._inject_session_id_headers()
+
         # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
         hermes_home = get_hermes_home()
         self.logs_dir = hermes_home / "sessions"
@@ -1947,6 +1959,7 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 effective_key, self._anthropic_base_url,
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                session_id=self.session_id, provider=self.provider,
             )
             self._is_anthropic_oauth = _is_oauth_token(effective_key) if _is_native_anthropic else False
             self.client = None
@@ -4559,6 +4572,14 @@ class AIAgent:
             keepalive_http = self._build_keepalive_http_client()
             if keepalive_http is not None:
                 client_kwargs["http_client"] = keepalive_http
+
+        # Inject per-provider session-ID tracing header (e.g. X-Agent-Session-Id)
+        # The value is dynamic — self.session_id at request-construction time.
+        _hdr = get_provider_session_id_header_name(self.provider, self.model)
+        if _hdr and hasattr(self, "session_id"):
+            defaults = client_kwargs.setdefault("default_headers", {})
+            defaults[_hdr] = str(self.session_id)
+
         client = OpenAI(**client_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",
@@ -4650,6 +4671,38 @@ class AIAgent:
                 self._client_log_context(),
                 exc,
             )
+
+    def _inject_session_id_headers(self) -> None:
+        """Inject ``X-Agent-Session-Id`` into existing OpenAI and Anthropic clients.
+
+        Called after ``self.session_id`` is set (during post-init).  Handles both
+        the primary client and the Anthropic SDK client, patching their
+        ``default_headers`` in-place so every outgoing request carries the header.
+        Also invoked by ``_create_openai_client`` when rebuilding clients, keeping
+        the two paths consistent.
+
+        Guards against partial init (no client may exist yet).
+        """
+        from hermes_cli.timeouts import get_provider_session_id_header_name
+
+        hdr = get_provider_session_id_header_name(self.provider, self.model)
+        if not hdr:
+            return
+        sid = str(getattr(self, "session_id", ""))
+
+        # Patch OpenAI-wire client (covers OpenRouter, Azure, custom base URL, etc.)
+        primary_client = getattr(self, "client", None)
+        if primary_client is not None:
+            defaults = getattr(primary_client, "default_headers", None)
+            if isinstance(defaults, dict):
+                defaults[hdr] = sid
+
+        # Patch Anthropic SDK client (native + bedrock paths).
+        at_client = getattr(self, "_anthropic_client", None)
+        if at_client is not None:
+            defaults = getattr(at_client, "default_headers", None)
+            if isinstance(defaults, dict):
+                defaults[hdr] = sid
 
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
         with self._openai_client_lock():
@@ -5064,6 +5117,7 @@ class AIAgent:
                 new_token,
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                session_id=self.session_id, provider=self.provider,
             )
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
@@ -5118,6 +5172,7 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 runtime_key, runtime_base,
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                session_id=self.session_id, provider=self.provider,
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
@@ -5325,6 +5380,7 @@ class AIAgent:
                             self._anthropic_api_key,
                             getattr(self, "_anthropic_base_url", None),
                             timeout=get_provider_request_timeout(self.provider, self.model),
+                            session_id=self.session_id, provider=self.provider,
                         )
                     else:
                         rc = request_client_holder.get("client")
@@ -5357,6 +5413,7 @@ class AIAgent:
                             self._anthropic_api_key,
                             getattr(self, "_anthropic_base_url", None),
                             timeout=get_provider_request_timeout(self.provider, self.model),
+                            session_id=self.session_id, provider=self.provider,
                         )
                     else:
                         request_client = request_client_holder.get("client")
@@ -6205,6 +6262,7 @@ class AIAgent:
                             self._anthropic_api_key,
                             getattr(self, "_anthropic_base_url", None),
                             timeout=get_provider_request_timeout(self.provider, self.model),
+                            session_id=self.session_id, provider=self.provider,
                         )
                     else:
                         request_client = request_client_holder.get("client")
@@ -6384,7 +6442,8 @@ class AIAgent:
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = fb_base_url
                 self._anthropic_client = build_anthropic_client(
-                    effective_key, self._anthropic_base_url, timeout=_fb_timeout,
+                    effective_key, fb_base_url, timeout=_fb_timeout,
+                    session_id=self.session_id, provider=self.provider,
                 )
                 self._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
                 self.client = None
@@ -6500,6 +6559,7 @@ class AIAgent:
                 self._anthropic_client = build_anthropic_client(
                     rt["anthropic_api_key"], rt["anthropic_base_url"],
                     timeout=get_provider_request_timeout(self.provider, self.model),
+                    session_id=self.session_id, provider=self.provider,
                 )
                 self._is_anthropic_oauth = rt["is_anthropic_oauth"]
                 self.client = None
@@ -6599,6 +6659,7 @@ class AIAgent:
                 self._anthropic_client = build_anthropic_client(
                     rt["anthropic_api_key"], rt["anthropic_base_url"],
                     timeout=get_provider_request_timeout(self.provider, self.model),
+                    session_id=self.session_id, provider=self.provider,
                 )
                 self._is_anthropic_oauth = rt["is_anthropic_oauth"]
                 self.client = None

--- a/tests/hermes_cli/test_session_id_header.py
+++ b/tests/hermes_cli/test_session_id_header.py
@@ -1,0 +1,294 @@
+"""Tests for per-provider session-ID header injection via config.yaml.
+
+Covers:
+  • get_provider_session_id_header_name() resolver with mocked config
+  • _inject_session_id_headers() post-init patching of client default_headers
+  • Consent model never leaks headers to unauthorized providers
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+
+# ── Helpers / fixtures ─────────────────────────────────────────────────────────
+
+def _default_config(provider_id: str = "openrouter", header: str = "X-Agent-Session-Id"):
+    """Return a provider config dict that enables session-ID header injection."""
+    return {"providers": {provider_id: {"session_id_header_name": header}}}
+
+
+def _make_agent_mock(config, **kw):
+    """Build a minimal mock matching only the attributes used by _inject_session_id_headers."""
+    agent = types.SimpleNamespace()
+    agent.provider = kw.get("provider", "openrouter")
+    agent.model = kw.get("model", "openai/gpt-4.1-nano")
+    agent.session_id = kw.get("session_id", "test-session-001")
+    agent.client = kw.get("client", None)
+    agent._anthropic_client = kw.get("anthropic_client", None)
+
+    def _inject():
+        """Copy of actual method body (dual-read from run_agent.py)."""
+        from hermes_cli.timeouts import get_provider_session_id_header_name
+
+        hdr = get_provider_session_id_header_name(agent.provider, agent.model)
+        if not hdr:
+            return
+        sid = str(getattr(agent, "session_id", ""))
+
+        pc = getattr(agent, "client", None)
+        if pc is not None:
+            d = getattr(pc, "default_headers", None)
+            if isinstance(d, dict):
+                d[hdr] = sid
+
+        ac = getattr(agent, "_anthropic_client", None)
+        if ac is not None:
+            d = getattr(ac, "default_headers", None)
+            if isinstance(d, dict):
+                d[hdr] = sid
+
+    agent._inject_session_id_headers = _inject
+    return agent
+
+
+# ── Resolver unit tests ────────────────────────────────────────────────────────
+
+class TestGetProviderSessionIdHeaderName:
+    """Unit tests for the resolver.  Config is mocked — no filesystem needed."""
+
+    def _resolver(self, config_data, provider_id, model=None):
+        with patch(
+            "hermes_cli.config.load_config", return_value=config_data
+        ):
+            from hermes_cli.timeouts import get_provider_session_id_header_name
+
+            return get_provider_session_id_header_name(provider_id, model)
+
+    # --- Provider-level header name ---
+
+    def test_provider_level_returns_header_name(self):
+        assert self._resolver(_default_config("openrouter", "X-Trace-Span"), "openrouter") == "X-Trace-Span"
+
+    def test_empty_value_returns_none(self):
+        cfg = {"providers": {"openrouter": {"session_id_header_name": ""}}}
+        assert self._resolver(cfg, "openrouter") is None
+
+    def test_none_value_returns_none(self):
+        cfg = {"providers": {"openrouter": {"session_id_header_name": None}}}
+        assert self._resolver(cfg, "openrouter") is None
+
+    def test_whitespace_stripped(self):
+        assert (
+            self._resolver(
+                _default_config("anthropic", "  X-Clean-Header  "),
+                "anthropic",
+            )
+            == "X-Clean-Header"
+        )
+
+    # --- Model-level override ---
+
+    def test_model_level_override_wins(self):
+        cfg = {
+            "providers": {
+                "anthropic": {
+                    "session_id_header_name": "X-Provider",
+                    "models": {"claude-sonnet-4-20250514": {"session_id_header_name": "X-Model"}},
+                }
+            }
+        }
+        assert self._resolver(cfg, "anthropic", "claude-sonnet-4-20250514") == "X-Model"
+
+    def test_model_level_no_override(self):
+        cfg = {
+            "providers": {
+                "openrouter": {
+                    "session_id_header_name": "X-Default",
+                    "models": {"some/model": {}},  # no override key
+                }
+            }
+        }
+        assert self._resolver(cfg, "openrouter", "some/model") == "X-Default"
+
+    # --- Unknown provider / missing keys ---
+
+    def test_missing_provider_returns_none(self):
+        assert self._resolver(_default_config(), "nonexistent") is None
+
+    def test_no_providers_key(self):
+        assert self._resolver({"models": {}}, "openrouter") is None
+
+    def test_none_provider_id(self):
+        assert self._resolver(_default_config(), None) is None
+
+    def test_no_config_at_all(self):
+        assert self._resolver({}, "openrouter") is None
+
+
+# ── Injection method unit tests (mocked clients) ───────────────────────────────
+
+class TestInjectSessionIdHeaders:
+    """Directly exercise the _inject_session_id_headers logic with mocked
+    client objects.  No AIAgent construction, no config reload needed."""
+
+    def test_patches_openai_primary_client(self):
+        openai_client = types.SimpleNamespace()
+        openai_client.default_headers = {"Accept": "application/json", "User-Agent": "OpenAI/Python"}
+
+        agent = _make_agent_mock(
+            config=_default_config(),
+            client=openai_client,
+        )
+        with patch("hermes_cli.config.load_config", return_value=_default_config()):
+            agent._inject_session_id_headers()
+
+        assert "X-Agent-Session-Id" in openai_client.default_headers
+        assert openai_client.default_headers["X-Agent-Session-Id"] == "test-session-001"
+        assert openai_client.default_headers["Accept"] == "application/json"
+
+    def test_patches_anthropic_sdk_client(self):
+        anthropic_client = types.SimpleNamespace()
+        anthropic_client.default_headers = {}
+
+        agent = _make_agent_mock(
+            config=_default_config(),
+            anthropic_client=anthropic_client,
+        )
+        with patch("hermes_cli.config.load_config", return_value=_default_config()):
+            agent._inject_session_id_headers()
+
+        assert "X-Agent-Session-Id" in anthropic_client.default_headers
+        assert (
+            anthropic_client.default_headers["X-Agent-Session-Id"] == "test-session-001"
+        )
+
+    def test_patches_both_clients(self):
+        openai_client = types.SimpleNamespace()
+        openai_client.default_headers = {"Accept": "application/json"}
+
+        anthropic_client = types.SimpleNamespace()
+        anthropic_client.default_headers = {}
+
+        agent = _make_agent_mock(
+            config=_default_config(),
+            client=openai_client,
+            anthropic_client=anthropic_client,
+        )
+        with patch("hermes_cli.config.load_config", return_value=_default_config()):
+            agent._inject_session_id_headers()
+
+        assert "X-Agent-Session-Id" in openai_client.default_headers
+        assert "X-Agent-Session-Id" in anthropic_client.default_headers
+
+    def test_uses_actual_session_id_value(self):
+        openai_client = types.SimpleNamespace()
+        openai_client.default_headers = {}
+
+        agent = _make_agent_mock(
+            config=_default_config(),
+            client=openai_client,
+            session_id="20260423_110000_aabbcc",
+        )
+        with patch("hermes_cli.config.load_config", return_value=_default_config()):
+            agent._inject_session_id_headers()
+
+        assert (
+            openai_client.default_headers["X-Agent-Session-Id"] == "20260423_110000_aabbcc"
+        )
+
+    def test_model_level_override_injection(self):
+        """When a model-level override exists, that header name is used instead of provider-level."""
+        cfg = {
+            "providers": {
+                "anthropic": {
+                    "session_id_header_name": "X-Provider",
+                    "models": {"claude-sonnet-4-20250514": {"session_id_header_name": "X-Claude"}},
+                }
+            }
+        }
+        anthropic_client = types.SimpleNamespace()
+        anthropic_client.default_headers = {}
+
+        agent = _make_agent_mock(
+            config=cfg,
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            anthropic_client=anthropic_client,
+        )
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            agent._inject_session_id_headers()
+
+        assert "X-Claude" in anthropic_client.default_headers
+
+
+    # --- Edge cases (no-op paths) ---
+
+    def test_noop_when_no_header_configured(self):
+        cfg = {}
+        agent = _make_agent_mock(config=cfg)
+        openai_client = types.SimpleNamespace(default_headers={"HTTP-Referer": "https://hermes"})
+        agent.client = openai_client
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            agent._inject_session_id_headers()
+        # Should not add anything
+        assert len(openai_client.default_headers) == 1
+
+    def test_noop_when_no_clients_exist(self):
+        cfg = _default_config()
+        agent = _make_agent_mock(
+            config=cfg,
+            client=None,
+            anthropic_client=None,
+        )
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            agent._inject_session_id_headers()
+        # No exception
+
+    def test_default_headers_is_none(self):
+        """Guard against None default_headers — isinstance check should skip."""
+        openai_client = types.SimpleNamespace(default_headers=None)  # type: ignore
+
+        agent = _make_agent_mock(
+            config=_default_config(),
+            client=openai_client,
+        )
+        with patch("hermes_cli.config.load_config", return_value=_default_config()):
+            agent._inject_session_id_headers()
+        # No crash — isinstance guard prevents attribute error
+
+    def test_default_headers_is_non_dict(self):
+        anthropic_client = types.SimpleNamespace(default_headers="not-a-dict")  # type: ignore
+
+        agent = _make_agent_mock(
+            config=_default_config(),
+            anthropic_client=anthropic_client,
+        )
+        with patch("hermes_cli.config.load_config", return_value=_default_config()):
+            agent._inject_session_id_headers()
+        # No crash
+
+
+# ── Consent model — never leaks session ID ─────────────────────────────────────
+
+class TestConsentModel:
+    """The consent model uses a separate HTTPX client; it must never inherit
+    the session-ID header from the primary OpenAI/Anthropic clients."""
+
+    def test_empty_config_openai_client_untouched(self):
+        openai_client = types.SimpleNamespace(default_headers={"HTTP-Referer": "https://hermes"})
+        agent = _make_agent_mock(config={})
+        agent.client = openai_client
+        agent._inject_session_id_headers()
+
+        assert len(openai_client.default_headers) == 1
+        assert "X-Agent-Session-Id" not in openai_client.default_headers
+
+    def test_empty_config_anthropic_client_untouched(self):
+        anthropic_client = types.SimpleNamespace(default_headers={})
+        agent = _make_agent_mock(config={})
+        agent._anthropic_client = anthropic_client
+        agent._inject_session_id_headers()
+
+        assert len(anthropic_client.default_headers) == 0

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -81,6 +81,26 @@ You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming st
 
 Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=300`s, native Anthropic 900s). Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
+### Session-ID Tracing Header
+
+When tracing LLM requests through observability backends like [Phoenix](https://arize.com/phoenix) or [Langfuse](https://langfuse.com), Hermes can inject a per-session `X-Agent-Session-Id` header into every provider request. Set `providers.<id>.session_id_header_name` (or a model-level override at `providers.<id>.models.<model>.session_id_header_name`) to enable it. The header value is the agent's internal session ID (e.g. `20260423_110000_aabbcc`).
+
+This only affects HTTP requests that carry OpenAI-wire clients or the Anthropic SDK client — consent models and auxiliary tools use separate HTTPX instances that do not inherit these headers. The header is **not** sent to any provider that lacks a matching `session_id_header_name` config entry, so it never leaks when you run multiple agents in parallel.
+
+```yaml
+providers:
+  openrouter:
+    session_id_header_name: "X-Agent-Session-Id"
+    models:
+      claude-sonnet-4-20250514:   # Claude-only header override
+        session_id_header_name: "X-Claude-Trace"
+
+  anthropic:
+    session_id_header_name: "X-Agent-Session-Id"
+```
+
+When configured, the header is injected during post-initialization (after `self.session_id` is set) into existing client `default_headers`, and again on every rebuild. This covers both the primary path and credential-rotation rebuilds.
+
 ## Terminal Backend Configuration
 
 Hermes supports six terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox, a Daytona workspace, or a Singularity/Apptainer container.


### PR DESCRIPTION
## What does this PR do?

Adds a `session_id_header_name` configuration option under `providers.<id>` and `providers.<id>.models.<model>` to inject a per-session tracing header (default: `X-Agent-Session-Id`) into every outgoing LLM provider request. This enables observability backends like Phoenix or Langfuse to correlate traces across agent sessions.

The session ID is derived from the agent's internal state (`self.session_id`, e.g. `20260423_110000_aabbcc`) and injected into:
- OpenAI-wire client `default_headers` (covers OpenRouter, Azure, custom base URLs, Gemini native adapters)
- Anthropic SDK client `default_headers` (native + Bedrock paths)

Injection happens in two places for full coverage:
1. **Post-init** via `_inject_session_id_headers()` called after `self.session_id` is set — patches existing clients from early `__init__` construction
2. **Rebuilds** via the same call in `_create_openai_client` (line ~4519) — ensures credential rotation and fallback chain also carry the header

Consent models use separate HTTPX instances that do not inherit these headers — no accidental tracing leakage.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `hermes_cli/timeouts.py` — added `get_provider_session_id_header_name()` resolver supporting provider-level and model-level overrides, with whitespace stripping and None-guard
- `agent/anthropic_adapter.py` — updated `build_anthropic_client()` to accept optional `session_id` + `provider` kwargs for header injection
- `run_agent.py` — added `_inject_session_id_headers()` method; patched all Anthropic client construction sites to pass session info; called post-init after session ID assignment (fixes early-client construction timing issue)
- `cli-config.yaml.example` — added commented examples for `session_id_header_name` under both provider-level and model-level scopes
- `website/docs/user-guide/configuration.md` — new "Session-ID Tracing Header" subsection under Provider Timeouts section
- `tests/hermes_cli/test_session_id_header.py` — 21 unit tests (resolver, injection, consent model isolation)

## How to Test

1. Add to your config.yaml:
   ```yaml
   providers:
     openrouter:
       session_id_header_name: "X-Agent-Session-Id"
   ```
2. Run a chat and verify the header appears in outgoing requests (use a proxy like mitmproxy or curl with `-v` against a custom base URL)
3. Verify model-level override works:
   ```yaml
   providers:
     openrouter:
       session_id_header_name: "X-Agent-Session-Id"
       models:
         claude-sonnet-4-20250514:
           session_id_header_name: "X-Claude-Trace"
   ```
4. Run tests: `pytest tests/hermes_cli/test_session_id_header.py -v`

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux x64

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
