### PR TITLE
fix(agent): preserve MiniMax context length on delta-only overflow (salvage #9170)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10574,9 +10574,30 @@ class AIAgent:
                         # Error is about the INPUT being too large — reduce context_length.
                         # Try to parse the actual limit from the error message
                         parsed_limit = parse_context_limit_from_error(error_msg)
+                        _provider_lower = (getattr(self, "provider", "") or "").lower()
+                        _base_lower = (getattr(self, "base_url", "") or "").rstrip("/").lower()
+                        is_minimax_provider = (
+                            _provider_lower in {"minimax", "minimax-cn"}
+                            or _base_lower.startswith((
+                                "https://api.minimax.io/anthropic",
+                                "https://api.minimaxi.com/anthropic",
+                            ))
+                        )
+                        minimax_delta_only_overflow = (
+                            is_minimax_provider
+                            and parsed_limit is None
+                            and "context window exceeds limit (" in error_msg
+                        )
                         if parsed_limit and parsed_limit < old_ctx:
                             new_ctx = parsed_limit
-                            self._vprint(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
+                            self._vprint(f"{self.log_prefix}Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
+                        elif minimax_delta_only_overflow:
+                            new_ctx = old_ctx
+                            self._vprint(
+                                f"{self.log_prefix}Provider reported overflow amount only; "
+                                f"keeping context_length at {old_ctx:,} tokens and compressing.",
+                                force=True,
+                            )
                         else:
                             # Step down to the next probe tier
                             new_ctx = get_next_probe_tier(old_ctx)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -409,6 +409,7 @@ AUTHOR_MAP = {
     "caliberoviv@gmail.com": "vivganes",
     "michaelfackerell@gmail.com": "MikeFac",
     "18024642@qq.com": "GuyCui",
+    "eumael.mkt@gmail.com": "maelrx",
 }
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -621,6 +621,10 @@ class TestParseContextLimitFromError:
         msg = "Error: context window of 4096 tokens exceeded"
         assert parse_context_limit_from_error(msg) == 4096
 
+    def test_minimax_delta_only_message_returns_none(self):
+        msg = "invalid params, context window exceeds limit (2013)"
+        assert parse_context_limit_from_error(msg) is None
+
     def test_completely_unrelated_error(self):
         assert parse_context_limit_from_error("Invalid API key") is None
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2567,6 +2567,89 @@ class TestRunConversation:
         assert result["final_response"] == "Recovered after compression"
         assert result["completed"] is True
 
+    def test_minimax_delta_overflow_keeps_known_context_length(self, agent):
+        """MiniMax reports overflow deltas like 'limit (2013)' without the real window.
+
+        Keep the known 204,800-token window and compress instead of probing down
+        to the generic 128K fallback tier.
+        """
+        self._setup_agent(agent)
+        agent.provider = "minimax"
+        agent.model = "MiniMax-M2.7-highspeed"
+        agent.base_url = "https://api.minimax.io/anthropic"
+        agent.context_compressor.context_length = 204_800
+        agent.context_compressor.threshold_tokens = int(
+            agent.context_compressor.context_length * agent.context_compressor.threshold_percent
+        )
+
+        err_400 = Exception(
+            "HTTP 400: invalid params, context window exceeds limit (2013)"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.context_compressor.context_length == 204_800
+        assert agent.context_compressor._context_probed is False
+        assert result["final_response"] == "Recovered after compression"
+        assert result["completed"] is True
+
+    def test_non_minimax_delta_overflow_still_probes_down(self, agent):
+        """Non-MiniMax providers should keep the generic probe-down behavior."""
+        self._setup_agent(agent)
+        agent.provider = "openrouter"
+        agent.model = "some/unknown-model"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = int(
+            agent.context_compressor.context_length * agent.context_compressor.threshold_percent
+        )
+
+        err_400 = Exception(
+            "HTTP 400: invalid params, context window exceeds limit (2013)"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.context_compressor.context_length == 128_000
+        assert result["final_response"] == "Recovered after compression"
+        assert result["completed"] is True
+
     def test_length_finish_reason_requests_continuation(self, agent):
         """Normal truncation (partial real content) triggers continuation."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
On MiniMax providers, treat `context window exceeds limit (N)` as an overflow *delta* — keep the known 204,800-token window and compress, instead of probing down to the generic 128k tier.

## Root cause
MiniMax's Anthropic-compatible endpoint returns `"invalid params, context window exceeds limit (2013)"` where `2013` is the overflow amount, not the window size.

1. `parse_context_limit_from_error()` correctly returns `None` for this message (the generic regex doesn't match numbers inside parentheticals).
2. Recovery falls through to `get_next_probe_tier(204800)` → returns `128000`.
3. `compressor.update_model(context_length=128000)` silently halves the window for the rest of the session.
4. User-visible symptom: context window shows 204,800 at session start, 128,000 after the first overflow round-trip. `/exit` + resume fixes it because `DEFAULT_CONTEXT_LENGTHS["minimax"] = 204800` is re-read from scratch. Reported in Discord against MiniMax M2.7.

## Changes
- `run_agent.py` (+22 / -1 around L10576): when the provider is MiniMax (by provider name OR Anthropic-compat base URL) and the message matches the delta-only pattern, keep `context_length` and compress without demoting the window.
- `tests/agent/test_model_metadata.py` (+4): regression — parser returns `None` for the MiniMax delta message.
- `tests/run_agent/test_run_agent.py` (+83): MiniMax path keeps 204,800; non-MiniMax providers still probe down to 128k for the same text.
- `scripts/release.py` (+1): AUTHOR_MAP entry for contributor attribution (separate commit).

## Validation
| | Before | After |
|---|---|---|
| MiniMax + delta-only overflow | context 204,800 → 128,000 | context stays at 204,800, compresses |
| Non-MiniMax + same text | probes to 128,000 | probes to 128,000 (unchanged) |
| Parser on delta msg | `None` | `None` (unchanged) |

`scripts/run_tests.sh tests/agent/test_model_metadata.py tests/run_agent/test_run_agent.py -k "minimax_delta or glm_prompt"` → 3/3 passed. Broader sweep across `test_minimax_provider.py`, `test_1630_context_overflow_loop.py`, `test_413_compression.py` → 151 passed, 1 pre-existing `_fallback_chain` failure on `origin/main` unrelated to this PR.

## Attribution
Salvage of #9170 by @maelrx. Cherry-picked onto current main (branch was 1,508 commits behind); authorship preserved via rebase-merge. Follow-up commit adds the contributor to `scripts/release.py` AUTHOR_MAP for release-notes CI.