### PR TITLE
fix(agent): include model in vision client cache key to prevent wrong model usage

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4039,6 +4039,7 @@ def _client_cache_key(
     provider: str,
     *,
     async_mode: bool,
+    model: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
@@ -4048,7 +4049,7 @@ def _client_cache_key(
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
     pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)
+    return (provider, async_mode, model or "", base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -4099,6 +4100,7 @@ def _refresh_nous_auxiliary_client(
     cache_key = _client_cache_key(
         cache_provider,
         async_mode=async_mode,
+        model=final_model,
         base_url=base_url,
         api_key=api_key,
         api_mode=api_mode,
@@ -4273,6 +4275,7 @@ def _get_cached_client(
     cache_key = _client_cache_key(
         provider,
         async_mode=async_mode,
+        model=model,
         base_url=base_url,
         api_key=api_key,
         api_mode=api_mode,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2160,6 +2160,7 @@ def _client_cache_key(
     provider: str,
     *,
     async_mode: bool,
+    model: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
@@ -2167,7 +2168,7 @@ def _client_cache_key(
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key)
+    return (provider, async_mode, model or "", base_url or "", api_key or "", api_mode or "", runtime_key)
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -2217,6 +2218,7 @@ def _refresh_nous_auxiliary_client(
     cache_key = _client_cache_key(
         cache_provider,
         async_mode=async_mode,
+        model=final_model,
         base_url=base_url,
         api_key=api_key,
         api_mode=api_mode,
@@ -2382,6 +2384,7 @@ def _get_cached_client(
     cache_key = _client_cache_key(
         provider,
         async_mode=async_mode,
+        model=model,
         base_url=base_url,
         api_key=api_key,
         api_mode=api_mode,

--- a/tests/agent/test_vision_client_cache_key.py
+++ b/tests/agent/test_vision_client_cache_key.py
@@ -1,0 +1,118 @@
+"""Tests for vision client cache key including model (#14085).
+
+Verifies that _client_cache_key() and _get_cached_client() distinguish
+between requests to the same provider with different models, so that
+e.g. two OpenRouter vision calls with different models do not collide.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _stub_resolve_provider_client(provider, model, async_mode, **kw):
+    """Return a unique mock client for each call."""
+    client = MagicMock(name=f"client-{provider}-{model}")
+    client.api_key = "test"
+    client.base_url = kw.get("explicit_base_url", "http://localhost:8081/v1")
+    return client, model or "default-model"
+
+
+@pytest.fixture(autouse=True)
+def _clean_client_cache():
+    """Clear the client cache before and after each test."""
+    import agent.auxiliary_client as ac
+    ac._client_cache.clear()
+    yield
+    ac._client_cache.clear()
+
+
+class TestCacheKeyIncludesModel:
+    """_client_cache_key must include the model so same-provider
+    requests with different models get separate cache entries."""
+
+    def test_different_models_produce_different_keys(self):
+        from agent.auxiliary_client import _client_cache_key
+
+        key_a = _client_cache_key("openrouter", async_mode=False,
+                                  model="google/gemini-3-flash-preview")
+        key_b = _client_cache_key("openrouter", async_mode=False,
+                                  model="openai/gpt-4o")
+
+        assert key_a != key_b, (
+            "Same provider with different models must produce different cache keys"
+        )
+
+    def test_same_model_produces_same_key(self):
+        from agent.auxiliary_client import _client_cache_key
+
+        key_a = _client_cache_key("openrouter", async_mode=False,
+                                  model="google/gemini-3-flash-preview")
+        key_b = _client_cache_key("openrouter", async_mode=False,
+                                  model="google/gemini-3-flash-preview")
+
+        assert key_a == key_b, (
+            "Same provider and model must produce the same cache key"
+        )
+
+    def test_none_model_matches_empty_string(self):
+        from agent.auxiliary_client import _client_cache_key
+
+        key_none = _client_cache_key("openrouter", async_mode=False, model=None)
+        key_empty = _client_cache_key("openrouter", async_mode=False, model="")
+
+        assert key_none == key_empty, (
+            "None and empty-string model should produce the same key"
+        )
+
+
+class TestGetCachedClientModelIsolation:
+    """_get_cached_client must return different clients for different
+    models on the same provider."""
+
+    def test_different_models_return_different_clients(self):
+        from agent.auxiliary_client import _get_cached_client
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   side_effect=_stub_resolve_provider_client):
+            client_a, model_a = _get_cached_client(
+                "openrouter", "google/gemini-3-flash-preview", async_mode=False)
+            client_b, model_b = _get_cached_client(
+                "openrouter", "openai/gpt-4o", async_mode=False)
+
+        assert client_a is not client_b, (
+            "Same provider with different models must NOT return the same "
+            "cached client — this is the bug from #14085"
+        )
+        assert model_a == "google/gemini-3-flash-preview"
+        assert model_b == "openai/gpt-4o"
+
+    def test_same_model_returns_cached_client(self):
+        from agent.auxiliary_client import _get_cached_client
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   side_effect=_stub_resolve_provider_client):
+            client_a, _ = _get_cached_client(
+                "openrouter", "google/gemini-3-flash-preview", async_mode=False)
+            client_b, _ = _get_cached_client(
+                "openrouter", "google/gemini-3-flash-preview", async_mode=False)
+
+        assert client_a is client_b, (
+            "Same provider and model should return the same cached client"
+        )
+
+    def test_resolve_called_once_per_model(self):
+        """resolve_provider_client should be called once per unique
+        (provider, model), not on every invocation."""
+        from agent.auxiliary_client import _get_cached_client
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   side_effect=_stub_resolve_provider_client) as mock_resolve:
+            _get_cached_client("openrouter", "model-a", async_mode=False)
+            _get_cached_client("openrouter", "model-a", async_mode=False)
+            _get_cached_client("openrouter", "model-b", async_mode=False)
+
+        assert mock_resolve.call_count == 2, (
+            "Expected 2 calls to resolve_provider_client (one per unique model), "
+            f"got {mock_resolve.call_count}"
+        )


### PR DESCRIPTION
## What does this PR do?

The vision client cache key did not include the model, so switching models between vision calls would return a cached client configured for the wrong model.

## Related Issue

Fixes #14085

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: Added model to vision client cache key.
- `tests/agent/test_vision_client_cache_key.py`: 6 tests covering key composition + cross-model reuse prevention.

## How to Test

1. Run the new test module:
   ```bash
   python -m pytest -o 'addopts=' tests/agent/test_vision_client_cache_key.py -v
   ```
   Result: `6 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest -o 'addopts=' tests/agent/test_vision_client_cache_key.py -v
6 passed
```
