### PR TITLE
fix(gateway): propagate LD_LIBRARY_PATH into generated systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1531,6 +1531,8 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     # (#8202). 30s of headroom covers the worst case we've observed.
     _drain_timeout = int(_get_restart_drain_timeout() or 0)
     restart_timeout = max(60, _drain_timeout) + 30
+    ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+    _ld_lib_env = ('Environment="LD_LIBRARY_PATH=' + ld_library_path + '"\n') if ld_library_path else ""
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -1567,7 +1569,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=on-failure
+{_ld_lib_env}Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
@@ -1599,7 +1601,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=on-failure
+{_ld_lib_env}Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -107,6 +107,27 @@ class TestGeneratedSystemdUnits:
 
         assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
+    def test_user_unit_includes_ld_library_path_when_set(self, monkeypatch):
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/opt/cuda/lib64:/usr/local/cuda/lib64")
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert 'Environment="LD_LIBRARY_PATH=/opt/cuda/lib64:/usr/local/cuda/lib64"' in unit
+
+    def test_user_unit_omits_ld_library_path_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "LD_LIBRARY_PATH" not in unit
+
+    def test_system_unit_includes_ld_library_path_when_set(self, monkeypatch):
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/opt/cuda/lib64")
+
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert 'Environment="LD_LIBRARY_PATH=/opt/cuda/lib64"' in unit
+
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=True)
 


### PR DESCRIPTION
## What does this PR do?

`generate_systemd_unit()` in `hermes_cli/gateway.py` already carries `PATH`, `VIRTUAL_ENV`, and `HERMES_HOME` into the systemd `Environment=` block at install time, but silently drops `LD_LIBRARY_PATH`. Tools that rely on dynamic library resolution at runtime — most notably `faster-whisper` / `ctranslate2` for local CUDA-backed STT — fail to find `libcublas.so` under systemd even though they work correctly in an interactive terminal.

Parity fix: capture `LD_LIBRARY_PATH` from the install-time environment and emit an `Environment=` line in both the user-service (`system=False`) and system-service (`system=True`) templates when the variable is set. When unset, the generated unit is unchanged — no behavior change for users without CUDA or a custom `LD_LIBRARY_PATH`.

## Related Issue

Fixes #14613

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/gateway.py`: capture `LD_LIBRARY_PATH` from `os.environ` and emit a conditional `Environment=` line in both systemd unit templates (+4 lines)
- `tests/hermes_cli/test_gateway_service.py`: 3 new tests in `TestGeneratedSystemdUnits` — set/unset for user service and set for system service (+21 lines)

## How to Test

```bash
pytest tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits -v
```

All 6 tests pass (3 existing + 3 new).

To verify end-to-end on a CUDA machine:
1. Ensure `LD_LIBRARY_PATH` includes your CUDA lib dir (e.g. `export LD_LIBRARY_PATH=/opt/cuda/lib64`)
2. Run `hermes gateway install`
3. Check `~/.config/systemd/user/hermes-gateway.service` — `Environment="LD_LIBRARY_PATH=/opt/cuda/lib64"` should appear
4. Start the gateway and confirm `faster-whisper` / `ctranslate2` loads without `libcublas.so` errors

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_gateway_service.py -v` and pre-existing failures are unrelated (`dotenv` not installed in local env)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — Linux/CUDA specific, no Windows/macOS impact
- [x] I've updated tool descriptions/schemas — or N/A