### PR TITLE
fix(switch_model): guard _fallback_chain access on partially-constructed agents

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2038,8 +2038,11 @@ class AIAgent:
         old_norm = (old_provider or "").strip().lower()
         new_norm = (new_provider or "").strip().lower()
         if old_norm and new_norm and old_norm != new_norm:
+            # getattr guards against partially-constructed agents (e.g. tests
+            # using AIAgent.__new__ to isolate switch_model behavior).
+            existing_chain = getattr(self, "_fallback_chain", []) or []
             self._fallback_chain = [
-                entry for entry in self._fallback_chain
+                entry for entry in existing_chain
                 if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
             ]
             self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError: 'AIAgent' object has no attribute '_fallback_chain'` in `AIAgent.switch_model()` when called on a partially-constructed agent. Three-line defensive guard using `getattr(..., default)`.

## Why?

`switch_model()` prunes `self._fallback_chain` when the user swaps primary providers (openrouter → anthropic, etc.). The original code read `self._fallback_chain` directly:

```python
self._fallback_chain = [
    entry for entry in self._fallback_chain  # AttributeError here
    if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
]
```

If `__init__` hasn't run (e.g. tests using `AIAgent.__new__(AIAgent)` with `__init__` patched to `return_value=None`), `_fallback_chain` doesn't exist yet and the attribute read raises.

## Reproduction

```
pytest tests/agent/test_minimax_provider.py::TestMinimaxSwitchModelCredentialGuard::test_switch_to_minimax_does_not_resolve_anthropic_token
```

Without this fix:
```
AttributeError: 'AIAgent' object has no attribute '_fallback_chain'
run_agent.py:2042: AttributeError
FAILED tests/agent/test_minimax_provider.py::...
```

With this fix:
```
41 passed in 4.32s
```

(That test was clearly written against an earlier version where the pruning block didn't exist, then the pruning was added later without updating the test fixture. Rather than force every caller to pre-populate `_fallback_chain`, this PR makes the consumer defensive.)

## Changes

### `run_agent.py:2041-2044`
```diff
     if old_norm and new_norm and old_norm != new_norm:
+        # getattr guards against partially-constructed agents (e.g. tests
+        # using AIAgent.__new__ to isolate switch_model behavior).
+        existing_chain = getattr(self, "_fallback_chain", []) or []
         self._fallback_chain = [
-            entry for entry in self._fallback_chain
+            entry for entry in existing_chain
             if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
         ]
```

## Which type of PR is this?

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

```
pytest tests/agent/test_minimax_provider.py -q
# 41 passed in 4.32s
```

## Risk

Minimal:
- `getattr(obj, name, default)` is idiomatic Python with zero runtime cost when the attribute exists.
- `or []` guards the unlikely case where someone manually set the attribute to None.
- No behaviour change for production code paths — `_fallback_chain` is always set by `__init__` in the normal agent construction path.

## Checklist

- [x] My changes follow the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
