### PR TITLE
fix(cli): surface delegate_task child progress in scrollback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7349,6 +7349,9 @@ class HermesCLI:
             self._stream_box_opened = False
         self._close_reasoning_box()
 
+        if tool_name == "delegate_task":
+            return
+
         from agent.display import get_tool_emoji
         emoji = get_tool_emoji(tool_name, default="⚡")
         _cprint(f"  ┊ {emoji} preparing {tool_name}…")
@@ -7372,8 +7375,101 @@ class HermesCLI:
         stacked line to scrollback on tool.completed so users can see the
         full history of tool calls (not just the current one in the spinner).
         """
+        if event_type == "subagent_progress":
+            event_type = "subagent.progress"
+        if event_type.startswith("subagent."):
+            if self.tool_progress_mode == "off":
+                return
+            from agent.display import KawaiiSpinner, get_tool_emoji, get_tool_preview_max_len
+
+            def _clean_subagent_text(text):
+                text = str(text or "").replace("\n", " ")
+                text = " ".join(text.split())
+                if text.startswith("🔀 "):
+                    text = text[2:].strip()
+                return text
+
+            def _truncate_subagent_text(text, limit=None, reserve=0):
+                text = _clean_subagent_text(text)
+                if not text:
+                    return text
+                max_width = max(20, self._get_tui_terminal_width() - max(int(reserve or 0), 0))
+                if limit:
+                    max_width = min(max_width, int(limit))
+                return self._trim_status_bar_text(text, max_width)
+
+            def _polish_subagent_summary(text):
+                text = _clean_subagent_text(text)
+                if not text:
+                    return text
+                while text.startswith("#") or text.startswith("-") or text.startswith("*"):
+                    text = text[1:].strip()
+                markdown_tokens = (
+                    "## ", "### ", "#### ", "--- ", "**", "`"
+                )
+                for token in markdown_tokens:
+                    text = text.replace(token, "")
+                text = text.replace(" - ", " ")
+                text = " ".join(text.split())
+                for sep in (". ", "! ", "? ", " — ", " | "):
+                    if sep in text:
+                        text = text.split(sep, 1)[0].strip()
+                        break
+                return _truncate_subagent_text(text, reserve=6)
+
+            def _is_decorative_thinking(text):
+                raw = _clean_subagent_text(text)
+                if not raw.endswith("..."):
+                    return False
+                lowered = raw[:-3].strip().lower()
+                try:
+                    verbs = {str(v).strip().lower() for v in KawaiiSpinner.get_thinking_verbs()}
+                except Exception:
+                    verbs = set()
+                return any(lowered.endswith(f" {verb}") or lowered == verb for verb in verbs if verb)
+
+            line = None
+            if event_type == "subagent.start":
+                text = _truncate_subagent_text(preview or kwargs.get("goal") or function_name or "delegated task", reserve=6)
+                line = f"  🔀 {text}"
+                self._spinner_text = f"🔀 {text}"
+                self._tool_start_time = time.monotonic()
+            elif event_type == "subagent.thinking":
+                text = _truncate_subagent_text(preview or function_name or "thinking", reserve=6)
+                self._spinner_text = f"💭 {text}"
+                if not _is_decorative_thinking(text):
+                    line = f"  💭 {text}"
+            elif event_type == "subagent.tool":
+                emoji = get_tool_emoji(function_name or "")
+                label = _truncate_subagent_text(preview or function_name or "tool", reserve=20)
+                _pl = get_tool_preview_max_len()
+                spinner_label = f"{emoji} {function_name or 'tool'}"
+                if label and label != function_name:
+                    spinner_label += f" {label}"
+                if _pl > 0 and len(spinner_label) > _pl:
+                    spinner_label = spinner_label[:_pl - 3] + "..."
+                line = f"  ↳ {emoji} {function_name or 'tool'}"
+                if preview:
+                    line += f'  "{label}"'
+                self._spinner_text = spinner_label
+            elif event_type == "subagent.progress":
+                text = _truncate_subagent_text(preview or kwargs.get("summary") or function_name or "progress", reserve=6)
+                self._spinner_text = f"🔀 {text}"
+            elif event_type == "subagent.complete":
+                text = _polish_subagent_summary(kwargs.get("summary") or preview or kwargs.get("status") or "completed")
+                status = str(kwargs.get("status") or "completed")
+                icon = "✅" if status == "completed" else ("⏱️" if status == "timeout" else "⚠️")
+                line = f"  {icon} {text}"
+                self._tool_start_time = 0.0
+            if line and self.tool_progress_mode in ("all", "new"):
+                _cprint(line)
+            self._invalidate()
+            return
         if event_type == "tool.completed":
             self._tool_start_time = 0.0
+            if function_name == "delegate_task":
+                self._invalidate()
+                return
             # Print stacked scrollback line for "all" / "new" modes
             if function_name and self.tool_progress_mode in ("all", "new"):
                 duration = kwargs.get("duration", 0.0)

--- a/tests/cli/test_tool_progress_scrollback.py
+++ b/tests/cli/test_tool_progress_scrollback.py
@@ -187,3 +187,111 @@ class TestToolProgressScrollback:
         # First entry consumed, second remains
         assert len(cli._pending_tool_info.get("terminal", [])) == 1
         assert cli._pending_tool_info["terminal"][0] == {"command": "pwd"}
+
+    def test_subagent_events_print_scrollback_lines(self):
+        """Delegated child progress should be visible in the CLI scrollback."""
+        cli = _make_cli(tool_progress="all")
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress("subagent.start", None, "Inspect repo", None, goal="Inspect repo")
+            cli._on_tool_progress("subagent.thinking", None, "Planning next step", None, goal="Inspect repo")
+            cli._on_tool_progress("subagent.tool", "read_file", "README.md", {"path": "README.md"}, goal="Inspect repo")
+            cli._on_tool_progress("subagent_progress", "Read README.md, PLAN.md", None, None, goal="Inspect repo")
+            cli._on_tool_progress("subagent.complete", None, "done", None, goal="Inspect repo", status="completed", summary="done")
+
+        rendered = "\n".join(call.args[0] for call in mock_print.call_args_list)
+        assert "Inspect repo" in rendered
+        assert "Planning next step" in rendered
+        assert "read_file" in rendered
+        assert "done" in rendered
+        assert "🔀 🔀" not in rendered
+        assert "Read README.md, PLAN.md" not in rendered
+        assert cli._spinner_text == "🔀 Read README.md, PLAN.md"
+
+    def test_subagent_start_prints_single_scrollback_line_and_updates_spinner(self):
+        """Delegated starts should announce the child run once and update the spinner."""
+        cli = _make_cli(tool_progress="all")
+        long_goal = "Step 1\nStep 2\nStep 3 " + ("A" * 180)
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress("subagent.start", None, long_goal, None, goal=long_goal)
+        mock_print.assert_called_once()
+        line = mock_print.call_args[0][0]
+        assert "Step 1 Step 2 Step 3" in line
+        assert "\n" not in line
+        assert line.endswith("...")
+        assert cli._spinner_text.endswith("...")
+
+    def test_subagent_start_uses_terminal_width_instead_of_short_fixed_cap(self):
+        """Wide terminals should keep more delegated text before truncating."""
+        cli = _make_cli(tool_progress="all")
+        goal = "Step 1 " + ("A" * 120)
+        with patch.object(cli, "_get_tui_terminal_width", return_value=160), \
+             patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress("subagent.start", None, goal, None, goal=goal)
+        line = mock_print.call_args[0][0]
+        assert goal in line
+        assert not line.endswith("...")
+
+    def test_delegate_task_preparation_and_completion_are_suppressed_from_scrollback(self):
+        """delegate_task should rely on child events instead of adding extra wrapper lines."""
+        cli = _make_cli(tool_progress="all")
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_gen_start("delegate_task")
+            cli._on_tool_progress(
+                "tool.started",
+                "delegate_task",
+                "Inspect repo",
+                {"goal": "Inspect repo"},
+            )
+            cli._on_tool_progress(
+                "tool.completed",
+                "delegate_task",
+                None,
+                None,
+                duration=1.2,
+                is_error=False,
+            )
+        mock_print.assert_not_called()
+
+    def test_subagent_complete_polishes_markdown_summary(self):
+        """Completion lines should strip markdown-heavy summaries down to one concise line."""
+        cli = _make_cli(tool_progress="all")
+        summary = "## SUMMARY\n- Found delegate tests. More detail below.\n- Extra text"
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress(
+                "subagent.complete",
+                None,
+                None,
+                None,
+                goal="Inspect repo",
+                status="completed",
+                summary=summary,
+            )
+        line = mock_print.call_args[0][0]
+        assert "##" not in line
+        assert "- " not in line
+        assert "Found delegate tests" in line
+        assert "More detail below" not in line
+
+    def test_decorative_subagent_thinking_is_suppressed(self):
+        """Face+verb thinking filler should update spinner only, not scrollback."""
+        cli = _make_cli(tool_progress="all")
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress("subagent.thinking", None, "(¬_¬) reflecting...", None, goal="Inspect repo")
+        mock_print.assert_not_called()
+        assert "reflecting" in cli._spinner_text
+
+    def test_subagent_tool_updates_spinner_text(self):
+        """A delegated child tool event should update the live spinner text."""
+        cli = _make_cli(tool_progress="all")
+        cli._on_tool_progress("subagent.tool", "read_file", "README.md", {"path": "README.md"}, goal="Inspect repo")
+        assert "read_file" in cli._spinner_text
+        assert "README.md" in cli._spinner_text
+
+    def test_subagent_events_suppressed_in_off_mode(self):
+        """tool_progress=off should suppress delegated scrollback output too."""
+        cli = _make_cli(tool_progress="off")
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress("subagent.start", None, "Inspect repo", None, goal="Inspect repo")
+            cli._on_tool_progress("subagent.progress", None, "Read README.md", None, goal="Inspect repo")
+            cli._on_tool_progress("subagent.complete", None, "done", None, goal="Inspect repo", status="completed")
+        mock_print.assert_not_called()


### PR DESCRIPTION
Summary
When delegate_task was invoked, the CLI did not clearly show what was happening inside the delegated child run. This made delegated work feel silent and opaque while the child process was actually running.

This change fixes that by surfacing delegated child activity in the CLI scrollback.

What changed
- show delegated child lifecycle/progress in CLI output
- preserve visible child start/progress/completion events during delegate_task runs
- avoid relying on wrapper-only delegate_task lines as the main signal
- trim delegated lines using terminal width instead of very short fixed character caps

Why
Previously, users could trigger delegate_task and see little or no useful output about the child process itself. The important issue was not just duplication, but that the delegated execution was not visibly traceable from the CLI.

After this fix, delegate_task runs expose what the child process is doing, so delegated work is observable and easier to follow.

Tests
- added/updated CLI scrollback coverage for delegated child events
- verified:
  uv run --extra dev python -m pytest -q tests/cli/test_tool_progress_scrollback.py tests/test_cli_skin_integration.py

Files changed
- cli.py
- tests/cli/test_tool_progress_scrollback.py
