### PR TITLE
fix(gateway): preserve LD_LIBRARY_PATH in generated systemd units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1523,6 +1523,10 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
             path_entries.append(resolved_node_dir)
 
     common_bin_paths = ["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
+    ld_library_path = os.environ.get("LD_LIBRARY_PATH")
+    ld_library_env = (
+        f'Environment="LD_LIBRARY_PATH={ld_library_path}"\n' if ld_library_path else ""
+    )
     # systemd's TimeoutStopSec must exceed the gateway's drain_timeout so
     # there's budget left for post-interrupt cleanup (tool subprocess kill,
     # adapter disconnect, session DB close) before systemd escalates to
@@ -1567,7 +1571,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=on-failure
+{ld_library_env}Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
@@ -1599,7 +1603,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=on-failure
+{ld_library_env}Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -100,6 +100,13 @@ class TestGeneratedSystemdUnits:
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
         assert "TimeoutStopSec=90" in unit
 
+    def test_user_unit_preserves_ld_library_path_when_present(self, monkeypatch):
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/opt/cuda/lib64:/usr/local/cuda/lib64")
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert 'Environment="LD_LIBRARY_PATH=/opt/cuda/lib64:/usr/local/cuda/lib64"' in unit
+
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
 
@@ -119,6 +126,13 @@ class TestGeneratedSystemdUnits:
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
         assert "TimeoutStopSec=90" in unit
         assert "WantedBy=multi-user.target" in unit
+
+    def test_system_unit_preserves_ld_library_path_when_present(self, monkeypatch):
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/opt/cuda/lib64")
+
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert 'Environment="LD_LIBRARY_PATH=/opt/cuda/lib64"' in unit
 
 
 class TestGatewayStopCleanup:


### PR DESCRIPTION
## Summary
- carry LD_LIBRARY_PATH into generated systemd user units when it is present in the install shell
- do the same for generated system units so CUDA-dependent tools keep their dynamic library path
- add regression coverage for both unit types

## Testing
- python3 -m pytest -o addopts= tests/hermes_cli/test_gateway_service.py -k GeneratedSystemdUnits or LD_LIBRARY_PATH

Closes #14613