### PR TITLE
feat(delegation): system_prompt_prepend for per-child persona slots

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -93,6 +93,40 @@ class TestChildSystemPrompt(unittest.TestCase):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
 
+    def test_system_prompt_prepend_inserted_at_top(self):
+        """Non-empty prepend appears BEFORE the standard subagent opener."""
+        persona = "You are email-agent. Always resolve timezones to UTC."
+        prompt = _build_child_system_prompt(
+            "Check my inbox",
+            system_prompt_prepend=persona,
+        )
+        # Persona lands above the standard opener
+        persona_idx = prompt.find("email-agent")
+        opener_idx = prompt.find("You are a focused subagent")
+        self.assertGreaterEqual(persona_idx, 0, "persona text missing")
+        self.assertGreater(opener_idx, persona_idx, "persona must precede opener")
+
+    def test_system_prompt_prepend_preserves_contract(self):
+        """Default subagent contract (task/summary instructions) still present."""
+        prompt = _build_child_system_prompt(
+            "Fix the tests",
+            system_prompt_prepend="You are bug-agent.",
+        )
+        self.assertIn("You are a focused subagent", prompt)
+        self.assertIn("YOUR TASK", prompt)
+        self.assertIn("Fix the tests", prompt)
+        self.assertIn("concise summary", prompt)
+
+    def test_empty_system_prompt_prepend_is_noop(self):
+        """None / empty / whitespace prepend values do not change the prompt."""
+        baseline = _build_child_system_prompt("Do something")
+        for val in (None, "", "   ", "\n\t  "):
+            prompt = _build_child_system_prompt("Do something", system_prompt_prepend=val)
+            self.assertEqual(
+                prompt, baseline,
+                f"prepend={val!r} should be a no-op",
+            )
+
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -467,8 +467,16 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    system_prompt_prepend: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
+
+    When ``system_prompt_prepend`` is non-empty, its trimmed text is
+    inserted AT THE TOP of the child's system prompt — before the
+    standard "You are a focused subagent..." opener. This lets plugin
+    callers (e.g. dobby-specialists) give each specialist its own
+    persona / domain guidance without losing Hermes's default subagent
+    contract (task/context/summary structure).
 
     When role='orchestrator', appends a delegation-capability block
     modeled on OpenClaw's buildSubagentSystemPrompt (canSpawn branch at
@@ -476,11 +484,14 @@ def _build_child_system_prompt(
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
-    parts = [
+    parts: list[str] = []
+    if system_prompt_prepend and system_prompt_prepend.strip():
+        parts.extend([system_prompt_prepend.strip(), ""])
+    parts.extend([
         "You are a focused subagent working on a specific delegated task.",
         "",
         f"YOUR TASK:\n{goal}",
-    ]
+    ])
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -781,6 +792,11 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Optional specialist persona / domain guidance — prepended to the
+    # standard subagent system prompt. Keeps Hermes's default contract
+    # intact (task/context/summary) while letting callers give each
+    # spawn a distinct voice or domain focus.
+    system_prompt_prepend: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -862,6 +878,7 @@ def _build_child_agent(
         goal,
         context,
         workspace_path=workspace_hint,
+        system_prompt_prepend=system_prompt_prepend,
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,


### PR DESCRIPTION
## Summary

Adds an optional `system_prompt_prepend` parameter to `_build_child_system_prompt` and `_build_child_agent` in `tools/delegate_tool.py`. When non-empty, the value is inserted **at the top** of the child's system prompt — before the standard *"You are a focused subagent..."* opener — so plugin callers can give each spawn a distinct persona or domain focus while still getting Hermes's default subagent contract (task / context / summary structure).

## Motivation

Today, every child agent spawned via `delegate_task` or a plugin tool receives the same generic subagent template. There's no sanctioned way for a plugin to give each specialist its own voice, domain rules, or safety constraints — the only workaround is smuggling persona text into the `context` arg, which is semantically wrong (context means per-call background, not a persistent identity) and easy to lose when callers pass their own context too.

This matters for plugin ecosystems that fan a parent agent out to many differently-scoped children — e.g. a plugin that routes tasks to a \`calendar-agent\` (always resolve timezones to a specific locale), an \`address-lookup-agent\` (safety-critical, never hallucinate), and a \`compose-agent\` (match a particular writing voice) all benefit from a real system-prompt slot they control.

## Changes

- `_build_child_system_prompt()` — new keyword param `system_prompt_prepend: Optional[str] = None`. When truthy (non-empty after `.strip()`), its contents are inserted before the standard opener, followed by a blank separator line. Existing behavior (YOUR TASK / CONTEXT / summary instructions / orchestrator block) is unchanged.
- `_build_child_agent()` — pass-through `system_prompt_prepend` parameter, forwarded to `_build_child_system_prompt`.
- Tests: three additions covering \"inserted at top\", \"standard contract still present\", \"empty values are a no-op\".

## Back-compat

Parameter defaults to `None`. `None`, `""`, and whitespace-only values are all treated as a true no-op — `_build_child_system_prompt()` output is byte-identical to pre-patch output for any existing caller. Existing tests (`test_goal_only`, `test_goal_with_context`, `test_empty_context_ignored`) pass unchanged.

## Test plan

- [x] Existing `TestChildSystemPrompt` tests still pass (3 passed)
- [x] New tests pass (3 added, 3 passed)
- [x] `test_system_prompt_prepend_inserted_at_top` — persona text appears before \"You are a focused subagent\"
- [x] `test_system_prompt_prepend_preserves_contract` — default subagent contract (opener, YOUR TASK, summary instructions) still present alongside the persona
- [x] `test_empty_system_prompt_prepend_is_noop` — `None`, `\"\"`, `\"   \"`, `\"\\n\\t  \"` all yield output identical to a no-prepend call

Run locally: \`pytest tests/tools/test_delegate.py::TestChildSystemPrompt -q\` → 6 passed.

## Notes

- No changes to the delegation wire protocol, `delegate_task` tool schema, or any public config key — the parameter is only reachable from callers of `_build_child_agent` (today that's internal delegate paths + plugin handlers).
- Zero runtime cost when unused (`None` short-circuits the `if` on every call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)