### PR TITLE
fix(web_server): guard GATEWAY_HEALTH_TIMEOUT against invalid env values

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -431,7 +431,14 @@ class EnvVarReveal(BaseModel):
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
-_GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
+try:
+    _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
+except (ValueError, TypeError):
+    _log.warning(
+        "Invalid GATEWAY_HEALTH_TIMEOUT value %r — using default 3.0s",
+        os.getenv("GATEWAY_HEALTH_TIMEOUT"),
+    )
+    _GATEWAY_HEALTH_TIMEOUT = 3.0
 
 
 def _probe_gateway_health() -> tuple[bool, dict | None]:


### PR DESCRIPTION
Salvage of #14751 (@sprmn24) onto current main.

## Summary
`_GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))` at module level in web_server.py crashes the entire web server at import if the env var holds a non-numeric value. Wrapped in try/except with a warning log and 3.0s fallback.

## Changes
- `hermes_cli/web_server.py`: try/except around the bare float() parse; warns via existing `_log`.

## Validation
E2E with real imports against this worktree:
| Env value | Before | After |
|---|---|---|
| `abc` | ValueError at import, server dies | Warning logged, timeout=3.0, server starts |
| `5.5` | 5.5 | 5.5 |
| unset | 3.0 | 3.0 |

Cherry-picked from PR #14751 commit 2beeedcd, authorship preserved.