### PR TITLE
fix: replace Unicode em-dash with ASCII in plugin.yaml description

### DIFF
--- a/plugins/disk-cleanup/plugin.yaml
+++ b/plugins/disk-cleanup/plugin.yaml
@@ -1,7 +1,7 @@
 name: disk-cleanup
 version: 2.0.0
-description: "Auto-track and clean up ephemeral files (test scripts, temp outputs, cron logs) created during Hermes sessions. Runs via plugin hooks — no agent action required."
-author: "@LVT382009 (original), NousResearch (plugin port)"
+description: 'Auto-track and clean up ephemeral files (test scripts, temp outputs, cron logs) created during Hermes sessions. Runs via plugin hooks -- no agent action required.'
+author: '@LVT382009 (original), NousResearch (plugin port)'
 hooks:
   - post_tool_call
   - on_session_end


### PR DESCRIPTION
## What does this PR do?

Fixes YAML parsing failures on Windows systems where the default encoding is GBK instead of UTF-8. The em-dash character in the disk-cleanup plugin description causes:

```
'gbk' codec can't decode byte 0x94 in position 186: illegal multibyte sequence
```

This replaces the Unicode em-dash with ASCII double-dash (--) and uses single quotes for YAML string values to ensure cross-platform compatibility.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/disk-cleanup/plugin.yaml`: Replaced Unicode em-dash with ASCII -- in description, changed double quotes to single quotes for YAML values

## How to Test

1. On a Windows system with GBK encoding, run `hermes gateway`
2. Verify no YAML parsing warning for `disk-cleanup/plugin.yaml`
3. Confirm the plugin loads correctly

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've considered cross-platform impact (Windows, macOS)

## Screenshots / Logs

Before (Windows GBK):
```
WARNING hermes_cli.plugins: Failed to parse .../plugins/disk-cleanup/plugin.yaml:
'gbk' codec can't decode byte 0x94 in position 186: illegal multibyte sequence
```

After:
```
Plugin loaded successfully
```