### PR TITLE
docs(cli): expand hermes import reference add description, warning, and examples

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -443,11 +443,21 @@ hermes backup --quick --label "pre-upgrade"  # Quick snapshot with label
 hermes import <zipfile> [options]
 ```
 
-Restore a previously created Hermes backup into your Hermes home directory.
+Restore a previously created Hermes backup into your Hermes home directory. Files are overlaid onto your current Hermes home — existing files are skipped unless `--force` is used.
 
 | Option | Description |
 |--------|-------------|
 | `-f`, `--force` | Overwrite existing files without confirmation. |
+
+:::warning
+Stop the gateway before importing to avoid conflicts with running processes.
+:::
+
+### Examples
+```bash
+hermes import ~/hermes-backup-20260423.zip           # Restore, skip existing files
+hermes import ~/hermes-backup-20260423.zip --force   # Restore, overwrite existing files
+```
 
 ## `hermes logs`
 


### PR DESCRIPTION
## What does this PR do?
The `hermes import` CLI reference entry was missing a description of its
overlay behavior, a safety warning, and usage examples making it much
less useful than the `hermes backup` entry above it.

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- `website/docs/reference/cli-commands.md`: expanded `hermes import` section with overlay behavior description, gateway warning, and two usage examples

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix