### PR TITLE
[codex] Add gpt-5.5 to fast-mode priority-processing allowlist

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1511,8 +1511,11 @@ def provider_label(provider: Optional[str]) -> str:
 
 # Models that support OpenAI Priority Processing (service_tier="priority").
 # See https://openai.com/api-priority-processing/ for the canonical list.
-# Only the bare model slug is stored (no vendor prefix).
+# Keep this aligned with newer Codex-discovered GPT-5 models that advertise
+# a fast tier before the static docs/tests catch up. Only the bare model slug
+# is stored (no vendor prefix).
 _PRIORITY_PROCESSING_MODELS: frozenset[str] = frozenset({
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.2",

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -111,12 +111,13 @@ class TestHandleFastCommand(unittest.TestCase):
 class TestPriorityProcessingModels(unittest.TestCase):
     """Verify the expanded Priority Processing model registry."""
 
-    def test_all_documented_models_supported(self):
+    def test_priority_processing_models_supported(self):
         from hermes_cli.models import model_supports_fast_mode
 
-        # All models from OpenAI's Priority Processing pricing table
+        # OpenAI Priority Processing models plus newly discovered GPT-5 models
+        # that advertise fast-tier support before the public pricing table catches up.
         supported = [
-            "gpt-5.4", "gpt-5.4-mini", "gpt-5.2",
+            "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2",
             "gpt-5.1", "gpt-5", "gpt-5-mini",
             "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
             "gpt-4o", "gpt-4o-mini",
@@ -128,6 +129,7 @@ class TestPriorityProcessingModels(unittest.TestCase):
     def test_vendor_prefix_stripped(self):
         from hermes_cli.models import model_supports_fast_mode
 
+        assert model_supports_fast_mode("openai/gpt-5.5") is True
         assert model_supports_fast_mode("openai/gpt-5.4") is True
         assert model_supports_fast_mode("openai/gpt-4.1") is True
         assert model_supports_fast_mode("openai/o3") is True
@@ -142,6 +144,9 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
     def test_resolve_overrides_returns_service_tier(self):
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        result = resolve_fast_mode_overrides("gpt-5.5")
+        assert result == {"service_tier": "priority"}
 
         result = resolve_fast_mode_overrides("gpt-5.4")
         assert result == {"service_tier": "priority"}

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -96,7 +96,7 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
         "credential_pool": None,
     }
 
-    route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.4", runtime_kwargs)
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.5", runtime_kwargs)
 
     assert route["runtime"]["provider"] == "openrouter"
     assert route["runtime"]["api_mode"] == "chat_completions"
@@ -127,7 +127,7 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
 
     response = await runner._handle_fast_command(_make_event("/fast fast"))
 
@@ -148,7 +148,7 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",


### PR DESCRIPTION
## Summary
- add `gpt-5.5` to the OpenAI priority-processing allowlist used by `/fast`
- add regression coverage for `gpt-5.5` model support and override resolution in CLI and gateway flows

## Why
- Hermes already supports `/fast`, but `gpt-5.5` was missing from the static fast-capable model registry
- Codex model metadata advertises a `fast` speed tier for `gpt-5.5`, so Hermes was lagging current model capability
- the lower request path already supports `service_tier`, so the bug was just the gate/allowlist

## Impact
- `/fast` now works for `gpt-5.5` in CLI and gateway flows
- the change is narrow and test-backed
- branch is rebased on current `upstream/main`

## Validation
- `uv run --extra dev pytest tests/cli/test_fast_command.py tests/gateway/test_fast_command.py tests/hermes_cli/test_timeouts.py`
- GitHub Actions: all non-`test` checks pass; the full `test` job is currently red on `main` with the same 14 baseline failures
