### PR TITLE
feat: support project-local skills and stack-based recommendations

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -18,8 +18,8 @@ from typing import Optional
 from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
-    get_all_skills_dirs,
     get_disabled_skill_names,
+    get_runtime_skills_dirs,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_platform,
@@ -483,21 +483,25 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
         except OSError as e:
             logger.debug("Could not remove skills prompt snapshot: %s", e)
 
-
-def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
+def _build_skills_manifest(skills_dirs: list[Path]) -> dict[str, list[int]]:
     """Build an mtime/size manifest of all SKILL.md and DESCRIPTION.md files."""
     manifest: dict[str, list[int]] = {}
-    for filename in ("SKILL.md", "DESCRIPTION.md"):
-        for path in iter_skill_index_files(skills_dir, filename):
-            try:
-                st = path.stat()
-            except OSError:
-                continue
-            manifest[str(path.relative_to(skills_dir))] = [st.st_mtime_ns, st.st_size]
+    for idx, skills_dir in enumerate(skills_dirs):
+        if not skills_dir.exists():
+            continue
+        prefix = f"{idx}:{skills_dir.resolve()}"
+        for filename in ("SKILL.md", "DESCRIPTION.md"):
+            for path in iter_skill_index_files(skills_dir, filename):
+                try:
+                    st = path.stat()
+                except OSError:
+                    continue
+                manifest[f"{prefix}:{path.relative_to(skills_dir)}"] = [st.st_mtime_ns, st.st_size]
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+
+def _load_skills_snapshot(skills_dirs: list[Path]) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -510,13 +514,14 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    if snapshot.get("manifest") != _build_skills_manifest(skills_dirs):
         return None
     return snapshot
 
 
+
 def _write_skills_snapshot(
-    skills_dir: Path,
+    skills_dirs: list[Path],
     manifest: dict[str, list[int]],
     skill_entries: list[dict],
     category_descriptions: dict[str, str],
@@ -625,27 +630,20 @@ def build_skills_system_prompt(
     """Build a compact skill index for the system prompt.
 
     Two-layer cache:
-      1. In-process LRU dict keyed by (skills_dir, tools, toolsets)
+      1. In-process LRU dict keyed by runtime skill dirs, tools, toolsets
       2. Disk snapshot (``.skills_prompt_snapshot.json``) validated by
          mtime/size manifest — survives process restarts
 
     Falls back to a full filesystem scan when both layers miss.
-
-    External skill directories (``skills.external_dirs`` in config.yaml) are
-    scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
-    are read-only — they appear in the index but new skills are always created
-    in the local dir.  Local skills take precedence when names collide.
     """
-    skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    runtime_dirs = [d.resolve() for d in get_runtime_skills_dirs()]
 
-    if not skills_dir.exists() and not external_dirs:
+    if not any(path.exists() for path in runtime_dirs):
         return ""
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
-    # Include the resolved platform so per-platform disabled-skill lists
-    # produce distinct cache entries (gateway serves multiple platforms).
     from gateway.session_context import get_session_env
+
     _platform_hint = (
         os.environ.get("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
@@ -653,8 +651,7 @@ def build_skills_system_prompt(
     )
     disabled = get_disabled_skill_names()
     cache_key = (
-        str(skills_dir.resolve()),
-        tuple(str(d) for d in external_dirs),
+        tuple(str(d) for d in runtime_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
@@ -667,13 +664,12 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(runtime_dirs)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
 
     if snapshot is not None:
-        # Fast path: use pre-parsed metadata from disk
         for entry in snapshot.get("skills", []):
             if not isinstance(entry, dict):
                 continue
@@ -699,69 +695,23 @@ def build_skills_system_prompt(
             for k, v in (snapshot.get("category_descriptions") or {}).items()
         }
     else:
-        # Cold path: full filesystem scan + write snapshot for next time
         skill_entries: list[dict] = []
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
-            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-            entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
-            skill_entries.append(entry)
-            if not is_compatible:
+        seen_skill_names: set[str] = set()
+
+        for skills_dir in runtime_dirs:
+            if not skills_dir.exists():
                 continue
-            skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                extract_skill_conditions(frontmatter),
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
-            )
 
-        # Read category-level DESCRIPTION.md files
-        for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
-            try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(skills_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions[cat] = str(cat_desc).strip().strip("'\"")
-            except Exception as e:
-                logger.debug("Could not read skill description %s: %s", desc_file, e)
-
-        _write_skills_snapshot(
-            skills_dir,
-            _build_skills_manifest(skills_dir),
-            skill_entries,
-            category_descriptions,
-        )
-
-    # ── External skill directories ─────────────────────────────────────
-    # Scan external dirs directly (no snapshot caching — they're read-only
-    # and typically small).  Local skills already in skills_by_category take
-    # precedence: we track seen names and skip duplicates from external dirs.
-    seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
-
-    for ext_dir in external_dirs:
-        if not ext_dir.exists():
-            continue
-        for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
-            try:
+            for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
                 is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-                if not is_compatible:
-                    continue
-                entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
+                entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
                 skill_name = entry["skill_name"]
                 frontmatter_name = entry["frontmatter_name"]
                 if frontmatter_name in seen_skill_names:
+                    continue
+                seen_skill_names.add(frontmatter_name)
+                skill_entries.append(entry)
+                if not is_compatible:
                     continue
                 if frontmatter_name in disabled or skill_name in disabled:
                     continue
@@ -771,26 +721,29 @@ def build_skills_system_prompt(
                     available_toolsets,
                 ):
                     continue
-                seen_skill_names.add(frontmatter_name)
                 skills_by_category.setdefault(entry["category"], []).append(
                     (frontmatter_name, entry["description"])
                 )
-            except Exception as e:
-                logger.debug("Error reading external skill %s: %s", skill_file, e)
 
-        # External category descriptions
-        for desc_file in iter_skill_index_files(ext_dir, "DESCRIPTION.md"):
-            try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(ext_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
-            except Exception as e:
-                logger.debug("Could not read external skill description %s: %s", desc_file, e)
+            for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
+                try:
+                    content = desc_file.read_text(encoding="utf-8")
+                    fm, _ = parse_frontmatter(content)
+                    cat_desc = fm.get("description")
+                    if not cat_desc:
+                        continue
+                    rel = desc_file.relative_to(skills_dir)
+                    cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
+                    category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
+                except Exception as e:
+                    logger.debug("Could not read skill description %s: %s", desc_file, e)
+
+        _write_skills_snapshot(
+            runtime_dirs,
+            _build_skills_manifest(runtime_dirs),
+            skill_entries,
+            category_descriptions,
+        )
 
     if not skills_by_category:
         result = ""
@@ -802,7 +755,6 @@ def build_skills_system_prompt(
                 index_lines.append(f"  {category}: {cat_desc}")
             else:
                 index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
             seen = set()
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
@@ -837,7 +789,6 @@ def build_skills_system_prompt(
             "Only proceed without loading a skill if genuinely none are relevant to the task."
         )
 
-    # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:
         _SKILLS_PROMPT_CACHE[cache_key] = result
         _SKILLS_PROMPT_CACHE.move_to_end(cache_key)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -345,17 +345,15 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_runtime_skills_dirs
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
+        dirs_to_scan = get_runtime_skills_dirs()
 
         for scan_dir in dirs_to_scan:
+            if not scan_dir.exists():
+                continue
             for skill_md in scan_dir.rglob("SKILL.md"):
                 if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
                     continue

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -168,6 +168,82 @@ def _normalize_string_set(values) -> Set[str]:
     return {str(v).strip() for v in values if str(v).strip()}
 
 
+# ── Runtime cwd / repo helpers ───────────────────────────────────────────
+
+
+def resolve_runtime_cwd(cwd: Path | str | None = None) -> Path:
+    """Resolve the active runtime cwd for session-scoped project inspection."""
+    if cwd is not None:
+        return Path(cwd).expanduser().resolve()
+
+    terminal_cwd = os.getenv("TERMINAL_CWD")
+    if terminal_cwd:
+        return Path(terminal_cwd).expanduser().resolve()
+
+    return Path(os.getcwd()).resolve()
+
+
+
+def find_git_root(start: Path | str) -> Optional[Path]:
+    """Walk *start* and its parents looking for a ``.git`` directory."""
+    current = Path(start).expanduser().resolve()
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+
+def get_project_local_skills_dirs(cwd: Path | str | None = None) -> List[Path]:
+    """Return project-local skill dirs from nearest cwd ancestor to git root.
+
+    Search order at each level is ``.hermes/skills`` first, then
+    ``.agents/skills``. If no git root is found, only the current directory is
+    inspected.
+    """
+    start = resolve_runtime_cwd(cwd)
+    stop_at = find_git_root(start)
+
+    directories = [start] if stop_at is None else [start, *start.parents]
+    result: List[Path] = []
+    seen: Set[Path] = set()
+
+    for directory in directories:
+        for rel in (".hermes/skills", ".agents/skills"):
+            candidate = directory / rel
+            if not candidate.is_dir():
+                continue
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            result.append(resolved)
+        if stop_at is not None and directory == stop_at:
+            break
+
+    return result
+
+
+
+def get_runtime_skills_dirs(cwd: Path | str | None = None) -> List[Path]:
+    """Return runtime skill directories with project-local precedence first."""
+    ordered: List[Path] = []
+    seen: Set[Path] = set()
+
+    for path in [
+        *get_project_local_skills_dirs(cwd),
+        get_skills_dir(),
+        *get_external_skills_dirs(),
+    ]:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(resolved)
+
+    return ordered
+
+
 # ── External skills directories ──────────────────────────────────────────
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7642,6 +7642,21 @@ Examples:
     )
     skills_search.add_argument("--limit", type=int, default=10, help="Max results")
 
+    skills_recommend = skills_subparsers.add_parser(
+        "recommend", help="Recommend skills for a project"
+    )
+    skills_recommend.add_argument("path", nargs="?", default=".", help="Project path (default: current directory)")
+    skills_recommend.add_argument(
+        "--source",
+        default="all",
+        choices=["all", "official"],
+        help="Filter recommendations by source (default: all)",
+    )
+    skills_recommend.add_argument("--limit", type=int, default=20, help="Max results per section")
+    skills_recommend.add_argument("--json", action="store_true", help="Print JSON output")
+    skills_recommend.add_argument("--install", action="store_true", help="Install recommended remote skills")
+    skills_recommend.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts during install")
+
     skills_install = skills_subparsers.add_parser("install", help="Install a skill")
     skills_install.add_argument(
         "identifier", help="Skill identifier (e.g. openai/skills/skill-creator)"
@@ -7666,7 +7681,7 @@ Examples:
 
     skills_list = skills_subparsers.add_parser("list", help="List installed skills")
     skills_list.add_argument(
-        "--source", default="all", choices=["all", "hub", "builtin", "local"]
+        "--source", default="all", choices=["all", "hub", "builtin", "local", "project-local"]
     )
 
     skills_check = skills_subparsers.add_parser(

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -600,7 +600,7 @@ def inspect_skill(identifier: str) -> Optional[dict]:
 
 
 def do_list(source_filter: str = "all", console: Optional[Console] = None) -> None:
-    """List installed skills, distinguishing hub, builtin, and local skills."""
+    """List installed skills, distinguishing hub, builtin, local, and project-local."""
     from tools.skills_hub import HubLockFile, ensure_hub_dirs
     from tools.skills_sync import _read_manifest
     from tools.skills_tool import _find_all_skills
@@ -622,6 +622,7 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
     hub_count = 0
     builtin_count = 0
     local_count = 0
+    project_local_count = 0
 
     for skill in sorted(all_skills, key=lambda s: (s.get("category") or "", s["name"])):
         name = skill["name"]
@@ -638,9 +639,14 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
             source_display = "builtin"
             trust = "builtin"
             builtin_count += 1
+        elif skill.get("scope") == "project-local":
+            source_type = "project-local"
+            source_display = skill.get("source", "project-local")
+            trust = "local"
+            project_local_count += 1
         else:
             source_type = "local"
-            source_display = "local"
+            source_display = skill.get("source", "local")
             trust = "local"
             local_count += 1
 
@@ -653,8 +659,58 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
 
     c.print(table)
     c.print(
-        f"[dim]{hub_count} hub-installed, {builtin_count} builtin, {local_count} local[/]\n"
+        f"[dim]{hub_count} hub-installed, {builtin_count} builtin, {local_count} local, {project_local_count} project-local[/]\n"
     )
+
+
+
+def do_recommend(path: str = ".", source: str = "all", limit: int = 20,
+                 install: bool = False, as_json: bool = False,
+                 skip_confirm: bool = False,
+                 console: Optional[Console] = None) -> None:
+    """Recommend skills for a project path based on stack detection."""
+    from tools.skills_recommend import recommend_skills
+
+    c = console or _console
+    result = recommend_skills(path, source_filter=source, limit=limit)
+
+    if as_json:
+        c.print(json.dumps(result, ensure_ascii=False))
+        return
+
+    detected = result.get("detected", {})
+    technologies = ", ".join(detected.get("technologies", [])) or "none"
+    combos = ", ".join(detected.get("combos", [])) or "none"
+    c.print(f"\n[bold]Project:[/] {detected.get('root', path)}")
+    c.print(f"[dim]Technologies:[/] {technologies}")
+    c.print(f"[dim]Combos:[/] {combos}\n")
+
+    sections = [
+        ("Already available in this project", result.get("available", [])),
+        ("Official Hermes optional skills", result.get("official", [])),
+        ("Third-party skills", result.get("third_party", [])),
+    ]
+
+    for title, items in sections:
+        c.print(f"[bold]{title}[/]")
+        if not items:
+            c.print("[dim]  (none)[/]\n")
+            continue
+        for item in items:
+            identifier = item.get("identifier", item.get("name", ""))
+            matched_on = ", ".join(item.get("matched_on", []))
+            reason = item.get("reason", "")
+            c.print(f"  - [cyan]{item.get('name', identifier)}[/] — {identifier}")
+            if matched_on:
+                c.print(f"    [dim]matched on:[/] {matched_on}")
+            if reason:
+                c.print(f"    [dim]{reason}[/]")
+        c.print()
+
+    if install:
+        installable = [*result.get("official", []), *result.get("third_party", [])]
+        for item in installable:
+            do_install(item["identifier"], force=False, skip_confirm=skip_confirm, console=c)
 
 
 def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> None:
@@ -1121,6 +1177,15 @@ def skills_command(args) -> None:
         do_browse(page=args.page, page_size=args.size, source=args.source)
     elif action == "search":
         do_search(args.query, source=args.source, limit=args.limit)
+    elif action == "recommend":
+        do_recommend(
+            path=getattr(args, "path", "."),
+            source=getattr(args, "source", "all"),
+            limit=getattr(args, "limit", 20),
+            install=getattr(args, "install", False),
+            as_json=getattr(args, "json", False),
+            skip_confirm=getattr(args, "yes", False),
+        )
     elif action == "install":
         do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False))
@@ -1173,10 +1238,11 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     """
     Parse and dispatch `/skills <subcommand> [args]` from the chat interface.
 
-    Examples:
+        /skills browse
         /skills search kubernetes
+        /skills recommend .
         /skills install openai/skills/skill-creator
-        /skills install openai/skills/skill-creator --force
+
         /skills inspect openai/skills/skill-creator
         /skills list
         /skills list --source hub
@@ -1250,6 +1316,33 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
                 query_parts.append(args[i])
                 i += 1
         do_search(" ".join(query_parts), source=source, limit=limit, console=c)
+
+    elif action == "recommend":
+        target_path = "."
+        source = "all"
+        limit = 20
+        as_json = "--json" in args
+        install = "--install" in args
+        positional = []
+        i = 0
+        while i < len(args):
+            if args[i] == "--source" and i + 1 < len(args):
+                source = args[i + 1]
+                i += 2
+            elif args[i] == "--limit" and i + 1 < len(args):
+                try:
+                    limit = int(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif args[i] in {"--json", "--install"}:
+                i += 1
+            else:
+                positional.append(args[i])
+                i += 1
+        if positional:
+            target_path = positional[0]
+        do_recommend(path=target_path, source=source, limit=limit, install=install, as_json=as_json, skip_confirm=True, console=c)
 
     elif action == "install":
         if not args:
@@ -1369,9 +1462,10 @@ def _print_skills_help(console: Console) -> None:
         "[bold]Skills Hub Commands:[/]\n\n"
         "  [cyan]browse[/] [--source official]   Browse all available skills (paginated)\n"
         "  [cyan]search[/] <query>              Search registries for skills\n"
+        "  [cyan]recommend[/] [path]            Recommend skills for the current project\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
-        "  [cyan]list[/] [--source hub|builtin|local] List installed skills\n"
+        "  [cyan]list[/] [--source hub|builtin|local|project-local] List installed skills\n"
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"
         "  [cyan]update[/] [name]               Update hub skills with upstream changes\n"
         "  [cyan]audit[/] [name]                Re-scan hub skills for security\n"

--- a/tests/agent/test_project_local_skills.py
+++ b/tests/agent/test_project_local_skills.py
@@ -1,0 +1,115 @@
+"""Tests for project-local skill discovery and runtime overlay ordering."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    return home
+
+
+class TestRuntimeCwdAndGitRoot:
+    def test_find_git_root_walks_parents(self, tmp_path):
+        repo = tmp_path / "repo"
+        nested = repo / "a" / "b"
+        (repo / ".git").mkdir(parents=True)
+        nested.mkdir(parents=True)
+
+        from agent.skill_utils import find_git_root
+
+        assert find_git_root(nested) == repo.resolve()
+
+    def test_find_git_root_returns_none_outside_repo(self, tmp_path):
+        isolated = tmp_path / "isolated"
+        isolated.mkdir()
+
+        from agent.skill_utils import find_git_root
+
+        assert find_git_root(isolated) is None
+
+    def test_resolve_runtime_cwd_prefers_terminal_cwd(self, tmp_path, monkeypatch):
+        env_cwd = tmp_path / "env-cwd"
+        env_cwd.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(env_cwd))
+
+        from agent.skill_utils import resolve_runtime_cwd
+
+        assert resolve_runtime_cwd() == env_cwd.resolve()
+
+
+class TestProjectLocalSkillsDirs:
+    def test_project_skill_dirs_prefer_dot_hermes_before_dot_agents(self, tmp_path):
+        repo = tmp_path / "repo"
+        cwd = repo / "src"
+        (repo / ".git").mkdir(parents=True)
+        (repo / ".hermes" / "skills").mkdir(parents=True)
+        (repo / ".agents" / "skills").mkdir(parents=True)
+        cwd.mkdir(parents=True)
+
+        from agent.skill_utils import get_project_local_skills_dirs
+
+        assert get_project_local_skills_dirs(cwd) == [
+            (repo / ".hermes" / "skills").resolve(),
+            (repo / ".agents" / "skills").resolve(),
+        ]
+
+    def test_project_skill_dirs_nearest_ancestor_first(self, tmp_path):
+        repo = tmp_path / "repo"
+        cwd = repo / "packages" / "app" / "src"
+        (repo / ".git").mkdir(parents=True)
+        (repo / ".hermes" / "skills").mkdir(parents=True)
+        (repo / ".agents" / "skills").mkdir(parents=True)
+        (repo / "packages" / "app" / ".hermes" / "skills").mkdir(parents=True)
+        (repo / "packages" / "app" / ".agents" / "skills").mkdir(parents=True)
+        cwd.mkdir(parents=True)
+
+        from agent.skill_utils import get_project_local_skills_dirs
+
+        assert get_project_local_skills_dirs(cwd) == [
+            (repo / "packages" / "app" / ".hermes" / "skills").resolve(),
+            (repo / "packages" / "app" / ".agents" / "skills").resolve(),
+            (repo / ".hermes" / "skills").resolve(),
+            (repo / ".agents" / "skills").resolve(),
+        ]
+
+    def test_project_skill_dirs_without_git_root_only_use_cwd(self, tmp_path):
+        cwd = tmp_path / "workspace"
+        parent = tmp_path
+        (cwd / ".hermes" / "skills").mkdir(parents=True)
+        (parent / ".agents" / "skills").mkdir(parents=True)
+
+        from agent.skill_utils import get_project_local_skills_dirs
+
+        assert get_project_local_skills_dirs(cwd) == [
+            (cwd / ".hermes" / "skills").resolve(),
+        ]
+
+
+class TestRuntimeSkillsDirs:
+    def test_runtime_skills_dirs_project_local_then_home_then_external(self, hermes_home, tmp_path):
+        repo = tmp_path / "repo"
+        cwd = repo / "src"
+        external = tmp_path / "external-skills"
+        external.mkdir(parents=True)
+        (repo / ".git").mkdir(parents=True)
+        (repo / ".hermes" / "skills").mkdir(parents=True)
+        cwd.mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external}\n"
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_runtime_skills_dirs
+
+            assert get_runtime_skills_dirs(cwd) == [
+                (repo / ".hermes" / "skills").resolve(),
+                (hermes_home / "skills").resolve(),
+                external.resolve(),
+            ]

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -3,7 +3,10 @@
 import builtins
 import importlib
 import logging
+import os
 import sys
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -30,6 +33,16 @@ from agent.prompt_builder import (
     WSL_ENVIRONMENT_HINT,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_skill_dirs(monkeypatch):
+    prompt_dirs = lambda: [Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "skills"]
+    monkeypatch.setitem(build_skills_system_prompt.__globals__, "get_runtime_skills_dirs", prompt_dirs)
+    import agent.prompt_builder as prompt_builder_module
+    prompt_builder_module.clear_skills_system_prompt_cache(clear_snapshot=True)
+    yield
+    prompt_builder_module.clear_skills_system_prompt_cache(clear_snapshot=True)
 
 
 # =========================================================================
@@ -266,6 +279,25 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_builds_index_with_project_local_skills(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        project_skills = tmp_path / "repo" / ".hermes" / "skills"
+        local_skills = tmp_path / "skills"
+        skill_dir = project_skills / "coding" / "project-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: project-debug\ndescription: Debug project-specific issues\n---\n"
+        )
+
+        with patch(
+            "agent.prompt_builder.get_runtime_skills_dirs",
+            return_value=[project_skills.resolve(), local_skills.resolve()],
+        ):
+            result = build_skills_system_prompt()
+
+        assert "project-debug" in result
+        assert "Debug project-specific issues" in result
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"
@@ -371,6 +403,60 @@ class TestBuildSkillsSystemPrompt:
 
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
+
+    def test_project_local_skill_overrides_home_skill_in_prompt(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_skill = tmp_path / "skills" / "tools" / "shared-skill"
+        project_skill = tmp_path / "repo" / ".hermes" / "skills" / "tools" / "shared-skill"
+        local_skill.mkdir(parents=True)
+        project_skill.mkdir(parents=True)
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Home description\n---\n"
+        )
+        (project_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Project description\n---\n"
+        )
+
+        with patch(
+            "agent.prompt_builder.get_runtime_skills_dirs",
+            return_value=[(tmp_path / "repo" / ".hermes" / "skills").resolve(), (tmp_path / "skills").resolve()],
+        ):
+            result = build_skills_system_prompt()
+
+        assert "shared-skill: Project description" in result
+        assert "shared-skill: Home description" not in result
+
+    def test_runtime_skill_dirs_change_invalidates_cached_prompt(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        project_a = tmp_path / "repo-a" / ".hermes" / "skills" / "tools" / "alpha-skill"
+        project_b = tmp_path / "repo-b" / ".hermes" / "skills" / "tools" / "beta-skill"
+        local_skills = tmp_path / "skills"
+        project_a.mkdir(parents=True)
+        project_b.mkdir(parents=True)
+        local_skills.mkdir(parents=True)
+        (project_a / "SKILL.md").write_text(
+            "---\nname: alpha-skill\ndescription: Alpha description\n---\n"
+        )
+        (project_b / "SKILL.md").write_text(
+            "---\nname: beta-skill\ndescription: Beta description\n---\n"
+        )
+
+        with patch(
+            "agent.prompt_builder.get_runtime_skills_dirs",
+            return_value=[(tmp_path / "repo-a" / ".hermes" / "skills").resolve(), local_skills.resolve()],
+        ):
+            first = build_skills_system_prompt()
+
+        with patch(
+            "agent.prompt_builder.get_runtime_skills_dirs",
+            return_value=[(tmp_path / "repo-b" / ".hermes" / "skills").resolve(), local_skills.resolve()],
+        ):
+            second = build_skills_system_prompt()
+
+        assert "alpha-skill" in first
+        assert "beta-skill" not in first
+        assert "beta-skill" in second
+        assert "alpha-skill" not in second
 
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_plan_path,
@@ -38,6 +39,17 @@ description: Description for {name}.
     return skill_dir
 
 
+@pytest.fixture(autouse=True)
+def _isolate_runtime_skill_dirs(monkeypatch):
+    import agent.skill_utils as skill_utils
+
+    monkeypatch.setattr(
+        skill_utils,
+        "get_runtime_skills_dirs",
+        lambda cwd=None: [skills_tool_module.SKILLS_DIR, *skill_utils.get_external_skills_dirs()],
+    )
+
+
 class TestScanSkillCommands:
     def test_finds_skills(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -45,6 +57,23 @@ class TestScanSkillCommands:
             result = scan_skill_commands()
         assert "/my-skill" in result
         assert result["/my-skill"]["name"] == "my-skill"
+
+    def test_project_local_skills_register_commands(self, tmp_path):
+        project_dir = tmp_path / "repo" / ".hermes" / "skills"
+        local_dir = tmp_path / "local-skills"
+        _make_skill(project_dir, "project-skill")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_runtime_skills_dirs",
+                return_value=[project_dir.resolve(), local_dir.resolve()],
+            ),
+        ):
+            result = scan_skill_commands()
+
+        assert "/project-skill" in result
+        assert result["/project-skill"]["skill_dir"] == str((project_dir / "project-skill").resolve())
 
     def test_empty_dir(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -100,6 +129,24 @@ class TestScanSkillCommands:
             result = scan_skill_commands()
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
+
+    def test_project_local_takes_precedence_over_local_with_same_name(self, tmp_path):
+        project_dir = tmp_path / "repo" / ".hermes" / "skills"
+        local_dir = tmp_path / "local-skills"
+        _make_skill(project_dir, "shared-skill", body="Project version.")
+        _make_skill(local_dir, "shared-skill", body="Local version.")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_runtime_skills_dirs",
+                return_value=[project_dir.resolve(), local_dir.resolve()],
+            ),
+        ):
+            result = scan_skill_commands()
+
+        assert "/shared-skill" in result
+        assert result["/shared-skill"]["skill_dir"] == str((project_dir / "shared-skill").resolve())
 
 
     def test_special_chars_stripped_from_cmd_key(self, tmp_path):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_recommend, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -45,6 +45,19 @@ _ALL_THREE_SKILLS = [
     {"name": "local-skill", "category": "x", "description": "local"},
 ]
 
+_ALL_FOUR_SKILLS = [
+    {"name": "hub-skill", "category": "x", "description": "hub"},
+    {"name": "builtin-skill", "category": "x", "description": "builtin"},
+    {"name": "local-skill", "category": "x", "description": "local", "scope": "local", "source": "local"},
+    {
+        "name": "project-skill",
+        "category": "x",
+        "description": "project",
+        "scope": "project-local",
+        "source": "project-local-hermes",
+    },
+]
+
 _BUILTIN_MANIFEST = {"builtin-skill": "abc123"}
 
 
@@ -62,11 +75,34 @@ def three_source_env(monkeypatch, hub_env):
     return hub_env
 
 
+@pytest.fixture()
+def four_source_env(monkeypatch, hub_env):
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile([_HUB_ENTRY]))
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda: list(_ALL_FOUR_SKILLS))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+
+    return hub_env
+
+
 def _capture(source_filter: str = "all") -> str:
     """Run do_list into a string buffer and return the output."""
     sink = StringIO()
     console = Console(file=sink, force_terminal=False, color_system=None)
     do_list(source_filter=source_filter, console=console)
+    return sink.getvalue()
+
+
+def _capture_recommend(monkeypatch, payload, *, as_json=False, source="all") -> str:
+    import tools.skills_recommend as recommend_mod
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    monkeypatch.setattr(recommend_mod, "recommend_skills", lambda path='.', source_filter='all', limit=20: payload)
+    do_recommend(path=".", source=source, as_json=as_json, console=console)
     return sink.getvalue()
 
 
@@ -154,6 +190,22 @@ def test_do_list_filter_builtin(three_source_env):
     assert "local-skill" not in output
 
 
+def test_do_list_distinguishes_project_local(four_source_env):
+    output = _capture()
+
+    assert "project-skill" in output
+    assert "1 hub-installed, 1 builtin, 1 local, 1 project-local" in output
+
+
+def test_do_list_filter_project_local(four_source_env):
+    output = _capture(source_filter="project-local")
+
+    assert "project-skill" in output
+    assert "builtin-skill" not in output
+    assert "hub-skill" not in output
+    assert "local-skill" not in output
+
+
 def test_do_check_reports_available_updates(monkeypatch):
     output = _capture_check(monkeypatch, [
         {"name": "hub-skill", "source": "skills.sh", "status": "update_available"},
@@ -179,6 +231,112 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_do_recommend_renders_grouped_sections(monkeypatch):
+    payload = {
+        "detected": {"technologies": ["docker"], "combos": [], "root": "/tmp/repo"},
+        "available": [
+            {
+                "name": "project-skill",
+                "identifier": "project-skill",
+                "source": "project-local-hermes",
+                "state": "available",
+                "matched_on": ["project-local"],
+                "reason": "Already available in this project.",
+                "score": 100,
+            }
+        ],
+        "official": [
+            {
+                "name": "docker-management",
+                "identifier": "official/devops/docker-management",
+                "source": "official",
+                "trust_level": "builtin",
+                "state": "installable",
+                "matched_on": ["docker"],
+                "reason": "Matched docker.",
+                "score": 50,
+            }
+        ],
+        "third_party": [
+            {
+                "name": "community-docker",
+                "identifier": "hub/docker",
+                "source": "github",
+                "trust_level": "trusted",
+                "state": "installable",
+                "matched_on": ["docker"],
+                "reason": "Matched docker.",
+                "score": 40,
+            }
+        ],
+    }
+
+    output = _capture_recommend(monkeypatch, payload)
+
+    assert "Already available in this project" in output
+    assert "Official Hermes optional skills" in output
+    assert "Third-party skills" in output
+    assert "project-skill" in output
+    assert "official/devops/docker-management" in output
+    assert "hub/docker" in output
+
+
+def test_do_recommend_json_output(monkeypatch):
+    payload = {
+        "detected": {"technologies": ["docker"], "combos": [], "root": "/tmp/repo"},
+        "available": [],
+        "official": [],
+        "third_party": [],
+    }
+
+    output = _capture_recommend(monkeypatch, payload, as_json=True)
+
+    assert '"technologies": ["docker"]' in output
+
+
+def test_handle_skills_slash_recommend_json(monkeypatch):
+    import tools.skills_recommend as recommend_mod
+
+    payload = {
+        "detected": {"technologies": ["docker"], "combos": [], "root": "/tmp/repo"},
+        "available": [],
+        "official": [],
+        "third_party": [],
+    }
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    monkeypatch.setattr(recommend_mod, "recommend_skills", lambda path='.', source_filter='all', limit=20: payload)
+
+    handle_skills_slash("/skills recommend . --json", console=console)
+
+    assert '"technologies": ["docker"]' in sink.getvalue()
+
+
+def test_handle_skills_slash_recommend_install_skips_confirm(monkeypatch):
+    import hermes_cli.skills_hub as cli_hub
+    import tools.skills_recommend as recommend_mod
+
+    payload = {
+        "detected": {"technologies": ["docker"], "combos": [], "root": "/tmp/repo"},
+        "available": [],
+        "official": [{"identifier": "official/devops/docker-management"}],
+        "third_party": [],
+    }
+    calls = []
+    monkeypatch.setattr(recommend_mod, "recommend_skills", lambda path='.', source_filter='all', limit=20: payload)
+    monkeypatch.setattr(
+        cli_hub,
+        "do_install",
+        lambda identifier, category="", force=False, skip_confirm=False, console=None: calls.append(
+            {"identifier": identifier, "skip_confirm": skip_confirm}
+        ),
+    )
+
+    handle_skills_slash("/skills recommend . --install", console=Console(file=StringIO(), force_terminal=False, color_system=None))
+
+    assert calls == [{"identifier": "official/devops/docker-management", "skip_confirm": True}]
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():

--- a/tests/tools/test_skills_recommend.py
+++ b/tests/tools/test_skills_recommend.py
@@ -1,0 +1,156 @@
+"""Tests for stack-aware skill recommendation helpers."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class _StubSource:
+    def __init__(self, items):
+        self._items = items
+
+    def inspect(self, identifier):
+        return self._items.get(identifier)
+
+
+def _write_json(path: Path, data: dict):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_detect_project_finds_nextjs_react_typescript(tmp_path):
+    project = tmp_path / "webapp"
+    project.mkdir()
+    _write_json(
+        project / "package.json",
+        {
+            "dependencies": {
+                "next": "15.0.0",
+                "react": "19.0.0",
+                "react-dom": "19.0.0",
+            },
+            "devDependencies": {"typescript": "5.0.0"},
+        },
+    )
+    (project / "tsconfig.json").write_text("{}", encoding="utf-8")
+
+    from tools.skills_recommend import detect_project
+
+    result = detect_project(project)
+
+    assert result.root == project.resolve()
+    assert {"nextjs", "react", "typescript"}.issubset(result.technologies)
+
+
+def test_detect_project_finds_python_and_fastapi(tmp_path):
+    project = tmp_path / "api"
+    project.mkdir()
+    (project / "requirements.txt").write_text("fastapi\nuvicorn\n", encoding="utf-8")
+
+    from tools.skills_recommend import detect_project
+
+    result = detect_project(project)
+
+    assert {"python", "fastapi"}.issubset(result.technologies)
+
+
+def test_detect_project_collects_project_local_skills(tmp_path):
+    project = tmp_path / "repo"
+    skill_dir = project / ".hermes" / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (project / ".git").mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Project skill\n---\n\n# My Skill\n",
+        encoding="utf-8",
+    )
+
+    from tools.skills_recommend import detect_project
+
+    result = detect_project(project)
+
+    assert [s["name"] for s in result.available_project_skills] == ["my-skill"]
+    assert result.available_project_skills[0]["source"] == "project-local-hermes"
+
+
+def test_recommend_skills_dedupes_and_prefers_combo_matches(tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    _write_json(
+        project / "package.json",
+        {
+            "dependencies": {
+                "next": "15.0.0",
+                "react": "19.0.0",
+                "react-dom": "19.0.0",
+            }
+        },
+    )
+
+    fake_meta = {
+        "hub/react": type(
+            "Meta",
+            (),
+            {
+                "name": "react-skill",
+                "description": "React skill",
+                "source": "github",
+                "trust_level": "trusted",
+                "identifier": "hub/react",
+            },
+        )(),
+        "hub/next": type(
+            "Meta",
+            (),
+            {
+                "name": "next-skill",
+                "description": "Next skill",
+                "source": "github",
+                "trust_level": "trusted",
+                "identifier": "hub/next",
+            },
+        )(),
+    }
+
+    with (
+        patch(
+            "tools.skills_recommend.RECOMMENDATION_MAP",
+            {
+                "react": {"hub": ["hub/react"]},
+                "nextjs": {"hub": ["hub/next"]},
+            },
+        ),
+        patch(
+            "tools.skills_recommend.COMBO_RECOMMENDATION_MAP",
+            {("nextjs", "react"): {"hub": ["hub/next"]}},
+        ),
+        patch(
+            "tools.skills_recommend.create_source_router",
+            return_value=[_StubSource(fake_meta)],
+        ),
+    ):
+        from tools.skills_recommend import recommend_skills
+
+        result = recommend_skills(project)
+
+    third_party = result["third_party"]
+    assert [r["identifier"] for r in third_party] == ["hub/next", "hub/react"]
+    assert third_party[0]["score"] > third_party[1]["score"]
+    assert "nextjs+react" in third_party[0]["matched_on"]
+
+
+def test_recommend_skills_respects_official_source_filter(tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "Dockerfile").write_text("FROM python:3.11\n", encoding="utf-8")
+
+    with patch(
+        "tools.skills_recommend.RECOMMENDATION_MAP",
+        {"docker": {"official": ["official/devops/docker-management"], "hub": ["hub/docker"]}},
+    ):
+        from tools.skills_recommend import recommend_skills
+
+        result = recommend_skills(project, source_filter="official")
+
+    assert [r["identifier"] for r in result["official"]] == ["official/devops/docker-management"]
+    assert result["third_party"] == []

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -44,6 +44,17 @@ description: Description for {name}.
     return skill_dir
 
 
+@pytest.fixture(autouse=True)
+def _isolate_runtime_skill_dirs(monkeypatch):
+    import agent.skill_utils as skill_utils
+
+    monkeypatch.setattr(
+        skill_utils,
+        "get_runtime_skills_dirs",
+        lambda cwd=None: [skills_tool_module.SKILLS_DIR, *skill_utils.get_external_skills_dirs()],
+    )
+
+
 # ---------------------------------------------------------------------------
 # _parse_frontmatter
 # ---------------------------------------------------------------------------
@@ -204,6 +215,26 @@ class TestFindAllSkills:
         assert "skill-a" in names
         assert "skill-b" in names
 
+    def test_project_local_skills_found_first(self, tmp_path):
+        project_dir = tmp_path / "repo" / ".hermes" / "skills"
+        local_dir = tmp_path / "local-skills"
+        _make_skill(project_dir, "project-only")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_runtime_skills_dirs",
+                return_value=[project_dir.resolve(), local_dir.resolve()],
+            ),
+        ):
+            skills = _find_all_skills()
+
+        assert len(skills) == 1
+        assert skills[0]["name"] == "project-only"
+        assert skills[0]["source"] == "project-local-hermes"
+        assert skills[0]["scope"] == "project-local"
+        assert skills[0]["source_dir"] == str(project_dir.resolve())
+
     def test_empty_directory(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skills = _find_all_skills()
@@ -255,6 +286,26 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
 
+    def test_project_local_takes_precedence_over_local_with_same_name(self, tmp_path):
+        project_dir = tmp_path / "repo" / ".hermes" / "skills"
+        local_dir = tmp_path / "local-skills"
+        _make_skill(project_dir, "shared-skill", body="Project body.")
+        _make_skill(local_dir, "shared-skill", body="Local body.")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_runtime_skills_dirs",
+                return_value=[project_dir.resolve(), local_dir.resolve()],
+            ),
+        ):
+            skills = _find_all_skills()
+
+        assert len(skills) == 1
+        assert skills[0]["name"] == "shared-skill"
+        assert skills[0]["source"] == "project-local-hermes"
+        assert skills[0]["source_dir"] == str(project_dir.resolve())
+
 
 # ---------------------------------------------------------------------------
 # skills_list
@@ -278,6 +329,26 @@ class TestSkillsList:
             raw = skills_list()
         result = json.loads(raw)
         assert result["count"] == 2
+
+    def test_lists_project_local_source_metadata(self, tmp_path):
+        project_dir = tmp_path / "repo" / ".hermes" / "skills"
+        local_dir = tmp_path / "local-skills"
+        _make_skill(project_dir, "alpha")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_runtime_skills_dirs",
+                return_value=[project_dir.resolve(), local_dir.resolve()],
+            ),
+        ):
+            raw = skills_list()
+
+        result = json.loads(raw)
+        assert result["count"] == 1
+        assert result["skills"][0]["source"] == "project-local-hermes"
+        assert result["skills"][0]["scope"] == "project-local"
+        assert result["skills"][0]["source_dir"] == str(project_dir.resolve())
 
     def test_category_filter(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -303,6 +374,26 @@ class TestSkillView:
         assert result["success"] is True
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
+
+    def test_view_project_local_skill_before_local(self, tmp_path):
+        project_dir = tmp_path / "repo" / ".hermes" / "skills"
+        local_dir = tmp_path / "local-skills"
+        _make_skill(project_dir, "my-skill", body="Project version.")
+        _make_skill(local_dir, "my-skill", body="Local version.")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_runtime_skills_dirs",
+                return_value=[project_dir.resolve(), local_dir.resolve()],
+            ),
+        ):
+            raw = skill_view("my-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Project version." in result["content"]
+        assert result["skill_dir"] == str((project_dir / "my-skill").resolve())
 
     def test_view_nonexistent_skill(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_recommend.py
+++ b/tools/skills_recommend.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Project stack detection and skill recommendation helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from agent.skill_utils import find_git_root, get_project_local_skills_dirs, parse_frontmatter
+from tools.skills_hub import create_source_router
+
+
+RECOMMENDATION_MAP: dict[str, dict[str, list[str]]] = {
+    "react": {
+        "hub": ["vercel-labs/agent-skills/vercel-react-best-practices"],
+    },
+    "nextjs": {
+        "hub": ["vercel-labs/next-skills/next-best-practices"],
+    },
+    "playwright": {
+        "hub": ["currents-dev/playwright-best-practices-skill/playwright-best-practices"],
+    },
+    "docker": {
+        "official": ["official/devops/docker-management"],
+    },
+    "fastapi": {
+        "hub": ["jezweb/claude-skills/fastapi"],
+    },
+}
+
+COMBO_RECOMMENDATION_MAP: dict[tuple[str, ...], dict[str, list[str]]] = {
+    ("nextjs", "react"): {
+        "hub": ["vercel-labs/next-skills/next-best-practices"],
+    },
+    ("nextjs", "playwright"): {
+        "hub": ["currents-dev/playwright-best-practices-skill/playwright-best-practices"],
+    },
+}
+
+_TRUST_RANK = {"builtin": 3, "trusted": 2, "community": 1}
+
+
+@dataclass
+class DetectedProject:
+    root: Path
+    technologies: set[str]
+    combos: set[str]
+    available_project_skills: list[dict[str, Any]]
+
+
+def _normalize_path(path: str | Path | None) -> Path:
+    if path is None:
+        candidate = Path.cwd()
+    else:
+        candidate = Path(path).expanduser()
+    if candidate.is_file():
+        candidate = candidate.parent
+    return candidate.resolve()
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def _load_package_json(root: Path) -> dict[str, Any]:
+    package_json = root / "package.json"
+    if not package_json.exists():
+        return {}
+    try:
+        return json.loads(package_json.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _dep_names(package_json: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for key in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        block = package_json.get(key)
+        if isinstance(block, dict):
+            names.update(str(name) for name in block.keys())
+    return names
+
+
+def _detect_technologies(root: Path) -> set[str]:
+    techs: set[str] = set()
+    package_json = _load_package_json(root)
+    deps = _dep_names(package_json)
+
+    if "next" in deps or any((root / name).exists() for name in ("next.config.js", "next.config.mjs", "next.config.ts")):
+        techs.add("nextjs")
+    if {"react", "react-dom"} & deps:
+        techs.add("react")
+    if "typescript" in deps or (root / "tsconfig.json").exists():
+        techs.add("typescript")
+    if {"tailwindcss", "@tailwindcss/vite"} & deps or any((root / name).exists() for name in ("tailwind.config.js", "tailwind.config.ts", "tailwind.config.cjs")):
+        techs.add("tailwind")
+    if (root / "components.json").exists():
+        techs.add("shadcn")
+    if {"playwright", "@playwright/test"} & deps or any((root / name).exists() for name in ("playwright.config.ts", "playwright.config.js")):
+        techs.add("playwright")
+    if {"@supabase/supabase-js", "@supabase/ssr"} & deps:
+        techs.add("supabase")
+    if "ai" in deps or any(name.startswith("@ai-sdk/") for name in deps):
+        techs.add("vercel-ai")
+
+    if any((root / name).exists() for name in ("requirements.txt", "pyproject.toml", "setup.py", "Pipfile")):
+        techs.add("python")
+        requirements = _read_text(root / "requirements.txt")
+        pyproject = _read_text(root / "pyproject.toml")
+        combined = f"{requirements}\n{pyproject}".lower()
+        if "fastapi" in combined:
+            techs.add("fastapi")
+        if "django" in combined:
+            techs.add("django")
+
+    if (root / "Dockerfile").exists():
+        techs.add("docker")
+
+    return techs
+
+
+def _detect_combos(technologies: set[str]) -> set[str]:
+    combos: set[str] = set()
+    for combo in COMBO_RECOMMENDATION_MAP:
+        if all(item in technologies for item in combo):
+            combos.add("+".join(combo))
+    return combos
+
+
+def _classify_project_skill_dir(scan_dir: Path) -> tuple[str, str]:
+    resolved = scan_dir.resolve()
+    if resolved.name == "skills" and resolved.parent.name == ".hermes":
+        return "project-local-hermes", "project-local"
+    if resolved.name == "skills" and resolved.parent.name == ".agents":
+        return "project-local-agents", "project-local"
+    return "project-local", "project-local"
+
+
+def _discover_project_skills(root: Path) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for scan_dir in get_project_local_skills_dirs(root):
+        source, scope = _classify_project_skill_dir(scan_dir)
+        for skill_md in sorted(scan_dir.rglob("SKILL.md")):
+            if any(part in {".git", ".github", ".hub"} for part in skill_md.parts):
+                continue
+            content = _read_text(skill_md)
+            if not content:
+                continue
+            frontmatter, body = parse_frontmatter(content)
+            name = str(frontmatter.get("name") or skill_md.parent.name)
+            if name in seen:
+                continue
+            seen.add(name)
+            description = str(frontmatter.get("description") or "").strip()
+            if not description:
+                for line in body.splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        description = line
+                        break
+            results.append(
+                {
+                    "name": name,
+                    "description": description,
+                    "source": source,
+                    "scope": scope,
+                    "source_dir": str(scan_dir.resolve()),
+                    "skill_dir": str(skill_md.parent.resolve()),
+                }
+            )
+    return results
+
+
+def detect_project(path: str | Path | None = None) -> DetectedProject:
+    start = _normalize_path(path)
+    root = find_git_root(start) or start
+    technologies = _detect_technologies(root)
+    combos = _detect_combos(technologies)
+    available_project_skills = _discover_project_skills(root)
+    return DetectedProject(
+        root=root.resolve(),
+        technologies=technologies,
+        combos=combos,
+        available_project_skills=available_project_skills,
+    )
+
+
+def _resolve_meta(identifier: str, sources: Iterable[Any]) -> dict[str, Any]:
+    for source in sources:
+        try:
+            meta = source.inspect(identifier)
+        except Exception:
+            meta = None
+        if meta:
+            return {
+                "name": getattr(meta, "name", identifier.rsplit("/", 1)[-1]),
+                "description": getattr(meta, "description", ""),
+                "source": getattr(meta, "source", "official" if identifier.startswith("official/") else "github"),
+                "trust_level": getattr(meta, "trust_level", "builtin" if identifier.startswith("official/") else "community"),
+            }
+    return {
+        "name": identifier.rsplit("/", 1)[-1],
+        "description": "",
+        "source": "official" if identifier.startswith("official/") else "github",
+        "trust_level": "builtin" if identifier.startswith("official/") else "community",
+    }
+
+
+def _add_recommendation(store: dict[str, dict[str, Any]], identifier: str, bucket: str, matched_on: str, score: int):
+    entry = store.get(identifier)
+    if entry is None:
+        store[identifier] = {
+            "identifier": identifier,
+            "bucket": bucket,
+            "matched_on": [matched_on],
+            "score": score,
+        }
+        return
+    if matched_on not in entry["matched_on"]:
+        entry["matched_on"].append(matched_on)
+    entry["score"] = max(entry["score"], score)
+
+
+def recommend_skills(path: str | Path | None = None, source_filter: str = "all", limit: int = 20) -> dict[str, Any]:
+    detected = detect_project(path)
+    remote: dict[str, dict[str, Any]] = {}
+
+    for tech in sorted(detected.technologies):
+        mapping = RECOMMENDATION_MAP.get(tech, {})
+        if source_filter in {"all", "official"}:
+            for identifier in mapping.get("official", []):
+                _add_recommendation(remote, identifier, "official", tech, 50)
+        if source_filter == "all":
+            for identifier in mapping.get("hub", []):
+                _add_recommendation(remote, identifier, "third_party", tech, 40)
+
+    for combo in sorted(detected.combos):
+        key = tuple(combo.split("+"))
+        mapping = COMBO_RECOMMENDATION_MAP.get(key, {})
+        if source_filter in {"all", "official"}:
+            for identifier in mapping.get("official", []):
+                _add_recommendation(remote, identifier, "official", combo, 80)
+        if source_filter == "all":
+            for identifier in mapping.get("hub", []):
+                _add_recommendation(remote, identifier, "third_party", combo, 70)
+
+    sources = create_source_router() if remote else []
+    official: list[dict[str, Any]] = []
+    third_party: list[dict[str, Any]] = []
+
+    for identifier, entry in remote.items():
+        meta = _resolve_meta(identifier, sources)
+        row = {
+            "identifier": identifier,
+            "name": meta["name"],
+            "description": meta["description"],
+            "source": meta["source"],
+            "trust_level": meta["trust_level"],
+            "state": "installable",
+            "matched_on": sorted(entry["matched_on"]),
+            "reason": f"Matched {', '.join(sorted(entry['matched_on']))}.",
+            "score": entry["score"],
+        }
+        if entry["bucket"] == "official":
+            official.append(row)
+        else:
+            third_party.append(row)
+
+    def _sort_key(item: dict[str, Any]):
+        return (-item["score"], -_TRUST_RANK.get(item.get("trust_level", "community"), 0), item["name"])
+
+    official.sort(key=_sort_key)
+    third_party.sort(key=_sort_key)
+
+    available = [
+        {
+            **skill,
+            "identifier": skill["name"],
+            "state": "available",
+            "matched_on": ["project-local"],
+            "reason": "Already available in this project.",
+            "score": 100,
+        }
+        for skill in detected.available_project_skills
+    ]
+
+    return {
+        "detected": {
+            "root": str(detected.root),
+            "technologies": sorted(detected.technologies),
+            "combos": sorted(detected.combos),
+        },
+        "available": available[:limit],
+        "official": official[:limit],
+        "third_party": third_party[:limit],
+    }

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -445,16 +445,15 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     Extract category from skill path based on directory structure.
 
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
-    Also works for external skill dirs configured via skills.external_dirs.
+    Also works for external and project-local runtime skill dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
     dirs_to_check = [SKILLS_DIR]
     try:
-        from agent.skill_utils import get_external_skills_dirs
-        dirs_to_check.extend(get_external_skills_dirs())
+        from agent.skill_utils import get_runtime_skills_dirs
+        dirs_to_check = get_runtime_skills_dirs()
     except Exception:
         pass
+
     for skills_dir in dirs_to_check:
         try:
             rel_path = skill_path.relative_to(skills_dir)
@@ -543,8 +542,30 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
+
+def _classify_skill_source(scan_dir: Path) -> tuple[str, str]:
+    """Return ``(source, scope)`` metadata for a scanned skill directory."""
+    resolved = scan_dir.resolve()
+    try:
+        local_dir = SKILLS_DIR.resolve()
+    except Exception:
+        local_dir = SKILLS_DIR
+
+    if resolved == local_dir:
+        return "local", "local"
+    if resolved.name == "skills" and resolved.parent.name == ".hermes":
+        return "project-local-hermes", "project-local"
+    if resolved.name == "skills" and resolved.parent.name == ".agents":
+        return "project-local-agents", "project-local"
+    return "external", "external"
+
+
+
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
-    """Recursively find all skills in ~/.hermes/skills/ and external dirs.
+    """Recursively find all runtime-visible skills.
+
+    Searches runtime dirs in precedence order: project-local overlays first,
+    then the local ``~/.hermes/skills/`` dir, then configured external dirs.
 
     Args:
         skip_disabled: If True, return ALL skills regardless of disabled
@@ -552,9 +573,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             filters out disabled skills.
 
     Returns:
-        List of skill metadata dicts (name, description, category).
+        List of skill metadata dicts (name, description, category, source, scope).
     """
-    from agent.skill_utils import get_external_skills_dirs
+    from agent.skill_utils import get_runtime_skills_dirs
 
     skills = []
     seen_names: set = set()
@@ -562,13 +583,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
-    dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    dirs_to_scan = get_runtime_skills_dirs()
 
     for scan_dir in dirs_to_scan:
+        if not scan_dir.exists():
+            continue
+        source, scope = _classify_skill_source(scan_dir)
         for skill_md in scan_dir.rglob("SKILL.md"):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
@@ -606,6 +626,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "name": name,
                     "description": description,
                     "category": category,
+                    "source": source,
+                    "scope": scope,
+                    "source_dir": str(scan_dir.resolve()),
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -678,28 +701,27 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
+        from agent.skill_utils import get_runtime_skills_dirs
+
+        runtime_dirs = get_runtime_skills_dirs()
         if not SKILLS_DIR.exists():
             SKILLS_DIR.mkdir(parents=True, exist_ok=True)
-            return json.dumps(
-                {
-                    "success": True,
-                    "skills": [],
-                    "categories": [],
-                    "message": f"No skills found. Skills directory created at {display_hermes_home()}/skills/",
-                },
-                ensure_ascii=False,
-            )
 
         # Find all skills
         all_skills = _find_all_skills()
 
         if not all_skills:
+            message = (
+                f"No skills found. Skills directory created at {display_hermes_home()}/skills/"
+                if not any(path.exists() for path in runtime_dirs)
+                else "No skills found in runtime skill directories."
+            )
             return json.dumps(
                 {
                     "success": True,
                     "skills": [],
                     "categories": [],
-                    "message": "No skills found in skills/ directory.",
+                    "message": message,
                 },
                 ensure_ascii=False,
             )
@@ -891,15 +913,11 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             # Plugin itself not found — fall through to flat-tree scan
             # which will return a normal "not found" with suggestions.
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_runtime_skills_dirs
 
-        # Build list of all skill directories to search
-        all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
+        all_dirs = get_runtime_skills_dirs()
 
-        if not all_dirs:
+        if not any(path.exists() for path in all_dirs):
             return json.dumps(
                 {
                     "success": False,
@@ -968,14 +986,12 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
-        # Security: warn if skill is loaded from outside trusted directories
-        # (local skills dir + configured external_dirs are all trusted)
+        # Security: warn if skill is loaded from outside trusted runtime skill directories.
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
         try:
-            _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
+            _trusted_dirs = [d.resolve() for d in all_dirs if d.exists()]
         except Exception:
-            pass
+            _trusted_dirs = []
         for _td in _trusted_dirs:
             try:
                 skill_md.resolve().relative_to(_td)


### PR DESCRIPTION
## Summary
- add runtime support for project-local skill overlays from `.hermes/skills` and `.agents/skills`
- load project-local skills across skills listing/viewing, slash command scanning, and prompt building with deterministic precedence
- add native stack detection and recommendations via `hermes skills recommend` with JSON/install flows

## Test Plan
- `/home/mint/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_project_local_skills.py tests/agent/test_external_skills.py tests/agent/test_prompt_builder.py tests/agent/test_skill_commands.py tests/tools/test_skills_tool.py tests/tools/test_skills_recommend.py tests/hermes_cli/test_skills_hub.py -q`
