### PR TITLE
fix(gateway): prefer repo-local .venv over ambient VIRTUAL_ENV

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1399,14 +1399,21 @@ def _detect_venv_dir() -> Path | None:
     """Detect the active virtualenv directory.
 
     Checks ``sys.prefix`` first (works regardless of the directory name),
-    then ``VIRTUAL_ENV`` env var (covers uv-managed environments where
-    sys.prefix == sys.base_prefix), then falls back to probing common
-    directory names under PROJECT_ROOT.
+    then probes common directory names under PROJECT_ROOT so Hermes prefers
+    its own repo-local venv over unrelated ambient shells, then falls back to
+    ``VIRTUAL_ENV`` (covers uv-managed environments where sys.prefix ==
+    sys.base_prefix).
     Returns ``None`` when no virtualenv can be found.
     """
     # If we're running inside a virtualenv, sys.prefix points to it.
     if sys.prefix != sys.base_prefix:
         venv = Path(sys.prefix)
+        if venv.is_dir():
+            return venv
+
+    # Prefer a repo-local virtualenv over an unrelated ambient shell venv.
+    for candidate in (".venv", "venv"):
+        venv = PROJECT_ROOT / candidate
         if venv.is_dir():
             return venv
 
@@ -1416,12 +1423,6 @@ def _detect_venv_dir() -> Path | None:
     _virtual_env = os.environ.get("VIRTUAL_ENV")
     if _virtual_env:
         venv = Path(_virtual_env)
-        if venv.is_dir():
-            return venv
-
-    # Fallback: check common virtualenv directory names under the project root.
-    for candidate in (".venv", "venv"):
-        venv = PROJECT_ROOT / candidate
         if venv.is_dir():
             return venv
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1349,6 +1349,27 @@ class TestSystemUnitPathRemapping:
         assert "WorkingDirectory=/home/alice/.hermes/hermes-agent" in unit
 
 
+class TestGatewayVenvDetection:
+    def test_get_python_path_prefers_project_local_venv_over_unrelated_virtual_env(self, monkeypatch, tmp_path):
+        project = tmp_path / "hermes-agent"
+        project.mkdir()
+        local_venv = project / ".venv" / "bin"
+        local_venv.mkdir(parents=True)
+        local_python = local_venv / "python"
+        local_python.write_text("", encoding="utf-8")
+
+        unrelated_venv = tmp_path / "webui-mvp" / "venv" / "bin"
+        unrelated_venv.mkdir(parents=True)
+        (unrelated_venv / "python").write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", project)
+        monkeypatch.setattr(gateway_cli.sys, "prefix", "/usr/local")
+        monkeypatch.setattr(gateway_cli.sys, "base_prefix", "/usr/local")
+        monkeypatch.setenv("VIRTUAL_ENV", str(unrelated_venv.parent))
+
+        assert gateway_cli.get_python_path() == str(local_python)
+
+
 class TestDockerAwareGateway:
     """Tests for Docker container awareness in gateway commands."""
 


### PR DESCRIPTION
## Summary
- prefer the repository-local `.venv`/`venv` before an unrelated ambient `VIRTUAL_ENV` when resolving the gateway interpreter
- prevent gateway startup from drifting into another project's virtualenv during local or automated runs
- add regression coverage for repo-local venv preference

## Problem
When Hermes is launched from a shell that already has some unrelated `VIRTUAL_ENV` activated, the gateway could resolve the wrong interpreter/environment instead of the checkout's own environment. That can make gateway startup miss the expected dependencies for the Hermes repo.

## Fix
- keep `sys.prefix` precedence when Hermes is already running inside a real active virtualenv
- otherwise prefer `PROJECT_ROOT/.venv` or `PROJECT_ROOT/venv`
- only fall back to ambient `VIRTUAL_ENV` if no repo-local venv exists

## Test Plan
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `pytest -q tests/hermes_cli/test_gateway_service.py -k 'prefers_project_local_venv_over_unrelated_virtual_env or detached or container or stop_profile_gateway_falls_back'`

🤖 This PR was created by an AI coding agent
🤖 This was written by an AI coding agent
