### PR TITLE
fix(agent): make _extract_error_body walk cause chain to match _extract_status_code

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1121,19 +1121,26 @@ def _extract_status_code(error: Exception) -> Optional[int]:
 
 
 def _extract_error_body(error: Exception) -> dict:
-    """Extract the structured error body from an SDK exception."""
-    body = getattr(error, "body", None)
-    if isinstance(body, dict):
-        return body
-    # Some errors have .response.json()
-    response = getattr(error, "response", None)
-    if response is not None:
-        try:
-            json_body = response.json()
-            if isinstance(json_body, dict):
-                return json_body
-        except Exception:
-            pass
+    """Extract the structured error body from an SDK exception, walking the cause chain."""
+    current = error
+    for _ in range(5):
+        body = getattr(current, "body", None)
+        if isinstance(body, dict):
+            return body
+        # Some errors have .response.json()
+        response = getattr(current, "response", None)
+        if response is not None:
+            try:
+                json_body = response.json()
+                if isinstance(json_body, dict):
+                    return json_body
+            except Exception:
+                pass
+        # Walk cause chain
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
     return {}
 
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -845,19 +845,26 @@ def _extract_status_code(error: Exception) -> Optional[int]:
 
 
 def _extract_error_body(error: Exception) -> dict:
-    """Extract the structured error body from an SDK exception."""
-    body = getattr(error, "body", None)
-    if isinstance(body, dict):
-        return body
-    # Some errors have .response.json()
-    response = getattr(error, "response", None)
-    if response is not None:
-        try:
-            json_body = response.json()
-            if isinstance(json_body, dict):
-                return json_body
-        except Exception:
-            pass
+    """Extract the structured error body from an SDK exception, walking the cause chain."""
+    current = error
+    for _ in range(5):
+        body = getattr(current, "body", None)
+        if isinstance(body, dict):
+            return body
+        # Some errors have .response.json()
+        response = getattr(current, "response", None)
+        if response is not None:
+            try:
+                json_body = response.json()
+                if isinstance(json_body, dict):
+                    return json_body
+            except Exception:
+                pass
+        # Walk cause chain
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
     return {}
 
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -128,6 +128,108 @@ class TestExtractErrorBody:
     def test_empty_when_no_body(self):
         assert _extract_error_body(Exception("generic")) == {}
 
+    def test_from_cause_chain(self):
+        """Body on a nested __cause__ exception must be found."""
+        inner = MockAPIError("inner", status_code=402, body={"error": {"message": "billing"}})
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        assert _extract_error_body(outer) == {"error": {"message": "billing"}}
+
+    def test_from_context_chain(self):
+        """Body on a nested __context__ exception must be found."""
+        inner = MockAPIError("inner", body={"error": {"message": "ctx"}})
+        outer = Exception("outer")
+        outer.__context__ = inner
+        assert _extract_error_body(outer) == {"error": {"message": "ctx"}}
+
+    def test_stops_at_first_body(self):
+        """Must return the first body found, not keep walking."""
+        deep = MockAPIError("deep", body={"error": {"message": "deep"}})
+        middle = MockAPIError("middle", body={"error": {"message": "middle"}})
+        middle.__cause__ = deep
+        outer = Exception("outer")
+        outer.__cause__ = middle
+        assert _extract_error_body(outer) == {"error": {"message": "middle"}}
+
+    def test_circular_cause_does_not_loop(self):
+        """Circular __cause__ must not infinite-loop."""
+        e = MockAPIError("circular", body=None)
+        e.__cause__ = e
+        assert _extract_error_body(e) == {}
+
+    def test_three_level_chain(self):
+        """Walk through two levels of plain exceptions to find body."""
+        inner = MockAPIError("inner", body={"error": {"message": "found"}})
+        middle = Exception("middle")
+        middle.__cause__ = inner
+        outer = RuntimeError("outer")
+        outer.__cause__ = middle
+        assert _extract_error_body(outer) == {"error": {"message": "found"}}
+
+    def test_response_json_on_nested_cause(self):
+        """response.json() on a nested exception must be found."""
+        class MockResponse:
+            def json(self):
+                return {"error": {"message": "from response"}}
+
+        class InnerError(Exception):
+            def __init__(self):
+                super().__init__("inner")
+                self.response = MockResponse()
+
+        inner = InnerError()
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        assert _extract_error_body(outer) == {"error": {"message": "from response"}}
+
+
+# ── Test: Cause-chain body + status_code integration ──────────────────
+
+class TestCauseChainIntegration:
+    """End-to-end: wrapping an API error must still classify correctly."""
+
+    def test_wrapped_402_billing_finds_body_and_status(self):
+        """Wrapped 402 with body must classify as billing, not unknown."""
+        inner = MockAPIError(
+            "Payment Required",
+            status_code=402,
+            body={"error": {"message": "Your credit balance is too low"}},
+        )
+        outer = Exception("provider call failed")
+        outer.__cause__ = inner
+        # Both helpers must find nested data
+        assert _extract_status_code(outer) == 402
+        assert _extract_error_body(outer) == {"error": {"message": "Your credit balance is too low"}}
+        # Full pipeline must classify correctly
+        result = classify_api_error(outer)
+        assert result.reason == FailoverReason.billing
+        assert result.status_code == 402
+
+    def test_wrapped_402_transient_rate_limit(self):
+        """Wrapped 402 with 'try again' body must classify as rate_limit."""
+        inner = MockAPIError(
+            "Usage limit",
+            status_code=402,
+            body={"error": {"message": "Usage limit reached, try again in 5 minutes"}},
+        )
+        outer = RuntimeError("SDK wrapper")
+        outer.__cause__ = inner
+        result = classify_api_error(outer)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.status_code == 402
+
+    def test_wrapped_429_rate_limit(self):
+        """Regression: status_code already walked the chain; body must too."""
+        inner = MockAPIError(
+            "rate limited",
+            status_code=429,
+            body={"error": {"message": "Too many requests"}},
+        )
+        outer = Exception("wrapper")
+        outer.__cause__ = inner
+        result = classify_api_error(outer)
+        assert result.reason == FailoverReason.rate_limit
+
 
 # ── Test: Error code extraction ────────────────────────────────────────
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -123,6 +123,108 @@ class TestExtractErrorBody:
     def test_empty_when_no_body(self):
         assert _extract_error_body(Exception("generic")) == {}
 
+    def test_from_cause_chain(self):
+        """Body on a nested __cause__ exception must be found."""
+        inner = MockAPIError("inner", status_code=402, body={"error": {"message": "billing"}})
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        assert _extract_error_body(outer) == {"error": {"message": "billing"}}
+
+    def test_from_context_chain(self):
+        """Body on a nested __context__ exception must be found."""
+        inner = MockAPIError("inner", body={"error": {"message": "ctx"}})
+        outer = Exception("outer")
+        outer.__context__ = inner
+        assert _extract_error_body(outer) == {"error": {"message": "ctx"}}
+
+    def test_stops_at_first_body(self):
+        """Must return the first body found, not keep walking."""
+        deep = MockAPIError("deep", body={"error": {"message": "deep"}})
+        middle = MockAPIError("middle", body={"error": {"message": "middle"}})
+        middle.__cause__ = deep
+        outer = Exception("outer")
+        outer.__cause__ = middle
+        assert _extract_error_body(outer) == {"error": {"message": "middle"}}
+
+    def test_circular_cause_does_not_loop(self):
+        """Circular __cause__ must not infinite-loop."""
+        e = MockAPIError("circular", body=None)
+        e.__cause__ = e
+        assert _extract_error_body(e) == {}
+
+    def test_three_level_chain(self):
+        """Walk through two levels of plain exceptions to find body."""
+        inner = MockAPIError("inner", body={"error": {"message": "found"}})
+        middle = Exception("middle")
+        middle.__cause__ = inner
+        outer = RuntimeError("outer")
+        outer.__cause__ = middle
+        assert _extract_error_body(outer) == {"error": {"message": "found"}}
+
+    def test_response_json_on_nested_cause(self):
+        """response.json() on a nested exception must be found."""
+        class MockResponse:
+            def json(self):
+                return {"error": {"message": "from response"}}
+
+        class InnerError(Exception):
+            def __init__(self):
+                super().__init__("inner")
+                self.response = MockResponse()
+
+        inner = InnerError()
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        assert _extract_error_body(outer) == {"error": {"message": "from response"}}
+
+
+# ── Test: Cause-chain body + status_code integration ──────────────────
+
+class TestCauseChainIntegration:
+    """End-to-end: wrapping an API error must still classify correctly."""
+
+    def test_wrapped_402_billing_finds_body_and_status(self):
+        """Wrapped 402 with body must classify as billing, not unknown."""
+        inner = MockAPIError(
+            "Payment Required",
+            status_code=402,
+            body={"error": {"message": "Your credit balance is too low"}},
+        )
+        outer = Exception("provider call failed")
+        outer.__cause__ = inner
+        # Both helpers must find nested data
+        assert _extract_status_code(outer) == 402
+        assert _extract_error_body(outer) == {"error": {"message": "Your credit balance is too low"}}
+        # Full pipeline must classify correctly
+        result = classify_api_error(outer)
+        assert result.reason == FailoverReason.billing
+        assert result.status_code == 402
+
+    def test_wrapped_402_transient_rate_limit(self):
+        """Wrapped 402 with 'try again' body must classify as rate_limit."""
+        inner = MockAPIError(
+            "Usage limit",
+            status_code=402,
+            body={"error": {"message": "Usage limit reached, try again in 5 minutes"}},
+        )
+        outer = RuntimeError("SDK wrapper")
+        outer.__cause__ = inner
+        result = classify_api_error(outer)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.status_code == 402
+
+    def test_wrapped_429_rate_limit(self):
+        """Regression: status_code already walked the chain; body must too."""
+        inner = MockAPIError(
+            "rate limited",
+            status_code=429,
+            body={"error": {"message": "Too many requests"}},
+        )
+        outer = Exception("wrapper")
+        outer.__cause__ = inner
+        result = classify_api_error(outer)
+        assert result.reason == FailoverReason.rate_limit
+
 
 # ── Test: Error code extraction ────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

`_extract_status_code()` already walked `__cause__`/`__context__` to find nested status codes, but `_extract_error_body()` only inspected the top-level exception. When a provider error was wrapped in an outer exception, the status code was found but the body message was lost, causing misclassification (e.g., transient rate limit classified as billing).

## Related Issue

Fixes #14195

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py` — `_extract_error_body()` now walks the `__cause__`/`__context__` chain to match `_extract_status_code()`'s behaviour
- `tests/agent/test_error_classifier.py` — tests for cause chain walking (120 passed in full suite)

## How to Test

1. ```bash
   python -m pytest -o 'addopts=' tests/agent/test_error_classifier.py -v
   ```
2. Result: 120 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest -o 'addopts=' tests/agent/test_error_classifier.py -v
120 passed
```
