### PR TITLE
fix: repair malformed MCP additionalProperties schemas

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -266,6 +266,22 @@ class TestSchemaConversion:
 
         assert schema["properties"]["items"]["items"]["properties"] == {}
 
+    def test_string_additional_properties_is_coerced_to_schema_object(self):
+        """Broken MCP schemas that emit additionalProperties='object' are repaired."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "type": "object",
+                    "additionalProperties": "object",
+                },
+            },
+        })
+
+        assert schema["properties"]["payload"]["additionalProperties"] == {"type": "object", "properties": {}}
+
     def test_convert_mcp_schema_survives_missing_inputschema_attribute(self):
         """A Tool object without .inputSchema must not crash registration."""
         import types

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2066,6 +2066,15 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
 
         repaired = {k: _repair_object_shape(v) for k, v in node.items()}
 
+        # Some MCP servers emit ``additionalProperties": "object"`` (or
+        # another scalar type string) instead of a schema object / boolean.
+        # OpenAI-compatible APIs reject that with:
+        #   'object' is not of type 'object', 'boolean'
+        # Coerce the shorthand string into a real schema node before the
+        # object-shape repair below runs.
+        if isinstance(repaired.get("additionalProperties"), str) and repaired.get("additionalProperties"):
+            repaired["additionalProperties"] = _repair_object_shape({"type": repaired["additionalProperties"]})
+
         # Coerce missing / null type when the shape is clearly an object
         # (has properties or required but no type).
         if not repaired.get("type") and (


### PR DESCRIPTION
## Summary

- Normalize malformed MCP schemas where `additionalProperties` is emitted as a scalar string shorthand, e.g. `"object"`.
- Convert the shorthand into a provider-valid JSON Schema object before tool registration.
- Add a regression test covering the broken MCP schema shape.

Fixes #14927.

## Problem

Some MCP servers expose tool schemas that contain:

```json
{
  "type": "object",
  "additionalProperties": "object"
}
```

OpenAI-compatible providers reject that during tool registration with HTTP 400:

```text
Invalid schema for function 'mcp_notion_notion_create_pages': 'object' is not of type 'object', 'boolean'.
param: tools[122].parameters
code: invalid_function_parameters
```

This breaks requests before any model turn runs when the malformed tool is present.

## Root Cause

Hermes already repairs several malformed MCP object schemas, but `additionalProperties` was only preserved when it was already a valid schema object or boolean. A scalar string type shorthand survived normalization and was passed through to the provider.

## Fix

When repairing object-shaped MCP schemas, coerce scalar string `additionalProperties` values into equivalent schema objects. For example:

```json
"additionalProperties": "object"
```

becomes:

```json
"additionalProperties": {
  "type": "object",
  "properties": {}
}
```

This keeps the MCP tool usable while producing a provider-valid JSON Schema.

## Test Plan

- `./venv/bin/pytest tests/tools/test_mcp_tool.py -q -k 'string_additional_properties_is_coerced_to_schema_object or missing_type_on_object_is_coerced or required_pruned_when_property_missing'`

Note: the full `tests/tools/test_mcp_tool.py -q` file currently has an unrelated pre-existing timing failure in `TestShutdown.test_shutdown_is_parallel` on my local checkout; the new targeted regression and adjacent schema-repair tests pass.
