### PR TITLE
feat(tools): expose current agent to plugin tool handlers via contextvar

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -70,6 +70,7 @@ from model_tools import (
     handle_function_call,
     check_toolset_requirements,
 )
+from tools.agent_context import current_agent
 from tools.terminal_tool import cleanup_vm, get_active_env, is_persistent_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
 from tools.interrupt import set_interrupt as _set_interrupt
@@ -7731,13 +7732,19 @@ class AIAgent:
         elif function_name == "delegate_task":
             return self._dispatch_delegate_task(function_args)
         else:
-            return handle_function_call(
-                function_name, function_args, effective_task_id,
-                tool_call_id=tool_call_id,
-                session_id=self.session_id or "",
-                enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                skip_pre_tool_call_hook=True,
-            )
+            # Expose the calling agent to plugin tool handlers via contextvar.
+            # Built-in delegate_task gets parent_agent via the hardcoded path
+            # above; every other tool (including plugin-registered ones) flows
+            # through handle_function_call, whose signature doesn't thread the
+            # agent through. See tools/agent_context.py for the full rationale.
+            with current_agent(self):
+                return handle_function_call(
+                    function_name, function_args, effective_task_id,
+                    tool_call_id=tool_call_id,
+                    session_id=self.session_id or "",
+                    enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                    skip_pre_tool_call_hook=True,
+                )
 
     @staticmethod
     def _wrap_verbose(label: str, text: str, indent: str = "     ") -> str:
@@ -8324,13 +8331,15 @@ class AIAgent:
                     spinner.start()
                 _spinner_result = None
                 try:
-                    function_result = handle_function_call(
-                        function_name, function_args, effective_task_id,
-                        tool_call_id=tool_call.id,
-                        session_id=self.session_id or "",
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                        skip_pre_tool_call_hook=True,
-                    )
+                    # See _invoke_tool for rationale on the current_agent wrap.
+                    with current_agent(self):
+                        function_result = handle_function_call(
+                            function_name, function_args, effective_task_id,
+                            tool_call_id=tool_call.id,
+                            session_id=self.session_id or "",
+                            enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                            skip_pre_tool_call_hook=True,
+                        )
                     _spinner_result = function_result
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
@@ -8344,13 +8353,15 @@ class AIAgent:
                         self._vprint(f"  {cute_msg}")
             else:
                 try:
-                    function_result = handle_function_call(
-                        function_name, function_args, effective_task_id,
-                        tool_call_id=tool_call.id,
-                        session_id=self.session_id or "",
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                        skip_pre_tool_call_hook=True,
-                    )
+                    # See _invoke_tool for rationale on the current_agent wrap.
+                    with current_agent(self):
+                        function_result = handle_function_call(
+                            function_name, function_args, effective_task_id,
+                            tool_call_id=tool_call.id,
+                            session_id=self.session_id or "",
+                            enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                            skip_pre_tool_call_hook=True,
+                        )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)

--- a/tests/tools/test_agent_context.py
+++ b/tests/tools/test_agent_context.py
@@ -1,0 +1,58 @@
+"""Tests for tools.agent_context — the current-agent contextvar.
+
+This contract is what plugin handlers rely on to access the calling agent
+when run_agent.py dispatches a non-delegate_task tool via
+model_tools.handle_function_call.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.agent_context import current_agent, get_current_agent
+
+
+class _FakeAgent:
+    """Minimal stand-in for AIAgent."""
+
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+
+
+def test_no_agent_by_default() -> None:
+    """Outside any context, there is no current agent."""
+    assert get_current_agent() is None
+
+
+def test_current_agent_visible_inside_context() -> None:
+    agent = _FakeAgent("a")
+    with current_agent(agent):
+        assert get_current_agent() is agent
+
+
+def test_current_agent_reset_on_exit() -> None:
+    agent = _FakeAgent("a")
+    with current_agent(agent):
+        pass
+    assert get_current_agent() is None
+
+
+def test_current_agent_reset_on_exception() -> None:
+    """The contextvar must be reset even when the body raises."""
+    agent = _FakeAgent("a")
+    with pytest.raises(ValueError, match="boom"):
+        with current_agent(agent):
+            assert get_current_agent() is agent
+            raise ValueError("boom")
+    assert get_current_agent() is None
+
+
+def test_current_agent_nesting() -> None:
+    """Inner context overrides outer for its duration, then restores."""
+    outer = _FakeAgent("outer")
+    inner = _FakeAgent("inner")
+    with current_agent(outer):
+        assert get_current_agent() is outer
+        with current_agent(inner):
+            assert get_current_agent() is inner
+        assert get_current_agent() is outer
+    assert get_current_agent() is None

--- a/tools/agent_context.py
+++ b/tools/agent_context.py
@@ -1,0 +1,80 @@
+"""Context variable for the currently-running AIAgent.
+
+Plugin-registered tool handlers (via ``PluginContext.register_tool``) do NOT
+receive ``parent_agent`` in their ``**kwargs`` — only the built-in
+``delegate_task`` tool gets that, via a hardcoded dispatch path in
+``run_agent.py`` (see ``AIAgent._dispatch_delegate_task``). Every other tool
+goes through ``model_tools.handle_function_call``, which doesn't thread the
+agent through.
+
+This module lets plugin handlers opt into accessing the currently-running
+agent by calling :func:`get_current_agent`. ``run_agent.py`` wraps each
+``handle_function_call`` dispatch with :func:`current_agent` so plugin tools
+can access ``self`` via context — enabling them to call
+``_build_child_agent(parent_agent=get_current_agent(), ...)`` to spawn
+children with per-call model / provider overrides that the global
+``delegation.model`` config can't express.
+
+Usage (in a plugin handler)::
+
+    from tools.agent_context import get_current_agent
+    from tools.delegate_tool import _build_child_agent, _run_single_child
+
+    def delegate_to_compose_handler(args, **kw):
+        agent = get_current_agent()
+        if agent is None:
+            return "Error: no parent agent in context"
+        child = _build_child_agent(
+            task_index=0, goal=args["goal"], context=args.get("context"),
+            toolsets=[], model="anthropic/claude-sonnet-4.6",
+            max_iterations=5, task_count=1, parent_agent=agent,
+            override_provider="openrouter",
+            override_api_key=os.environ["OPENROUTER_API_KEY"],
+            role="leaf",
+        )
+        return _run_single_child(task_index=0, goal=args["goal"],
+                                 child=child, parent_agent=agent)
+
+The contextvar is scoped per-call via :func:`current_agent`, which is
+contextvars-safe for async + threads when used with ``copy_context()``
+at spawn boundaries (as ``_run_single_child``'s thread pool already does).
+
+Why a new module rather than adding a kwarg to ``handle_function_call``:
+backward compatibility. Third-party code and plugins calling
+``handle_function_call`` directly (e.g. ``hermes chat`` CLI paths, test
+harnesses) keep working unchanged.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator, Optional
+
+_current_agent: ContextVar[Optional[Any]] = ContextVar(
+    "hermes_current_agent", default=None,
+)
+
+
+def get_current_agent() -> Optional[Any]:
+    """Return the AIAgent currently dispatching a tool call, or ``None``.
+
+    Returns ``None`` when called outside a ``handle_function_call`` dispatch
+    (e.g. at module import, from a test that didn't enter the context, or
+    from a plugin's ``register()`` callback). Plugin handlers should always
+    guard against this and return a clear error to the caller.
+    """
+    return _current_agent.get()
+
+
+@contextmanager
+def current_agent(agent: Any) -> Iterator[None]:
+    """Bind *agent* as the current agent for the duration of the ``with`` block.
+
+    Safe under exceptions (the contextvar is always reset in ``finally``).
+    Nestable — inner scopes override outer for their duration.
+    """
+    token = _current_agent.set(agent)
+    try:
+        yield
+    finally:
+        _current_agent.reset(token)


### PR DESCRIPTION
## Problem

Plugin-registered tools (via `PluginContext.register_tool`) dispatch through
`model_tools.handle_function_call`, whose signature doesn't thread the calling
`AIAgent` through. Only the built-in `delegate_task` has access to the parent
agent, via a hardcoded path in `AIAgent._dispatch_delegate_task`.

This blocks a legitimate plugin pattern: registering a custom
`delegate_to_<name>` tool whose handler calls `_build_child_agent` with a
per-call model/provider override — useful when `delegation.model` (one
global) doesn't fit, e.g. per-specialist model selection in an
orchestrator-style parent where different sub-agents warrant different
underlying models.

## Fix

New module `tools/agent_context.py` — a `ContextVar` + `current_agent()`
context manager.

`run_agent.py` — the three `handle_function_call` dispatch sites in
`AIAgent` (`_invoke_tool` + both sequential dispatch paths in the main loop)
wrapped with `with current_agent(self):`. Plugin handlers can then call
`from tools.agent_context import get_current_agent` to retrieve the caller.

## Backward compatibility

Strictly additive:
- `delegate_task`'s hardcoded path (`_dispatch_delegate_task`) is untouched
- Existing tools behave identically — they simply don't read the contextvar
- Third-party callers of `handle_function_call` directly (CLI, test
  harnesses) work unchanged — the wrap is at the caller side in
  `run_agent.py`, not inside `handle_function_call`
- Plugin handlers that don't opt in see zero change

## Tests

`tests/tools/test_agent_context.py` covers the full contract:
- Default `None` outside any context
- Agent visible inside context
- Reset on normal exit
- Reset on exception (context manager guarantees finally)
- Nestable (inner scope overrides outer for its duration, then restores)

All tests pass locally.

## Use case

Plugin handler example that the current runtime blocks, and this PR unblocks:

```python
def delegate_to_compose_handler(args, **kw):
    from tools.agent_context import get_current_agent
    from tools.delegate_tool import _build_child_agent, _run_single_child

    agent = get_current_agent()
    if agent is None:
        return "Error: no parent agent in context"

    child = _build_child_agent(
        task_index=0, goal=args["goal"], context=args.get("context"),
        toolsets=[], model="anthropic/claude-sonnet-4.6",
        max_iterations=5, task_count=1, parent_agent=agent,
        override_provider="openrouter",
        override_api_key=os.environ["OPENROUTER_API_KEY"],
        role="leaf",
    )
    return _run_single_child(
        task_index=0, goal=args["goal"], child=child, parent_agent=agent,
    )
```

Happy to iterate on naming (`current_agent` / `calling_agent` / other), the
module path, or the API shape if maintainers prefer a different design. Also
happy to add a short docs/plugins section explaining the new capability.