### PR TITLE
fix(weixin): guard live_adapter session reuse against cross-loop calls

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1982,7 +1982,21 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    # Guard: aiohttp ClientSession is bound to the event loop that created it.
+    # When send_message is invoked via _run_async from the gateway, the coroutine
+    # runs in a fresh thread with a new event loop, and reusing the old session
+    # causes "Timeout context manager should be used inside a task".
+    _session_loop = getattr(send_session, '_loop', None)
+    try:
+        _current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _current_loop = None
+    if (
+        live_adapter is not None
+        and send_session is not None
+        and not send_session.closed
+        and _session_loop is _current_loop
+    ):
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:


### PR DESCRIPTION
## Bug Description

When `send_message` is invoked from the gateway context (e.g., cron jobs or tool callbacks), `_run_async` spawns the coroutine in a fresh thread with a new event loop. Reusing the `live_adapter`'s `ClientSession` (which was bound to the gateway's original event loop) causes `aiohttp` to raise:

```
Timeout context manager should be used inside a task
```

This prevents Weixin proactive message delivery from working reliably in gateway mode.

## Root Cause

`aiohttp.ClientSession` is bound to the event loop that created it. In the current code (`gateway/platforms/weixin.py`), `send_weixin_direct()` unconditionally reuses `live_adapter._send_session` if it exists and is not closed, without checking whether the current running loop matches the session's bound loop.

## Fix

Before reusing the live adapter's session, verify that `send_session._loop` matches `asyncio.get_running_loop()`. If the loops differ (cross-loop call), fall back to creating a new `ClientSession`.

### Changes
- `gateway/platforms/weixin.py`: added `_session_loop` / `_current_loop` check in `send_weixin_direct()`

## Testing

- Verified that proactive `send_message` to Weixin works from gateway context after the fix
- Patch cleanly applies against `origin/main` (v0.11.0 + post-release commits)

## Related

- This is a production bugfix; no new dependencies or API changes.
- Fixes Weixin proactive message delivery failures in multi-threaded gateway scenarios.
