### PR TITLE
fix: restore WeCom Callback setup entrypoint

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3108,6 +3108,14 @@ def _setup_wecom():
     print_success("💬 WeCom configured!")
 
 
+def _setup_wecom_callback():
+    """Configure WeCom Callback (self-built app) via the standard platform setup."""
+    wecom_callback_platform = next(
+        p for p in _PLATFORMS if p["key"] == "wecom_callback"
+    )
+    _setup_standard_platform(wecom_callback_platform)
+
+
 def _is_service_installed() -> bool:
     """Check if the gateway is installed as a system service."""
     if supports_systemd_services():

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2274,6 +2274,7 @@ def setup_gateway(config: dict):
         or get_env_value("DINGTALK_CLIENT_ID")
         or get_env_value("FEISHU_APP_ID")
         or get_env_value("WECOM_BOT_ID")
+        or get_env_value("WECOM_CALLBACK_CORP_ID")
         or get_env_value("WEIXIN_ACCOUNT_ID")
         or get_env_value("BLUEBUBBLES_SERVER_URL")
         or get_env_value("QQ_APP_ID")

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -223,6 +223,51 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_setup_wecom_callback_delegates_to_gateway_helper(monkeypatch):
+    called = []
+
+    monkeypatch.setattr(
+        "hermes_cli.gateway._setup_wecom_callback",
+        lambda: called.append(True),
+    )
+
+    setup_mod._setup_wecom_callback()
+
+    assert called == [True]
+
+
+def test_setup_gateway_treats_wecom_callback_as_messaging(monkeypatch, capsys):
+    env = {"WECOM_CALLBACK_CORP_ID": ""}
+
+    def fake_get_env_value(key):
+        return env.get(key, "")
+
+    def fake_setup_wecom_callback():
+        env["WECOM_CALLBACK_CORP_ID"] = "wxcorp"
+
+    monkeypatch.setattr(setup_mod, "get_env_value", fake_get_env_value)
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *_args, **_kwargs: [0])
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        setup_mod,
+        "_GATEWAY_PLATFORMS",
+        [("WeCom Callback (Self-Built App)", "WECOM_CALLBACK_CORP_ID", fake_setup_wecom_callback)],
+    )
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_installed", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: False)
+
+    setup_mod.setup_gateway({})
+
+    out = capsys.readouterr().out
+    assert "Messaging platforms configured!" in out
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- restore the missing gateway helper used by the WeCom Callback setup wizard
- treat WECOM_CALLBACK_CORP_ID as a configured messaging platform in gateway setup
- add regression tests covering the setup delegation and messaging summary path

## Testing
- python3 -m pytest -o addopts= tests/hermes_cli/test_setup.py -k wecom_callback

Closes #14861