### PR TITLE
fix(install): drop autostash by ref instead of SHA

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -752,7 +752,11 @@ clone_repo() {
                 if [ "$restore_now" = "yes" ]; then
                     log_info "Restoring local changes..."
                     if git stash apply "$autostash_ref"; then
-                        git stash drop "$autostash_ref" >/dev/null
+                        local autostash_drop_ref
+                        autostash_drop_ref="$(git stash list --format='%gd %H' | awk -v sha="$autostash_ref" '$2 == sha {print $1; exit}')"
+                        if [ -n "$autostash_drop_ref" ]; then
+                            git stash drop "$autostash_drop_ref" >/dev/null
+                        fi
                         log_warn "Local changes were restored on top of the updated codebase."
                         log_warn "Review git diff / git status if Hermes behaves unexpectedly."
                     else


### PR DESCRIPTION
## Summary

- `git rev-parse refs/stash` returns a commit SHA. `git stash apply <sha>` accepts that, but `git stash drop <sha>` rejects it with `"<sha>" is not a stash reference` — drop only takes `stash@{N}`.
- The autostash cleanup in `scripts/install.sh` therefore always fails: `set -e` makes the installer exit 1, even though `git stash apply` already re-applied the user's changes. From the user's perspective a successful update looks broken, and an orphan `hermes-install-autostash-…` stash piles up after every run.
- Fix: after `apply` succeeds, look the matching `stash@{N}` ref up by SHA in `git stash list` and drop that. Keeps the SHA for `apply` (robust against intervening stash operations) and uses the symbolic ref only where `drop` requires it.

## Repro

1. In an existing install, leave a local change in the working tree (e.g. `echo "" >> cli.py`).
2. `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`
3. Observe at the end:
   ```
   error: '<sha>' is not a stash reference
   ```
   exit code 1, working tree still dirty (apply succeeded), and `git stash list` shows a leftover `hermes-install-autostash-…` entry.

## Test plan

- [x] Reproduced the bug end-to-end on `main` against a real install.
- [x] Verified the `awk -v sha=… '\$2 == sha {print \$1; exit}'` lookup works on macOS BSD awk in a throwaway repo (resolves to `stash@{0}`, `git stash drop` succeeds, stash list empty).
- [ ] Maintainer to spot-check on Linux (GNU awk) and Termux — the awk pattern is plain POSIX, no GNU-isms, so it should be fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)