### PR TITLE
perf(tui): reuse slash catalog for static completions

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -1,6 +1,87 @@
 import { describe, expect, it } from 'vitest'
 
-import { completionRequestForInput } from '../hooks/useCompletion.js'
+import { completionRequestForInput, getLocalSlashCompletion } from '../hooks/useCompletion.js'
+import type { SlashCatalog } from '../types.js'
+
+const catalog: SlashCatalog = {
+  canon: {
+    '/bg': '/background',
+    '/background': '/background',
+    '/help': '/help',
+    '/model': '/model',
+    '/new': '/new',
+    '/reasoning': '/reasoning',
+    '/reset': '/new'
+  },
+  categories: [],
+  pairs: [
+    ['/new', 'Start a new session'],
+    ['/background', 'Run a prompt in the background'],
+    ['/reasoning', 'Manage reasoning effort and display'],
+    ['/help', 'Show available commands'],
+    ['/model', 'Switch model for this session'],
+    ['/compact', 'Toggle compact display mode'],
+    ['/gif-search', 'Search for GIFs across providers']
+  ],
+  skillCount: 1,
+  sub: {
+    '/reasoning': ['none', 'low', 'high', 'show', 'hide']
+  }
+}
+
+describe('getLocalSlashCompletion', () => {
+  it('completes cached top-level slash commands and aliases locally', () => {
+    expect(getLocalSlashCompletion('/he', catalog)).toEqual({
+      items: [{ display: '/help', meta: 'Show available commands', text: 'help' }],
+      replace_from: 1
+    })
+
+    expect(getLocalSlashCompletion('/re', catalog)).toEqual({
+      items: [
+        {
+          display: '/reset',
+          meta: 'Start a new session (alias for /new)',
+          text: 'reset'
+        },
+        {
+          display: '/reasoning',
+          meta: 'Manage reasoning effort and display',
+          text: 'reasoning'
+        }
+      ],
+      replace_from: 1
+    })
+  })
+
+  it('adds a trailing space for exact local command matches', () => {
+    expect(getLocalSlashCompletion('/help', catalog)).toEqual({
+      items: [{ display: '/help', meta: 'Show available commands', text: 'help ' }],
+      replace_from: 1
+    })
+
+    expect(getLocalSlashCompletion('/gif-search', catalog)).toEqual({
+      items: [{ display: '/gif-search', meta: 'Search for GIFs across providers', text: 'gif-search ' }],
+      replace_from: 1
+    })
+  })
+
+  it('completes static subcommands locally', () => {
+    expect(getLocalSlashCompletion('/reasoning sh', catalog)).toEqual({
+      items: [{ display: 'show', text: 'show' }],
+      replace_from: 11
+    })
+
+    expect(getLocalSlashCompletion('/reasoning show', catalog)).toEqual({
+      items: [],
+      replace_from: 11
+    })
+  })
+
+  it('falls back to the gateway for runtime subcommand sources and unknown slash prefixes', () => {
+    expect(getLocalSlashCompletion('/model so', catalog)).toBeNull()
+    expect(getLocalSlashCompletion('/plugin', catalog)).toBeNull()
+  })
+})
 
 describe('completionRequestForInput', () => {
   it('routes real slash commands to slash completion', () => {
@@ -9,6 +90,10 @@ describe('completionRequestForInput', () => {
       params: { text: '/help' },
       replaceFrom: 1
     })
+  })
+
+  it('leaves model completion to the model picker', () => {
+    expect(completionRequestForInput('/model so')).toBeNull()
   })
 
   it('does not route absolute paths through slash completion', () => {

--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { getLocalSlashCompletion } from '../hooks/useCompletion.js'
+import type { SlashCatalog } from '../types.js'
+
+const catalog: SlashCatalog = {
+  canon: {
+    '/bg': '/background',
+    '/background': '/background',
+    '/help': '/help',
+    '/model': '/model',
+    '/new': '/new',
+    '/reasoning': '/reasoning',
+    '/reset': '/new'
+  },
+  categories: [],
+  pairs: [
+    ['/new', 'Start a new session'],
+    ['/background', 'Run a prompt in the background'],
+    ['/reasoning', 'Manage reasoning effort and display'],
+    ['/help', 'Show available commands'],
+    ['/model', 'Switch model for this session'],
+    ['/compact', 'Toggle compact display mode'],
+    ['/gif-search', 'Search for GIFs across providers']
+  ],
+  skillCount: 1,
+  sub: {
+    '/reasoning': ['none', 'low', 'high', 'show', 'hide']
+  }
+}
+
+describe('getLocalSlashCompletion', () => {
+  it('completes cached top-level slash commands and aliases locally', () => {
+    expect(getLocalSlashCompletion('/he', catalog)).toEqual({
+      items: [{ display: '/help', meta: 'Show available commands', text: 'help' }],
+      replace_from: 1
+    })
+
+    expect(getLocalSlashCompletion('/re', catalog)).toEqual({
+      items: [
+        {
+          display: '/reset',
+          meta: 'Start a new session (alias for /new)',
+          text: 'reset'
+        },
+        {
+          display: '/reasoning',
+          meta: 'Manage reasoning effort and display',
+          text: 'reasoning'
+        }
+      ],
+      replace_from: 1
+    })
+  })
+
+  it('adds a trailing space for exact local command matches', () => {
+    expect(getLocalSlashCompletion('/help', catalog)).toEqual({
+      items: [{ display: '/help', meta: 'Show available commands', text: 'help ' }],
+      replace_from: 1
+    })
+
+    expect(getLocalSlashCompletion('/gif-search', catalog)).toEqual({
+      items: [{ display: '/gif-search', meta: 'Search for GIFs across providers', text: 'gif-search ' }],
+      replace_from: 1
+    })
+  })
+
+  it('completes static subcommands locally', () => {
+    expect(getLocalSlashCompletion('/reasoning sh', catalog)).toEqual({
+      items: [{ display: 'show', text: 'show' }],
+      replace_from: 11
+    })
+
+    expect(getLocalSlashCompletion('/reasoning show', catalog)).toEqual({
+      items: [],
+      replace_from: 11
+    })
+  })
+
+  it('falls back to the gateway for runtime subcommand sources and unknown slash prefixes', () => {
+    expect(getLocalSlashCompletion('/model so', catalog)).toBeNull()
+    expect(getLocalSlashCompletion('/plugin', catalog)).toBeNull()
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -172,6 +172,7 @@ export interface ComposerState {
 }
 
 export interface UseComposerStateOptions {
+  catalog: null | SlashCatalog
   gw: GatewayClient
   onClipboardPaste: (quiet?: boolean) => Promise<void> | void
   onImageAttached?: (info: ImageAttachResponse) => void

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -151,6 +151,7 @@ export interface ComposerState {
 }
 
 export interface UseComposerStateOptions {
+  catalog: null | SlashCatalog
   gw: GatewayClient
   onClipboardPaste: (quiet?: boolean) => Promise<void> | void
   onImageAttached?: (info: ImageAttachResponse) => void

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -99,6 +99,7 @@ export function looksLikeDroppedPath(text: string): boolean {
 }
 
 export function useComposerState({
+  catalog,
   gw,
   onClipboardPaste,
   onImageAttached,
@@ -124,7 +125,7 @@ export function useComposerState({
   } = useQueue()
 
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
-  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
+  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw, catalog)
 
   const clearIn = useCallback(() => {
     setInput('')

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -98,6 +98,7 @@ export function looksLikeDroppedPath(text: string): boolean {
 }
 
 export function useComposerState({
+  catalog,
   gw,
   onClipboardPaste,
   onImageAttached,
@@ -113,7 +114,7 @@ export function useComposerState({
     useQueue()
 
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
-  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
+  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw, catalog)
 
   const clearIn = useCallback(() => {
     setInput('')

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -193,6 +193,7 @@ export function useMainApp(gw: GatewayClient) {
   }, [selection])
 
   const composer = useComposerState({
+    catalog,
     gw,
     onClipboardPaste: quiet => clipboardPasteRef.current(quiet),
     onImageAttached: info => {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -136,6 +136,7 @@ export function useMainApp(gw: GatewayClient) {
   }, [selection, ui.theme.color.selectionBg])
 
   const composer = useComposerState({
+    catalog,
     gw,
     onClipboardPaste: quiet => clipboardPasteRef.current(quiet),
     onImageAttached: info => {

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -5,8 +5,108 @@ import { looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
+import type { SlashCatalog } from '../types.js'
 
 const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
+const DYNAMIC_SLASH_COMMANDS = new Set(['/model', '/personality', '/skin'])
+
+const completionText = (cmdName: string, word: string) => (cmdName === word ? `${cmdName} ` : cmdName)
+
+interface LocalSlashEntry {
+  display: string
+  meta: string
+  name: string
+}
+
+const buildLocalSlashEntries = (catalog: SlashCatalog): LocalSlashEntry[] => {
+  const aliasesByCanonical = new Map<string, string[]>()
+
+  for (const [raw, canonical] of Object.entries(catalog.canon)) {
+    const name = raw.toLowerCase()
+    const canonicalName = canonical.toLowerCase()
+
+    if (name === canonicalName) {
+      continue
+    }
+
+    const aliases = aliasesByCanonical.get(canonicalName) ?? []
+    aliases.push(name)
+    aliasesByCanonical.set(canonicalName, aliases)
+  }
+
+  const entries: LocalSlashEntry[] = []
+
+  for (const [command, description] of catalog.pairs) {
+    const display = command.toLowerCase()
+    const meta = String(description)
+
+    entries.push({ display, meta, name: display })
+
+    for (const alias of aliasesByCanonical.get(display) ?? []) {
+      entries.push({
+        display: alias,
+        meta: `${meta} (alias for ${display})`,
+        name: alias
+      })
+    }
+  }
+
+  return entries
+}
+
+export function getLocalSlashCompletion(text: string, catalog: null | SlashCatalog): CompletionResponse | null {
+  if (!catalog || !looksLikeSlashCommand(text)) {
+    return null
+  }
+
+  const entries = buildLocalSlashEntries(catalog)
+  const localNames = new Set(entries.map(entry => entry.name))
+  const parts = text.split(/\s+/, 2)
+  const baseInput = (parts[0] ?? '').toLowerCase()
+  const baseCanonical = (catalog.canon[baseInput] ?? baseInput).toLowerCase()
+  const replaceFrom = text.includes(' ') ? text.lastIndexOf(' ') + 1 : 1
+
+  if (parts.length > 1 || text.endsWith(' ')) {
+    if (DYNAMIC_SLASH_COMMANDS.has(baseCanonical)) {
+      return null
+    }
+
+    const subText = parts[1] ?? ''
+
+    if (!subText.includes(' ')) {
+      const subs = catalog.sub[baseCanonical] ?? []
+
+      if (subs.length) {
+        return {
+          items: subs
+            .filter(sub => sub.startsWith(subText.toLowerCase()) && sub !== subText.toLowerCase())
+            .slice(0, 30)
+            .map(sub => ({ display: sub, text: sub })),
+          replace_from: replaceFrom
+        }
+      }
+    }
+
+    if (localNames.has(baseInput) || localNames.has(baseCanonical)) {
+      return { items: [], replace_from: replaceFrom }
+    }
+
+    return null
+  }
+
+  const word = text.slice(1).toLowerCase()
+
+  const items = entries
+    .filter(entry => entry.name.slice(1).startsWith(word))
+    .slice(0, 30)
+    .map(entry => ({
+      display: entry.display,
+      meta: entry.meta,
+      text: completionText(entry.name.slice(1), word)
+    }))
+
+  return items.length ? { items, replace_from: 1 } : null
+}
 
 export function completionRequestForInput(
   input: string
@@ -38,7 +138,7 @@ export function completionRequestForInput(
   }
 }
 
-export function useCompletion(input: string, blocked: boolean, gw: GatewayClient) {
+export function useCompletion(input: string, blocked: boolean, gw: GatewayClient, catalog: null | SlashCatalog) {
   const [completions, setCompletions] = useState<CompletionItem[]>([])
   const [compIdx, setCompIdx] = useState(0)
   const [compReplace, setCompReplace] = useState(0)
@@ -76,6 +176,16 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
         return
       }
 
+      const localSlash = request.method === 'complete.slash' ? getLocalSlashCompletion(input, catalog) : null
+
+      if (localSlash) {
+        setCompletions(localSlash.items ?? [])
+        setCompIdx(0)
+        setCompReplace(localSlash.replace_from ?? 1)
+
+        return
+      }
+
       gw.request<CompletionResponse>(request.method, request.params)
         .then(raw => {
           if (ref.current !== input) {
@@ -106,7 +216,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     }, 60)
 
     return () => clearTimeout(t)
-  }, [blocked, gw, input])
+  }, [blocked, catalog, gw, input])
 
   return { completions, compIdx, setCompIdx, compReplace }
 }

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -4,10 +4,111 @@ import type { CompletionItem } from '../app/interfaces.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
+import type { SlashCatalog } from '../types.js'
 
 const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
+const DYNAMIC_SLASH_COMMANDS = new Set(['/model', '/personality', '/skin'])
 
-export function useCompletion(input: string, blocked: boolean, gw: GatewayClient) {
+const completionText = (cmdName: string, word: string) => (cmdName === word ? `${cmdName} ` : cmdName)
+
+interface LocalSlashEntry {
+  display: string
+  meta: string
+  name: string
+}
+
+const buildLocalSlashEntries = (catalog: SlashCatalog): LocalSlashEntry[] => {
+  const aliasesByCanonical = new Map<string, string[]>()
+
+  for (const [raw, canonical] of Object.entries(catalog.canon)) {
+    const name = raw.toLowerCase()
+    const canonicalName = canonical.toLowerCase()
+
+    if (name === canonicalName) {
+      continue
+    }
+
+    const aliases = aliasesByCanonical.get(canonicalName) ?? []
+
+    aliases.push(name)
+    aliasesByCanonical.set(canonicalName, aliases)
+  }
+
+  const entries: LocalSlashEntry[] = []
+
+  for (const [command, description] of catalog.pairs) {
+    const display = command.toLowerCase()
+    const meta = String(description)
+
+    entries.push({ display, meta, name: display })
+
+    for (const alias of aliasesByCanonical.get(display) ?? []) {
+      entries.push({
+        display: alias,
+        meta: `${meta} (alias for ${display})`,
+        name: alias
+      })
+    }
+  }
+
+  return entries
+}
+
+export function getLocalSlashCompletion(text: string, catalog: null | SlashCatalog): CompletionResponse | null {
+  if (!catalog || !text.startsWith('/')) {
+    return null
+  }
+
+  const entries = buildLocalSlashEntries(catalog)
+  const localNames = new Set(entries.map(entry => entry.name))
+  const parts = text.split(/\s+/, 2)
+  const baseInput = (parts[0] ?? '').toLowerCase()
+  const baseCanonical = (catalog.canon[baseInput] ?? baseInput).toLowerCase()
+  const replaceFrom = text.includes(' ') ? text.lastIndexOf(' ') + 1 : 1
+
+  if (parts.length > 1 || text.endsWith(' ')) {
+    if (DYNAMIC_SLASH_COMMANDS.has(baseCanonical)) {
+      return null
+    }
+
+    const subText = parts[1] ?? ''
+
+    if (!subText.includes(' ')) {
+      const subs = catalog.sub[baseCanonical] ?? []
+
+      if (subs.length) {
+        return {
+          items: subs
+            .filter(sub => sub.startsWith(subText.toLowerCase()) && sub !== subText.toLowerCase())
+            .slice(0, 30)
+            .map(sub => ({ display: sub, text: sub })),
+          replace_from: replaceFrom
+        }
+      }
+    }
+
+    if (localNames.has(baseInput) || localNames.has(baseCanonical)) {
+      return { items: [], replace_from: replaceFrom }
+    }
+
+    return null
+  }
+
+  const word = text.slice(1).toLowerCase()
+
+  const items = entries
+    .filter(entry => entry.name.slice(1).startsWith(word))
+    .slice(0, 30)
+    .map(entry => ({
+      display: entry.display,
+      meta: entry.meta,
+      text: completionText(entry.name.slice(1), word)
+    }))
+
+  return items.length ? { items, replace_from: 1 } : null
+}
+
+export function useCompletion(input: string, blocked: boolean, gw: GatewayClient, catalog: null | SlashCatalog) {
   const [completions, setCompletions] = useState<CompletionItem[]>([])
   const [compIdx, setCompIdx] = useState(0)
   const [compReplace, setCompReplace] = useState(0)
@@ -49,6 +150,16 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
         return
       }
 
+      const localSlash = isSlash ? getLocalSlashCompletion(input, catalog) : null
+
+      if (localSlash) {
+        setCompletions(localSlash.items ?? [])
+        setCompIdx(0)
+        setCompReplace(localSlash.replace_from ?? 1)
+
+        return
+      }
+
       const req = isSlash
         ? gw.request<CompletionResponse>('complete.slash', { text: input })
         : gw.request<CompletionResponse>('complete.path', { word: pathWord })
@@ -83,7 +194,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     }, 60)
 
     return () => clearTimeout(t)
-  }, [blocked, gw, input])
+  }, [blocked, catalog, gw, input])
 
   return { completions, compIdx, setCompIdx, compReplace }
 }


### PR DESCRIPTION
## Summary
- reuse the loaded `commands.catalog` data for TUI top-level slash command, alias, and static subcommand completion
- keep gateway RPC fallback for dynamic completion sources like `/model`, `/skin`, and `/personality`
- add focused tests for local slash completion behavior

## Why this helps
This keeps static slash completion local to the TUI when we already have the command catalog in memory, which removes an unnecessary RPC round-trip for common paths like `/help`, `/new`, and static subcommands such as `/reasoning show`.

Dynamic completion sources still stay dynamic:
- `/model`
- `/personality`
- `/skin`

## Testing
- [x] `cd ui-tui && npm test -- --run src/__tests__/useCompletion.test.ts`
- [x] `cd ui-tui && npm run type-check`
