### PR TITLE
fix(compression): three bugs causing auto-compression to never trigger

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -296,6 +296,7 @@ class ContextCompressor(ContextEngine):
         self._previous_summary = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._last_compression_time = 0.0
 
     def update_model(
         self,
@@ -317,6 +318,8 @@ class ContextCompressor(ContextEngine):
             int(context_length * self.threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
         )
+        if self.threshold_tokens >= context_length:
+            self.threshold_tokens = int(context_length * self.threshold_percent)
 
     def __init__(
         self,
@@ -353,10 +356,17 @@ class ContextCompressor(ContextEngine):
         # the percentage would suggest a lower value.  This prevents premature
         # compression on large-context models at 50% while keeping the % sane
         # for models right at the minimum.
+        # However, when context_length <= MINIMUM_CONTEXT_LENGTH the floor
+        # would make threshold >= 100% of context, which is unreachable — the
+        # API errors out before prompt_tokens can reach that value.  In that
+        # case fall back to the percentage-based value so compression can
+        # actually trigger.
         self.threshold_tokens = max(
             int(self.context_length * threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
         )
+        if self.threshold_tokens >= self.context_length:
+            self.threshold_tokens = int(self.context_length * threshold_percent)
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context
@@ -388,6 +398,8 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
+        self._last_compression_time: float = 0.0
+        self._ANTI_THRASH_RECOVERY_SECONDS: float = 300.0
         self._summary_failure_cooldown_until: float = 0.0
 
     def update_from_response(self, usage: Dict[str, Any]):
@@ -406,15 +418,28 @@ class ContextCompressor(ContextEngine):
         if tokens < self.threshold_tokens:
             return False
         # Anti-thrashing: back off if recent compressions were ineffective
+        # Auto-recovery: if enough time has passed since the last compression
+        # attempt, reset the counter.  Without this, a session that had two
+        # ineffective compressions early on will never auto-compress again,
+        # even as the context grows far beyond the threshold.
         if self._ineffective_compression_count >= 2:
-            if not self.quiet_mode:
-                logger.warning(
-                    "Compression skipped — last %d compressions saved <10%% each. "
-                    "Consider /new to start a fresh session, or /compress <topic> "
-                    "for focused compression.",
-                    self._ineffective_compression_count,
-                )
-            return False
+            _elapsed = time.monotonic() - self._last_compression_time
+            if _elapsed > self._ANTI_THRASH_RECOVERY_SECONDS:
+                self._ineffective_compression_count = 0
+                if not self.quiet_mode:
+                    logger.info(
+                        "Anti-thrashing reset: %.0fs since last compression attempt",
+                        _elapsed,
+                    )
+            else:
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression skipped — last %d compressions saved <10%% each. "
+                        "Consider /new to start a fresh session, or /compress <topic> "
+                        "for focused compression.",
+                        self._ineffective_compression_count,
+                    )
+                return False
         return True
 
     # ------------------------------------------------------------------
@@ -1258,6 +1283,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Anti-thrashing: track compression effectiveness
         savings_pct = (saved_estimate / display_tokens * 100) if display_tokens > 0 else 0
         self._last_compression_savings_pct = savings_pct
+        self._last_compression_time = time.monotonic()
         if savings_pct < 10:
             self._ineffective_compression_count += 1
         else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7595,9 +7595,14 @@ class AIAgent:
 
         # Update token estimate after compaction so pressure calculations
         # use the post-compression count, not the stale pre-compression one.
-        _compressed_est = (
-            estimate_tokens_rough(new_system_prompt)
-            + estimate_messages_tokens_rough(compressed)
+        # Use estimate_request_tokens_rough (not estimate_messages_tokens_rough)
+        # to include tools schema tokens — with 50+ tools enabled, schemas alone
+        # can add 20-30K tokens, and omitting them causes the next compression
+        # cycle to trigger much later than the configured threshold.
+        _compressed_est = estimate_request_tokens_rough(
+            compressed,
+            system_prompt=new_system_prompt or "",
+            tools=self.tools or None,
         )
         self.context_compressor.last_prompt_tokens = _compressed_est
         self.context_compressor.last_completion_tokens = 0


### PR DESCRIPTION
## Summary

Fixes three bugs in the context auto-compression system that collectively cause compression to never trigger for models with `context_length` at or near `MINIMUM_CONTEXT_LENGTH` (64000 tokens).

## Bug 1: MINIMUM_CONTEXT_LENGTH floor makes threshold=100% when context_length==64000

Closes #14690

When `context_length == MINIMUM_CONTEXT_LENGTH == 64000`, the floor value in `threshold_tokens` calculation dominates:

```python
# Before: max(44800, 64000) = 64000 = 100% of context → compression never triggers
self.threshold_tokens = max(
    int(self.context_length * threshold_percent),
    MINIMUM_CONTEXT_LENGTH,
)
```

**Fix**: Fall back to percentage-based value when floor >= context_length:
```python
if self.threshold_tokens >= self.context_length:
    self.threshold_tokens = int(self.context_length * threshold_percent)
```

Applied in both `__init__` and `update_model`.

## Bug 2: Anti-thrashing protection permanently disables compression with no recovery

Closes #14694

After 2 consecutive ineffective compressions (<10% savings each), `should_compress()` returns `False` forever. No timeout, decay, or auto-recovery mechanism exists.

**Fix**: Add time-based auto-recovery (300 seconds). If enough time has passed since the last compression attempt, reset the counter:
```python
if self._ineffective_compression_count >= 2:
    _elapsed = time.monotonic() - self._last_compression_time
    if _elapsed > self._ANTI_THRASH_RECOVERY_SECONDS:
        self._ineffective_compression_count = 0
    else:
        return False
```

## Bug 3: Post-compression token estimate excludes tools schema

Closes #14695

After compression, `last_prompt_tokens` is set using `estimate_messages_tokens_rough()` which omits tools schema tokens (20-30K with 50+ tools). This causes the next compression cycle to trigger much later than the configured threshold.

**Fix**: Use `estimate_request_tokens_rough()` which includes tools schema, consistent with the preflight compression check pattern:
```python
# Before:
_compressed_est = estimate_tokens_rough(new_system_prompt) + estimate_messages_tokens_rough(compressed)

# After:
_compressed_est = estimate_request_tokens_rough(
    compressed, system_prompt=new_system_prompt or "", tools=self.tools or None,
)
```

## Testing

Verified with unit-level tests:
- Bug 1: `context_length=64000, threshold=0.7` → `threshold_tokens=44800` (70%), `should_compress(44800)=True`
- Bug 2: Anti-thrashing blocks within 300s window, auto-recovers after 300s elapsed
- Bug 3: `estimate_request_tokens_rough` includes tools schema in token count

## Files Changed

- `agent/context_compressor.py`: Bug 1 fix (L320-321, L363-368) + Bug 2 fix (L299, L398-401, L418-436, L1283)
- `run_agent.py`: Bug 3 fix (L7596-7607)