### PR TITLE
fix(cli): inherit profile config in load_cli_config for hermes chat

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -429,7 +429,39 @@ def load_cli_config() -> Dict[str, Any]:
         try:
             with open(config_path, "r", encoding="utf-8") as f:
                 file_config = yaml.safe_load(f) or {}
-            
+
+            # Profile inheritance: when HERMES_HOME points at a profile
+            # directory (e.g. ``hermes --profile xuangu chat``), the profile
+            # config usually only overrides a few fields (e.g. ``discord:``)
+            # and expects ``model:`` / ``custom_providers:`` / ``providers:``
+            # / ``delegation:`` / ``fallback_model:`` to inherit from the root
+            # ``~/.hermes/config.yaml`` — the same way ``hermes_cli.config.
+            # load_config`` does for every other command (status, model, run,
+            # platform gateway, cron subagents).  Without this merge, profile-
+            # scoped ``hermes chat -q`` would silently fall through to the
+            # empty defaults below and produce ``No inference provider
+            # configured`` even when the root config is perfectly valid.
+            try:
+                from hermes_cli.config import _apply_profile_model_inheritance
+
+                # ``_apply_profile_model_inheritance`` is a no-op when
+                # ``config_path`` is NOT under a ``profiles/<name>/`` dir
+                # (it returns the user_config unchanged), so the root-level
+                # stale-key fallback logic further below keeps its meaning.
+                # We intentionally skip ``_normalize_root_model_keys`` here
+                # — that normalizer would promote legacy root-level
+                # ``provider:`` into ``model.provider`` and defeat the
+                # "stale root key is only a FALLBACK" protection that the
+                # downstream code in this function relies on.
+                file_config = _apply_profile_model_inheritance(
+                    file_config, config_path
+                )
+            except Exception:
+                # Inheritance is best-effort — if the private helper moves
+                # or raises, keep the pre-existing yaml-only behavior so
+                # ``chat`` never fails to start due to this merge.
+                pass
+
             _file_has_terminal_config = "terminal" in file_config
 
             # Handle model config - can be string (new format) or dict (old format)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -205,7 +205,7 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_hermes_home, get_default_hermes_root  # noqa: F811,E402
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -3062,10 +3062,206 @@ def read_raw_config() -> Dict[str, Any]:
         config_path = get_config_path()
         if config_path.exists():
             with open(config_path, encoding="utf-8") as f:
-                return yaml.safe_load(f) or {}
+                data = yaml.safe_load(f) or {}
+                if isinstance(data, dict):
+                    return data
     except Exception:
         pass
     return {}
+
+
+def _coerce_model_config(model_value: Any) -> Dict[str, Any]:
+    """Return a dict-shaped model config for merge/diff operations."""
+    if isinstance(model_value, dict):
+        return copy.deepcopy(model_value)
+    if isinstance(model_value, str) and model_value:
+        return {"default": model_value}
+    return {}
+
+
+def _get_profile_root_config_path(config_path: Path) -> Optional[Path]:
+    """Return the root config path when *config_path* belongs to a named profile."""
+    config_home = config_path.parent.resolve()
+    root_home = get_default_hermes_root().resolve()
+    if config_home == root_home:
+        return None
+    if config_home.parent.name != "profiles":
+        return None
+    if config_home.parent.parent.resolve() != root_home:
+        return None
+    return root_home / "config.yaml"
+
+
+# Provider-related sections that should be inherited by named profiles from the
+# root ~/.hermes/config.yaml.  Without this, e.g. ``model.provider: custom:hub``
+# in a profile fails to resolve because ``custom_providers`` is only defined at
+# the root.
+#
+# Sections split into two groups:
+#   - REPLACE_SECTIONS: whole-value replacement. Profile fully overrides if set.
+#     (list-shaped or standalone structures)
+#   - MERGE_SECTIONS: deep-merged dict sections. Profile can override specific
+#     sub-keys while still inheriting root defaults (like the ``model`` field).
+_INHERITED_PROFILE_REPLACE_SECTIONS = (
+    "custom_providers",
+    "fallback_providers",
+    "providers",
+    "fallback_model",
+)
+_INHERITED_PROFILE_MERGE_SECTIONS = (
+    "delegation",
+)
+_INHERITED_PROFILE_PROVIDER_SECTIONS = (
+    _INHERITED_PROFILE_REPLACE_SECTIONS + _INHERITED_PROFILE_MERGE_SECTIONS
+)
+
+
+def _load_inherited_profile_root(
+    config_path: Path,
+    *,
+    expand: bool = False,
+) -> Dict[str, Any]:
+    """Return the normalized root config dict inherited by a named profile."""
+    root_config_path = _get_profile_root_config_path(config_path)
+    if root_config_path is None or not root_config_path.exists():
+        return {}
+
+    try:
+        with open(root_config_path, encoding="utf-8") as f:
+            root_config = yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+    if not isinstance(root_config, dict):
+        return {}
+
+    normalized_root = _normalize_root_model_keys(root_config)
+    if expand:
+        normalized_root = _expand_env_vars(normalized_root)
+    return normalized_root
+
+
+def _load_inherited_profile_model(
+    config_path: Path,
+    *,
+    expand: bool = False,
+) -> Dict[str, Any]:
+    """Load the root-level model config inherited by a named profile."""
+    normalized_root = _load_inherited_profile_root(config_path, expand=expand)
+    if not normalized_root:
+        return {}
+    return _coerce_model_config(normalized_root.get("model"))
+
+
+def _apply_profile_model_inheritance(
+    user_config: Dict[str, Any],
+    config_path: Path,
+) -> Dict[str, Any]:
+    """Merge root-level model + provider sections into a named profile as defaults.
+
+    - ``model`` is deep-merged (profile overrides root field-by-field).
+    - ``custom_providers`` / ``fallback_providers`` / ``providers`` /
+      ``delegation`` / ``fallback_model`` are inherited as a whole when the
+      profile doesn't define them, so references like ``custom:hub`` resolve
+      correctly inside the profile scope (cron jobs, gateway, CLI).
+    """
+    normalized_root = _load_inherited_profile_root(config_path)
+    if not normalized_root:
+        return user_config
+
+    merged_config = dict(user_config)
+
+    inherited_model = _coerce_model_config(normalized_root.get("model"))
+    if inherited_model:
+        profile_model = _coerce_model_config(merged_config.get("model"))
+        if profile_model:
+            merged_config["model"] = _deep_merge(
+                copy.deepcopy(inherited_model), profile_model
+            )
+        else:
+            merged_config["model"] = copy.deepcopy(inherited_model)
+
+    for key in _INHERITED_PROFILE_REPLACE_SECTIONS:
+        if key not in normalized_root:
+            continue
+        if key in merged_config and merged_config[key] not in (None, [], {}):
+            continue
+        merged_config[key] = copy.deepcopy(normalized_root[key])
+
+    for key in _INHERITED_PROFILE_MERGE_SECTIONS:
+        if key not in normalized_root:
+            continue
+        inherited_section = normalized_root[key]
+        profile_section = merged_config.get(key)
+        if isinstance(inherited_section, dict) and isinstance(profile_section, dict):
+            # Empty strings in the profile are treated as "not set" so they
+            # don't shadow a meaningful inherited value (e.g. delegation
+            # template left blank by the user).
+            cleaned_profile = {
+                k: v for k, v in profile_section.items() if v != ""
+            }
+            merged_config[key] = _deep_merge(
+                copy.deepcopy(inherited_section), cleaned_profile
+            )
+        elif key not in merged_config or merged_config[key] in (None, [], {}):
+            merged_config[key] = copy.deepcopy(inherited_section)
+
+    return merged_config
+
+
+def _diff_nested_dict(base: Dict[str, Any], current: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only the keys in *current* whose values differ from *base*."""
+    diff: Dict[str, Any] = {}
+    for key, value in current.items():
+        if key not in base:
+            diff[key] = copy.deepcopy(value)
+            continue
+
+        base_value = base[key]
+        if isinstance(base_value, dict) and isinstance(value, dict):
+            nested = _diff_nested_dict(base_value, value)
+            if nested:
+                diff[key] = nested
+        elif value != base_value:
+            diff[key] = copy.deepcopy(value)
+    return diff
+
+
+def _strip_inherited_profile_model(
+    config: Dict[str, Any],
+    config_path: Path,
+) -> Dict[str, Any]:
+    """Persist only profile-specific overrides, not inherited root values.
+
+    Strips the ``model`` sub-fields that match the inherited root values, and
+    drops inherited provider-related sections entirely when the profile's copy
+    is byte-equal to the root's.
+    """
+    normalized_root = _load_inherited_profile_root(config_path, expand=True)
+    if not normalized_root:
+        return config
+
+    stripped_config = dict(config)
+
+    inherited_model = _coerce_model_config(normalized_root.get("model"))
+    if inherited_model:
+        effective_model = _coerce_model_config(stripped_config.get("model"))
+        if not effective_model:
+            stripped_config.pop("model", None)
+        else:
+            model_overrides = _diff_nested_dict(inherited_model, effective_model)
+            if model_overrides:
+                stripped_config["model"] = model_overrides
+            else:
+                stripped_config.pop("model", None)
+
+    for key in _INHERITED_PROFILE_PROVIDER_SECTIONS:
+        if key not in stripped_config or key not in normalized_root:
+            continue
+        if stripped_config[key] == normalized_root[key]:
+            stripped_config.pop(key, None)
+
+    return stripped_config
 
 
 def load_config() -> Dict[str, Any]:
@@ -3086,6 +3282,8 @@ def load_config() -> Dict[str, Any]:
                     agent_user_config["max_turns"] = user_config["max_turns"]
                 user_config["agent"] = agent_user_config
                 user_config.pop("max_turns", None)
+            user_config = _normalize_root_model_keys(user_config)
+            user_config = _apply_profile_model_inheritance(user_config, config_path)
 
             config = _deep_merge(config, user_config)
         except Exception as e:
@@ -3186,6 +3384,7 @@ def save_config(config: Dict[str, Any]):
             raw_existing,
             _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
         )
+    normalized = _strip_inherited_profile_model(normalized, config_path)
 
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -345,3 +345,130 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestProfileInheritance:
+    """When HERMES_HOME points at ``profiles/<name>/``, ``load_cli_config``
+    must inherit ``model`` / ``custom_providers`` / ``providers`` /
+    ``delegation`` / ``fallback_model`` from the root ``~/.hermes/config.yaml``
+    — the same way ``hermes_cli.config.load_config`` does for every other
+    command (status / model / platform gateway / cron subagents).
+
+    Regression guard for the bug where ``hermes --profile X chat -q ...``
+    reported ``No inference provider configured`` on any profile that did
+    not redundantly copy the model section from the root config.
+    """
+
+    def _write_root_and_profile(self, tmp_path, root_yaml, profile_yaml):
+        import yaml
+
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        (hermes_root / "config.yaml").write_text(yaml.safe_dump(root_yaml))
+
+        profile_dir = hermes_root / "profiles" / "myprofile"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text(yaml.safe_dump(profile_yaml))
+
+        return hermes_root, profile_dir
+
+    def test_profile_inherits_model_from_root(self, tmp_path, monkeypatch):
+        """A profile with no ``model:`` section must pick up the root's model."""
+        hermes_root, profile_dir = self._write_root_and_profile(
+            tmp_path,
+            root_yaml={
+                "model": {
+                    "default": "glm-5-turbo",
+                    "provider": "custom:hub",
+                },
+            },
+            profile_yaml={
+                # Profile only overrides discord — must still inherit model.
+                "discord": {"token": "fake"},
+            },
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", profile_dir)
+        cfg = cli.load_cli_config()
+
+        assert cfg["model"]["default"] == "glm-5-turbo"
+        assert cfg["model"]["provider"] == "custom:hub"
+
+    def test_profile_inherits_custom_providers_from_root(self, tmp_path, monkeypatch):
+        """Custom providers (e.g. ``custom:hub``) referenced by ``model.provider``
+        must be visible inside the profile scope — otherwise ``resolve_runtime_
+        provider`` cannot resolve the provider referenced by the inherited model.
+        """
+        hermes_root, profile_dir = self._write_root_and_profile(
+            tmp_path,
+            root_yaml={
+                "model": {"default": "glm-5-turbo", "provider": "custom:hub"},
+                "custom_providers": {
+                    "custom:hub": {
+                        "base_url": "https://hub.example.com/v1",
+                        "api_key_env": "HUB_API_KEY",
+                    },
+                },
+            },
+            profile_yaml={"discord": {"token": "fake"}},
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", profile_dir)
+        cfg = cli.load_cli_config()
+
+        providers = cfg.get("custom_providers") or {}
+        assert isinstance(providers, dict)
+        assert "custom:hub" in providers
+        assert providers["custom:hub"]["base_url"] == "https://hub.example.com/v1"
+
+    def test_profile_can_override_inherited_model(self, tmp_path, monkeypatch):
+        """When the profile explicitly sets a model, it wins over the root's."""
+        hermes_root, profile_dir = self._write_root_and_profile(
+            tmp_path,
+            root_yaml={
+                "model": {"default": "glm-5-turbo", "provider": "custom:hub"},
+            },
+            profile_yaml={
+                "model": {"default": "anthropic/claude-sonnet-4"},
+            },
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", profile_dir)
+        cfg = cli.load_cli_config()
+
+        assert cfg["model"]["default"] == "anthropic/claude-sonnet-4"
+        # provider falls through from root (profile didn't override it)
+        assert cfg["model"]["provider"] == "custom:hub"
+
+    def test_root_only_config_unchanged(self, tmp_path, monkeypatch):
+        """When HERMES_HOME is the root (not a profile), inheritance is a no-op.
+
+        This guards against the regression where the inheritance shortcut
+        would accidentally re-normalize root-level keys and defeat the
+        ``load_cli_config`` stale-root-key fallback protection that lives
+        further down in this function.
+        """
+        import yaml
+
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        (hermes_root / "config.yaml").write_text(yaml.safe_dump({
+            "provider": "opencode-go",  # stale root key
+            "model": {"default": "google/gemini-3-flash-preview"},
+        }))
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", hermes_root)
+        cfg = cli.load_cli_config()
+
+        # Stale root-level "opencode-go" must NOT leak through when
+        # HERMES_HOME is the root — same guarantee as the existing
+        # TestRootLevelProviderOverride suite.
+        assert cfg["model"]["provider"] != "opencode-go"


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #14642.** The first commit on this branch (``config: inherit provider sections from root into named profiles``) is identical to #14642 — please merge #14642 first, then this PR will show only the `cli.py` + test diff.

## Summary

\`hermes --profile X chat -q \"...\"\` currently reports \`No inference provider configured\` on **every** profile, even when the root \`~/.hermes/config.yaml\` has a valid \`model\` + \`custom_providers\` stanza that every other command (\`status\`, \`model\`, platform gateway, cron subagents) happily picks up.

This is an adjacent bug to #14642: that PR makes profile→root inheritance work inside \`hermes_cli.config.load_config()\`; this PR makes the same inheritance apply in \`cli.py::load_cli_config()\`, which is the loader backing \`hermes chat\`.

## Root cause

- \`hermes_cli.config.load_config()\` calls \`_apply_profile_model_inheritance(user_config, config_path)\` right after the yaml load, so every code path routed through it (Discord gateway, cron subagents, \`status\`, \`model\`, etc.) sees the inherited root config under a profile.
- \`cli.py::load_cli_config()\` does the yaml load by hand via \`yaml.safe_load\` and **skips the inheritance step**. Result, under \`HERMES_HOME=~/.hermes/profiles/<name>\`:
  - \`CLI_CONFIG[\"model\"]\` collapses to the default \`{'default': '', 'provider': 'auto'}\`.
  - \`CLI_CONFIG[\"custom_providers\"]\` stays at the default \`[]\`.
  - Downstream \`resolve_runtime_provider(\"auto\", ...)\` has nothing to resolve and raises \`No inference provider configured\`.

Cross-verified across two unrelated profiles (discord-only yamls) — this is framework-wide, not profile-specific. It stayed hidden because \`hermes chat\` under a profile is rare in day-to-day use (Discord gateway is the usual entry point, and the gateway uses \`load_config\`, not \`load_cli_config\`).

## Fix (cli.py)

In \`cli.py::load_cli_config()\`, right after the \`yaml.safe_load\` call, invoke \`_apply_profile_model_inheritance(file_config, config_path)\` inside a best-effort \`try/except\`. The helper is a no-op when \`config_path\` is NOT under \`profiles/<name>/\`, so the root-level stale-key fallback logic further down in the function (the \`provider:\` at the yaml root that is only used as a *fallback* when \`model.provider\` is unset) keeps its meaning.

Deliberately skip \`_normalize_root_model_keys\` here — that normalizer would promote legacy root-level \`provider:\` into \`model.provider\` and break the existing \`test_root_provider_ignored_when_default_model_provider_exists\` contract (covered below).

## Reproduce on \`main\`

\`\`\`bash
hermes --profile xuangu    chat -q \"ping\"
hermes --profile mupeiling chat -q \"ping\"
# → \"No inference provider configured. Run 'hermes model' ...\"
\`\`\`

Diagnostic:
\`\`\`bash
HERMES_HOME=~/.hermes/profiles/xuangu venv/bin/python -c \"
import sys; sys.path.insert(0, '.')
import cli
print('load_cli_config model:', cli.CLI_CONFIG.get('model'))
from hermes_cli.config import load_config
print('load_config     model:', load_config().get('model'))
\"
# Before: load_cli_config sees empty defaults, load_config sees root's model.
# After:  both see root's model.
\`\`\`

## Test Plan

New \`tests/cli/test_cli_init.py::TestProfileInheritance\` class, 4 cases:

- \`test_profile_inherits_model_from_root\` — profile with only \`discord:\` set must still see root's \`model.default\` / \`model.provider\`.
- \`test_profile_inherits_custom_providers_from_root\` — the \`custom_providers\` dict containing references like \`custom:hub\` must reach \`CLI_CONFIG\` so \`resolve_runtime_provider\` can resolve the provider referenced by the inherited model.
- \`test_profile_can_override_inherited_model\` — explicit profile model wins, but unspecified fields fall through from root.
- \`test_root_only_config_unchanged\` — when \`HERMES_HOME\` is the root (no profile in the path), the pre-existing stale-root-key fallback behavior is preserved.

\`\`\`bash
venv/bin/python -m pytest \\\\
  tests/cli/test_cli_init.py \\\\
  tests/hermes_cli/test_config.py \\\\
  tests/hermes_cli/test_profiles.py \\\\
  tests/hermes_cli/test_config_drift.py \\\\
  tests/hermes_cli/test_ignore_user_config_flags.py \\\\
  -q
\`\`\`

→ **177 passed** on this branch.

## Manual verification

After the patch:

\`\`\`
\$ hermes --profile xuangu chat -q \"回复一个字：好\"
...
╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮
    好
╰──────────────────────────────────────────────────────────────────────────────╯
\`\`\`

Same on \`mupeiling\` (cross-profile verification confirming this is framework-wide).

## Scope (excluding #14642 commit)

- \`cli.py\`: +34 / -1 (the fix is 11 added lines + an extensive comment explaining why \`_normalize_root_model_keys\` is *not* called here).
- \`tests/cli/test_cli_init.py\`: +127 (the \`TestProfileInheritance\` class, including the root-only regression guard).

Made with [Cursor](https://cursor.com)