### PR TITLE
fix(browser): guard command timeout cache invalidation

### DIFF
--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -115,6 +115,14 @@ class TestCommandTimeoutCache:
             _get_command_timeout()
         mock_read.assert_called_once()
 
+    def test_returns_default_when_cleanup_race_clears_cached_value(self):
+        import tools.browser_tool as bt
+
+        bt._cached_command_timeout = None
+        bt._command_timeout_resolved = True
+
+        assert bt._get_command_timeout() == bt.DEFAULT_COMMAND_TIMEOUT
+
 
 # ---------------------------------------------------------------------------
 # Caching: _discover_homebrew_node_dirs

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -184,7 +184,14 @@ def _get_command_timeout() -> int:
     """
     global _cached_command_timeout, _command_timeout_resolved
     if _command_timeout_resolved:
-        return _cached_command_timeout  # type: ignore[return-value]
+        cached = _cached_command_timeout
+        if isinstance(cached, int):
+            return max(cached, 5)
+        logger.debug(
+            "browser.command_timeout cache was invalidated during cleanup; "
+            "falling back to default timeout"
+        )
+        return DEFAULT_COMMAND_TIMEOUT
 
     _command_timeout_resolved = True
     result = DEFAULT_COMMAND_TIMEOUT


### PR DESCRIPTION
## Summary
- make `tools.browser_tool._get_command_timeout()` fall back to the default timeout when cleanup invalidates the cached value mid-read
- preserve the existing cache behavior for valid integer timeouts
- add a regression test for the cleanup race window

## Testing
- `python3 -m pytest -o addopts='' -q tests/tools/test_browser_hardening.py`

Closes #14783
