### PR TITLE
feat(skills): add suprawall-security skill

### DIFF
--- a/optional-skills/suprawall-security/README.md
+++ b/optional-skills/suprawall-security/README.md
@@ -1,0 +1,18 @@
+# SupraWall Security Skill
+
+Deterministic security enforcement for Hermes Agent.
+
+## Overview
+
+SupraWall is a security layer that intercepts tool calls to enforce safety, privacy, and budget constraints.
+
+## Features
+
+- **Gating**: ALLOW/DENY/REQUIRE_APPROVAL for every tool.
+- **PII Scrubbing**: Automatic detection and redaction of sensitive data.
+- **Vault**: Secure credential injection.
+- **Budgeting**: Enforce cost and token limits.
+
+## Configuration
+
+Requires `SUPRAWALL_API_KEY` in your environment.

--- a/optional-skills/suprawall-security/examples/check_tool_call.py
+++ b/optional-skills/suprawall-security/examples/check_tool_call.py
@@ -1,0 +1,20 @@
+import os
+from hermes_agent.skills.suprawall import suprawall_check
+
+def main():
+      # Example usage of suprawall_check
+      tool_name = "browser_open_url"
+      arguments = {"url": "https://example.com"}
+
+    result = suprawall_check(tool_name, arguments)
+
+    if result["status"] == "ALLOW":
+              print(f"Tool call to {tool_name} is allowed.")
+elif result["status"] == "DENY":
+          print(f"Tool call to {tool_name} is denied: {result['reason']}")
+elif result["status"] == "REQUIRE_APPROVAL":
+          print(f"Tool call to {tool_name} requires approval.")
+
+if __name__ == "__main__":
+      main()
+  

--- a/optional-skills/suprawall-security/plugin.yaml
+++ b/optional-skills/suprawall-security/plugin.yaml
@@ -1,0 +1,24 @@
+name: suprawall-security
+version: 1.0.0
+description: >
+  Deterministic security enforcement for Hermes Agent.
+    Intercepts every tool call with ALLOW/DENY/REQUIRE_APPROVAL gating,
+      PII scrubbing, vault credential injection, and budget caps.
+      author: SupraWall Contributors
+      license: Apache-2.0
+      homepage: https://supra-wall.com
+
+      provides_tools:
+        - suprawall_check
+          - suprawall_vault_get
+
+          provides_hooks:
+            - pre_tool_call
+              - post_tool_call
+
+              provides_commands:
+                - suprawall
+
+                requires_env:
+                  - SUPRAWALL_API_KEY
+                  


### PR DESCRIPTION
This PR adds the SupraWall Security skill to the optional-skills directory.

SupraWall is a security layer that intercepts tool calls to enforce safety, privacy, and budget constraints.

Included files:
- plugin.yaml: Skill definition.
- - README.md: Documentation.
- - examples/check_tool_call.py: Example usage.
- 