### PR TITLE
fix(cli): retry MCP config reload after failed apply

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7223,7 +7223,6 @@ class HermesCLI:
             return  # File unchanged — fast path
 
         # File changed — check whether mcp_servers section changed
-        self._config_mtime = mtime
         try:
             with open(cfg_path, encoding="utf-8") as f:
                 new_cfg = _yaml.safe_load(f) or {}
@@ -7232,21 +7231,37 @@ class HermesCLI:
 
         new_mcp = new_cfg.get("mcp_servers") or {}
         if new_mcp == self._config_mcp_servers:
+            self._config_mtime = mtime
             return  # mcp_servers unchanged (some other section was edited)
 
-        self._config_mcp_servers = new_mcp
         # Notify user and reload.  Run in a separate thread with a hard
         # timeout so a hung MCP server cannot block the process_loop
         # indefinitely (which would freeze the entire TUI).
         print()
         print("🔄 MCP server config changed — reloading connections...")
+        reload_state = {"success": False}
+
+        def _run_reload() -> None:
+            try:
+                reload_state["success"] = bool(self._reload_mcp())
+            except Exception:
+                reload_state["success"] = False
+
         _reload_thread = threading.Thread(
-            target=self._reload_mcp, daemon=True
+            target=_run_reload, daemon=True
         )
         _reload_thread.start()
         _reload_thread.join(timeout=30)
         if _reload_thread.is_alive():
             print("  ⚠️  MCP reload timed out (30s). Some servers may not have reconnected.")
+            return
+
+        if not reload_state["success"]:
+            print("  ↻ MCP config reload did not apply; watcher will retry on the next poll.")
+            return
+
+        self._config_mtime = mtime
+        self._config_mcp_servers = new_mcp
 
     def _reload_mcp(self):
         """Reload MCP servers: disconnect all, re-read config.yaml, reconnect.
@@ -7329,9 +7344,11 @@ class HermesCLI:
                     pass  # Best-effort
 
             print(f"  ✅ Agent updated — {len(self.agent.tools if self.agent else [])} tool(s) available")
+            return True
 
         except Exception as e:
             print(f"  ❌ MCP reload failed: {e}")
+            return False
 
     # ====================================================================
     # Tool-call generation indicator (shown during streaming)

--- a/tests/cli/test_cli_mcp_config_watch.py
+++ b/tests/cli/test_cli_mcp_config_watch.py
@@ -80,6 +80,30 @@ class TestMCPConfigWatch:
 
         obj._reload_mcp.assert_called_once()
 
+    def test_reload_failure_is_retried_on_next_poll(self, tmp_path):
+        """A failed reload should not poison the watcher state."""
+        import yaml
+
+        obj, cfg_file = _make_cli(tmp_path, mcp_servers={})
+        obj._reload_mcp = MagicMock(side_effect=[RuntimeError("reload failed"), True])
+
+        cfg_file.write_text(yaml.dump({"mcp_servers": {"github": {"url": "https://mcp.github.com"}}}))
+        obj._config_mtime = 0.0
+
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file):
+            obj._check_config_mcp_changes()
+
+        assert obj._reload_mcp.call_count == 1
+        assert obj._config_mcp_servers == {}
+        assert obj._config_mtime == 0.0
+
+        obj._last_config_check = 0.0
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file):
+            obj._check_config_mcp_changes()
+
+        assert obj._reload_mcp.call_count == 2
+        assert obj._config_mcp_servers == {"github": {"url": "https://mcp.github.com"}}
+
     def test_interval_throttle_skips_check(self, tmp_path):
         """If called within CONFIG_WATCH_INTERVAL, stat() is skipped."""
         obj, cfg_file = _make_cli(tmp_path)


### PR DESCRIPTION
## Summary
- only mark config watcher state as applied after MCP reload succeeds
- keep failed or timed out reloads dirty so the next poll retries automatically
- add a regression test covering a failed reload followed by a successful retry

Closes #14716

## Testing
- python3 -m pytest -o addopts= tests/cli/test_cli_mcp_config_watch.py
- python3 -m pytest -o addopts= tests/tools/test_mcp_stability.py -k reload_timeout