### PR TITLE
fix(mcp): rewrite draft-07 definitions refs to $defs for Moonshot/Kimi (salvage #14802)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -120,6 +120,72 @@ class TestSchemaConversion:
 
         assert schema["parameters"] == {"type": "object", "properties": {}}
 
+    def test_definitions_refs_are_rewritten_to_defs(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            name="submit",
+            description="Submit a payload",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "input": {"$ref": "#/definitions/Payload"},
+                },
+                "required": ["input"],
+                "definitions": {
+                    "Payload": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                        },
+                        "required": ["query"],
+                    }
+                },
+            },
+        )
+
+        schema = _convert_mcp_schema("forms", mcp_tool)
+
+        assert schema["parameters"]["properties"]["input"]["$ref"] == "#/$defs/Payload"
+        assert "$defs" in schema["parameters"]
+        assert "definitions" not in schema["parameters"]
+
+    def test_nested_definition_refs_are_rewritten_recursively(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            name="nested",
+            description="Nested schema",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/Entry"},
+                    },
+                },
+                "definitions": {
+                    "Entry": {
+                        "type": "object",
+                        "properties": {
+                            "child": {"$ref": "#/definitions/Child"},
+                        },
+                    },
+                    "Child": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        )
+
+        schema = _convert_mcp_schema("forms", mcp_tool)
+
+        assert schema["parameters"]["properties"]["items"]["items"]["$ref"] == "#/$defs/Entry"
+        assert schema["parameters"]["$defs"]["Entry"]["properties"]["child"]["$ref"] == "#/$defs/Child"
+
     def test_tool_name_prefix_format(self):
         from tools.mcp_tool import _convert_mcp_schema
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2019,14 +2019,37 @@ def _make_check_fn(server_name: str):
 # ---------------------------------------------------------------------------
 
 def _normalize_mcp_input_schema(schema: dict | None) -> dict:
-    """Normalize MCP input schemas for LLM tool-calling compatibility."""
+    """Normalize MCP input schemas for LLM tool-calling compatibility.
+
+    MCP servers can emit plain JSON Schema with ``definitions`` /
+    ``#/definitions/...`` references.  Kimi / Moonshot rejects that form and
+    requires local refs to point into ``#/$defs/...`` instead.  Normalize the
+    common draft-07 shape here so MCP tool schemas remain portable across
+    OpenAI-compatible providers.
+    """
     if not schema:
         return {"type": "object", "properties": {}}
 
-    if schema.get("type") == "object" and "properties" not in schema:
-        return {**schema, "properties": {}}
+    def _rewrite_local_refs(node):
+        if isinstance(node, dict):
+            normalized = {}
+            for key, value in node.items():
+                out_key = "$defs" if key == "definitions" else key
+                normalized[out_key] = _rewrite_local_refs(value)
+            ref = normalized.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/definitions/"):
+                normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
+            return normalized
+        if isinstance(node, list):
+            return [_rewrite_local_refs(item) for item in node]
+        return node
 
-    return schema
+    normalized = _rewrite_local_refs(schema)
+
+    if normalized.get("type") == "object" and "properties" not in normalized:
+        return {**normalized, "properties": {}}
+
+    return normalized
 
 
 def sanitize_mcp_name_component(value: str) -> str:


### PR DESCRIPTION
Salvage of #14802 by @helix4u — authorship preserved via cherry-pick.

## Summary
MCP tool schemas that use draft-07 `definitions` / `#/definitions/...` refs are now rewritten to `$defs` / `#/$defs/...` form at registration time, so they pass Moonshot's flavored JSON Schema validator.

## Why
Reported by TaylorFay in community: HTTP 400 `tools.function.parameters is not a valid moonshot flavored json schema` when routing to `moonshotai/kimi-k2.6` via Nous with MCP servers loaded (tinybird, chartmogul, dataforseo, plain — 203 tools). Moonshot requires local refs to point into `#/$defs/...`, not `#/definitions/...`.

## Changes
- `tools/mcp_tool.py`: `_normalize_mcp_input_schema()` now recursively rewrites `definitions` → `$defs` and `#/definitions/X` → `#/$defs/X`
- `tests/tools/test_mcp_tool.py`: 2 new regression tests (top-level + nested)

## Validation
- `pytest tests/tools/test_mcp_tool.py -k 'SchemaConversion or definitions_refs or nested_definition_refs'` → 7/7 passed
- E2E: fed a realistic draft-07 MCP schema with nested refs through `_normalize_mcp_input_schema()`, verified all rewrites + passthroughs

## Scope note
This covers one of three known Moonshot-schema rejection modes (`$defs` ref format). Follow-up PR will cover the other two (missing `type` on properties, `type` at `anyOf` parent) as a general `agent/moonshot_schema.py` sanitizer applied by model-name route, not just at MCP ingestion.

Closes #14802.