### PR TITLE
fix: skill load failures return None instead of queued sentinel (#14713)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -439,7 +439,9 @@ def build_skill_invocation_message(
         user_instruction: Optional text the user typed after the command.
 
     Returns:
-        The formatted message string, or None if the skill wasn't found.
+        The formatted message string, or ``None`` if the skill was not found
+        or the skill payload could not be loaded (callers must not queue
+        ``None`` as user input; see #14713).
     """
     commands = get_skill_commands()
     skill_info = commands.get(cmd_key)
@@ -448,7 +450,13 @@ def build_skill_invocation_message(
 
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
-        return f"[Failed to load skill: {skill_info['name']}]"
+        logger.warning(
+            "Skill registered at %s but payload failed to load (name=%r); "
+            "not sending a synthetic user message (#14713)",
+            cmd_key,
+            skill_info.get("name"),
+        )
+        return None
 
     loaded_skill, skill_dir, skill_name = loaded
     activation_note = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3820,6 +3820,12 @@ class GatewayRunner:
                     if msg:
                         event.text = msg
                         # Fall through to normal message processing with skill content
+                    else:
+                        _disp = _skill_name or command
+                        return (
+                            f"Failed to load skill **{_disp}**. "
+                            "Check SKILL.md and any required setup, then try again."
+                        )
                 else:
                     # Not an active skill — check if it's a known-but-disabled or
                     # uninstalled skill and give actionable guidance.

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -285,6 +285,15 @@ Generate some audio.
             msg = build_skill_invocation_message("/nonexistent")
         assert msg is None
 
+    def test_returns_none_when_payload_load_fails(self, tmp_path):
+        """#14713: failed loads must not return a truthy sentinel queued as input."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "fragile-skill")
+            scan_skill_commands()
+        with patch("agent.skill_commands._load_skill_payload", return_value=None):
+            msg = build_skill_invocation_message("/fragile-skill", "task")
+        assert msg is None
+
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3025,6 +3025,11 @@ def _(rid, params: dict) -> dict:
                         "name": cmds[key].get("name", name),
                     },
                 )
+            return _err(
+                rid,
+                5030,
+                f"Failed to load skill: {cmds[key].get('name', name)}",
+            )
     except Exception:
         pass
 
@@ -3111,6 +3116,7 @@ def _(rid, params: dict) -> dict:
             )
             if msg:
                 return _ok(rid, {"type": "send", "message": msg})
+            return _err(rid, 5030, "Failed to load the bundled /plan skill")
         except Exception as e:
             return _err(rid, 5030, f"plan skill failed: {e}")
 


### PR DESCRIPTION
## Summary
Fixes #14713.

`build_skill_invocation_message()` used to return a truthy string like `[Failed to load skill: …]` when `_load_skill_payload` failed. The CLI only checked truthiness, so that string was queued as normal user input while still printing success-style messaging for `/plan`.

## Changes
- **agent/skill_commands.py**: On payload load failure, log a warning and return `None` (docstring updated). Same contract as “unknown skill” for callers that already branch on falsy messages.
- **gateway/run.py**: When a skill command resolves but the message is `None`, return an explicit user-facing error instead of falling through to the agent with stale/empty text.
- **tui_gateway/server.py**: Return HTTP-style `_err(..., 5030, …)` for skill slash and `/plan` when the invocation message is missing (avoids falling through to “not a quick/plugin/skill command”).

## Tests
- **tests/agent/test_skill_commands.py**: `test_returns_none_when_payload_load_fails` — patches `_load_skill_payload` to `None` and asserts `build_skill_invocation_message` returns `None`.

## Notes
Local pytest was not run (environment Python \< 3.11); CI matrix should cover `tests/agent/test_skill_commands.py`.

Made with [Cursor](https://cursor.com)