### PR TITLE
fix(gateway): raise API server body limit for image payloads

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -58,7 +58,26 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+def _parse_max_request_bytes(default: int = 10_000_000) -> int:
+    """Resolve the API server request-body limit.
+
+    Default is 10 MB — accommodates long agent conversations with tool calls
+    and small image payloads.  Override via ``API_SERVER_MAX_REQUEST_BYTES``
+    (raw byte count) for vision-heavy workloads.
+    """
+    raw = os.environ.get("API_SERVER_MAX_REQUEST_BYTES")
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "API_SERVER_MAX_REQUEST_BYTES=%r is not a valid integer; using default %d",
+            raw, default,
+        )
+        return default
+
+MAX_REQUEST_BYTES = _parse_max_request_bytes()
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,7 +53,20 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+def _parse_max_request_bytes(default: int = 20_000_000) -> int:
+    raw = os.environ.get("API_SERVER_MAX_REQUEST_BYTES")
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "API_SERVER_MAX_REQUEST_BYTES=%r is not a valid integer; using default %d",
+            raw, default,
+        )
+        return default
+
+MAX_REQUEST_BYTES = _parse_max_request_bytes()  # 20 MB default — large enough for images
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -2488,7 +2501,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            self._app = web.Application(
+                middlewares=mws,
+                client_max_size=MAX_REQUEST_BYTES,
+            )
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)

--- a/tests/gateway/test_api_server_payload_limit.py
+++ b/tests/gateway/test_api_server_payload_limit.py
@@ -1,0 +1,146 @@
+"""Tests for API server request body size limits.
+
+Regression test for #13875: the API server rejected image payloads >1MB
+because MAX_REQUEST_BYTES was hardcoded to 1MB and not passed to
+aiohttp's web.Application(client_max_size=...).
+
+The fix:
+1. Raises the default from 1MB to 20MB (images/vision payloads)
+2. Makes it configurable via API_SERVER_MAX_REQUEST_BYTES env var
+3. Passes client_max_size to web.Application() so aiohttp enforces
+   the same limit as the middleware
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.api_server import MAX_REQUEST_BYTES, _parse_max_request_bytes
+
+
+class TestMaxRequestBytesDefault:
+    """Default MAX_REQUEST_BYTES should be large enough for images."""
+
+    def test_default_is_10mb(self):
+        assert MAX_REQUEST_BYTES == 10_000_000
+
+    def test_default_allows_typical_image(self):
+        """A base64-encoded 5MB image is ~6.7MB -- must be under the limit."""
+        typical_b64_image_size = 5 * 1024 * 1024 * 4 // 3  # ~6.67 MB
+        assert typical_b64_image_size < MAX_REQUEST_BYTES
+
+    def test_old_1mb_limit_not_present(self):
+        """The old hardcoded 1MB limit must not be the active value."""
+        assert MAX_REQUEST_BYTES != 1_000_000, (
+            "MAX_REQUEST_BYTES is still 1MB -- the old limit that blocked images"
+        )
+
+
+class TestParseMaxRequestBytes:
+    """The env var parser should handle all input gracefully."""
+
+    def test_returns_default_when_unset(self):
+        assert _parse_max_request_bytes() == 10_000_000
+
+    def test_custom_default(self):
+        assert _parse_max_request_bytes(default=5_000_000) == 5_000_000
+
+    def test_valid_env_override(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "50000000")
+        assert _parse_max_request_bytes() == 50_000_000
+
+    def test_env_can_reduce_limit(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "1000000")
+        assert _parse_max_request_bytes() == 1_000_000
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        """Non-numeric env var should not crash — fall back to default."""
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "20mb")
+        result = _parse_max_request_bytes()
+        assert result == 10_000_000
+
+    def test_empty_string_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "")
+        result = _parse_max_request_bytes()
+        assert result == 10_000_000
+
+
+class TestBodyLimitMiddleware:
+    """The body_limit_middleware should reject oversized requests."""
+
+    @pytest.fixture
+    def middleware(self):
+        from gateway.platforms.api_server import body_limit_middleware
+        if body_limit_middleware is None:
+            pytest.skip("aiohttp not available")
+        return body_limit_middleware
+
+    @pytest.mark.asyncio
+    async def test_allows_request_under_limit(self, middleware):
+        """A 5MB request (under 10MB limit) should pass through."""
+        from aiohttp import web
+        from unittest.mock import AsyncMock
+
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {"Content-Length": str(5_000_000)}
+
+        handler = AsyncMock(return_value=web.Response(text="ok"))
+        response = await middleware(request, handler)
+
+        handler.assert_called_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_over_limit(self, middleware):
+        """A request exceeding MAX_REQUEST_BYTES should get 413."""
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {"Content-Length": str(MAX_REQUEST_BYTES + 1)}
+
+        handler = MagicMock()
+        response = await middleware(request, handler)
+
+        handler.assert_not_called()
+        assert response.status == 413
+
+    @pytest.mark.asyncio
+    async def test_allows_get_regardless_of_size(self, middleware):
+        """GET requests should not be checked for body size."""
+        from aiohttp import web
+        from unittest.mock import AsyncMock
+
+        request = MagicMock()
+        request.method = "GET"
+        request.headers = {"Content-Length": str(999_999_999)}
+
+        handler = AsyncMock(return_value=web.Response(text="ok"))
+        response = await middleware(request, handler)
+
+        handler.assert_called_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_content_length(self, middleware):
+        """Non-numeric Content-Length should get 400."""
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {"Content-Length": "not-a-number"}
+
+        handler = MagicMock()
+        response = await middleware(request, handler)
+
+        assert response.status == 400
+
+
+class TestApplicationClientMaxSize:
+    """web.Application must receive client_max_size so aiohttp enforces
+    the limit on chunked transfers (not just Content-Length header)."""
+
+    def test_source_passes_client_max_size(self):
+        """Guard: client_max_size must be set in Application constructor."""
+        from pathlib import Path
+        source = (Path(__file__).parent.parent.parent
+                  / "gateway" / "platforms" / "api_server.py").read_text()
+        assert "client_max_size=MAX_REQUEST_BYTES" in source, (
+            "web.Application() must pass client_max_size=MAX_REQUEST_BYTES "
+            "so aiohttp enforces the same limit as the middleware"
+        )

--- a/tests/gateway/test_api_server_payload_limit.py
+++ b/tests/gateway/test_api_server_payload_limit.py
@@ -1,0 +1,146 @@
+"""Tests for API server request body size limits.
+
+Regression test for #13875: the API server rejected image payloads >1MB
+because MAX_REQUEST_BYTES was hardcoded to 1MB and not passed to
+aiohttp's web.Application(client_max_size=...).
+
+The fix:
+1. Raises the default from 1MB to 20MB (images/vision payloads)
+2. Makes it configurable via API_SERVER_MAX_REQUEST_BYTES env var
+3. Passes client_max_size to web.Application() so aiohttp enforces
+   the same limit as the middleware
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.api_server import MAX_REQUEST_BYTES, _parse_max_request_bytes
+
+
+class TestMaxRequestBytesDefault:
+    """Default MAX_REQUEST_BYTES should be large enough for images."""
+
+    def test_default_is_20mb(self):
+        assert MAX_REQUEST_BYTES == 20_000_000
+
+    def test_default_allows_typical_image(self):
+        """A base64-encoded 5MB image is ~6.7MB -- must be under the limit."""
+        typical_b64_image_size = 5 * 1024 * 1024 * 4 // 3  # ~6.67 MB
+        assert typical_b64_image_size < MAX_REQUEST_BYTES
+
+    def test_old_1mb_limit_not_present(self):
+        """The old hardcoded 1MB limit must not be the active value."""
+        assert MAX_REQUEST_BYTES != 1_000_000, (
+            "MAX_REQUEST_BYTES is still 1MB -- the old limit that blocked images"
+        )
+
+
+class TestParseMaxRequestBytes:
+    """The env var parser should handle all input gracefully."""
+
+    def test_returns_default_when_unset(self):
+        assert _parse_max_request_bytes() == 20_000_000
+
+    def test_custom_default(self):
+        assert _parse_max_request_bytes(default=5_000_000) == 5_000_000
+
+    def test_valid_env_override(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "50000000")
+        assert _parse_max_request_bytes() == 50_000_000
+
+    def test_env_can_reduce_limit(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "1000000")
+        assert _parse_max_request_bytes() == 1_000_000
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        """Non-numeric env var should not crash — fall back to default."""
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "20mb")
+        result = _parse_max_request_bytes()
+        assert result == 20_000_000
+
+    def test_empty_string_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "")
+        result = _parse_max_request_bytes()
+        assert result == 20_000_000
+
+
+class TestBodyLimitMiddleware:
+    """The body_limit_middleware should reject oversized requests."""
+
+    @pytest.fixture
+    def middleware(self):
+        from gateway.platforms.api_server import body_limit_middleware
+        if body_limit_middleware is None:
+            pytest.skip("aiohttp not available")
+        return body_limit_middleware
+
+    @pytest.mark.asyncio
+    async def test_allows_request_under_limit(self, middleware):
+        """A 15MB request (under 20MB limit) should pass through."""
+        from aiohttp import web
+        from unittest.mock import AsyncMock
+
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {"Content-Length": str(15_000_000)}
+
+        handler = AsyncMock(return_value=web.Response(text="ok"))
+        response = await middleware(request, handler)
+
+        handler.assert_called_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_over_limit(self, middleware):
+        """A request exceeding MAX_REQUEST_BYTES should get 413."""
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {"Content-Length": str(MAX_REQUEST_BYTES + 1)}
+
+        handler = MagicMock()
+        response = await middleware(request, handler)
+
+        handler.assert_not_called()
+        assert response.status == 413
+
+    @pytest.mark.asyncio
+    async def test_allows_get_regardless_of_size(self, middleware):
+        """GET requests should not be checked for body size."""
+        from aiohttp import web
+        from unittest.mock import AsyncMock
+
+        request = MagicMock()
+        request.method = "GET"
+        request.headers = {"Content-Length": str(999_999_999)}
+
+        handler = AsyncMock(return_value=web.Response(text="ok"))
+        response = await middleware(request, handler)
+
+        handler.assert_called_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_content_length(self, middleware):
+        """Non-numeric Content-Length should get 400."""
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {"Content-Length": "not-a-number"}
+
+        handler = MagicMock()
+        response = await middleware(request, handler)
+
+        assert response.status == 400
+
+
+class TestApplicationClientMaxSize:
+    """web.Application must receive client_max_size so aiohttp enforces
+    the limit on chunked transfers (not just Content-Length header)."""
+
+    def test_source_passes_client_max_size(self):
+        """Guard: client_max_size must be set in Application constructor."""
+        from pathlib import Path
+        source = (Path(__file__).parent.parent.parent
+                  / "gateway" / "platforms" / "api_server.py").read_text()
+        assert "client_max_size=MAX_REQUEST_BYTES" in source, (
+            "web.Application() must pass client_max_size=MAX_REQUEST_BYTES "
+            "so aiohttp enforces the same limit as the middleware"
+        )


### PR DESCRIPTION
## What does this PR do?

`MAX_REQUEST_BYTES` was hardcoded to 1MB, blocking all multimodal/vision usage through the API gateway. Additionally, the limit was only enforced in the `body_limit_middleware` (Content-Length header check) but not passed to aiohttp's `web.Application(client_max_size=...)`, meaning chunked transfers bypassed the check entirely.

## Related Issue

Fixes #13875

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`:
  - Raised default from 1MB to 20MB (handles base64-encoded images up to ~15MB)
  - Made configurable via `API_SERVER_MAX_REQUEST_BYTES` env var (follows existing `API_SERVER_*` naming convention)
  - Wrapped in `_parse_max_request_bytes()` with try/except — invalid env var values log a warning and fall back to default instead of crashing module import
  - Added `client_max_size=MAX_REQUEST_BYTES` to `web.Application()` so aiohttp enforces the same limit on chunked transfers
- `tests/gateway/test_api_server_payload_limit.py` (new): 14 tests covering default value, env override, invalid/empty env var fallback, middleware allow/reject/GET-passthrough/invalid-CL, and source guardrail for `client_max_size`

## How to Test

```bash
python -m pytest -o 'addopts=' tests/gateway/test_api_server_payload_limit.py -v
```

Result: 14 passed. Full API server suite: 117 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest -o 'addopts=' tests/gateway/test_api_server_payload_limit.py -v
14 passed

Full API server suite: 117 passed
```
