### PR TITLE
fix(tools): add fallback normalization for CamelCase/_tool-suffix drift in tool dispatch

### DIFF
--- a/tests/tools/test_tool_name_normalize.py
+++ b/tests/tools/test_tool_name_normalize.py
@@ -1,0 +1,154 @@
+"""Tests for tool name normalization fallback in ToolRegistry.dispatch().
+
+Covers CamelCase and _tool-suffix drift that Claude models intermittently
+emit (e.g. ``TodoTool_tool``, ``Patch_tool``, ``BrowserClick_tool``).
+"""
+
+import json
+
+from tools.registry import ToolRegistry, _normalize_tool_name
+
+
+def _dummy_handler(args, **kwargs):
+    return json.dumps({"ok": True})
+
+
+def _make_schema(name="test_tool"):
+    return {
+        "name": name,
+        "description": f"A {name}",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _make_registry_with_tools(*tool_names):
+    """Return a ToolRegistry pre-populated with the given tool names."""
+    reg = ToolRegistry()
+    for tname in tool_names:
+        reg.register(
+            name=tname,
+            toolset="core",
+            schema=_make_schema(tname),
+            handler=_dummy_handler,
+        )
+    return reg
+
+
+# ------------------------------------------------------------------
+# Unit tests for _normalize_tool_name helper
+# ------------------------------------------------------------------
+
+class TestNormalizeToolName:
+    def test_todo_tool_tool_resolves_to_todo(self):
+        """TodoTool_tool -> strip _tool -> TodoTool -> snake -> todo_tool -> strip _tool -> todo"""
+        known = {"todo", "patch", "terminal", "browser_click"}
+        assert _normalize_tool_name("TodoTool_tool", known) == "todo"
+
+    def test_patch_tool_resolves_to_patch(self):
+        """Patch_tool -> strip _tool -> Patch -> snake -> patch"""
+        known = {"todo", "patch", "terminal", "browser_click"}
+        assert _normalize_tool_name("Patch_tool", known) == "patch"
+
+    def test_terminal_tool_resolves_to_terminal(self):
+        """Terminal_tool -> strip _tool -> Terminal -> snake -> terminal"""
+        known = {"todo", "patch", "terminal", "browser_click"}
+        assert _normalize_tool_name("Terminal_tool", known) == "terminal"
+
+    def test_browser_click_tool_resolves(self):
+        """BrowserClick_tool -> strip _tool -> BrowserClick -> snake -> browser_click"""
+        known = {"todo", "patch", "terminal", "browser_click"}
+        assert _normalize_tool_name("BrowserClick_tool", known) == "browser_click"
+
+    def test_exact_name_returns_none(self):
+        """An already-exact name should not be found by normalize (caller uses exact match)."""
+        known = {"todo", "patch"}
+        assert _normalize_tool_name("todo", known) is None
+
+    def test_unknown_tool_returns_none(self):
+        """A name that doesn't match anything after normalization returns None."""
+        known = {"todo", "patch", "terminal", "browser_click"}
+        assert _normalize_tool_name("NotARealTool_tool", known) is None
+
+    def test_camel_case_only_without_suffix(self):
+        """BrowserClick (no _tool suffix) -> browser_click"""
+        known = {"browser_click"}
+        assert _normalize_tool_name("BrowserClick", known) == "browser_click"
+
+    def test_already_snake_with_suffix(self):
+        """browser_click_tool -> strip _tool -> browser_click"""
+        known = {"browser_click"}
+        assert _normalize_tool_name("browser_click_tool", known) == "browser_click"
+
+
+# ------------------------------------------------------------------
+# Integration tests through dispatch()
+# ------------------------------------------------------------------
+
+class TestDispatchNormalization:
+    def test_todo_tool_tool_dispatches(self):
+        reg = _make_registry_with_tools("todo", "patch", "terminal", "browser_click")
+        result = json.loads(reg.dispatch("TodoTool_tool", {}))
+        assert result == {"ok": True}
+
+    def test_patch_tool_dispatches(self):
+        reg = _make_registry_with_tools("todo", "patch", "terminal", "browser_click")
+        result = json.loads(reg.dispatch("Patch_tool", {}))
+        assert result == {"ok": True}
+
+    def test_terminal_tool_dispatches(self):
+        reg = _make_registry_with_tools("todo", "patch", "terminal", "browser_click")
+        result = json.loads(reg.dispatch("Terminal_tool", {}))
+        assert result == {"ok": True}
+
+    def test_browser_click_tool_dispatches(self):
+        reg = _make_registry_with_tools("todo", "patch", "terminal", "browser_click")
+        result = json.loads(reg.dispatch("BrowserClick_tool", {}))
+        assert result == {"ok": True}
+
+    def test_exact_match_still_works(self):
+        reg = _make_registry_with_tools("todo")
+        result = json.loads(reg.dispatch("todo", {}))
+        assert result == {"ok": True}
+
+    def test_unknown_tool_still_returns_error(self):
+        reg = _make_registry_with_tools("todo", "patch", "terminal", "browser_click")
+        result = json.loads(reg.dispatch("NotARealTool_tool", {}))
+        assert "error" in result
+        assert "Unknown tool" in result["error"]
+
+    def test_exact_match_wins_over_normalization(self):
+        """If a tool is registered with the exact drifted name, use it directly."""
+        reg = ToolRegistry()
+
+        def exact_handler(args, **kw):
+            return json.dumps({"handler": "exact"})
+
+        def normalized_handler(args, **kw):
+            return json.dumps({"handler": "normalized"})
+
+        reg.register(
+            name="Patch_tool",
+            toolset="core",
+            schema=_make_schema("Patch_tool"),
+            handler=exact_handler,
+        )
+        reg.register(
+            name="patch",
+            toolset="core",
+            schema=_make_schema("patch"),
+            handler=normalized_handler,
+        )
+        # Exact match should win -- no normalization needed.
+        result = json.loads(reg.dispatch("Patch_tool", {}))
+        assert result["handler"] == "exact"
+
+    def test_normalization_logs_warning(self, caplog):
+        """Normalization should emit a warning so drift stays visible."""
+        import logging
+
+        reg = _make_registry_with_tools("todo")
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            reg.dispatch("TodoTool_tool", {})
+
+        assert any("Tool name normalized" in msg for msg in caplog.messages)
+        assert any("TodoTool_tool" in msg and "todo" in msg for msg in caplog.messages)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import re
 import threading
 import time
 from pathlib import Path
@@ -72,6 +73,42 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
         except Exception as e:
             logger.warning("Could not import tool module %s: %s", mod_name, e)
     return imported
+
+
+def _normalize_tool_name(name: str, known_names: set) -> Optional[str]:
+    """Try to recover a registered tool name from a CamelCase/_tool-suffix variant.
+
+    Claude models intermittently emit names like ``TodoTool_tool``,
+    ``Patch_tool``, or ``BrowserClick_tool``.  This helper applies two
+    transformations in a bounded loop (max 4 iterations) until a match is
+    found in *known_names*:
+
+      1. Strip a trailing ``_tool`` suffix.
+      2. Convert CamelCase to snake_case.
+
+    Returns the matched registered name, or ``None`` if no match is found.
+    """
+    candidate = name
+    for _ in range(4):
+        # Pass 1: strip _tool suffix
+        if candidate.endswith("_tool") and len(candidate) > 5:
+            candidate = candidate[:-5]
+            if candidate in known_names:
+                return candidate
+
+        # Pass 2: CamelCase -> snake_case
+        snake = re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", candidate)
+        snake = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", snake)
+        snake = snake.lower()
+        if snake != candidate:
+            candidate = snake
+            if candidate in known_names:
+                return candidate
+        else:
+            # No further transforms possible — stop early.
+            break
+
+    return None
 
 
 class ToolEntry:
@@ -390,13 +427,28 @@ class ToolRegistry:
     def dispatch(self, name: str, args: dict, **kwargs) -> str:
         """Execute a tool handler by name.
 
+        * Exact match is tried first.
+        * On miss, ``_normalize_tool_name()`` attempts to recover the
+          canonical name from CamelCase / ``_tool``-suffix drift.
         * Async handlers are bridged automatically via ``_run_async()``.
         * All exceptions are caught and returned as ``{"error": "..."}``
           for consistent error format.
         """
         entry = self.get_entry(name)
         if not entry:
-            return json.dumps({"error": f"Unknown tool: {name}"})
+            # Fallback: try normalizing the name before giving up.
+            with self._lock:
+                known = set(self._tools.keys())
+            normalized = _normalize_tool_name(name, known)
+            if normalized:
+                logger.warning(
+                    "Tool name normalized: '%s' -> '%s' (model drift detected)",
+                    name,
+                    normalized,
+                )
+                entry = self.get_entry(normalized)
+            if not entry:
+                return json.dumps({"error": f"Unknown tool: {name}"})
         try:
             if entry.is_async:
                 from model_tools import _run_async

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import re
 import threading
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
@@ -71,6 +72,42 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
         except Exception as e:
             logger.warning("Could not import tool module %s: %s", mod_name, e)
     return imported
+
+
+def _normalize_tool_name(name: str, known_names: set) -> Optional[str]:
+    """Try to recover a registered tool name from a CamelCase/_tool-suffix variant.
+
+    Claude models intermittently emit names like ``TodoTool_tool``,
+    ``Patch_tool``, or ``BrowserClick_tool``.  This helper applies two
+    transformations in a bounded loop (max 4 iterations) until a match is
+    found in *known_names*:
+
+      1. Strip a trailing ``_tool`` suffix.
+      2. Convert CamelCase to snake_case.
+
+    Returns the matched registered name, or ``None`` if no match is found.
+    """
+    candidate = name
+    for _ in range(4):
+        # Pass 1: strip _tool suffix
+        if candidate.endswith("_tool") and len(candidate) > 5:
+            candidate = candidate[:-5]
+            if candidate in known_names:
+                return candidate
+
+        # Pass 2: CamelCase -> snake_case
+        snake = re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", candidate)
+        snake = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", snake)
+        snake = snake.lower()
+        if snake != candidate:
+            candidate = snake
+            if candidate in known_names:
+                return candidate
+        else:
+            # No further transforms possible — stop early.
+            break
+
+    return None
 
 
 class ToolEntry:
@@ -292,13 +329,28 @@ class ToolRegistry:
     def dispatch(self, name: str, args: dict, **kwargs) -> str:
         """Execute a tool handler by name.
 
+        * Exact match is tried first.
+        * On miss, ``_normalize_tool_name()`` attempts to recover the
+          canonical name from CamelCase / ``_tool``-suffix drift.
         * Async handlers are bridged automatically via ``_run_async()``.
         * All exceptions are caught and returned as ``{"error": "..."}``
           for consistent error format.
         """
         entry = self.get_entry(name)
         if not entry:
-            return json.dumps({"error": f"Unknown tool: {name}"})
+            # Fallback: try normalizing the name before giving up.
+            with self._lock:
+                known = set(self._tools.keys())
+            normalized = _normalize_tool_name(name, known)
+            if normalized:
+                logger.warning(
+                    "Tool name normalized: '%s' -> '%s' (model drift detected)",
+                    name,
+                    normalized,
+                )
+                entry = self.get_entry(normalized)
+            if not entry:
+                return json.dumps({"error": f"Unknown tool: {name}"})
         try:
             if entry.is_async:
                 from model_tools import _run_async


### PR DESCRIPTION
## What does this PR do?

Adds `_normalize_tool_name()` helper that strips `_tool` suffixes and converts CamelCase to snake_case before tool registry lookup. Claude models intermittently emit names like `TodoTool_tool` or `Patch_tool` — trivially normalizable but previously returned "Unknown tool" errors.

## Related Issue

Fixes #14784

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/registry.py`: Added `_normalize_tool_name()` fallback normalization.
- `tests/tools/test_tool_name_normalize.py`: 16 tests covering CamelCase / `_tool`-suffix variants.

## How to Test

1. Run the new test module:
   ```bash
   python -m pytest -o 'addopts=' tests/tools/test_tool_name_normalize.py -v
   ```
   Result: `16 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest -o 'addopts=' tests/tools/test_tool_name_normalize.py -v
16 passed
```
