### PR TITLE
fix(tools): guard _get_command_timeout against None return after browser cleanup race

### DIFF
--- a/tests/tools/test_browser_timeout_race.py
+++ b/tests/tools/test_browser_timeout_race.py
@@ -1,0 +1,47 @@
+"""Regression tests for _get_command_timeout race after cleanup_all_browsers.
+
+Issue #14331: When cleanup_all_browsers() resets the timeout cache and a
+concurrent thread calls _get_command_timeout() during the window where
+_command_timeout_resolved is True but _cached_command_timeout is still None,
+the function must return DEFAULT_COMMAND_TIMEOUT instead of None.
+"""
+
+
+class TestGetCommandTimeoutRace:
+    def setup_method(self):
+        from tools import browser_tool
+
+        self.browser_tool = browser_tool
+        self.orig_cached = browser_tool._cached_command_timeout
+        self.orig_resolved = browser_tool._command_timeout_resolved
+
+    def teardown_method(self):
+        self.browser_tool._cached_command_timeout = self.orig_cached
+        self.browser_tool._command_timeout_resolved = self.orig_resolved
+
+    def test_returns_default_when_cache_is_none_but_resolved(self):
+        """Simulate the race: resolved=True but cached=None after cleanup."""
+        bt = self.browser_tool
+        bt._command_timeout_resolved = True
+        bt._cached_command_timeout = None
+
+        result = bt._get_command_timeout()
+        assert result == bt.DEFAULT_COMMAND_TIMEOUT
+        assert isinstance(result, int)
+
+    def test_max_does_not_raise_type_error(self):
+        """The call-site uses max(_get_command_timeout(), 60); must not TypeError."""
+        bt = self.browser_tool
+        bt._command_timeout_resolved = True
+        bt._cached_command_timeout = None
+
+        value = max(bt._get_command_timeout(), 60)
+        assert value >= 60
+
+    def test_returns_cached_value_when_set(self):
+        """Normal path: cached value is an int, return it directly."""
+        bt = self.browser_tool
+        bt._command_timeout_resolved = True
+        bt._cached_command_timeout = 45
+
+        assert bt._get_command_timeout() == 45

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -205,7 +205,7 @@ def _get_command_timeout() -> int:
     """
     global _cached_command_timeout, _command_timeout_resolved
     if _command_timeout_resolved:
-        return _cached_command_timeout  # type: ignore[return-value]
+        return _cached_command_timeout or DEFAULT_COMMAND_TIMEOUT
 
     _command_timeout_resolved = True
     result = DEFAULT_COMMAND_TIMEOUT

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -184,7 +184,7 @@ def _get_command_timeout() -> int:
     """
     global _cached_command_timeout, _command_timeout_resolved
     if _command_timeout_resolved:
-        return _cached_command_timeout  # type: ignore[return-value]
+        return _cached_command_timeout or DEFAULT_COMMAND_TIMEOUT
 
     _command_timeout_resolved = True
     result = DEFAULT_COMMAND_TIMEOUT


### PR DESCRIPTION
## What does this PR do?

Guards `_get_command_timeout()` in `browser_tool.py` against returning `None` after a browser cleanup race condition, preventing a `TypeError` crash.

## Related Issue

Fixes #14783

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_tool.py`: Added None guard in `_get_command_timeout()`
- `tests/tools/test_browser_timeout_race.py`: 3 tests for the race condition

## How to Test

1. Run:
   ```bash
   python -m pytest -o 'addopts=' tests/tools/test_browser_timeout_race.py -v
   ```
2. Confirm result: 3 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest -o 'addopts=' tests/tools/test_browser_timeout_race.py -v
# 3 passed
```
