### PR TITLE
fix(cli): persist first-run config edits to user home

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1730,11 +1730,14 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
 
 def save_config_value(key_path: str, value: any) -> bool:
     """
-    Save a value to the active config file at the specified key path.
+    Save a value to the user config file at the specified key path.
     
-    Respects the same lookup order as load_cli_config():
+    Respects the same lookup order as load_cli_config() for reads:
     1. ~/.hermes/config.yaml (user config - preferred, used if it exists)
     2. ./cli-config.yaml (project config - fallback)
+
+    User-initiated writes always persist to ~/.hermes/config.yaml so first-run
+    preference changes do not mutate the repo/project fallback config.
     
     Args:
         key_path: Dot-separated path like "agent.system_prompt"
@@ -1743,18 +1746,20 @@ def save_config_value(key_path: str, value: any) -> bool:
     Returns:
         True if successful, False otherwise
     """
-    # Use the same precedence as load_cli_config: user config first, then project config
+    # Read with the same precedence as load_cli_config, but always persist user
+    # changes to ~/.hermes/config.yaml so project fallback config stays untouched.
     user_config_path = _hermes_home / 'config.yaml'
     project_config_path = Path(__file__).parent / 'cli-config.yaml'
-    config_path = user_config_path if user_config_path.exists() else project_config_path
+    source_config_path = user_config_path if user_config_path.exists() else project_config_path
+    config_path = user_config_path
     
     try:
         # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
         config_path.parent.mkdir(parents=True, exist_ok=True)
         
         # Load existing config
-        if config_path.exists():
-            with open(config_path, 'r') as f:
+        if source_config_path.exists():
+            with open(source_config_path, 'r') as f:
                 config = yaml.safe_load(f) or {}
         else:
             config = {}

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -96,3 +96,35 @@ class TestSaveConfigValueAtomic:
 
         assert result is False
         assert config_env.read_text() == original_content
+
+    def test_missing_user_config_writes_to_user_home_not_project_fallback(self, tmp_path, monkeypatch):
+        """First-run writes should target ~/.hermes/config.yaml, not repo cli-config.yaml."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        project_config = project_dir / "cli-config.yaml"
+        project_config.write_text(yaml.dump({
+            "model": {"default": "fallback-model", "provider": "openrouter"},
+            "display": {"skin": "default"},
+        }))
+        original_project = project_config.read_text()
+
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        monkeypatch.setattr(cli, "__file__", str(project_dir / "cli.py"))
+
+        mock_atomic = MagicMock()
+        monkeypatch.setattr("utils.atomic_yaml_write", mock_atomic)
+
+        from cli import save_config_value
+        result = save_config_value("display.skin", "ares")
+
+        assert result is True
+        written_path, written_data = mock_atomic.call_args[0]
+        assert Path(written_path) == hermes_home / "config.yaml"
+        assert written_data["model"]["default"] == "fallback-model"
+        assert written_data["model"]["provider"] == "openrouter"
+        assert written_data["display"]["skin"] == "ares"
+        assert project_config.read_text() == original_project


### PR DESCRIPTION
## Summary
- write user-initiated config edits to ~/.hermes/config.yaml even on first run
- keep reading project cli-config.yaml as the fallback baseline when user config is absent
- add a regression test covering the missing-user-config case from #14714

## Testing
- python3 -m pytest -o addopts= -q tests/cli/test_cli_save_config_value.py

Closes #14714