### PR TITLE
chore: add [test] optional extra for local pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,15 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
+# Minimal install to run the unit test suite locally or in CI-like scripts:
+#   pip install -e ".[test]"
+# (Full tooling remains under [dev].)
+test = [
+  "pytest>=9.0.2,<10",
+  "pytest-asyncio>=1.3.0,<2",
+  "pytest-xdist>=3.0,<4",
+  "pytest-split>=0.9,<1",
+]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,15 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
+# Minimal install to run the unit test suite locally or in CI-like scripts:
+#   pip install -e ".[test]"
+# (Full tooling remains under [dev].)
+test = [
+  "pytest>=9.0.2,<10",
+  "pytest-asyncio>=1.3.0,<2",
+  "pytest-xdist>=3.0,<4",
+  "pytest-split>=0.9,<1",
+]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = ["croniter>=6.0.0,<7"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -41,6 +41,14 @@ fi
 
 PYTHON="$VENV/bin/python"
 
+# ── Ensure pytest is installed (declared in pyproject optional-deps [test]) ──
+if ! "$PYTHON" -c "import pytest" 2>/dev/null; then
+  echo "error: pytest is not installed in $VENV" >&2
+  echo "  From the repo root, install the test extra (requires Python >=3.11):" >&2
+  echo "    cd \"$REPO_ROOT\" && \"$PYTHON\" -m pip install -e \".[test]\"" >&2
+  exit 1
+fi
+
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"


### PR DESCRIPTION
## Summary
Makes it straightforward to install **pytest** and the usual plugins used by `scripts/run_tests.sh` without pulling the full `[dev]` extra.

## Usage
With Python **>=3.11** and a venv:

```bash
cd /path/to/hermes-agent
python3.12 -m venv .venv
source .venv/bin/activate
pip install -e ".[test]"
scripts/run_tests.sh tests/agent/test_skill_commands.py -q
```

## Changes
- **pyproject.toml**: new optional-dependencies group `test` (pytest, pytest-asyncio, pytest-xdist, pytest-split).
- **scripts/run_tests.sh**: if pytest is missing, exit with the exact `pip install -e ".[test]"` line instead of a cryptic import error later.

`[dev]` is unchanged (still includes pytest for full contributor installs).

Made with [Cursor](https://cursor.com)