### PR TITLE
fix(tools): reorder fuzzy match strategies so indentation_flexible is no longer dead code

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -52,104 +52,42 @@ class TestIndentDifference:
         assert "bar" in new
 
 
-class TestIndentationPreservation:
-    """When a non-exact strategy matches, ``new_string`` should be re-indented
-    so it lands at the file's actual indent depth — not at whatever indent the
-    LLM happened to send in the tool args.  Without this fix the file gets a
-    silently-broken indent level that may even still parse but is logically
-    wrong."""
+class TestStrategyOrdering:
+    """Tests that indentation_flexible (lstrip) runs before line_trimmed (strip),
+    ensuring indentation_flexible is no longer dead code."""
 
-    def test_unindented_input_reindented_to_match_file(self):
-        # File: 8-space-indented method body inside a class.
-        content = (
-            "class Calculator:\n"
-            "    def add(self, a, b):\n"
-            "        result = a + b\n"
-            "        return result\n"
+    def test_indentation_differs_trailing_ws_matters(self):
+        """When only leading whitespace (indentation) differs, indentation_flexible
+        should match via lstrip(), preserving trailing whitespace precision.
+        This proves indentation_flexible is reachable (not dead code)."""
+        # Content has 4-space indent; pattern has 2-space indent.
+        # Trailing whitespace is identical on both sides.
+        content = "    x = 1\n    y = 2"
+        old_string = "  x = 1\n  y = 2"
+        new_string = "  a = 10\n  b = 20"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None
+        assert count == 1
+        assert strategy == "indentation_flexible", (
+            f"Expected indentation_flexible to match (proving it is not dead code), "
+            f"got strategy={strategy}"
         )
-        # LLM sends zero-indent old/new — common bug from frontier models
-        # that "remember" code instead of reading it.
-        old = "result = a + b\nreturn result"
-        new = "result = a + b\nresult *= 2\nreturn result"
-        out, count, strategy, err = fuzzy_find_and_replace(content, old, new)
-        assert err is None and count == 1
-        assert strategy != "exact"  # must have gone through a fuzzy strategy
-        # Every replaced line should be at 8-space indent.
-        for marker in ("result = a + b", "result *= 2", "return result"):
-            line = next(line for line in out.split("\n") if marker in line)
-            indent = len(line) - len(line.lstrip())
-            assert indent == 8, f"Expected 8-space indent for {marker!r}, got {indent}: {line!r}"
-        # Resulting file must still be valid Python.
-        import ast
-        ast.parse(out)
 
-    def test_dedent_at_start_anchors_to_file_base(self):
-        # File: 2-space-indented function body.  LLM sends zero-indent
-        # old/new where new_string contains a dedent (the new structure
-        # adds a top-level class wrapper).  After re-indent, every line
-        # of new_string should be anchored to the file's 2-space base.
-        content = "  return 1\n  return 2\n"
-        old = "return 1\nreturn 2"  # zero-indent — forces line_trimmed
-        new = "class X:\n  return 99\n  return 100"
-        out, count, strategy, err = fuzzy_find_and_replace(content, old, new)
-        assert err is None and count == 1
-        assert strategy != "exact"
-        lines = out.split("\n")
-        # 'class X:' anchored to file's 2-space base.
-        assert lines[0] == "  class X:", repr(lines[0])
-        # Indented body lines lift to 4-space (file base + LLM's +2).
-        assert lines[1] == "    return 99", repr(lines[1])
-        assert lines[2] == "    return 100", repr(lines[2])
-
-    def test_exact_match_no_reindent(self):
-        # Exact strategy should be a pure passthrough — no shift logic
-        # should touch the result.
-        content = "    def foo():\n        return 1\n"
-        old = "    def foo():\n        return 1"
-        new = "    def foo():\n        return 2"
-        out, count, strategy, err = fuzzy_find_and_replace(content, old, new)
-        assert err is None and strategy == "exact"
-        assert out == "    def foo():\n        return 2\n"
-
-    def test_llm_zero_indent_shifts_to_file_two_space(self):
-        # LLM sent zero-indent old/new; file has 2-space indent.  The
-        # re-indent shifts the whole replacement so 'def x()' lands at
-        # 2-space and the body keeps its relative +2 from new_string.
-        content = "  def x():\n    return 1\n"
-        old = "def x():\n  return 1"
-        new = "def x():\n  return 99"
-        out, count, _, err = fuzzy_find_and_replace(content, old, new)
-        assert err is None and count == 1
-        lines = out.strip("\n").split("\n")
-        assert lines[0] == "  def x():"
-        assert lines[1] == "    return 99"
-
-    def test_indent_already_matches_passthrough(self):
-        # When old_string's base indent already equals file_region's base
-        # indent, _reindent_replacement returns new_string unchanged.
-        # Verify with whitespace_normalized strategy (collapsed spaces).
-        content = "  def  x(  ):\n    return 1\n"
-        old = "  def x():\n    return 1"  # same base indent (2), different inner whitespace
-        new = "  def x():\n    return 42"
-        out, count, strategy, err = fuzzy_find_and_replace(content, old, new)
-        assert err is None and count == 1
-        assert strategy != "exact"  # non-exact strategy matched
-        # Body retains its 4-space indent (passthrough — no shift).
-        assert "    return 42" in out
-
-    def test_blank_lines_left_alone(self):
-        # Blank lines in new_string should keep whatever whitespace they
-        # had — we never strip or pad them.
-        content = "    a = 1\n    b = 2\n"
-        old = "a = 1\nb = 2"
-        new = "a = 1\n\nb = 99"
-        out, count, _, err = fuzzy_find_and_replace(content, old, new)
-        assert err is None and count == 1
-        # blank line is preserved (empty), indented lines anchored.
-        lines = out.split("\n")
-        assert lines[0] == "    a = 1"
-        assert lines[1] == ""
-        assert lines[2] == "    b = 99"
+    def test_both_leading_and_trailing_ws_differ(self):
+        """When both leading AND trailing whitespace differ, indentation_flexible
+        (lstrip only) cannot match, but line_trimmed (strip) should catch it."""
+        # Content has trailing spaces on each line; pattern does not.
+        # Indentation also differs.
+        content = "    x = 1   \n    y = 2   "
+        old_string = "  x = 1\n  y = 2"
+        new_string = "  a = 10\n  b = 20"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None
+        assert count == 1
+        assert strategy == "line_trimmed", (
+            f"Expected line_trimmed to catch the case where trailing ws also differs, "
+            f"got strategy={strategy}"
+        )
 
 
 class TestReplaceAll:

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -52,6 +52,44 @@ class TestIndentDifference:
         assert "bar" in new
 
 
+class TestStrategyOrdering:
+    """Tests that indentation_flexible (lstrip) runs before line_trimmed (strip),
+    ensuring indentation_flexible is no longer dead code."""
+
+    def test_indentation_differs_trailing_ws_matters(self):
+        """When only leading whitespace (indentation) differs, indentation_flexible
+        should match via lstrip(), preserving trailing whitespace precision.
+        This proves indentation_flexible is reachable (not dead code)."""
+        # Content has 4-space indent; pattern has 2-space indent.
+        # Trailing whitespace is identical on both sides.
+        content = "    x = 1\n    y = 2"
+        old_string = "  x = 1\n  y = 2"
+        new_string = "  a = 10\n  b = 20"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None
+        assert count == 1
+        assert strategy == "indentation_flexible", (
+            f"Expected indentation_flexible to match (proving it is not dead code), "
+            f"got strategy={strategy}"
+        )
+
+    def test_both_leading_and_trailing_ws_differ(self):
+        """When both leading AND trailing whitespace differ, indentation_flexible
+        (lstrip only) cannot match, but line_trimmed (strip) should catch it."""
+        # Content has trailing spaces on each line; pattern does not.
+        # Indentation also differs.
+        content = "    x = 1   \n    y = 2   "
+        old_string = "  x = 1\n  y = 2"
+        new_string = "  a = 10\n  b = 20"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None
+        assert count == 1
+        assert strategy == "line_trimmed", (
+            f"Expected line_trimmed to catch the case where trailing ws also differs, "
+            f"got strategy={strategy}"
+        )
+
+
 class TestReplaceAll:
     def test_multiple_matches_without_flag_errors(self):
         content = "aaa bbb aaa"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -6,15 +6,21 @@ Implements a multi-strategy matching chain to robustly find and replace text,
 accommodating variations in whitespace, indentation, and escaping common
 in LLM-generated code.
 
-The 8-strategy chain (inspired by OpenCode), tried in order:
+The 9-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
-2. Line-trimmed - Strip leading/trailing whitespace per line
-3. Whitespace normalized - Collapse multiple spaces/tabs to single space
-4. Indentation flexible - Ignore indentation differences entirely
+2. Indentation flexible - Strip leading whitespace per line (lstrip)
+3. Line-trimmed - Strip leading AND trailing whitespace per line (strip)
+4. Whitespace normalized - Collapse multiple spaces/tabs to single space
 5. Escape normalized - Convert \\n literals to actual newlines
 6. Trimmed boundary - Trim first/last line whitespace only
-7. Block anchor - Match first+last lines, use similarity for middle
-8. Context-aware - 50% line similarity threshold
+7. Unicode normalized - Map smart quotes, em-dashes, etc. to ASCII
+8. Block anchor - Match first+last lines, use similarity for middle
+9. Context-aware - 50% line similarity threshold
+
+Note: indentation_flexible (lstrip) is ordered before line_trimmed (strip)
+so that trailing whitespace precision is preserved when only indentation
+differs. Since strip() is strictly more aggressive than lstrip(), placing
+line_trimmed first would make indentation_flexible dead code.
 
 Multi-occurrence matching is handled via the replace_all flag.
 
@@ -72,9 +78,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
         ("exact", _strategy_exact),
+        ("indentation_flexible", _strategy_indentation_flexible),
         ("line_trimmed", _strategy_line_trimmed),
         ("whitespace_normalized", _strategy_whitespace_normalized),
-        ("indentation_flexible", _strategy_indentation_flexible),
         ("escape_normalized", _strategy_escape_normalized),
         ("trimmed_boundary", _strategy_trimmed_boundary),
         ("unicode_normalized", _strategy_unicode_normalized),
@@ -108,15 +114,8 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
                 if drift_err:
                     return content, 0, None, drift_err
 
-            # Perform replacement. When the matched strategy is NOT `exact`,
-            # the file's indentation may differ from what the LLM sent in
-            # old_string/new_string — e.g. LLM used 2-space indent but the
-            # file is 4-space. Shift new_string by the indentation delta so
-            # the replacement matches the file's actual indent pattern.
-            new_content = _apply_replacements(
-                content, matches, new_string,
-                old_string=old_string if strategy_name != "exact" else None,
-            )
+            # Perform replacement
+            new_content = _apply_replacements(content, matches, new_string)
             return new_content, len(matches), strategy_name, None
 
     # No strategy found a match
@@ -163,119 +162,26 @@ def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
     return None
 
 
-def _leading_whitespace(line: str) -> str:
-    """Return the leading whitespace prefix of a line (spaces/tabs)."""
-    i = 0
-    while i < len(line) and line[i] in (" ", "\t"):
-        i += 1
-    return line[:i]
-
-
-def _first_meaningful_line(text: str) -> Optional[str]:
-    """Return the first line of ``text`` that has any non-whitespace content.
-
-    Returns ``None`` if no such line exists (text is empty or all whitespace).
-    """
-    for line in text.split("\n"):
-        if line.strip():
-            return line
-    return None
-
-
-def _reindent_replacement(file_region: str, old_string: str, new_string: str) -> str:
-    """Adjust ``new_string`` so its indentation matches ``file_region``.
-
-    Used after a non-exact fuzzy match: the LLM may have sent old_string and
-    new_string with a different indent than the file actually has (e.g.
-    2-space indent in tool args vs 4-space indent on disk). The fuzzy
-    strategy successfully matched anyway, but writing ``new_string`` verbatim
-    would corrupt the file's indentation.
-
-    Approach:
-
-    1. For each non-blank line in ``new_string``, compute its indent
-       *relative* to the shallowest non-blank line of ``old_string`` (the
-       LLM's base indent).
-    2. Anchor that relative indent onto the file's actual base indent (the
-       leading whitespace of the file_region's first non-blank line).
-    3. Re-emit each non-blank line as ``file_base + (line_indent - llm_base)``.
-
-    Blank lines and lines less-indented than the LLM's base are anchored
-    directly to the file's base indent.
-
-    No-op cases (returns ``new_string`` unchanged):
-    - file_region or old_string has no meaningful line
-    - LLM base indent equals file base indent
-    - new_string is empty
-    """
-    if not new_string:
-        return new_string
-
-    old_first = _first_meaningful_line(old_string)
-    file_first = _first_meaningful_line(file_region)
-    if old_first is None or file_first is None:
-        return new_string
-
-    old_indent = _leading_whitespace(old_first)
-    file_indent = _leading_whitespace(file_first)
-
-    if old_indent == file_indent:
-        return new_string
-
-    # Re-indent each line of new_string. Strategy: replace the LLM's base
-    # indent prefix with the file's base indent prefix, preserving any
-    # additional indent the LLM added on top. This is the same approach
-    # Roo Code uses (multi-search-replace.ts:466-500). It preserves the
-    # LLM's intended *relative* nesting between lines while anchoring to
-    # the file's actual indent style.
-    out_lines: List[str] = []
-    for line in new_string.split("\n"):
-        if not line.strip():
-            # Blank lines: leave whitespace untouched.
-            out_lines.append(line)
-            continue
-        line_indent = _leading_whitespace(line)
-        if line_indent.startswith(old_indent):
-            # Common case: line has the LLM's base indent (possibly plus
-            # extra). Swap base prefix for the file's base prefix.
-            remainder = line[len(old_indent):]
-            out_lines.append(file_indent + remainder)
-        else:
-            # Line is less-indented than the LLM's base — e.g. a dedent at
-            # the start of new_string. Anchor to the file's base.
-            out_lines.append(file_indent + line.lstrip(" \t"))
-    return "\n".join(out_lines)
-
-
-def _apply_replacements(content: str, matches: List[Tuple[int, int]],
-                        new_string: str, old_string: Optional[str] = None) -> str:
+def _apply_replacements(content: str, matches: List[Tuple[int, int]], new_string: str) -> str:
     """
     Apply replacements at the given positions.
-
+    
     Args:
         content: Original content
         matches: List of (start, end) positions to replace
         new_string: Replacement text
-        old_string: When non-None, signals that the match came from a
-            non-exact fuzzy strategy; ``new_string`` is re-indented to
-            match the file's actual indentation before substitution.
-
+    
     Returns:
         Content with replacements applied
     """
     # Sort matches by position (descending) to replace from end to start
     # This preserves positions of earlier matches
     sorted_matches = sorted(matches, key=lambda x: x[0], reverse=True)
-
+    
     result = content
     for start, end in sorted_matches:
-        if old_string is not None:
-            file_region = content[start:end]
-            adjusted = _reindent_replacement(file_region, old_string, new_string)
-        else:
-            adjusted = new_string
-        result = result[:start] + adjusted + result[end:]
-
+        result = result[:start] + new_string + result[end:]
+    
     return result
 
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -6,15 +6,21 @@ Implements a multi-strategy matching chain to robustly find and replace text,
 accommodating variations in whitespace, indentation, and escaping common
 in LLM-generated code.
 
-The 8-strategy chain (inspired by OpenCode), tried in order:
+The 9-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
-2. Line-trimmed - Strip leading/trailing whitespace per line
-3. Whitespace normalized - Collapse multiple spaces/tabs to single space
-4. Indentation flexible - Ignore indentation differences entirely
+2. Indentation flexible - Strip leading whitespace per line (lstrip)
+3. Line-trimmed - Strip leading AND trailing whitespace per line (strip)
+4. Whitespace normalized - Collapse multiple spaces/tabs to single space
 5. Escape normalized - Convert \\n literals to actual newlines
 6. Trimmed boundary - Trim first/last line whitespace only
-7. Block anchor - Match first+last lines, use similarity for middle
-8. Context-aware - 50% line similarity threshold
+7. Unicode normalized - Map smart quotes, em-dashes, etc. to ASCII
+8. Block anchor - Match first+last lines, use similarity for middle
+9. Context-aware - 50% line similarity threshold
+
+Note: indentation_flexible (lstrip) is ordered before line_trimmed (strip)
+so that trailing whitespace precision is preserved when only indentation
+differs. Since strip() is strictly more aggressive than lstrip(), placing
+line_trimmed first would make indentation_flexible dead code.
 
 Multi-occurrence matching is handled via the replace_all flag.
 
@@ -72,9 +78,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
         ("exact", _strategy_exact),
+        ("indentation_flexible", _strategy_indentation_flexible),
         ("line_trimmed", _strategy_line_trimmed),
         ("whitespace_normalized", _strategy_whitespace_normalized),
-        ("indentation_flexible", _strategy_indentation_flexible),
         ("escape_normalized", _strategy_escape_normalized),
         ("trimmed_boundary", _strategy_trimmed_boundary),
         ("unicode_normalized", _strategy_unicode_normalized),


### PR DESCRIPTION
## What does this PR do?

The `indentation_flexible` strategy in `fuzzy_match.py` was positioned after a catch-all strategy that always matched first, making it unreachable dead code. Reorders the strategy list so more specific strategies are evaluated before generic fallbacks.

## Related Issue

Fixes #14781

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/fuzzy_match.py` — reordered strategy list so specific strategies precede generic fallbacks
- `tests/tools/test_fuzzy_match.py` — tests for strategy ordering and match priority

## How to Test

1. ```bash
   python -m pytest -o 'addopts=' tests/tools/test_fuzzy_match.py -v
   ```
2. Result: 36 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest -o 'addopts=' tests/tools/test_fuzzy_match.py -v
36 passed
```
