### PR TITLE
feat(codex): add gpt-5.5 and wire live model discovery into picker

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -123,6 +123,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "claude": 200000,
     # OpenAI — GPT-5 family (most have 400k; specific overrides first)
     # Source: https://developers.openai.com/api/docs/models
+    # GPT-5.5 (launched Apr 23 2026). Verified via live ChatGPT codex/models
+    # endpoint: bare slug `gpt-5.5`, no -pro/-mini variants. 400k context on Codex.
+    "gpt-5.5": 400000,
     "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4-mini": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4": 1050000,               # GPT-5.4, GPT-5.4 Pro (1.05M context)

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,6 +12,7 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
+    "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
     "gpt-5.3-codex",
@@ -21,6 +22,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
+    ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.3-codex", ("gpt-5.2-codex",)),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1678,7 +1678,19 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     if normalized == "openai-codex":
         from hermes_cli.codex_models import get_codex_model_ids
 
-        return get_codex_model_ids()
+        # Pass the live OAuth access token so the picker matches whatever
+        # ChatGPT lists for this account right now (new models appear without
+        # a Hermes release). Falls back to the hardcoded catalog if no token
+        # or the endpoint is unreachable.
+        access_token = None
+        try:
+            from hermes_cli.auth import resolve_codex_runtime_credentials
+
+            creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+            access_token = creds.get("api_key")
+        except Exception:
+            access_token = None
+        return get_codex_model_ids(access_token=access_token)
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())


### PR DESCRIPTION
## Summary
OpenAI launched GPT-5.5 on Codex today (Apr 23 2026). Add it to the static catalog and pipe the user's OAuth access token into `provider_model_ids('openai-codex')` so `/model` mid-session and the gateway picker hit the live ChatGPT `codex/models` endpoint — new models appear for each user according to what ChatGPT actually lists for their account, without a Hermes release.

## Changes
- `hermes_cli/codex_models.py`: add `gpt-5.5` to `DEFAULT_CODEX_MODELS` + forward-compat
- `agent/model_metadata.py`: 400k context length entry for `gpt-5.5`
- `hermes_cli/models.py`: resolve codex OAuth token via `resolve_codex_runtime_credentials()` and pass to `get_codex_model_ids()` in the `openai-codex` branch

## Validation
Live endpoint probe against my codex account:
```
gpt-5.4      pri=-1  visibility=list
gpt-5.5      pri= 0  visibility=list    <-- new, featured
gpt-5.4-mini pri= 4  visibility=list
gpt-5.3-codex pri=6  visibility=list
gpt-5.2      pri=10  visibility=list
```

`hermes chat --provider openai-codex --model gpt-5.5 -q '...'` completes end-to-end; model replies identifying as `gpt-5.5`.

| | Before | After |
|---|---|---|
| `/model` in-session on codex | hardcoded list, topped out at 5.4 | live from ChatGPT endpoint |
| Gateway model picker on codex | hardcoded list | live from ChatGPT endpoint |
| Fallback when no token / endpoint down | 5.4 → 5.1-codex-mini | 5.5 → 5.1-codex-mini |
| `hermes model` subcommand | already live | unchanged |