### PR TITLE
fix(tools): auto-quote hyphenated tokens in fact_store FTS5 queries

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,7 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,33 @@ try:
     from . import holographic as hrr
 except ImportError:
     import holographic as hrr  # type: ignore[no-redef]
+
+
+# FTS5 operators that must not be quoted
+_FTS5_OPERATORS = frozenset({"AND", "OR", "NOT", "NEAR"})
+
+# Matches unquoted tokens containing at least one hyphen (e.g., pve-01, lxc-103)
+_HYPHENATED_TOKEN_RE = re.compile(r'(?<!")\b(\w+(?:-\w+)+)\b(?!")')
+
+
+def _sanitize_fts5_query(query: str) -> str:
+    """Wrap unquoted hyphenated tokens in double quotes for FTS5.
+
+    FTS5's default unicode61 tokenizer treats ``-`` as a separator, so a
+    bare ``pve-01`` is parsed as *column* ``pve`` *operator* ``01`` and
+    raises ``OperationalError: no such column: 01``.  Quoting the token
+    (``"pve-01"``) turns it into a phrase query that works correctly.
+
+    Already-quoted phrases and FTS5 boolean operators (AND, OR, NOT, NEAR)
+    are preserved.
+    """
+    def _maybe_quote(m: re.Match) -> str:
+        token = m.group(1)
+        if token.upper() in _FTS5_OPERATORS:
+            return token
+        return f'"{token}"'
+
+    return _HYPHENATED_TOKEN_RE.sub(_maybe_quote, query)
 
 
 class FactRetriever:
@@ -496,6 +524,7 @@ class FactRetriever:
         # We need to join facts_fts with facts to get all columns
         params: list = []
         where_clauses = ["facts_fts MATCH ?"]
+        query = _sanitize_fts5_query(query)
         params.append(query)
 
         if category:

--- a/tests/plugins/memory/test_fts5_hyphen_sanitizer.py
+++ b/tests/plugins/memory/test_fts5_hyphen_sanitizer.py
@@ -1,0 +1,147 @@
+"""Tests for FTS5 hyphenated query sanitization in holographic retrieval."""
+
+import sqlite3
+import pytest
+
+from plugins.memory.holographic.retrieval import _sanitize_fts5_query
+
+
+class TestSanitizeFTS5Query:
+    """Unit tests for the _sanitize_fts5_query helper."""
+
+    def test_hyphenated_token_quoted(self):
+        assert _sanitize_fts5_query("pve-01") == '"pve-01"'
+
+    def test_multiple_hyphenated_tokens(self):
+        result = _sanitize_fts5_query("lxc-103 AND pve-01")
+        assert '"lxc-103"' in result
+        assert '"pve-01"' in result
+        assert "AND" in result
+
+    def test_already_quoted_preserved(self):
+        assert _sanitize_fts5_query('"pve-01"') == '"pve-01"'
+
+    def test_no_hyphens_unchanged(self):
+        assert _sanitize_fts5_query("hello world") == "hello world"
+
+    def test_single_word_unchanged(self):
+        assert _sanitize_fts5_query("hello") == "hello"
+
+    def test_fts5_operators_preserved(self):
+        result = _sanitize_fts5_query("pve-01 NOT lxc-103")
+        assert "NOT" in result
+        assert '"pve-01"' in result
+        assert '"lxc-103"' in result
+
+    def test_or_operator_preserved(self):
+        result = _sanitize_fts5_query("pve-01 OR pve-02")
+        assert "OR" in result
+
+    def test_multi_hyphen_token(self):
+        assert _sanitize_fts5_query("my-multi-part-name") == '"my-multi-part-name"'
+
+    def test_mixed_plain_and_hyphenated(self):
+        result = _sanitize_fts5_query("server pve-01 hardware")
+        assert result == 'server "pve-01" hardware'
+
+    def test_empty_string(self):
+        assert _sanitize_fts5_query("") == ""
+
+
+class TestFTS5Integration:
+    """Integration tests using real SQLite FTS5 to verify queries don't crash."""
+
+    @pytest.fixture()
+    def fts_conn(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            "CREATE VIRTUAL TABLE test_fts USING fts5(content, tags)"
+        )
+        conn.execute(
+            "INSERT INTO test_fts(content, tags) VALUES (?, ?)",
+            ("PVE-01 hardware: i5-13500T, IP 10.20.90.00", "pve-01,homelab"),
+        )
+        conn.execute(
+            "INSERT INTO test_fts(content, tags) VALUES (?, ?)",
+            ("LXC-103 running pihole DNS", "lxc-103,dns"),
+        )
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_raw_hyphen_raises(self, fts_conn):
+        """The raw (unsanitized) query MUST fail — this is the bug."""
+        with pytest.raises(sqlite3.OperationalError, match="no such column"):
+            fts_conn.execute(
+                "SELECT * FROM test_fts WHERE test_fts MATCH ?", ("pve-01",)
+            )
+
+    def test_sanitized_hyphen_succeeds(self, fts_conn):
+        sanitized = _sanitize_fts5_query("pve-01")
+        rows = fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", (sanitized,)
+        ).fetchall()
+        assert len(rows) >= 1
+        assert "PVE-01" in rows[0][0]
+
+    def test_sanitized_multiple_tokens(self, fts_conn):
+        sanitized = _sanitize_fts5_query("lxc-103")
+        rows = fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", (sanitized,)
+        ).fetchall()
+        assert len(rows) >= 1
+
+    def test_plain_query_still_works(self, fts_conn):
+        rows = fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", ("hardware",)
+        ).fetchall()
+        assert len(rows) >= 1
+
+    @pytest.mark.parametrize(
+        "dash_char",
+        [
+            "‐",  # HYPHEN
+            "‑",  # NON-BREAKING HYPHEN
+            "–",  # EN DASH
+            "—",  # EM DASH
+            "−",  # MINUS SIGN
+            "­",  # SOFT HYPHEN
+            "﹣",  # SMALL HYPHEN-MINUS
+            "－",  # FULLWIDTH HYPHEN-MINUS
+            "⁃",  # HYPHEN BULLET
+        ],
+        ids=[
+            "U+2010-HYPHEN",
+            "U+2011-NON-BREAKING-HYPHEN",
+            "U+2013-EN-DASH",
+            "U+2014-EM-DASH",
+            "U+2212-MINUS-SIGN",
+            "U+00AD-SOFT-HYPHEN",
+            "U+FE63-SMALL-HYPHEN-MINUS",
+            "U+FF0D-FULLWIDTH-HYPHEN-MINUS",
+            "U+2043-HYPHEN-BULLET",
+        ],
+    )
+    def test_unicode_dash_unsanitized_does_not_raise(self, fts_conn, dash_char):
+        """Lock down current FTS5 behavior: bare Unicode-dash queries do NOT
+        trigger the ``no such column`` parser path that ASCII ``-`` hits.
+
+        The sanitizer is intentionally ASCII-only because only U+002D is
+        FTS5's NOT-operator prefix.  If a future SQLite/unicode61 update
+        starts treating any of these dashes as operator prefixes, this test
+        fails — alerting us before we ship a silent regression.
+        """
+        query = f"pve{dash_char}01"
+        # No ``pytest.raises`` — any exception fails the test.
+        fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", (query,)
+        ).fetchall()
+
+    def test_mixed_ascii_hyphen_and_unicode_dash(self, fts_conn):
+        """``pve-01–02`` sanitizes to ``"pve-01"–02`` (ASCII portion quoted,
+        en-dash passes through) and parses cleanly in FTS5."""
+        sanitized = _sanitize_fts5_query("pve-01–02")
+        assert sanitized == '"pve-01"–02'
+        fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", (sanitized,)
+        ).fetchall()

--- a/tests/plugins/memory/test_fts5_hyphen_sanitizer.py
+++ b/tests/plugins/memory/test_fts5_hyphen_sanitizer.py
@@ -1,0 +1,98 @@
+"""Tests for FTS5 hyphenated query sanitization in holographic retrieval."""
+
+import sqlite3
+import pytest
+
+from plugins.memory.holographic.retrieval import _sanitize_fts5_query
+
+
+class TestSanitizeFTS5Query:
+    """Unit tests for the _sanitize_fts5_query helper."""
+
+    def test_hyphenated_token_quoted(self):
+        assert _sanitize_fts5_query("pve-01") == '"pve-01"'
+
+    def test_multiple_hyphenated_tokens(self):
+        result = _sanitize_fts5_query("lxc-103 AND pve-01")
+        assert '"lxc-103"' in result
+        assert '"pve-01"' in result
+        assert "AND" in result
+
+    def test_already_quoted_preserved(self):
+        assert _sanitize_fts5_query('"pve-01"') == '"pve-01"'
+
+    def test_no_hyphens_unchanged(self):
+        assert _sanitize_fts5_query("hello world") == "hello world"
+
+    def test_single_word_unchanged(self):
+        assert _sanitize_fts5_query("hello") == "hello"
+
+    def test_fts5_operators_preserved(self):
+        result = _sanitize_fts5_query("pve-01 NOT lxc-103")
+        assert "NOT" in result
+        assert '"pve-01"' in result
+        assert '"lxc-103"' in result
+
+    def test_or_operator_preserved(self):
+        result = _sanitize_fts5_query("pve-01 OR pve-02")
+        assert "OR" in result
+
+    def test_multi_hyphen_token(self):
+        assert _sanitize_fts5_query("my-multi-part-name") == '"my-multi-part-name"'
+
+    def test_mixed_plain_and_hyphenated(self):
+        result = _sanitize_fts5_query("server pve-01 hardware")
+        assert result == 'server "pve-01" hardware'
+
+    def test_empty_string(self):
+        assert _sanitize_fts5_query("") == ""
+
+
+class TestFTS5Integration:
+    """Integration tests using real SQLite FTS5 to verify queries don't crash."""
+
+    @pytest.fixture()
+    def fts_conn(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            "CREATE VIRTUAL TABLE test_fts USING fts5(content, tags)"
+        )
+        conn.execute(
+            "INSERT INTO test_fts(content, tags) VALUES (?, ?)",
+            ("PVE-01 hardware: i5-13500T, IP 10.20.90.00", "pve-01,homelab"),
+        )
+        conn.execute(
+            "INSERT INTO test_fts(content, tags) VALUES (?, ?)",
+            ("LXC-103 running pihole DNS", "lxc-103,dns"),
+        )
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_raw_hyphen_raises(self, fts_conn):
+        """The raw (unsanitized) query MUST fail — this is the bug."""
+        with pytest.raises(sqlite3.OperationalError, match="no such column"):
+            fts_conn.execute(
+                "SELECT * FROM test_fts WHERE test_fts MATCH ?", ("pve-01",)
+            )
+
+    def test_sanitized_hyphen_succeeds(self, fts_conn):
+        sanitized = _sanitize_fts5_query("pve-01")
+        rows = fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", (sanitized,)
+        ).fetchall()
+        assert len(rows) >= 1
+        assert "PVE-01" in rows[0][0]
+
+    def test_sanitized_multiple_tokens(self, fts_conn):
+        sanitized = _sanitize_fts5_query("lxc-103")
+        rows = fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", (sanitized,)
+        ).fetchall()
+        assert len(rows) >= 1
+
+    def test_plain_query_still_works(self, fts_conn):
+        rows = fts_conn.execute(
+            "SELECT * FROM test_fts WHERE test_fts MATCH ?", ("hardware",)
+        ).fetchall()
+        assert len(rows) >= 1


### PR DESCRIPTION
## What does this PR do?

FTS5's default unicode61 tokenizer treats hyphens as separators, so a query like "pve-01" is parsed as a column-restriction operator and fails with `OperationalError: no such column: 01`. Since the exception was silently caught, users got empty results with no error indication. Adds automatic quoting of hyphenated tokens.

## Related Issue

Fixes #14024

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/holographic/retrieval.py`: Auto-quote hyphenated tokens in FTS5 queries
- `tests/plugins/memory/test_fts5_hyphen_sanitizer.py`: 14 tests

## How to Test

1. Run:
   ```bash
   python -m pytest -o 'addopts=' tests/plugins/memory/test_fts5_hyphen_sanitizer.py -v
   ```
2. Confirm result: 14 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest -o 'addopts=' tests/plugins/memory/test_fts5_hyphen_sanitizer.py -v
# 14 passed
```
