### PR TITLE
Use reasoning content for context summaries

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2910,9 +2910,17 @@ def extract_content_or_reasoning(response) -> str:
     import re
 
     msg = response.choices[0].message
-    content = (msg.content or "").strip()
+    raw_content = getattr(msg, "content", None)
+    if isinstance(raw_content, str):
+        content = raw_content.strip()
+    else:
+        content = raw_content
 
     if content:
+        # Preserve non-string payloads for callers that know how to coerce them
+        # (e.g. llama.cpp-style dict content), while still normalizing text.
+        if not isinstance(content, str):
+            return content
         # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
         cleaned = re.sub(
             r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -24,7 +24,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 from agent.context_engine import ContextEngine
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -801,7 +801,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
+            content = extract_content_or_reasoning(response)
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,6 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
@@ -171,6 +172,35 @@ class TestNonStringContent:
         # None content → empty string → standardized compaction handoff prefix added
         assert summary is not None
         assert summary == SUMMARY_PREFIX
+
+    def test_reasoning_content_used_when_message_content_is_none(self):
+        mock_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=None,
+                        reasoning="summary from reasoning",
+                        reasoning_content=None,
+                        reasoning_details=None,
+                    )
+                )
+            ]
+        )
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary(messages)
+
+        assert isinstance(summary, str)
+        assert summary.startswith(SUMMARY_PREFIX)
+        assert "summary from reasoning" in summary
 
     def test_summary_call_does_not_force_temperature(self):
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary

- Route context-compression summaries through `extract_content_or_reasoning()`.
- Preserve existing non-string content handling by making the helper tolerate non-string `message.content` payloads.
- Add a regression test for reasoning-only summary responses.

## Why

Some OpenAI-compatible reasoning runtimes can return `message.content=None` while placing usable text in structured reasoning fields. Context compression previously read `response.choices[0].message.content` directly, which caused the generated summary to be empty even when `extract_content_or_reasoning()` could recover the text.

This also keeps the existing llama.cpp-style non-string content path working after switching the compressor to the shared extraction helper.

## Validation

- `python -m pytest tests/agent/test_context_compressor.py -q`
