### PR TITLE
fix(mcp): coerce stringified arrays/objects in tool args (salvage #12640)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -418,6 +418,31 @@ def _coerce_value(value: str, expected_type):
         return _coerce_number(value, integer_only=(expected_type == "integer"))
     if expected_type == "boolean":
         return _coerce_boolean(value)
+    if expected_type == "array":
+        return _coerce_json(value, list)
+    if expected_type == "object":
+        return _coerce_json(value, dict)
+    return value
+
+
+def _coerce_json(value: str, expected_python_type: type):
+    """Parse *value* as JSON when the schema expects an array or object.
+
+    Handles model output drift where a complex oneOf/discriminated-union schema
+    causes the LLM to emit the array/object as a JSON string instead of a native
+    structure.  Returns the original string if parsing fails or yields the wrong
+    Python type.
+    """
+    try:
+        parsed = json.loads(value)
+    except (ValueError, TypeError):
+        return value
+    if isinstance(parsed, expected_python_type):
+        logger.debug(
+            "coerce_tool_args: coerced string to %s via json.loads",
+            expected_python_type.__name__,
+        )
+        return parsed
     return value
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -167,6 +167,7 @@ AUTHOR_MAP = {
     "socrates1024@gmail.com": "socrates1024",
     "seanalt555@gmail.com": "Salt-555",
     "satelerd@gmail.com": "satelerd",
+    "dan@danlynn.com": "danklynn",
     "numman.ali@gmail.com": "nummanali",
     "rohithsaimidigudla@gmail.com": "whitehatjr1001",
     "0xNyk@users.noreply.github.com": "0xNyk",

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -134,6 +134,31 @@ class TestCoerceValue:
         """A non-numeric string in [number, string] should stay a string."""
         assert _coerce_value("hello", ["number", "string"]) == "hello"
 
+    def test_array_type_parsed_from_json_string(self):
+        """Stringified JSON arrays are parsed into native lists."""
+        assert _coerce_value('["a", "b"]', "array") == ["a", "b"]
+        assert _coerce_value("[1, 2, 3]", "array") == [1, 2, 3]
+
+    def test_object_type_parsed_from_json_string(self):
+        """Stringified JSON objects are parsed into native dicts."""
+        assert _coerce_value('{"k": "v"}', "object") == {"k": "v"}
+        assert _coerce_value('{"n": 1}', "object") == {"n": 1}
+
+    def test_array_invalid_json_preserved(self):
+        """Unparseable strings are returned unchanged."""
+        assert _coerce_value("not-json", "array") == "not-json"
+
+    def test_object_invalid_json_preserved(self):
+        assert _coerce_value("not-json", "object") == "not-json"
+
+    def test_array_type_wrong_shape_preserved(self):
+        """A JSON object passed for an 'array' slot is preserved as a string."""
+        assert _coerce_value('{"k": "v"}', "array") == '{"k": "v"}'
+
+    def test_object_type_wrong_shape_preserved(self):
+        """A JSON array passed for an 'object' slot is preserved as a string."""
+        assert _coerce_value('["a"]', "object") == '["a"]'
+
 
 # ── Full coerce_tool_args with registry ───────────────────────────────────
 
@@ -211,6 +236,32 @@ class TestCoerceToolArgs:
             result = coerce_tool_args("test_tool", args)
             assert result["items"] == [1, 2, 3]
             assert result["config"] == {"key": "val"}
+
+    def test_coerces_stringified_array_arg(self):
+        """Regression for #3947 — MCP servers using z.array() expect lists, not strings."""
+        schema = self._mock_schema({
+            "messageIds": {"type": "array", "items": {"type": "string"}},
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"messageIds": '["abc", "def"]'}
+            result = coerce_tool_args("test_tool", args)
+            assert result["messageIds"] == ["abc", "def"]
+
+    def test_coerces_stringified_object_arg(self):
+        """Stringified JSON objects get parsed into dicts."""
+        schema = self._mock_schema({"config": {"type": "object"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"config": '{"max": 50}'}
+            result = coerce_tool_args("test_tool", args)
+            assert result["config"] == {"max": 50}
+
+    def test_invalid_json_array_preserved_as_string(self):
+        """If the string isn't valid JSON, pass it through — let the tool decide."""
+        schema = self._mock_schema({"items": {"type": "array"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"items": "not-json"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["items"] == "not-json"
 
     def test_extra_args_without_schema_left_alone(self):
         """Args not in the schema properties are not touched."""


### PR DESCRIPTION
Salvage of #12640 by @danklynn — authorship preserved via cherry-pick.

## Summary
MCP tool calls where the model emits arrays or objects as JSON strings are now parsed into native Python types before dispatch, closing the last gap in the existing `coerce_tool_args` pipeline (which already handled integer / number / boolean).

## Why
Reported in #3947 (steveant, March 2026) — running the `@gongrzhe/server-gmail-autoauth-mcp` server, calls to `batch_modify_emails` and `search_emails` 400ed with Zod validation errors:

```
{"code":"invalid_type","expected":"array","received":"string","path":["messageIds"]}
{"code":"invalid_type","expected":"number","received":"string","path":["maxResults"]}
```

Number/boolean coercion was already in `_coerce_value`; array/object was the missing branch.

## Changes
- `model_tools.py` (+25, @danklynn): `_coerce_value` now handles `type: array` and `type: object` via `json.loads`, falling back to the original string when parsing fails or the parsed type doesn't match the schema shape (e.g. array schema but string parses to object → return original).
- `tests/run_agent/test_tool_arg_coercion.py` (+51): 9 new regression tests (unit-level `_coerce_value` + integration-level `coerce_tool_args`, including the issue #3947 gmail scenario end-to-end).
- `scripts/release.py` (+1): AUTHOR_MAP entry for dan@danlynn.com → danklynn so release-notes CI attributes the contributor commit correctly.

## Validation
| | Result |
|---|---|
| `tests/run_agent/test_tool_arg_coercion.py` | 51 / 51 passed (42 pre-existing + 9 new) |
| E2E via `execute_code` | gmail-mcp scenario: stringified `messageIds` / `maxResults` coerced; tricky inputs (literal `["str"]` for a declared `string` param, non-JSON for an array slot) preserved untouched |

## Closes
- #3947 (issue, steveant)
- #12640 (superseded by this salvage, authorship preserved)

## Also supersedes
- #9728 (@aeyeopsdev) — same fix with recursive `items`/`properties` walk; rejected Option B during review because each parsed element is already a valid JSON primitive at that point, so the extra walk duplicates work.
- #4145 (@apexscaleai) — older 364-LOC version that duplicated coercion in `tools/mcp_tool.py`; this lives in the shared `_coerce_value` path so MCP and built-in tools both get it.