### PR TITLE
fix: prevent NOUS_EXTRA_BODY tags list from growing unboundedly

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2218,10 +2218,14 @@ def _build_call_kwargs(
     if tools:
         kwargs["tools"] = tools
 
-    # Provider-specific extra_body
-    merged_extra = dict(extra_body or {})
+    # Provider-specific extra_body — deep-copy to avoid mutating the caller's
+    # dict (or the module-level NOUS_EXTRA_BODY constant's tags list).
+    merged_extra = {
+        k: list(v) if isinstance(v, list) else v
+        for k, v in (extra_body or {}).items()
+    }
     if provider == "nous" or auxiliary_is_nous:
-        merged_extra.setdefault("tags", []).extend(["product=hermes-agent"])
+        merged_extra.setdefault("tags", []).append("product=hermes-agent")
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1624,3 +1624,36 @@ class TestAnthropicCompatImageConversion:
         }]
         result = _convert_openai_images_to_anthropic(messages)
         assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+
+class TestBuildCallKwargsExtraBody:
+    """Regression: _build_call_kwargs must not mutate the caller's extra_body dict."""
+
+    def test_nous_tags_not_accumulated(self):
+        """NOUS_EXTRA_BODY tags list must not grow across calls."""
+        from agent.auxiliary_client import NOUS_EXTRA_BODY, _build_call_kwargs
+
+        original_tags = list(NOUS_EXTRA_BODY["tags"])
+        msgs = [{"role": "user", "content": "hi"}]
+        for _ in range(5):
+            _build_call_kwargs("nous", "test-model", msgs, extra_body=NOUS_EXTRA_BODY)
+        assert NOUS_EXTRA_BODY["tags"] == original_tags, (
+            f"NOUS_EXTRA_BODY tags mutated: {NOUS_EXTRA_BODY['tags']}"
+        )
+
+    def test_caller_dict_not_mutated(self):
+        """Caller's extra_body dict must not be modified."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        caller_body = {"tags": ["custom-tag"], "other": 42}
+        msgs = [{"role": "user", "content": "hi"}]
+        _build_call_kwargs("nous", "test-model", msgs, extra_body=caller_body)
+        assert caller_body == {"tags": ["custom-tag"], "other": 42}
+
+    def test_merged_extra_has_tag(self):
+        """Returned kwargs should contain the product tag."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        msgs = [{"role": "user", "content": "hi"}]
+        kw = _build_call_kwargs("nous", "test-model", msgs)
+        assert "product=hermes-agent" in kw["extra_body"]["tags"]


### PR DESCRIPTION
## Problem

`_build_call_kwargs()` in `agent/auxiliary_client.py` uses `dict()` for a shallow copy of `extra_body`, then calls `.extend()` on the shared `tags` list. This mutates the module-level `NOUS_EXTRA_BODY` constant, causing `'product=hermes-agent'` to accumulate on every call.

**Reproduction:**
```python
from agent.auxiliary_client import NOUS_EXTRA_BODY, _build_call_kwargs
msgs = [{"role": "user", "content": "hi"}]
for _ in range(3):
    _build_call_kwargs("nous", "model", msgs, extra_body=NOUS_EXTRA_BODY)
print(NOUS_EXTRA_BODY["tags"])
# ['product=hermes-agent', 'product=hermes-agent', 'product=hermes-agent', 'product=hermes-agent']
```

## Fix

Deep-copies list values in `extra_body` to avoid shared mutation. Changes `dict()` shallow copy to a comprehension that copies lists, and uses `.append()` instead of `.extend()`.

## Before vs After

| | Before | After |
|---|---|---|
| Tags after 3 calls | 4 entries | 1 entry (stable) |
| NOUS_EXTRA_BODY mutated | Yes | No |

## Tests

- 3 new regression tests in `TestBuildCallKwargsExtraBody`
- Tests verify: no accumulation, no caller mutation, tag present in output
