### PR TITLE
fix(usage): fall back to Anthropic token names for OpenAI-compat servers

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -531,7 +531,11 @@ def normalize_usage(
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
         prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
+        if not prompt_total:
+            prompt_total = _to_int(getattr(response_usage, "input_tokens", 0))
         output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
+        if not output_tokens:
+            output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
         details = getattr(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -106,6 +106,34 @@ def test_normalize_usage_openai_prefers_prompt_tokens_details_over_top_level():
     assert normalized.cache_write_tokens == 150
 
 
+def test_normalize_usage_openai_falls_back_to_anthropic_usage_names():
+    usage = SimpleNamespace(
+        input_tokens=11477,
+        output_tokens=235,
+    )
+
+    normalized = normalize_usage(usage, provider="custom", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 11477
+    assert normalized.output_tokens == 235
+
+
+def test_normalize_usage_openai_prefers_openai_usage_names_when_both_exist():
+    usage = SimpleNamespace(
+        prompt_tokens=3000,
+        completion_tokens=700,
+        input_tokens=11477,
+        output_tokens=235,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=1800),
+    )
+
+    normalized = normalize_usage(usage, provider="custom", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 1200
+    assert normalized.cache_read_tokens == 1800
+    assert normalized.output_tokens == 700
+
+
 def test_openrouter_models_api_pricing_is_converted_from_per_token_to_per_million(monkeypatch):
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_model_metadata",


### PR DESCRIPTION
## Summary
- fall back to input_tokens when chat-completions usage does not include prompt_tokens
- fall back to output_tokens when chat-completions usage does not include completion_tokens
- add regression coverage for Anthropic-named usage objects while keeping OpenAI names preferred

## Testing
- python3 -m pytest -o addopts= tests/agent/test_usage_pricing.py

Closes #14686