### PR TITLE
fix(acp): replay conversation history via session_update on load_session

### DIFF
--- a/acp_adapter/replay.py
+++ b/acp_adapter/replay.py
@@ -1,0 +1,102 @@
+"""Translate a persisted Hermes conversation history into ACP session updates.
+
+The ACP spec requires ``session/load`` to stream the prior conversation back to
+the client via ``session_update`` notifications before resolving, so editors
+such as Zed can reconstruct the thread after a reconnect. The live-prompt
+callbacks in :mod:`acp_adapter.events` and the tool-call builders in
+:mod:`acp_adapter.tools` already know how to translate each event type into an
+ACP payload; this module reuses those helpers against stored messages.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Iterable, List, Mapping
+
+import acp
+
+from .tools import build_tool_complete, build_tool_start, make_tool_call_id
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_tool_arguments(raw: Any) -> dict:
+    """Normalize persisted OpenAI-style tool arguments into a plain dict."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {"raw": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"raw": parsed}
+    return {}
+
+
+def build_replay_notifications(history: Iterable[Mapping[str, Any]]) -> List[Any]:
+    """Return ACP session_update notifications mirroring a persisted history.
+
+    The returned list preserves message order and reuses the same builder
+    helpers the live event callbacks use, so replayed updates are
+    indistinguishable from fresh events on the wire:
+
+    * ``user`` messages → :func:`acp.update_user_message_text`
+    * ``assistant`` reasoning → :func:`acp.update_agent_thought_text`
+    * ``assistant`` text → :func:`acp.update_agent_message_text`
+    * ``assistant`` tool_calls → :func:`build_tool_start` (paired with the
+      matching ``tool`` result via :func:`build_tool_complete`)
+
+    Entries with no recoverable payload are skipped rather than aborting the
+    replay — the goal is best-effort reconstruction, not strict fidelity.
+    """
+    updates: List[Any] = []
+
+    for msg in history:
+        if not isinstance(msg, Mapping):
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        text = str(content).strip() if content else ""
+
+        if role == "user":
+            if text:
+                updates.append(acp.update_user_message_text(text))
+            continue
+
+        if role == "assistant":
+            reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+            if reasoning:
+                reasoning_text = str(reasoning).strip()
+                if reasoning_text:
+                    updates.append(acp.update_agent_thought_text(reasoning_text))
+            if text:
+                updates.append(acp.update_agent_message_text(text))
+
+            tool_calls = msg.get("tool_calls") or []
+            if isinstance(tool_calls, list):
+                for call in tool_calls:
+                    if not isinstance(call, Mapping):
+                        continue
+                    fn = call.get("function") or {}
+                    if not isinstance(fn, Mapping):
+                        fn = {}
+                    name = str(fn.get("name") or call.get("name") or "").strip()
+                    if not name:
+                        continue
+                    tc_id = str(call.get("id") or "").strip() or make_tool_call_id()
+                    args = _parse_tool_arguments(fn.get("arguments") or call.get("arguments"))
+                    updates.append(build_tool_start(tc_id, name, args))
+            continue
+
+        if role == "tool":
+            tc_id = str(msg.get("tool_call_id") or "").strip()
+            if not tc_id:
+                continue
+            tool_name = str(msg.get("tool_name") or msg.get("name") or "").strip() or "tool"
+            updates.append(build_tool_complete(tc_id, tool_name, result=text or None))
+            continue
+
+    return updates

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -60,6 +60,7 @@ from acp_adapter.events import (
     make_tool_progress_cb,
 )
 from acp_adapter.permissions import make_approval_callback
+from acp_adapter.replay import build_replay_notifications
 from acp_adapter.session import SessionManager, SessionState
 
 logger = logging.getLogger(__name__)
@@ -399,9 +400,37 @@ class HermesACPAgent(acp.Agent):
             logger.warning("load_session: session %s not found", session_id)
             return None
         await self._register_session_mcp_servers(state, mcp_servers)
-        logger.info("Loaded session %s", session_id)
+        logger.info(
+            "Loaded session %s (%d persisted messages)",
+            session_id,
+            len(state.history),
+        )
+        # Per ACP spec, session/load must stream the stored conversation back
+        # to the client via session_update notifications before resolving so
+        # editors (Zed, etc.) can rebuild the thread on reconnect.
+        await self._replay_session_history(session_id, state.history)
         self._schedule_available_commands_update(session_id)
         return LoadSessionResponse(models=self._build_model_state(state))
+
+    async def _replay_session_history(
+        self,
+        session_id: str,
+        history: list[dict[str, Any]],
+    ) -> None:
+        """Emit session_update notifications mirroring a persisted history."""
+        if not self._conn or not history:
+            return
+        for update in build_replay_notifications(history):
+            try:
+                await self._conn.session_update(
+                    session_id=session_id, update=update
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to emit replay notification for session %s",
+                    session_id,
+                    exc_info=True,
+                )
 
     async def resume_session(
         self,

--- a/tests/acp/test_replay.py
+++ b/tests/acp/test_replay.py
@@ -1,0 +1,289 @@
+"""Unit tests for acp_adapter.replay.build_replay_notifications."""
+
+from acp.schema import (
+    AgentMessageChunk,
+    AgentThoughtChunk,
+    ToolCallProgress,
+    ToolCallStart,
+    UserMessageChunk,
+)
+
+from acp_adapter.replay import build_replay_notifications
+
+
+# ---------------------------------------------------------------------------
+# Basic role handling
+# ---------------------------------------------------------------------------
+
+
+class TestBasicRoles:
+    def test_empty_history_returns_empty_list(self):
+        assert build_replay_notifications([]) == []
+
+    def test_user_message_emits_user_chunk(self):
+        updates = build_replay_notifications(
+            [{"role": "user", "content": "hello"}]
+        )
+        assert len(updates) == 1
+        assert isinstance(updates[0], UserMessageChunk)
+
+    def test_assistant_text_emits_agent_chunk(self):
+        updates = build_replay_notifications(
+            [{"role": "assistant", "content": "hi there"}]
+        )
+        assert len(updates) == 1
+        assert isinstance(updates[0], AgentMessageChunk)
+
+    def test_order_is_preserved(self):
+        updates = build_replay_notifications([
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third"},
+            {"role": "assistant", "content": "fourth"},
+        ])
+        types = [type(u).__name__ for u in updates]
+        assert types == [
+            "UserMessageChunk",
+            "AgentMessageChunk",
+            "UserMessageChunk",
+            "AgentMessageChunk",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+
+
+class TestSkipConditions:
+    def test_empty_content_user_is_skipped(self):
+        assert build_replay_notifications(
+            [{"role": "user", "content": ""}]
+        ) == []
+
+    def test_whitespace_only_content_is_skipped(self):
+        assert build_replay_notifications(
+            [{"role": "user", "content": "   \n\t"}]
+        ) == []
+
+    def test_none_content_on_assistant_without_tools_emits_nothing(self):
+        # Assistant turns that contain only tool_calls may have content=None;
+        # when there are also no tool_calls, emit nothing.
+        assert build_replay_notifications(
+            [{"role": "assistant", "content": None}]
+        ) == []
+
+    def test_system_messages_are_skipped(self):
+        # System prompts aren't part of the ACP conversation stream.
+        assert build_replay_notifications(
+            [{"role": "system", "content": "you are a helpful assistant"}]
+        ) == []
+
+    def test_non_mapping_entries_are_skipped(self):
+        assert build_replay_notifications(
+            [None, "not a message", 42, {"role": "user", "content": "real"}]
+        ) == [u for u in build_replay_notifications(
+            [{"role": "user", "content": "real"}]
+        )]
+
+    def test_unknown_role_is_skipped(self):
+        assert build_replay_notifications(
+            [{"role": "bogus", "content": "nope"}]
+        ) == []
+
+
+# ---------------------------------------------------------------------------
+# Reasoning / thinking
+# ---------------------------------------------------------------------------
+
+
+class TestReasoning:
+    def test_assistant_reasoning_precedes_text(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": "final answer",
+            "reasoning": "let me think...",
+        }])
+        assert len(updates) == 2
+        assert isinstance(updates[0], AgentThoughtChunk)
+        assert isinstance(updates[1], AgentMessageChunk)
+
+    def test_reasoning_content_used_when_reasoning_absent(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "internal monologue",
+        }])
+        assert any(isinstance(u, AgentThoughtChunk) for u in updates)
+
+    def test_reasoning_without_content_still_emits(self):
+        # Pure reasoning turn with no visible text (happens during
+        # multi-step reasoning-first providers).
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": None,
+            "reasoning": "just thinking",
+        }])
+        assert len(updates) == 1
+        assert isinstance(updates[0], AgentThoughtChunk)
+
+    def test_empty_reasoning_does_not_emit_thought_chunk(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "   ",
+        }])
+        assert all(not isinstance(u, AgentThoughtChunk) for u in updates)
+
+
+# ---------------------------------------------------------------------------
+# Tool calls
+# ---------------------------------------------------------------------------
+
+
+class TestToolCalls:
+    def test_assistant_tool_call_emits_start(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_abc",
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "arguments": '{"command": "ls"}',
+                },
+            }],
+        }])
+        starts = [u for u in updates if isinstance(u, ToolCallStart)]
+        assert len(starts) == 1
+        assert starts[0].tool_call_id == "call_abc"
+
+    def test_tool_result_emits_progress_with_matching_id(self):
+        updates = build_replay_notifications([
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_xyz",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "x"}'},
+                }],
+            },
+            {
+                "role": "tool",
+                "content": "file contents here",
+                "tool_call_id": "call_xyz",
+                "tool_name": "read_file",
+            },
+        ])
+        starts = [u for u in updates if isinstance(u, ToolCallStart)]
+        progress = [u for u in updates if isinstance(u, ToolCallProgress)]
+        assert len(starts) == 1
+        assert len(progress) == 1
+        assert starts[0].tool_call_id == progress[0].tool_call_id == "call_xyz"
+
+    def test_tool_result_without_id_is_skipped(self):
+        # A tool result without tool_call_id can't be correlated to a start
+        # event; emitting a stray progress notification would dangle.
+        updates = build_replay_notifications([
+            {"role": "tool", "content": "orphan", "tool_name": "terminal"},
+        ])
+        assert updates == []
+
+    def test_tool_call_with_malformed_arguments_is_handled(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_bad",
+                "function": {"name": "terminal", "arguments": "not-valid-json"},
+            }],
+        }])
+        starts = [u for u in updates if isinstance(u, ToolCallStart)]
+        assert len(starts) == 1
+        assert starts[0].tool_call_id == "call_bad"
+
+    def test_tool_call_without_id_generates_fallback(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "function": {"name": "terminal", "arguments": "{}"},
+            }],
+        }])
+        starts = [u for u in updates if isinstance(u, ToolCallStart)]
+        assert len(starts) == 1
+        assert starts[0].tool_call_id  # non-empty
+
+    def test_tool_call_without_name_is_skipped(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call_nameless", "function": {}}],
+        }])
+        assert updates == []
+
+    def test_assistant_text_and_tool_calls_both_emit(self):
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": "let me check that file",
+            "tool_calls": [{
+                "id": "call_1",
+                "function": {"name": "read_file", "arguments": '{"path": "x"}'},
+            }],
+        }])
+        assert any(isinstance(u, AgentMessageChunk) for u in updates)
+        assert any(isinstance(u, ToolCallStart) for u in updates)
+
+    def test_tool_calls_list_of_dict_args_is_handled(self):
+        # Providers may hand us a dict (already-parsed) rather than a JSON str.
+        updates = build_replay_notifications([{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_parsed",
+                "function": {"name": "terminal", "arguments": {"command": "pwd"}},
+            }],
+        }])
+        starts = [u for u in updates if isinstance(u, ToolCallStart)]
+        assert len(starts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Realistic conversation
+# ---------------------------------------------------------------------------
+
+
+class TestRealisticConversation:
+    def test_full_conversation_roundtrip(self):
+        history = [
+            {"role": "user", "content": "run `pwd`"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning": "I'll run pwd.",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "terminal", "arguments": '{"command": "pwd"}'},
+                }],
+            },
+            {
+                "role": "tool",
+                "content": "/home/user",
+                "tool_call_id": "call_1",
+                "tool_name": "terminal",
+            },
+            {"role": "assistant", "content": "You're in /home/user."},
+            {"role": "user", "content": "thanks"},
+        ]
+        updates = build_replay_notifications(history)
+        types = [type(u).__name__ for u in updates]
+        assert types == [
+            "UserMessageChunk",       # "run pwd"
+            "AgentThoughtChunk",      # reasoning
+            "ToolCallStart",          # terminal call_1
+            "ToolCallProgress",       # tool result for call_1
+            "AgentMessageChunk",      # "You're in /home/user."
+            "UserMessageChunk",       # "thanks"
+        ]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -26,6 +26,8 @@ from acp.schema import (
     SetSessionModeResponse,
     SessionInfo,
     TextContentBlock,
+    ToolCallProgress,
+    ToolCallStart,
     Usage,
 )
 from acp_adapter.server import HermesACPAgent, HERMES_VERSION
@@ -228,6 +230,204 @@ class TestSessionOps:
     async def test_resume_session_creates_new_if_missing(self, agent):
         resume_resp = await agent.resume_session(cwd="/tmp", session_id="nonexistent")
         assert isinstance(resume_resp, ResumeSessionResponse)
+
+
+# ---------------------------------------------------------------------------
+# load_session conversation history replay (per ACP spec)
+# ---------------------------------------------------------------------------
+
+
+def _notification_types(mock_conn) -> list[str]:
+    """Return the type names of every session_update payload the mock saw."""
+    types: list[str] = []
+    for call in mock_conn.session_update.await_args_list:
+        update = call.kwargs.get("update")
+        if update is None and len(call.args) >= 2:
+            update = call.args[1]
+        if update is not None:
+            types.append(type(update).__name__)
+    return types
+
+
+class TestLoadSessionReplay:
+    @pytest.mark.asyncio
+    async def test_load_session_replays_text_messages(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+            {"role": "user", "content": "what's 2+2?"},
+            {"role": "assistant", "content": "4"},
+        ]
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        assert isinstance(resp, LoadSessionResponse)
+
+        types = _notification_types(mock_conn)
+        # UserMessageChunk + AgentMessageChunk must appear in interleaved order,
+        # and all four must precede any AvailableCommandsUpdate (per ACP spec
+        # ordering — history before live state).
+        history_types = [
+            t for t in types
+            if t in ("UserMessageChunk", "AgentMessageChunk")
+        ]
+        assert history_types == [
+            "UserMessageChunk",
+            "AgentMessageChunk",
+            "UserMessageChunk",
+            "AgentMessageChunk",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_load_session_replays_tool_calls(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "show pwd"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command": "pwd"}',
+                    },
+                }],
+            },
+            {
+                "role": "tool",
+                "content": "/home/user",
+                "tool_call_id": "call_1",
+                "tool_name": "terminal",
+            },
+            {"role": "assistant", "content": "You are in /home/user."},
+        ]
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+
+        # Extract the actual update objects so we can correlate IDs.
+        updates = []
+        for call in mock_conn.session_update.await_args_list:
+            update = call.kwargs.get("update") or (
+                call.args[1] if len(call.args) >= 2 else None
+            )
+            if update is not None:
+                updates.append(update)
+
+        tool_starts = [u for u in updates if isinstance(u, ToolCallStart)]
+        tool_progress = [u for u in updates if isinstance(u, ToolCallProgress)]
+
+        assert len(tool_starts) == 1
+        assert len(tool_progress) == 1
+        assert tool_starts[0].tool_call_id == "call_1"
+        assert tool_progress[0].tool_call_id == "call_1"
+
+    @pytest.mark.asyncio
+    async def test_load_session_replays_reasoning(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "solve it"},
+            {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning": "After careful deliberation...",
+            },
+        ]
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+
+        types = _notification_types(mock_conn)
+        # Reasoning must come before the visible answer.
+        thought_idx = types.index("AgentThoughtChunk")
+        message_idx = types.index("AgentMessageChunk")
+        assert thought_idx < message_idx
+
+    @pytest.mark.asyncio
+    async def test_load_session_empty_history_emits_no_history_chunks(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        # state.history is already an empty list from create_session.
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        assert isinstance(resp, LoadSessionResponse)
+
+        types = _notification_types(mock_conn)
+        # No user/agent/tool chunks — only the commands update (which may or
+        # may not have fired synchronously) is acceptable.
+        assert not any(
+            t in ("UserMessageChunk", "AgentMessageChunk", "AgentThoughtChunk",
+                  "ToolCallStart", "ToolCallProgress")
+            for t in types
+        )
+
+    @pytest.mark.asyncio
+    async def test_load_session_not_found_emits_no_replay(self, agent):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.load_session(cwd="/tmp", session_id="does-not-exist")
+        assert resp is None
+        # No notifications emitted for an unknown session.
+        mock_conn.session_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_load_session_replay_survives_notification_failure(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third"},
+        ]
+
+        # First call raises; subsequent calls must still fire.
+        calls_seen: list = []
+
+        async def flaky(**kwargs):
+            calls_seen.append(kwargs.get("update"))
+            if len(calls_seen) == 1:
+                raise RuntimeError("transient client error")
+            return None
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock(side_effect=flaky)
+        agent._conn = mock_conn
+
+        resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        # load_session must still resolve even though one replay step failed.
+        assert isinstance(resp, LoadSessionResponse)
+        # And subsequent messages after the failure were still emitted.
+        assert len(calls_seen) >= 3
+
+    @pytest.mark.asyncio
+    async def test_load_session_without_conn_does_not_crash(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [{"role": "user", "content": "hello"}]
+
+        agent._conn = None
+        resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        assert isinstance(resp, LoadSessionResponse)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What you see before this PR

Open a Hermes session from Zed, have a multi-turn conversation with a few tool calls, close Zed, reopen it and click the same session. The thread panel comes back blank — just the composer, no history. The session is still in `~/.hermes/state.db` (search finds it fine, `/resume` from the CLI shows it fine), but Zed itself has no way to rebuild the transcript. Users have been patching around this by parsing the SQLite file directly, which obviously isn't how the protocol is meant to work.

### Why it happens

The ACP spec for `session/load` is explicit: before resolving the response, the agent must stream the stored conversation back to the client as `session_update` notifications — a `user_message_chunk` for each user turn, `agent_message_chunk` / `agent_thought_chunk` for assistant turns, plus `tool_call` + `tool_call_update` pairs for every completed tool invocation. The client replays those into its own view.

`HermesACPAgent.load_session` was only doing half the job: update the CWD, register the ACP-provided MCP servers, schedule the `available_commands_update`, return. No history replay at all. Persistence worked (that half landed ages ago — see `SessionManager._persist` / `_restore`), but the notification side was never wired up.

### The fix

A new module `acp_adapter/replay.py` owns the mapping from a persisted message dict to ACP notifications. It deliberately doesn't reinvent anything — it leans on the same `build_tool_start` / `build_tool_complete` helpers in `acp_adapter/tools.py` that the live `tool_progress_cb` and `step_cb` callbacks use, plus the same `acp.update_*_text` functions the message/thought callbacks use. A replayed `ToolCallStart` on the wire is byte-identical to a live one; the client can't tell them apart, which is the point.

`load_session` now calls a thin `_replay_session_history` that iterates those notifications with `await self._conn.session_update(...)` before scheduling the commands update. Notifications are awaited (not scheduled via `call_soon`) so the spec-required ordering is preserved.

A few design choices worth flagging:
- Tool call IDs come from the persisted OpenAI-style `tool_calls[].id`; when it's missing, `make_tool_call_id()` generates one. Correlation between `tool_call` start and `tool_call_update` is by that ID, same as live.
- Empty content, whitespace-only content, `None` content on a pure-reasoning turn, and unknown roles are all skipped silently rather than emitting noise.
- Per-notification exceptions are caught and logged at `debug` — one flaky chunk shouldn't abort the rest of the replay.
- No `_conn` (e.g. in isolation tests) is a no-op; `load_session` still resolves cleanly.

### Verification

- `tests/acp/test_replay.py` — 23 unit tests covering each role, reasoning ordering, tool call correlation, malformed JSON arguments, orphan tool results, dict-vs-JSON argument formats, a full realistic conversation round-trip.
- `tests/acp/test_server.py::TestLoadSessionReplay` — 7 integration tests covering text replay ordering, tool call ID correlation across `load_session`, reasoning-before-answer sequencing, empty history, not-found returning `None` without emitting anything, surviving a transient `session_update` failure mid-replay, and the no-`_conn` path.
- `pytest tests/acp/` — 185 passed. There's one failure in `test_ping_suppression.py` on Windows that's already red on `main` (pre-existing asyncio + `WindowsProactorEventLoop` issue), unrelated to this change.
- `ruff check` clean on the two new files.

Closes #12285.