### PR TITLE
fix(agent): pass config_context_length in fallback activation path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6430,11 +6430,15 @@ class AIAgent:
             # Without this, compression decisions use the primary model's
             # context window (e.g. 200K) instead of the fallback's (e.g. 32K),
             # causing oversized sessions to overflow the fallback.
+            # Also pass _config_context_length so the explicit config override
+            # (model.context_length in config.yaml) is respected — without this,
+            # the fallback activation drops to 128K even when config says 204800.
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 from agent.model_metadata import get_model_context_length
                 fb_context_length = get_model_context_length(
                     self.model, base_url=self.base_url,
                     api_key=self.api_key, provider=self.provider,
+                    config_context_length=getattr(self, "_config_context_length", None),
                 )
                 self.context_compressor.update_model(
                     model=self.model,


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `_try_activate_fallback()` calls `get_model_context_length()` without the `config_context_length` parameter. This causes the fallback activation to ignore the explicit `model.context_length` value in `config.yaml` and instead fall through to `DEFAULT_FALLBACK_CONTEXT` (128K).

## Root cause

In `run_agent.py`, the `switch_model()` method (line 1988) correctly passes `config_context_length=getattr(self, '_config_context_length', None)` when calling `get_model_context_length()`. However, `_try_activate_fallback()` (line 6435) was missing this parameter.

The resolution chain in `get_model_context_length()` is:
- **Step 0**: If `config_context_length` is passed → return it immediately (respects config.yaml)
- **Steps 1-8**: Various probes (cache, endpoint, providers)
- **Step 9**: `DEFAULT_FALLBACK_CONTEXT` (128K) — the fallback for everything that fails

Without `config_context_length` passed, a fallback activation that fails all probes lands at step 9 → 128K, overwriting the correct 204800 value from config.

## The crash cascade

1. Fallback model activates
2. `get_model_context_length()` called without config override → returns 128K
3. `context_compressor.update_model(128K)` overwrites the correct 204800
4. Status bar now shows 128K instead of 204.8K
5. Actual context grows past 128K → context exceeded error
6. Auto-compression fires on a corrupted session state → amnesia

## Changes

### `run_agent.py` — line ~6438

```diff
 fb_context_length = get_model_context_length(
     self.model, base_url=self.base_url,
     api_key=self.api_key, provider=self.provider,
+    config_context_length=getattr(self, "_config_context_length", None),
 )
```

This mirrors the existing correct behavior in `switch_model()` at line 1988.

## Risk

Very low:
- One-line addition, identical to what `switch_model()` already does
- Only affects the fallback activation path (error recovery)
- Does not change behavior for successful model switches

## Testing

- Manual: Switch to MiniMax-M2.7, trigger a fallback (e.g. API error), verify status bar still shows 204.8K not 128K
- Automated: Add a unit test that calls `_try_activate_fallback()` with a mocked `_config_context_length` and verifies `get_model_context_length` is called with that parameter

Fixes: context_length forced to 128K on fallback activation even when config.yaml has a higher value
