### PR TITLE
fix(gateway): track background watcher tasks in _background_tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2242,13 +2242,17 @@ class GatewayRunner:
             from tools.process_registry import process_registry
             while process_registry.pending_watchers:
                 watcher = process_registry.pending_watchers.pop(0)
-                asyncio.create_task(self._run_process_watcher(watcher))
+                task = asyncio.create_task(self._run_process_watcher(watcher))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher for proactive memory flushing
-        asyncio.create_task(self._session_expiry_watcher())
+        task = asyncio.create_task(self._session_expiry_watcher())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -2257,7 +2261,9 @@ class GatewayRunner:
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        task = asyncio.create_task(self._platform_reconnect_watcher())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
         logger.info("Press Ctrl+C to stop")
         
@@ -11135,7 +11141,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 logger.info("Shutdown diagnostic — no other hermes processes found")
         except Exception:
             pass
-        asyncio.create_task(runner.stop())
+        _stop_task = asyncio.create_task(runner.stop())
+        _stop_task.add_done_callback(lambda t: logger.error("Gateway stop failed: %s", t.exception()) if not t.cancelled() and t.exception() else None)
 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)


### PR DESCRIPTION
## What does this PR do?

Four `asyncio.create_task()` calls in `gateway/run.py` were launched fire-and-forget — the task handles were discarded immediately, so `_background_tasks` never tracked them. On shutdown, these tasks could not be cancelled or joined, causing orphaned tasks and silently dropped exceptions.

## Type of Change
- [x] Bug fix

## Root Cause

The existing pattern used throughout the file is:
```python
task = asyncio.create_task(...)
self._background_tasks.add(task)
task.add_done_callback(self._background_tasks.discard)
```
Three watcher tasks and the signal handler's `runner.stop()` call skipped this registration entirely.

## Changes Made

- `_run_process_watcher` (recovered watchers loop) — each task now stored and registered with discard callback
- `_session_expiry_watcher` — task handle stored and registered in `_background_tasks`
- `_platform_reconnect_watcher` — task handle stored and registered in `_background_tasks`
- signal handler `runner.stop()` — stored in `_stop_task` with exception-logging done callback (`_background_tasks` not accessible in signal handler scope)

## How to Test

1. Start gateway with a platform that fails at startup (triggers reconnect watcher)
2. Send Ctrl+C during active processing
3. Observe clean shutdown with no `Task was destroyed but it is pending` warnings in logs

## Checklist
- [x] Follows existing `_background_tasks` pattern used throughout the file
- [x] No new dependencies
- [x] Only touches the affected task creation sites