### PR TITLE
fix(config): defer URL validation for base_url containing env var placeholder

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2022,6 +2022,14 @@ def _normalize_custom_provider_entry(
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()
+            # If the candidate contains an env-var placeholder, defer validation
+            # until after _expand_env_vars() runs in load_config().  Skipping
+            # validation here prevents a false-positive "not a valid URL" warning
+            # when the config writer intended ${PROVIDER_BASE_URL} to be
+            # expanded before URL validation.
+            if "${" in candidate:
+                base_url = candidate
+                break
             parsed = urlparse(candidate)
             if parsed.scheme and parsed.netloc:
                 base_url = candidate

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -180,3 +180,26 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry)
         assert result is not None
         assert "models" not in result
+
+    def test_env_var_placeholder_in_base_url_not_rejected(self):
+        """A base_url containing ${ENV_VAR} should not be rejected as invalid
+        URL — validation is deferred until after env-var expansion in
+        load_config().  Regression test for issue #14457."""
+        entry = {
+            "name": "my-provider",
+            "base_url": "${MY_PROVIDER_BASE_URL}",
+            "api_key": "env:MY_PROVIDER_API_KEY",
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["base_url"] == "${MY_PROVIDER_BASE_URL}"
+
+    def test_multiple_env_vars_in_base_url(self):
+        """base_url with multiple env-var placeholders is accepted."""
+        entry = {
+            "name": "multi-var-provider",
+            "base_url": "${SCHEME}://${HOST}:${PORT}/v1",
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["base_url"] == "${SCHEME}://${HOST}:${PORT}/v1"


### PR DESCRIPTION
Closes #14457

## Problem

Custom provider `base_url` values containing environment-variable placeholders like `${PROVIDER_A_BASE_URL}` were being validated with `urlparse()` before environment-variable expansion ran in `load_config()`.  Since `urlparse('${PROVIDER_A_BASE_URL}')` finds no URL scheme or netloc, the provider was silently skipped with a false-positive warning:

```
providers.?: 'base_url' value '${PROVIDER_A_BASE_URL}' is not a valid URL (no scheme or host) — skipped
```

## Fix

Added a simple guard in `_normalize_custom_provider_entry()` in `hermes_cli/config.py`: if the candidate `base_url` contains `${`, skip URL validation and accept it verbatim — `load_config()` will expand the placeholder and the expanded result goes through the normal path.

**Changed file:** `hermes_cli/config.py` (+8 lines)

## Testing

- All 18 tests in `tests/hermes_cli/test_provider_config_validation.py` pass
- Added 2 regression tests:
  - `test_env_var_placeholder_in_base_url_not_rejected`
  - `test_multiple_env_vars_in_base_url`
