### PR TITLE
fix(gateway): use Slack slash command in onboarding

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4414,12 +4414,13 @@ class GatewayRunner:
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
+                    sethome_cmd = "/hermes sethome" if source.platform == Platform.SLACK else "/sethome"
                     await adapter.send(
                         source.chat_id,
                         f"📬 No home channel is set for {platform_name.title()}. "
                         f"A home channel is where Hermes delivers cron job results "
                         f"and cross-platform messages.\n\n"
-                        f"Type /sethome to make this chat your home channel, "
+                        f"Type {sethome_cmd} to make this chat your home channel, "
                         f"or ignore to skip."
                     )
         

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -12,9 +12,9 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
-def _make_source() -> SessionSource:
+def _make_source(platform: Platform = Platform.TELEGRAM) -> SessionSource:
     return SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=platform,
         user_id="u1",
         chat_id="c1",
         user_name="tester",
@@ -22,24 +22,24 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str) -> MessageEvent:
+def _make_event(text: str, *, platform: Platform = Platform.TELEGRAM) -> MessageEvent:
     return MessageEvent(
         text=text,
-        source=_make_source(),
+        source=_make_source(platform),
         message_id="m1",
     )
 
 
-def _make_runner(session_entry: SessionEntry):
+def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.TELEGRAM):
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        platforms={platform: PlatformConfig(enabled=True, token="***")}
     )
     adapter = MagicMock()
     adapter.send = AsyncMock()
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
@@ -222,6 +222,93 @@ async def test_handle_message_persists_agent_token_counts(monkeypatch):
         session_entry.session_key,
         last_prompt_tokens=80,
     )
+
+
+@pytest.mark.asyncio
+async def test_first_run_slack_home_channel_onboarding_uses_parent_command(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source(Platform.SLACK)),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry, platform=Platform.SLACK)
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = False
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": "openai/test-model",
+        }
+    )
+
+    monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello", platform=Platform.SLACK))
+
+    assert result == "ok"
+    runner.adapters[Platform.SLACK].send.assert_awaited_once()
+    onboarding = runner.adapters[Platform.SLACK].send.await_args.args[1]
+    assert "/hermes sethome" in onboarding
+    assert "Type /sethome" not in onboarding
+
+
+@pytest.mark.asyncio
+async def test_first_run_non_slack_home_channel_onboarding_keeps_direct_command(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source(Platform.TELEGRAM)),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry, platform=Platform.TELEGRAM)
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = False
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": "openai/test-model",
+        }
+    )
+
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello", platform=Platform.TELEGRAM))
+
+    assert result == "ok"
+    runner.adapters[Platform.TELEGRAM].send.assert_awaited_once()
+    onboarding = runner.adapters[Platform.TELEGRAM].send.await_args.args[1]
+    assert "Type /sethome" in onboarding
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #14632.

## Root cause
The first-run home-channel onboarding message in `gateway/run.py` was platform-agnostic and always suggested `/sethome`. That is wrong on Slack, where Hermes dispatches slash commands through `/hermes <subcommand>`.

## What changed
- use `/hermes sethome` in the onboarding hint for Slack only
- preserve `/sethome` for platforms that support direct top-level commands
- add regression tests for both Slack and non-Slack onboarding paths

## Tests
- `python -m pytest tests/gateway/test_status_command.py -q --tb=short`
- `git diff --check`
