### PR TITLE
fix(agent): respect no_proxy in _build_keepalive_http_client

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -181,6 +181,40 @@ def _get_proxy_from_env() -> Optional[str]:
     return None
 
 
+def _should_bypass_proxy(url: str) -> bool:
+    """Return True when *url* matches a ``no_proxy``/``NO_PROXY`` pattern.
+
+    Pattern matching follows the standard convention used by curl, wget, and
+    the Python ``urllib`` stack:
+
+    * Comma-separated hostnames or domain suffixes (leading dot optional).
+    * ``*`` matches everything (bypass proxy for all hosts).
+    * Comparison is case-insensitive and performed against the hostname part
+      of *url*.
+    """
+    no_proxy = os.environ.get("no_proxy", os.environ.get("NO_PROXY", "")).strip()
+    if not no_proxy:
+        return False
+
+    from urllib.parse import urlparse
+
+    hostname = (urlparse(url).hostname or "").lower()
+    if not hostname:
+        return False
+
+    for pattern in no_proxy.split(","):
+        pattern = pattern.strip().lower()
+        if not pattern:
+            continue
+        if pattern == "*":
+            return True
+        # Strip optional leading dot so ".example.com" matches like "example.com"
+        pattern = pattern.lstrip(".")
+        if hostname == pattern or hostname.endswith("." + pattern):
+            return True
+    return False
+
+
 def _install_safe_stdio() -> None:
     """Wrap stdout/stderr so best-effort console output cannot crash the agent."""
     for stream_name in ("stdout", "stderr"):
@@ -4466,7 +4500,7 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client() -> Any:
+    def _build_keepalive_http_client(base_url: Optional[str] = None) -> Any:
         try:
             import httpx as _httpx
             import socket as _socket
@@ -4482,6 +4516,12 @@ class AIAgent:
             # from env vars (allow_env_proxies = trust_env and transport is None).
             # Explicitly read proxy settings to ensure HTTP_PROXY/HTTPS_PROXY work.
             _proxy = _get_proxy_from_env()
+            # Respect no_proxy / NO_PROXY: if the target base URL matches a
+            # bypass pattern, do not route through the proxy.  Without this,
+            # localhost/LAN endpoints behind a proxy env var fail with
+            # connection-refused or tunnel errors (#14451).
+            if _proxy and base_url and _should_bypass_proxy(base_url):
+                _proxy = None
             return _httpx.Client(
                 transport=_httpx.HTTPTransport(socket_options=_sock_opts),
                 proxy=_proxy,
@@ -4539,7 +4579,7 @@ class AIAgent:
                     if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
                 }
                 if "http_client" not in safe_kwargs:
-                    keepalive_http = self._build_keepalive_http_client()
+                    keepalive_http = self._build_keepalive_http_client(base_url=base_url)
                     if keepalive_http is not None:
                         safe_kwargs["http_client"] = keepalive_http
                 client = GeminiNativeClient(**safe_kwargs)
@@ -4568,7 +4608,9 @@ class AIAgent:
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
         if "http_client" not in client_kwargs:
-            keepalive_http = self._build_keepalive_http_client()
+            keepalive_http = self._build_keepalive_http_client(
+                base_url=str(client_kwargs.get("base_url") or ""),
+            )
             if keepalive_http is not None:
                 client_kwargs["http_client"] = keepalive_http
         client = OpenAI(**client_kwargs)

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 
 import httpx
 
-from run_agent import AIAgent, _get_proxy_from_env
+from run_agent import AIAgent, _get_proxy_from_env, _should_bypass_proxy
 
 
 def _make_agent():
@@ -141,5 +141,140 @@ def test_create_openai_client_no_proxy_when_env_unset(mock_openai, monkeypatch):
     assert "HTTPProxy" not in pool_types, (
         "No proxy env set but httpx.Client still mounted HTTPProxy; "
         "pools were %r" % (pool_types,)
+    )
+    http_client.close()
+
+
+# ---------------------------------------------------------------------------
+# _should_bypass_proxy unit tests (#14451)
+# ---------------------------------------------------------------------------
+
+def test_should_bypass_proxy_no_env(monkeypatch):
+    """Without no_proxy set, nothing is bypassed."""
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    assert _should_bypass_proxy("http://localhost:11434") is False
+    assert _should_bypass_proxy("https://api.openai.com") is False
+
+
+def test_should_bypass_proxy_localhost_match(monkeypatch):
+    """no_proxy=localhost should match localhost URLs."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "localhost")
+    assert _should_bypass_proxy("http://localhost:11434/v1") is True
+    assert _should_bypass_proxy("https://api.openai.com/v1") is False
+
+
+def test_should_bypass_proxy_remote_still_proxied(monkeypatch):
+    """Remote hosts must not match a localhost-only no_proxy."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "localhost,127.0.0.1")
+    assert _should_bypass_proxy("https://api.anthropic.com/v1") is False
+
+
+def test_should_bypass_proxy_wildcard(monkeypatch):
+    """no_proxy=* should bypass all hosts."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "*")
+    assert _should_bypass_proxy("https://api.openai.com/v1") is True
+    assert _should_bypass_proxy("http://localhost:11434") is True
+
+
+def test_should_bypass_proxy_domain_suffix(monkeypatch):
+    """Domain suffixes (with or without leading dot) should match subdomains."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", ".example.com")
+    assert _should_bypass_proxy("https://api.example.com/v1") is True
+    assert _should_bypass_proxy("https://example.com/v1") is True
+    assert _should_bypass_proxy("https://notexample.com/v1") is False
+
+
+def test_should_bypass_proxy_case_insensitive(monkeypatch):
+    """Pattern matching must be case-insensitive."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "LOCALHOST")
+    assert _should_bypass_proxy("http://Localhost:8080") is True
+
+
+def test_should_bypass_proxy_reads_NO_PROXY_uppercase(monkeypatch):
+    """NO_PROXY (uppercase) should be respected when no_proxy is absent."""
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.setenv("NO_PROXY", "localhost")
+    assert _should_bypass_proxy("http://localhost:11434") is True
+
+
+def test_should_bypass_proxy_empty_string(monkeypatch):
+    """Empty no_proxy should not bypass anything."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "  ")
+    assert _should_bypass_proxy("http://localhost:11434") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: _build_keepalive_http_client respects no_proxy (#14451)
+# ---------------------------------------------------------------------------
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_no_proxy_bypasses_localhost(mock_openai, monkeypatch):
+    """With HTTPS_PROXY set but no_proxy=localhost, a localhost base_url must
+    NOT route through the proxy."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("no_proxy", "localhost")
+
+    agent = _make_agent()
+    kwargs = {
+        "api_key": "test-key",
+        "base_url": "http://localhost:11434/v1",
+    }
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = _extract_http_client(forwarded)
+    assert isinstance(http_client, httpx.Client)
+    pool_types = [
+        type(mount._pool).__name__
+        for mount in http_client._mounts.values()
+        if mount is not None and hasattr(mount, "_pool")
+    ]
+    assert "HTTPProxy" not in pool_types, (
+        "no_proxy=localhost should suppress proxy for localhost base_url; "
+        "pools were %r" % (pool_types,)
+    )
+    http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_no_proxy_still_proxies_remote(mock_openai, monkeypatch):
+    """With HTTPS_PROXY set and no_proxy=localhost, a remote base_url must
+    still route through the proxy."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("no_proxy", "localhost")
+
+    agent = _make_agent()
+    kwargs = {
+        "api_key": "test-key",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = _extract_http_client(forwarded)
+    assert isinstance(http_client, httpx.Client)
+    proxied_pools = [
+        type(mount._pool).__name__
+        for mount in http_client._mounts.values()
+        if mount is not None and hasattr(mount, "_pool")
+    ]
+    assert "HTTPProxy" in proxied_pools, (
+        "Remote base_url should still use proxy when no_proxy only lists "
+        "localhost; pools were %r" % (proxied_pools,)
     )
     http_client.close()


### PR DESCRIPTION
## What does this PR do?

`_get_proxy_from_env()` reads `HTTP(S)_PROXY` but never checks `no_proxy`/`NO_PROXY`. The custom `httpx.Client` in `_build_keepalive_http_client()` applies the proxy unconditionally to all requests, including localhost and LAN endpoints that should bypass it. This causes connection-refused or tunnel errors when users run local models (Ollama, LM Studio) behind a corporate proxy.

## Related Issue

Fixes #14451

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Added `no_proxy` check in `_get_proxy_from_env()`
- `tests/run_agent/test_create_openai_client_proxy_env.py`: 15 tests

## How to Test

```bash
python -m pytest -o 'addopts=' tests/run_agent/test_create_openai_client_proxy_env.py -v
```

Result: 15 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.14.2

### Documentation & Housekeeping

- [x] N/A for all documentation items