### PR TITLE
fix(feishu): fail-closed on missing encrypt_key and empty card-action token

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2445,7 +2445,10 @@ class FeishuAdapter(BasePlatformAdapter):
         """Route Feishu interactive card button clicks as synthetic COMMAND events."""
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
-        if token and self._is_card_action_duplicate(token):
+        if not token:
+            logger.debug("[Feishu] Dropping card action with missing token")
+            return
+        if self._is_card_action_duplicate(token):
             logger.debug("[Feishu] Dropping duplicate card action token: %s", token)
             return
 
@@ -2947,8 +2950,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
 
-        # Timing-safe signature verification (only enforced when encrypt_key is set).
-        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
+        # Timing-safe signature verification (fail-closed: rejected when encrypt_key is missing).
+        if not self._is_webhook_signature_valid(request.headers, body_bytes):
             logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
             self._record_webhook_anomaly(remote_ip, "401-sig")
             return web.Response(status=401, text="Invalid signature")
@@ -2987,6 +2990,8 @@ class FeishuAdapter(BasePlatformAdapter):
             SHA256(timestamp + nonce + encrypt_key + body_string)
         Headers checked: x-lark-request-timestamp, x-lark-request-nonce, x-lark-signature.
         """
+        if not self._encrypt_key:
+            return False
         timestamp = str(headers.get("x-lark-request-timestamp", "") or "")
         nonce = str(headers.get("x-lark-request-nonce", "") or "")
         signature = str(headers.get("x-lark-signature", "") or "")

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1473,8 +1473,9 @@ class TestAdapterBehavior(unittest.TestCase):
 
         self.assertTrue(submit.called)
 
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(os.environ, {"FEISHU_ENCRYPT_KEY": "test_secret"}, clear=True)
     def test_webhook_request_uses_same_message_dispatch_path(self):
+        import hashlib
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -1485,10 +1486,13 @@ class TestAdapterBehavior(unittest.TestCase):
             "header": {"event_type": "im.message.receive_v1"},
             "event": {"message": {"message_id": "om_test"}},
         }).encode("utf-8")
+        timestamp, nonce, encrypt_key = "1700000000", "testnonce", "test_secret"
+        content = f"{timestamp}{nonce}{encrypt_key}" + body.decode("utf-8")
+        sig = hashlib.sha256(content.encode("utf-8")).hexdigest()
         request = SimpleNamespace(
             remote="127.0.0.1",
             content_length=None,
-            headers={},
+            headers={"x-lark-request-timestamp": timestamp, "x-lark-request-nonce": nonce, "x-lark-signature": sig},
             read=AsyncMock(return_value=body),
         )
 
@@ -3063,6 +3067,93 @@ class TestWebhookSecurity(unittest.TestCase):
         response = asyncio.run(adapter._handle_webhook_request(request))
         self.assertEqual(response.status, 200)
         self.assertIn(b"test_challenge_token", response.body)
+
+class TestCardActionSecurity(unittest.TestCase):
+    """Tests for card-action token validation: empty token must be rejected (fail-closed)."""
+
+    def _make_adapter(self) -> "FeishuAdapter":
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        with patch.dict(os.environ, {"FEISHU_APP_ID": "cli", "FEISHU_APP_SECRET": "sec"}, clear=True):
+            return FeishuAdapter(PlatformConfig())
+
+    def test_card_action_empty_token_dropped(self):
+        """Card actions with an empty token must be silently dropped (fail-closed)."""
+        adapter = self._make_adapter()
+        adapter._dispatch_inbound_event = AsyncMock()
+        event = SimpleNamespace(token="", context=None, operator=None, action=None)
+        data = SimpleNamespace(event=event)
+        asyncio.run(adapter._handle_card_action_event(data))
+        adapter._dispatch_inbound_event.assert_not_awaited()
+
+    def test_card_action_missing_token_attribute_dropped(self):
+        """Card actions where the token attribute is absent must also be dropped."""
+        adapter = self._make_adapter()
+        adapter._dispatch_inbound_event = AsyncMock()
+        # event has no 'token' attribute at all
+        event = SimpleNamespace(context=None, operator=None, action=None)
+        data = SimpleNamespace(event=event)
+        asyncio.run(adapter._handle_card_action_event(data))
+        adapter._dispatch_inbound_event.assert_not_awaited()
+
+    def test_card_action_valid_token_not_dropped(self):
+        """Card actions with a non-empty token must proceed past the token guard."""
+        adapter = self._make_adapter()
+        # Stub out downstream calls so the test stays focused on the guard.
+        adapter._is_card_action_duplicate = Mock(return_value=False)
+        adapter._dispatch_inbound_event = AsyncMock()
+        context = SimpleNamespace(open_chat_id="oc_chat")
+        operator = SimpleNamespace(open_id="ou_user")
+        action = SimpleNamespace(tag="button", value={"cmd": "hello"})
+        event = SimpleNamespace(token="tok_valid", context=context, operator=operator, action=action)
+        data = SimpleNamespace(event=event)
+        # We only assert the token guard was passed; downstream may still exit early.
+        asyncio.run(adapter._handle_card_action_event(data))
+        adapter._is_card_action_duplicate.assert_called_once_with("tok_valid")
+
+
+class TestWebhookFailClosed(unittest.TestCase):
+    """Tests for webhook signature validation: missing encrypt_key must fail-closed."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def _make_adapter(self, encrypt_key: str = ""):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        with patch.dict(os.environ, {"FEISHU_APP_ID": "cli", "FEISHU_APP_SECRET": "sec", "FEISHU_ENCRYPT_KEY": encrypt_key}, clear=True):
+            return FeishuAdapter(PlatformConfig())
+
+    def test_signature_missing_encrypt_key_rejected(self):
+        """_is_webhook_signature_valid returns False when encrypt_key is empty (fail-closed)."""
+        import hashlib
+
+        adapter = self._make_adapter("")
+        body = b'{"type":"event"}'
+        timestamp = "1700000000"
+        nonce = "abc123"
+        # Attacker computes HMAC using an empty key — must still be rejected.
+        content = f"{timestamp}{nonce}" + body.decode("utf-8")
+        sig = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        headers = {"x-lark-request-timestamp": timestamp, "x-lark-request-nonce": nonce, "x-lark-signature": sig}
+        self.assertFalse(adapter._is_webhook_signature_valid(headers, body))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_webhook_request_rejects_when_encrypt_key_not_configured(self):
+        """Non-challenge webhook requests must be rejected with 401 when encrypt_key is absent."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps({"header": {"event_type": "im.message.receive_v1"}}).encode()
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=None,
+            headers={},
+            read=AsyncMock(return_value=body),
+        )
+        response = asyncio.run(adapter._handle_webhook_request(request))
+        self.assertEqual(response.status, 401)
 
 
 class TestDedupTTL(unittest.TestCase):


### PR DESCRIPTION
# fix(feishu): fail-closed on missing encrypt_key and empty card-action token

## What does this PR do?

Feishu webhook mode had two fail-open authentication paths that allowed unauthenticated requests to reach command dispatch:

1. **Webhook signature bypass**: `_handle_webhook_request` only ran signature verification when `self._encrypt_key` was truthy. When `FEISHU_ENCRYPT_KEY` was unset (defaulting to `""`), the entire check was short-circuited, accepting any request. Additionally, `_is_webhook_signature_valid` did not guard against an empty key, meaning an attacker who knew the key was absent could craft a valid HMAC over an empty string and still pass if the guard was ever reached.

2. **Card-action empty token accepted**: `_handle_card_action_event` guarded the dedup check with `if token and …`, so a card-action callback with an empty `token` bypassed deduplication entirely and proceeded to command dispatch.

This PR makes both paths fail-closed:
- `_is_webhook_signature_valid` now returns `False` immediately when `encrypt_key` is empty.
- The call-site condition is changed from `if self._encrypt_key and not …` to `if not …`, so verification always runs.
- `_handle_card_action_event` now explicitly drops events with a missing or empty token before the dedup check.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py`: add early `if not self._encrypt_key: return False` guard at the top of `_is_webhook_signature_valid`
- `gateway/platforms/feishu.py`: change `if self._encrypt_key and not self._is_webhook_signature_valid(…)` → `if not self._is_webhook_signature_valid(…)` in `_handle_webhook_request`
- `gateway/platforms/feishu.py`: add `if not token: return` before the dedup check in `_handle_card_action_event`
- `tests/gateway/test_feishu.py`: add `TestWebhookFailClosed` (2 cases) and `TestCardActionSecurity` (3 cases) covering the new fail-closed behaviour
- `tests/gateway/test_feishu.py`: update `test_webhook_request_uses_same_message_dispatch_path` to supply a valid signature, as it previously relied on the fail-open behaviour

## How to Test

1. Start Hermes with `FEISHU_ENCRYPT_KEY` unset and webhook mode enabled.
2. Send a POST to the webhook endpoint with a valid JSON body but no signature headers — expect `HTTP 401`.
3. Send a card-action callback with `"token": ""` — confirm the event is dropped and no command is dispatched.
4. Run the test suite: `pytest tests/gateway/test_feishu.py -q` — all tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# Before fix — no encrypt_key set, request accepted
HTTP 200 OK

# After fix — no encrypt_key set, request rejected
WARNING [Feishu] Webhook rejected: invalid signature from 127.0.0.1
HTTP 401 Invalid signature
```

```
pytest tests/gateway/test_feishu.py -q
194 passed, 96 warnings in 5.25s
```
