### PR TITLE
fix: normalize analytics skill payloads

### DIFF
--- a/web/src/lib/api.analytics.test.ts
+++ b/web/src/lib/api.analytics.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeAnalyticsResponse, type AnalyticsResponse } from "./api.ts";
+
+test("normalizeAnalyticsResponse fills in missing skill analytics for older backends", () => {
+  const raw = {
+    daily: [],
+    by_model: [],
+    totals: {
+      total_input: 0,
+      total_output: 0,
+      total_cache_read: 0,
+      total_reasoning: 0,
+      total_estimated_cost: 0,
+      total_actual_cost: 0,
+      total_sessions: 0,
+      total_api_calls: 0,
+    },
+  } as AnalyticsResponse;
+
+  const normalized = normalizeAnalyticsResponse(raw);
+
+  assert.deepEqual(normalized.skills, {
+    summary: {
+      total_skill_loads: 0,
+      total_skill_edits: 0,
+      total_skill_actions: 0,
+      distinct_skills_used: 0,
+    },
+    top_skills: [],
+  });
+});
+
+test("normalizeAnalyticsResponse preserves populated skill analytics", () => {
+  const raw: AnalyticsResponse = {
+    daily: [],
+    by_model: [],
+    totals: {
+      total_input: 0,
+      total_output: 0,
+      total_cache_read: 0,
+      total_reasoning: 0,
+      total_estimated_cost: 0,
+      total_actual_cost: 0,
+      total_sessions: 0,
+      total_api_calls: 0,
+    },
+    skills: {
+      summary: {
+        total_skill_loads: 2,
+        total_skill_edits: 1,
+        total_skill_actions: 3,
+        distinct_skills_used: 2,
+      },
+      top_skills: [
+        {
+          skill: "systematic-debugging",
+          view_count: 2,
+          manage_count: 1,
+          total_count: 3,
+          percentage: 100,
+          last_used_at: 1713900000,
+        },
+      ],
+    },
+  };
+
+  const normalized = normalizeAnalyticsResponse(raw);
+
+  assert.deepEqual(normalized.skills, raw.skills);
+});

--- a/web/src/lib/api.analytics.test.ts
+++ b/web/src/lib/api.analytics.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeAnalyticsResponse, type AnalyticsResponse } from "./api";
+
+const totals = {
+  total_input: 0,
+  total_output: 0,
+  total_cache_read: 0,
+  total_reasoning: 0,
+  total_estimated_cost: 0,
+  total_actual_cost: 0,
+  total_sessions: 0,
+  total_api_calls: 0,
+};
+
+describe("normalizeAnalyticsResponse", () => {
+  it("fills in missing skill analytics for older backends", () => {
+    const raw: AnalyticsResponse = {
+      daily: [],
+      by_model: [],
+      totals,
+    };
+
+    const normalized = normalizeAnalyticsResponse(raw);
+
+    expect(normalized.skills).toEqual({
+      summary: {
+        total_skill_loads: 0,
+        total_skill_edits: 0,
+        total_skill_actions: 0,
+        distinct_skills_used: 0,
+      },
+      top_skills: [],
+    });
+  });
+
+  it("fills in partially-missing skill analytics fields", () => {
+    const raw: AnalyticsResponse = {
+      daily: [],
+      by_model: [],
+      totals,
+      skills: {},
+    };
+
+    const normalized = normalizeAnalyticsResponse(raw);
+
+    expect(normalized.skills.summary.total_skill_loads).toBe(0);
+    expect(normalized.skills.top_skills).toEqual([]);
+  });
+
+  it("preserves populated skill analytics", () => {
+    const raw: AnalyticsResponse = {
+      daily: [],
+      by_model: [],
+      totals,
+      skills: {
+        summary: {
+          total_skill_loads: 2,
+          total_skill_edits: 1,
+          total_skill_actions: 3,
+          distinct_skills_used: 2,
+        },
+        top_skills: [
+          {
+            skill: "systematic-debugging",
+            view_count: 2,
+            manage_count: 1,
+            total_count: 3,
+            percentage: 100,
+            last_used_at: 1713900000,
+          },
+        ],
+      },
+    };
+
+    const normalized = normalizeAnalyticsResponse(raw);
+
+    expect(normalized.skills).toEqual(raw.skills);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -52,8 +52,8 @@ export const api = {
     if (params.component && params.component !== "all") qs.set("component", params.component);
     return fetchJSON<LogsResponse>(`/api/logs?${qs.toString()}`);
   },
-  getAnalytics: (days: number) =>
-    fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`),
+  getAnalytics: (days: number): Promise<NormalizedAnalyticsResponse> =>
+    fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`).then(normalizeAnalyticsResponse),
   getConfig: () => fetchJSON<Record<string, unknown>>("/api/config"),
   getDefaults: () => fetchJSON<Record<string, unknown>>("/api/config/defaults"),
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
@@ -355,9 +355,31 @@ export interface AnalyticsResponse {
     total_sessions: number;
     total_api_calls: number;
   };
+  skills?: {
+    summary?: AnalyticsSkillsSummary;
+    top_skills?: AnalyticsSkillEntry[];
+  };
+}
+
+export type NormalizedAnalyticsResponse = Omit<AnalyticsResponse, "skills"> & {
   skills: {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];
+  };
+};
+
+export function normalizeAnalyticsResponse(raw: AnalyticsResponse): NormalizedAnalyticsResponse {
+  return {
+    ...raw,
+    skills: {
+      summary: {
+        total_skill_loads: raw.skills?.summary?.total_skill_loads ?? 0,
+        total_skill_edits: raw.skills?.summary?.total_skill_edits ?? 0,
+        total_skill_actions: raw.skills?.summary?.total_skill_actions ?? 0,
+        distinct_skills_used: raw.skills?.summary?.distinct_skills_used ?? 0,
+      },
+      top_skills: Array.isArray(raw.skills?.top_skills) ? raw.skills.top_skills : [],
+    },
   };
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -465,10 +465,10 @@ export const api = {
     if (params.component && params.component !== "all") qs.set("component", params.component);
     return fetchJSON<LogsResponse>(`/api/logs?${qs.toString()}`);
   },
-  getAnalytics: (days: number, profile = getManagementProfile()) =>
+  getAnalytics: (days: number, profile = getManagementProfile()): Promise<NormalizedAnalyticsResponse> =>
     fetchJSON<AnalyticsResponse>(
       appendProfileParam(`/api/analytics/usage?days=${days}`, profile),
-    ),
+    ).then(normalizeAnalyticsResponse),
   getModelsAnalytics: (days: number, profile = getManagementProfile()) =>
     fetchJSON<ModelsAnalyticsResponse>(
       appendProfileParam(`/api/analytics/models?days=${days}`, profile),
@@ -2038,9 +2038,31 @@ export interface AnalyticsResponse {
     total_sessions: number;
     total_api_calls: number;
   };
+  skills?: {
+    summary?: AnalyticsSkillsSummary;
+    top_skills?: AnalyticsSkillEntry[];
+  };
+}
+
+export type NormalizedAnalyticsResponse = Omit<AnalyticsResponse, "skills"> & {
   skills: {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];
+  };
+};
+
+export function normalizeAnalyticsResponse(raw: AnalyticsResponse): NormalizedAnalyticsResponse {
+  return {
+    ...raw,
+    skills: {
+      summary: {
+        total_skill_loads: raw.skills?.summary?.total_skill_loads ?? 0,
+        total_skill_edits: raw.skills?.summary?.total_skill_edits ?? 0,
+        total_skill_actions: raw.skills?.summary?.total_skill_actions ?? 0,
+        distinct_skills_used: raw.skills?.summary?.distinct_skills_used ?? 0,
+      },
+      top_skills: Array.isArray(raw.skills?.top_skills) ? raw.skills.top_skills : [],
+    },
   };
 }
 

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -7,7 +7,12 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { AnalyticsResponse, AnalyticsDailyEntry, AnalyticsModelEntry, AnalyticsSkillEntry } from "@/lib/api";
+import type {
+  AnalyticsDailyEntry,
+  AnalyticsModelEntry,
+  AnalyticsSkillEntry,
+  NormalizedAnalyticsResponse,
+} from "@/lib/api";
 import { timeAgo } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -277,7 +282,7 @@ function SkillTable({ skills }: { skills: AnalyticsSkillEntry[] }) {
 
 export default function AnalyticsPage() {
   const [days, setDays] = useState(30);
-  const [data, setData] = useState<AnalyticsResponse | null>(null);
+  const [data, setData] = useState<NormalizedAnalyticsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { t } = useI18n();

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type {
-  AnalyticsResponse,
+  NormalizedAnalyticsResponse,
   AnalyticsDailyEntry,
   AnalyticsModelEntry,
   AnalyticsSkillEntry,
@@ -405,7 +405,7 @@ function SkillTable({ skills }: { skills: AnalyticsSkillEntry[] }) {
 
 export default function AnalyticsPage() {
   const [days, setDays] = useState(30);
-  const [data, setData] = useState<AnalyticsResponse | null>(null);
+  const [data, setData] = useState<NormalizedAnalyticsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Gated on `dashboard.show_token_analytics` (default off).  When off the


### PR DESCRIPTION
## Summary
- normalize `/api/analytics/usage` responses at the frontend API boundary so older backends missing `skills` do not crash the analytics page
- update `AnalyticsPage` to consume the normalized response type instead of the raw payload
- add regression coverage for both missing and populated skill analytics payloads

## Test Plan
- node --test web/src/lib/api.analytics.test.ts
- uv run --extra web --extra dev pytest -q tests/hermes_cli/test_web_server.py -k analytics_usage
- cd web && npm run build