### PR TITLE
fix(terminal): honor configured cwd at session init

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -130,6 +130,32 @@ class TestEmbedStdinHeredoc:
 
 
 class TestInitSessionFailure:
+    def test_init_session_bootstrap_changes_to_configured_cwd(self):
+        env = _TestableEnv(cwd="/tmp/configured")
+
+        calls = []
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            calls.append({"cmd": cmd, "login": login})
+            return MagicMock()
+
+        env._run_bash = mock_run_bash
+        env._wait_for_process = MagicMock(
+            return_value={
+                "output": f"{env._cwd_marker}/tmp/configured{env._cwd_marker}",
+                "returncode": 0,
+            }
+        )
+        env.init_session()
+
+        assert len(calls) == 1
+        assert calls[0]["login"] is True
+        assert (
+            "cd /tmp/configured" in calls[0]["cmd"]
+            or "cd '/tmp/configured'" in calls[0]["cmd"]
+        )
+        assert env._snapshot_ready is True
+
     def test_snapshot_ready_false_on_failure(self):
         env = _TestableEnv()
 
@@ -147,16 +173,18 @@ class TestInitSessionFailure:
         env._snapshot_ready = False
 
         calls = []
+
         def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
             calls.append({"login": login})
-            # Return a mock process handle
-            mock = MagicMock()
-            mock.poll.return_value = 0
-            mock.returncode = 0
-            mock.stdout = iter([])
-            return mock
+            return MagicMock()
 
         env._run_bash = mock_run_bash
+        env._wait_for_process = MagicMock(
+            return_value={
+                "output": f"{env._cwd_marker}/tmp{env._cwd_marker}",
+                "returncode": 0,
+            }
+        )
         env.execute("echo test")
 
         assert len(calls) == 1

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -299,6 +299,11 @@ class BaseEnvironment(ABC):
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
 
+    @staticmethod
+    def _quote_cwd_for_shell(cwd: str) -> str:
+        """Quote a cwd for shell ``cd`` while preserving ``~`` expansion."""
+        return shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
+
     # ------------------------------------------------------------------
     # Abstract methods
     # ------------------------------------------------------------------
@@ -335,6 +340,7 @@ class BaseEnvironment(ABC):
         instead of running with ``bash -l``.
         """
         # Full capture: env vars, functions (filtered), aliases, shell options.
+        quoted_cwd = self._quote_cwd_for_shell(self.cwd)
         bootstrap = (
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
@@ -342,6 +348,7 @@ class BaseEnvironment(ABC):
             f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
             f"echo 'set +e' >> {self._snapshot_path}\n"
             f"echo 'set +u' >> {self._snapshot_path}\n"
+            f"cd {quoted_cwd} || exit 126\n"
             f"pwd -P > {self._cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )
@@ -380,9 +387,7 @@ class BaseEnvironment(ABC):
             parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
 
         # cd to working directory — let bash expand ~ natively
-        quoted_cwd = (
-            shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
-        )
+        quoted_cwd = self._quote_cwd_for_shell(cwd)
         parts.append(f"builtin cd {quoted_cwd} || exit 126")
 
         # Run the actual command


### PR DESCRIPTION
## Summary

Apply upstream PR #7802 behavior so `BaseEnvironment.init_session()` captures its initial snapshot after cd'ing into the configured cwd. This preserves SSH terminal.cwd instead of letting the remote login shell home directory overwrite it.

**Upstream reference:** https://github.com/NousResearch/hermes-agent/pull/7802
**Upstream commit:** 12e3ef9aeeda177f8f5535379a2998f3974b9ff9

## Why this is still needed

Main branch already has `4c136288 fix(local): respect configured cwd in init_session()` which passes `cwd=self.cwd` to `subprocess.Popen`. However, this only fixes the **local** backend. SSH, Docker, Daytona and other remote backends use different `_run_bash()` implementations (remote shell execution) that don't support a `cwd` parameter — they rely on the bootstrap script in `BaseEnvironment.init_session()`.

This PR fixes the root cause for all non-local backends by adding `cd {quoted_cwd}` to the init_session bootstrap script.

## Changes

### `tools/environments/base.py`
- Added `_quote_cwd_for_shell()` static method to extract cwd quoting logic.
- Modified `init_session()` bootstrap script to include `cd {quoted_cwd} || exit 126` before writing pwd, so the initial snapshot captures environment from the configured working directory.
- Refactored inline `quoted_cwd` computation in `_wrap_command()` to use the new static method.

### `tests/tools/test_base_environment.py`
- Added `TestInitSessionFailure.test_init_session_bootstrap_changes_to_configured_cwd`: verifies that `init_session()` runs a login shell with `cd` into the configured cwd and sets `_snapshot_ready = True`.
- Updated existing test mocks to use `_wait_for_process` return values instead of raw process handles.

## Testing

All 16 tests in `tests/tools/test_base_environment.py` pass (CI-parity via `scripts/run_tests.sh`).
