### PR TITLE
fix(doctor): handle .env directory gracefully instead of crashing

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -246,9 +246,9 @@ def run_doctor(args):
     
     # Check ~/.hermes/.env (primary location for user config)
     env_path = HERMES_HOME / '.env'
-    if env_path.exists():
+    if env_path.is_file():
         check_ok(f"{_DHH}/.env file exists")
-        
+
         # Check for common issues
         content = env_path.read_text()
         if _has_provider_env_config(content):
@@ -259,7 +259,7 @@ def run_doctor(args):
     else:
         # Also check project root as fallback
         fallback_env = PROJECT_ROOT / '.env'
-        if fallback_env.exists():
+        if fallback_env.is_file():
             check_ok(".env file exists (in project directory)")
         else:
             check_fail(f"{_DHH}/.env file missing")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -397,3 +397,39 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
     )
     assert not any(url == "https://opencode.ai/zen/go/v1/models" for url, _, _ in calls)
     assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)
+
+
+def test_doctor_handles_env_directory_gracefully(monkeypatch, tmp_path, capsys):
+    """Doctor should not crash when ~/.hermes/.env is a directory."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").mkdir()  # directory, not file
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    # Should NOT crash; should report .env is missing and suggest setup
+    assert "IsADirectoryError" not in out
+    assert "Run 'hermes setup'" in out


### PR DESCRIPTION
## Issue

If `~/.hermes/.env` exists as a directory (e.g. from a Docker volume mount or accidental `mkdir`), `hermes doctor` crashes with an unhandled `IsADirectoryError` because it checks `Path.exists()` before calling `read_text()`.

## Fix

Replace `exists()` with `is_file()` in both the primary and fallback `.env` checks in `hermes_cli/doctor.py`. This ensures:
- A directory at `.env` is treated as "missing" (doctor continues and advises running `hermes setup`).
- A regular file at `.env` continues to work exactly as before.

## Test

Added `test_doctor_handles_env_directory_gracefully` in `tests/hermes_cli/test_doctor.py`.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| `~/.hermes/.env` is a directory | `IsADirectoryError` crash | Doctor continues; warns ".env file missing" |
| `~/.hermes/.env` is a regular file | Works normally | Works normally (no change) |
| `./.env` (project root) is a directory | Misleading "file exists" message | Treated as missing |
