### PR TITLE
fix(bedrock): resolve context length via static table before custom-endpoint probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1047,6 +1047,7 @@ def get_model_context_length(
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
     1. Persistent cache (previously discovered via probing)
+    1b. AWS Bedrock static table (must precede custom-endpoint probe)
     2. Active endpoint metadata (/models for explicit custom endpoints)
     3. Local server query (for local endpoints)
     4. Anthropic /v1/models API (API-key users only, not OAuth)
@@ -1070,6 +1071,26 @@ def get_model_context_length(
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
             return cached
+
+    # 1b. AWS Bedrock — use static context length table.
+    # Bedrock's ListFoundationModels API doesn't expose context window sizes,
+    # so we maintain a curated table in bedrock_adapter.py that reflects
+    # AWS-imposed limits (e.g. 200K for Claude models vs 1M on the native
+    # Anthropic API).  This must run BEFORE the custom-endpoint probe at
+    # step 2 — bedrock-runtime.<region>.amazonaws.com is not in
+    # _URL_TO_PROVIDER, so it would otherwise be treated as a custom endpoint,
+    # fail the /models probe (Bedrock doesn't expose that shape), and fall
+    # back to the 128K default before reaching the original step 4b branch.
+    if provider == "bedrock" or (
+        base_url
+        and base_url_hostname(base_url).startswith("bedrock-runtime.")
+        and base_url_host_matches(base_url, "amazonaws.com")
+    ):
+        try:
+            from agent.bedrock_adapter import get_bedrock_context_length
+            return get_bedrock_context_length(model)
+        except ImportError:
+            pass  # boto3 not installed — fall through to generic resolution
 
     # 2. Active endpoint metadata for truly custom/unknown endpoints.
     # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
@@ -1116,19 +1137,7 @@ def get_model_context_length(
         if ctx:
             return ctx
 
-    # 4b. AWS Bedrock — use static context length table.
-    # Bedrock's ListFoundationModels doesn't expose context window sizes,
-    # so we maintain a curated table in bedrock_adapter.py.
-    if provider == "bedrock" or (
-        base_url
-        and base_url_hostname(base_url).startswith("bedrock-runtime.")
-        and base_url_host_matches(base_url, "amazonaws.com")
-    ):
-        try:
-            from agent.bedrock_adapter import get_bedrock_context_length
-            return get_bedrock_context_length(model)
-        except ImportError:
-            pass  # boto3 not installed — fall through to generic resolution
+    # 4b. (Bedrock handled earlier at step 1b — before custom-endpoint probe.)
 
     # 5. Provider-aware lookups (before generic OpenRouter cache)
     # These are provider-specific and take priority over the generic OR cache,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -377,6 +377,57 @@ class TestGetModelContextLength:
 
 
 # =========================================================================
+# Bedrock context resolution — must run BEFORE custom-endpoint probe
+# =========================================================================
+
+class TestBedrockContextResolution:
+    """Regression tests for Bedrock context-length resolution order.
+
+    Bug: because ``bedrock-runtime.<region>.amazonaws.com`` is not listed in
+    ``_URL_TO_PROVIDER``, ``_is_known_provider_base_url`` returned False and
+    the custom-endpoint probe at step 2 ran first — fetching ``/models`` from
+    Bedrock (which it doesn't serve), returning the 128K default-fallback
+    before execution ever reached the Bedrock branch.
+
+    Fix: promote the Bedrock branch ahead of the custom-endpoint probe.
+    """
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_bedrock_provider_returns_static_table_before_probe(self, mock_fetch):
+        """provider='bedrock' resolves via static table, bypasses /models probe."""
+        ctx = get_model_context_length(
+            "anthropic.claude-opus-4-v1:0",
+            provider="bedrock",
+            base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+        )
+        # Must return the static Bedrock table value (200K for Claude),
+        # NOT DEFAULT_FALLBACK_CONTEXT (128K).
+        assert ctx == 200000
+        mock_fetch.assert_not_called()
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_bedrock_url_without_provider_hint(self, mock_fetch):
+        """bedrock-runtime host infers Bedrock even when provider is omitted."""
+        ctx = get_model_context_length(
+            "anthropic.claude-sonnet-4-v1:0",
+            base_url="https://bedrock-runtime.us-west-2.amazonaws.com",
+        )
+        assert ctx == 200000
+        mock_fetch.assert_not_called()
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_non_bedrock_url_still_probes(self, mock_fetch):
+        """Non-Bedrock hosts still reach the custom-endpoint probe."""
+        mock_fetch.return_value = {"some-model": {"context_length": 50000}}
+        ctx = get_model_context_length(
+            "some-model",
+            base_url="https://api.example.com/v1",
+        )
+        assert ctx == 50000
+        assert mock_fetch.called
+
+
+# =========================================================================
 # _strip_provider_prefix — Ollama model:tag vs provider:model
 # =========================================================================
 


### PR DESCRIPTION
## What does this PR do?

Fixes a resolution-order bug in `get_model_context_length()` that caused every AWS Bedrock model to report the 128K default-fallback context length instead of the correct value from the static Bedrock table (200K for Claude, etc.).

The predicate for Bedrock detection is unchanged — only the **position** of that branch in the resolution order moves from step 4b to step 1b, so it runs before the custom-endpoint probe.

## Why?

`bedrock-runtime.<region>.amazonaws.com` is not in `_URL_TO_PROVIDER`, so `_is_known_provider_base_url()` returns False for Bedrock URLs. The original resolution order then:

1. Treated Bedrock as a custom endpoint (`_is_custom_endpoint` → True).
2. Called `fetch_endpoint_model_metadata()` → `GET /models` on the Bedrock URL (Bedrock doesn't serve this shape).
3. Matched no models → fell through to `return DEFAULT_FALLBACK_CONTEXT` (128K) at the "probe-down" branch on line 1109.
4. Never reached the Bedrock branch at step 4b.

Result: users on Bedrock saw 128K context for Claude Sonnet/Opus 4.x (which actually support 200K on Bedrock), triggering premature auto-compression and reducing usable context.

## Changes

### `agent/model_metadata.py`
- Promote the Bedrock static-table branch from step 4b → step 1b, so it runs **before** the custom-endpoint probe.
- Remove the now-dead step 4b block, replaced by a breadcrumb comment.
- Update the resolution-order docstring to reflect the new step 1b position.

### `tests/agent/test_model_metadata.py`
- New `TestBedrockContextResolution` class (3 regression tests):
  - `provider="bedrock"` returns the static-table value and does **not** call `fetch_endpoint_model_metadata` (assert-not-called is the regression guard — the bug would have called it).
  - `base_url="https://bedrock-runtime.us-west-2.amazonaws.com"` works without an explicit `provider` hint.
  - Non-Bedrock custom endpoints still reach the probe (no over-reach).

## Which type of PR is this?

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

```
pytest tests/agent/test_model_metadata.py -q
# 83 passed in 1.95s (3 new + 80 existing)
```

Also manually verified with `provider="bedrock"` on Claude Opus 4.7 — returns 200000 rather than 128000.

## Risk

Very low:
- Predicate is identical to the original step 4b — no behaviour change for non-Bedrock paths.
- Original step 4b was dead code for the user-facing case (always hit the 128K fallback first), so removing it cannot regress behaviour.
- Bedrock path now short-circuits before any network I/O — faster too.
- `ImportError` fall-through preserved for users without `boto3` installed.

## Checklist

- [x] My changes follow the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstring updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

## Related work

Complements #14710 (stale-connection client eviction on Bedrock) — correct context sizing is a prerequisite for the compression logic triggered by the error paths in that PR.
