### PR TITLE
fix(web_server): guard GATEWAY_HEALTH_TIMEOUT against invalid env values

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -331,7 +331,14 @@ class EnvVarReveal(BaseModel):
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
-_GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
+try:
+    _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
+except (ValueError, TypeError):
+    _log.warning(
+        "Invalid GATEWAY_HEALTH_TIMEOUT value %r — using default 3.0s",
+        os.getenv("GATEWAY_HEALTH_TIMEOUT"),
+    )
+    _GATEWAY_HEALTH_TIMEOUT = 3.0
 
 
 def _probe_gateway_health() -> tuple[bool, dict | None]:


### PR DESCRIPTION
## What does this PR do?

`_GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))` runs at module level. Any non-numeric value (e.g. `GATEWAY_HEALTH_TIMEOUT=abc`) raises `ValueError` at import time, crashing the web server before it starts — with no useful error message.

## Type of Change
- [x] Bug fix

## Root Cause

`float()` is called directly on the env var with no guard. A misconfigured environment silently kills the entire dashboard process at startup.

## Changes Made

- Wrapped the `float()` call in `try/except (ValueError, TypeError)`
- Logs a warning with the bad value using the existing `_log` logger
- Falls back to `3.0` seconds so the server starts normally

## How to Test

1. Set `GATEWAY_HEALTH_TIMEOUT=abc` in `~/.hermes/.env`
2. Run `hermes gateway` with web dashboard enabled
3. Before: server crashes at import with `ValueError`
4. After: warning logged, server starts with 3.0s default

## Checklist
- [x] Reuses existing `_log` logger already defined in the file
- [x] No new dependencies
- [x] Only touches the affected line