### PR TITLE
fix(nix): expose hermes binary to TUI setup handoff

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -141,6 +141,14 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             (echo "FAIL: HERMES_TUI_DIR not in wrapper"; exit 1)
           echo "PASS: HERMES_TUI_DIR set in wrapper"
 
+          grep -q "HERMES_BIN" ${hermes-agent}/bin/hermes || \
+            (echo "FAIL: HERMES_BIN not in wrapper"; exit 1)
+          echo "PASS: HERMES_BIN set in wrapper"
+
+          HERMES_BIN=$(sed -n "s/^export HERMES_BIN='\(.*\)'/\1/p" ${hermes-agent}/bin/hermes)
+          test -x "$HERMES_BIN" || (echo "FAIL: HERMES_BIN=$HERMES_BIN not executable"; exit 1)
+          echo "PASS: HERMES_BIN executable at $HERMES_BIN"
+
           echo "=== All bundled TUI checks passed ==="
           mkdir -p $out
           echo "ok" > $out/result

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -98,6 +98,7 @@ stdenv.mkDerivation {
           --set HERMES_TUI_DIR $out/ui-tui \
           --set HERMES_PYTHON ${hermesVenv}/bin/python3 \
           --set HERMES_NODE ${nodejs_22}/bin/node \
+          --set HERMES_BIN $out/bin/hermes \
           ${lib.optionalString (extraPythonPackages != [ ]) ''--suffix PYTHONPATH : "${pythonPath}"''}
       '')
       [


### PR DESCRIPTION
## Summary
- set HERMES_BIN in the Nix wrapper so TUI /provider and /setup handoffs can re-launch the same Hermes runtime
- extend the bundled TUI Nix check to verify HERMES_BIN is present and executable

Fixes #14647

## Testing
- git diff --check
- source .venv/bin/activate && scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py

Note: I could not run the Nix check locally because nix is not installed in this environment.