### PR TITLE
fix: restore topic resume recency across session resets

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -188,6 +188,49 @@ class PlatformConfig:
 
 
 @dataclass
+class TopicResumeConfig:
+    """Configuration for topic/thread resume continuity."""
+    enabled: bool = True
+    recent_message_count: int = 8
+    max_message_chars: int = 400
+    include_recent_messages: bool = True
+    include_workspace_decisions: bool = True
+    include_open_loops: bool = True
+    include_next_actions: bool = True
+    trigger_on_new_session: bool = True
+    trigger_on_auto_reset: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "recent_message_count": self.recent_message_count,
+            "max_message_chars": self.max_message_chars,
+            "include_recent_messages": self.include_recent_messages,
+            "include_workspace_decisions": self.include_workspace_decisions,
+            "include_open_loops": self.include_open_loops,
+            "include_next_actions": self.include_next_actions,
+            "trigger_on_new_session": self.trigger_on_new_session,
+            "trigger_on_auto_reset": self.trigger_on_auto_reset,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TopicResumeConfig":
+        if not data:
+            return cls()
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), True),
+            recent_message_count=int(data.get("recent_message_count", 8)),
+            max_message_chars=int(data.get("max_message_chars", 400)),
+            include_recent_messages=_coerce_bool(data.get("include_recent_messages"), True),
+            include_workspace_decisions=_coerce_bool(data.get("include_workspace_decisions"), True),
+            include_open_loops=_coerce_bool(data.get("include_open_loops"), True),
+            include_next_actions=_coerce_bool(data.get("include_next_actions"), True),
+            trigger_on_new_session=_coerce_bool(data.get("trigger_on_new_session"), True),
+            trigger_on_auto_reset=_coerce_bool(data.get("trigger_on_auto_reset"), True),
+        )
+
+
+@dataclass
 class StreamingConfig:
     """Configuration for real-time token streaming to messaging platforms."""
     enabled: bool = False
@@ -257,6 +300,9 @@ class GatewayConfig:
 
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
+
+    # Topic/thread resume continuity
+    topic_resume: TopicResumeConfig = field(default_factory=TopicResumeConfig)
 
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
@@ -372,6 +418,7 @@ class GatewayConfig:
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "topic_resume": self.topic_resume.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
         }
     
@@ -441,6 +488,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            topic_resume=TopicResumeConfig.from_dict(data.get("topic_resume", {})),
             session_store_max_age_days=session_store_max_age_days,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -273,13 +273,15 @@ from gateway.config import (
     load_gateway_config,
 )
 from gateway.session import (
-    SessionStore,
-    SessionSource,
     SessionContext,
+    SessionSource,
+    SessionStore,
     build_session_context,
     build_session_context_prompt,
     build_session_key,
 )
+from gateway.topic_resume import build_topic_resume_context, build_topic_resume_prompt
+
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -3846,12 +3848,33 @@ class GatewayRunner:
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+
+        _topic_resume_ctx = None
+        try:
+            _topic_resume_ctx = build_topic_resume_context(
+                source=source,
+                session_store=self.session_store,
+                session_entry=session_entry,
+                config=getattr(self.config, "topic_resume", None),
+                hermes_home=_hermes_home,
+                is_new_session=_is_new_session,
+            )
+        except Exception as e:
+            logger.debug("Topic resume context assembly failed (non-fatal): %s", e, exc_info=True)
+            _topic_resume_ctx = None
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
         if getattr(session_entry, 'was_auto_reset', False):
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
-            if reset_reason == "suspended":
+            if _topic_resume_ctx:
+                if reset_reason == "suspended":
+                    context_note = "[System note: The user's previous session was stopped and suspended, but topic continuity context was restored from the topic workspace and recent topic messages.]"
+                elif reset_reason == "daily":
+                    context_note = "[System note: The user's session was automatically reset by the daily schedule, but topic continuity context was restored from the topic workspace and recent topic messages.]"
+                else:
+                    context_note = "[System note: The user's previous session expired due to inactivity, but topic continuity context was restored from the topic workspace and recent topic messages.]"
+            elif reset_reason == "suspended":
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
@@ -3910,6 +3933,9 @@ class GatewayRunner:
 
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
+
+        if _topic_resume_ctx:
+            context_prompt += "\n\n" + build_topic_resume_prompt(_topic_resume_ctx)
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.
@@ -8366,6 +8392,7 @@ class GatewayRunner:
         runtime: dict,
         enabled_toolsets: list,
         ephemeral_prompt: str,
+        session_id: str,
     ) -> str:
         """Compute a stable string key from agent config values.
 
@@ -8394,6 +8421,7 @@ class GatewayRunner:
                 # reasoning_config excluded — it's set per-message on the
                 # cached agent and doesn't affect system prompt or tools.
                 ephemeral_prompt or "",
+                session_id or "",
             ],
             sort_keys=True,
             default=str,
@@ -9501,6 +9529,7 @@ class GatewayRunner:
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
+                session_id,
             )
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -366,6 +366,7 @@ class SessionEntry:
     was_auto_reset: bool = False
     auto_reset_reason: Optional[str] = None  # "idle" or "daily"
     reset_had_activity: bool = False  # whether the expired session had any messages
+    previous_session_id: Optional[str] = None  # expired session used for recency hydration
     
     # Set by the background expiry watcher after it successfully flushes
     # memories for this session.  Persisted to sessions.json so the flag
@@ -407,6 +408,7 @@ class SessionEntry:
             "last_prompt_tokens": self.last_prompt_tokens,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
+            "previous_session_id": self.previous_session_id,
             "memory_flushed": self.memory_flushed,
             "suspended": self.suspended,
             "resume_pending": self.resume_pending,
@@ -459,6 +461,7 @@ class SessionEntry:
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
+            previous_session_id=data.get("previous_session_id"),
             memory_flushed=data.get("memory_flushed", False),
             suspended=data.get("suspended", False),
             resume_pending=data.get("resume_pending", False),
@@ -769,11 +772,13 @@ class SessionStore:
                     auto_reset_reason = reset_reason
                     # Track whether the expired session had any real conversation
                     reset_had_activity = entry.total_tokens > 0
+                    previous_session_id = entry.session_id
                     db_end_session_id = entry.session_id
             else:
                 was_auto_reset = False
                 auto_reset_reason = None
                 reset_had_activity = False
+                previous_session_id = None
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -790,6 +795,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                previous_session_id=previous_session_id,
             )
 
             self._entries[session_key] = entry

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1010,6 +1010,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                previous_session_id=old_entry.session_id,
             )
 
             self._entries[session_key] = new_entry

--- a/gateway/topic_resume.py
+++ b/gateway/topic_resume.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+import json
+import logging
+import re
+
+from gateway.config import TopicResumeConfig
+from gateway.session import SessionEntry, SessionSource
+
+
+logger = logging.getLogger(__name__)
+
+
+_SECTION_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+
+
+@dataclass
+class TopicResumeContext:
+    workspace_id: str | None
+    workspace_path: str | None
+    summary: str | None
+    current_state: str | None
+    decisions: list[str]
+    open_loops: list[str]
+    next_actions: list[str]
+    operating_contract: list[str]
+    topic_specific_instructions: list[str]
+    recent_messages: list[dict[str, str]]
+    source_of_truth: list[str]
+    was_auto_resume: bool
+
+
+def _normalize_bullets(body: str | None) -> list[str]:
+    if not body:
+        return []
+    items: list[str] = []
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("- "):
+            items.append(line[2:].strip())
+        else:
+            items.append(line)
+    return items
+
+
+def _extract_section(text: str, heading: str) -> str | None:
+    matches = list(_SECTION_RE.finditer(text))
+    for index, match in enumerate(matches):
+        if match.group(1).strip() != heading:
+            continue
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        return text[start:end].strip()
+    return None
+
+
+def resolve_topic_workspace(source: SessionSource, hermes_home: Path) -> Path | None:
+    if not source.thread_id:
+        return None
+
+    root = hermes_home / "topic-workspaces"
+    if not root.exists():
+        return None
+
+    for topic_json in root.glob("*/meta/topic.json"):
+        try:
+            data = json.loads(topic_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if (
+            str(data.get("platform", "")).lower() == source.platform.value.lower()
+            and str(data.get("chat_id")) == str(source.chat_id)
+            and str(data.get("thread_id")) == str(source.thread_id)
+        ):
+            return topic_json.parent.parent
+    return None
+
+
+def parse_workspace_state(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    summary = _extract_section(text, "Summary") or ""
+    current_state = _extract_section(text, "Current State") or ""
+    decisions = _normalize_bullets(_extract_section(text, "Decisions"))
+    open_loops = _normalize_bullets(_extract_section(text, "Open Loops"))
+    next_actions = _normalize_bullets(_extract_section(text, "Next Actions"))
+    operating_contract = _normalize_bullets(_extract_section(text, "Operating Contract"))
+    topic_specific_instructions = _normalize_bullets(_extract_section(text, "Topic-Specific Instructions"))
+    return {
+        "summary": summary,
+        "current_state": current_state,
+        "decisions": decisions,
+        "open_loops": open_loops,
+        "next_actions": next_actions,
+        "operating_contract": operating_contract,
+        "topic_specific_instructions": topic_specific_instructions,
+    }
+
+
+def load_recent_topic_messages(session_store, session_id: str, limit: int = 8, max_chars: int = 400) -> list[dict[str, str]]:
+    transcript = session_store.load_transcript(session_id) or []
+    filtered = [
+        {"role": msg.get("role", "unknown"), "content": (msg.get("content") or "")}
+        for msg in transcript
+        if msg.get("role") in {"user", "assistant"} and msg.get("content")
+    ]
+    recent = filtered[-limit:]
+    results: list[dict[str, str]] = []
+    for item in recent:
+        content = item["content"]
+        if len(content) > max_chars:
+            content = content[:max_chars] + "…"
+        results.append({"role": item["role"], "content": content})
+    return results
+
+
+def build_topic_resume_context(
+    *,
+    source: SessionSource,
+    session_store,
+    session_entry: SessionEntry,
+    config: TopicResumeConfig,
+    hermes_home: Path,
+    is_new_session: bool,
+) -> TopicResumeContext | None:
+    if not config.enabled:
+        return None
+    if not source.thread_id:
+        return None
+
+    is_auto_reset = bool(getattr(session_entry, "was_auto_reset", False))
+    should_trigger = (
+        config.trigger_on_auto_reset if is_auto_reset
+        else (is_new_session and config.trigger_on_new_session)
+    )
+    if not should_trigger:
+        return None
+
+    workspace = resolve_topic_workspace(source, hermes_home)
+    if not workspace:
+        return None
+
+    state = parse_workspace_state(workspace / "state.md")
+    recent_messages: list[dict[str, str]] = []
+    recent_session_id = session_entry.session_id
+    if bool(getattr(session_entry, "was_auto_reset", False)) and getattr(session_entry, "previous_session_id", None):
+        recent_session_id = session_entry.previous_session_id
+    if config.include_recent_messages:
+        recent_messages = load_recent_topic_messages(
+            session_store,
+            recent_session_id,
+            limit=config.recent_message_count,
+            max_chars=config.max_message_chars,
+        )
+
+    logger.info(
+        "Topic resume: workspace=%s trigger=%s recent_source_session=%s recent_count=%d",
+        workspace.name,
+        "auto_reset" if bool(getattr(session_entry, "was_auto_reset", False)) else "new_session",
+        recent_session_id,
+        len(recent_messages),
+    )
+
+    source_of_truth = ["state.md"]
+    if recent_messages:
+        source_of_truth.append(f"recent_messages(session_id={recent_session_id})")
+
+    return TopicResumeContext(
+        workspace_id=workspace.name,
+        workspace_path=str(workspace),
+        summary=state["summary"],
+        current_state=state["current_state"],
+        decisions=state["decisions"] if config.include_workspace_decisions else [],
+        open_loops=state["open_loops"] if config.include_open_loops else [],
+        next_actions=state["next_actions"] if config.include_next_actions else [],
+        operating_contract=state["operating_contract"],
+        topic_specific_instructions=state["topic_specific_instructions"],
+        recent_messages=recent_messages,
+        source_of_truth=source_of_truth,
+        was_auto_resume=bool(getattr(session_entry, "was_auto_reset", False)),
+    )
+
+
+def build_topic_resume_prompt(ctx: TopicResumeContext) -> str:
+    lines = [
+        "## Topic Resume Context",
+        "",
+        "This conversation belongs to an ongoing topic workspace. Treat the following as the current source of truth unless the user explicitly changes it.",
+        "",
+        f"**Workspace:** {ctx.workspace_id or 'unknown'}",
+        f"**Resume source:** {' + '.join(ctx.source_of_truth)}",
+    ]
+    if ctx.summary:
+        lines.extend(["", f"**Summary:** {ctx.summary}"])
+    if ctx.current_state:
+        lines.extend(["", f"**Current State:** {ctx.current_state}"])
+    if ctx.operating_contract:
+        lines.extend(["", "**Operating Contract:**"])
+        lines.extend([f"- {item}" for item in ctx.operating_contract])
+    if ctx.topic_specific_instructions:
+        lines.extend(["", "**Topic-Specific Instructions:**"])
+        lines.extend([f"- {item}" for item in ctx.topic_specific_instructions])
+    if ctx.open_loops:
+        lines.extend(["", "**Open Loops:**"])
+        lines.extend([f"- {item}" for item in ctx.open_loops])
+    if ctx.next_actions:
+        lines.extend(["", "**Next Actions:**"])
+        lines.extend([f"- {item}" for item in ctx.next_actions])
+    if ctx.recent_messages:
+        lines.extend(["", "**Recent Topic Messages:**"])
+        for item in ctx.recent_messages:
+            lines.append(f"- {item['role'].title()}: {item['content']}")
+    lines.extend([
+        "",
+        "If your planned reply would violate the operating contract or recent topic workflow, rewrite it to stay consistent with this topic's established behavior.",
+    ])
+    return "\n".join(lines)

--- a/gateway/topic_resume.py
+++ b/gateway/topic_resume.py
@@ -147,7 +147,7 @@ def build_topic_resume_context(
     state = parse_workspace_state(workspace / "state.md")
     recent_messages: list[dict[str, str]] = []
     recent_session_id = session_entry.session_id
-    if bool(getattr(session_entry, "was_auto_reset", False)) and getattr(session_entry, "previous_session_id", None):
+    if is_new_session and getattr(session_entry, "previous_session_id", None):
         recent_session_id = session_entry.previous_session_id
     if config.include_recent_messages:
         recent_messages = load_recent_topic_messages(

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -35,8 +35,8 @@ class TestAgentConfigSignature:
 
         runtime = {"api_key": "sk-test12345678", "base_url": "https://openrouter.ai/api/v1",
                     "provider": "openrouter", "api_mode": "chat_completions"}
-        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
-        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
+        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
+        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
         assert sig1 == sig2
 
     def test_model_change_different_signature(self):
@@ -44,8 +44,8 @@ class TestAgentConfigSignature:
 
         runtime = {"api_key": "sk-test12345678", "base_url": "https://openrouter.ai/api/v1",
                     "provider": "openrouter"}
-        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
-        sig2 = GatewayRunner._agent_config_signature("claude-opus-4.6", runtime, ["hermes-telegram"], "")
+        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
+        sig2 = GatewayRunner._agent_config_signature("claude-opus-4.6", runtime, ["hermes-telegram"], "", "session-a")
         assert sig1 != sig2
 
     def test_same_token_prefix_different_full_token_changes_signature(self):
@@ -66,8 +66,8 @@ class TestAgentConfigSignature:
         }
 
         assert rt1["api_key"][:8] == rt2["api_key"][:8]
-        sig1 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt1, ["hermes-telegram"], "")
-        sig2 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt2, ["hermes-telegram"], "")
+        sig1 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt1, ["hermes-telegram"], "", "session-a")
+        sig2 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt2, ["hermes-telegram"], "", "session-a")
         assert sig1 != sig2
 
     def test_provider_change_different_signature(self):
@@ -75,16 +75,16 @@ class TestAgentConfigSignature:
 
         rt1 = {"api_key": "sk-test12345678", "base_url": "https://openrouter.ai/api/v1", "provider": "openrouter"}
         rt2 = {"api_key": "sk-test12345678", "base_url": "https://api.anthropic.com", "provider": "anthropic"}
-        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", rt1, ["hermes-telegram"], "")
-        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", rt2, ["hermes-telegram"], "")
+        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", rt1, ["hermes-telegram"], "", "session-a")
+        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", rt2, ["hermes-telegram"], "", "session-a")
         assert sig1 != sig2
 
     def test_toolset_change_different_signature(self):
         from gateway.run import GatewayRunner
 
         runtime = {"api_key": "sk-test12345678", "base_url": "https://openrouter.ai/api/v1", "provider": "openrouter"}
-        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
-        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-discord"], "")
+        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
+        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-discord"], "", "session-a")
         assert sig1 != sig2
 
     def test_reasoning_not_in_signature(self):
@@ -94,8 +94,8 @@ class TestAgentConfigSignature:
         runtime = {"api_key": "sk-test12345678", "base_url": "https://openrouter.ai/api/v1", "provider": "openrouter"}
         # Same config — signature should be identical regardless of what
         # reasoning_config the caller might have (it's not passed in)
-        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
-        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
+        sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
+        sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
         assert sig1 == sig2
 
 
@@ -110,7 +110,7 @@ class TestAgentCacheLifecycle:
         session_key = "telegram:12345"
         runtime = {"api_key": "test", "base_url": "https://openrouter.ai/api/v1",
                     "provider": "openrouter", "api_mode": "chat_completions"}
-        sig = runner._agent_config_signature("anthropic/claude-sonnet-4", runtime, ["hermes-telegram"], "")
+        sig = runner._agent_config_signature("anthropic/claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
 
         # First message — create and cache
         agent1 = AIAgent(
@@ -138,7 +138,7 @@ class TestAgentCacheLifecycle:
         runtime = {"api_key": "test", "base_url": "https://openrouter.ai/api/v1",
                     "provider": "openrouter", "api_mode": "chat_completions"}
 
-        old_sig = runner._agent_config_signature("anthropic/claude-sonnet-4", runtime, ["hermes-telegram"], "")
+        old_sig = runner._agent_config_signature("anthropic/claude-sonnet-4", runtime, ["hermes-telegram"], "", "session-a")
         agent1 = AIAgent(
             model="anthropic/claude-sonnet-4", api_key="test",
             base_url="https://openrouter.ai/api/v1", provider="openrouter",
@@ -149,7 +149,7 @@ class TestAgentCacheLifecycle:
             runner._agent_cache[session_key] = (agent1, old_sig)
 
         # New model → different signature
-        new_sig = runner._agent_config_signature("anthropic/claude-opus-4.6", runtime, ["hermes-telegram"], "")
+        new_sig = runner._agent_config_signature("anthropic/claude-opus-4.6", runtime, ["hermes-telegram"], "", "session-a")
         assert new_sig != old_sig
 
         with runner._agent_cache_lock:

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -166,6 +166,17 @@ class TestSessionEntryReason:
         assert entry2.was_auto_reset is True
         assert entry2.reset_had_activity is True
 
+    def test_manual_reset_preserves_previous_session_id(self, tmp_path):
+        store = _make_store(tmp_path=tmp_path)
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        entry2 = store.reset_session(entry1.session_key)
+
+        assert entry2 is not None
+        assert entry2.session_id != entry1.session_id
+        assert entry2.previous_session_id == entry1.session_id
+
 
 # ---------------------------------------------------------------------------
 # SessionResetPolicy notify config

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -129,6 +129,7 @@ class TestSessionEntryReason:
         assert entry2.was_auto_reset is True
         assert entry2.auto_reset_reason == "idle"
         assert entry2.session_id != entry1.session_id
+        assert entry2.previous_session_id == entry1.session_id
 
     def test_reset_had_activity_false_when_no_tokens(self, tmp_path):
         """Expired session with no tokens → reset_had_activity=False."""

--- a/tests/gateway/test_topic_resume.py
+++ b/tests/gateway/test_topic_resume.py
@@ -243,6 +243,44 @@ def test_build_topic_resume_context_uses_previous_session_messages_after_auto_re
 
 
 
+def test_build_topic_resume_context_uses_previous_session_messages_for_manual_new_session(tmp_path):
+    from gateway.topic_resume import build_topic_resume_context
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    session_entry = _make_session_entry()
+    session_entry.was_auto_reset = False
+    session_entry.session_id = "session-new"
+    session_entry.previous_session_id = "session-old"
+
+    store = _FakeSessionStore(
+        messages_by_session_id={
+            "session-old": [
+                {"role": "user", "content": "Last thing we did was verify the hydration bug."},
+                {"role": "assistant", "content": "Next I should patch the resume path."},
+            ],
+            "session-new": [
+                {"role": "user", "content": "brand new empty session"},
+            ],
+        }
+    )
+
+    ctx = build_topic_resume_context(
+        source=_make_source(),
+        session_store=store,
+        session_entry=session_entry,
+        config=GatewayConfig().topic_resume,
+        hermes_home=tmp_path / ".hermes",
+        is_new_session=True,
+    )
+
+    assert ctx is not None
+    assert ctx.recent_messages == [
+        {"role": "user", "content": "Last thing we did was verify the hydration bug."},
+        {"role": "assistant", "content": "Next I should patch the resume path."},
+    ]
+
+
+
 def test_build_topic_resume_prompt_includes_contract_and_recent_messages(tmp_path):
     from gateway.topic_resume import build_topic_resume_context, build_topic_resume_prompt
 

--- a/tests/gateway/test_topic_resume.py
+++ b/tests/gateway/test_topic_resume.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, TopicResumeConfig
+from gateway.session import SessionEntry, SessionSource
+
+
+UTC = timezone.utc
+
+
+def _make_workspace(root: Path, workspace_id: str) -> Path:
+    ws = root / ".hermes" / "topic-workspaces" / workspace_id
+    (ws / "meta").mkdir(parents=True, exist_ok=True)
+    (ws / "meta" / "topic.json").write_text(
+        '{\n'
+        '  "platform": "telegram",\n'
+        '  "chat_id": "-1003748162924",\n'
+        '  "thread_id": "853",\n'
+        '  "topic_name": "Recorder Project",\n'
+        f'  "workspace_id": "{workspace_id}"\n'
+        '}\n',
+        encoding="utf-8",
+    )
+    (ws / "state.md").write_text(
+        "# Topic\n\n"
+        "Topic Name: Recorder Project\n"
+        f"Workspace ID: {workspace_id}\n"
+        "Platform: Telegram\n"
+        "Chat ID: -1003748162924\n"
+        "Thread ID: 853\n"
+        "Status: active\n"
+        "Created: 2026-04-18T22:59:41+00:00\n"
+        "Last Updated: 2026-04-23T13:50:00+00:00\n\n"
+        "## Summary\n"
+        "Build a lightweight local-first Windows game recorder.\n\n"
+        "## Current State\n"
+        "Latest checkpoint is commit `a4727a3`; black-screen capture remains unresolved.\n\n"
+        "## Decisions\n"
+        "- Keep Electron as the shell.\n"
+        "- Prefer OBS-class capture backend.\n\n"
+        "## Open Loops\n"
+        "- Run the next Windows rerun on `a4727a3`.\n"
+        "- Inspect the black-screen hook boundary.\n\n"
+        "## Next Actions\n"
+        "- Del: rerun on Windows and send logs.\n"
+        "- Reno: inspect audio and black-screen behavior.\n\n"
+        "## Operating Contract\n"
+        "- Del gives the goal.\n"
+        "- Reno writes the short practical plan.\n"
+        "- Codex expands the plan and executes the code.\n"
+        "- Reno supervises and updates Del.\n"
+        "- Do not ask Del to manually shuttle prompts into Codex unless he explicitly asks for that mode.\n\n"
+        "## Topic-Specific Instructions\n"
+        "- Preserve the Recorder Project workflow on resume.\n",
+        encoding="utf-8",
+    )
+    return ws
+
+
+class _FakeSessionStore:
+    def __init__(self, messages=None, messages_by_session_id=None):
+        self._messages = messages or []
+        self._messages_by_session_id = messages_by_session_id or {}
+
+    def load_transcript(self, session_id: str):
+        if session_id in self._messages_by_session_id:
+            return list(self._messages_by_session_id[session_id])
+        return list(self._messages)
+
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003748162924",
+        chat_name="Recorder Project",
+        chat_type="group",
+        user_id="1352028621",
+        user_name="Addel Hamoudhy",
+        thread_id="853",
+    )
+
+
+
+def _make_session_entry() -> SessionEntry:
+    now = datetime(2026, 4, 23, 14, 0, tzinfo=UTC)
+    return SessionEntry(
+        session_key="agent:main:telegram:group:-1003748162924:853",
+        session_id="session-recorder",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        was_auto_reset=True,
+        auto_reset_reason="idle",
+        reset_had_activity=True,
+    )
+
+
+
+def test_topic_resume_config_round_trip_in_gateway_config():
+    cfg = GatewayConfig.from_dict(
+        {
+            "topic_resume": {
+                "enabled": False,
+                "recent_message_count": 5,
+                "max_message_chars": 222,
+                "include_recent_messages": False,
+                "trigger_on_auto_reset": True,
+            }
+        }
+    )
+
+    assert isinstance(cfg.topic_resume, TopicResumeConfig)
+    assert cfg.topic_resume.enabled is False
+    assert cfg.topic_resume.recent_message_count == 5
+    assert cfg.topic_resume.max_message_chars == 222
+    assert cfg.topic_resume.include_recent_messages is False
+    assert cfg.to_dict()["topic_resume"]["trigger_on_auto_reset"] is True
+
+
+
+def test_resolve_topic_workspace_matches_platform_chat_and_thread(tmp_path):
+    from gateway.topic_resume import resolve_topic_workspace
+
+    ws = _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    source = _make_source()
+
+    resolved = resolve_topic_workspace(source, tmp_path / ".hermes")
+
+    assert resolved == ws
+
+
+
+def test_parse_workspace_state_extracts_operating_contract(tmp_path):
+    from gateway.topic_resume import parse_workspace_state
+
+    ws = _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    parsed = parse_workspace_state(ws / "state.md")
+
+    assert parsed["summary"].startswith("Build a lightweight")
+    assert "a4727a3" in parsed["current_state"]
+    assert parsed["open_loops"][0] == "Run the next Windows rerun on `a4727a3`."
+    assert any("Codex expands the plan" in item for item in parsed["operating_contract"])
+    assert any("manually shuttle prompts into Codex" in item for item in parsed["operating_contract"])
+
+
+
+def test_load_recent_topic_messages_filters_to_user_and_assistant_and_truncates():
+    from gateway.topic_resume import load_recent_topic_messages
+
+    transcript = [
+        {"role": "system", "content": "ignore me"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "tool", "content": "ignore me too"},
+        {"role": "user", "content": "u2" * 300},
+        {"role": "assistant", "content": "a2"},
+    ]
+    store = _FakeSessionStore(transcript)
+
+    recent = load_recent_topic_messages(store, "session-recorder", limit=3, max_chars=40)
+
+    assert [item["role"] for item in recent] == ["assistant", "user", "assistant"]
+    assert recent[1]["content"].endswith("…")
+    assert len(recent[1]["content"]) == 41
+
+
+
+def test_build_topic_resume_context_combines_workspace_and_recent_messages(tmp_path):
+    from gateway.topic_resume import build_topic_resume_context
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    source = _make_source()
+    session_entry = _make_session_entry()
+    store = _FakeSessionStore(
+        [
+            {"role": "user", "content": "Can we continue from last night?"},
+            {"role": "assistant", "content": "Yes, same recorder workflow as before."},
+        ]
+    )
+    cfg = GatewayConfig()
+
+    ctx = build_topic_resume_context(
+        source=source,
+        session_store=store,
+        session_entry=session_entry,
+        config=cfg.topic_resume,
+        hermes_home=tmp_path / ".hermes",
+        is_new_session=True,
+    )
+
+    assert ctx is not None
+    assert ctx.workspace_id == "telegram--1003748162924-853-recorder-project"
+    assert "a4727a3" in (ctx.current_state or "")
+    assert any("Codex expands the plan" in item for item in ctx.operating_contract)
+    assert ctx.recent_messages[0]["role"] == "user"
+    assert ctx.was_auto_resume is True
+
+
+
+def test_build_topic_resume_context_uses_previous_session_messages_after_auto_reset(tmp_path):
+    from gateway.topic_resume import build_topic_resume_context
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    source = _make_source()
+    session_entry = _make_session_entry()
+    session_entry.session_id = "session-new"
+    session_entry.previous_session_id = "session-old"
+
+    store = _FakeSessionStore(
+        messages_by_session_id={
+            "session-old": [
+                {"role": "user", "content": "I sent fresh Windows logs late last night."},
+                {"role": "assistant", "content": "Good, I am reviewing those logs now."},
+            ],
+            "session-new": [
+                {"role": "user", "content": "where are we at here. what are we waiting on?"},
+            ],
+        }
+    )
+
+    ctx = build_topic_resume_context(
+        source=source,
+        session_store=store,
+        session_entry=session_entry,
+        config=GatewayConfig().topic_resume,
+        hermes_home=tmp_path / ".hermes",
+        is_new_session=True,
+    )
+
+    assert ctx is not None
+    assert ctx.recent_messages == [
+        {"role": "user", "content": "I sent fresh Windows logs late last night."},
+        {"role": "assistant", "content": "Good, I am reviewing those logs now."},
+    ]
+
+
+
+def test_build_topic_resume_prompt_includes_contract_and_recent_messages(tmp_path):
+    from gateway.topic_resume import build_topic_resume_context, build_topic_resume_prompt
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    ctx = build_topic_resume_context(
+        source=_make_source(),
+        session_store=_FakeSessionStore(
+            [
+                {"role": "user", "content": "Please continue on the recorder project."},
+                {"role": "assistant", "content": "I’ll keep the same Codex-supervised workflow."},
+            ]
+        ),
+        session_entry=_make_session_entry(),
+        config=GatewayConfig().topic_resume,
+        hermes_home=tmp_path / ".hermes",
+        is_new_session=True,
+    )
+
+    prompt = build_topic_resume_prompt(ctx)
+
+    assert "## Topic Resume Context" in prompt
+    assert "Operating Contract" in prompt
+    assert "Do not ask Del to manually shuttle prompts into Codex" in prompt
+    assert "Recent Topic Messages" in prompt
+    assert "Please continue on the recorder project." in prompt
+
+
+
+def test_build_topic_resume_context_skips_when_feature_disabled(tmp_path):
+    from gateway.topic_resume import build_topic_resume_context
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    cfg = TopicResumeConfig(enabled=False)
+
+    ctx = build_topic_resume_context(
+        source=_make_source(),
+        session_store=_FakeSessionStore([]),
+        session_entry=_make_session_entry(),
+        config=cfg,
+        hermes_home=tmp_path / ".hermes",
+        is_new_session=True,
+    )
+
+    assert ctx is None
+
+
+
+def test_build_topic_resume_context_respects_auto_reset_trigger_flag(tmp_path):
+    from gateway.topic_resume import build_topic_resume_context
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+    session_entry = _make_session_entry()
+    session_entry.was_auto_reset = True
+    cfg = TopicResumeConfig(trigger_on_new_session=True, trigger_on_auto_reset=False)
+
+    ctx = build_topic_resume_context(
+        source=_make_source(),
+        session_store=_FakeSessionStore(
+            [{"role": "user", "content": "fresh but should be ignored"}]
+        ),
+        session_entry=session_entry,
+        config=cfg,
+        hermes_home=tmp_path / ".hermes",
+        is_new_session=True,
+    )
+
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_passes_topic_resume_context_prompt_to_run_agent(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    _make_workspace(tmp_path, "telegram--1003748162924-853-recorder-project")
+
+    now = datetime(2026, 4, 23, 14, 0, tzinfo=UTC)
+    session_entry = SessionEntry(
+        session_key="agent:main:telegram:group:-1003748162924:853",
+        session_id="session-recorder",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        was_auto_reset=True,
+        auto_reset_reason="idle",
+        reset_had_activity=False,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(topic_resume=TopicResumeConfig())
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner.adapters[Platform.TELEGRAM].send = AsyncMock()
+    runner.hooks = SimpleNamespace(emit=MagicMock())
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "Please continue from where we left off."},
+        {"role": "assistant", "content": "Same recorder workflow as before."},
+    ]
+    runner.session_store.config = runner.config
+    runner._set_session_env = MagicMock(return_value=[])
+    runner._clear_session_env = MagicMock()
+    runner._bind_adapter_run_generation = MagicMock()
+    runner._is_session_run_current = MagicMock(return_value=True)
+    runner._format_session_info = MagicMock(return_value="")
+    runner._update_runtime_status = MagicMock()
+    runner._resolve_session_agent_runtime = MagicMock()
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner._active_event_loop = None
+    runner._loop_thread = None
+    runner.delivery_router = MagicMock()
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._background_tasks = set()
+    runner._should_send_voice_reply = MagicMock(return_value=False)
+
+    captured = {}
+
+    async def _fake_run_agent(**kwargs):
+        captured["context_prompt"] = kwargs["context_prompt"]
+        return {"final_response": "ok", "messages": [], "api_calls": 1}
+
+    runner._run_agent = _fake_run_agent
+
+    async def _fake_emit(*args, **kwargs):
+        return None
+
+    runner.hooks.emit = _fake_emit
+
+    source = _make_source()
+    event = SimpleNamespace(
+        text="Continue the recorder project",
+        message_id="m1",
+        channel_prompt=None,
+        metadata=None,
+        auto_skill=None,
+        media_urls=[],
+        media_types=[],
+        quoted_text=None,
+        quoted_sender_name=None,
+        quoted_media_urls=[],
+        quoted_media_types=[],
+        sender_name=None,
+        sender_id=None,
+        message_type=None,
+        reply_to_message_id=None,
+        source=source,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path / ".hermes")
+    monkeypatch.setattr("gateway.run._config_path", tmp_path / ".hermes" / "config.yaml")
+    (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".hermes" / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    await runner._handle_message_with_agent(event, source, session_entry.session_key, 1)
+
+    assert "## Topic Resume Context" in captured["context_prompt"]
+    assert "Recorder Project" in captured["context_prompt"]
+    assert "Do not ask Del to manually shuttle prompts into Codex" in captured["context_prompt"]
+
+
+
+def test_agent_config_signature_changes_when_session_id_changes():
+    from gateway.run import GatewayRunner
+
+    runtime = {
+        "provider": "openai-codex",
+        "api_key": "secret-token",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "responses",
+    }
+
+    sig_a = GatewayRunner._agent_config_signature(
+        "gpt-5.4",
+        runtime,
+        ["file", "terminal"],
+        "topic prompt",
+        "session-a",
+    )
+    sig_b = GatewayRunner._agent_config_signature(
+        "gpt-5.4",
+        runtime,
+        ["file", "terminal"],
+        "topic prompt",
+        "session-b",
+    )
+
+    assert sig_a != sig_b

--- a/website/docs/developer-guide/topic-resume-continuity.md
+++ b/website/docs/developer-guide/topic-resume-continuity.md
@@ -1,0 +1,56 @@
+# Topic Resume Continuity
+
+Hermes topic continuity for Telegram/forum threads should be built from two layers:
+
+1. **Canonical state** from the topic workspace `state.md`
+2. **Recency** from the most recent user/assistant messages in the prior topic session
+
+## Expected resume stack
+
+When a threaded/topic session is resumed after an idle or daily auto-reset:
+
+1. Resolve the topic workspace from `platform + chat_id + thread_id`
+2. Read `state.md`
+3. Prioritize:
+   - `Operating Contract`
+   - `Topic-Specific Instructions`
+   - `Open Loops`
+   - `Next Actions`
+4. Load the last 5 to 10 user/assistant messages from the **previous session id**, not the fresh post-reset session id
+5. Inject that topic resume context into the new turn before the model responds
+
+## Why the previous session matters
+
+After an auto-reset, the new session is usually empty or contains only the current morning check-in message.
+If topic recency is loaded from the fresh session id, Hermes will fall back to stale `state.md` and lose the last real conversational checkpoint.
+
+The correct source for recent topic messages after auto-reset is:
+
+- `SessionEntry.previous_session_id`
+
+If there was no auto-reset, recent topic messages can be loaded from the current `session_id`.
+
+## Agent cache rule
+
+Gateway agent caching must not survive a session boundary.
+
+If a cached `AIAgent` is reused across a new `session_id`, stale session-scoped context can leak into the next turn.
+To prevent that, the cache signature must include `session_id`.
+
+## Logging guidance
+
+Topic resume should log enough to answer "what did Hermes actually look at?" without forensic digging.
+Recommended fields:
+
+- workspace id
+- trigger type (`new_session` vs `auto_reset`)
+- recent-source session id
+- recent message count
+
+## Regression coverage
+
+At minimum, keep tests for:
+
+1. auto-reset preserving `previous_session_id`
+2. topic resume reading recent messages from `previous_session_id`
+3. cache signature changing when `session_id` changes


### PR DESCRIPTION
## Summary
- preserve `previous_session_id` across auto-reset session boundaries
- hydrate topic resume recency from the prior topic session instead of the fresh reset session
- include `session_id` in the gateway agent-cache signature so stale cached agents cannot cross session boundaries
- add regression coverage for previous-session hydration, cache/session-id boundaries, and auto-reset trigger gating
- add a developer note documenting the topic resume continuity contract

## Verification
- `pytest tests/gateway/test_topic_resume.py -q`
- `pytest tests/gateway/test_session_reset_notify.py -q`
- `pytest tests/gateway/test_session.py -q`
- `pytest tests/gateway/test_agent_cache.py -q`
- `pytest tests/gateway/test_topic_resume.py tests/gateway/test_session_reset_notify.py tests/gateway/test_agent_cache.py -q`

## Notes
A broader `pytest tests/gateway -q` run still shows unrelated pre-existing failures in other gateway areas (matrix, telegram approval buttons, whatsapp, api_server keepalive), which were intentionally left out of this fix scope.
