### PR TITLE
fix(weixin): auto-reconnect polling session on connection errors

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1283,9 +1283,27 @@ class WeixinAdapter(BasePlatformAdapter):
                     asyncio.create_task(self._process_message_safe(message))
             except asyncio.CancelledError:
                 break
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                # Connection-level error: recreate the polling session to recover from broken connections.
+                logger.warning(
+                    "[%s] connection error, recreating poll session: %s",
+                    self.name,
+                    exc,
+                )
+                if self._poll_session and not self._poll_session.closed:
+                    await self._poll_session.close()
+                self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
+                consecutive_failures = 0
+                await asyncio.sleep(RETRY_DELAY_SECONDS)
             except Exception as exc:
                 consecutive_failures += 1
-                logger.error("[%s] poll error (%d/%d): %s", self.name, consecutive_failures, MAX_CONSECUTIVE_FAILURES, exc)
+                logger.error(
+                    "[%s] poll error (%d/%d): %s",
+                    self.name,
+                    consecutive_failures,
+                    MAX_CONSECUTIVE_FAILURES,
+                    exc,
+                )
                 await asyncio.sleep(BACKOFF_DELAY_SECONDS if consecutive_failures >= MAX_CONSECUTIVE_FAILURES else RETRY_DELAY_SECONDS)
                 if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                     consecutive_failures = 0


### PR DESCRIPTION
## Problem

The WeChat (weixin) long-polling loop uses a single `aiohttp.ClientSession`. When the underlying TCP connection is dropped by the server or network (e.g., "Server disconnected"), the session becomes unusable. The previous code kept retrying with the same stale session, causing continuous poll errors and potential message loss.

## Reproduction

1. Start the gateway with WeChat (weixin) platform enabled.
2. Wait for a network hiccup or server-side connection drop (e.g., idle timeout, NAT table expiry, or WeChat server restart).
3. Observe the logs: the adapter logs repeated `poll error` messages with `aiohttp.ClientConnectionError` or `asyncio.TimeoutError`, and messages stop being received until the gateway is manually restarted.

## Fix

- Catch connection-level exceptions (`aiohttp.ClientError`, `asyncio.TimeoutError`) separately from other errors.
- On such exceptions, close the stale `ClientSession` and create a fresh one with a new SSL connector.
- Reset the `consecutive_failures` counter and use a short retry delay (`RETRY_DELAY_SECONDS`).
- Other exception handling (API errors, session expiry, etc.) remains unchanged.

This ensures that transient network issues or server-side disconnections are recovered automatically without manual intervention or full adapter restart. The polling loop re-establishes the HTTP connection and resumes normal operation.

## Verification

- Simulated connection drop by blocking traffic to `ilinkai.weixin.qq.com` — adapter reconnects and resumes polling within seconds after traffic is restored.
- No regression in normal operation: messages continue to flow through the new session.
- No configuration changes required; fully backward-compatible.