### PR TITLE
feat(image_gen): add per-call Codex output controls

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -1,7 +1,7 @@
 """OpenAI image generation backend — ChatGPT/Codex OAuth variant.
 
 Identical model catalog and tier semantics to the ``openai`` image-gen plugin
-(``gpt-image-2`` at low/medium/high quality), but routes the request through
+(``gpt-image-2`` at auto/low/medium/high quality), but routes the request through
 the Codex Responses API ``image_generation`` tool instead of the
 ``images.generate`` REST endpoint. This lets users who are already
 authenticated with Codex/ChatGPT generate images without configuring a
@@ -9,17 +9,21 @@ separate ``OPENAI_API_KEY``.
 
 Selection precedence for the tier (first hit wins):
 
-1. ``OPENAI_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
-2. ``image_gen.openai-codex.model`` in ``config.yaml``
-3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
-4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
+1. Per-call ``quality`` override (``auto``, ``low``, ``medium``, ``high``)
+2. ``OPENAI_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
+3. ``image_gen.openai-codex.model`` in ``config.yaml``
+4. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
+5. :data:`DEFAULT_MODEL` — ``gpt-image-2-auto``
 
-Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
+Output is saved under ``$HERMES_HOME/cache/images/`` using the requested format
+(``png`` by default, or ``jpeg``/``webp`` when selected per call).
 """
 
 from __future__ import annotations
 
 import logging
+import re
+import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -41,6 +45,12 @@ logger = logging.getLogger(__name__)
 API_MODEL = "gpt-image-2"
 
 _MODELS: Dict[str, Dict[str, Any]] = {
+    "gpt-image-2-auto": {
+        "display": "GPT Image 2 (Auto)",
+        "speed": "varies",
+        "strengths": "Provider-selected balance of quality, latency, and cost",
+        "quality": "auto",
+    },
     "gpt-image-2-low": {
         "display": "GPT Image 2 (Low)",
         "speed": "~15s",
@@ -61,13 +71,22 @@ _MODELS: Dict[str, Dict[str, Any]] = {
     },
 }
 
-DEFAULT_MODEL = "gpt-image-2-medium"
+DEFAULT_MODEL = "gpt-image-2-auto"
+
+_QUALITY_TO_TIER = {
+    "low": "gpt-image-2-low",
+    "medium": "gpt-image-2-medium",
+    "high": "gpt-image-2-high",
+}
+_VALID_QUALITIES = {"auto", "low", "medium", "high"}
+_VALID_OUTPUT_FORMATS = {"png", "jpeg", "webp"}
 
 _SIZES = {
     "landscape": "1536x1024",
     "square": "1024x1024",
     "portrait": "1024x1536",
 }
+_SIZE_RE = re.compile(r"^(\d+)x(\d+)$")
 
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
@@ -124,6 +143,103 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+def _validate_gpt_image_2_size(size: str) -> Optional[str]:
+    """Return an error message when *size* violates gpt-image-2 limits."""
+    if size == "auto":
+        return None
+    match = _SIZE_RE.match(size)
+    if not match:
+        return "size must be 'auto' or '<width>x<height>'"
+    width = int(match.group(1))
+    height = int(match.group(2))
+    if width <= 0 or height <= 0:
+        return "width and height must be positive integers"
+    pixels = width * height
+    if width % 16 != 0 or height % 16 != 0:
+        return "both width and height must be multiples of 16"
+    if max(width, height) >= 3840:
+        return "maximum edge length must be less than 3840px"
+    if max(width / height, height / width) > 3:
+        return "aspect ratio must not exceed 3:1"
+    if pixels < 655_360:
+        return "total pixels must be at least 655,360"
+    if pixels > 8_294_400:
+        return "total pixels must not exceed 8,294,400"
+    return None
+
+
+def _resolve_generation_options(
+    *,
+    aspect: str,
+    quality: Optional[str] = None,
+    size: Optional[str] = None,
+    output_format: Optional[str] = None,
+    output_compression: Optional[Any] = None,
+) -> Tuple[
+    Optional[str], Optional[Dict[str, Any]], Optional[str], Optional[str],
+    Optional[str], Optional[int], Optional[str],
+]:
+    """Resolve tier/model, API quality, size, format, and compression.
+
+    Returns ``(tier_id, meta, api_quality, api_size, output_format,
+    output_compression, error)``. ``quality='auto'`` is passed through to the
+    API without pinning a low/medium/high tier.
+    """
+    tier_id, meta = _resolve_model()
+    api_quality = meta["quality"]
+
+    if quality is not None:
+        quality = str(quality).strip().lower()
+        if quality:
+            if quality not in _VALID_QUALITIES:
+                return None, None, None, None, None, None, (
+                    "quality must be one of: auto, low, medium, high"
+                )
+            api_quality = quality
+            if quality == "auto":
+                tier_id = "gpt-image-2-auto"
+                meta = _MODELS[tier_id]
+            else:
+                tier_id = _QUALITY_TO_TIER[quality]
+                meta = _MODELS[tier_id]
+
+    api_size = _SIZES.get(aspect, _SIZES["square"])
+    if size is not None:
+        size = str(size).strip().lower()
+        if size:
+            error = _validate_gpt_image_2_size(size)
+            if error:
+                return None, None, None, None, None, None, f"Invalid size '{size}': {error}"
+            api_size = size
+
+    api_format = "png"
+    if output_format is not None:
+        api_format = str(output_format).strip().lower()
+        if api_format not in _VALID_OUTPUT_FORMATS:
+            return None, None, None, None, None, None, (
+                "output_format must be one of: png, jpeg, webp"
+            )
+
+    api_compression: Optional[int] = None
+    if output_compression is not None:
+        if api_format not in {"jpeg", "webp"}:
+            return None, None, None, None, None, None, (
+                "output_compression is only supported with jpeg/webp output_format"
+            )
+        try:
+            api_compression = int(output_compression)
+        except (TypeError, ValueError):
+            return None, None, None, None, None, None, (
+                "output_compression must be an integer from 0 to 100"
+            )
+        if not 0 <= api_compression <= 100:
+            return None, None, None, None, None, None, (
+                "output_compression must be an integer from 0 to 100"
+            )
+
+    return tier_id, meta, api_quality, api_size, api_format, api_compression, None
+
+
 def _read_codex_access_token() -> Optional[str]:
     """Return a usable Codex OAuth token, or None.
 
@@ -161,47 +277,69 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    output_format: str = "png",
+    output_compression: Optional[int] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
+    tool: Dict[str, Any] = {
+        "type": "image_generation",
+        "model": API_MODEL,
+        "size": size,
+        "quality": quality,
+        "output_format": output_format,
+        "background": "opaque",
+        "partial_images": 0,
+    }
+    if output_compression is not None:
+        tool["output_compression"] = output_compression
 
-    with client.responses.stream(
-        model=_CODEX_CHAT_MODEL,
-        store=False,
-        instructions=_CODEX_INSTRUCTIONS,
-        input=[{
-            "type": "message",
-            "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
-        }],
-        tools=[{
-            "type": "image_generation",
-            "model": API_MODEL,
-            "size": size,
-            "quality": quality,
-            "output_format": "png",
-            "background": "opaque",
-            "partial_images": 1,
-        }],
-        tool_choice={
-            "type": "allowed_tools",
-            "mode": "required",
-            "tools": [{"type": "image_generation"}],
-        },
-    ) as stream:
-        for event in stream:
-            event_type = getattr(event, "type", "")
-            if event_type == "response.output_item.done":
-                item = getattr(event, "item", None)
-                if getattr(item, "type", None) == "image_generation_call":
-                    result = getattr(item, "result", None)
-                    if isinstance(result, str) and result:
-                        image_b64 = result
-            elif event_type == "response.image_generation_call.partial_image":
-                partial = getattr(event, "partial_image_b64", None)
-                if isinstance(partial, str) and partial:
-                    image_b64 = partial
-        final = stream.get_final_response()
+    # OpenAI SDK 2.31.0 can emit noisy Pydantic serializer warnings when the
+    # API returns gpt-image-2 fields its generated response schema has not yet
+    # learned, especially custom sizes such as 1152x2496. The API accepts these
+    # values and generation succeeds; keep this quirk scoped to the Codex image
+    # stream so CLI users do not see alarming warnings for valid requests.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Pydantic serializer warnings:.*",
+            category=UserWarning,
+        )
+        with client.responses.stream(
+            model=_CODEX_CHAT_MODEL,
+            store=False,
+            instructions=_CODEX_INSTRUCTIONS,
+            input=[{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt}],
+            }],
+            tools=[tool],
+            tool_choice={
+                "type": "allowed_tools",
+                "mode": "required",
+                "tools": [{"type": "image_generation"}],
+            },
+        ) as stream:
+            for event in stream:
+                event_type = getattr(event, "type", "")
+                if event_type == "response.output_item.done":
+                    item = getattr(event, "item", None)
+                    if getattr(item, "type", None) == "image_generation_call":
+                        result = getattr(item, "result", None)
+                        if isinstance(result, str) and result:
+                            image_b64 = result
+                elif event_type == "response.image_generation_call.partial_image":
+                    partial = getattr(event, "partial_image_b64", None)
+                    if isinstance(partial, str) and partial:
+                        image_b64 = partial
+            final = stream.get_final_response()
 
     # Final-response sweep covers the case where the stream finished before
     # we observed the ``output_item.done`` event for the image call.
@@ -304,8 +442,21 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        tier_id, meta, api_quality, size, output_format, output_compression, option_error = _resolve_generation_options(
+            aspect=aspect,
+            quality=kwargs.get("quality"),
+            size=kwargs.get("size"),
+            output_format=kwargs.get("output_format"),
+            output_compression=kwargs.get("output_compression"),
+        )
+        if option_error:
+            return error_response(
+                error=option_error,
+                error_type="invalid_argument",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
 
         client = _build_codex_client()
         if client is None:
@@ -323,7 +474,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 client,
                 prompt=prompt,
                 size=size,
-                quality=meta["quality"],
+                quality=api_quality,
+                output_format=output_format,
+                output_compression=output_compression,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
@@ -347,7 +500,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             )
 
         try:
-            saved_path = save_b64_image(b64, prefix=f"openai_codex_{tier_id}")
+            saved_path = save_b64_image(
+                b64,
+                prefix=f"openai_codex_{tier_id}",
+                extension=output_format,
+            )
         except Exception as exc:
             return error_response(
                 error=f"Could not save image to cache: {exc}",
@@ -364,7 +521,12 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra={
+                "size": size,
+                "quality": api_quality,
+                "output_format": output_format,
+                "output_compression": output_compression,
+            },
         )
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -9,6 +9,7 @@ endpoint.
 from __future__ import annotations
 
 import importlib
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -51,6 +52,24 @@ class _FakeStream:
         return self._final
 
 
+class _WarningFakeStream(_FakeStream):
+    def __iter__(self):
+        warnings.warn(
+            "Pydantic serializer warnings: simulated stale ImageGeneration schema",
+            UserWarning,
+            stacklevel=2,
+        )
+        return super().__iter__()
+
+    def get_final_response(self):
+        warnings.warn(
+            "Pydantic serializer warnings: simulated stale ImageGeneration schema",
+            UserWarning,
+            stacklevel=2,
+        )
+        return super().get_final_response()
+
+
 @pytest.fixture(autouse=True)
 def _tmp_hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -75,11 +94,16 @@ class TestMetadata:
         assert provider.display_name == "OpenAI (Codex auth)"
 
     def test_default_model(self, provider):
-        assert provider.default_model() == "gpt-image-2-medium"
+        assert provider.default_model() == "gpt-image-2-auto"
 
-    def test_list_models_three_tiers(self, provider):
+    def test_list_models_includes_auto_and_three_explicit_tiers(self, provider):
         ids = [m["id"] for m in provider.list_models()]
-        assert ids == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        assert ids == [
+            "gpt-image-2-auto",
+            "gpt-image-2-low",
+            "gpt-image-2-medium",
+            "gpt-image-2-high",
+        ]
 
     def test_setup_schema_has_no_required_env_vars(self, provider):
         schema = provider.get_setup_schema()
@@ -147,9 +171,9 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="landscape")
 
         assert result["success"] is True
-        assert result["model"] == "gpt-image-2-medium"
+        assert result["model"] == "gpt-image-2-auto"
         assert result["provider"] == "openai-codex"
-        assert result["quality"] == "medium"
+        assert result["quality"] == "auto"
 
         saved = Path(result["image"])
         assert saved.exists()
@@ -193,11 +217,150 @@ class TestGenerate:
         tool = captured["tools"][0]
         assert tool["type"] == "image_generation"
         assert tool["model"] == "gpt-image-2"
-        assert tool["quality"] == "medium"
+        assert tool["quality"] == "auto"
         assert tool["size"] == "1024x1536"
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
-        assert tool["partial_images"] == 1
+        assert tool["partial_images"] == 0
+
+    def test_per_call_quality_and_custom_size_override_request_shape(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate(
+            "a detailed cyberpunk iPhone wallpaper with readable micro-signage",
+            aspect_ratio="portrait",
+            quality="high",
+            size="1152x2496",
+        )
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-high"
+        assert result["quality"] == "high"
+        assert result["size"] == "1152x2496"
+        tool = captured["tools"][0]
+        assert tool["quality"] == "high"
+        assert tool["size"] == "1152x2496"
+
+    def test_per_call_format_and_compression_override_request_shape(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate(
+            "a moody editorial photo of a glass city at dawn",
+            output_format="webp",
+            output_compression=85,
+        )
+
+        assert result["success"] is True
+        assert result["output_format"] == "webp"
+        assert result["output_compression"] == 85
+        assert Path(result["image"]).suffix == ".webp"
+        tool = captured["tools"][0]
+        assert tool["output_format"] == "webp"
+        assert tool["output_compression"] == 85
+
+    @pytest.mark.parametrize("bad_format", ["gif", "bmp", ""])
+    def test_invalid_output_format_returns_invalid_argument(self, provider, monkeypatch, bad_format):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        result = provider.generate("a cat", output_format=bad_format)
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    @pytest.mark.parametrize("bad_compression", [-1, 101, "crunchy"])
+    def test_invalid_output_compression_returns_invalid_argument(self, provider, monkeypatch, bad_compression):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        result = provider.generate("a cat", output_format="webp", output_compression=bad_compression)
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_png_rejects_output_compression(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        result = provider.generate("a cat", output_format="png", output_compression=80)
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "jpeg/webp" in result["error"]
+
+    def test_per_call_quality_auto_is_forwarded_without_pinning_tier(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a polished app hero screen", quality="auto", size="auto")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-auto"
+        assert result["quality"] == "auto"
+        assert result["size"] == "auto"
+        tool = captured["tools"][0]
+        assert tool["quality"] == "auto"
+        assert tool["size"] == "auto"
+
+    @pytest.mark.parametrize("bad_size", [
+        "1150x2496", "4000x2000", "512x512", "3000x1000",
+        "0x1024", "1024x0", "-1024x1024", "1024x-1024",
+    ])
+    def test_invalid_custom_size_returns_invalid_argument(self, provider, monkeypatch, bad_size):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        result = provider.generate("a cat", size=bad_size)
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert bad_size in result["error"]
 
     def test_partial_image_event_used_when_done_missing(self, provider, monkeypatch):
         """If the stream never emits output_item.done, fall back to the
@@ -244,6 +407,43 @@ class TestGenerate:
         result = provider.generate("a cat")
         assert result["success"] is True
         assert Path(result["image"]).exists()
+
+    def test_stale_openai_sdk_pydantic_warning_is_suppressed(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        output_item = SimpleNamespace(
+            type="image_generation_call",
+            status="completed",
+            id="ig_warning",
+            result=_b64_png(),
+        )
+        done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+        final_response = SimpleNamespace(output=[], status="completed", output_text="")
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                stream=lambda **kwargs: _WarningFakeStream([done_event], final_response)
+            )
+        )
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = provider.generate(
+                "a detailed Hermes Agent iPhone launch screen with terminal glyphs",
+                aspect_ratio="portrait",
+                quality="auto",
+                size="1152x2496",
+                output_format="webp",
+                output_compression=85,
+            )
+
+        assert result["success"] is True
+        assert result["size"] == "1152x2496"
+        assert result["output_format"] == "webp"
+        assert not any(
+            str(warning.message).startswith("Pydantic serializer warnings:")
+            for warning in caught
+        )
 
     def test_empty_response_returns_error(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,16 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_prompt_aspect_and_optional_provider_overrides(self, image_tool):
+        """The agent-facing schema exposes only the prompt plus safe output
+        controls; model/provider selection remains a user-level config choice."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {
+            "prompt", "aspect_ratio", "quality", "size",
+            "output_format", "output_compression",
+        }
+        assert props["quality"]["enum"] == ["auto", "low", "medium", "high"]
+        assert props["output_format"]["enum"] == ["png", "jpeg", "webp"]
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -15,11 +15,14 @@ def _reset_registry():
 
 
 class _FakeCodexProvider(ImageGenProvider):
+    last_kwargs = None
+
     @property
     def name(self) -> str:
         return "codex"
 
     def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        type(self).last_kwargs = kwargs
         return {
             "success": True,
             "image": "/tmp/codex-test.png",
@@ -51,6 +54,37 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_forwards_generation_overrides_to_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+        _FakeCodexProvider.last_kwargs = None
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "draw an intricate neon city map",
+            "portrait",
+            quality="high",
+            size="1152x2496",
+            output_format="webp",
+            output_compression=85,
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert _FakeCodexProvider.last_kwargs == {
+            "quality": "high",
+            "size": "1152x2496",
+            "output_format": "webp",
+            "output_compression": 85,
+        }
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -873,6 +873,26 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "quality": {
+                "type": "string",
+                "enum": ["auto", "low", "medium", "high"],
+                "description": "Optional generation quality override for providers that support it. Low is cheaper/faster, medium is balanced, high gives strongest fidelity; auto lets the provider choose.",
+            },
+            "size": {
+                "type": "string",
+                "description": "Optional provider-specific output size override such as '1024x1024' or '1152x2496'. For gpt-image-2 custom sizes must use multiples of 16 and meet OpenAI's pixel/aspect limits; 'auto' lets the provider choose.",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["png", "jpeg", "webp"],
+                "description": "Optional output format override for providers that support it. PNG is best for UI/text/editing; JPEG/WebP can be smaller for photos or previews.",
+            },
+            "output_compression": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Optional compression level for JPEG/WebP outputs only. Higher values preserve more detail; ignored/invalid for PNG.",
+            },
         },
         "required": ["prompt"],
     },
@@ -900,7 +920,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, **provider_kwargs):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -950,7 +970,16 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        clean_kwargs = {
+            key: value
+            for key, value in provider_kwargs.items()
+            if value is not None and value != ""
+        }
+        result = provider.generate(
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+            **clean_kwargs,
+        )
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
@@ -980,7 +1009,14 @@ def _handle_image_generate(args, **kw):
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(
+        prompt,
+        aspect_ratio,
+        quality=args.get("quality"),
+        size=args.get("size"),
+        output_format=args.get("output_format"),
+        output_compression=args.get("output_compression"),
+    )
     if dispatched is not None:
         return dispatched
 


### PR DESCRIPTION
## What does this PR do?

Adds per-call output controls for the bundled `openai-codex` image generation backend. This lets callers keep `openai-codex` selected globally while overriding safe output options for a single generation:

- `quality`: `auto`, `low`, `medium`, `high`
- `size`: `auto` or a validated custom `WIDTHxHEIGHT` for `gpt-image-2`
- `output_format`: `png`, `jpeg`, `webp`
- `output_compression`: `0-100` for `jpeg`/`webp`

The provider keeps unsafe or currently-unhelpful knobs fixed:

- `background`: remains `opaque` because `gpt-image-2` does not support transparent backgrounds
- `partial_images`: remains `0` to avoid extra image output token cost when Hermes is not surfacing previews
- model selection remains provider-owned (`gpt-image-2`)

The default Codex image tier is now `gpt-image-2-auto`, matching OpenAI's provider-selected quality behavior while still allowing explicit `low`/`medium`/`high` overrides.

## Related Issue

Follow-up to #14317. No separate issue found for per-call `openai-codex` output controls.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/image_generation_tool.py`
  - Exposes optional `quality`, `size`, `output_format`, and `output_compression` arguments in the `image_generate` schema.
  - Forwards those controls to plugin image providers.
- `plugins/image_gen/openai-codex/__init__.py`
  - Adds `gpt-image-2-auto` as the default selectable tier.
  - Resolves per-call quality overrides ahead of env/config defaults.
  - Validates custom `gpt-image-2` sizes against OpenAI constraints.
  - Validates output format and JPEG/WebP compression combinations.
  - Saves generated files with an extension matching the selected output format.
  - Keeps `partial_images=0` to avoid extra preview-token cost.
- Tests
  - Adds coverage for per-call quality, custom size, output format/compression, invalid sizes, and plugin-dispatch forwarding.

## How to Test

1. Select the Codex image backend:
   ```bash
   hermes config set image_gen.provider openai-codex
   hermes config set image_gen.model gpt-image-2-auto
   ```
2. Generate normally, or call `image_generate` with overrides such as:
   - `quality="high"`
   - `size="1152x2496"`
   - `output_format="webp"`
   - `output_compression=85`
3. Run tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_image_gen_picker.py tests/tools/test_image_generation*.py tests/plugins/image_gen/ -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Targeted test suite:

```text
scripts/run_tests.sh tests/hermes_cli/test_image_gen_picker.py tests/tools/test_image_generation*.py tests/plugins/image_gen/ -q

152 passed in 1.49s
```

Full test suite was attempted using the canonical runner with a clean temporary `HERMES_HOME`:

```text
TMP_HERMES_HOME=$(mktemp -d)
ulimit -n 8192
HERMES_HOME="$TMP_HERMES_HOME" scripts/run_tests.sh -q
```

Result in this local macOS environment:

```text
39 failed, 14916 passed, 40 skipped, 149 warnings in 247.94s
```

The failures appear unrelated to this PR (provider switching, WSL/systemd service tests, file write-deny temp paths, transcription local-command detection, process cleanup timing, etc.). The image generation tests touched by this PR pass.