### PR TITLE
feat: add Telegram quick-reply buttons

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -199,6 +199,110 @@ def _wrap_markdown_tables(text: str) -> str:
     return '\n'.join(out)
 
 
+def _telegram_button_callback_data(label: str, explicit: Optional[str] = None) -> str:
+    """Return compact callback_data for generic Telegram quick-reply buttons."""
+    raw = explicit or label
+    # Telegram Bot API caps callback_data at 64 bytes.  The qb: prefix tells
+    # the callback handler to turn the tap into a normal user message.
+    payload = str(raw).strip() or str(label).strip() or "Button"
+    data = f"qb:{payload}"
+    encoded = data.encode("utf-8")
+    if len(encoded) <= 64:
+        return data
+    return encoded[:64].decode("utf-8", errors="ignore")
+
+
+def _extract_button_specs_from_components(components: Any) -> list[list[dict]]:
+    """Normalize generic/Discord-style component payloads into button rows.
+
+    Supports the Discord Components v2 shape used by the ``quick-buttons``
+    skill (``blocks`` with ``actions.buttons`` or ``section.accessory.button``)
+    plus a small platform-neutral shorthand: ``{"buttons": [...]}`` or a list
+    of button dicts / rows.
+    """
+    if not components:
+        return []
+
+    rows: list[list[dict]] = []
+
+    def _button_from(value: Any) -> Optional[dict]:
+        if not isinstance(value, dict):
+            return None
+        button = value.get("button") if isinstance(value.get("button"), dict) else value
+        label = button.get("label") or button.get("text") or button.get("title")
+        if not label:
+            return None
+        return {
+            "label": str(label),
+            "url": button.get("url"),
+            "callback_data": (
+                button.get("callback_data")
+                or button.get("callbackData")
+                or button.get("value")
+                or button.get("custom_id")
+                or button.get("customId")
+            ),
+        }
+
+    def _append_button_row(buttons: Any) -> None:
+        row = []
+        for item in buttons or []:
+            spec = _button_from(item)
+            if spec:
+                row.append(spec)
+        if row:
+            # Telegram allows up to 8 inline buttons per row; keep rows readable.
+            for i in range(0, len(row), 4):
+                rows.append(row[i:i + 4])
+
+    if isinstance(components, dict):
+        if isinstance(components.get("buttons"), list):
+            _append_button_row(components["buttons"])
+        for block in components.get("blocks", []) or []:
+            if not isinstance(block, dict):
+                continue
+            if isinstance(block.get("buttons"), list):
+                _append_button_row(block["buttons"])
+            accessory = block.get("accessory")
+            if isinstance(accessory, dict):
+                spec = _button_from(accessory)
+                if spec:
+                    rows.append([spec])
+    elif isinstance(components, list):
+        if components and all(isinstance(row, list) for row in components):
+            for row in components:
+                _append_button_row(row)
+        else:
+            _append_button_row(components)
+
+    return rows
+
+
+def _telegram_inline_keyboard_from_components(components: Any) -> Any:
+    """Build Telegram InlineKeyboardMarkup from generic button components."""
+    rows = _extract_button_specs_from_components(components)
+    if not rows:
+        return None
+    keyboard_rows = []
+    for row in rows:
+        keyboard_row = []
+        for button in row:
+            label = button["label"][:64]
+            if button.get("url"):
+                keyboard_row.append(InlineKeyboardButton(label, url=button["url"]))
+            else:
+                keyboard_row.append(InlineKeyboardButton(
+                    label,
+                    callback_data=_telegram_button_callback_data(
+                        label,
+                        button.get("callback_data"),
+                    ),
+                ))
+        if keyboard_row:
+            keyboard_rows.append(keyboard_row)
+    return InlineKeyboardMarkup(keyboard_rows) if keyboard_rows else None
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -998,6 +1102,9 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
+            reply_markup = _telegram_inline_keyboard_from_components(
+                metadata.get("components") if metadata else None
+            )
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1030,6 +1137,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
+                                reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
@@ -1043,6 +1151,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     message_thread_id=effective_thread_id,
+                                    reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                     **self._link_preview_kwargs(),
                                 )
                             else:
@@ -1614,6 +1723,60 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- Generic quick-reply callbacks (qb:<text>) ---
+        # These are produced by send(..., metadata={"components": ...}) and
+        # by send_message(..., components=...). Treat a tap like a normal user
+        # message so agent conversations can continue without requiring typing.
+        if data.startswith("qb:"):
+            selected = data[3:].strip()
+            if not selected:
+                await query.answer(text="No button payload.")
+                return
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(caller_id):
+                await query.answer(text="⛔ You are not authorized to use this button.")
+                return
+            await query.answer(text=selected[:120])
+            try:
+                chat = query.message.chat if query.message else None
+                if not chat:
+                    return
+                chat_type = "dm"
+                if getattr(chat, "type", None) in (ChatType.GROUP, ChatType.SUPERGROUP):
+                    chat_type = "group"
+                elif getattr(chat, "type", None) == ChatType.CHANNEL:
+                    chat_type = "channel"
+                thread_id_raw = getattr(query.message, "message_thread_id", None)
+                thread_id_str = str(thread_id_raw) if thread_id_raw is not None else None
+                if chat_type == "group" and thread_id_str is None and getattr(chat, "is_forum", False):
+                    thread_id_str = self._GENERAL_TOPIC_THREAD_ID
+                user = query.from_user
+                source = self.build_source(
+                    chat_id=str(chat.id),
+                    chat_name=getattr(chat, "title", None) or getattr(chat, "full_name", None),
+                    chat_type=chat_type,
+                    user_id=str(getattr(user, "id", "")) if user else None,
+                    user_name=getattr(user, "full_name", None) or getattr(user, "first_name", None),
+                    thread_id=thread_id_str,
+                )
+                event = MessageEvent(
+                    text=selected,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    raw_message=query.message,
+                    message_id=str(getattr(query.message, "message_id", "")),
+                    platform_update_id=getattr(update, "update_id", None),
+                    timestamp=getattr(query.message, "date", None),
+                )
+                try:
+                    await query.edit_message_reply_markup(reply_markup=None)
+                except Exception:
+                    pass
+                await self.handle_message(event)
+            except Exception as exc:
+                logger.error("Failed to dispatch Telegram quick-reply callback: %s", exc, exc_info=True)
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/tests/gateway/test_telegram_quick_reply_buttons.py
+++ b/tests/gateway/test_telegram_quick_reply_buttons.py
@@ -1,0 +1,150 @@
+"""Tests for generic Telegram quick-reply buttons."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+import gateway.platforms.telegram as telegram_mod  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter(extra=None):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="token", extra=extra or {}))
+    adapter._bot = AsyncMock()
+    return adapter
+
+
+def test_extracts_discord_component_blocks():
+    components = {
+        "reusable": True,
+        "blocks": [
+            {
+                "type": "section",
+                "text": "Approve?",
+                "accessory": {
+                    "type": "button",
+                    "button": {"label": "Yes", "style": "success"},
+                },
+            },
+            {
+                "type": "actions",
+                "buttons": [
+                    {"label": "Review", "custom_id": "Review first"},
+                    {"label": "Later"},
+                ],
+            },
+        ],
+    }
+
+    rows = telegram_mod._extract_button_specs_from_components(components)
+
+    assert [[button["label"] for button in row] for row in rows] == [["Yes"], ["Review", "Later"]]
+    assert rows[1][0]["callback_data"] == "Review first"
+
+
+def test_builds_inline_keyboard(monkeypatch):
+    class FakeButton:
+        def __init__(self, label, **kwargs):
+            self.label = label
+            self.kwargs = kwargs
+
+    class FakeMarkup:
+        def __init__(self, rows):
+            self.rows = rows
+
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardMarkup", FakeMarkup)
+
+    markup = telegram_mod._telegram_inline_keyboard_from_components({
+        "buttons": [
+            {"label": "Yes"},
+            {"label": "Docs", "url": "https://example.com"},
+        ]
+    })
+
+    assert markup.rows[0][0].label == "Yes"
+    assert markup.rows[0][0].kwargs["callback_data"] == "qb:Yes"
+    assert markup.rows[0][1].kwargs["url"] == "https://example.com"
+
+
+def test_adapter_send_attaches_components_to_last_chunk(monkeypatch):
+    class FakeButton:
+        def __init__(self, label, **kwargs):
+            self.label = label
+            self.kwargs = kwargs
+
+    class FakeMarkup:
+        def __init__(self, rows):
+            self.rows = rows
+
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardMarkup", FakeMarkup)
+
+    adapter = _make_adapter()
+    msg = MagicMock(message_id=123)
+    adapter._bot.send_message = AsyncMock(return_value=msg)
+
+    result = __import__("asyncio").run(adapter.send(
+        "42",
+        "Want me to continue?",
+        metadata={"components": {"buttons": [{"label": "Continue"}, {"label": "Stop"}] }},
+    ))
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args.kwargs
+    assert kwargs["reply_markup"].rows[0][0].kwargs["callback_data"] == "qb:Continue"
+
+
+def test_quick_reply_callback_dispatches_as_message(monkeypatch):
+    adapter = _make_adapter()
+    handled = []
+
+    async def fake_handle(event):
+        handled.append(event)
+
+    adapter.handle_message = fake_handle
+
+    chat = MagicMock(id=42, type="private", title=None, full_name="Colm")
+    message = MagicMock(chat=chat, message_thread_id=None, message_id=9, date=None)
+    user = MagicMock(id=7, full_name="Colm Quish", first_name="Colm")
+    query = MagicMock(data="qb:Continue", message=message, from_user=user)
+    query.answer = AsyncMock()
+    query.edit_message_reply_markup = AsyncMock()
+    update = MagicMock(callback_query=query, update_id=99)
+
+    __import__("asyncio").run(adapter._handle_callback_query(update, MagicMock()))
+
+    assert len(handled) == 1
+    assert handled[0].text == "Continue"
+    assert handled[0].source.chat_id == "42"
+    assert handled[0].source.user_id == "7"
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -326,6 +326,24 @@ class TestSendToPlatformChunking:
         for call in send.await_args_list:
             assert len(call.args[2]) <= 2020  # each chunk fits the limit
 
+    def test_telegram_components_forwarded_to_last_chunk(self):
+        """Generic interactive components are attached to the final Telegram chunk."""
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+        components = {"buttons": [{"label": "Yes"}, {"label": "No"}]}
+        with patch("tools.send_message_tool._send_telegram", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.TELEGRAM,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "123",
+                    "Question?",
+                    components=components,
+                )
+            )
+        assert result["success"] is True
+        send.assert_awaited_once()
+        assert send.await_args.kwargs["components"] == components
+
     def test_slack_messages_are_formatted_before_send(self, monkeypatch):
         _ensure_slack_mock(monkeypatch)
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -125,6 +125,10 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send"
+            },
+            "components": {
+                "type": "object",
+                "description": "Optional interactive components. Telegram supports inline quick-reply buttons using either {'buttons': [{'label': 'Yes'}]} or Discord Components v2-style blocks. Button taps are delivered back as normal user messages."
             }
         },
         "required": []
@@ -155,6 +159,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    components = args.get("components")
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -281,6 +286,7 @@ def _handle_send(args):
                 cleaned_message,
                 thread_id=thread_id,
                 media_files=media_files,
+                components=components,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -401,7 +407,7 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, components=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -468,6 +474,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 media_files=media_files if is_last else [],
                 thread_id=thread_id,
                 disable_link_previews=disable_link_previews,
+                components=components if is_last else None,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -585,7 +592,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     return last_result
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, components=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -623,6 +630,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             thread_kwargs["message_thread_id"] = int(thread_id)
         if disable_link_previews:
             thread_kwargs["disable_web_page_preview"] = True
+        if components:
+            try:
+                from gateway.platforms.telegram import _telegram_inline_keyboard_from_components
+                reply_markup = _telegram_inline_keyboard_from_components(components)
+                if reply_markup is not None:
+                    thread_kwargs["reply_markup"] = reply_markup
+            except Exception:
+                logger.debug("Failed to build Telegram inline keyboard from components", exc_info=True)
 
         last_msg = None
         warnings = []


### PR DESCRIPTION
## Summary
- add generic Telegram inline quick-reply button support from send/metadata components
- support the existing Discord Components v2-style quick-buttons payload plus a simple {buttons: [...]} shorthand
- route Telegram quick-reply taps back into the chat as normal user messages so the agent can continue without typing
- expose optional components on the send_message tool for Telegram direct sends

## Verification
- uv run --extra dev pytest tests/gateway/test_telegram_quick_reply_buttons.py tests/tools/test_send_message_tool.py::TestSendToPlatformChunking::test_telegram_components_forwarded_to_last_chunk
- uv run --extra dev python -m py_compile gateway/platforms/telegram.py tools/send_message_tool.py

Note: uv currently warns about pyproject.toml line 161 (exclude-newer = "7 days") but tests/compile passed.