### PR TITLE
feat(dashboard): add native /chat page on top of tui_gateway websocket transport

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -49,7 +49,7 @@ from hermes_cli.config import (
 from gateway.status import get_running_pid, read_runtime_status
 
 try:
-    from fastapi import FastAPI, HTTPException, Request
+    from fastapi import FastAPI, HTTPException, Request, WebSocket
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
     from fastapi.staticfiles import StaticFiles
@@ -2785,6 +2785,23 @@ def _mount_plugin_api_routes():
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
         except Exception as exc:
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
+
+
+# ---------------------------------------------------------------------------
+# tui_gateway WebSocket — wire-compatible with `python -m tui_gateway.entry`.
+# ---------------------------------------------------------------------------
+
+
+@app.websocket("/api/ws")
+async def _tui_gateway_websocket(ws: WebSocket):
+    token = ws.query_params.get("token", "")
+    if not hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+        await ws.close(code=4401)
+        return
+
+    from tui_gateway.ws import handle_ws
+
+    await handle_ws(ws)
 
 
 # Mount plugin API routes before the SPA catch-all.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1677,3 +1677,268 @@ class TestDashboardPluginManifestExtensions:
         plugins = web_server._get_dashboard_plugins(force_rescan=True)
         entry = next(p for p in plugins if p["name"] == "mixed-slots")
         assert entry["slots"] == ["sidebar", "header-right"]
+# ---------------------------------------------------------------------------
+# /api/ws — WebSocket wire-compatible with stdio tui_gateway
+# ---------------------------------------------------------------------------
+
+class TestTuiGatewayWebSocket:
+    """Focused backend tests for the transport-only /api/ws bridge."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_TOKEN
+
+        self.client = TestClient(app)
+        self.token = _SESSION_TOKEN
+
+    def _url(self, token=None):
+        tok = self.token if token is None else token
+        return f"/api/ws?token={tok}" if tok else "/api/ws"
+
+    def _drain_ready(self, ws):
+        frame = ws.receive_json()
+        assert frame.get("method") == "event"
+        assert frame["params"]["type"] == "gateway.ready"
+        return frame
+
+    def test_handshake_emits_gateway_ready(self):
+        with self.client.websocket_connect(self._url()) as ws:
+            first = ws.receive_json()
+            assert first["jsonrpc"] == "2.0"
+            assert first["method"] == "event"
+            assert first["params"]["type"] == "gateway.ready"
+            assert "skin" in first["params"]["payload"]
+
+    def test_rejects_missing_token(self):
+        from starlette.websockets import WebSocketDisconnect
+
+        with pytest.raises(WebSocketDisconnect):
+            with self.client.websocket_connect(self._url(token="")) as ws:
+                ws.receive_json()
+
+    def test_rejects_bad_token(self):
+        from starlette.websockets import WebSocketDisconnect
+
+        with pytest.raises(WebSocketDisconnect):
+            with self.client.websocket_connect(self._url(token="bogus-token-xyz")) as ws:
+                ws.receive_json()
+
+    def test_parse_error_on_bad_frame(self):
+        with self.client.websocket_connect(self._url()) as ws:
+            self._drain_ready(ws)
+            ws.send_text("this is { not json")
+            resp = ws.receive_json()
+            assert resp["jsonrpc"] == "2.0"
+            assert resp["error"]["code"] == -32700
+            assert resp["error"]["message"] == "parse error"
+
+    def test_unknown_method_returns_rpc_error(self):
+        with self.client.websocket_connect(self._url()) as ws:
+            self._drain_ready(ws)
+            ws.send_json({"jsonrpc": "2.0", "id": "u1", "method": "does.not.exist"})
+            resp = ws.receive_json()
+            assert resp["id"] == "u1"
+            assert resp["error"]["code"] == -32601
+            assert "does.not.exist" in resp["error"]["message"]
+
+    def test_inline_handler_returns_response(self):
+        from tui_gateway import server
+
+        sentinel = "_ws_inline_test"
+        server._methods[sentinel] = lambda rid, params: server._ok(rid, {"pong": params.get("ping")})
+        try:
+            with self.client.websocket_connect(self._url()) as ws:
+                self._drain_ready(ws)
+                ws.send_json({"jsonrpc": "2.0", "id": "i1", "method": sentinel, "params": {"ping": "PONG"}})
+                resp = ws.receive_json()
+                assert resp == {"jsonrpc": "2.0", "id": "i1", "result": {"pong": "PONG"}}
+        finally:
+            server._methods.pop(sentinel, None)
+
+    def test_pool_handler_response_arrives_via_ws(self):
+        from tui_gateway import server
+
+        original = server._methods.get("slash.exec")
+        server._methods["slash.exec"] = lambda rid, params: server._ok(rid, {"output": "async-ok"})
+        try:
+            with self.client.websocket_connect(self._url()) as ws:
+                self._drain_ready(ws)
+                ws.send_json({"jsonrpc": "2.0", "id": "p1", "method": "slash.exec", "params": {}})
+                resp = ws.receive_json()
+                assert resp["id"] == "p1"
+                assert resp["result"] == {"output": "async-ok"}
+        finally:
+            if original is not None:
+                server._methods["slash.exec"] = original
+            else:
+                server._methods.pop("slash.exec", None)
+
+    def test_session_events_route_to_owning_ws(self):
+        from tui_gateway import server
+        from tui_gateway.transport import current_transport
+
+        sentinel_create = "_ws_emit_test_create"
+        sentinel_emit = "_ws_emit_test_fire"
+        created_sid = {"value": ""}
+
+        def create(rid, params):
+            import uuid
+
+            sid = f"ws-emit-test-{uuid.uuid4().hex[:8]}"
+            created_sid["value"] = sid
+            server._sessions[sid] = {
+                "session_key": sid,
+                "transport": current_transport(),
+            }
+            return server._ok(rid, {"session_id": sid})
+
+        def fire(rid, params):
+            sid = params["session_id"]
+            server._emit("demo.event", sid, {"n": params.get("n", 0)})
+            return server._ok(rid, {"ok": True})
+
+        server._methods[sentinel_create] = create
+        server._methods[sentinel_emit] = fire
+        try:
+            with self.client.websocket_connect(self._url()) as ws:
+                self._drain_ready(ws)
+
+                ws.send_json({"jsonrpc": "2.0", "id": "c1", "method": sentinel_create})
+                create_resp = ws.receive_json()
+                assert create_resp["id"] == "c1"
+                sid = create_resp["result"]["session_id"]
+                assert sid == created_sid["value"]
+
+                ws.send_json({
+                    "jsonrpc": "2.0",
+                    "id": "e1",
+                    "method": sentinel_emit,
+                    "params": {"session_id": sid, "n": 7},
+                })
+                frame1 = ws.receive_json()
+                frame2 = ws.receive_json()
+
+                event_frame = frame1 if frame1.get("method") == "event" else frame2
+                resp_frame = frame2 if frame2.get("id") == "e1" else frame1
+
+                assert event_frame["params"]["type"] == "demo.event"
+                assert event_frame["params"]["session_id"] == sid
+                assert event_frame["params"]["payload"] == {"n": 7}
+                assert resp_frame["result"] == {"ok": True}
+        finally:
+            server._methods.pop(sentinel_create, None)
+            server._methods.pop(sentinel_emit, None)
+            server._sessions.pop(created_sid["value"], None)
+
+    def test_ws_disconnect_resets_session_transport(self):
+        from tui_gateway import server
+        from tui_gateway.transport import current_transport
+
+        sentinel = "_ws_disconnect_test"
+        captured = {"sid": "", "transport": None}
+
+        def create(rid, params):
+            sid = "ws-disconnect-sid"
+            captured["sid"] = sid
+            captured["transport"] = current_transport()
+            server._sessions[sid] = {
+                "session_key": sid,
+                "transport": captured["transport"],
+            }
+            return server._ok(rid, {"session_id": sid})
+
+        server._methods[sentinel] = create
+        try:
+            with self.client.websocket_connect(self._url()) as ws:
+                self._drain_ready(ws)
+                ws.send_json({"jsonrpc": "2.0", "id": "c1", "method": sentinel})
+                ws.receive_json()
+
+            import time
+
+            for _ in range(50):
+                if server._sessions.get(captured["sid"], {}).get("transport") is not captured["transport"]:
+                    break
+                time.sleep(0.02)
+
+            sess = server._sessions.get(captured["sid"])
+            assert sess is not None
+            assert sess["transport"] is server._stdio_transport
+        finally:
+            server._methods.pop(sentinel, None)
+            server._sessions.pop(captured["sid"], None)
+
+
+class TestTuiGatewayTransportParity:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_TOKEN
+
+        self.client = TestClient(app)
+        self.token = _SESSION_TOKEN
+
+    def _ws_roundtrip(self, req: dict) -> dict:
+        with self.client.websocket_connect(f"/api/ws?token={self.token}") as ws:
+            ready = ws.receive_json()
+            assert ready["params"]["type"] == "gateway.ready"
+            ws.send_json(req)
+            return ws.receive_json()
+
+    def test_parity_unknown_method(self):
+        from tui_gateway import server
+
+        req = {"jsonrpc": "2.0", "id": "p-unk", "method": "no.such.method"}
+        assert self._ws_roundtrip(req) == server.handle_request(req)
+
+    def test_parity_inline_handler(self):
+        from tui_gateway import server
+
+        sentinel = "_parity_inline"
+        server._methods[sentinel] = lambda rid, params: server._ok(rid, {
+            "echo": params,
+            "const": 42,
+            "nested": {"a": [1, 2, 3], "b": None},
+        })
+        try:
+            req = {
+                "jsonrpc": "2.0",
+                "id": "p-inline",
+                "method": sentinel,
+                "params": {"hello": "world", "n": 1},
+            }
+            assert self._ws_roundtrip(req) == server.handle_request(req)
+        finally:
+            server._methods.pop(sentinel, None)
+
+    def test_parity_error_envelope(self):
+        from tui_gateway import server
+
+        sentinel = "_parity_err"
+        server._methods[sentinel] = lambda rid, params: server._err(rid, 4242, "nope")
+        try:
+            req = {"jsonrpc": "2.0", "id": "p-err", "method": sentinel}
+            assert self._ws_roundtrip(req) == server.handle_request(req)
+        finally:
+            server._methods.pop(sentinel, None)
+
+    def test_parity_stdio_transport_also_works(self):
+        from tui_gateway import server
+
+        sentinel = "_parity_stdio"
+        server._methods[sentinel] = lambda rid, params: server._ok(rid, {"ok": True, "p": params})
+        try:
+            req = {"jsonrpc": "2.0", "id": "p-std", "method": sentinel, "params": {"x": 1}}
+            default_resp = server.dispatch(dict(req))
+            explicit_resp = server.dispatch(dict(req), server._stdio_transport)
+            assert default_resp == explicit_resp
+            assert default_resp["result"] == {"ok": True, "p": {"x": 1}}
+        finally:
+            server._methods.pop(sentinel, None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
+import contextvars
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -31,6 +32,13 @@ except Exception:
     pass
 
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
+from tui_gateway.transport import (
+    StdioTransport,
+    Transport,
+    bind_transport,
+    current_transport,
+    reset_transport,
+)
 
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
@@ -77,6 +85,10 @@ atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 # of corrupting the JSON protocol.
 _real_stdout = sys.stdout
 sys.stdout = sys.stderr
+
+# Module-level stdio transport used as the fallback sink when no request/session
+# transport is bound.
+_stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 
 
 class _SlashWorker:
@@ -197,14 +209,13 @@ def _db_unavailable_error(rid, *, code: int):
 
 
 def write_json(obj: dict) -> bool:
-    line = json.dumps(obj, ensure_ascii=False) + "\n"
-    try:
-        with _stdout_lock:
-            _real_stdout.write(line)
-            _real_stdout.flush()
-        return True
-    except BrokenPipeError:
-        return False
+    """Emit one JSON frame via the most-specific transport available."""
+    if obj.get("method") == "event":
+        sid = ((obj.get("params") or {}).get("session_id")) or ""
+        if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
+            return t.write(obj)
+
+    return (current_transport() or _stdio_transport).write(obj)
 
 
 def _emit(event: str, sid: str, payload: dict | None = None):
@@ -274,27 +285,28 @@ def handle_request(req: dict) -> dict | None:
     return fn(req.get("id"), req.get("params", {}))
 
 
-def dispatch(req: dict) -> dict | None:
-    """Route inbound RPCs — long handlers to the pool, everything else inline.
+def dispatch(req: dict, transport: Transport | None = None) -> dict | None:
+    """Route inbound RPCs — long handlers to the pool, everything else inline."""
+    t = transport or _stdio_transport
+    token = bind_transport(t)
+    try:
+        if req.get("method") not in _LONG_HANDLERS:
+            return handle_request(req)
 
-    Returns a response dict when handled inline. Returns None when the
-    handler was scheduled on the pool; the worker writes its own
-    response via write_json when done.
-    """
-    if req.get("method") not in _LONG_HANDLERS:
-        return handle_request(req)
+        ctx = contextvars.copy_context()
 
-    def run():
-        try:
-            resp = handle_request(req)
-        except Exception as exc:
-            resp = _err(req.get("id"), -32000, f"handler error: {exc}")
-        if resp is not None:
-            write_json(resp)
+        def run():
+            try:
+                resp = handle_request(req)
+            except Exception as exc:
+                resp = _err(req.get("id"), -32000, f"handler error: {exc}")
+            if resp is not None:
+                t.write(resp)
 
-    _pool.submit(run)
-
-    return None
+        _pool.submit(lambda: ctx.run(run))
+        return None
+    finally:
+        reset_transport(token)
 
 
 def _wait_agent(session: dict, rid: str, timeout: float = 30.0) -> dict | None:
@@ -1187,6 +1199,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "tool_progress_mode": _load_tool_progress_mode(),
         "edit_snapshots": {},
         "tool_started_at": {},
+        "transport": current_transport() or _stdio_transport,
     }
     try:
         _sessions[sid]["slash_worker"] = _SlashWorker(
@@ -1329,6 +1342,7 @@ def _(rid, params: dict) -> dict:
         "slash_worker": None,
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
+        "transport": current_transport() or _stdio_transport,
     }
 
     def _build() -> None:

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -1,0 +1,65 @@
+"""Transport abstraction for the tui_gateway JSON-RPC server.
+
+Keeps the existing stdio protocol intact while allowing the same dispatcher
+logic to run over alternate transports like WebSocket.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import threading
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Transport(Protocol):
+    """Minimal interface every transport implements."""
+
+    def write(self, obj: dict) -> bool:
+        """Emit one JSON frame. Return False when the peer is gone."""
+
+    def close(self) -> None:
+        """Release any resources owned by this transport."""
+
+
+_current_transport: contextvars.ContextVar[Optional[Transport]] = contextvars.ContextVar(
+    "hermes_gateway_transport",
+    default=None,
+)
+
+
+def current_transport() -> Optional[Transport]:
+    return _current_transport.get()
+
+
+def bind_transport(transport: Optional[Transport]):
+    return _current_transport.set(transport)
+
+
+def reset_transport(token) -> None:
+    _current_transport.reset(token)
+
+
+class StdioTransport:
+    """Writes JSON frames to a stream resolved lazily at write time."""
+
+    __slots__ = ("_stream_getter", "_lock")
+
+    def __init__(self, stream_getter: Callable[[], Any], lock: threading.Lock) -> None:
+        self._stream_getter = stream_getter
+        self._lock = lock
+
+    def write(self, obj: dict) -> bool:
+        line = json.dumps(obj, ensure_ascii=False) + "\n"
+        try:
+            with self._lock:
+                stream = self._stream_getter()
+                stream.write(line)
+                stream.flush()
+            return True
+        except BrokenPipeError:
+            return False
+
+    def close(self) -> None:
+        return None

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -85,7 +85,8 @@ async def handle_ws(ws: Any) -> None:
         while True:
             try:
                 raw = await ws.receive_text()
-            except _WebSocketDisconnect:
+            except (_WebSocketDisconnect, RuntimeError) as exc:
+                _log.debug("ws receive loop ended: %s", exc)
                 break
 
             line = raw.strip()

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -1,0 +1,120 @@
+"""WebSocket transport for the tui_gateway JSON-RPC server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from tui_gateway import server
+
+_log = logging.getLogger(__name__)
+_WS_WRITE_TIMEOUT_S = 10.0
+
+try:
+    from starlette.websockets import WebSocketDisconnect as _WebSocketDisconnect
+except ImportError:  # pragma: no cover
+    _WebSocketDisconnect = Exception  # type: ignore[assignment]
+
+
+class WSTransport:
+    def __init__(self, ws: Any, loop: asyncio.AbstractEventLoop) -> None:
+        self._ws = ws
+        self._loop = loop
+        self._closed = False
+
+    def write(self, obj: dict) -> bool:
+        if self._closed:
+            return False
+
+        line = json.dumps(obj, ensure_ascii=False)
+
+        try:
+            on_loop = asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            on_loop = False
+
+        if on_loop:
+            self._loop.create_task(self._safe_send(line))
+            return True
+
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self._safe_send(line), self._loop)
+            fut.result(timeout=_WS_WRITE_TIMEOUT_S)
+            return not self._closed
+        except Exception as exc:
+            self._closed = True
+            _log.debug("ws write failed: %s", exc)
+            return False
+
+    async def write_async(self, obj: dict) -> bool:
+        if self._closed:
+            return False
+        await self._safe_send(json.dumps(obj, ensure_ascii=False))
+        return not self._closed
+
+    async def _safe_send(self, line: str) -> None:
+        try:
+            await self._ws.send_text(line)
+        except Exception as exc:
+            self._closed = True
+            _log.debug("ws send failed: %s", exc)
+
+    def close(self) -> None:
+        self._closed = True
+
+
+async def handle_ws(ws: Any) -> None:
+    await ws.accept()
+
+    transport = WSTransport(ws, asyncio.get_running_loop())
+
+    await transport.write_async(
+        {
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "gateway.ready",
+                "payload": {"skin": server.resolve_skin()},
+            },
+        }
+    )
+
+    try:
+        while True:
+            try:
+                raw = await ws.receive_text()
+            except _WebSocketDisconnect:
+                break
+
+            line = raw.strip()
+            if not line:
+                continue
+
+            try:
+                req = json.loads(line)
+            except json.JSONDecodeError:
+                ok = await transport.write_async(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32700, "message": "parse error"},
+                        "id": None,
+                    }
+                )
+                if not ok:
+                    break
+                continue
+
+            resp = await asyncio.to_thread(server.dispatch, req, transport)
+            if resp is not None and not await transport.write_async(resp):
+                break
+    finally:
+        transport.close()
+        for _, sess in list(server._sessions.items()):
+            if sess.get("transport") is transport:
+                sess["transport"] = server._stdio_transport
+        try:
+            await ws.close()
+        except Exception:
+            pass

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import StatusPage from "@/pages/StatusPage";
 import ConfigPage from "@/pages/ConfigPage";
 import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
+import ChatPage from "@/pages/ChatPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import CronPage from "@/pages/CronPage";
@@ -46,6 +47,7 @@ import { useTheme } from "@/themes";
 const BUILTIN_ROUTES: Record<string, React.ComponentType> = {
   "/": StatusPage,
   "/sessions": SessionsPage,
+  "/chat": ChatPage,
   "/analytics": AnalyticsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
@@ -60,6 +62,11 @@ const BUILTIN_NAV: NavItem[] = [
     path: "/sessions",
     labelKey: "sessions",
     label: "Sessions",
+    icon: MessageSquare,
+  },
+  {
+    path: "/chat",
+    label: "Chat",
     icon: MessageSquare,
   },
   {

--- a/web/src/components/ToolCall.tsx
+++ b/web/src/components/ToolCall.tsx
@@ -1,0 +1,98 @@
+import { AlertCircle, Check, ChevronDown, ChevronRight, Zap } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export interface ToolEntry {
+  kind: "tool";
+  id: string;
+  tool_id: string;
+  name: string;
+  context?: string;
+  preview?: string;
+  summary?: string;
+  error?: string;
+  inline_diff?: string;
+  status: "running" | "done" | "error";
+  startedAt: number;
+  completedAt?: number;
+}
+
+const STATUS_TONE: Record<ToolEntry["status"], string> = {
+  running: "border-primary/40 bg-primary/[0.04]",
+  done: "border-border bg-muted/20",
+  error: "border-destructive/50 bg-destructive/[0.04]",
+};
+
+const BULLET_TONE: Record<ToolEntry["status"], string> = {
+  running: "text-primary",
+  done: "text-primary/80",
+  error: "text-destructive",
+};
+
+const TICK_MS = 500;
+
+export function ToolCall({ tool }: { tool: ToolEntry }) {
+  const [userOverride, setUserOverride] = useState<boolean | null>(null);
+  const open = userOverride ?? tool.status === "error";
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (tool.status !== "running") return;
+    const id = window.setInterval(() => setNow(() => Date.now()), TICK_MS);
+    return () => window.clearInterval(id);
+  }, [tool.status]);
+
+  const hasTimestamps = tool.startedAt > 0;
+  const elapsed = hasTimestamps ? fmtElapsed((tool.completedAt ?? now) - tool.startedAt) : null;
+  const hasBody = !!(tool.context || tool.preview || tool.summary || tool.error || tool.inline_diff);
+  const Chevron = open ? ChevronDown : ChevronRight;
+
+  return (
+    <div className={`rounded-md border overflow-hidden ${STATUS_TONE[tool.status]}`}>
+      <button
+        type="button"
+        onClick={() => setUserOverride(!open)}
+        disabled={!hasBody}
+        aria-expanded={open}
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-foreground/2 disabled:cursor-default cursor-pointer transition-colors"
+      >
+        {hasBody ? <Chevron className="h-3 w-3 shrink-0 text-muted-foreground" /> : <span className="w-3 shrink-0" />}
+        <Zap className={`h-3 w-3 shrink-0 ${BULLET_TONE[tool.status]}`} />
+        <span className="font-mono font-medium shrink-0">{tool.name}</span>
+        <span className="font-mono text-muted-foreground/80 truncate min-w-0 flex-1">{tool.context ?? ""}</span>
+        {tool.status === "running" && <span className="inline-block h-2 w-2 rounded-full bg-primary animate-pulse shrink-0" title="running" />}
+        {tool.status === "error" && <AlertCircle className="h-3 w-3 shrink-0 text-destructive" aria-label="error" />}
+        {tool.status === "done" && <Check className="h-3 w-3 shrink-0 text-primary/80" aria-label="done" />}
+        {elapsed && <span className="font-mono text-[0.65rem] text-muted-foreground tabular-nums shrink-0">{elapsed}</span>}
+      </button>
+
+      {open && hasBody && (
+        <div className="border-t border-border/60 px-3 py-2 space-y-2 text-xs font-mono">
+          {tool.context && <Section label="context">{tool.context}</Section>}
+          {tool.preview && tool.status === "running" && <Section label="streaming">{tool.preview}</Section>}
+          {tool.inline_diff && <Section label="diff"><pre className="whitespace-pre overflow-x-auto text-[0.7rem] leading-snug">{tool.inline_diff}</pre></Section>}
+          {tool.summary && <Section label="result"><span className="text-foreground/90 whitespace-pre-wrap">{tool.summary}</span></Section>}
+          {tool.error && <Section label="error" tone="error"><span className="text-destructive whitespace-pre-wrap">{tool.error}</span></Section>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Section({ label, children, tone }: { label: string; children: React.ReactNode; tone?: "error" }) {
+  return (
+    <div className="flex gap-3">
+      <span className={`uppercase tracking-wider text-[0.6rem] shrink-0 w-14 pt-0.5 ${tone === "error" ? "text-destructive/80" : "text-muted-foreground/60"}`}>{label}</span>
+      <div className="flex-1 min-w-0 text-muted-foreground">{children}</div>
+    </div>
+  );
+}
+
+function fmtElapsed(ms: number): string {
+  const sec = Math.max(0, ms) / 1000;
+  if (sec < 1) return `${Math.round(ms)}ms`;
+  if (sec < 10) return `${sec.toFixed(1)}s`;
+  if (sec < 60) return `${Math.round(sec)}s`;
+  const m = Math.floor(sec / 60);
+  const s = Math.round(sec % 60);
+  return s ? `${m}m ${s}s` : `${m}m`;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -173,3 +173,16 @@ code { font-size: 0.875rem; }
   display: none;
 }
 
+/* Mobile Safari / in-app browsers can add aggressive tap highlights to code
+   blocks and preformatted regions. Keep code readable and selection-driven
+   instead of flashing a filled overlay on tap. */
+pre,
+code {
+  -webkit-tap-highlight-color: transparent;
+}
+
+pre {
+  user-select: text;
+  -webkit-user-select: text;
+}
+

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -1,0 +1,163 @@
+export type GatewayEventName =
+  | "gateway.ready"
+  | "session.info"
+  | "message.start"
+  | "message.delta"
+  | "message.complete"
+  | "tool.start"
+  | "tool.progress"
+  | "tool.complete"
+  | "error"
+  | (string & {});
+
+export interface GatewayEvent<P = unknown> {
+  type: GatewayEventName;
+  session_id?: string;
+  payload?: P;
+}
+
+export type ConnectionState = "idle" | "connecting" | "open" | "closed" | "error";
+
+interface Pending {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+export class GatewayClient {
+  private ws: WebSocket | null = null;
+  private reqId = 0;
+  private pending = new Map<string, Pending>();
+  private listeners = new Map<string, Set<(ev: GatewayEvent) => void>>();
+  private _state: ConnectionState = "idle";
+  private stateListeners = new Set<(s: ConnectionState) => void>();
+
+  get state(): ConnectionState {
+    return this._state;
+  }
+
+  private setState(s: ConnectionState) {
+    if (this._state === s) return;
+    this._state = s;
+    for (const cb of this.stateListeners) cb(s);
+  }
+
+  onState(cb: (s: ConnectionState) => void): () => void {
+    this.stateListeners.add(cb);
+    cb(this._state);
+    return () => this.stateListeners.delete(cb);
+  }
+
+  on<P = unknown>(type: GatewayEventName, cb: (ev: GatewayEvent<P>) => void): () => void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(cb as (ev: GatewayEvent) => void);
+    return () => set!.delete(cb as (ev: GatewayEvent) => void);
+  }
+
+  async connect(token?: string): Promise<void> {
+    if (this._state === "open" || this._state === "connecting") return;
+    this.setState("connecting");
+
+    const resolved = token ?? window.__HERMES_SESSION_TOKEN__ ?? "";
+    if (!resolved) {
+      this.setState("error");
+      throw new Error("Session token not available — page must be served by the Hermes dashboard");
+    }
+
+    const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(`${scheme}//${location.host}/api/ws?token=${encodeURIComponent(resolved)}`);
+    this.ws = ws;
+
+    await new Promise<void>((resolve, reject) => {
+      const onOpen = () => {
+        ws.removeEventListener("error", onError);
+        this.setState("open");
+        resolve();
+      };
+      const onError = () => {
+        ws.removeEventListener("open", onOpen);
+        this.setState("error");
+        reject(new Error("WebSocket connection failed"));
+      };
+      ws.addEventListener("open", onOpen, { once: true });
+      ws.addEventListener("error", onError, { once: true });
+    });
+
+    ws.addEventListener("message", (ev) => {
+      try {
+        this.dispatch(JSON.parse(ev.data));
+      } catch {
+        // ignore malformed frames
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      this.setState("closed");
+      this.rejectAllPending(new Error("WebSocket closed"));
+    });
+  }
+
+  close() {
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  private dispatch(msg: Record<string, unknown>) {
+    const id = msg.id as string | undefined;
+    if (id !== undefined && this.pending.has(id)) {
+      const p = this.pending.get(id)!;
+      this.pending.delete(id);
+      clearTimeout(p.timer);
+      const err = msg.error as { message?: string } | undefined;
+      if (err) p.reject(new Error(err.message ?? "request failed"));
+      else p.resolve(msg.result);
+      return;
+    }
+
+    if (msg.method !== "event") return;
+    const params = (msg.params ?? {}) as GatewayEvent;
+    if (typeof params.type !== "string") return;
+    for (const cb of this.listeners.get(params.type) ?? []) cb(params);
+  }
+
+  private rejectAllPending(err: Error) {
+    for (const p of this.pending.values()) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  request<T = unknown>(method: string, params: Record<string, unknown> = {}, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<T> {
+    if (!this.ws || this._state !== "open") {
+      return Promise.reject(new Error(`gateway not connected (state=${this._state})`));
+    }
+
+    const id = `w${++this.reqId}`;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) reject(new Error(`request timed out: ${method}`));
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        resolve: (v) => resolve(v as T),
+        reject,
+        timer,
+      });
+
+      try {
+        this.ws!.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      } catch (e) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+  }
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
 import { AlertCircle, Copy, RefreshCw, Send, Square } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 type MessageRole = "user" | "assistant" | "system";
 
@@ -58,6 +58,7 @@ export default function ChatPage() {
   const transcriptEndRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const resumeId = searchParams.get("resume") ?? "";
 
@@ -90,7 +91,7 @@ export default function ChatPage() {
 
   const pushSystem = useCallback((text: string) => pushMessage("system", text), [pushMessage]);
 
-  const bootstrap = useCallback(async () => {
+  const bootstrap = useCallback(async (opts?: { fresh?: boolean }) => {
     const seq = ++bootstrapSeqRef.current;
     setEntries([]);
     setSessionId("");
@@ -176,7 +177,7 @@ export default function ChatPage() {
     try {
       await gw.connect();
       if (!isCurrent()) return;
-      if (resumeId) {
+      if (resumeId && !opts?.fresh) {
         const resp = await gw.request<SessionResumeResponse>("session.resume", { session_id: resumeId, cols: 100 });
         if (!isCurrent()) return;
         setSessionId(resp.session_id);
@@ -192,6 +193,11 @@ export default function ChatPage() {
       setConnectError(err instanceof Error ? err.message : String(err));
     }
   }, [pushMessage, pushSystem, resumeId, updateStreamingAssistant]);
+
+  const startNewSession = useCallback(() => {
+    if (resumeId) navigate("/chat", { replace: true });
+    void bootstrap({ fresh: true });
+  }, [bootstrap, navigate, resumeId]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -264,8 +270,8 @@ export default function ChatPage() {
               <Copy className="h-3.5 w-3.5" /> {sessionId}
             </button>
           )}
-          <Button onClick={bootstrap} variant="outline" size="sm">
-            <RefreshCw className="h-3.5 w-3.5" /> Reset
+          <Button onClick={startNewSession} variant="outline" size="sm">
+            <RefreshCw className="h-3.5 w-3.5" /> New session
           </Button>
           {busy && (
             <Button onClick={interrupt} variant="outline" size="sm">

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,0 +1,358 @@
+import { H2 } from "@nous-research/ui";
+import { Markdown } from "@/components/Markdown";
+import { ToolCall, type ToolEntry } from "@/components/ToolCall";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import { AlertCircle, Copy, RefreshCw, Send, Square } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+type MessageRole = "user" | "assistant" | "system";
+
+interface TextMessage {
+  kind: "message";
+  id: string;
+  role: MessageRole;
+  text: string;
+  streaming?: boolean;
+  error?: boolean;
+}
+
+type ChatEntry = TextMessage | ToolEntry;
+
+interface HydratedMessage {
+  role: "user" | "assistant" | "system" | "tool";
+  text?: string;
+  name?: string;
+  context?: string;
+}
+
+interface SessionResumeResponse {
+  session_id: string;
+  resumed: string;
+  message_count: number;
+  messages: HydratedMessage[];
+}
+
+interface SessionInfoPayload {
+  model?: string;
+  provider?: string;
+  cwd?: string;
+}
+
+const STATE_BADGE: Record<ConnectionState, "outline" | "warning" | "success" | "destructive"> = {
+  idle: "outline",
+  connecting: "warning",
+  open: "success",
+  closed: "outline",
+  error: "destructive",
+};
+
+const randId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+export default function ChatPage() {
+  const gwRef = useRef<GatewayClient | null>(null);
+  const transcriptEndRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const [searchParams] = useSearchParams();
+  const resumeId = searchParams.get("resume") ?? "";
+
+  const [connState, setConnState] = useState<ConnectionState>("idle");
+  const [sessionId, setSessionId] = useState("");
+  const [sessionInfo, setSessionInfo] = useState<SessionInfoPayload | null>(null);
+  const [entries, setEntries] = useState<ChatEntry[]>([]);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [connectError, setConnectError] = useState("");
+  const [runtimeError, setRuntimeError] = useState("");
+
+  const updateStreamingAssistant = useCallback((fn: (m: TextMessage) => TextMessage) => {
+    setEntries((list) => {
+      for (let i = list.length - 1; i >= 0; i--) {
+        const e = list[i];
+        if (e.kind === "message" && e.role === "assistant" && e.streaming) {
+          const next = list.slice();
+          next[i] = fn(e);
+          return next;
+        }
+      }
+      return list;
+    });
+  }, []);
+
+  const pushMessage = useCallback((role: MessageRole, text: string, extra: Partial<TextMessage> = {}) => {
+    setEntries((list) => [...list, { kind: "message", id: randId(role[0]), role, text, ...extra }]);
+  }, []);
+
+  const pushSystem = useCallback((text: string) => pushMessage("system", text), [pushMessage]);
+
+  const bootstrap = useCallback(async () => {
+    setEntries([]);
+    setSessionId("");
+    setSessionInfo(null);
+    setBusy(false);
+    setConnectError("");
+    setRuntimeError("");
+
+    gwRef.current?.close();
+    const gw = new GatewayClient();
+    gwRef.current = gw;
+    gw.onState(setConnState);
+
+    gw.on<SessionInfoPayload>("session.info", (ev) => {
+      if (ev.payload) setSessionInfo(ev.payload);
+    });
+
+    gw.on("message.start", () => {
+      pushMessage("assistant", "", { streaming: true });
+      setBusy(true);
+    });
+
+    gw.on<{ text?: string }>("message.delta", (ev) => {
+      const delta = ev.payload?.text ?? "";
+      if (!delta) return;
+      updateStreamingAssistant((m) => ({ ...m, text: m.text + delta }));
+    });
+
+    gw.on<{ text?: string }>("message.complete", (ev) => {
+      updateStreamingAssistant((m) => ({ ...m, text: ev.payload?.text ?? m.text, streaming: false }));
+      setBusy(false);
+    });
+
+    gw.on<{ tool_id: string; name?: string; context?: string }>("tool.start", (ev) => {
+      if (!ev.payload) return;
+      const row: ToolEntry = {
+        kind: "tool",
+        id: `t-${ev.payload.tool_id}`,
+        tool_id: ev.payload.tool_id,
+        name: ev.payload.name ?? "tool",
+        context: ev.payload.context,
+        status: "running",
+        startedAt: Date.now(),
+      };
+      setEntries((list) => {
+        for (let i = list.length - 1; i >= 0; i--) {
+          const e = list[i];
+          if (e.kind === "message" && e.role === "assistant" && e.streaming) {
+            return [...list.slice(0, i), row, ...list.slice(i)];
+          }
+        }
+        return [...list, row];
+      });
+    });
+
+    gw.on<{ name?: string; preview?: string }>("tool.progress", (ev) => {
+      const name = ev.payload?.name ?? "";
+      const preview = ev.payload?.preview ?? "";
+      if (!name || !preview) return;
+      setEntries((list) => list.map((e) => e.kind === "tool" && e.status === "running" && e.name === name ? { ...e, preview } : e));
+    });
+
+    gw.on<{ tool_id: string; summary?: string; error?: string; inline_diff?: string }>("tool.complete", (ev) => {
+      if (!ev.payload) return;
+      setEntries((list) => list.map((e) => e.kind === "tool" && e.tool_id === ev.payload!.tool_id ? { ...e, status: ev.payload?.error ? "error" : "done", summary: ev.payload?.summary, error: ev.payload?.error, inline_diff: ev.payload?.inline_diff, completedAt: Date.now() } : e));
+    });
+
+    gw.on<{ message?: string }>("error", (ev) => {
+      setRuntimeError(ev.payload?.message ?? "unknown error");
+      setBusy(false);
+    });
+
+    try {
+      await gw.connect();
+      if (resumeId) {
+        const resp = await gw.request<SessionResumeResponse>("session.resume", { session_id: resumeId, cols: 100 });
+        setSessionId(resp.session_id);
+        setEntries(hydrateMessages(resp.messages ?? []));
+        pushSystem(`resumed session ${resp.resumed} · ${resp.message_count ?? resp.messages?.length ?? 0} messages`);
+      } else {
+        const { session_id } = await gw.request<{ session_id: string }>("session.create", { cols: 100 });
+        setSessionId(session_id);
+      }
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : String(err));
+    }
+  }, [pushMessage, pushSystem, resumeId, updateStreamingAssistant]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    bootstrap();
+    return () => {
+      gwRef.current?.close();
+      gwRef.current = null;
+    };
+  }, [bootstrap]);
+
+  useEffect(() => {
+    transcriptEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [entries]);
+
+  const submitUserMessage = useCallback(async (text: string) => {
+    const gw = gwRef.current;
+    const trimmed = text.trim();
+    if (!gw || !sessionId || !trimmed) return;
+    setRuntimeError("");
+    if (trimmed.startsWith("/")) {
+      pushSystem(trimmed);
+      try {
+        const resp = await gw.request<{ output?: string }>("slash.exec", { session_id: sessionId, command: trimmed });
+        if (resp.output) pushSystem(resp.output);
+      } catch (err) {
+        setRuntimeError(err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+
+    pushMessage("user", trimmed);
+    try {
+      await gw.request("prompt.submit", { session_id: sessionId, text: trimmed });
+    } catch (err) {
+      setRuntimeError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+      updateStreamingAssistant((m) => ({ ...m, streaming: false, error: true }));
+    }
+  }, [sessionId, pushMessage, pushSystem, updateStreamingAssistant]);
+
+  const send = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || busy || !sessionId) return;
+    setDraft("");
+    await submitUserMessage(text);
+  }, [busy, draft, sessionId, submitUserMessage]);
+
+  const interrupt = useCallback(() => {
+    gwRef.current?.request("session.interrupt", { session_id: sessionId }).catch(() => {});
+  }, [sessionId]);
+
+  return (
+    <div className="space-y-4 font-courier normal-case">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <H2 variant="sm">Chat</H2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Native dashboard chat over <code>/api/ws</code>, aligned to the built-in Hermes Web UI direction.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={STATE_BADGE[connState]}>{connState}</Badge>
+          {sessionInfo?.model && <Badge variant="outline">{sessionInfo.model}</Badge>}
+          {sessionId && (
+            <button
+              onClick={() => navigator.clipboard?.writeText(sessionId).catch(() => {})}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+              title="Copy session id"
+            >
+              <Copy className="h-3.5 w-3.5" /> {sessionId}
+            </button>
+          )}
+          <Button onClick={bootstrap} variant="outline" size="sm">
+            <RefreshCw className="h-3.5 w-3.5" /> Reset
+          </Button>
+          {busy && (
+            <Button onClick={interrupt} variant="outline" size="sm">
+              <Square className="h-3.5 w-3.5" fill="currentColor" /> Interrupt
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {(connectError || runtimeError) && (
+        <Card className="border-destructive/40 bg-destructive/5">
+          <CardContent className="py-3 flex items-start gap-2 text-sm">
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0 text-destructive" />
+            <div>{connectError || runtimeError}</div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent className="p-0">
+          <div className="min-h-[420px] max-h-[65vh] overflow-y-auto p-4 sm:p-6 space-y-3">
+            {entries.length === 0 && !connectError && (
+              <div className="h-[320px] flex items-center justify-center text-center px-4">
+                <div className="max-w-md space-y-3">
+                  <div className="text-base text-foreground/80">{connState === "open" ? "hermes is ready" : "connecting to gateway…"}</div>
+                  <div className="text-xs text-muted-foreground/70 leading-relaxed">same agent, same tools, now inside the built-in Hermes dashboard.</div>
+                  <div className="text-xs text-muted-foreground/60">Open a past conversation from the Sessions page when you want to resume context.</div>
+                </div>
+              </div>
+            )}
+
+            {entries.map((entry) => entry.kind === "tool" ? <ToolCall key={entry.id} tool={entry} /> : <MessageRow key={entry.id} message={entry} />)}
+            <div ref={transcriptEndRef} />
+          </div>
+
+          <div className="border-t border-border p-3 sm:p-4">
+            <div className="flex items-stretch overflow-hidden rounded-md border border-border bg-background/40">
+              <textarea
+                ref={textareaRef}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                    void send();
+                  }
+                }}
+                placeholder={connState !== "open" ? "waiting for gateway…" : "message hermes… (Enter to send, Shift+Enter for newline, / for slash commands)"}
+                rows={1}
+                className="flex-1 resize-none bg-transparent px-3.5 py-2.5 text-sm leading-relaxed placeholder:text-muted-foreground/50 focus:outline-none min-h-[44px] max-h-[200px]"
+                style={{ fieldSizing: "content" } as React.CSSProperties}
+                disabled={connState !== "open" || !sessionId}
+              />
+              <button
+                type="button"
+                onClick={() => void send()}
+                disabled={connState !== "open" || !sessionId || busy || draft.trim().length === 0}
+                aria-label="Send message"
+                className="shrink-0 w-11 flex items-center justify-center border-l border-border bg-foreground/90 text-background transition-colors cursor-pointer hover:bg-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <Send className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="text-xs text-muted-foreground">
+        Resume older conversations from <Link to="/sessions" className="underline hover:text-foreground">Sessions</Link>.
+      </div>
+    </div>
+  );
+}
+
+function MessageRow({ message }: { message: TextMessage }) {
+  if (message.role === "user") {
+    return <div className="flex justify-end"><div className="max-w-[80%] rounded-lg bg-primary text-primary-foreground px-3 py-2 whitespace-pre-wrap text-sm">{message.text}</div></div>;
+  }
+  if (message.role === "system") {
+    return <div className="flex justify-center"><div className="max-w-full rounded-md border border-dashed border-border bg-muted/20 px-3 py-1.5 text-xs text-muted-foreground font-mono whitespace-pre-wrap">{message.text}</div></div>;
+  }
+  return (
+    <div className="flex justify-start">
+      <div className={`max-w-[85%] rounded-lg border px-3.5 py-2.5 ${message.error ? "border-destructive/50 bg-destructive/5" : "border-border bg-muted/30"}`}>
+        {message.text ? <Markdown content={message.text} /> : <span className="inline-flex items-center gap-1 text-muted-foreground text-sm italic">thinking…</span>}
+      </div>
+    </div>
+  );
+}
+
+function hydrateMessages(list: HydratedMessage[]): ChatEntry[] {
+  return list.map((m, i): ChatEntry => m.role === "tool" ? {
+    kind: "tool",
+    id: `h-tool-${i}`,
+    tool_id: `h-tool-${i}`,
+    name: m.name ?? "tool",
+    context: m.context || undefined,
+    status: "done",
+    startedAt: 0,
+  } : {
+    kind: "message",
+    id: `h-msg-${i}`,
+    role: m.role,
+    text: m.text ?? "",
+  });
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -54,6 +54,7 @@ const randId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toSt
 
 export default function ChatPage() {
   const gwRef = useRef<GatewayClient | null>(null);
+  const bootstrapSeqRef = useRef(0);
   const transcriptEndRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -90,6 +91,7 @@ export default function ChatPage() {
   const pushSystem = useCallback((text: string) => pushMessage("system", text), [pushMessage]);
 
   const bootstrap = useCallback(async () => {
+    const seq = ++bootstrapSeqRef.current;
     setEntries([]);
     setSessionId("");
     setSessionInfo(null);
@@ -100,30 +102,38 @@ export default function ChatPage() {
     gwRef.current?.close();
     const gw = new GatewayClient();
     gwRef.current = gw;
-    gw.onState(setConnState);
+
+    const isCurrent = () => gwRef.current === gw && bootstrapSeqRef.current === seq;
+
+    gw.onState((state) => {
+      if (isCurrent()) setConnState(state);
+    });
 
     gw.on<SessionInfoPayload>("session.info", (ev) => {
-      if (ev.payload) setSessionInfo(ev.payload);
+      if (isCurrent() && ev.payload) setSessionInfo(ev.payload);
     });
 
     gw.on("message.start", () => {
+      if (!isCurrent()) return;
       pushMessage("assistant", "", { streaming: true });
       setBusy(true);
     });
 
     gw.on<{ text?: string }>("message.delta", (ev) => {
+      if (!isCurrent()) return;
       const delta = ev.payload?.text ?? "";
       if (!delta) return;
       updateStreamingAssistant((m) => ({ ...m, text: m.text + delta }));
     });
 
     gw.on<{ text?: string }>("message.complete", (ev) => {
+      if (!isCurrent()) return;
       updateStreamingAssistant((m) => ({ ...m, text: ev.payload?.text ?? m.text, streaming: false }));
       setBusy(false);
     });
 
     gw.on<{ tool_id: string; name?: string; context?: string }>("tool.start", (ev) => {
-      if (!ev.payload) return;
+      if (!isCurrent() || !ev.payload) return;
       const row: ToolEntry = {
         kind: "tool",
         id: `t-${ev.payload.tool_id}`,
@@ -145,6 +155,7 @@ export default function ChatPage() {
     });
 
     gw.on<{ name?: string; preview?: string }>("tool.progress", (ev) => {
+      if (!isCurrent()) return;
       const name = ev.payload?.name ?? "";
       const preview = ev.payload?.preview ?? "";
       if (!name || !preview) return;
@@ -152,27 +163,32 @@ export default function ChatPage() {
     });
 
     gw.on<{ tool_id: string; summary?: string; error?: string; inline_diff?: string }>("tool.complete", (ev) => {
-      if (!ev.payload) return;
+      if (!isCurrent() || !ev.payload) return;
       setEntries((list) => list.map((e) => e.kind === "tool" && e.tool_id === ev.payload!.tool_id ? { ...e, status: ev.payload?.error ? "error" : "done", summary: ev.payload?.summary, error: ev.payload?.error, inline_diff: ev.payload?.inline_diff, completedAt: Date.now() } : e));
     });
 
     gw.on<{ message?: string }>("error", (ev) => {
+      if (!isCurrent()) return;
       setRuntimeError(ev.payload?.message ?? "unknown error");
       setBusy(false);
     });
 
     try {
       await gw.connect();
+      if (!isCurrent()) return;
       if (resumeId) {
         const resp = await gw.request<SessionResumeResponse>("session.resume", { session_id: resumeId, cols: 100 });
+        if (!isCurrent()) return;
         setSessionId(resp.session_id);
         setEntries(hydrateMessages(resp.messages ?? []));
         pushSystem(`resumed session ${resp.resumed} · ${resp.message_count ?? resp.messages?.length ?? 0} messages`);
       } else {
         const { session_id } = await gw.request<{ session_id: string }>("session.create", { cols: 100 });
+        if (!isCurrent()) return;
         setSessionId(session_id);
       }
     } catch (err) {
+      if (!isCurrent()) return;
       setConnectError(err instanceof Error ? err.message : String(err));
     }
   }, [pushMessage, pushSystem, resumeId, updateStreamingAssistant]);

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
+import { Link } from "react-router-dom";
 import {
   ChevronDown,
   ChevronLeft,
@@ -329,6 +330,13 @@ function SessionRow({
           <Badge variant="outline" className="text-[10px]">
             {session.source ?? "local"}
           </Badge>
+          <Link
+            to={`/chat?resume=${encodeURIComponent(session.id)}`}
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex items-center justify-center gap-2 whitespace-nowrap font-mondwest text-[0.6rem] tracking-[0.1em] uppercase transition-colors cursor-pointer h-7 px-2 border border-border bg-transparent hover:bg-foreground/10 hover:text-foreground"
+          >
+            Open in chat
+          </Link>
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
## Summary

Adds a native `/chat` page to the built-in dashboard on top of the transport foundation from #14814.

The browser client speaks the same `tui_gateway` JSON-RPC event model used by `hermes --tui`, so the built-in Web UI can create/resume sessions, stream assistant output, show live tool activity, and interrupt runs without introducing a separate browser-only backend.

## Why

Once the transport layer exists, the next focused change is the smallest useful built-in dashboard chat UI.

This PR is intentionally scoped as that single logical change:

- browser chat UX on top of the transport in #14814
- not a broader redesign of all dashboard UX
- not a second backend service just for web chat

That keeps the review question narrow:

> Is this the right MVP surface for native dashboard chat on top of the transport foundation?

## What changed

- added `web/src/lib/gatewayClient.ts`
  - browser WebSocket client for `tui_gateway` JSON-RPC
  - RPC request/response tracking
  - event subscription for streaming updates
- added `web/src/components/ToolCall.tsx`
  - tool start / progress / complete rendering
- added `web/src/pages/ChatPage.tsx`
  - create new session
  - resume existing session
  - stream assistant output
  - support slash commands
  - support interrupt
  - support a true **New session** flow even when arriving via `?resume=`
- updated `web/src/App.tsx`
  - adds `/chat` route
- updated `web/src/pages/SessionsPage.tsx`
  - adds open-in-chat entry point
- updated `web/src/index.css`
  - chat transcript and mobile-safe layout styling

## How to test

```bash
npm run build
python -m pytest tests/hermes_cli/test_web_server.py -q
```

Manual verification:

1. launch the built-in dashboard
2. open `/chat`
3. create a new session and send a prompt
4. confirm streaming assistant output appears live
5. confirm tool cards appear during tool execution
6. interrupt an active run
7. open a past session from `/sessions`
8. confirm `New session` starts a fresh chat instead of reusing the resumed session

## Tested on

- Ubuntu Linux

Observed locally after rebasing onto current `main` and #14814:

- `npm run build` ✅
- `123 passed` — `python -m pytest tests/hermes_cli/test_web_server.py -q`
- manual smoke test confirmed `/chat` loads, streams, resumes, interrupts, and starts a genuinely fresh session

## Cross-platform impact

This change is dashboard/frontend code plus browser WebSocket usage on top of the existing FastAPI server. It does not add platform-specific shell behavior.

I only tested on Linux, so browser/platform verification on Windows/macOS would still be useful.

## Related issues / PRs

- Refs #8183
- Depends on #14814
- Refs #501
- Refs #12710
- Refs #13379
- Refs #13823

## Notes for reviewers

- This is intentionally the smallest useful built-in dashboard chat MVP.
- It reuses the existing Hermes session model instead of adding a separate web-only chat backend.
- Presentation polish is still possible later, but the core question here is whether this is the right native dashboard path once the transport exists.
