### PR TITLE
fix(windows): native Git Bash terminal — exit 126 with empty output

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,6 +10,7 @@ import codecs
 import json
 import logging
 import os
+import platform as _platform
 import select
 import shlex
 import subprocess
@@ -19,6 +20,8 @@ import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import IO, Callable, Protocol
+
+_IS_WINDOWS_BASE = _platform.system() == "Windows"
 
 from hermes_constants import get_hermes_home
 from tools.interrupt import is_interrupted
@@ -465,6 +468,24 @@ class BaseEnvironment(ABC):
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
         def _drain():
+            # Windows: select.select does not work with pipe file descriptors —
+            # it raises OSError (WinError 10038: not a socket).  Without this
+            # branch the drain thread exits immediately on the first iteration,
+            # no stdout is ever captured, and self.cwd is never updated from
+            # the __HERMES_CWD__ marker.  Use blocking reads instead: Python
+            # 3.7+ subprocess on Windows does not propagate pipe handles to
+            # grandchild processes, so EOF arrives promptly when bash exits.
+            if _IS_WINDOWS_BASE:
+                try:
+                    while True:
+                        chunk = proc.stdout.read(4096)
+                        if not chunk:
+                            break
+                        output_chunks.append(chunk)
+                except Exception:
+                    pass
+                return
+
             fd = proc.stdout.fileno()
             idle_after_exit = 0
             try:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -176,6 +176,44 @@ def _find_bash() -> str:
 _find_shell = _find_bash
 
 
+def _win_to_posix_path(path: str) -> str:
+    """Convert a Windows path (``C:\\Users\\…``) to a Git Bash POSIX path
+    (``/c/Users/…``).
+
+    Git Bash's ``builtin cd`` does not accept single-quoted Windows paths with
+    backslashes — it requires POSIX form — so ``builtin cd 'C:\\Users\\…'``
+    fails and the wrapper script exits 126.  Converting to ``/c/Users/…``
+    before interpolating into the script fixes it.  No-op off Windows.
+    """
+    if not _IS_WINDOWS:
+        return path
+    if len(path) >= 2 and path[1] == ':' and path[0].isalpha():
+        drive = path[0].lower()
+        rest = path[2:].replace('\\', '/')
+        if rest and not rest.startswith('/'):
+            rest = '/' + rest
+        return f"/{drive}{rest}"
+    return path
+
+
+def _posix_to_win_path(path: str) -> str:
+    """Convert a Git Bash POSIX path (``/c/Users/…``) back to a Windows path
+    (``C:/Users/…``).
+
+    After ``init_session``, ``self.cwd`` can be updated from Git Bash's
+    ``pwd -P`` output, which emits ``/c/Users/…``.  Windows ``CreateProcess``
+    (invoked via ``subprocess.Popen(cwd=…)``) does not understand that form.
+    Convert back so Popen succeeds.  No-op off Windows.
+    """
+    if not _IS_WINDOWS:
+        return path
+    if len(path) >= 3 and path[0] == '/' and path[2] == '/' and path[1].isalpha():
+        drive = path[1].upper()
+        rest = path[3:]
+        return f"{drive}:/{rest}"
+    return path
+
+
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
@@ -311,6 +349,12 @@ class LocalEnvironment(BaseEnvironment):
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.
 
+        On Windows, return the system temp dir (``C:/Users/…/Temp``) with
+        forward slashes — that path is valid for both Windows ``open()`` and
+        Git Bash ``source``/``pwd``, so the session snapshot and CWD files
+        are readable from both sides. The old ``/tmp`` fallback resolved to
+        ``C:\\tmp`` under Windows Python and silently ``FileNotFoundError``'d.
+
         Termux does not provide /tmp by default, but exposes a POSIX TMPDIR.
         Prefer POSIX-style env vars when available, keep using /tmp on regular
         Unix systems, and only fall back to tempfile.gettempdir() when it also
@@ -320,6 +364,10 @@ class LocalEnvironment(BaseEnvironment):
         override the temp root explicitly (for example via terminal.env or a
         custom TMPDIR), then fall back to the host process environment.
         """
+        if _IS_WINDOWS:
+            td = tempfile.gettempdir().replace('\\', '/')
+            return td.rstrip('/') or 'C:/Temp'
+
         for env_var in ("TMPDIR", "TMP", "TEMP"):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
             if candidate and candidate.startswith("/"):
@@ -333,6 +381,21 @@ class LocalEnvironment(BaseEnvironment):
             return candidate.rstrip("/") or "/"
 
         return "/tmp"
+
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        """Override to convert a Windows cwd to POSIX form before it reaches
+        the generated bash script.
+
+        ``BaseEnvironment._wrap_command`` emits ``builtin cd {shlex.quote(cwd)}
+        || exit 126``.  When ``cwd`` is a Windows path, ``shlex.quote`` wraps
+        it in single quotes with literal backslashes
+        (``'C:\\Users\\…'``), which Git Bash's ``builtin cd`` does not accept —
+        producing exit code 126 on every command.  Converting to POSIX form
+        (``/c/Users/…``) restores expected behavior. No-op off Windows.
+        """
+        if _IS_WINDOWS:
+            cwd = _win_to_posix_path(cwd)
+        return super()._wrap_command(command, cwd)
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
@@ -351,6 +414,12 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # On Windows, self.cwd may be a Git Bash POSIX path (/c/Users/…)
+        # after init_session updates it from the pwd -P marker. Windows
+        # CreateProcess (via subprocess.Popen(cwd=)) does not understand that
+        # form, so convert back to a Windows path for the Popen call only.
+        popen_cwd = _posix_to_win_path(self.cwd) if _IS_WINDOWS else self.cwd
+
         proc = subprocess.Popen(
             args,
             text=True,
@@ -361,7 +430,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            cwd=self.cwd,
+            cwd=popen_cwd,
         )
 
         if stdin_data is not None:


### PR DESCRIPTION
Fixes #14638.

## What this PR does

Makes the **native-Windows / Git Bash** `terminal.backend: local` path actually work. Currently every `terminal()` call returns `exit_code: 126` with empty output; after this patch, `echo hello` returns `hello`, cwd persists across calls, and multi-line stdout is captured.

## Root causes (three compounding bugs)

1. **`select.select` does not accept pipe fds on Windows.** `_drain` in `base.py` hits `OSError 10038` on the first iteration and exits without reading stdout → empty output, `self.cwd` never updated from the `__HERMES_CWD__` marker.
2. **`get_temp_dir()` falls back to `/tmp`.** Python on Windows resolves that to `C:\tmp` (doesn't exist), so `_update_cwd`'s `open()` silently `FileNotFoundError`s.
3. **`builtin cd 'C:\Users\...' \|\| exit 126`** — Git Bash's builtin `cd` does not accept single-quoted Windows backslash paths. Needs POSIX form (`/c/Users/...`). This is the direct source of the 126.

## Fix

- `base.py`: Windows branch in `_drain` uses blocking `proc.stdout.read(4096)` instead of `select.select` (Py 3.7+ subprocess on Windows doesn't propagate pipe handles to grandchildren, so EOF arrives promptly).
- `local.py`: `get_temp_dir()` returns `tempfile.gettempdir().replace('\', '/')` on Windows — path valid for both Python and Git Bash.
- `local.py`: new `_win_to_posix_path` / `_posix_to_win_path` helpers. `LocalEnvironment._wrap_command` is overridden to convert cwd before interpolation; `_run_bash` converts back for `subprocess.Popen(cwd=)`.

All three are Windows-only branches; non-Windows code paths are untouched.

## Verified locally

On Windows 11 + Git for Windows:

```
TEST 1 echo:  {\"output\": \"hello_from_fork\", \"exit_code\": 0, \"error\": null}
TEST 2 pwd:   {\"output\": \"/c/Users/WIN10/Projects/hermes-agent\", \"exit_code\": 0}
TEST 3 cd:    {\"output\": \"/tmp\", \"exit_code\": 0}
TEST 4 after: {\"output\": \"/tmp\", \"exit_code\": 0}   # cwd persisted
```

## Known gaps (NOT in this PR)

This fixes the core terminal path only. Still broken on Windows/Git Bash:

- `pty=True` — imports `pty` / `termios` which don't exist on Windows.
- Process-tree kill — `_kill_process` on Windows only `proc.terminate()`s; backgrounded grandchildren can leak.
- Browser tool `WinError 193` — `npx.cmd` / `agent-browser` shim launched without `shell=True`.
- Docker / SSH backend cwd translation on Windows hosts — untested here.

Happy to follow up with separate PRs for any of these.

## Scope decision is yours

I realize this might be against current direction — the install docs say *"Requires WSL2 on Windows"* while the code's `_find_bash()` still searches `C:\Program Files\Git\bin\bash.exe`. If Git Bash support was deliberately deprecated, **happy to flip this PR** into the opposite change instead: delete the Windows branch in `_find_bash()`, fail loud at init with a clear *\"install WSL2\"* message, so users don't waste time debugging mysterious exit-126s.

Either direction is better than the current state (code half-supports Git Bash but silently fails). Let me know which you prefer and I'll adjust.

---

Why native Git Bash matters (user side, for context): WSL2 carries a ~1–2 GB RAM baseline, conflicts with VirtualBox/Android emulators via Hyper-V, and access to Windows-hosted repos incurs 9p filesystem perf costs. For users on constrained machines (which is the reporter's case), the native path is meaningfully cheaper — if it works.