### PR TITLE
docs(readme): fix stale RL submodule section, /skills messaging row, test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Set a personality | `/personality [name]` | `/personality [name]` |
 | Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
-| Browse skills | `/skills` or `/<skill-name>` | `/skills` or `/<skill-name>` |
+| Browse skills | `/skills` or `/<skill-name>` | `/<skill-name>` |
 | Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |
 
@@ -157,14 +157,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
-python -m pytest tests/ -q
+scripts/run_tests.sh
 ```
 
-> **RL Training (optional):** To work on the RL/Tinker-Atropos integration:
-> ```bash
-> git submodule update --init tinker-atropos
-> uv pip install -e "./tinker-atropos"
-> ```
+> **RL Training (optional):** The RL/Atropos integration (`environments/`) ships via the `atroposlib` and `tinker` dependencies pulled in by `.[all,dev]` — no submodule setup required.
 
 ---
 


### PR DESCRIPTION
## Summary
Three small README accuracy fixes found during a coverage audit.

## Changes
- **RL Training section** — the submodule instructions are stale. No `.gitmodules` exists, `tinker-atropos/` is an empty directory, and `atroposlib` + `tinker` are already regular pip deps in `pyproject.toml` pulled in by `.[all,dev]`. Replaced the broken block with a one-line note.
- **CLI vs Messaging table** — `/skills` is registered as `cli_only=True` in `COMMAND_REGISTRY`, so it doesn't work on messaging platforms. Dropped it from the messaging column; `/<skill-name>` still works there.
- **Contributor test command** — switched from bare `python -m pytest tests/ -q` to `scripts/run_tests.sh`, which AGENTS.md designates as the canonical runner (enforces hermetic env parity with CI: unset credential vars, TZ=UTC, LANG=C.UTF-8, -n 4 xdist workers).

## Validation
- All other README claims verified: 16/16 docs URLs return 200, every `hermes` subcommand referenced exists, every slash command in the table is in `COMMAND_REGISTRY` with correct CLI/gateway scoping, `claw migrate` flags match `--help` output, terminal-backends count matches `tools/environments/`.