### PR TITLE
feat(browser): expand Browser Use provider config and metadata

### DIFF
--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -54,7 +54,10 @@ class TestResolveCdpOverride:
             "session_name": "cloud-session",
             "bb_session_id": "bu_123",
             "cdp_url": "https://cdp.browser-use.example/session",
-            "features": {"browser_use": True},
+            "features": {"browser_use": True, "proxies": True},
+            "provider": "browser-use",
+            "live_url": "https://live.browser-use.example/session",
+            "external_call_id": "call-browser-use-cdp",
         }
 
         response = Mock()
@@ -72,6 +75,10 @@ class TestResolveCdpOverride:
             session_info = browser_tool._get_session_info("task-browser-use")
 
         assert session_info["cdp_url"] == WS_URL
+        assert session_info["provider"] == "browser-use"
+        assert session_info["live_url"] == "https://live.browser-use.example/session"
+        assert session_info["external_call_id"] == "call-browser-use-cdp"
+        assert session_info["features"] == {"browser_use": True, "proxies": True}
         provider.create_session.assert_called_once_with("task-browser-use")
         mock_get.assert_called_once_with(
             "https://cdp.browser-use.example/session/json/version",

--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -146,6 +146,152 @@ def test_browser_use_explicit_local_mode_stays_local_even_when_managed_gateway_i
     assert provider is None
 
 
+def test_browser_use_alias_selects_provider(tmp_path):
+    _install_fake_tools_package()
+    (tmp_path / "config.yaml").write_text("browser:\n  cloud_provider: Browser Use\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update({
+        "HERMES_HOME": str(tmp_path),
+        "BROWSER_USE_API_KEY": "direct-browser-use-key",
+    })
+    env.pop("TOOL_GATEWAY_USER_TOKEN", None)
+    env.pop("BROWSER_USE_GATEWAY_URL", None)
+
+    with patch.dict(os.environ, env, clear=True):
+        browser_tool = _load_tool_module("tools.browser_tool", "browser_tool.py")
+        provider = browser_tool._get_cloud_provider()
+
+    assert provider is not None
+    assert type(provider).__name__ == "BrowserUseProvider"
+
+
+def test_browser_use_direct_config_controls_payload_and_metadata(tmp_path):
+    _install_fake_tools_package()
+    (tmp_path / "config.yaml").write_text(
+        "browser:\n"
+        "  browser_use:\n"
+        "    timeout_minutes: 17\n"
+        "    proxy_country_code: ca\n"
+        "    profile_id: profile-123\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update({
+        "HERMES_HOME": str(tmp_path),
+        "BROWSER_USE_API_KEY": "direct-browser-use-key",
+    })
+    env.pop("TOOL_GATEWAY_USER_TOKEN", None)
+    env.pop("BROWSER_USE_GATEWAY_URL", None)
+
+    class _Response:
+        status_code = 200
+        ok = True
+        text = ""
+        headers = {}
+
+        def json(self):
+            return {
+                "id": "bu_direct_session_1",
+                "connectUrl": "wss://connect.browser-use.example/direct",
+                "liveUrl": "https://live.browser-use.example/direct",
+            }
+
+    with patch.dict(os.environ, env, clear=True):
+        browser_use_module = _load_tool_module(
+            "tools.browser_providers.browser_use",
+            "browser_providers/browser_use.py",
+        )
+
+        with patch.object(browser_use_module.requests, "post", return_value=_Response()) as post:
+            provider = browser_use_module.BrowserUseProvider()
+            session = provider.create_session("task-browser-use-direct")
+
+    sent_payload = post.call_args.kwargs["json"]
+    assert sent_payload == {
+        "timeout": 17,
+        "proxyCountryCode": "ca",
+        "profileId": "profile-123",
+    }
+    assert session["provider"] == "browser-use"
+    assert session["config_source"] == "direct_api_key"
+    assert session["managed_mode"] is False
+    assert session["timeout_minutes"] == 17
+    assert session["proxy_country_code"] == "ca"
+    assert session["profile_id"] == "profile-123"
+    assert session["live_url"] == "https://live.browser-use.example/direct"
+    assert session["features"]["browser_use"] is True
+    assert session["features"]["managed"] is False
+    assert session["features"]["proxies"] is True
+    assert session["features"]["profile"] is True
+
+
+def test_browser_use_malformed_root_config_does_not_break_provider_discovery(tmp_path):
+    _install_fake_tools_package()
+    (tmp_path / "config.yaml").write_text("[]\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update({
+        "HERMES_HOME": str(tmp_path),
+        "BROWSER_USE_API_KEY": "direct-browser-use-key",
+    })
+    env.pop("TOOL_GATEWAY_USER_TOKEN", None)
+    env.pop("BROWSER_USE_GATEWAY_URL", None)
+
+    with patch.dict(os.environ, env, clear=True):
+        browser_tool = _load_tool_module("tools.browser_tool", "browser_tool.py")
+        provider = browser_tool._get_cloud_provider()
+
+    assert provider is not None
+    assert type(provider).__name__ == "BrowserUseProvider"
+
+
+def test_browser_use_invalid_nested_config_values_are_ignored(tmp_path):
+    _install_fake_tools_package()
+    (tmp_path / "config.yaml").write_text(
+        "browser:\n"
+        "  browser_use:\n"
+        "    timeout_minutes: false\n"
+        "    proxy_country_code: []\n"
+        "    profile_id: {}\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update({
+        "HERMES_HOME": str(tmp_path),
+        "BROWSER_USE_API_KEY": "direct-browser-use-key",
+    })
+    env.pop("TOOL_GATEWAY_USER_TOKEN", None)
+    env.pop("BROWSER_USE_GATEWAY_URL", None)
+
+    class _Response:
+        status_code = 200
+        ok = True
+        text = ""
+        headers = {}
+
+        def json(self):
+            return {
+                "id": "bu_direct_session_invalid",
+                "connectUrl": "wss://connect.browser-use.example/invalid",
+            }
+
+    with patch.dict(os.environ, env, clear=True):
+        browser_use_module = _load_tool_module(
+            "tools.browser_providers.browser_use",
+            "browser_providers/browser_use.py",
+        )
+
+        with patch.object(browser_use_module.requests, "post", return_value=_Response()) as post:
+            provider = browser_use_module.BrowserUseProvider()
+            session = provider.create_session("task-browser-use-invalid")
+
+    assert post.call_args.kwargs["json"] == {}
+    assert session["timeout_minutes"] is None
+    assert session["proxy_country_code"] is None
+    assert session["profile_id"] is None
+    assert session["features"]["proxies"] is False
+    assert session["features"]["profile"] is False
+
+
 def test_browserbase_does_not_use_gateway_only_configuration():
     _install_fake_tools_package()
     env = os.environ.copy()
@@ -203,7 +349,16 @@ def test_browser_use_managed_gateway_adds_idempotency_key_and_persists_external_
     sent_payload = post.call_args.kwargs["json"]
     assert sent_payload["timeout"] == 5
     assert sent_payload["proxyCountryCode"] == "us"
+    assert session["provider"] == "browser-use"
+    assert session["config_source"] == "managed_gateway"
+    assert session["managed_mode"] is True
+    assert session["timeout_minutes"] == 5
+    assert session["proxy_country_code"] == "us"
     assert session["external_call_id"] == "call-browser-use-1"
+    assert session["features"]["browser_use"] is True
+    assert session["features"]["managed"] is True
+    assert session["features"]["proxies"] is True
+    assert session["features"]["profile"] is False
 
 
 def test_browser_use_managed_gateway_reuses_pending_idempotency_key_after_timeout():

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -90,8 +90,20 @@ class TestNormalizeBrowserCloudProvider:
     def test_whitespace_only_returns_default(self):
         assert normalize_browser_cloud_provider("   ") == "local"
 
-    def test_known_provider_normalized(self):
-        assert normalize_browser_cloud_provider("BrowserBase") == "browserbase"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("BrowserBase", "browserbase"),
+            ("browser base", "browserbase"),
+            ("browser_base", "browserbase"),
+            ("Browser Use", "browser-use"),
+            ("browser_use", "browser-use"),
+            ("browseruse", "browser-use"),
+            ("browser-use", "browser-use"),
+        ],
+    )
+    def test_known_provider_aliases_normalized(self, raw, expected):
+        assert normalize_browser_cloud_provider(raw) == expected
 
     def test_strips_whitespace(self):
         assert normalize_browser_cloud_provider("  Local  ") == "local"

--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -21,6 +21,64 @@ _DEFAULT_MANAGED_TIMEOUT_MINUTES = 5
 _DEFAULT_MANAGED_PROXY_COUNTRY_CODE = "us"
 
 
+def _read_browser_use_settings() -> Dict[str, Any]:
+    """Return the optional browser.browser_use config block."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        config = read_raw_config() or {}
+    except Exception as exc:
+        logger.debug("Could not read browser.browser_use config: %s", exc)
+        return {}
+
+    if not isinstance(config, dict):
+        logger.debug("Ignoring malformed root config for browser.browser_use: %r", type(config).__name__)
+        return {}
+
+    browser_cfg = config.get("browser")
+    if not isinstance(browser_cfg, dict):
+        return {}
+
+    browser_use_cfg = browser_cfg.get("browser_use")
+    if not isinstance(browser_use_cfg, dict):
+        return {}
+
+    return browser_use_cfg
+
+
+def _coerce_timeout_minutes(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool):
+        logger.debug("Ignoring invalid browser.browser_use.timeout_minutes=%r", value)
+        return None
+    try:
+        return max(int(value), 1)
+    except (TypeError, ValueError):
+        logger.debug("Ignoring invalid browser.browser_use.timeout_minutes=%r", value)
+        return None
+
+
+def _coerce_proxy_country_code(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        logger.debug("Ignoring invalid browser.browser_use.proxy_country_code=%r", value)
+        return None
+    proxy_country_code = value.strip().lower()
+    return proxy_country_code or None
+
+
+def _coerce_profile_id(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        logger.debug("Ignoring invalid browser.browser_use.profile_id=%r", value)
+        return None
+    profile_id = value.strip()
+    return profile_id or None
+
+
 def _get_or_create_pending_create_key(task_id: str) -> str:
     with _pending_create_keys_lock:
         existing = _pending_create_keys.get(task_id)
@@ -74,12 +132,21 @@ class BrowserUseProvider(CloudBrowserProvider):
     # ------------------------------------------------------------------
 
     def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+        browser_use_cfg = _read_browser_use_settings()
+        timeout_minutes = _coerce_timeout_minutes(browser_use_cfg.get("timeout_minutes"))
+        proxy_country_code = _coerce_proxy_country_code(browser_use_cfg.get("proxy_country_code"))
+        profile_id = _coerce_profile_id(browser_use_cfg.get("profile_id"))
+
         api_key = os.environ.get("BROWSER_USE_API_KEY")
         if api_key and not prefers_gateway("browser"):
             return {
                 "api_key": api_key,
                 "base_url": _BASE_URL,
                 "managed_mode": False,
+                "config_source": "direct_api_key",
+                "timeout_minutes": timeout_minutes,
+                "proxy_country_code": proxy_country_code,
+                "profile_id": profile_id,
             }
 
         managed = resolve_managed_tool_gateway("browser-use")
@@ -90,7 +157,32 @@ class BrowserUseProvider(CloudBrowserProvider):
             "api_key": managed.nous_user_token,
             "base_url": managed.gateway_origin.rstrip("/"),
             "managed_mode": True,
+            "config_source": "managed_gateway",
+            "timeout_minutes": timeout_minutes,
+            "proxy_country_code": proxy_country_code,
+            "profile_id": profile_id,
         }
+
+    def _build_create_payload(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        managed_mode = bool(config.get("managed_mode"))
+        timeout_minutes = config.get("timeout_minutes")
+        proxy_country_code = config.get("proxy_country_code")
+        profile_id = config.get("profile_id")
+
+        payload: Dict[str, Any] = {}
+        if managed_mode:
+            payload["timeout"] = timeout_minutes or _DEFAULT_MANAGED_TIMEOUT_MINUTES
+            payload["proxyCountryCode"] = proxy_country_code or _DEFAULT_MANAGED_PROXY_COUNTRY_CODE
+        else:
+            if timeout_minutes is not None:
+                payload["timeout"] = timeout_minutes
+            if proxy_country_code:
+                payload["proxyCountryCode"] = proxy_country_code
+
+        if profile_id:
+            payload["profileId"] = profile_id
+
+        return payload
 
     def _get_config(self) -> Dict[str, Any]:
         config = self._get_config_or_none()
@@ -125,16 +217,11 @@ class BrowserUseProvider(CloudBrowserProvider):
         if managed_mode:
             headers["X-Idempotency-Key"] = _get_or_create_pending_create_key(task_id)
 
-        # Keep gateway-backed sessions short so billing authorization does not
-        # default to a long Browser-Use timeout when Hermes only needs a task-
-        # scoped ephemeral browser.
-        payload = (
-            {
-                "timeout": _DEFAULT_MANAGED_TIMEOUT_MINUTES,
-                "proxyCountryCode": _DEFAULT_MANAGED_PROXY_COUNTRY_CODE,
-            }
-            if managed_mode
-            else {}
+        payload = self._build_create_payload(config)
+        logger.debug(
+            "Creating Browser Use session via %s with payload keys=%s",
+            config.get("config_source", "unknown"),
+            sorted(payload.keys()),
         )
 
         response = requests.post(
@@ -158,16 +245,35 @@ class BrowserUseProvider(CloudBrowserProvider):
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
         external_call_id = response.headers.get("x-external-call-id") if managed_mode else None
 
-        logger.info("Created Browser Use session %s", session_name)
+        logger.info(
+            "Created Browser Use session %s via %s",
+            session_name,
+            config.get("config_source", "unknown"),
+        )
 
         cdp_url = session_data.get("cdpUrl") or session_data.get("connectUrl") or ""
+        live_url = session_data.get("liveUrl") or session_data.get("liveURL")
+        proxy_country_code = payload.get("proxyCountryCode")
+        profile_id = payload.get("profileId")
 
         return {
             "session_name": session_name,
             "bb_session_id": session_data["id"],
             "cdp_url": cdp_url,
-            "features": {"browser_use": True},
+            "features": {
+                "browser_use": True,
+                "managed": managed_mode,
+                "proxies": bool(proxy_country_code),
+                "profile": bool(profile_id),
+            },
+            "provider": "browser-use",
+            "config_source": config.get("config_source"),
+            "managed_mode": managed_mode,
+            "timeout_minutes": payload.get("timeout"),
+            "proxy_country_code": proxy_country_code,
+            "profile_id": profile_id,
             "external_call_id": external_call_id,
+            "live_url": live_url,
         }
 
     def close_session(self, session_id: str) -> bool:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -10,6 +10,16 @@ from typing import Any, Dict
 _DEFAULT_BROWSER_PROVIDER = "local"
 _DEFAULT_MODAL_MODE = "auto"
 _VALID_MODAL_MODES = {"auto", "direct", "managed"}
+_BROWSER_PROVIDER_ALIASES = {
+    "browser use": "browser-use",
+    "browser-use": "browser-use",
+    "browser_use": "browser-use",
+    "browseruse": "browser-use",
+    "browser base": "browserbase",
+    "browser-base": "browserbase",
+    "browser_base": "browserbase",
+    "browserbase": "browserbase",
+}
 
 
 def managed_nous_tools_enabled() -> bool:
@@ -38,7 +48,9 @@ def managed_nous_tools_enabled() -> bool:
 def normalize_browser_cloud_provider(value: object | None) -> str:
     """Return a normalized browser provider key."""
     provider = str(value or _DEFAULT_BROWSER_PROVIDER).strip().lower()
-    return provider or _DEFAULT_BROWSER_PROVIDER
+    if not provider:
+        return _DEFAULT_BROWSER_PROVIDER
+    return _BROWSER_PROVIDER_ALIASES.get(provider, provider)
 
 
 def coerce_modal_mode(value: object | None) -> str:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1208,12 +1208,22 @@ Configure browser automation behavior:
 
 ```yaml
 browser:
+  cloud_provider: local          # local | browser-use | browserbase | firecrawl
   inactivity_timeout: 120        # Seconds before auto-closing idle sessions
-  command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
+  command_timeout: 30            # Timeout in seconds for browser commands (screenshot, navigate, etc.)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
+  browser_use:
+    timeout_minutes: 5           # Optional Browser Use session timeout override
+    proxy_country_code: us       # Optional Browser Use proxy country override
+    profile_id: ""               # Optional Browser Use cloud profile ID for persisted auth/cookies
   camofox:
     managed_persistence: false   # When true, Camofox sessions persist cookies/logins across restarts
 ```
+
+- `cloud_provider` — explicitly choose which browser backend Hermes should prefer. `local` disables cloud fallback entirely. Browser Use aliases like `Browser Use`, `browser_use`, and `browseruse` are normalized to `browser-use`.
+- `browser.browser_use.timeout_minutes` — optional Browser Use session timeout override. If omitted, managed Browser Use sessions keep Hermes’s current safe default.
+- `browser.browser_use.proxy_country_code` — optional Browser Use proxy country override. If omitted, managed Browser Use sessions keep Hermes’s current safe default.
+- `browser.browser_use.profile_id` — optional Browser Use cloud profile ID used when you want a hosted browser session to start with a persisted Browser Use profile.
 
 The browser toolset supports multiple providers. See the [Browser feature page](/docs/user-guide/features/browser) for details on Browserbase, Browser Use, and local Chrome CDP setup.
 


### PR DESCRIPTION
## Summary
- expand Browser Use provider config handling for direct sessions, including timeout, proxy country, and profile selection
- preserve richer Browser Use session metadata through backend helpers and browser session inspection, including provider/live URL/external call ID/features
- add regression coverage and configuration docs for Browser Use alias selection, direct config payloads, and surfaced metadata

## Test Plan
- `source ../../venv/bin/activate && pytest tests/tools/test_tool_backend_helpers.py tests/tools/test_managed_browserbase_and_modal.py tests/tools/test_browser_cloud_fallback.py tests/tools/test_browser_cdp_override.py tests/cli/test_cli_browser_connect.py tests/tools/test_browser_cleanup.py tests/tools/test_browser_hardening.py tests/tools/test_browser_secret_exfil.py -q`
- result: `118 passed in 10.86s`
