### PR TITLE
fix(file_tools): prevent agent from silently disabling exec approval via config write

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -321,4 +321,65 @@ class TestSearchHints:
         assert "offset=100" in raw
 
 
+class TestSensitivePathCheck:
+    """Verify that _check_sensitive_path blocks writes to protected locations."""
+
+    def test_hermes_config_blocked_for_write_file(self, tmp_path, monkeypatch):
+        fake_config = tmp_path / "config.yaml"
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+
+    def test_hermes_config_blocked_via_tilde_path(self, tmp_path, monkeypatch):
+        fake_config = tmp_path / "config.yaml"
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+
+    def test_hermes_config_blocked_for_patch(self, tmp_path, monkeypatch):
+        fake_config = tmp_path / "config.yaml"
+        fake_config.write_text("approvals:\n  mode: manual\n")
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="replace",
+            path=str(fake_config),
+            old_string="mode: manual",
+            new_string="mode: off",
+        ))
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+
+    def test_system_path_still_blocked(self, monkeypatch):
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/some/other/path")
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool("/etc/passwd", "evil"))
+        assert "error" in result
+        assert "sensitive system path" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_normal_file_not_blocked(self, mock_get, monkeypatch):
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/home/user/.hermes/config.yaml")
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/other.txt", "bytes": 5}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool("/tmp/other.txt", "hello"))
+        assert result["status"] == "ok"
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -117,6 +117,26 @@ _SENSITIVE_PATH_PREFIXES = (
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
+_hermes_config_resolved: str | None = None
+_hermes_config_resolved_loaded = False
+
+
+def _get_hermes_config_resolved() -> str | None:
+    """Return the resolved absolute path of the Hermes config file (cached)."""
+    global _hermes_config_resolved, _hermes_config_resolved_loaded
+    if _hermes_config_resolved_loaded:
+        return _hermes_config_resolved
+    _hermes_config_resolved_loaded = True
+    try:
+        from hermes_cli.config import get_config_path
+        _hermes_config_resolved = str(get_config_path().resolve())
+    except Exception:
+        try:
+            _hermes_config_resolved = str(Path("~/.hermes/config.yaml").expanduser().resolve())
+        except Exception:
+            _hermes_config_resolved = None
+    return _hermes_config_resolved
+
 
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
@@ -134,6 +154,17 @@ def _check_sensitive_path(filepath: str) -> str | None:
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
+    # Prevent agents from modifying the Hermes config file directly.
+    # approvals.mode and other security settings live here; a malicious or
+    # prompt-injected agent could silently disable exec approval by writing to
+    # this file.
+    hermes_config = _get_hermes_config_resolved()
+    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
+        return (
+            f"Refusing to write to Hermes config file: {filepath}\n"
+            "Agent cannot modify security-sensitive configuration. "
+            "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+        )
     return None
 
 


### PR DESCRIPTION
# fix(file_tools): prevent agent from silently disabling exec approval via config write

## What does this PR do?

`write_file` and `patch` tools had no protection against writes to `~/.hermes/config.yaml`. A malicious or prompt-injected agent could exploit this to silently disable exec approval:

1. Call `read_file("~/.hermes/config.yaml")` to read the current config.
2. Call `write_file` or `patch` to set `approvals.mode: off`.
3. All subsequent `execute_code` calls bypass `check_all_command_guards()` entirely — `approval_mode == "off"` causes it to return `{"approved": True}` unconditionally.

This PR adds `~/.hermes/config.yaml` to the sensitive path protection in `_check_sensitive_path()`. Any attempt by an agent to write to the config file is rejected before reaching the filesystem, regardless of whether the path is expressed as an absolute path or via `~`.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_tools.py`: add `_get_hermes_config_resolved()` to lazily resolve and cache the canonical path of `~/.hermes/config.yaml` (via `get_config_path().resolve()`, with `expanduser` fallback)
- `tools/file_tools.py`: add a guard at the end of `_check_sensitive_path()` that rejects writes when the target path matches the Hermes config file — covers both `write_file` and `patch` entry points
- `tests/tools/test_file_tools.py`: add `TestSensitivePathCheck` with 5 cases covering the new protection and verifying no regression on normal file writes or existing system-path blocks

## How to Test

1. Run the new test class: `pytest tests/tools/test_file_tools.py::TestSensitivePathCheck -v` — all 5 cases should pass.
2. Run the full file tools suite: `pytest tests/tools/test_file_tools.py -q` — all 28 tests should pass.
3. In a live session, ask the agent to write `approvals:\n  mode: off` to `~/.hermes/config.yaml` — confirm it receives an error response containing "Refusing to write to Hermes config file".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# Agent attempts to disable exec approval
write_file("~/.hermes/config.yaml", "approvals:\n  mode: off\n")
→ {"error": "Refusing to write to Hermes config file: ~/.hermes/config.yaml\nAgent cannot modify security-sensitive configuration. Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."}
```

```
pytest tests/tools/test_file_tools.py -q
28 passed, 6 warnings in 0.75s
```
