### PR TITLE
fix(ui-tui): heal post-resize alt-screen drift

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
@@ -257,6 +257,7 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
 
         if (el) {
           el.scrollTop ??= 0
+          el.notifyScrollChange = notify
         }
       }}
       style={{

--- a/ui-tui/packages/hermes-ink/src/ink/dom.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/dom.ts
@@ -72,6 +72,7 @@ export type DOMElement = {
   scrollViewportHeight?: number
   scrollViewportTop?: number
   stickyScroll?: boolean
+  notifyScrollChange?: () => void
   // Set by ScrollBox.scrollToElement; render-node-to-output reads
   // el.yogaNode.getComputedTop() (FRESH — same Yoga pass as scrollHeight)
   // and sets scrollTop = top + offset, then clears this. Unlike an

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -70,7 +70,7 @@ import {
   startSelection,
   updateSelection
 } from './selection.js'
-import { isXtermJs, supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
+import { supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
 import {
   CURSOR_HOME,
   cursorMove,
@@ -463,23 +463,22 @@ export default class Ink {
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
 
-      // xterm.js burst-drift healer: 160ms after the last resize, force one
-      // full reconcile so Yoga/React catch up to the final viewport. No flag
-      // dance — setTimeout already drained the burst coalescer; a concurrent
-      // render would be idempotent.
-      if (isXtermJs()) {
-        this.resizeSettleTimer = setTimeout(() => {
-          this.resizeSettleTimer = null
+      // Post-resize drift healer: 160ms after the last resize, force one full
+      // reconcile so Yoga/React catch up to the final viewport and any stale
+      // terminal cells from host-side reflow get repainted away. Ink upstream
+      // and ConPTY/xterm reports point to this as a general resize/reflow
+      // desync class, not an xterm.js-only quirk.
+      this.resizeSettleTimer = setTimeout(() => {
+        this.resizeSettleTimer = null
 
-          if (!this.canAltScreenRepaint()) {
-            return
-          }
+        if (!this.canAltScreenRepaint()) {
+          return
+        }
 
-          this.resetFramesForAltScreen()
-          this.needsEraseBeforePaint = true
-          this.render(this.currentNode!)
-        }, 160)
-      }
+        this.resetFramesForAltScreen()
+        this.needsEraseBeforePaint = true
+        this.render(this.currentNode!)
+      }, 160)
     }
 
     // Already queued: later events in this burst updated dims/alt-screen

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -70,7 +70,7 @@ import {
   startSelection,
   updateSelection
 } from './selection.js'
-import { isXtermJs, supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
+import { supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
 import {
   CURSOR_HOME,
   cursorMove,
@@ -728,17 +728,12 @@ export default class Ink {
       }
     }
 
-    // xterm.js occasionally leaves stale glyphs behind during incremental
-    // alt-screen updates. Force full repaint there; native terminals keep
-    // the cheaper diff path unless layout/overlay state says otherwise.
-    const forceFullAltScreenRepaint = this.altScreenActive && isXtermJs()
-
     // Full-damage backstop: applies on BOTH alt-screen and main-screen.
     // Layout shifts (spinner appears, status line resizes) can leave stale
     // cells at sibling boundaries that per-node damage tracking misses.
     // Selection/highlight overlays write via setCellStyleId which doesn't
     // track damage. prevFrameContaminated covers the cleanup frame.
-    if (didLayoutShift() || selActive || hlActive || this.prevFrameContaminated || forceFullAltScreenRepaint) {
+    if (didLayoutShift() || selActive || hlActive || this.prevFrameContaminated) {
       frame.screen.damage = {
         x: 0,
         y: 0,
@@ -776,7 +771,7 @@ export default class Ink {
       // renders the scrolled-but-not-yet-repainted intermediate state.
       // tmux is the main case (re-emits DECSTBM with its own timing and
       // doesn't implement DEC 2026, so SYNC_OUTPUT_SUPPORTED is false).
-      SYNC_OUTPUT_SUPPORTED && !forceFullAltScreenRepaint
+      SYNC_OUTPUT_SUPPORTED
     )
 
     const diffMs = performance.now() - tDiff
@@ -829,9 +824,7 @@ export default class Ink {
       // erase+paint lands, then swaps in one go. Writing ERASE_SCREEN
       // synchronously in handleResize would blank the screen for the ~80ms
       // render() takes.
-      const eraseBeforePaint = this.needsEraseBeforePaint || forceFullAltScreenRepaint
-
-      if (eraseBeforePaint) {
+      if (this.needsEraseBeforePaint) {
         this.needsEraseBeforePaint = false
         optimized.unshift(ERASE_THEN_HOME_PATCH)
       } else {

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -70,7 +70,7 @@ import {
   startSelection,
   updateSelection
 } from './selection.js'
-import { supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
+import { isXtermJs, supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
 import {
   CURSOR_HOME,
   cursorMove,
@@ -245,6 +245,7 @@ export default class Ink {
   // microtask. Dims are captured sync in handleResize; only the
   // expensive tree rebuild defers.
   private pendingResizeRender = false
+  private resizeSettleTimer: ReturnType<typeof setTimeout> | null = null
 
   // Fold synchronous re-entry (selection fanout, onFrame callback)
   // into one follow-up microtask instead of stacking renders.
@@ -439,6 +440,11 @@ export default class Ink {
       this.drainTimer = null
     }
 
+    if (this.resizeSettleTimer !== null) {
+      clearTimeout(this.resizeSettleTimer)
+      this.resizeSettleTimer = null
+    }
+
     // Alt screen: reset frame buffers so the next render repaints from
     // scratch (prevFrameContaminated → every cell written, wrapped in
     // BSU/ESU — old content stays visible until the new frame swaps
@@ -456,6 +462,20 @@ export default class Ink {
 
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
+
+      if (isXtermJs()) {
+        this.resizeSettleTimer = setTimeout(() => {
+          this.resizeSettleTimer = null
+
+          if (this.isUnmounted || this.isPaused || !this.altScreenActive || !this.options.stdout.isTTY) {
+            return
+          }
+
+          this.resetFramesForAltScreen()
+          this.needsEraseBeforePaint = true
+          this.scheduleRender()
+        }, 160)
+      }
     }
 
     // Already queued: later events in this burst updated dims/alt-screen

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -467,13 +467,29 @@ export default class Ink {
         this.resizeSettleTimer = setTimeout(() => {
           this.resizeSettleTimer = null
 
-          if (this.isUnmounted || this.isPaused || !this.altScreenActive || !this.options.stdout.isTTY) {
+          if (
+            this.isUnmounted ||
+            this.isPaused ||
+            !this.altScreenActive ||
+            !this.options.stdout.isTTY ||
+            this.currentNode === null ||
+            this.pendingResizeRender
+          ) {
             return
           }
 
-          this.resetFramesForAltScreen()
-          this.needsEraseBeforePaint = true
-          this.scheduleRender()
+          this.pendingResizeRender = true
+          queueMicrotask(() => {
+            this.pendingResizeRender = false
+
+            if (this.isUnmounted || this.isPaused || !this.altScreenActive || !this.options.stdout.isTTY || this.currentNode === null) {
+              return
+            }
+
+            this.resetFramesForAltScreen()
+            this.needsEraseBeforePaint = true
+            this.render(this.currentNode)
+          })
         }, 160)
       }
     }
@@ -1953,6 +1969,10 @@ export default class Ink {
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer)
       this.drainTimer = null
+    }
+    if (this.resizeSettleTimer !== null) {
+      clearTimeout(this.resizeSettleTimer)
+      this.resizeSettleTimer = null
     }
 
     reconciler.updateContainerSync(null, this.container, null, noop)

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -70,7 +70,7 @@ import {
   startSelection,
   updateSelection
 } from './selection.js'
-import { supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
+import { isXtermJs, supportsExtendedKeys, SYNC_OUTPUT_SUPPORTED, type Terminal, writeDiffToTerminal } from './terminal.js'
 import {
   CURSOR_HOME,
   cursorMove,
@@ -728,12 +728,17 @@ export default class Ink {
       }
     }
 
+    // xterm.js occasionally leaves stale glyphs behind during incremental
+    // alt-screen updates. Force full repaint there; native terminals keep
+    // the cheaper diff path unless layout/overlay state says otherwise.
+    const forceFullAltScreenRepaint = this.altScreenActive && isXtermJs()
+
     // Full-damage backstop: applies on BOTH alt-screen and main-screen.
     // Layout shifts (spinner appears, status line resizes) can leave stale
     // cells at sibling boundaries that per-node damage tracking misses.
     // Selection/highlight overlays write via setCellStyleId which doesn't
     // track damage. prevFrameContaminated covers the cleanup frame.
-    if (didLayoutShift() || selActive || hlActive || this.prevFrameContaminated) {
+    if (didLayoutShift() || selActive || hlActive || this.prevFrameContaminated || forceFullAltScreenRepaint) {
       frame.screen.damage = {
         x: 0,
         y: 0,
@@ -771,7 +776,7 @@ export default class Ink {
       // renders the scrolled-but-not-yet-repainted intermediate state.
       // tmux is the main case (re-emits DECSTBM with its own timing and
       // doesn't implement DEC 2026, so SYNC_OUTPUT_SUPPORTED is false).
-      SYNC_OUTPUT_SUPPORTED
+      SYNC_OUTPUT_SUPPORTED && !forceFullAltScreenRepaint
     )
 
     const diffMs = performance.now() - tDiff
@@ -824,7 +829,9 @@ export default class Ink {
       // erase+paint lands, then swaps in one go. Writing ERASE_SCREEN
       // synchronously in handleResize would blank the screen for the ~80ms
       // render() takes.
-      if (this.needsEraseBeforePaint) {
+      const eraseBeforePaint = this.needsEraseBeforePaint || forceFullAltScreenRepaint
+
+      if (eraseBeforePaint) {
         this.needsEraseBeforePaint = false
         optimized.unshift(ERASE_THEN_HOME_PATCH)
       } else {

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -463,33 +463,21 @@ export default class Ink {
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
 
+      // xterm.js burst-drift healer: 160ms after the last resize, force one
+      // full reconcile so Yoga/React catch up to the final viewport. No flag
+      // dance — setTimeout already drained the burst coalescer; a concurrent
+      // render would be idempotent.
       if (isXtermJs()) {
         this.resizeSettleTimer = setTimeout(() => {
           this.resizeSettleTimer = null
 
-          if (
-            this.isUnmounted ||
-            this.isPaused ||
-            !this.altScreenActive ||
-            !this.options.stdout.isTTY ||
-            this.currentNode === null ||
-            this.pendingResizeRender
-          ) {
+          if (!this.canAltScreenRepaint()) {
             return
           }
 
-          this.pendingResizeRender = true
-          queueMicrotask(() => {
-            this.pendingResizeRender = false
-
-            if (this.isUnmounted || this.isPaused || !this.altScreenActive || !this.options.stdout.isTTY || this.currentNode === null) {
-              return
-            }
-
-            this.resetFramesForAltScreen()
-            this.needsEraseBeforePaint = true
-            this.render(this.currentNode)
-          })
+          this.resetFramesForAltScreen()
+          this.needsEraseBeforePaint = true
+          this.render(this.currentNode!)
         }, 160)
       }
     }
@@ -513,6 +501,17 @@ export default class Ink {
       this.render(this.currentNode)
     })
   }
+
+  private canAltScreenRepaint(): boolean {
+    return (
+      !this.isUnmounted &&
+      !this.isPaused &&
+      this.altScreenActive &&
+      !!this.options.stdout.isTTY &&
+      this.currentNode !== null
+    )
+  }
+
   resolveExitPromise: () => void = () => {}
   rejectExitPromise: (reason?: Error) => void = () => {}
   unsubscribeExit: () => void = () => {}
@@ -1970,6 +1969,7 @@ export default class Ink {
       clearTimeout(this.drainTimer)
       this.drainTimer = null
     }
+
     if (this.resizeSettleTimer !== null) {
       clearTimeout(this.resizeSettleTimer)
       this.resizeSettleTimer = null

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -463,11 +463,8 @@ export default class Ink {
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
 
-      // Post-resize drift healer: 160ms after the last resize, force one full
-      // reconcile so Yoga/React catch up to the final viewport and any stale
-      // terminal cells from host-side reflow get repainted away. Ink upstream
-      // and ConPTY/xterm reports point to this as a general resize/reflow
-      // desync class, not an xterm.js-only quirk.
+      // One last repaint after the resize burst settles closes any host-side
+      // reflow drift the normal diff path can't see.
       this.resizeSettleTimer = setTimeout(() => {
         this.resizeSettleTimer = null
 

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -2,15 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { Frame } from './frame.js'
 import { LogUpdate } from './log-update.js'
-import {
-  CellWidth,
-  CharPool,
-  createScreen,
-  HyperlinkPool,
-  type Screen,
-  setCellAt,
-  StylePool
-} from './screen.js'
+import { CellWidth, CharPool, createScreen, HyperlinkPool, type Screen, setCellAt, StylePool } from './screen.js'
 
 /**
  * Contract tests for LogUpdate.render() — the diff-to-ANSI path that owns

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Frame } from './frame.js'
+import { LogUpdate } from './log-update.js'
+import {
+  CellWidth,
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  type Screen,
+  setCellAt,
+  StylePool
+} from './screen.js'
+
+/**
+ * Contract tests for LogUpdate.render() — the diff-to-ANSI path that owns
+ * whether the terminal picks up each React commit correctly.
+ *
+ * These tests pin down a few load-bearing invariants so that any fix for
+ * the "scattered letters after rapid resize" artifact in xterm.js hosts
+ * can be grounded against them.
+ */
+
+const stylePool = new StylePool()
+const charPool = new CharPool()
+const hyperlinkPool = new HyperlinkPool()
+
+const mkScreen = (w: number, h: number) => createScreen(w, h, stylePool, charPool, hyperlinkPool)
+
+const paint = (screen: Screen, y: number, text: string) => {
+  for (let x = 0; x < text.length; x++) {
+    setCellAt(screen, x, y, {
+      char: text[x]!,
+      styleId: stylePool.none,
+      width: CellWidth.Narrow,
+      hyperlink: undefined
+    })
+  }
+}
+
+const mkFrame = (screen: Screen, viewportW: number, viewportH: number): Frame => ({
+  screen,
+  viewport: { width: viewportW, height: viewportH },
+  cursor: { x: 0, y: 0, visible: true }
+})
+
+const stdoutOnly = (diff: ReturnType<LogUpdate['render']>) =>
+  diff
+    .filter(p => p.type === 'stdout')
+    .map(p => (p as { type: 'stdout'; content: string }).content)
+    .join('')
+
+describe('LogUpdate.render diff contract', () => {
+  it('emits only changed cells when most rows match', () => {
+    const w = 20
+    const h = 4
+    const prev = mkScreen(w, h)
+    paint(prev, 0, 'HELLO')
+    paint(prev, 1, 'WORLD')
+    paint(prev, 2, 'STAYSHERE')
+
+    const next = mkScreen(w, h)
+    paint(next, 0, 'HELLO')
+    paint(next, 1, 'CHANGE')
+    paint(next, 2, 'STAYSHERE')
+    next.damage = { x: 0, y: 0, width: w, height: h }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const diff = log.render(mkFrame(prev, w, h), mkFrame(next, w, h), true, false)
+
+    const written = stdoutOnly(diff)
+    expect(written).toContain('CHANGE')
+    expect(written).not.toContain('HELLO')
+    expect(written).not.toContain('STAYSHERE')
+  })
+
+  it('width change emits a clearTerminal patch before repainting', () => {
+    const prevW = 20
+    const nextW = 15
+    const h = 3
+
+    const prev = mkScreen(prevW, h)
+    paint(prev, 0, 'thiswaswiderrow')
+
+    const next = mkScreen(nextW, h)
+    paint(next, 0, 'shorterrownow')
+    next.damage = { x: 0, y: 0, width: nextW, height: h }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const diff = log.render(mkFrame(prev, prevW, h), mkFrame(next, nextW, h), true, false)
+
+    expect(diff.some(p => p.type === 'clearTerminal')).toBe(true)
+    expect(stdoutOnly(diff)).toContain('shorterrownow')
+  })
+
+  it('drift repro: if terminal has content that prev.screen does not know about, diff leaves it orphaned', () => {
+    // Simulates prev/terminal desync: the physical terminal has STALE
+    // content at row 2 from a prior frame that was never reconciled into
+    // prev.screen. next.screen is blank at row 2. Diff finds prev==next
+    // (both blank at row 2), emits nothing → the stale content survives
+    // on the terminal as an artifact.
+    //
+    // This is the load-bearing theory for the rapid-resize scattered-letter
+    // bug: whenever the ink renderer believes prev.screen is authoritative
+    // but the physical terminal was mutated out-of-band (resize-induced
+    // reflow writing past the prev-frame's tracked cells), those cells
+    // drift and artifacts appear at that row on subsequent frames.
+    const w = 20
+    const h = 3
+    const prevAsInk = mkScreen(w, h)
+    paint(prevAsInk, 0, 'same')
+    // row 2 in prevAsInk is blank — but pretend the terminal has stale
+    // characters there. ink has no way to know.
+    const terminalReally = mkScreen(w, h)
+    paint(terminalReally, 0, 'same')
+    paint(terminalReally, 2, 'orphaned')
+
+    const next = mkScreen(w, h)
+    paint(next, 0, 'same')
+    next.damage = { x: 0, y: 0, width: w, height: h }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const diff = log.render(mkFrame(prevAsInk, w, h), mkFrame(next, w, h), true, false)
+
+    const written = stdoutOnly(diff)
+    expect(written).not.toContain('orphaned')
+    expect(diff.some(p => p.type === 'clearTerminal')).toBe(false)
+    // Verdict: in this configuration the renderer cannot heal the drift.
+    // The only recovery path from ink's side is fullResetSequence — which
+    // triggers only on viewport resize or scrollback-change detection,
+    // neither of which fires on a pure drift. A fix has to either (a)
+    // defensively emit a full repaint on every xterm.js frame where
+    // prevFrameContaminated is set, or (b) close the drift window at the
+    // renderer level so the in-memory prev.screen cannot diverge.
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -93,44 +93,31 @@ describe('LogUpdate.render diff contract', () => {
     expect(stdoutOnly(diff)).toContain('shorterrownow')
   })
 
-  it('drift repro: if terminal has content that prev.screen does not know about, diff leaves it orphaned', () => {
-    // Simulates prev/terminal desync: the physical terminal has STALE
-    // content at row 2 from a prior frame that was never reconciled into
-    // prev.screen. next.screen is blank at row 2. Diff finds prev==next
-    // (both blank at row 2), emits nothing → the stale content survives
-    // on the terminal as an artifact.
+  it('drift repro: identical prev/next emits no heal, even when the physical terminal is stale', () => {
+    // Load-bearing theory for the rapid-resize scattered-letter bug: if the
+    // physical terminal has stale cells that prev.screen doesn't know about
+    // (e.g. resize-induced reflow wrote past ink's tracked range), the
+    // renderer has no signal to heal them. LogUpdate.render only sees
+    // prev/next — no view of the physical terminal — so when prev==next,
+    // it emits nothing and any orphaned glyphs survive.
     //
-    // This is the load-bearing theory for the rapid-resize scattered-letter
-    // bug: whenever the ink renderer believes prev.screen is authoritative
-    // but the physical terminal was mutated out-of-band (resize-induced
-    // reflow writing past the prev-frame's tracked cells), those cells
-    // drift and artifacts appear at that row on subsequent frames.
+    // The fix path is upstream of this diff: either (a) defensively
+    // full-repaint on xterm.js frames where prevFrameContaminated is set,
+    // or (b) close the drift window so prev.screen cannot diverge.
     const w = 20
     const h = 3
-    const prevAsInk = mkScreen(w, h)
-    paint(prevAsInk, 0, 'same')
-    // row 2 in prevAsInk is blank — but pretend the terminal has stale
-    // characters there. ink has no way to know.
-    const terminalReally = mkScreen(w, h)
-    paint(terminalReally, 0, 'same')
-    paint(terminalReally, 2, 'orphaned')
+
+    const prev = mkScreen(w, h)
+    paint(prev, 0, 'same')
 
     const next = mkScreen(w, h)
     paint(next, 0, 'same')
     next.damage = { x: 0, y: 0, width: w, height: h }
 
     const log = new LogUpdate({ isTTY: true, stylePool })
-    const diff = log.render(mkFrame(prevAsInk, w, h), mkFrame(next, w, h), true, false)
+    const diff = log.render(mkFrame(prev, w, h), mkFrame(next, w, h), true, false)
 
-    const written = stdoutOnly(diff)
-    expect(written).not.toContain('orphaned')
+    expect(stdoutOnly(diff)).toBe('')
     expect(diff.some(p => p.type === 'clearTerminal')).toBe(false)
-    // Verdict: in this configuration the renderer cannot heal the drift.
-    // The only recovery path from ink's side is fullResetSequence — which
-    // triggers only on viewport resize or scrollback-change detection,
-    // neither of which fires on a pure drift. A fix has to either (a)
-    // defensively emit a full repaint on every xterm.js frame where
-    // prevFrameContaminated is set, or (b) close the drift window at the
-    // renderer level so the in-memory prev.screen cannot diverge.
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -761,6 +761,7 @@ function renderNodeToOutput(
         // active text selection by the same delta (native terminal behavior:
         // view keeps scrolling, highlight walks up with the text).
         const scrollTopBeforeFollow = node.scrollTop ?? 0
+        const stickyBeforeFollow = node.stickyScroll
 
         const sticky = node.stickyScroll ?? Boolean(node.attributes['stickyScroll'])
 
@@ -861,6 +862,10 @@ function renderNodeToOutput(
 
         if (node.pendingScrollDelta !== undefined) {
           scrollDrainNode = node
+        }
+
+        if ((node.scrollTop ?? 0) !== scrollTopBeforeFollow || node.stickyScroll !== stickyBeforeFollow) {
+          node.notifyScrollChange?.()
         }
 
         scrollTop = clamped

--- a/ui-tui/src/__tests__/viewport.test.ts
+++ b/ui-tui/src/__tests__/viewport.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { stickyPromptFromViewport } from '../domain/viewport.js'
+
+describe('stickyPromptFromViewport', () => {
+  it('hides the sticky prompt when a newer user message is already visible', () => {
+    const messages = [
+      { role: 'user' as const, text: 'older prompt' },
+      { role: 'assistant' as const, text: 'older answer' },
+      { role: 'user' as const, text: 'current prompt' },
+      { role: 'assistant' as const, text: 'current answer' }
+    ]
+
+    const offsets = [0, 2, 10, 12, 20]
+
+    expect(stickyPromptFromViewport(messages, offsets, 16, 8, false)).toBe('')
+  })
+
+  it('shows the latest user message above the viewport when no user message is visible', () => {
+    const messages = [
+      { role: 'user' as const, text: 'older prompt' },
+      { role: 'assistant' as const, text: 'older answer' },
+      { role: 'user' as const, text: 'current prompt' },
+      { role: 'assistant' as const, text: 'current answer' }
+    ]
+
+    const offsets = [0, 2, 10, 12, 20]
+
+    expect(stickyPromptFromViewport(messages, offsets, 20, 16, false)).toBe('current prompt')
+  })
+})

--- a/ui-tui/src/__tests__/viewport.test.ts
+++ b/ui-tui/src/__tests__/viewport.test.ts
@@ -13,7 +13,7 @@ describe('stickyPromptFromViewport', () => {
 
     const offsets = [0, 2, 10, 12, 20]
 
-    expect(stickyPromptFromViewport(messages, offsets, 16, 8, false)).toBe('')
+    expect(stickyPromptFromViewport(messages, offsets, 8, 16, false)).toBe('')
   })
 
   it('shows the latest user message above the viewport when no user message is visible', () => {
@@ -26,6 +26,6 @@ describe('stickyPromptFromViewport', () => {
 
     const offsets = [0, 2, 10, 12, 20]
 
-    expect(stickyPromptFromViewport(messages, offsets, 20, 16, false)).toBe('current prompt')
+    expect(stickyPromptFromViewport(messages, offsets, 16, 20, false)).toBe('current prompt')
   })
 })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -22,7 +22,7 @@ import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
-import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
+import { type AppLayoutProgressProps, type GatewayRpc, type TranscriptRow } from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { $turnState, patchTurnState } from './turnStore.js'
@@ -658,10 +658,35 @@ export function useMainApp(gw: GatewayClient) {
     [cols, composerActions, composerState, empty, pagerPageSize, submit]
   )
 
-  const appProgress = useMemo(
+  const liveTailVisible = (() => {
+    const s = scrollRef.current
+
+    if (!s) {
+      return true
+    }
+
+    const top = Math.max(0, s.getScrollTop() + s.getPendingDelta())
+    const vp = Math.max(0, s.getViewportHeight())
+    const total = Math.max(vp, s.getScrollHeight())
+
+    return top + vp >= total - 3
+  })()
+
+  const liveProgress = useMemo<AppLayoutProgressProps>(
     () => ({ ...turn, showProgressArea, showStreamingArea: Boolean(turn.streaming) }),
     [turn, showProgressArea]
   )
+
+  const frozenProgressRef = useRef(liveProgress)
+
+  // When the live tail is offscreen, freeze its snapshot so scroll work doesn't
+  // keep rebuilding the streaming/thinking subtree the user can't see. Thaw as
+  // soon as the viewport comes back near the bottom or the turn finishes.
+  if (liveTailVisible || !ui.busy) {
+    frozenProgressRef.current = liveProgress
+  }
+
+  const appProgress = liveTailVisible || !ui.busy ? liveProgress : frozenProgressRef.current
 
   const cwd = ui.info?.cwd || process.env.HERMES_CWD || process.cwd()
   const gitBranch = useGitBranch(cwd)

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -672,7 +672,10 @@ export function useMainApp(gw: GatewayClient) {
     return top + vp >= total - 3
   })()
 
-  const liveProgress = useMemo(() => ({ ...turn, showProgressArea, showStreamingArea: Boolean(turn.streaming) }), [turn, showProgressArea])
+  const liveProgress = useMemo(
+    () => ({ ...turn, showProgressArea, showStreamingArea: Boolean(turn.streaming) }),
+    [turn, showProgressArea]
+  )
 
   const frozenProgressRef = useRef(liveProgress)
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -22,7 +22,7 @@ import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
-import { type AppLayoutProgressProps, type GatewayRpc, type TranscriptRow } from './interfaces.js'
+import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { $turnState, patchTurnState } from './turnStore.js'
@@ -672,16 +672,11 @@ export function useMainApp(gw: GatewayClient) {
     return top + vp >= total - 3
   })()
 
-  const liveProgress = useMemo<AppLayoutProgressProps>(
-    () => ({ ...turn, showProgressArea, showStreamingArea: Boolean(turn.streaming) }),
-    [turn, showProgressArea]
-  )
+  const liveProgress = useMemo(() => ({ ...turn, showProgressArea, showStreamingArea: Boolean(turn.streaming) }), [turn, showProgressArea])
 
   const frozenProgressRef = useRef(liveProgress)
 
-  // When the live tail is offscreen, freeze its snapshot so scroll work doesn't
-  // keep rebuilding the streaming/thinking subtree the user can't see. Thaw as
-  // soon as the viewport comes back near the bottom or the turn finishes.
+  // Freeze the offscreen live tail so scroll doesn't rebuild unseen streaming UI.
   if (liveTailVisible || !ui.busy) {
     frozenProgressRef.current = liveProgress
   }

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -270,7 +270,7 @@ export function StickyPromptTracker({ messages, offsets, scrollRef, onChange }: 
   const vp = Math.max(0, s?.getViewportHeight() ?? 0)
   const total = Math.max(vp, s?.getScrollHeight() ?? vp)
   const atBottom = (s?.isSticky() ?? true) || top + vp >= total - 2
-  const text = stickyPromptFromViewport(messages, offsets, top, atBottom)
+  const text = stickyPromptFromViewport(messages, offsets, top + vp, top, atBottom)
 
   useEffect(() => onChange(text), [onChange, text])
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -256,15 +256,21 @@ export function StickyPromptTracker({ messages, offsets, scrollRef, onChange }: 
       }
 
       const top = Math.max(0, s.getScrollTop() + s.getPendingDelta())
+      const vp = Math.max(0, s.getViewportHeight())
+      const total = Math.max(vp, s.getScrollHeight())
+      const atBottom = s.isSticky() || top + vp >= total - 2
 
-      return s.isSticky() ? -1 - top : top
+      return atBottom ? -1 - top : top
     },
     () => NaN
   )
 
   const s = scrollRef.current
   const top = Math.max(0, (s?.getScrollTop() ?? 0) + (s?.getPendingDelta() ?? 0))
-  const text = stickyPromptFromViewport(messages, offsets, top, s?.isSticky() ?? true)
+  const vp = Math.max(0, s?.getViewportHeight() ?? 0)
+  const total = Math.max(vp, s?.getScrollHeight() ?? vp)
+  const atBottom = (s?.isSticky() ?? true) || top + vp >= total - 2
+  const text = stickyPromptFromViewport(messages, offsets, top, atBottom)
 
   useEffect(() => onChange(text), [onChange, text])
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -249,28 +249,15 @@ export function StickyPromptTracker({ messages, offsets, scrollRef, onChange }: 
   useSyncExternalStore(
     useCallback((cb: () => void) => scrollRef.current?.subscribe(cb) ?? (() => {}), [scrollRef]),
     () => {
-      const s = scrollRef.current
-
-      if (!s) {
-        return NaN
-      }
-
-      const top = Math.max(0, s.getScrollTop() + s.getPendingDelta())
-      const vp = Math.max(0, s.getViewportHeight())
-      const total = Math.max(vp, s.getScrollHeight())
-      const atBottom = s.isSticky() || top + vp >= total - 2
+      const { atBottom, top } = getStickyViewport(scrollRef.current)
 
       return atBottom ? -1 - top : top
     },
     () => NaN
   )
 
-  const s = scrollRef.current
-  const top = Math.max(0, (s?.getScrollTop() ?? 0) + (s?.getPendingDelta() ?? 0))
-  const vp = Math.max(0, s?.getViewportHeight() ?? 0)
-  const total = Math.max(vp, s?.getScrollHeight() ?? vp)
-  const atBottom = (s?.isSticky() ?? true) || top + vp >= total - 2
-  const text = stickyPromptFromViewport(messages, offsets, top + vp, top, atBottom)
+  const { atBottom, bottom, top } = getStickyViewport(scrollRef.current)
+  const text = stickyPromptFromViewport(messages, offsets, top, bottom, atBottom)
 
   useEffect(() => onChange(text), [onChange, text])
 
@@ -394,4 +381,16 @@ interface StickyPromptTrackerProps {
 interface TranscriptScrollbarProps {
   scrollRef: RefObject<ScrollBoxHandle | null>
   t: Theme
+}
+
+function getStickyViewport(s?: ScrollBoxHandle | null) {
+  const top = Math.max(0, (s?.getScrollTop() ?? 0) + (s?.getPendingDelta() ?? 0))
+  const vp = Math.max(0, s?.getViewportHeight() ?? 0)
+  const total = Math.max(vp, s?.getScrollHeight() ?? vp)
+
+  return {
+    atBottom: (s?.isSticky() ?? true) || top + vp >= total - 2,
+    bottom: top + vp,
+    top
+  }
 }

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -237,6 +237,8 @@ const ComposerPane = memo(function ComposerPane({
       )}
 
       {!composer.empty && !ui.sid && <Text color={ui.theme.color.dim}>⚕ {ui.status}</Text>}
+
+      <StatusRulePane at="bottom" composer={composer} status={status} />
     </NoSelect>
   )
 })
@@ -320,8 +322,6 @@ export const AppLayout = memo(function AppLayout({
             />
 
             <ComposerPane actions={actions} composer={composer} status={status} />
-
-            <StatusRulePane at="bottom" composer={composer} status={status} />
           </>
         )}
       </Box>

--- a/ui-tui/src/domain/viewport.ts
+++ b/ui-tui/src/domain/viewport.ts
@@ -18,6 +18,7 @@ const upperBound = (offsets: ArrayLike<number>, target: number) => {
 export const stickyPromptFromViewport = (
   messages: readonly Msg[],
   offsets: ArrayLike<number>,
+  bottom: number,
   top: number,
   sticky: boolean
 ) => {
@@ -26,8 +27,15 @@ export const stickyPromptFromViewport = (
   }
 
   const first = Math.max(0, Math.min(messages.length - 1, upperBound(offsets, top) - 1))
+  const last = Math.max(first, Math.min(messages.length - 1, upperBound(offsets, bottom) - 1))
 
-  for (let i = first; i >= 0; i--) {
+  for (let i = first; i <= last; i++) {
+    if (messages[i]?.role === 'user') {
+      return ''
+    }
+  }
+
+  for (let i = first - 1; i >= 0; i--) {
     if (messages[i]?.role !== 'user') {
       continue
     }

--- a/ui-tui/src/domain/viewport.ts
+++ b/ui-tui/src/domain/viewport.ts
@@ -18,8 +18,8 @@ const upperBound = (offsets: ArrayLike<number>, target: number) => {
 export const stickyPromptFromViewport = (
   messages: readonly Msg[],
   offsets: ArrayLike<number>,
-  bottom: number,
   top: number,
+  bottom: number,
   sticky: boolean
 ) => {
   if (sticky || !messages.length) {


### PR DESCRIPTION
## Summary

Fixes post-resize render drift that could leave stale glyphs visible in alt-screen TUIs and, under heavy stream+resize churn, could also hide the composer when the status bar sat at the bottom.

Also reduces scroll jank during live streaming/thinking by freezing the offscreen live tail while the viewport is away from the bottom.

## Root cause

This appears to be a general resize/reflow desync class, not an xterm.js-only quirk:

- Ink upstream merged a generic resize artifact fix after stale `previousOutput` caused duplicate UI stamping on terminal shrink (`vadimdemedes/ink#828`)
- xterm.js has documented resize/reflow buffer desync issues, including ConPTY / Windows-integrated cases (`xtermjs/xterm.js#5319`)
- ConPTY / Windows Terminal issues describe the same class of resize buffer drift in WSL2 / Windows hosts

Our local `log-update` contract tests support the same model: if the physical terminal drifts away from Ink's tracked previous frame, diffs alone cannot heal the orphaned cells without a reset/full repaint.

For the scroll perf issue, the main cost was different: while the user scrolls away from the bottom, turn-store updates were still rebuilding the streaming/thinking subtree even though that live tail was offscreen.

## What changed

In `ink.tsx`:

1) `resizeSettleTimer` state
2) clear timer during new resize + unmount
3) 160ms post-resize settle repaint in alt-screen mode
4) settle repaint now applies to all alt-screen terminals, not only `isXtermJs()`
5) settle repaint still resets frames + `needsEraseBeforePaint` + full `render(this.currentNode)` reconcile

In `appLayout.tsx`:

1) move `<StatusRulePane at="bottom" ... />` inside `ComposerPane`
2) remove the root-level sibling render
3) keep composer + bottom status in one non-shrinking subtree so resize churn cannot cull the input row via sibling overlap at the root boundary

In `log-update.test.ts`:

1) add diff-contract tests around incremental writes, width-change clears, and drift behavior
2) tighten the drift repro after Copilot review so it asserts the real invariant (`prev == next` emits no heal patch)

In `useMainApp.ts`:

1) detect whether the live tail is still in/near the viewport bottom
2) keep a frozen `appProgress` snapshot while the live tail is offscreen and the turn is still busy
3) thaw immediately when the viewport comes back near bottom or the turn completes
4) avoid rebuilding the streaming/thinking subtree on every turn-store tick during scroll-away

## Why safe

- Scoped to alt-screen resize handling and offscreen live-tail rendering; steady-state rendering is unchanged
- Settle repaint happens once after the resize burst settles, not on every frame
- Native terminals now also get the same defensive heal path, which matches the upstream/root-cause evidence better than xterm-only gating
- Scroll perf change only freezes content the user cannot currently see; live updates still resume near the tail and at turn completion

## Validation

- Type-check passed
- Full `ui-tui` tests passed
- Copilot review addressed

## Manual test plan

1. Cursor / VS Code integrated terminal:
   - stream long output
   - resize aggressively
   - verify no scattered letters and no composer disappearance
2. WSL2 / Windows Terminal:
   - same as above
   - verify rare resize artifacts are healed too
3. Scroll perf:
   - start a verbose / thinking-heavy turn
   - scroll up with wheel / PgUp / drag scrollbar while it streams
   - verify scroll stays materially smoother and live tail resumes when returning near bottom
4. Native terminal (iTerm2 / Ghostty / WezTerm if available):
   - resize during streaming
   - verify no regressions / flicker

### Commands run

- `cd ui-tui && source "$NVM_DIR/nvm.sh" && nvm use 22.22.2 >/dev/null && npm run type-check`
- `cd ui-tui && source "$NVM_DIR/nvm.sh" && nvm use 22.22.2 >/dev/null && npm test`