### PR TITLE
fix(gateway): use /hermes sethome in onboarding hint on Slack

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4414,12 +4414,20 @@ class GatewayRunner:
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
+                    # Slack dispatches all Hermes commands through a single
+                    # parent slash command `/hermes`; bare `/sethome` is not
+                    # registered and would fail with "app did not respond".
+                    sethome_cmd = (
+                        "/hermes sethome"
+                        if source.platform == Platform.SLACK
+                        else "/sethome"
+                    )
                     await adapter.send(
                         source.chat_id,
                         f"📬 No home channel is set for {platform_name.title()}. "
                         f"A home channel is where Hermes delivers cron job results "
                         f"and cross-platform messages.\n\n"
-                        f"Type /sethome to make this chat your home channel, "
+                        f"Type {sethome_cmd} to make this chat your home channel, "
                         f"or ignore to skip."
                     )
         


### PR DESCRIPTION
## Summary

Fixes the Slack-specific first-run onboarding hint so it shows the correct slash-command syntax.

Closes #14632.

## Problem

On a fresh Slack install, the gateway posts this onboarding message:

> 📬 No home channel is set for Slack. ...
>
> Type `/sethome` to make this chat your home channel, or ignore to skip.

But Slack's adapter registers **only** the parent command `/hermes` (`gateway/platforms/slack.py:211`) and dispatches subcommands via `slack_subcommand_map()`. So typing `/sethome` as instructed fails:

> `/sethome` failed because the app did not respond. Please try again or contact the app developer.

…with this warning in the gateway log:

```
WARNING slack_bolt.AsyncApp: Unhandled request ({'type': None, 'command': '/sethome'})
```

The correct invocation on Slack is `/hermes sethome`.

## Change

Branch the hint text on `source.platform`:

- `Platform.SLACK` → `/hermes sethome`
- everything else → `/sethome` (unchanged — Telegram, Discord, Matrix, Mattermost, etc. all register `/sethome` directly)

Added a short comment explaining *why* Slack is special so the branch doesn't look arbitrary to future readers.

## Diff

```diff
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
+                    # Slack dispatches all Hermes commands through a single
+                    # parent slash command `/hermes`; bare `/sethome` is not
+                    # registered and would fail with "app did not respond".
+                    sethome_cmd = (
+                        "/hermes sethome"
+                        if source.platform == Platform.SLACK
+                        else "/sethome"
+                    )
                     await adapter.send(
                         source.chat_id,
                         f"📬 No home channel is set for {platform_name.title()}. "
                         f"A home channel is where Hermes delivers cron job results "
                         f"and cross-platform messages.\n\n"
-                        f"Type /sethome to make this chat your home channel, "
+                        f"Type {sethome_cmd} to make this chat your home channel, "
                         f"or ignore to skip."
                     )
```

## Testing

- `python -c "import ast; ast.parse(open('gateway/run.py').read())"` → OK
- `grep -r "No home channel is set" tests/` → no test pins this string, so no test update needed
- Manually verified on a live Slack workspace: `/hermes sethome` succeeds (sets home channel), whereas `/sethome` produces "app did not respond" + `slack_bolt` Unhandled request warning

## Notes for reviewers

A more general refactor would introduce something like `adapter.format_slash_command("sethome")` so platform-specific wire formats live in the adapter rather than call sites. I kept this PR minimal and focused on the user-visible bug. Happy to follow up with that refactor if you'd like — it would also compose cleanly with #11832 (per-profile Slack slash-command names), where the Slack adapter would return `"/<profile_name> sethome"` instead of hardcoding `/hermes`.
