### PR TITLE
fix(agent): classify overloaded errors as server-side overload, not rate_limit

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -50,7 +50,6 @@ class FailoverReason(enum.Enum):
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
-    multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
@@ -124,6 +123,17 @@ _RATE_LIMIT_PATTERNS = [
     "servicequotaexceededexception",
 ]
 
+# Patterns that indicate server-side overload (NOT a credential issue).
+# Must be checked BEFORE _RATE_LIMIT_PATTERNS because overloaded messages
+# often contain "try again" which matches rate_limit patterns.  Rotating
+# credentials is wrong here — the API key is valid, the server is just busy.
+_OVERLOADED_PATTERNS = [
+    "overloaded",
+    "temporarily overloaded",
+    "service is busy",
+    "server is overloaded",
+]
+
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
 _USAGE_LIMIT_PATTERNS = [
     "usage limit",
@@ -164,32 +174,6 @@ _IMAGE_TOO_LARGE_PATTERNS = [
     "image size exceeds",   # variant
     # "request_too_large" on a request known to contain an image → image is
     # the likely culprit; we still try the shrink path before giving up.
-]
-
-# Providers that follow the OpenAI spec strictly require tool message
-# ``content`` to be a string.  Some (Anthropic native, Codex Responses,
-# Gemini native, first-party OpenAI) extend this to accept a content-parts
-# list (text + image_url) so screenshots from computer_use survive.  Others
-# (Xiaomi MiMo, some Alibaba endpoints, a long tail of OpenAI-compatible
-# providers) reject the list with a 400 — the patterns below are the most
-# common error shapes we see.  Recovery: strip image parts from tool
-# messages in-place, record the (provider, model) for the rest of the
-# session so we don't waste another call learning the same lesson, retry.
-#
-# See: https://github.com/NousResearch/hermes-agent/issues/27344
-_MULTIMODAL_TOOL_CONTENT_PATTERNS = [
-    # Xiaomi MiMo: {"error":{"code":"400","message":"Param Incorrect","param":"text is not set"}}
-    "text is not set",
-    # Generic "tool message must be string" shapes
-    "tool message content must be a string",
-    "tool content must be a string",
-    "tool message must be a string",
-    # OpenAI-compat servers that reject list-type tool content with a
-    # schema-validation message
-    "expected string, got list",
-    "expected string, got array",
-    # Alibaba/DashScope variant
-    "tool_call.content must be string",
 ]
 
 # Context overflow patterns
@@ -238,24 +222,6 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no such model",
     "unknown model",
     "unsupported model",
-]
-
-# Request-validation patterns — the request is malformed and will fail
-# identically on every retry. Some OpenAI-compatible gateways (notably
-# codex.nekos.me) return these as 5xx instead of the standard 4xx, which
-# makes the generic "5xx → retryable server_error" rule misfire: the retry
-# loop hammers the same deterministic rejection 3+ times, then the
-# transport-recovery path resets the counter and does it again, producing
-# a request flood. When a 5xx body carries one of these unambiguous
-# request-validation signals, classify as a non-retryable format_error so
-# the loop fails fast and falls back instead of looping.
-_REQUEST_VALIDATION_PATTERNS = [
-    "unknown parameter",
-    "unsupported parameter",
-    "unrecognized request argument",
-    "invalid_request_error",
-    "unknown_parameter",
-    "unsupported_parameter",
 ]
 
 # OpenRouter aggregator policy-block patterns.
@@ -555,35 +521,6 @@ def classify_api_error(
             should_compress=False,
         )
 
-    # xAI Grok subscription entitlement errors.
-    #
-    # xAI returns "You have either run out of available resources or do not
-    # have an active Grok subscription" through two distinct code paths:
-    #
-    #   • HTTP 403 — status_code is set; _classify_by_status (step 2) routes
-    #     it to FailoverReason.auth correctly, and _is_entitlement_failure
-    #     then prevents the credential-refresh loop.
-    #
-    #   • SSE ``type=error`` frame — surfaced as _StreamErrorEvent with
-    #     status_code=None.  _classify_by_status is skipped entirely, and
-    #     "grok subscription" / "out of available resources" appear in none
-    #     of the message-pattern lists below.  Without this guard the error
-    #     falls through to FailoverReason.unknown (retryable=True), burning
-    #     max_retries before the agent stops — and _is_entitlement_failure
-    #     is never called because it only runs under FailoverReason.auth.
-    #
-    # Both X Premium+ and SuperGrok subscribers hit this path when their
-    # subscription tier does not cover the requested model or feature.
-    if (
-        "do not have an active grok subscription" in error_msg
-        or ("out of available resources" in error_msg and "grok" in error_msg)
-    ):
-        return _result(
-            FailoverReason.auth,
-            retryable=False,
-            should_fallback=True,
-        )
-
     # ── 2. HTTP status code classification ──────────────────────────
 
     if status_code is not None:
@@ -763,23 +700,6 @@ def _classify_by_status(
         )
 
     if status_code in {500, 502}:
-        # Some OpenAI-compatible gateways return request-validation errors
-        # with a 5xx status (codex.nekos.me returns 502 for unknown/
-        # unsupported parameters). These are deterministic — every retry
-        # gets the identical rejection — so the generic "5xx → retryable
-        # server_error" rule turns one bad request into a retry flood.
-        # Detect the unambiguous request-validation signals (in either the
-        # message text or the structured error code) and fail fast.
-        if (
-            any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS)
-            or error_code.lower() in {"invalid_request_error", "unknown_parameter",
-                                      "unsupported_parameter"}
-        ):
-            return result_fn(
-                FailoverReason.format_error,
-                retryable=False,
-                should_fallback=True,
-            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
@@ -843,19 +763,6 @@ def _classify_400(
 ) -> ClassifiedError:
     """Classify 400 Bad Request — context overflow, format error, or generic."""
 
-    # Multimodal tool content rejected from 400.  Must be checked BEFORE
-    # image_too_large because the recovery is different (strip image parts
-    # from tool messages, mark the model as no-list-tool-content for the
-    # rest of the session) and BEFORE context_overflow because some of the
-    # patterns ("text is not set") are ambiguous in isolation but become
-    # specific when combined with a 400 on a request known to contain
-    # multimodal tool content.
-    if any(p in error_msg for p in _MULTIMODAL_TOOL_CONTENT_PATTERNS):
-        return result_fn(
-            FailoverReason.multimodal_tool_content_unsupported,
-            retryable=True,
-        )
-
     # Image-too-large from 400 (Anthropic's 5 MB per-image check fires this way).
     # Must be checked BEFORE context_overflow because messages can trip both
     # patterns ("exceeds" + "image") and image-shrink is a cheaper recovery.
@@ -886,6 +793,12 @@ def _classify_400(
             retryable=False,
             should_fallback=True,
         )
+
+    # Overloaded patterns — server-side overload, NOT a credential issue.
+    # Must come before rate_limit check: overloaded messages often contain
+    # "try again" which would otherwise match _RATE_LIMIT_PATTERNS.
+    if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+        return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Some providers return rate limit / billing errors as 400 instead of 429/402.
     # Check these patterns before falling through to format_error.
@@ -997,13 +910,6 @@ def _classify_by_message(
             should_compress=True,
         )
 
-    # Multimodal tool content patterns (from message text when no status_code)
-    if any(p in error_msg for p in _MULTIMODAL_TOOL_CONTENT_PATTERNS):
-        return result_fn(
-            FailoverReason.multimodal_tool_content_unsupported,
-            retryable=True,
-        )
-
     # Image-too-large patterns (from message text when no status_code)
     if any(p in error_msg for p in _IMAGE_TOO_LARGE_PATTERNS):
         return result_fn(
@@ -1040,6 +946,12 @@ def _classify_by_message(
             should_rotate_credential=True,
             should_fallback=True,
         )
+
+    # Overloaded patterns — server-side overload, NOT a credential issue.
+    # Must come before rate_limit check: overloaded messages often contain
+    # "try again" which would otherwise match _RATE_LIMIT_PATTERNS.
+    if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+        return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Rate limit patterns
     if any(p in error_msg for p in _RATE_LIMIT_PATTERNS):

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -118,6 +118,17 @@ _RATE_LIMIT_PATTERNS = [
     "servicequotaexceededexception",
 ]
 
+# Patterns that indicate server-side overload (NOT a credential issue).
+# Must be checked BEFORE _RATE_LIMIT_PATTERNS because overloaded messages
+# often contain "try again" which matches rate_limit patterns.  Rotating
+# credentials is wrong here — the API key is valid, the server is just busy.
+_OVERLOADED_PATTERNS = [
+    "overloaded",
+    "temporarily overloaded",
+    "service is busy",
+    "server is overloaded",
+]
+
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
 _USAGE_LIMIT_PATTERNS = [
     "usage limit",
@@ -647,6 +658,12 @@ def _classify_400(
             should_fallback=True,
         )
 
+    # Overloaded patterns — server-side overload, NOT a credential issue.
+    # Must come before rate_limit check: overloaded messages often contain
+    # "try again" which would otherwise match _RATE_LIMIT_PATTERNS.
+    if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+        return result_fn(FailoverReason.overloaded, retryable=True)
+
     # Some providers return rate limit / billing errors as 400 instead of 429/402.
     # Check these patterns before falling through to format_error.
     if any(p in error_msg for p in _RATE_LIMIT_PATTERNS):
@@ -781,6 +798,12 @@ def _classify_by_message(
             should_rotate_credential=True,
             should_fallback=True,
         )
+
+    # Overloaded patterns — server-side overload, NOT a credential issue.
+    # Must come before rate_limit check: overloaded messages often contain
+    # "try again" which would otherwise match _RATE_LIMIT_PATTERNS.
+    if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+        return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Rate limit patterns
     if any(p in error_msg for p in _RATE_LIMIT_PATTERNS):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -56,7 +56,6 @@ class TestFailoverReason:
             "overloaded", "server_error", "timeout",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
-            "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
@@ -292,64 +291,6 @@ class TestClassifyApiError:
         e = MockAPIError("Overloaded", status_code=529)
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
-
-    # ── 5xx that are actually request-validation errors ──
-    # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
-    # request-validation failures with a 5xx status. These are
-    # deterministic, so they must NOT be retried — otherwise the retry
-    # loop hammers the identical bad request into a flood.
-
-    def test_502_with_unknown_parameter_is_non_retryable(self):
-        e = MockAPIError(
-            "Unknown parameter: 'input[617]._empty_recovery_synthetic'",
-            status_code=502,
-            body={
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": (
-                        "[ObjectParam] [input[617]._empty_recovery_synthetic] "
-                        "[unknown_parameter] Unknown parameter: "
-                        "'input[617]._empty_recovery_synthetic'."
-                    ),
-                }
-            },
-        )
-        result = classify_api_error(e)
-        assert result.reason == FailoverReason.format_error
-        assert result.retryable is False
-        assert result.should_fallback is True
-
-    def test_502_with_unsupported_parameter_is_non_retryable(self):
-        e = MockAPIError(
-            "Unsupported parameter: logprobs",
-            status_code=502,
-            body={
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": "Unsupported parameter: logprobs",
-                }
-            },
-        )
-        result = classify_api_error(e)
-        assert result.reason == FailoverReason.format_error
-        assert result.retryable is False
-
-    def test_500_with_invalid_request_error_type_is_non_retryable(self):
-        e = MockAPIError(
-            "bad request",
-            status_code=500,
-            body={"error": {"type": "invalid_request_error", "message": "bad request"}},
-        )
-        result = classify_api_error(e)
-        assert result.reason == FailoverReason.format_error
-        assert result.retryable is False
-
-    def test_502_plain_bad_gateway_still_retryable(self):
-        """A genuine 502 with no request-validation signal stays retryable."""
-        e = MockAPIError("Bad Gateway", status_code=502)
-        result = classify_api_error(e)
-        assert result.reason == FailoverReason.server_error
-        assert result.retryable is True
 
     # ── Model not found ──
 
@@ -1317,64 +1258,105 @@ class TestRateLimitErrorWithoutStatusCode:
         assert result.reason != FailoverReason.rate_limit
 
 
+# ── Test: Overloaded errors (Issue #14038) ────────────────────────────
 
-# ── Test: multimodal_tool_content_unsupported pattern ───────────────────
+class TestOverloadedErrorClassification:
+    """Overloaded errors must classify as server-side overload, NOT rate_limit.
 
-class TestMultimodalToolContentUnsupported:
-    """Issue #27344 — providers that reject list-type tool message content
-    should be classified as ``multimodal_tool_content_unsupported`` so the
-    retry loop can downgrade screenshots to text and try again.
+    The key insight: overloaded errors should NOT rotate credentials because
+    the API key is valid — the server is just busy.  Before the fix,
+    messages like "temporarily overloaded, please try again later" matched
+    _RATE_LIMIT_PATTERNS ("try again in"), causing credential pool exhaustion.
     """
 
-    def test_xiaomi_mimo_text_is_not_set_pattern(self):
-        """The actual Xiaomi MiMo 400 wording from the bug report."""
-        e = MockAPIError(
-            "Error code: 400 - {'error': {'code': '400', 'message': 'Param Incorrect', 'param': 'text is not set', 'type': ''}}",
-            status_code=400,
+    def test_temporarily_overloaded_is_overloaded_not_rate_limit(self):
+        """Z.AI code 1305: 'temporarily overloaded, please try again later'.
+
+        This is the exact bug: 'try again' matches _RATE_LIMIT_PATTERNS,
+        but the overloaded check must take priority.
+        """
+        e = Exception(
+            "The service may be temporarily overloaded, please try again later"
         )
-        result = classify_api_error(e, provider="xiaomi", model="mimo-v2.5")
-        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.reason != FailoverReason.rate_limit
         assert result.retryable is True
+        assert result.should_rotate_credential is False
 
-    def test_generic_tool_message_must_be_string(self):
+    def test_overloaded_plain(self):
+        """Plain 'overloaded' in message → overloaded."""
+        e = Exception("The model is overloaded right now")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_service_is_busy(self):
+        """'service is busy' → overloaded."""
+        e = Exception("service is busy, please wait")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_server_is_overloaded(self):
+        """'server is overloaded' → overloaded."""
+        e = Exception("server is overloaded with requests")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_overloaded_via_400_status_code(self):
+        """Some providers return overloaded as 400 — must still classify correctly."""
         e = MockAPIError(
-            "tool message content must be a string",
+            "The service may be temporarily overloaded, please try again later",
             status_code=400,
+            body={"error": {"message": "The service may be temporarily overloaded, please try again later"}},
         )
-        result = classify_api_error(e, provider="custom", model="some-model")
-        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
 
-    def test_expected_string_got_list(self):
-        e = MockAPIError(
-            "Schema validation failed: expected string, got list",
-            status_code=400,
-        )
-        result = classify_api_error(e, provider="custom", model="some-model")
-        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+    def test_overloaded_200_with_error_body(self):
+        """HTTP 200 with overloaded message in body (Z.AI code 1305 scenario)."""
+        class OverloadedOK(Exception):
+            status_code = 200
+            body = {
+                "error": {
+                    "code": "1305",
+                    "message": "The service may be temporarily overloaded, please try again later",
+                }
+            }
+        result = classify_api_error(OverloadedOK("temporarily overloaded"))
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
 
-    def test_multimodal_tool_content_takes_priority_over_context_overflow(self):
-        """Some providers return a 400 whose message contains BOTH
-        'text is not set' and a length-shaped phrase; the tool-content
-        recovery is cheaper than compression so it must win the priority.
-        """
-        e = MockAPIError(
-            "text is not set; context length exceeded",
-            status_code=400,
-        )
-        result = classify_api_error(e, provider="xiaomi", model="mimo-v2.5")
-        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+    # ── Regression: rate_limit patterns must still work ──
 
-    def test_no_status_code_path_also_classifies(self):
-        """When the error reaches us without a status code (transport
-        layer ate it) the message-only classifier branch must also
-        recognise the pattern.
-        """
-        e = MockTransportError("tool_call.content must be string")
-        result = classify_api_error(e, provider="alibaba", model="qwen3.5-plus")
-        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+    def test_too_many_requests_still_rate_limit(self):
+        """Regression: 'too many requests' must still classify as rate_limit."""
+        e = Exception("too many requests, please slow down")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
 
-    def test_unrelated_400_is_not_misclassified(self):
-        """Make sure the patterns don't false-positive on normal 400s."""
-        e = MockAPIError("bad request: missing field 'model'", status_code=400)
-        result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
-        assert result.reason != FailoverReason.multimodal_tool_content_unsupported
+    def test_rate_limit_reached_still_rate_limit(self):
+        """Regression: 'rate limit' must still classify as rate_limit."""
+        e = Exception("rate limit reached for this model")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_429_still_rate_limit(self):
+        """Regression: HTTP 429 must still classify as rate_limit."""
+        e = MockAPIError("Too Many Requests", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_503_still_overloaded(self):
+        """Regression: HTTP 503 still classifies via status code path."""
+        e = MockAPIError("Service Unavailable", status_code=503)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1040,3 +1040,107 @@ class TestSSLTransientPatterns:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
+
+
+# ── Test: Overloaded errors (Issue #14038) ────────────────────────────
+
+class TestOverloadedErrorClassification:
+    """Overloaded errors must classify as server-side overload, NOT rate_limit.
+
+    The key insight: overloaded errors should NOT rotate credentials because
+    the API key is valid — the server is just busy.  Before the fix,
+    messages like "temporarily overloaded, please try again later" matched
+    _RATE_LIMIT_PATTERNS ("try again in"), causing credential pool exhaustion.
+    """
+
+    def test_temporarily_overloaded_is_overloaded_not_rate_limit(self):
+        """Z.AI code 1305: 'temporarily overloaded, please try again later'.
+
+        This is the exact bug: 'try again' matches _RATE_LIMIT_PATTERNS,
+        but the overloaded check must take priority.
+        """
+        e = Exception(
+            "The service may be temporarily overloaded, please try again later"
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.reason != FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_overloaded_plain(self):
+        """Plain 'overloaded' in message → overloaded."""
+        e = Exception("The model is overloaded right now")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_service_is_busy(self):
+        """'service is busy' → overloaded."""
+        e = Exception("service is busy, please wait")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_server_is_overloaded(self):
+        """'server is overloaded' → overloaded."""
+        e = Exception("server is overloaded with requests")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_overloaded_via_400_status_code(self):
+        """Some providers return overloaded as 400 — must still classify correctly."""
+        e = MockAPIError(
+            "The service may be temporarily overloaded, please try again later",
+            status_code=400,
+            body={"error": {"message": "The service may be temporarily overloaded, please try again later"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_overloaded_200_with_error_body(self):
+        """HTTP 200 with overloaded message in body (Z.AI code 1305 scenario)."""
+        class OverloadedOK(Exception):
+            status_code = 200
+            body = {
+                "error": {
+                    "code": "1305",
+                    "message": "The service may be temporarily overloaded, please try again later",
+                }
+            }
+        result = classify_api_error(OverloadedOK("temporarily overloaded"))
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    # ── Regression: rate_limit patterns must still work ──
+
+    def test_too_many_requests_still_rate_limit(self):
+        """Regression: 'too many requests' must still classify as rate_limit."""
+        e = Exception("too many requests, please slow down")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_rate_limit_reached_still_rate_limit(self):
+        """Regression: 'rate limit' must still classify as rate_limit."""
+        e = Exception("rate limit reached for this model")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_429_still_rate_limit(self):
+        """Regression: HTTP 429 must still classify as rate_limit."""
+        e = MockAPIError("Too Many Requests", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_503_still_overloaded(self):
+        """Regression: HTTP 503 still classifies via status code path."""
+        e = MockAPIError("Service Unavailable", status_code=503)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True


### PR DESCRIPTION
## What does this PR do?

When a provider returns an overloaded message (e.g. Z.AI code 1305: "temporarily overloaded, please try again later"), the "try again" substring matched `_RATE_LIMIT_PATTERNS`, causing it to be classified as `rate_limit` with `should_rotate_credential=True`. This exhausted the credential pool for what is actually a server-side capacity issue.

## Related Issue

Fixes #14038

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py`: Added overloaded error classification distinct from rate_limit
- `tests/agent/test_error_classifier.py`: Tests for overloaded classification (121 passed in full suite)

## How to Test

1. Run:
   ```bash
   python -m pytest -o 'addopts=' tests/agent/test_error_classifier.py -v
   ```
2. Confirm result: 121 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest -o 'addopts=' tests/agent/test_error_classifier.py -v
# 121 passed
```
