### PR TITLE
fix(agent): fallback to input_tokens/output_tokens for OpenAI-compat local servers

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -530,8 +530,18 @@ def normalize_usage(
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
+        # OpenAI-style names first; fall back to Anthropic-style
+        # (input_tokens/output_tokens). Local OpenAI-compatible servers like
+        # mlx_vlm.server emit the Anthropic names in chat_completions responses,
+        # and the OpenAI Python client preserves them as extra attributes.
+        prompt_value = getattr(response_usage, "prompt_tokens", None)
+        if prompt_value is None:
+            prompt_value = getattr(response_usage, "input_tokens", 0)
+        prompt_total = _to_int(prompt_value)
+        output_value = getattr(response_usage, "completion_tokens", None)
+        if output_value is None:
+            output_value = getattr(response_usage, "output_tokens", 0)
+        output_tokens = _to_int(output_value)
         details = getattr(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -696,8 +696,18 @@ def normalize_usage(
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
+        # OpenAI-style names first; fall back to Anthropic-style
+        # (input_tokens/output_tokens). Local OpenAI-compatible servers like
+        # mlx_vlm.server emit the Anthropic names in chat_completions responses,
+        # and the OpenAI Python client preserves them as extra attributes.
+        prompt_value = getattr(response_usage, "prompt_tokens", None)
+        if prompt_value is None:
+            prompt_value = getattr(response_usage, "input_tokens", 0)
+        prompt_total = _to_int(prompt_value)
+        output_value = getattr(response_usage, "completion_tokens", None)
+        if output_value is None:
+            output_value = getattr(response_usage, "output_tokens", 0)
+        output_tokens = _to_int(output_value)
         details = getattr(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -145,6 +145,56 @@ def test_estimate_usage_cost_marks_subscription_routes_included():
     assert float(result.amount_usd) == 0.0
 
 
+def test_normalize_usage_openai_compat_fallback_to_anthropic_names():
+    """Local OpenAI-compatible servers (mlx_vlm, etc.) emit input_tokens/output_tokens
+    instead of prompt_tokens/completion_tokens. Regression guard for #14686.
+    """
+    usage = SimpleNamespace(
+        input_tokens=11477,
+        output_tokens=235,
+        total_tokens=11712,
+    )
+
+    normalized = normalize_usage(usage, provider="custom", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 11477
+    assert normalized.output_tokens == 235
+    assert normalized.prompt_tokens == 11477
+
+
+def test_normalize_usage_openai_compat_prefers_openai_names_when_both_present():
+    """When both OpenAI-style and Anthropic-style fields are present,
+    OpenAI-style takes priority (no real server emits both, but defensive).
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        input_tokens=9999,
+        output_tokens=8888,
+    )
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 1000
+    assert normalized.output_tokens == 200
+
+
+def test_normalize_usage_openai_compat_preserves_zero_openai_names():
+    """Zero-valued OpenAI fields are present values, not a signal to fall back."""
+    usage = SimpleNamespace(
+        prompt_tokens=0,
+        completion_tokens=0,
+        input_tokens=9999,
+        output_tokens=8888,
+    )
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 0
+    assert normalized.output_tokens == 0
+    assert normalized.prompt_tokens == 0
+
+
 def test_estimate_usage_cost_refuses_cache_pricing_without_official_cache_rate(monkeypatch):
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_model_metadata",


### PR DESCRIPTION
## What does this PR do?

Fixes `normalize_usage()` in `agent/usage_pricing.py` so that OpenAI-compatible local servers (e.g. `mlx_vlm.server`) that emit Anthropic-style `input_tokens` / `output_tokens` instead of OpenAI-style `prompt_tokens` / `completion_tokens` are handled correctly.

Previously, the `else` branch only read `prompt_tokens` and `completion_tokens`. When a local server returned `input_tokens`/`output_tokens`, both values were read as 0. This caused:
- Context progress bar stuck at 0% forever
- Auto-compression thresholds never triggering
- Long sessions eventually OOM-ing the context window

The fix adds a defensive fallback: try OpenAI-style names first, then fall back to Anthropic-style names. OpenAI-style takes priority when both are present.

Fixes #14686

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py` — `normalize_usage()` else-branch now reads `input_tokens`/`output_tokens` as fallback
- `tests/agent/test_usage_pricing.py` — added 2 regression tests:
  - `test_normalize_usage_openai_compat_fallback_to_anthropic_names` (mlx_vlm shape)
  - `test_normalize_usage_openai_compat_prefers_openai_names_when_both_present` (priority defense)

## How to Test

1. `pytest tests/agent/test_usage_pricing.py -v` — all 11 tests pass
2. The fix can be exercised by pointing Hermes at any local OpenAI-compatible server that returns `input_tokens`/`output_tokens` in usage (e.g. `mlx_vlm.server`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (focused: `tests/agent/test_usage_pricing.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 aarch64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
