### PR TITLE
fix(agent): scope subdirectory hint discovery to active workspace boundary

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -16,6 +16,7 @@ Inspired by Block/goose's SubdirectoryHintTracker.
 import logging
 import os
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
@@ -45,14 +46,28 @@ _COMMAND_TOOLS = {"terminal"}
 # Prevents scanning all the way to / for deeply nested paths.
 _MAX_ANCESTOR_WALK = 5
 
-
-def _is_ancestor_or_same(a: Path, b: Path) -> bool:
-    """Check if *a* is the same as or an ancestor of *b* (parent directory check)."""
+def _find_git_root(start: Path) -> Optional[Path]:
+    """Return the git repository root containing *start*, or None."""
     try:
-        b.relative_to(a)
-        return True
-    except ValueError:
-        return False
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start) if start.is_dir() else str(start.parent),
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip()).resolve()
+    except Exception:
+        pass
+    return None
+
+
+def _is_within_workspace(path: Path, workspace_root: Path) -> bool:
+    """Check if *path* is inside *workspace_root* (symlink-safe)."""
+    resolved = path.resolve()
+    resolved_root = workspace_root.resolve()
+    # Use trailing sep to prevent /foo/bar matching /foo/barbaz
+    return resolved == resolved_root or str(resolved).startswith(str(resolved_root) + os.sep)
+
 
 class SubdirectoryHintTracker:
     """Track which directories the agent visits and load hints on first access.
@@ -72,6 +87,9 @@ class SubdirectoryHintTracker:
         self._loaded_dirs: Set[Path] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
+        # Workspace boundary: git root if available, otherwise working_dir
+        git_root = _find_git_root(self.working_dir)
+        self._workspace_root = git_root if git_root else self.working_dir
 
     def check_tool_call(
         self,
@@ -120,11 +138,13 @@ class SubdirectoryHintTracker:
     def _add_path_candidate(self, raw_path: str, candidates: Set[Path]):
         """Resolve a raw path and add its directory + ancestors to candidates.
 
-        Walks up from the resolved directory toward the filesystem root,
-        stopping at the first directory already in ``_loaded_dirs`` (or after
-        ``_MAX_ANCESTOR_WALK`` levels).  This ensures that reading
-        ``project/src/main.py`` discovers ``project/AGENTS.md`` even when
-        ``project/src/`` has no hint files of its own.
+        Walks up from the resolved directory toward the workspace root,
+        stopping at the first directory already in ``_loaded_dirs``, at the
+        workspace boundary, or after ``_MAX_ANCESTOR_WALK`` levels.
+
+        Paths outside the workspace boundary are silently skipped to prevent
+        unrelated AGENTS.md / CLAUDE.md / .cursorrules files from being
+        injected into the agent context.
         """
         try:
             p = Path(raw_path).expanduser()
@@ -134,9 +154,14 @@ class SubdirectoryHintTracker:
             # Use parent if it's a file path (has extension or doesn't exist as dir)
             if p.suffix or (p.exists() and p.is_file()):
                 p = p.parent
-            # Walk up ancestors — stop at already-loaded or root
+            # Skip paths outside the workspace boundary entirely
+            if not _is_within_workspace(p, self._workspace_root):
+                return
+            # Walk up ancestors — stop at already-loaded, workspace root, or fs root
             for _ in range(_MAX_ANCESTOR_WALK):
                 if p in self._loaded_dirs:
+                    break
+                if not _is_within_workspace(p, self._workspace_root):
                     break
                 if self._is_valid_subdir(p):
                     candidates.add(p)
@@ -167,13 +192,7 @@ class SubdirectoryHintTracker:
             self._add_path_candidate(token, candidates)
 
     def _is_valid_subdir(self, path: Path) -> bool:
-        """Check if path is a valid directory to scan for hints.
-
-        Only allow subdirectories within the working directory tree.
-        This prevents loading AGENTS.md from outside the active workspace
-        (e.g. ~/.codex/AGENTS.md, ~/.claude/CLAUDE.md), which causes
-        cross-agent context contamination and instruction mixup.
-        """
+        """Check if path is a valid directory to scan for hints."""
         try:
             if not path.is_dir():
                 return False
@@ -181,42 +200,11 @@ class SubdirectoryHintTracker:
             return False
         if path in self._loaded_dirs:
             return False
-        # Reject paths outside the working directory tree.
-        # path.resolve() may differ from working_dir.resolve() due to symlinks,
-        # but path.is_relative_to(working_dir) handles both absolute and
-        # symlinked paths correctly on Python 3.9+.
-        try:
-            if not path.is_relative_to(self.working_dir):
-                return False
-        except (OSError, ValueError):
-            # Older Python or path resolution error — fall back to parent
-            # check as a best-effort safeguard.
-            if not _is_ancestor_or_same(self.working_dir, path):
-                return False
         return True
 
     def _load_hints_for_directory(self, directory: Path) -> Optional[str]:
-        """Load hint files from a directory. Returns formatted text or None.
-
-        Only loads hints from directories within the working directory tree.
-        """
+        """Load hint files from a directory. Returns formatted text or None."""
         self._loaded_dirs.add(directory)
-
-        # Reject paths outside the working directory tree.
-        try:
-            if not directory.is_relative_to(self.working_dir):
-                logger.debug(
-                    "Skipping hint files in %s — outside working_dir %s",
-                    directory, self.working_dir,
-                )
-                return None
-        except (OSError, ValueError):
-            if not _is_ancestor_or_same(self.working_dir, directory):
-                logger.debug(
-                    "Skipping hint files in %s — outside working_dir %s",
-                    directory, self.working_dir,
-                )
-                return None
 
         found_hints = []
         for filename in _HINT_FILENAMES:

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -16,6 +16,7 @@ Inspired by Block/goose's SubdirectoryHintTracker.
 import logging
 import os
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
@@ -45,6 +46,29 @@ _COMMAND_TOOLS = {"terminal"}
 # Prevents scanning all the way to / for deeply nested paths.
 _MAX_ANCESTOR_WALK = 5
 
+def _find_git_root(start: Path) -> Optional[Path]:
+    """Return the git repository root containing *start*, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start) if start.is_dir() else str(start.parent),
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip()).resolve()
+    except Exception:
+        pass
+    return None
+
+
+def _is_within_workspace(path: Path, workspace_root: Path) -> bool:
+    """Check if *path* is inside *workspace_root* (symlink-safe)."""
+    resolved = path.resolve()
+    resolved_root = workspace_root.resolve()
+    # Use trailing sep to prevent /foo/bar matching /foo/barbaz
+    return resolved == resolved_root or str(resolved).startswith(str(resolved_root) + os.sep)
+
+
 class SubdirectoryHintTracker:
     """Track which directories the agent visits and load hints on first access.
 
@@ -63,6 +87,9 @@ class SubdirectoryHintTracker:
         self._loaded_dirs: Set[Path] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
+        # Workspace boundary: git root if available, otherwise working_dir
+        git_root = _find_git_root(self.working_dir)
+        self._workspace_root = git_root if git_root else self.working_dir
 
     def check_tool_call(
         self,
@@ -111,11 +138,13 @@ class SubdirectoryHintTracker:
     def _add_path_candidate(self, raw_path: str, candidates: Set[Path]):
         """Resolve a raw path and add its directory + ancestors to candidates.
 
-        Walks up from the resolved directory toward the filesystem root,
-        stopping at the first directory already in ``_loaded_dirs`` (or after
-        ``_MAX_ANCESTOR_WALK`` levels).  This ensures that reading
-        ``project/src/main.py`` discovers ``project/AGENTS.md`` even when
-        ``project/src/`` has no hint files of its own.
+        Walks up from the resolved directory toward the workspace root,
+        stopping at the first directory already in ``_loaded_dirs``, at the
+        workspace boundary, or after ``_MAX_ANCESTOR_WALK`` levels.
+
+        Paths outside the workspace boundary are silently skipped to prevent
+        unrelated AGENTS.md / CLAUDE.md / .cursorrules files from being
+        injected into the agent context.
         """
         try:
             p = Path(raw_path).expanduser()
@@ -125,9 +154,14 @@ class SubdirectoryHintTracker:
             # Use parent if it's a file path (has extension or doesn't exist as dir)
             if p.suffix or (p.exists() and p.is_file()):
                 p = p.parent
-            # Walk up ancestors — stop at already-loaded or root
+            # Skip paths outside the workspace boundary entirely
+            if not _is_within_workspace(p, self._workspace_root):
+                return
+            # Walk up ancestors — stop at already-loaded, workspace root, or fs root
             for _ in range(_MAX_ANCESTOR_WALK):
                 if p in self._loaded_dirs:
+                    break
+                if not _is_within_workspace(p, self._workspace_root):
                     break
                 if self._is_valid_subdir(p):
                     candidates.add(p)

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.subdirectory_hints import SubdirectoryHintTracker
+from agent.subdirectory_hints import SubdirectoryHintTracker, _is_within_workspace
 
 
 @pytest.fixture
@@ -122,75 +122,19 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Frontend rules" in result
 
-    def test_outside_working_dir_rejected(self, tmp_path, project):
-        """Paths outside working_dir are rejected — no hints from outside workspace.
-
-        Note: project fixture returns tmp_path, so we need a path whose ancestor
-        is outside project. We simulate this by creating a directory at the same
-        level as project but not inside it — which requires creating a parent
-        tree. Since tmp_path / "other" IS inside tmp_path (=project), we need
-        a different approach: use tmp_path.parent as the reference for "outside".
-        """
-        # Create a directory at the same level as tmp_path (project),
-        # which means it's a sibling of project — not a child.
-        # Since tmp_path IS project, tmp_path.parent / "other" is a sibling.
-        parent = tmp_path.parent
-        other_project = parent / "other"
-        other_project.mkdir(exist_ok=True)
-        (other_project / "AGENTS.md").write_text("Other project rules")
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        result = tracker.check_tool_call(
-            "read_file", {"path": str(other_project / "file.py")}
-        )
-        # Outside workspace — should NOT load hints
-        assert result is None
-
-    def test_outside_working_dir_absolute_path_rejected(self, tmp_path, project):
-        """Absolute paths like ~/.codex/AGENTS.md are rejected."""
-        # Create a directory at the parent level of project, simulating ~/.codex
-        parent = tmp_path.parent
-        outside_dir = parent / ".test-codex"
-        outside_dir.mkdir(exist_ok=True)
-        (outside_dir / "AGENTS.md").write_text("Codex contamination rules")
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        result = tracker.check_tool_call(
-            "read_file", {"path": str(outside_dir / "AGENTS.md")}
-        )
-        # Reading a hint file outside working_dir — should NOT load hints
-        assert result is None
-
-    def test_inside_workspace_subdir_allowed(self, project):
-        """Paths inside working_dir are still allowed."""
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        result = tracker.check_tool_call(
-            "read_file", {"path": str(project / "backend" / "src" / "main.py")}
-        )
-        assert result is not None
-        assert "Backend-specific instructions" in result
-
-    def test_sibling_repo_not_loaded_via_ancestor_walk(self, tmp_path, project):
-        """Ancestor walk from inside working_dir should NOT discover sibling repo hints."""
-        # Create a nested structure inside working_dir
-        deep_dir = project / "deep" / "nested" / "very" / "deep"
-        deep_dir.mkdir(parents=True)
-        (deep_dir / "file.py").write_text("deep file")
-        # Also create a sibling directory at the parent level
-        parent = tmp_path.parent
-        sibling = parent / "sibling-repo"
-        sibling.mkdir(exist_ok=True)
-        (sibling / "AGENTS.md").write_text("Sibling repo rules")
-        # Create a .cursorrules in the deep/nested/very dir so ancestor walk
-        # discovers it (fixture's deep/nested/path is NOT an ancestor of very/deep)
-        (deep_dir / ".cursorrules").write_text("Deep cursorrules")
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        result = tracker.check_tool_call(
-            "read_file", {"path": str(deep_dir / "file.py")}
-        )
-        # Should discover deep cursorrules from the file's own directory
-        # but NOT sibling repo hints
-        assert result is not None
-        assert "Deep cursorrules" in result
-        assert "Sibling repo rules" not in result
+    def test_outside_workspace_blocked(self, tmp_path, project):
+        """Paths outside the workspace boundary must NOT load hints."""
+        # Create a directory outside the project workspace (sibling of tmp_path)
+        import tempfile
+        with tempfile.TemporaryDirectory() as other_root:
+            other_project = Path(other_root) / "other"
+            other_project.mkdir()
+            (other_project / "AGENTS.md").write_text("Other project rules")
+            tracker = SubdirectoryHintTracker(working_dir=str(project))
+            result = tracker.check_tool_call(
+                "read_file", {"path": str(other_project / "file.py")}
+            )
+            assert result is None, "Hints from outside workspace must not be loaded"
 
     def test_workdir_arg(self, project):
         """The workdir argument from terminal tool is checked."""
@@ -292,37 +236,80 @@ class TestPermissionErrorHandling:
             assert result is None or isinstance(result, str)
 
 
-class TestOutsideWorkspaceRejection:
-    """Direct tests for _is_valid_subdir rejecting outside-workspace paths."""
+class TestWorkspaceBoundary:
+    """Tests that hint discovery is scoped to the workspace boundary."""
 
-    def test_is_valid_subdir_rejects_outside_path(self, tmp_path, project):
-        """_is_valid_subdir should return False for paths outside working_dir.
-
-        Note: tmp_path / "other" is inside tmp_path (=project), so we use
-        tmp_path.parent / "other" to create a true outside-path sibling.
-        """
-        parent = tmp_path.parent
-        other_project = parent / "other"
-        other_project.mkdir(exist_ok=True)
+    def test_path_within_workspace_discovered(self, project):
+        """Paths inside the workspace load hints normally."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))
-        assert tracker._is_valid_subdir(other_project) is False
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+        )
+        assert result is not None
+        assert "Backend-specific" in result
 
-    def test_is_valid_subdir_allows_inside_path(self, project):
-        """_is_valid_subdir should return True for paths inside working_dir."""
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        backend = project / "backend"
-        assert tracker._is_valid_subdir(backend) is True
+    def test_path_outside_workspace_blocked(self, tmp_path):
+        """Paths outside the workspace must not load hints."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "AGENTS.md").write_text("Injected instructions")
 
-    def test_is_valid_subdir_rejects_parent_dir(self, tmp_path, project):
-        """_is_valid_subdir should reject parent directories outside working_dir."""
-        parent = tmp_path.parent
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        assert tracker._is_valid_subdir(parent) is False
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(outside / "file.py")}
+        )
+        assert result is None
 
-    def test_is_valid_subdir_rejects_sibling_dir(self, tmp_path, project):
-        """_is_valid_subdir should reject a sibling directory (simulating ~/.codex)."""
-        parent = tmp_path.parent
-        outside = parent / ".test-codex"
-        outside.mkdir(exist_ok=True)
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        assert tracker._is_valid_subdir(outside) is False
+    def test_ancestor_walk_stops_at_workspace_boundary(self, tmp_path):
+        """Walking up from a deep path must stop at the workspace root."""
+        workspace = tmp_path / "workspace"
+        deep = workspace / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        # Put AGENTS.md above the workspace — it must NOT be found
+        (tmp_path / "AGENTS.md").write_text("Should not be discovered")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(deep / "file.py")}
+        )
+        assert result is None
+
+    def test_terminal_command_outside_workspace_blocked(self, tmp_path):
+        """Terminal commands with paths outside workspace must not trigger hints."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "external"
+        outside.mkdir()
+        (outside / "AGENTS.md").write_text("External instructions")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "terminal", {"command": f"cat {outside}/file.py"}
+        )
+        assert result is None
+
+
+class TestIsWithinWorkspace:
+    """Unit tests for the _is_within_workspace helper."""
+
+    def test_same_directory(self, tmp_path):
+        assert _is_within_workspace(tmp_path, tmp_path) is True
+
+    def test_subdirectory(self, tmp_path):
+        child = tmp_path / "sub"
+        child.mkdir()
+        assert _is_within_workspace(child, tmp_path) is True
+
+    def test_outside(self, tmp_path):
+        other = tmp_path.parent / "other"
+        assert _is_within_workspace(other, tmp_path) is False
+
+    def test_prefix_attack(self, tmp_path):
+        """Ensure /foo/bar does not match /foo/barbaz."""
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        attack = tmp_path / "project-evil"
+        attack.mkdir()
+        assert _is_within_workspace(attack, workspace) is False

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.subdirectory_hints import SubdirectoryHintTracker
+from agent.subdirectory_hints import SubdirectoryHintTracker, _is_within_workspace
 
 
 @pytest.fixture
@@ -122,17 +122,19 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Frontend rules" in result
 
-    def test_outside_working_dir_still_checked(self, tmp_path, project):
-        """Paths outside working_dir are still checked for hints."""
-        other_project = tmp_path / "other"
-        other_project.mkdir()
-        (other_project / "AGENTS.md").write_text("Other project rules")
-        tracker = SubdirectoryHintTracker(working_dir=str(project))
-        result = tracker.check_tool_call(
-            "read_file", {"path": str(other_project / "file.py")}
-        )
-        assert result is not None
-        assert "Other project rules" in result
+    def test_outside_workspace_blocked(self, tmp_path, project):
+        """Paths outside the workspace boundary must NOT load hints."""
+        # Create a directory outside the project workspace (sibling of tmp_path)
+        import tempfile
+        with tempfile.TemporaryDirectory() as other_root:
+            other_project = Path(other_root) / "other"
+            other_project.mkdir()
+            (other_project / "AGENTS.md").write_text("Other project rules")
+            tracker = SubdirectoryHintTracker(working_dir=str(project))
+            result = tracker.check_tool_call(
+                "read_file", {"path": str(other_project / "file.py")}
+            )
+            assert result is None, "Hints from outside workspace must not be loaded"
 
     def test_workdir_arg(self, project):
         """The workdir argument from terminal tool is checked."""
@@ -232,3 +234,82 @@ class TestPermissionErrorHandling:
             )
             # Result may be None (backend skipped) — the key point is no crash
             assert result is None or isinstance(result, str)
+
+
+class TestWorkspaceBoundary:
+    """Tests that hint discovery is scoped to the workspace boundary."""
+
+    def test_path_within_workspace_discovered(self, project):
+        """Paths inside the workspace load hints normally."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+        )
+        assert result is not None
+        assert "Backend-specific" in result
+
+    def test_path_outside_workspace_blocked(self, tmp_path):
+        """Paths outside the workspace must not load hints."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "AGENTS.md").write_text("Injected instructions")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(outside / "file.py")}
+        )
+        assert result is None
+
+    def test_ancestor_walk_stops_at_workspace_boundary(self, tmp_path):
+        """Walking up from a deep path must stop at the workspace root."""
+        workspace = tmp_path / "workspace"
+        deep = workspace / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        # Put AGENTS.md above the workspace — it must NOT be found
+        (tmp_path / "AGENTS.md").write_text("Should not be discovered")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(deep / "file.py")}
+        )
+        assert result is None
+
+    def test_terminal_command_outside_workspace_blocked(self, tmp_path):
+        """Terminal commands with paths outside workspace must not trigger hints."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "external"
+        outside.mkdir()
+        (outside / "AGENTS.md").write_text("External instructions")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "terminal", {"command": f"cat {outside}/file.py"}
+        )
+        assert result is None
+
+
+class TestIsWithinWorkspace:
+    """Unit tests for the _is_within_workspace helper."""
+
+    def test_same_directory(self, tmp_path):
+        assert _is_within_workspace(tmp_path, tmp_path) is True
+
+    def test_subdirectory(self, tmp_path):
+        child = tmp_path / "sub"
+        child.mkdir()
+        assert _is_within_workspace(child, tmp_path) is True
+
+    def test_outside(self, tmp_path):
+        other = tmp_path.parent / "other"
+        assert _is_within_workspace(other, tmp_path) is False
+
+    def test_prefix_attack(self, tmp_path):
+        """Ensure /foo/bar does not match /foo/barbaz."""
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        attack = tmp_path / "project-evil"
+        attack.mkdir()
+        assert _is_within_workspace(attack, workspace) is False


### PR DESCRIPTION
## What does this PR do?

Post-tool-call path discovery scanned any directory for `AGENTS.md`, `CLAUDE.md`, and `.cursorrules` files, even those outside the intended workspace. A tool call touching a file elsewhere on disk could silently inject unrelated instruction files into the agent context, causing unexpected behavior drift and cross-project leakage.

## Related Issue

Fixes #14471

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/subdirectory_hints.py`: Scoped discovery to active workspace boundary
- `tests/agent/test_subdirectory_hints.py`: 26 tests

## How to Test

```bash
python -m pytest -o 'addopts=' tests/agent/test_subdirectory_hints.py -v
```

Result: 26 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest -o 'addopts=' tests/agent/test_subdirectory_hints.py -v
26 passed
```
