### PR TITLE
fix(cli): isolate custom provider credentials when providers share base_url

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -304,8 +304,15 @@ def _iter_custom_providers(config: Optional[dict] = None):
         yield _normalize_custom_pool_name(name), entry
 
 
-def get_custom_provider_pool_key(base_url: str) -> Optional[str]:
-    """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching base_url.
+def get_custom_provider_pool_key(
+    base_url: str, provider_name: Optional[str] = None
+) -> Optional[str]:
+    """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching entry.
+
+    When *provider_name* is given, both name and base_url must match.  This
+    prevents two providers that share the same base_url from returning each
+    other's pool key.  When omitted, the first URL match wins (legacy
+    behaviour).
 
     Returns None if no match is found.
     """
@@ -314,8 +321,13 @@ def get_custom_provider_pool_key(base_url: str) -> Optional[str]:
     normalized_url = base_url.strip().rstrip("/")
     for norm_name, entry in _iter_custom_providers():
         entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
-        if entry_url and entry_url == normalized_url:
-            return f"{CUSTOM_POOL_PREFIX}{norm_name}"
+        if not entry_url or entry_url != normalized_url:
+            continue
+        if provider_name is not None:
+            entry_name = entry.get("name", "")
+            if _normalize_custom_pool_name(entry_name) != _normalize_custom_pool_name(provider_name):
+                continue
+        return f"{CUSTOM_POOL_PREFIX}{norm_name}"
     return None
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -257,9 +257,10 @@ def _try_resolve_from_custom_pool(
     base_url: str,
     provider_label: str,
     api_mode_override: Optional[str] = None,
+    provider_name: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
-    pool_key = get_custom_provider_pool_key(base_url)
+    pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
         return None
     try:
@@ -411,7 +412,10 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    pool_result = _try_resolve_from_custom_pool(
+        base_url, "custom", custom_provider.get("api_mode"),
+        provider_name=custom_provider.get("name"),
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -866,6 +866,46 @@ def test_get_custom_provider_pool_key(tmp_path, monkeypatch):
     assert get_custom_provider_pool_key("") is None
 
 
+def test_get_custom_provider_pool_key_isolates_by_name(tmp_path, monkeypatch):
+    """Two providers sharing base_url should resolve to different pool keys when provider_name is given."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+    import yaml
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "provider-alpha",
+                "base_url": "https://api.shared-host.com/v1",
+                "api_key": "key-alpha",
+            },
+            {
+                "name": "provider-beta",
+                "base_url": "https://api.shared-host.com/v1",
+                "api_key": "key-beta",
+            },
+        ]
+    }))
+
+    from agent.credential_pool import get_custom_provider_pool_key
+
+    # Without provider_name: first URL match wins (legacy)
+    assert get_custom_provider_pool_key("https://api.shared-host.com/v1") == "custom:provider-alpha"
+
+    # With provider_name: each gets its own pool key
+    assert get_custom_provider_pool_key(
+        "https://api.shared-host.com/v1", provider_name="provider-alpha"
+    ) == "custom:provider-alpha"
+    assert get_custom_provider_pool_key(
+        "https://api.shared-host.com/v1", provider_name="provider-beta"
+    ) == "custom:provider-beta"
+
+    # Non-existent provider name with matching URL: returns None
+    assert get_custom_provider_pool_key(
+        "https://api.shared-host.com/v1", provider_name="provider-gamma"
+    ) is None
+
+
 def test_list_custom_pool_providers(tmp_path, monkeypatch):
     """list_custom_pool_providers returns custom: pool keys from auth.json."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## What does this PR do?

`get_custom_provider_pool_key()` resolved pool keys by `base_url` alone, so two custom providers sharing the same `base_url` would return the first provider's pool key — sending the wrong API credentials.

Adds an optional `provider_name` parameter to `get_custom_provider_pool_key()` so the provider identity is part of the cache key.

## Related Issue

Fixes #14141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py` — added `provider_name` to pool key resolution
- `hermes_cli/runtime_provider.py` — pass provider name through to pool key
- `tests/agent/test_credential_pool.py` — 32 tests

## How to Test

1. ```bash
   python -m pytest -o 'addopts=' tests/agent/test_credential_pool.py -v
   ```
2. Result: 32 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest -o 'addopts=' tests/agent/test_credential_pool.py -v
32 passed
```
