### PR TITLE
fix: support /reasoning --global and cron reasoning overrides

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6787,9 +6787,10 @@ class HermesCLI:
             /reasoning show|on      Show model thinking/reasoning in output
             /reasoning hide|off     Hide model thinking/reasoning from output
         """
-        parts = cmd.strip().split(maxsplit=1)
+        parts = cmd.strip().split(None, 1)
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
 
-        if len(parts) < 2:
+        if not raw_args:
             # Show current state
             rc = self.reasoning_config
             if rc is None:
@@ -6801,10 +6802,18 @@ class HermesCLI:
             display_state = "on ✓" if self.show_reasoning else "off"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide> [--global]{_RST}")
             return
 
-        arg = parts[1].strip().lower()
+        from hermes_constants import parse_reasoning_command_args
+
+        arg, persist_global, parse_error = parse_reasoning_command_args(raw_args)
+        if parse_error:
+            _cprint(f"  {_DIM}(._.) {parse_error}{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
+            _cprint(f"  {_DIM}Display:      show, hide{_RST}")
+            _cprint(f"  {_DIM}Flag:         --global{_RST}")
+            return
 
         # Display toggle
         if arg in ("show", "on"):
@@ -6826,18 +6835,22 @@ class HermesCLI:
         # Effort level change
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
-            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
+            _cprint(f"  {_DIM}(._.) Unknown argument: {raw_args.lower()}{_RST}")
             _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
+            _cprint(f"  {_DIM}Flag:         --global{_RST}")
             return
 
         self.reasoning_config = parsed
         self.agent = None  # Force agent re-init with new reasoning config
 
-        if save_config_value("agent.reasoning_effort", arg):
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
+        if persist_global:
+            if save_config_value("agent.reasoning_effort", arg):
+                _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
+            else:
+                _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only; config save failed){_RST}")
         else:
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only — add --global to persist){_RST}")
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -15,7 +15,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, parse_reasoning_effort
 from typing import Optional, Dict, List, Any
 
 logger = logging.getLogger(__name__)
@@ -59,6 +59,19 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
         if text and text not in normalized:
             normalized.append(text)
     return normalized
+
+
+def _normalize_reasoning_effort(reasoning_effort: Optional[Any]) -> Optional[str]:
+    if reasoning_effort is None:
+        return None
+    text = str(reasoning_effort).strip().lower()
+    if not text:
+        return None
+    if parse_reasoning_effort(text) is None:
+        raise ValueError(
+            "Invalid reasoning_effort. Expected one of: none, minimal, low, medium, high, xhigh."
+        )
+    return text
 
 
 def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
@@ -383,6 +396,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     script: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
@@ -400,6 +414,7 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        reasoning_effort: Optional per-job reasoning override
         script: Optional path to a Python script whose stdout is injected into the
                 prompt each run.  The script runs before the agent turn, and its output
                 is prepended as context.  Useful for data collection / change detection.
@@ -428,6 +443,7 @@ def create_job(
     normalized_model = str(model).strip() if isinstance(model, str) else None
     normalized_provider = str(provider).strip() if isinstance(provider, str) else None
     normalized_base_url = str(base_url).strip().rstrip("/") if isinstance(base_url, str) else None
+    normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
     normalized_model = normalized_model or None
     normalized_provider = normalized_provider or None
     normalized_base_url = normalized_base_url or None
@@ -444,6 +460,7 @@ def create_job(
         "model": normalized_model,
         "provider": normalized_provider,
         "base_url": normalized_base_url,
+        "reasoning_effort": normalized_reasoning_effort,
         "script": normalized_script,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
@@ -499,6 +516,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates
+
+        if "reasoning_effort" in updates:
+            updated["reasoning_effort"] = _normalize_reasoning_effort(updated.get("reasoning_effort"))
 
         if "skills" in updates or "skill" in updates:
             normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -808,9 +808,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception:
             pass
 
-        # Reasoning config from config.yaml
+        # Reasoning config from job override or config.yaml
         from hermes_constants import parse_reasoning_effort
-        effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        effort = str(job.get("reasoning_effort") or _cfg.get("agent", {}).get("reasoning_effort", "")).strip()
         reasoning_config = parse_reasoning_effort(effort)
 
         # Prefill messages from env or config.yaml

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -615,6 +615,7 @@ class GatewayRunner:
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -678,6 +679,9 @@ class GatewayRunner:
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
         self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        # Per-session reasoning overrides from /reasoning command.
+        # Key: session_key, Value: dict like {"enabled": bool, "effort": str?}
+        self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
@@ -1343,6 +1347,30 @@ class GatewayRunner:
         if effort and effort.strip() and result is None:
             logger.warning("Unknown reasoning_effort '%s', using default (medium)", effort)
         return result
+
+    def _get_reasoning_config_for_session(
+        self,
+        *,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+    ) -> dict | None:
+        """Return the effective reasoning config for a session.
+
+        Session-scoped `/reasoning` overrides win over config.yaml. When no
+        override exists, fall back to the persisted global config.
+        """
+        resolved_session_key = session_key
+        if not resolved_session_key and source is not None:
+            try:
+                resolved_session_key = self._session_key_for_source(source)
+            except Exception:
+                resolved_session_key = None
+
+        overrides = getattr(self, "_session_reasoning_overrides", {}) or {}
+        override = overrides.get(resolved_session_key) if resolved_session_key else None
+        if override is not None:
+            return dict(override)
+        return self._load_reasoning_config()
 
     @staticmethod
     def _load_service_tier() -> str | None:
@@ -4613,6 +4641,7 @@ class GatewayRunner:
                 self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
+                self._session_reasoning_overrides.pop(session_key, None)
                 response = (response or "") + (
                     "\n\n🔄 Session auto-reset — the conversation exceeded the "
                     "maximum context size and could not be compressed further. "
@@ -4900,6 +4929,7 @@ class GatewayRunner:
         # Clear any session-scoped model override so the next agent picks up
         # the configured default instead of the previously switched model.
         self._session_model_overrides.pop(session_key, None)
+        self._session_reasoning_overrides.pop(session_key, None)
 
         # Fire plugin on_session_finalize hook (session boundary)
         try:
@@ -6431,7 +6461,7 @@ class GatewayRunner:
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            reasoning_config = self._load_reasoning_config()
+            reasoning_config = self._get_reasoning_config_for_session(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
@@ -6599,7 +6629,7 @@ class GatewayRunner:
                 return
 
             platform_key = _platform_config_key(source.platform)
-            reasoning_config = self._load_reasoning_config()
+            reasoning_config = self._get_reasoning_config_for_session(session_key=session_key)
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
             pr = self._provider_routing
@@ -6711,10 +6741,12 @@ class GatewayRunner:
             /reasoning hide|off     Hide model reasoning from responses
         """
         import yaml
+        from hermes_constants import parse_reasoning_command_args, parse_reasoning_effort
 
-        args = event.get_command_args().strip().lower()
+        raw_args = event.get_command_args().strip()
         config_path = _hermes_home / "config.yaml"
-        self._reasoning_config = self._load_reasoning_config()
+        session_key = self._session_key_for_source(event.source)
+        self._reasoning_config = self._get_reasoning_config_for_session(session_key=session_key)
         self._show_reasoning = self._load_show_reasoning()
 
         def _save_config_key(key_path: str, value):
@@ -6737,7 +6769,7 @@ class GatewayRunner:
                 logger.error("Failed to save config key %s: %s", key_path, e)
                 return False
 
-        if not args:
+        if not raw_args:
             # Show current state
             rc = self._reasoning_config
             if rc is None:
@@ -6751,7 +6783,16 @@ class GatewayRunner:
                 "🧠 **Reasoning Settings**\n\n"
                 f"**Effort:** `{level}`\n"
                 f"**Display:** {display_state}\n\n"
-                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|show|hide>`"
+                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|show|hide> [--global]`"
+            )
+
+        args, persist_global, parse_error = parse_reasoning_command_args(raw_args)
+        if parse_error:
+            return (
+                f"⚠️ {parse_error}\n\n"
+                "**Valid levels:** none, minimal, low, medium, high, xhigh\n"
+                "**Display:** show, hide\n"
+                "**Flag:** --global"
             )
 
         # Display toggle (per-platform)
@@ -6771,22 +6812,29 @@ class GatewayRunner:
 
         # Effort level change
         effort = args.strip()
-        if effort == "none":
-            parsed = {"enabled": False}
-        elif effort in ("minimal", "low", "medium", "high", "xhigh"):
-            parsed = {"enabled": True, "effort": effort}
-        else:
+        parsed = parse_reasoning_effort(effort)
+        if parsed is None:
             return (
-                f"⚠️ Unknown argument: `{effort}`\n\n"
+                f"⚠️ Unknown argument: `{raw_args}`\n\n"
                 "**Valid levels:** none, minimal, low, medium, high, xhigh\n"
-                "**Display:** show, hide"
+                "**Display:** show, hide\n"
+                "**Flag:** --global"
             )
 
         self._reasoning_config = parsed
-        if _save_config_key("agent.reasoning_effort", effort):
-            return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
-        else:
-            return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
+        session_overrides = getattr(self, "_session_reasoning_overrides", None)
+        if session_overrides is None:
+            session_overrides = self._session_reasoning_overrides = {}
+
+        if persist_global:
+            session_overrides.pop(session_key, None)
+            if _save_config_key("agent.reasoning_effort", effort):
+                return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
+            session_overrides[session_key] = parsed
+            return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only; config save failed)"
+
+        session_overrides[session_key] = parsed
+        return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only — use `--global` to persist)"
 
     async def _handle_fast_command(self, event: MessageEvent) -> str:
         """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats."""
@@ -9551,7 +9599,7 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
-            reasoning_config = self._load_reasoning_config()
+            reasoning_config = self._get_reasoning_config_for_session(session_key=session_key)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             # Set up stream consumer for token streaming or interim commentary.

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import shlex
 from pathlib import Path
 
 
@@ -139,6 +140,36 @@ def get_subprocess_home() -> str | None:
 
 
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+
+
+def parse_reasoning_command_args(raw_args: str) -> tuple[str, bool, str | None]:
+    """Parse `/reasoning` arguments into (value, persist_global, error).
+
+    Accepts one positional value plus an optional ``--global`` flag in any order.
+    Returns the normalized positional value (or "" when omitted), whether the
+    change should persist globally, and an error string for unsupported flags or
+    multiple positional arguments.
+    """
+    try:
+        tokens = shlex.split(str(raw_args or ""))
+    except ValueError as exc:
+        return ("", False, str(exc))
+
+    value = ""
+    persist_global = False
+    for token in tokens:
+        normalized = str(token or "").strip().lower()
+        if not normalized:
+            continue
+        if normalized == "--global":
+            persist_global = True
+            continue
+        if normalized.startswith("--"):
+            return ("", persist_global, f"Unknown flag: {normalized}")
+        if value:
+            return ("", persist_global, f"Unknown argument: {' '.join(tokens)}")
+        value = normalized
+    return (value, persist_global, None)
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -155,6 +155,33 @@ class TestHandleReasoningCommand(unittest.TestCase):
         level = rc.get("effort", "medium")
         self.assertEqual(level, "xhigh")
 
+    @patch("cli._cprint")
+    @patch("cli.save_config_value")
+    def test_handle_reasoning_command_accepts_global_flag(self, mock_save, _mock_print):
+        from cli import HermesCLI
+
+        stub = self._make_cli()
+        stub._current_reasoning_callback = lambda: None
+        mock_save.return_value = True
+
+        HermesCLI._handle_reasoning_command(stub, "/reasoning medium --global")
+
+        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "medium"})
+        mock_save.assert_called_once_with("agent.reasoning_effort", "medium")
+
+    @patch("cli._cprint")
+    @patch("cli.save_config_value")
+    def test_handle_reasoning_command_defaults_to_session_only(self, mock_save, _mock_print):
+        from cli import HermesCLI
+
+        stub = self._make_cli()
+        stub._current_reasoning_callback = lambda: None
+
+        HermesCLI._handle_reasoning_command(stub, "/reasoning high")
+
+        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
+        mock_save.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Reasoning extraction and result dict

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -645,7 +645,7 @@ class TestRunJobSessionPersistence:
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
                  return_value={
-                     "api_key": "test-key",
+                     "api_key": "***",
                      "base_url": "https://example.invalid/v1",
                      "provider": "openrouter",
                      "api_mode": "chat_completions",
@@ -672,6 +672,77 @@ class TestRunJobSessionPersistence:
         assert call_args[0][0].startswith("cron_test-job_")
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
+
+    def test_run_job_prefers_job_reasoning_effort_over_global_config(self, tmp_path):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "reasoning_effort": "high",
+        }
+        fake_db = MagicMock()
+        (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: low\n", encoding="utf-8")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+    def test_run_job_falls_back_to_global_reasoning_effort_when_job_unset(self, tmp_path):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: low\n", encoding="utf-8")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "low"}
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -33,6 +33,7 @@ def _make_runner():
     runner._ephemeral_system_prompt = ""
     runner._prefill_messages = []
     runner._reasoning_config = None
+    runner._session_reasoning_overrides = {}
     runner._show_reasoning = False
     runner._provider_routing = {}
     runner._fallback_model = None
@@ -110,13 +111,35 @@ class TestReasoningCommand:
 
         runner = _make_runner()
         runner._reasoning_config = {"enabled": True, "effort": "medium"}
+        session_key = runner._session_key_for_source(_make_event().source)
 
         result = await runner._handle_reasoning_command(_make_event("/reasoning low"))
 
         saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        assert saved["agent"]["reasoning_effort"] == "low"
+        assert saved["agent"]["reasoning_effort"] == "medium"
+        assert runner._session_reasoning_overrides[session_key] == {"enabled": True, "effort": "low"}
         assert runner._reasoning_config == {"enabled": True, "effort": "low"}
-        assert "takes effect on next message" in result
+        assert "this session only" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_global_flag_persists(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        session_key = runner._session_key_for_source(_make_event().source)
+
+        result = await runner._handle_reasoning_command(_make_event("/reasoning low --global"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "low"
+        assert session_key not in runner._session_reasoning_overrides
+        assert runner._reasoning_config == {"enabled": True, "effort": "low"}
+        assert "saved to config" in result
 
     def test_run_agent_reloads_reasoning_config_per_message(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"

--- a/tests/gateway/test_session_reasoning_reset.py
+++ b/tests/gateway/test_session_reasoning_reset.py
@@ -1,0 +1,93 @@
+"""Tests that /new (and its /reset alias) clears session-scoped reasoning overrides."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.reset_session.return_value = session_entry
+    runner.session_store._entries = {session_key: session_entry}
+    runner.session_store._generate_session_key.return_value = session_key
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache_lock = None
+    runner._is_user_authorized = lambda _source: True
+    runner._format_session_info = lambda: ""
+
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_new_command_clears_session_reasoning_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._session_reasoning_overrides
+
+
+@pytest.mark.asyncio
+async def test_new_command_only_clears_own_reasoning_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    other_key = "other_session_key"
+
+    runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
+    runner._session_reasoning_overrides[other_key] = {"enabled": False}
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._session_reasoning_overrides
+    assert other_key in runner._session_reasoning_overrides

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -95,6 +95,7 @@ def _session(agent=None, **extra):
         "image_counter": 0,
         "cols": 80,
         "slash_worker": None,
+        "reasoning_config_override": None,
         "show_reasoning": False,
         "tool_progress_mode": "all",
         **extra,
@@ -148,12 +149,90 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     )
     assert resp_effort["result"]["value"] == "low"
     assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+    assert server._sessions["sid"]["reasoning_config_override"] == {"enabled": True, "effort": "low"}
 
     resp_show = server.handle_request(
         {"id": "2", "method": "config.set", "params": {"session_id": "sid", "key": "reasoning", "value": "show"}}
     )
     assert resp_show["result"]["value"] == "show"
     assert server._sessions["sid"]["show_reasoning"] is True
+
+
+def test_config_set_reasoning_global_clears_session_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    agent = types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "low"})
+    server._sessions["sid"] = _session(
+        agent=agent,
+        reasoning_config_override={"enabled": True, "effort": "low"},
+    )
+
+    resp = server.handle_request(
+        {"id": "3", "method": "config.set", "params": {"session_id": "sid", "key": "reasoning", "value": "high --global"}}
+    )
+
+    assert resp["result"]["value"] == "high"
+    assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+    assert server._sessions["sid"]["reasoning_config_override"] is None
+    assert "reasoning_effort: high" in (tmp_path / "config.yaml").read_text(encoding="utf-8")
+
+
+def test_config_set_reasoning_global_falls_back_to_session_override_on_save_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    agent = types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "low"})
+    server._sessions["sid"] = _session(
+        agent=agent,
+        reasoning_config_override={"enabled": True, "effort": "low"},
+    )
+    monkeypatch.setattr(server, "_write_config_key", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("disk full")))
+
+    resp = server.handle_request(
+        {"id": "3b", "method": "config.set", "params": {"session_id": "sid", "key": "reasoning", "value": "high --global"}}
+    )
+
+    assert resp["result"]["value"] == "high"
+    assert "warning" in resp["result"]
+    assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+    assert server._sessions["sid"]["reasoning_config_override"] == {"enabled": True, "effort": "high"}
+
+
+def test_config_get_reasoning_prefers_session_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\ndisplay:\n  show_reasoning: false\n",
+        encoding="utf-8",
+    )
+    server._sessions["sid"] = _session(
+        reasoning_config_override={"enabled": False},
+        show_reasoning=True,
+    )
+
+    resp = server.handle_request(
+        {"id": "4", "method": "config.get", "params": {"session_id": "sid", "key": "reasoning"}}
+    )
+
+    assert resp["result"] == {"value": "none", "display": "show"}
+
+
+def test_reset_session_agent_reapplies_reasoning_override(monkeypatch):
+    session = _session(reasoning_config_override={"enabled": True, "effort": "high"})
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: None)
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"reasoning_config": agent.reasoning_config})
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda _session: None)
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda sid, key, session_id=None, session=None: types.SimpleNamespace(
+            reasoning_config=server._effective_reasoning_config(session)
+        ),
+    )
+
+    info = server._reset_session_agent("sid", session)
+
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "high"}
+    assert info == {"reasoning_config": {"enabled": True, "effort": "high"}}
 
 
 def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch):
@@ -290,7 +369,7 @@ def test_config_set_personality_resets_history_and_returns_info(monkeypatch):
 
     server._sessions["sid"] = session
     monkeypatch.setattr(server, "_available_personalities", lambda cfg=None: {"helpful": "You are helpful."})
-    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: new_agent)
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None, session=None: new_agent)
     monkeypatch.setattr(server, "_session_info", lambda agent: {"model": getattr(agent, "model", "?")})
     monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -172,6 +172,31 @@ class TestUnifiedCronjobTool:
         assert updated["job"]["provider"] == "openrouter"
         assert updated["job"]["base_url"] is None
 
+    def test_reasoning_runtime_override_can_set_and_update(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                reasoning_effort="high",
+            )
+        )
+        job_id = created["job_id"]
+        assert created["job"]["reasoning_effort"] == "high"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["reasoning_effort"] == "high"
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=job_id,
+                reasoning_effort="none",
+            )
+        )
+        assert updated["success"] is True
+        assert updated["job"]["reasoning_effort"] == "none"
+
     def test_create_skill_backed_job(self):
         result = json.loads(
             cronjob(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -201,6 +201,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "reasoning_effort": job.get("reasoning_effort"),
         "schedule": job.get("schedule_display"),
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -232,6 +233,7 @@ def cronjob(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
     task_id: str = None,
@@ -270,6 +272,7 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                reasoning_effort=_normalize_optional_job_value(reasoning_effort),
                 script=_normalize_optional_job_value(script),
             )
             return json.dumps(
@@ -353,6 +356,8 @@ def cronjob(
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            if reasoning_effort is not None:
+                updates["reasoning_effort"] = _normalize_optional_job_value(reasoning_effort)
             if script is not None:
                 # Pass empty string to clear an existing script
                 if script:
@@ -459,6 +464,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a Python script that runs before each cron job execution. Its stdout is injected into the prompt as context. Use for data collection and change detection. Relative paths resolve under {display_hermes_home()}/scripts/. On update, pass empty string to clear."
             },
+            "reasoning_effort": {
+                "type": "string",
+                "description": "Optional per-job reasoning override. Valid values: none, minimal, low, medium, high, xhigh. When omitted, cron falls back to agent.reasoning_effort from config.yaml."
+            },
         },
         "required": ["action"]
     }
@@ -501,6 +510,7 @@ registry.register(
         model=_mo[1],
         provider=_mo[0] or args.get("provider"),
         base_url=args.get("base_url"),
+        reasoning_effort=args.get("reasoning_effort"),
         reason=args.get("reason"),
         script=args.get("script"),
         task_id=kw.get("task_id"),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -420,6 +420,15 @@ def _load_reasoning_config() -> dict | None:
     return parse_reasoning_effort(effort)
 
 
+def _effective_reasoning_config(session: dict | None = None) -> dict | None:
+    override = None
+    if isinstance(session, dict):
+        override = session.get("reasoning_config_override")
+    if override is not None:
+        return dict(override)
+    return _load_reasoning_config()
+
+
 def _load_service_tier() -> str | None:
     raw = str(_load_cfg().get("agent", {}).get("service_tier", "") or "").strip().lower()
     if not raw or raw in {"normal", "default", "standard", "off", "none"}:
@@ -954,7 +963,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
 def _reset_session_agent(sid: str, session: dict) -> dict:
     tokens = _set_session_context(session["session_key"])
     try:
-        new_agent = _make_agent(sid, session["session_key"], session_id=session["session_key"])
+        new_agent = _make_agent(sid, session["session_key"], session_id=session["session_key"], session=session)
     finally:
         _clear_session_context(tokens)
     session["agent"] = new_agent
@@ -974,8 +983,12 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     return info
 
 
-def _make_agent(sid: str, key: str, session_id: str | None = None):
+def _make_agent(sid: str, key: str, session_id: str | None = None, session: dict | None = None):
     from run_agent import AIAgent
+
+    if session is None:
+        session = _sessions.get(sid)
+
     cfg = _load_cfg()
     system_prompt = cfg.get("agent", {}).get("system_prompt", "") or ""
     if not system_prompt:
@@ -984,7 +997,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         model=_resolve_model(),
         quiet_mode=True,
         verbose_logging=_load_tool_progress_mode() == "verbose",
-        reasoning_config=_load_reasoning_config(),
+        reasoning_config=_effective_reasoning_config(session),
         service_tier=_load_service_tier(),
         enabled_toolsets=_load_enabled_toolsets(),
         platform="tui",
@@ -1006,6 +1019,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "image_counter": 0,
         "cols": cols,
         "slash_worker": None,
+        "reasoning_config_override": None,
         "show_reasoning": _load_show_reasoning(),
         "tool_progress_mode": _load_tool_progress_mode(),
         "edit_snapshots": {},
@@ -1136,6 +1150,7 @@ def _(rid, params: dict) -> dict:
         "history_version": 0,
         "image_counter": 0,
         "running": False,
+        "reasoning_config_override": None,
         "session_key": key,
         "show_reasoning": _load_show_reasoning(),
         "slash_worker": None,
@@ -1931,9 +1946,12 @@ def _(rid, params: dict) -> dict:
 
     if key == "reasoning":
         try:
-            from hermes_constants import parse_reasoning_effort
+            from hermes_constants import parse_reasoning_command_args, parse_reasoning_effort
 
-            arg = str(value or "").strip().lower()
+            raw_args = str(value or "").strip()
+            arg, persist_global, parse_error = parse_reasoning_command_args(raw_args)
+            if parse_error:
+                return _err(rid, 4002, parse_error)
             if arg in ("show", "on"):
                 _write_config_key("display.show_reasoning", True)
                 if session:
@@ -1948,10 +1966,30 @@ def _(rid, params: dict) -> dict:
             parsed = parse_reasoning_effort(arg)
             if parsed is None:
                 return _err(rid, 4002, f"unknown reasoning value: {value}")
-            _write_config_key("agent.reasoning_effort", arg)
+
+            persist_error = None
+            persisted = False
+            if persist_global or not session:
+                try:
+                    _write_config_key("agent.reasoning_effort", arg)
+                    persisted = True
+                except Exception as exc:
+                    persist_error = exc
+
+            if session:
+                if persist_global and persisted:
+                    session["reasoning_config_override"] = None
+                else:
+                    session["reasoning_config_override"] = dict(parsed)
+            elif persist_error is not None:
+                raise persist_error
+
             if session and session.get("agent") is not None:
                 session["agent"].reasoning_config = parsed
-            return _ok(rid, {"key": key, "value": arg})
+            resp = {"key": key, "value": arg}
+            if persist_error is not None and session:
+                resp["warning"] = f"config save failed; kept session-only override: {persist_error}"
+            return _ok(rid, resp)
         except Exception as e:
             return _err(rid, 5001, str(e))
 
@@ -2029,6 +2067,7 @@ def _(rid, params: dict) -> dict:
 @method("config.get")
 def _(rid, params: dict) -> dict:
     key = params.get("key", "")
+    session = _sessions.get(params.get("session_id", ""))
     if key == "provider":
         try:
             from hermes_cli.models import list_available_providers, normalize_provider
@@ -2051,8 +2090,15 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"value": _load_cfg().get("display", {}).get("personality", "default")})
     if key == "reasoning":
         cfg = _load_cfg()
-        effort = str(cfg.get("agent", {}).get("reasoning_effort", "medium") or "medium")
-        display = "show" if bool(cfg.get("display", {}).get("show_reasoning", False)) else "hide"
+        reasoning_config = _effective_reasoning_config(session)
+        if reasoning_config is None:
+            effort = "medium"
+        elif reasoning_config.get("enabled") is False:
+            effort = "none"
+        else:
+            effort = str(reasoning_config.get("effort", "medium") or "medium")
+        display_on = bool(session.get("show_reasoning")) if session else bool(cfg.get("display", {}).get("show_reasoning", False))
+        display = "show" if display_on else "hide"
         return _ok(rid, {"value": effort, "display": display})
     if key == "details_mode":
         allowed_dm = frozenset({"hidden", "collapsed", "expanded"})

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -225,12 +225,12 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
-    help: 'inspect or set reasoning effort (updates live agent)',
+    help: 'inspect or set reasoning effort (session-only by default; add --global to persist)',
     name: 'reasoning',
     run: (arg, ctx) => {
       if (!arg) {
         return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning' })
+          .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning', session_id: ctx.sid })
           .then(
             ctx.guarded<ConfigGetValueResponse>(
               r => r.value && ctx.transcript.sys(`reasoning: ${r.value} · display ${r.display || 'hide'}`)


### PR DESCRIPTION
## Summary
- share `/reasoning` argument parsing across CLI, gateway, and TUI so `--global` works consistently
- keep session-scoped reasoning overrides separate from persisted global config, including reset/restart paths
- let cron jobs store and honor per-job `reasoning_effort` with global fallback

## Testing
- `python -m pytest tests/cli/test_reasoning_command.py tests/gateway/test_reasoning_command.py tests/gateway/test_session_reasoning_reset.py tests/test_tui_gateway_server.py tests/tools/test_cronjob_tools.py -q -o addopts=""`
- `python -m pytest tests/cron/test_scheduler.py -q -o addopts="" -k "prefers_job_reasoning_effort_over_global_config or falls_back_to_global_reasoning_effort_when_job_unset"`

## Notes
- `tests/cron/test_scheduler.py` still has 4 pre-existing unrelated failures around silent delivery / empty-response handling on current `main`; I verified they reproduce in a clean worktree at `HEAD`, so they are not introduced by this PR.