### PR TITLE
[codex] Guard untrusted context probe shrink

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -677,6 +677,29 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _should_keep_context_length_on_untrusted_probe(
+    *,
+    parsed_limit: Optional[int],
+    old_ctx: int,
+    new_ctx: Optional[int],
+    approx_tokens: Optional[int],
+) -> bool:
+    """Return True when a guessed probe tier is less credible than current usage.
+
+    If the provider gives a concrete parseable limit, trust it.  When Hermes is
+    only guessing the next probe tier, do not shrink the model window below the
+    prompt we are actively trying to recover from; that usually creates an
+    artificial overflow loop rather than useful compression.
+    """
+    if parsed_limit is not None:
+        return False
+    if not new_ctx or new_ctx >= old_ctx:
+        return False
+    if not approx_tokens or approx_tokens <= 0:
+        return False
+    return new_ctx < approx_tokens
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -10603,6 +10626,23 @@ class AIAgent:
                             # Step down to the next probe tier
                             new_ctx = get_next_probe_tier(old_ctx)
 
+                        kept_untrusted_probe = _should_keep_context_length_on_untrusted_probe(
+                            parsed_limit=parsed_limit,
+                            old_ctx=old_ctx,
+                            new_ctx=new_ctx,
+                            approx_tokens=approx_tokens,
+                        )
+                        if kept_untrusted_probe:
+                            attempted_ctx = new_ctx
+                            new_ctx = old_ctx
+                            self._vprint(
+                                f"{self.log_prefix}Provider did not report a parseable context limit; "
+                                f"keeping context_length at {old_ctx:,} tokens instead of "
+                                f"probing down to {attempted_ctx:,}, which is below the "
+                                f"current prompt estimate (~{approx_tokens:,}).",
+                                force=True,
+                            )
+
                         if new_ctx and new_ctx < old_ctx:
                             compressor.update_model(
                                 model=self.model,
@@ -10624,6 +10664,8 @@ class AIAgent:
                                     parsed_limit and parsed_limit == new_ctx
                                 )
                             self._vprint(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens", force=True)
+                        elif kept_untrusted_probe:
+                            self._vprint(f"{self.log_prefix}⚠️  Context length exceeded — keeping current context tier and attempting compression...", force=True)
                         else:
                             self._vprint(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...", force=True)
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2619,6 +2619,51 @@ class TestRunConversation:
         assert result["final_response"] == "Recovered after compression"
         assert result["completed"] is True
 
+    def test_untrusted_probe_below_prompt_keeps_known_context_length(self, agent):
+        """Do not shrink a known large context below the prompt being recovered.
+
+        Codex can report a context overflow without a parseable limit.  If the
+        local prompt estimate is already above the guessed next tier, keep the
+        known model window and compress instead of forcing a 128K artificial
+        window.
+        """
+        self._setup_agent(agent)
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.4"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent.context_compressor.context_length = 1_050_000
+        agent.context_compressor.threshold_tokens = int(
+            agent.context_compressor.context_length * agent.context_compressor.threshold_percent
+        )
+
+        err_400 = Exception("Your input exceeds the context window of this model.")
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch("run_agent.estimate_messages_tokens_rough", return_value=285_378),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.context_compressor.context_length == 1_050_000
+        assert agent.context_compressor._context_probed is False
+        assert result["final_response"] == "Recovered after compression"
+        assert result["completed"] is True
+
     def test_non_minimax_delta_overflow_still_probes_down(self, agent):
         """Non-MiniMax providers should keep the generic probe-down behavior."""
         self._setup_agent(agent)

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -296,6 +296,39 @@ class TestContextNotHalvedOnOutputCapError:
         new_ctx = get_next_probe_tier(200_000)
         assert new_ctx == 128_000
 
+    def test_untrusted_probe_below_current_prompt_keeps_context(self):
+        """Do not step down to a guessed tier below the prompt being recovered."""
+        from run_agent import _should_keep_context_length_on_untrusted_probe
+
+        assert _should_keep_context_length_on_untrusted_probe(
+            parsed_limit=None,
+            old_ctx=1_050_000,
+            new_ctx=128_000,
+            approx_tokens=285_378,
+        )
+
+    def test_parseable_provider_limit_is_trusted_even_below_prompt(self):
+        """A concrete provider limit is more authoritative than local estimates."""
+        from run_agent import _should_keep_context_length_on_untrusted_probe
+
+        assert not _should_keep_context_length_on_untrusted_probe(
+            parsed_limit=128_000,
+            old_ctx=1_050_000,
+            new_ctx=128_000,
+            approx_tokens=285_378,
+        )
+
+    def test_untrusted_probe_above_current_prompt_can_step_down(self):
+        """Keep existing probe behavior when the guessed tier can fit the prompt."""
+        from run_agent import _should_keep_context_length_on_untrusted_probe
+
+        assert not _should_keep_context_length_on_untrusted_probe(
+            parsed_limit=None,
+            old_ctx=1_050_000,
+            new_ctx=400_000,
+            approx_tokens=285_378,
+        )
+
     def test_output_cap_error_safety_margin(self):
         """The ephemeral value includes a 64-token safety margin below available_out."""
         from agent.model_metadata import parse_available_output_tokens_from_error


### PR DESCRIPTION
## Summary

Keep a known model context length when Hermes only guessed the next context probe tier and that guessed tier is already below the prompt being recovered.

This is a narrower alternative to #14499. It follows the same recovery shape as #14743: if the provider error does not contain a trustworthy parseable context limit, do not mutate `context_length` to an untrusted lower value. Compress with the known window instead, or fail closed if compression cannot reduce the session.

## User impact

This is a high-frequency Codex/GPT-5.4 usability issue for my setup. I hit this at least five times per day, and it significantly disrupts normal Hermes usage. Local session history shows the issue was reported repeatedly on 2026-04-23 and 2026-04-24, including after `hermes update`.

The observed failure mode from the attached evidence in #14499:

```text
Provider: openai-codex Model: gpt-5.4
Endpoint: https://chatgpt.com/backend-api/codex
Context: 492 msgs, ~285,378 tokens
Context length exceeded - stepping down: 1,050,000 -> 128,000 tokens
gpt-5.4 270K/128K
```

Once Hermes believes the context is 128K, an otherwise recoverable long-session overflow turns into repeated compression/failure against an artificially tiny window.

## What changed

- Added `_should_keep_context_length_on_untrusted_probe(...)`.
- When `parse_context_limit_from_error(...)` returns no concrete limit and `get_next_probe_tier(...)` would shrink below the current prompt estimate, keep `old_ctx`.
- Preserve existing behavior when:
  - provider returned a concrete parseable limit;
  - guessed probe tier is still above current prompt estimate;
  - normal non-Codex unknown-provider probe-down applies.
- Added pure helper tests and a `run_conversation` regression test modeled after #14743.

## Related work

- #14743: merged MiniMax fix that preserves known context length when provider overflow text is not a real context limit.
- #14499: broader previous attempt that changed global probe tiers. This PR is intentionally narrower.
- #5173 / #5174 / #5179: related GPT-5.4 context resolution/cache issues, but do not cover this untrusted probe shrink path.

## Validation

```text
./venv/bin/python -m pytest tests/test_ctx_halving_fix.py tests/run_agent/test_run_agent.py::TestRunConversation::test_untrusted_probe_below_prompt_keeps_known_context_length tests/run_agent/test_run_agent.py::TestRunConversation::test_minimax_delta_overflow_keeps_known_context_length tests/run_agent/test_run_agent.py::TestRunConversation::test_non_minimax_delta_overflow_still_probes_down -q
30 passed in 7.37s
```

```text
./venv/bin/python -m py_compile run_agent.py
git diff --check
```