### PR TITLE
Change auto_archive_duration type to string

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -669,8 +669,8 @@ def _build_schema(
             "description": "Snowflake ID for forward pagination (fetch_messages).",
         },
         "auto_archive_duration": {
-            "type": "integer",
-            "enum": [60, 1440, 4320, 10080],
+            "type": "string",
+            "enum": ["60", "1440", "4320", "10080"],
             "description": "Thread archive duration in minutes (create_thread, default 1440).",
         },
     }
@@ -883,7 +883,7 @@ registry.register(
         limit=args.get("limit", 50),
         before=args.get("before", ""),
         after=args.get("after", ""),
-        auto_archive_duration=args.get("auto_archive_duration", 1440),
+        auto_archive_duration=int(args.get("auto_archive_duration", 1440)),
         task_id=kw.get("task_id"),
     ),
     check_fn=check_discord_tool_requirements,


### PR DESCRIPTION
Fixes #13653

## What does this PR do?

Fixes a bug where cron jobs fail with Google AI API validation errors when using the `discord_server` tool. The issue is that the `auto_archive_duration` parameter had an integer enum `[60, 1440, 4320, 10080]`, but Google AI API requires string enums. This caused cron jobs (which include the `discord_server` tool in their tool list) to fail with errors like:
- `function_declarations[11].parameters.required[0]: property is not defined`
- `parameters.properties[11].value.enum[0]: cannot be empty` / `TYPE_STRING, 60`

## Related Issue

Fixes #13653

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/discord_tool.py`: Changed `auto_archive_duration` schema enum from integers `[60, 1440, 4320, 10080]` to strings `["60", "1440", "4320", "10080"]`
- `tools/discord_tool.py`: Updated handler to convert string input back to integer with `int(args.get("auto_archive_duration", 1440))`

## How to Test

1. Reproduce the original issue: Create a cron job and run it - it should fail with the error shown in #13653
2. After the fix: Run the same cron job - it should succeed
3. Verify the schema: Check that `auto_archive_duration` in `_STATIC_SCHEMA` now has string enum values
4. It's likely related to using the gemma-4 model, or just Gemini models in general, so test with those

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

