### PR TITLE
feat(api_server): surface prompt-cache tokens and model in usage block

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1030,6 +1030,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "prompt_tokens": usage.get("input_tokens", 0),
                 "completion_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "prompt_tokens_details": {
+                    "cached_tokens": usage.get("cache_read_tokens", 0),
+                },
+                "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                "cache_write_tokens": usage.get("cache_write_tokens", 0),
+                "model": usage.get("model", ""),
             },
         }
 
@@ -1127,7 +1133,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 last_activity = await _emit(delta)
 
             # Get usage from completed agent
-            usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            usage = {
+                "input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+                "cache_read_tokens": 0, "cache_write_tokens": 0, "model": "",
+            }
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
@@ -1143,6 +1152,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     "prompt_tokens": usage.get("input_tokens", 0),
                     "completion_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "prompt_tokens_details": {
+                        "cached_tokens": usage.get("cache_read_tokens", 0),
+                    },
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
+                    "model": usage.get("model", ""),
                 },
             }
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
@@ -1268,7 +1283,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response_text = ""
         agent_error: Optional[str] = None
-        usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        usage: Dict[str, int] = {
+            "input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0, "model": "",
+        }
 
         try:
             # response.created — initial envelope, status=in_progress
@@ -1533,6 +1551,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "input_tokens_details": {
+                        "cached_tokens": usage.get("cache_read_tokens", 0),
+                    },
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
+                    "model": usage.get("model", ""),
                 }
                 await _write_event("response.failed", {
                     "type": "response.failed",
@@ -1545,6 +1569,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "input_tokens_details": {
+                        "cached_tokens": usage.get("cache_read_tokens", 0),
+                    },
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
+                    "model": usage.get("model", ""),
                 }
                 await _write_event("response.completed", {
                     "type": "response.completed",
@@ -1831,6 +1861,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": usage.get("input_tokens", 0),
                 "output_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "input_tokens_details": {
+                    "cached_tokens": usage.get("cache_read_tokens", 0),
+                },
+                "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                "cache_write_tokens": usage.get("cache_write_tokens", 0),
+                "model": usage.get("model", ""),
             },
         }
 
@@ -2203,6 +2239,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0) or 0,
+                "model": getattr(agent, "model", "") or "",
             }
             return result, usage
 
@@ -2372,6 +2411,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                        "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                        "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0) or 0,
+                        "model": getattr(agent, "model", "") or "",
                     }
                     return r, u
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1755,6 +1755,127 @@ class TestUsageCounting:
             assert data["usage"]["total_tokens"] == 280
 
 
+class TestCacheAwareUsage:
+    """Prompt-cache tokens and model are surfaced on every usage block."""
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_exposes_cache_breakdown(self, adapter):
+        mock_result = {"final_response": "Hi", "messages": [], "api_calls": 1}
+        usage = {
+            "input_tokens": 25000,
+            "output_tokens": 5,
+            "total_tokens": 25005,
+            "cache_read_tokens": 22000,
+            "cache_write_tokens": 2500,
+            "model": "claude-opus-4-7",
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 22000
+            assert data["usage"]["cache_read_tokens"] == 22000
+            assert data["usage"]["cache_write_tokens"] == 2500
+            assert data["usage"]["model"] == "claude-opus-4-7"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_defaults_when_cache_fields_absent(self, adapter):
+        """Missing cache fields default to 0 / empty — no KeyError."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
+            assert data["usage"]["cache_read_tokens"] == 0
+            assert data["usage"]["cache_write_tokens"] == 0
+            assert data["usage"]["model"] == ""
+
+    @pytest.mark.asyncio
+    async def test_responses_exposes_cache_breakdown(self, adapter):
+        """/v1/responses uses input_tokens_details (OpenAI Responses convention)."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "cache_read_tokens": 60,
+            "cache_write_tokens": 30,
+            "model": "claude-sonnet-4",
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "Hi"},
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["usage"]["input_tokens_details"]["cached_tokens"] == 60
+            assert data["usage"]["cache_read_tokens"] == 60
+            assert data["usage"]["cache_write_tokens"] == 30
+            assert data["usage"]["model"] == "claude-sonnet-4"
+
+    @pytest.mark.asyncio
+    async def test_openai_fields_still_match_sum(self, adapter):
+        """Cache tokens are sub-totals of prompt_tokens, not additions."""
+        mock_result = {"final_response": "Hi", "messages": [], "api_calls": 1}
+        usage = {
+            "input_tokens": 24700,
+            "output_tokens": 9,
+            "total_tokens": 24709,
+            "cache_read_tokens": 22000,
+            "cache_write_tokens": 2600,
+            "model": "claude-opus-4-7",
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+
+            data = await resp.json()
+            assert data["usage"]["total_tokens"] == (
+                data["usage"]["prompt_tokens"] + data["usage"]["completion_tokens"]
+            )
+            cached = data["usage"]["prompt_tokens_details"]["cached_tokens"]
+            assert cached <= data["usage"]["prompt_tokens"]
+
+
 # ---------------------------------------------------------------------------
 # Truncation
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -79,7 +79,15 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
     "message": {"role": "assistant", "content": "Here's a fibonacci function..."},
     "finish_reason": "stop"
   }],
-  "usage": {"prompt_tokens": 50, "completion_tokens": 200, "total_tokens": 250}
+  "usage": {
+    "prompt_tokens": 24721,
+    "completion_tokens": 200,
+    "total_tokens": 24921,
+    "prompt_tokens_details": {"cached_tokens": 22000},
+    "cache_read_tokens": 22000,
+    "cache_write_tokens": 2500,
+    "model": "claude-opus-4-7"
+  }
 }
 ```
 
@@ -134,7 +142,15 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
     {"type": "function_call_output", "call_id": "call_1", "output": "README.md src/ tests/"},
     {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Your project has..."}]}
   ],
-  "usage": {"input_tokens": 50, "output_tokens": 200, "total_tokens": 250}
+  "usage": {
+    "input_tokens": 24721,
+    "output_tokens": 200,
+    "total_tokens": 24921,
+    "input_tokens_details": {"cached_tokens": 22000},
+    "cache_read_tokens": 22000,
+    "cache_write_tokens": 2500,
+    "model": "claude-opus-4-7"
+  }
 }
 ```
 
@@ -156,6 +172,56 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
 ```
 
 Uploaded files (`input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
+
+#### Usage block — prompt-cache breakdown
+
+Every response's `usage` block includes prompt-cache breakdown and the actual
+model used. This applies to `/v1/chat/completions`, `/v1/responses`, and the
+streaming variants of both (the final SSE chunk carries the full `usage`).
+
+On Anthropic, a cache-read token costs 10% of the base input rate and a 1-hour
+cache-write costs 200%. Clients that only see the flat `prompt_tokens` field
+can miscalculate cost by up to 20x once the cache warms up, so Hermes surfaces
+the breakdown in two places:
+
+1. **OpenAI-compatible field** — `prompt_tokens_details.cached_tokens`
+   (chat completions) or `input_tokens_details.cached_tokens` (responses).
+   Matches the shape the OpenAI Python SDK already parses, so existing
+   cost-tracking code against other OpenAI-compat backends reads it correctly
+   without any changes.
+
+2. **Flat additions on the `usage` object** — three extra fields for clients
+   that want the full picture:
+
+   | Field | Meaning |
+   | --- | --- |
+   | `cache_read_tokens` | Subset of `prompt_tokens` served from the cache — billed at 10% of the base input rate |
+   | `cache_write_tokens` | Subset of `prompt_tokens` written to the cache this turn — billed at 1.25x (5m TTL) or 2x (1h TTL) the base input rate |
+   | `model` | The model actually used — may differ from the requested model if the fallback provider chain rewrote it mid-turn |
+
+The cache fields are **sub-totals of `prompt_tokens`, not additions** —
+`total_tokens` still equals `prompt_tokens + completion_tokens` as required
+by OpenAI's usage contract. They're informational, so a client that ignores
+them gets the same behavior as before this feature shipped.
+
+**Computing cost from the usage block** (pseudo-code for Claude Sonnet 4,
+\$3/M input, \$15/M output, 1.25x write, 0.1x read):
+
+```python
+base_input_rate = 3.0 / 1_000_000
+base_output_rate = 15.0 / 1_000_000
+
+cached = usage["cache_read_tokens"]
+written = usage["cache_write_tokens"]
+uncached = usage["prompt_tokens"] - cached - written
+
+cost = (
+    uncached * base_input_rate
+    + written * base_input_rate * 1.25   # or 2.0 if HERMES_CACHE_TTL=1h
+    + cached * base_input_rate * 0.10
+    + usage["completion_tokens"] * base_output_rate
+)
+```
 
 #### Multi-turn with previous_response_id
 


### PR DESCRIPTION
## What does this PR do?

Enriches the `usage` block returned from `/v1/chat/completions`, `/v1/responses`, `/v1/runs`, and their SSE streaming variants with prompt-cache token breakdown and the actually-used model — as flat sibling fields on `usage` so clients get the full picture in one place.

**Why:** On Anthropic, a cache-read token costs 10% of base input rate, a 1h cache-write costs 200%. A client that only sees OpenAI's flat `prompt_tokens` can miscalculate cost by up to 20x once the cache warms up. `AIAgent` already tracks `session_cache_read_tokens` and `session_cache_write_tokens` (`run_agent.py:1760-1761`) — they just weren't surfaced over HTTP.

**Shape (backwards-compatible — all new fields are additive):**

```json
"usage": {
  "prompt_tokens": 24721,
  "completion_tokens": 5,
  "total_tokens": 24726,
  "prompt_tokens_details": { "cached_tokens": 22643 },
  "cache_read_tokens": 22643,
  "cache_write_tokens": 2088,
  "model": "claude-opus-4-7"
}
```

`cached_tokens` under `prompt_tokens_details` (or `input_tokens_details` for the Responses API) matches OpenAI's own prompt-cache reporting shape, so existing OpenAI SDK usage parsers read it correctly without any changes. `cache_write_tokens` and `model` live as flat sibling fields — no namespaced sub-object — so the full breakdown is always in one place.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py`:
  - `_run_agent()` and `_run_sync()` thread cache tokens + model through the usage dict
  - Non-streaming `/v1/chat/completions` response: flat `cache_read_tokens`, `cache_write_tokens`, `model` + OpenAI-compat `prompt_tokens_details.cached_tokens`
  - Streaming `/v1/chat/completions` `finish_chunk`: same
  - `/v1/responses` completed + failed envelopes, plus non-streaming path: same, using `input_tokens_details.cached_tokens` (Responses API convention)
  - Default fallback dict extended so missing cache fields never raise `KeyError`
- `tests/gateway/test_api_server.py` — new `TestCacheAwareUsage` class (4 tests)
- `website/docs/user-guide/features/api-server.md` — 2 example blocks refreshed + new "Usage block — prompt-cache breakdown" subsection with cost-calculation pseudo-code

## How to Test

```bash
# Unit tests
pytest tests/gateway/test_api_server.py::TestCacheAwareUsage -v
pytest tests/gateway/test_api_server.py::TestUsageCounting -v   # still passes

# End-to-end (requires running gateway with an Anthropic model):
curl -sS -X POST http://127.0.0.1:8642/v1/chat/completions \
  -H "Authorization: Bearer *** \
  -H "Content-Type: application/json" \
  -d '{"model":"hermes-agent","messages":[{"role":"user","content":"hi"}],"stream":false}' \
  | jq .usage
```

First call shows `cache_write_tokens > 0, cache_read_tokens == 0`; subsequent calls within the TTL window flip to `cache_read_tokens > 0, cache_write_tokens` only covering the delta.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit follows Conventional Commits (`feat(api_server): ...`)
- [x] Searched existing PRs — no duplicates
- [x] PR contains **only** changes related to this feature
- [x] `pytest tests/gateway/test_api_server.py::TestCacheAwareUsage tests/gateway/test_api_server.py::TestUsageCounting -q` — 6/6 pass
- [x] Added tests (4 new cases including a regression guard for the `total = prompt + completion` invariant)
- [x] Tested on my platform: macOS 15 (darwin 25.0)

### Documentation & Housekeeping

- [x] Updated `website/docs/user-guide/features/api-server.md` — refreshed two `usage` example blocks + new subsection explaining the cache fields with cost-calculation pseudo-code
- [x] `cli-config.yaml.example` — **N/A** (response shape change, no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — **N/A**
- [x] Cross-platform impact — **N/A** (response JSON is platform-independent)
- [x] Tool descriptions/schemas — **N/A**

## Screenshots / Logs

**Live gateway response** (fresh session, cache cold):

```json
{
  "prompt_tokens": 29204,
  "completion_tokens": 6,
  "total_tokens": 29210,
  "prompt_tokens_details": { "cached_tokens": 0 },
  "cache_read_tokens": 0,
  "cache_write_tokens": 29198,
  "model": "claude-opus-4-7"
}
```

**Second turn on same session** (cache warm, 91% hit rate):

```json
{
  "prompt_tokens": 24737,
  "completion_tokens": 5,
  "total_tokens": 24742,
  "prompt_tokens_details": { "cached_tokens": 22643 },
  "cache_read_tokens": 22643,
  "cache_write_tokens": 2088,
  "model": "claude-opus-4-7"
}
```

Test output:
```
tests/gateway/test_api_server.py::TestCacheAwareUsage — 4 passed
tests/gateway/test_api_server.py::TestUsageCounting — 2 passed (unchanged)
```