### PR TITLE
feat: add qwen3.6-plus to Alibaba provider catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -325,6 +325,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "qwen3.6-plus",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",


### PR DESCRIPTION
Adds the latest Qwen 3.6 Plus model to the Alibaba (DashScope) provider model list so it appears in the Model Picker UI.