### PR TITLE
fix(tui): remove 'q' alias from /quit, add to /queue

### DIFF
--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -70,7 +70,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
-    aliases: ['exit', 'q'],
+    aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
     run: (_arg, ctx) => ctx.session.die()
@@ -333,6 +333,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['q'],
     help: 'inspect or enqueue a message',
     name: 'queue',
     run: (arg, ctx) => {


### PR DESCRIPTION
## Summary

Fixes the TUI frontend slash command registry where `/q` was incorrectly resolving to `/quit` instead of `/queue`.

## Problem

PR #10538 fixed the Python backend (`hermes_cli/commands.py`) by removing `'q'` from `/quit`'s aliases, but the same bug persisted in the TUI TypeScript registry (`ui-tui/src/app/slash/commands/core.ts`).

The TUI's flat command lookup silently overwrote `/queue`'s `q` alias with `/quit`'s, making the documented `/q` shorthand for queueing prompts unusable — it always exited instead.

## Changes

- `core.ts`: Remove `'q'` from `/quit`'s aliases (keeps `'exit'`)
- `core.ts`: Add `aliases: ['q']` to `/queue` command

## Related

- Fixes #10467
- Follow-up to #10538 (backend fix)

## Verification

- `/q <msg>` now correctly queues a message
- `/quit` and `/exit` still exit the TUI
