### PR TITLE
修复 Telegram 发送卡住后会话锁不释放

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1143,6 +1143,55 @@ class BasePlatformAdapter(ABC):
         Default is a no-op for platforms with one-shot typing indicators.
         """
         pass
+
+    def _get_delivery_timeout_seconds(self) -> float:
+        """Return the per-delivery hard timeout for adapter send operations."""
+        raw = (
+            self.config.extra.get("delivery_timeout_seconds")
+            or os.getenv("HERMES_GATEWAY_DELIVERY_TIMEOUT")
+            or 60
+        )
+        try:
+            timeout = float(raw)
+        except (TypeError, ValueError):
+            timeout = 60.0
+        return timeout if timeout > 0 else 0.0
+
+    async def _run_with_delivery_timeout(
+        self,
+        awaitable: Awaitable[Any],
+        *,
+        operation: str,
+        chat_id: str,
+    ) -> Any:
+        """Bound adapter delivery so a stuck send cannot lock the session forever."""
+        timeout = self._get_delivery_timeout_seconds()
+        if timeout <= 0:
+            return await awaitable
+        try:
+            return await asyncio.wait_for(awaitable, timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            logger.error(
+                "[%s] %s timed out after %.1fs for chat %s",
+                self.name,
+                operation,
+                timeout,
+                chat_id,
+            )
+            raise RuntimeError(
+                f"{operation} timed out after {timeout:.1f}s"
+            ) from exc
+
+    def clear_session_lock(self, session_key: str) -> bool:
+        """Drop adapter-level lock and queued message for a session."""
+        cleared = False
+        if session_key in self._pending_messages:
+            del self._pending_messages[session_key]
+            cleared = True
+        if session_key in self._active_sessions:
+            del self._active_sessions[session_key]
+            cleared = True
+        return cleared
     
     async def send_image(
         self,
@@ -2135,10 +2184,14 @@ class BasePlatformAdapter(ABC):
                 # Play TTS audio before text (voice-first experience)
                 if _tts_path and Path(_tts_path).exists():
                     try:
-                        await self.play_tts(
+                        await self._run_with_delivery_timeout(
+                            self.play_tts(
+                                chat_id=event.source.chat_id,
+                                audio_path=_tts_path,
+                                metadata=_thread_metadata,
+                            ),
+                            operation="tts delivery",
                             chat_id=event.source.chat_id,
-                            audio_path=_tts_path,
-                            metadata=_thread_metadata,
                         )
                     finally:
                         try:
@@ -2149,11 +2202,15 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
-                    result = await self._send_with_retry(
+                    result = await self._run_with_delivery_timeout(
+                        self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=text_content,
+                            reply_to=event.message_id,
+                            metadata=_thread_metadata,
+                        ),
+                        operation="response delivery",
                         chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=event.message_id,
-                        metadata=_thread_metadata,
                     )
                     _record_delivery(result)
 
@@ -2175,18 +2232,26 @@ class BasePlatformAdapter(ABC):
                         )
                         # Route animated GIFs through send_animation for proper playback
                         if self._is_animation_url(image_url):
-                            img_result = await self.send_animation(
+                            img_result = await self._run_with_delivery_timeout(
+                                self.send_animation(
+                                    chat_id=event.source.chat_id,
+                                    animation_url=image_url,
+                                    caption=alt_text if alt_text else None,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="animation delivery",
                                 chat_id=event.source.chat_id,
-                                animation_url=image_url,
-                                caption=alt_text if alt_text else None,
-                                metadata=_thread_metadata,
                             )
                         else:
-                            img_result = await self.send_image(
+                            img_result = await self._run_with_delivery_timeout(
+                                self.send_image(
+                                    chat_id=event.source.chat_id,
+                                    image_url=image_url,
+                                    caption=alt_text if alt_text else None,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="image delivery",
                                 chat_id=event.source.chat_id,
-                                image_url=image_url,
-                                caption=alt_text if alt_text else None,
-                                metadata=_thread_metadata,
                             )
                         if not img_result.success:
                             logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
@@ -2204,28 +2269,44 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(media_path).suffix.lower()
                         if ext in _AUDIO_EXTS:
-                            media_result = await self.send_voice(
+                            media_result = await self._run_with_delivery_timeout(
+                                self.send_voice(
+                                    chat_id=event.source.chat_id,
+                                    audio_path=media_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="audio delivery",
                                 chat_id=event.source.chat_id,
-                                audio_path=media_path,
-                                metadata=_thread_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
-                            media_result = await self.send_video(
+                            media_result = await self._run_with_delivery_timeout(
+                                self.send_video(
+                                    chat_id=event.source.chat_id,
+                                    video_path=media_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="video delivery",
                                 chat_id=event.source.chat_id,
-                                video_path=media_path,
-                                metadata=_thread_metadata,
                             )
                         elif ext in _IMAGE_EXTS:
-                            media_result = await self.send_image_file(
+                            media_result = await self._run_with_delivery_timeout(
+                                self.send_image_file(
+                                    chat_id=event.source.chat_id,
+                                    image_path=media_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="image file delivery",
                                 chat_id=event.source.chat_id,
-                                image_path=media_path,
-                                metadata=_thread_metadata,
                             )
                         else:
-                            media_result = await self.send_document(
+                            media_result = await self._run_with_delivery_timeout(
+                                self.send_document(
+                                    chat_id=event.source.chat_id,
+                                    file_path=media_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="document delivery",
                                 chat_id=event.source.chat_id,
-                                file_path=media_path,
-                                metadata=_thread_metadata,
                             )
 
                         if not media_result.success:
@@ -2240,22 +2321,34 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _IMAGE_EXTS:
-                            await self.send_image_file(
+                            await self._run_with_delivery_timeout(
+                                self.send_image_file(
+                                    chat_id=event.source.chat_id,
+                                    image_path=file_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="image file delivery",
                                 chat_id=event.source.chat_id,
-                                image_path=file_path,
-                                metadata=_thread_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            await self._run_with_delivery_timeout(
+                                self.send_video(
+                                    chat_id=event.source.chat_id,
+                                    video_path=file_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="video delivery",
                                 chat_id=event.source.chat_id,
-                                video_path=file_path,
-                                metadata=_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            await self._run_with_delivery_timeout(
+                                self.send_document(
+                                    chat_id=event.source.chat_id,
+                                    file_path=file_path,
+                                    metadata=_thread_metadata,
+                                ),
+                                operation="document delivery",
                                 chat_id=event.source.chat_id,
-                                file_path=file_path,
-                                metadata=_thread_metadata,
                             )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
@@ -2308,14 +2401,18 @@ class BasePlatformAdapter(ABC):
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
                 _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-                await self.send(
-                    chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
+                await self._run_with_delivery_timeout(
+                    self.send(
+                        chat_id=event.source.chat_id,
+                        content=(
+                            f"Sorry, I encountered an error ({error_type}).\n"
+                            f"{error_detail}\n"
+                            "Try again or use /reset to start a fresh session."
+                        ),
+                        metadata=_thread_metadata,
                     ),
-                    metadata=_thread_metadata,
+                    operation="error delivery",
+                    chat_id=event.source.chat_id,
                 )
             except Exception:
                 pass  # Last resort — don't let error reporting crash the handler

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5224,6 +5224,7 @@ class GatewayRunner:
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        adapter = self.adapters.get(source.platform)
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
@@ -5234,6 +5235,8 @@ class GatewayRunner:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_pending",
             )
+            if adapter and hasattr(adapter, "clear_session_lock"):
+                adapter.clear_session_lock(session_key)
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key[:20])
             return "⚡ Stopped. The agent hadn't started yet — you can continue this session."
         if agent:
@@ -5245,9 +5248,15 @@ class GatewayRunner:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_handler",
             )
+            if adapter and hasattr(adapter, "clear_session_lock"):
+                adapter.clear_session_lock(session_key)
+            self._pending_messages.pop(session_key, None)
             return "⚡ Stopped. You can continue this session."
-        else:
-            return "No active task to stop."
+        if adapter and hasattr(adapter, "clear_session_lock") and adapter.clear_session_lock(session_key):
+            self._pending_messages.pop(session_key, None)
+            logger.info("STOP for session %s — adapter lock cleared without running agent", session_key[:20])
+            return "⚡ Unlocked the stuck session. You can continue this session."
+        return "No active task to stop."
 
     async def _handle_restart_command(self, event: MessageEvent) -> str:
         """Handle /restart command - drain active work, then restart the gateway."""

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -222,6 +222,42 @@ class TestBasePlatformTopicSessions:
         ]
 
     @pytest.mark.asyncio
+    async def test_process_message_background_delivery_timeout_releases_session(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.extra["delivery_timeout_seconds"] = 0.01
+        session_key = build_session_key(_make_event("-1001", "17585").source)
+        delivered = asyncio.Event()
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "ack"
+
+        async def hanging_send(*_args, **_kwargs):
+            delivered.set()
+            await asyncio.Event().wait()
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._send_with_retry = hanging_send
+        adapter._keep_typing = hold_typing
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        event = _make_event("-1001", "17585")
+        await asyncio.wait_for(
+            adapter._process_message_background(event, session_key),
+            timeout=0.2,
+        )
+
+        assert delivered.is_set()
+        assert session_key not in adapter._active_sessions
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.FAILURE),
+        ]
+
+    @pytest.mark.asyncio
     async def test_cancel_background_tasks_marks_expected_cancellation_cancelled(self):
         adapter = DummyTelegramAdapter()
         release = asyncio.Event()

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -23,8 +23,8 @@ class _FakeAdapter:
     """Minimal adapter stub for testing."""
 
     def __init__(self):
-        self._pending_messages = {}
         self._active_sessions = {}
+        self._pending_messages = {}
         self.interrupted_sessions = []
 
     async def send(self, chat_id, text, **kwargs):
@@ -35,6 +35,19 @@ class _FakeAdapter:
         event = self._active_sessions.get(session_key)
         if event is not None:
             event.set()
+
+    def get_pending_message(self, session_key):
+        return self._pending_messages.pop(session_key, None)
+
+    def clear_session_lock(self, session_key):
+        cleared = False
+        if session_key in self._pending_messages:
+            del self._pending_messages[session_key]
+            cleared = True
+        if session_key in self._active_sessions:
+            del self._active_sessions[session_key]
+            cleared = True
+        return cleared
 
 
 def _make_runner():
@@ -442,6 +455,25 @@ async def test_stop_clears_pending_messages():
     # Pending messages must be cleared
     assert session_key not in runner._pending_messages
     adapter.get_pending_message.assert_called_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_adapter_lock_without_running_agent():
+    """If only the adapter-level session lock remains, /stop must release it."""
+    runner = _make_runner()
+    stop_event = _make_event(text="/stop")
+    session_key = build_session_key(stop_event.source)
+    runner.session_store.get_or_create_session.return_value = MagicMock(session_key=session_key)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._pending_messages[session_key] = _make_event(text="queued")
+
+    result = await runner._handle_stop_command(stop_event)
+
+    assert result is not None
+    assert "unlocked" in result.lower()
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._pending_messages
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## 改动
- 给 gateway adapter 发送/投递阶段增加硬超时，避免 Telegram send 卡住后 `_active_sessions` 永久占用
- 增加 `clear_session_lock()`，统一清理 adapter 层 active/pending 状态
- 修复 `/stop`：即使没有 running agent，也能清理 adapter 层假死会话锁
- 增加回归测试覆盖发送卡住释放会话、/stop 清理 adapter 锁

## 验证
- 在原本本地分支：`python -m pytest tests/gateway/test_base_topic_sessions.py tests/gateway/test_session_race_guard.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_gateway_shutdown.py -q` -> 42 passed
- 干净 PR 分支基于最新 `origin/main` cherry-pick 后：`python -m pytest tests/gateway/test_base_topic_sessions.py tests/gateway/test_session_race_guard.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_gateway_shutdown.py -q` -> 74 passed
- 原本本地分支曾运行 `python -m pytest tests/gateway/ -q`；结果 2899 passed, 5 failed, 10 errors，失败集中在既有 Discord / Telegram approval buttons 相关测试，与本改动无关。
