### PR TITLE
fix(moa): replace deprecated gemini-3-pro-preview + forward max_tokens

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ AUTHOR_MAP = {
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "343873859@qq.com": "DrStrangerUJN",
     "jefferson@heimdallstrategy.com": "Mind-Dragon",
+    "130918800+devorun@users.noreply.github.com": "devorun",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/tools/test_mixture_of_agents_tool.py
+++ b/tests/tools/test_mixture_of_agents_tool.py
@@ -8,14 +8,17 @@ import pytest
 moa = importlib.import_module("tools.mixture_of_agents_tool")
 
 
-def test_moa_defaults_track_current_openrouter_frontier_models():
-    assert moa.REFERENCE_MODELS == [
-        "anthropic/claude-opus-4.6",
-        "google/gemini-3-pro-preview",
-        "openai/gpt-5.4-pro",
-        "deepseek/deepseek-v3.2",
-    ]
-    assert moa.AGGREGATOR_MODEL == "anthropic/claude-opus-4.6"
+def test_moa_defaults_are_well_formed():
+    # Invariants, not a catalog snapshot: the exact model list churns with
+    # OpenRouter availability (see PR #6636 where gemini-3-pro-preview was
+    # removed upstream). What we care about is that the defaults are present
+    # and valid vendor/model slugs.
+    assert isinstance(moa.REFERENCE_MODELS, list)
+    assert len(moa.REFERENCE_MODELS) >= 1
+    for m in moa.REFERENCE_MODELS:
+        assert isinstance(m, str) and "/" in m and not m.startswith("/")
+    assert isinstance(moa.AGGREGATOR_MODEL, str)
+    assert "/" in moa.AGGREGATOR_MODEL
 
 
 @pytest.mark.asyncio

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 # Keep this list aligned with current top-tier OpenRouter frontier options.
 REFERENCE_MODELS = [
     "anthropic/claude-opus-4.6",
-    "google/gemini-3-pro-preview",
+    "google/gemini-2.5-pro",
     "openai/gpt-5.4-pro",
     "deepseek/deepseek-v3.2",
 ]
@@ -129,6 +129,7 @@ async def _run_reference_model_safe(
             api_params = {
                 "model": model,
                 "messages": [{"role": "user", "content": user_prompt}],
+                "max_tokens": max_tokens,
                 "extra_body": {
                     "reasoning": {
                         "enabled": True,
@@ -203,6 +204,7 @@ async def _run_aggregator_model(
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt}
         ],
+        "max_tokens": max_tokens,
         "extra_body": {
             "reasoning": {
                 "enabled": True,


### PR DESCRIPTION
Salvage of #6636 (@devorun) onto current main.

## Summary
Stops MoA from 404-looping on OpenRouter after `google/gemini-3-pro-preview` was pulled upstream, and forwards `max_tokens` on both reference and aggregator calls (was missing — the API silently accepted the param-less request but user-set limits were ignored).

Reported via Norbert's Discord cron failure (paste.rs/Q5WEB): 6 retries × 4 frontier models × 600s idle timeout = one dead cron job + $4.63 burned.

## Changes
- tools/mixture_of_agents_tool.py: `google/gemini-3-pro-preview` → `google/gemini-2.5-pro`; add `max_tokens` to both `chat.completions.create()` calls
- tests/tools/test_mixture_of_agents_tool.py: convert the catalog-snapshot test to an invariant (non-empty, well-formed vendor/model slugs) — the old test was a change-detector that would flip red on the next churn anyway
- scripts/release.py: AUTHOR_MAP entry for @devorun

## Validation
```
tests/tools/test_mixture_of_agents_tool.py .................. 3 passed
```

Does NOT fix the bigger cost problem (MoA still calls 3+ frontier models when the agent decides to use it, and cron currently ignores `hermes tools` config so users can't disable it there). Those are separate follow-ups — next PR wires cron to `_get_platform_tools()` so `hermes tools` actually gates cron toolsets.

Closes #6636.