### PR TITLE
feat(config): expose "max" as a valid reasoning effort level

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1997,7 +1997,7 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._run_simple_slash(interaction, f"/model {name}".strip())
 
         @tree.command(name="reasoning", description="Show or change reasoning effort")
-        @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, or xhigh.")
+        @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, xhigh, or max.")
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
             await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1344,7 +1344,7 @@ class GatewayRunner:
         """Load reasoning effort from config.yaml.
 
         Reads agent.reasoning_effort from config.yaml. Valid: "none",
-        "minimal", "low", "medium", "high", "xhigh". Returns None to use
+        "minimal", "low", "medium", "high", "xhigh", "max". Returns None to use
         default (medium).
         """
         from hermes_constants import parse_reasoning_effort
@@ -6788,7 +6788,7 @@ class GatewayRunner:
 
         Usage:
             /reasoning              Show current effort level and display state
-            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
+            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh, max)
             /reasoning show|on      Show model reasoning in responses
             /reasoning hide|off     Hide model reasoning from responses
         """
@@ -6833,7 +6833,7 @@ class GatewayRunner:
                 "🧠 **Reasoning Settings**\n\n"
                 f"**Effort:** `{level}`\n"
                 f"**Display:** {display_state}\n\n"
-                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|show|hide>`"
+                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|max|show|hide>`"
             )
 
         # Display toggle (per-platform)
@@ -6853,14 +6853,15 @@ class GatewayRunner:
 
         # Effort level change
         effort = args.strip()
+        from hermes_constants import VALID_REASONING_EFFORTS
         if effort == "none":
             parsed = {"enabled": False}
-        elif effort in ("minimal", "low", "medium", "high", "xhigh"):
+        elif effort in VALID_REASONING_EFFORTS:
             parsed = {"enabled": True, "effort": effort}
         else:
             return (
                 f"⚠️ Unknown argument: `{effort}`\n\n"
-                "**Valid levels:** none, minimal, low, medium, high, xhigh\n"
+                f"**Valid levels:** none, {', '.join(VALID_REASONING_EFFORTS)}\n"
                 "**Display:** show, hide"
             )
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -119,7 +119,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
+               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "show", "hide", "on", "off")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2984,7 +2984,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             str(effort).strip().lower() for effort in efforts if str(effort).strip()
         )
     )
-    canonical_order = ("minimal", "low", "medium", "high", "xhigh")
+    canonical_order = ("minimal", "low", "medium", "high", "xhigh", "max")
     ordered = [effort for effort in canonical_order if effort in deduped]
     ordered.extend(effort for effort in deduped if effort not in canonical_order)
     if not ordered:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -138,13 +138,13 @@ def get_subprocess_home() -> str | None:
     return None
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -111,3 +111,47 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestParseReasoningEffort:
+    """Tests for parse_reasoning_effort() — reasoning effort parsing and validation."""
+
+    def test_empty_string_returns_none(self):
+        """Empty input defers to caller's default."""
+        from hermes_constants import parse_reasoning_effort
+        assert parse_reasoning_effort("") is None
+        assert parse_reasoning_effort("   ") is None
+
+    def test_none_disables_reasoning(self):
+        """'none' explicitly disables reasoning."""
+        from hermes_constants import parse_reasoning_effort
+        assert parse_reasoning_effort("none") == {"enabled": False}
+        assert parse_reasoning_effort("NONE") == {"enabled": False}
+
+    def test_standard_levels(self):
+        """Each canonical effort level round-trips correctly."""
+        from hermes_constants import parse_reasoning_effort
+        for level in ("minimal", "low", "medium", "high", "xhigh"):
+            assert parse_reasoning_effort(level) == {"enabled": True, "effort": level}
+
+    def test_max_level_accepted(self):
+        """'max' is the strongest adaptive-thinking level on Claude 4.6+/4.7."""
+        from hermes_constants import parse_reasoning_effort
+        assert parse_reasoning_effort("max") == {"enabled": True, "effort": "max"}
+
+    def test_case_insensitive(self):
+        """Effort strings are case-insensitive."""
+        from hermes_constants import parse_reasoning_effort
+        assert parse_reasoning_effort("MAX") == {"enabled": True, "effort": "max"}
+        assert parse_reasoning_effort("XHigh") == {"enabled": True, "effort": "xhigh"}
+
+    def test_unknown_level_returns_none(self):
+        """Unrecognized levels return None so caller can fall back to default."""
+        from hermes_constants import parse_reasoning_effort
+        assert parse_reasoning_effort("extreme") is None
+        assert parse_reasoning_effort("ultra") is None
+
+    def test_valid_reasoning_efforts_includes_max(self):
+        """VALID_REASONING_EFFORTS exposes 'max' as a supported level."""
+        from hermes_constants import VALID_REASONING_EFFORTS
+        assert "max" in VALID_REASONING_EFFORTS


### PR DESCRIPTION
## What does this PR do?

Exposes Anthropic's `"max"` reasoning effort level end-to-end in the
user-facing API. The adapter already handles it correctly — this PR
closes a gap-fill where the surface-level validator and UI strings
stop one level short of what the backend supports.

### Background

Anthropic's adaptive-thinking output_config.effort has five levels on
Claude 4.6+ / 4.7:

```
low < medium < high < xhigh < max
```

`agent/anthropic_adapter.py` already:

- Maps all five correctly via `ADAPTIVE_EFFORT_MAP` (top of file).
- Has an `xhigh → max` downgrade for pre-4.7 models that don't
  accept xhigh.
- Documents `max` as a valid level in the module docstring.

### The gap

`VALID_REASONING_EFFORTS` in `hermes_constants.py` stops at `"xhigh"`,
so `parse_reasoning_effort("max")` silently returns `None`. The
gateway and CLI surfaces then either reject the input or fall back
to the default (medium), and the adapter never receives `max`.

The same hardcoded short list is duplicated in four other places
(gateway handler, gateway help text, CLI tab-completion tuple, CLI
effort picker, Discord slash command description), which also need
updating.

### Fix

Add `"max"` to `VALID_REASONING_EFFORTS` and every duplicated
surface that displays/accepts it. While here, replace the open-coded
`("minimal", "low", "medium", "high", "xhigh")` tuple in the gateway
handler with a reference to `VALID_REASONING_EFFORTS` so the next
Anthropic level addition only requires one edit.

Zero behavior change for any previously valid input. The only new
behavior: `"max"` now round-trips from `/reasoning max` →
`config.yaml` `agent.reasoning_effort: max` → Anthropic
`output_config.effort: "max"`.

## Related Issue

No dedicated tracking issue. Closely follows the existing xhigh
support path. Loosely related:

- Existing adapter logic in `agent/anthropic_adapter.py`
  (`ADAPTIVE_EFFORT_MAP`, `_XHIGH_EFFORT_SUBSTRINGS`) already treats
  `max` as the top level.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_constants.py`
  - Add `"max"` to `VALID_REASONING_EFFORTS`.
  - Update `parse_reasoning_effort()` docstring.
- `gateway/run.py`
  - Replace hardcoded tuple in `_handle_reasoning_command` with
    `VALID_REASONING_EFFORTS`; error-message valid-list now derives
    from the constant.
  - Update three help/usage strings to include `max`.
- `hermes_cli/commands.py` — add `"max"` to `/reasoning`
  subcommand tuple (drives tab completion).
- `hermes_cli/main.py` — add `"max"` to the canonical-order tuple in
  `_prompt_reasoning_effort_selection()`.
- `gateway/platforms/discord.py` — update Discord slash-command
  `describe(effort=...)` text.
- `tests/test_hermes_constants.py` — new `TestParseReasoningEffort`
  class with 7 tests covering empty / `"none"` / standard levels /
  `"max"` / case-insensitivity / unknown inputs /
  `VALID_REASONING_EFFORTS` membership.

## How to Test

### Automated

```bash
pytest tests/test_hermes_constants.py -q
# 18 passed
```

### Manual

Before:

```
/reasoning max
⚠️ Unknown argument: `max`
Valid levels: none, minimal, low, medium, high, xhigh
```

After:

```
/reasoning max
🧠 ✓ Reasoning effort set to `max` (saved to config)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(config):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/test_hermes_constants.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Amazon Linux, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `/reasoning` help text and docstrings updated in-tree
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (the `agent.reasoning_effort` key already exists, only its valid value set widened)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure Python, no OS-specific code
- [x] I've updated tool descriptions/schemas — Discord `app_commands.describe` updated
