### PR TITLE
fix(install): resolve autostash by stash ref and tolerate stale stash drop (#14735)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -725,10 +725,21 @@ clone_repo() {
             local autostash_ref=""
             if [ -n "$(git status --porcelain)" ]; then
                 local stash_name
-                stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
+                stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)-$$"
                 log_info "Local changes detected, stashing before update..."
                 git stash push --include-untracked -m "$stash_name"
-                autostash_ref="$(git rev-parse --verify refs/stash)"
+                # Resolve stash@{n} by message — raw commit OIDs are not always accepted by
+                # `git stash drop` and become stale if a prior install was interrupted (#14735).
+                while IFS= read -r line; do
+                    if [[ "$line" == *"$stash_name"* ]]; then
+                        autostash_ref="${line%%:*}"
+                        break
+                    fi
+                done < <(git stash list)
+                if [ -z "$autostash_ref" ]; then
+                    log_error "Could not locate autostash entry after git stash push (message: $stash_name)."
+                    exit 1
+                fi
             fi
 
             git fetch origin
@@ -752,7 +763,10 @@ clone_repo() {
                 if [ "$restore_now" = "yes" ]; then
                     log_info "Restoring local changes..."
                     if git stash apply "$autostash_ref"; then
-                        git stash drop "$autostash_ref" >/dev/null
+                        if ! git stash drop "$autostash_ref" >/dev/null 2>&1; then
+                            log_warn "Could not drop installer autostash $autostash_ref (ref missing or already removed)."
+                            log_warn "Inspect git stash list and drop manually if a duplicate entry remains."
+                        fi
                         log_warn "Local changes were restored on top of the updated codebase."
                         log_warn "Review git diff / git status if Hermes behaves unexpectedly."
                     else


### PR DESCRIPTION
## Summary

Fixes installer update flow when local changes are stashed before `git pull`: use a stable `stash@{n}` reference derived from `git stash list` instead of a raw OID from `refs/stash`, and avoid aborting the whole install script when `git stash drop` fails after a successful `git stash apply`.

Closes https://github.com/NousResearch/hermes-agent/issues/14735

## Problem

`scripts/install.sh` captured the stash tip via `git rev-parse --verify refs/stash` and later ran `git stash drop <oid>`. After an interrupted install, that reference may no longer be a valid stash ref for `git stash drop`, which fails under `set -e` and stops the rest of onboarding.

## Changes

- `scripts/install.sh` (`clone_repo` update path):
  - Include `$$` in the autostash message for uniqueness.
  - After `git stash push`, locate the matching entry in `git stash list` and use the `stash@{n}` prefix as `autostash_ref`.
  - After successful `git stash apply`, run `git stash drop` inside a non-fatal branch: log a warning and continue if drop fails.

## Verification

- Manual: re-run installer after interrupting mid-update with a dirty tree; script should not exit solely on `stash drop`.
- CI: existing workflows unchanged; change is shell-only in `scripts/install.sh`.

## Notes

Behavior for failed `git stash apply` is unchanged (still exits with manual recovery instructions).