### PR TITLE
fix(delegate): remove model-facing max_iterations override; config is authoritative

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,7 +69,10 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
-        self.assertIn("max_iterations", props)
+        # max_iterations is intentionally NOT exposed to the model — it's
+        # config-authoritative via delegation.max_iterations so users get
+        # predictable budgets.
+        self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1558,7 +1558,18 @@ def delegate_task(
     # Load config
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
-    effective_max_iter = max_iterations or default_max_iter
+    # Model-supplied max_iterations is ignored — the config value is authoritative
+    # so users get predictable budgets. The kwarg is retained for internal callers
+    # and tests; a model-emitted value here would only shrink the budget and
+    # surprise the user mid-run. Log and drop it if one slips through from a
+    # cached tool schema or a stale provider.
+    if max_iterations is not None and max_iterations != default_max_iter:
+        logger.debug(
+            "delegate_task: ignoring caller-supplied max_iterations=%s; "
+            "using delegation.max_iterations=%s from config",
+            max_iterations, default_max_iter,
+        )
+    effective_max_iter = default_max_iter
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -2096,13 +2107,6 @@ DELEGATE_TASK_SCHEMA = {
                     "Batch mode: tasks to run in parallel (limit configurable via delegation.max_concurrent_children, default 3). Each gets "
                     "its own subagent with isolated context and terminal session. "
                     "When provided, top-level goal/context/toolsets are ignored."
-                ),
-            },
-            "max_iterations": {
-                "type": "integer",
-                "description": (
-                    "Max tool-calling turns per subagent (default: 50). "
-                    "Only set lower for simple tasks."
                 ),
             },
             "role": {


### PR DESCRIPTION
## Summary
`delegate_task` exposed `max_iterations` in its JSON schema and used `max_iterations or default_max_iter`, so any model-emitted value silently overrode the user's `delegation.max_iterations` config. This session hit it: a forensic audit ran with a 40-iteration cap while the user's config was set to 250, because I guessed 40 in the call.

Now the config value is authoritative — models cannot emit the parameter, and if one slips through from a stale schema cache or an internal caller, it's logged and ignored.

## Changes
- `tools/delegate_tool.py`: drop `max_iterations` from `DELEGATE_TASK_SCHEMA['parameters']['properties']`.
- `tools/delegate_tool.py`: in `delegate_task()`, always use `default_max_iter` from config; log a debug message if a stale caller supplies one.
- Python kwarg kept on the function signature for internal plumbing (`_build_child_agent` tests pass it through).
- `tests/tools/test_delegate.py::test_schema_valid`: flip the assertion to `assertNotIn('max_iterations', props)` with a comment explaining it's an intentional contract.

## Validation
| | Before | After |
|---|---|---|
| Model emits `max_iterations: 40` | subagent capped at 40 | value ignored, uses config (e.g. 250) |
| Schema exposes param to model | yes | no |
| Internal callers passing kwarg | honored | ignored, debug-logged |
| `tests/tools/test_delegate.py` | 1 fail (change-detector) | 106/106 pass |