### PR TITLE
fix(skills): #13263 guide unknown skill-as-tool calls to skill_view

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -119,6 +119,18 @@ class TestUnknownToolDispatch:
         assert "error" in result
         assert "Unknown tool" in result["error"]
 
+    def test_unknown_tool_that_matches_skill_returns_skill_hint(self, monkeypatch):
+        reg = ToolRegistry()
+        monkeypatch.setattr(
+            "agent.skill_commands.get_skill_commands",
+            lambda: {"/text2sql": {"name": "text2sql"}},
+        )
+        result = json.loads(reg.dispatch("text2sql", {}))
+        assert "error" in result
+        assert result["suggested_tool"] == "skill_view"
+        assert result["suggested_skill"] == "text2sql"
+        assert "Skills are not callable tools" in result["hint"]
+
 
 class TestToolsetAvailability:
     def test_no_check_fn_is_available(self):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -289,6 +289,40 @@ class ToolRegistry:
     # Dispatch
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _unknown_tool_payload(name: str) -> dict:
+        """Build a structured unknown-tool error payload with skill hints.
+
+        Some users (and model retries) accidentally call a skill name as a tool
+        (e.g. ``text2sql``). Surface a direct correction path so the model can
+        self-heal instead of drifting to unrelated skills/tools.
+        """
+        payload = {"error": f"Unknown tool: {name}"}
+        normalized = (name or "").strip().lower()
+        if not normalized:
+            return payload
+        try:
+            from agent.skill_commands import get_skill_commands
+
+            command_map = get_skill_commands() or {}
+            command_names = {key.lstrip("/") for key in command_map.keys()}
+            hyphen_name = normalized.replace("_", "-")
+            underscore_name = normalized.replace("-", "_")
+            if (
+                normalized in command_names
+                or hyphen_name in command_names
+                or underscore_name in command_names
+            ):
+                payload["hint"] = (
+                    "Skills are not callable tools. Load the skill with "
+                    f"skill_view(\"{hyphen_name}\") or invoke it via /{hyphen_name}."
+                )
+                payload["suggested_tool"] = "skill_view"
+                payload["suggested_skill"] = hyphen_name
+        except Exception:
+            pass
+        return payload
+
     def dispatch(self, name: str, args: dict, **kwargs) -> str:
         """Execute a tool handler by name.
 
@@ -298,7 +332,7 @@ class ToolRegistry:
         """
         entry = self.get_entry(name)
         if not entry:
-            return json.dumps({"error": f"Unknown tool: {name}"})
+            return json.dumps(self._unknown_tool_payload(name))
         try:
             if entry.is_async:
                 from model_tools import _run_async


### PR DESCRIPTION
## What does this PR do?

This fixes a CLI failure mode where a skill name (for example `text2sql`) is treated as a tool call.
If the unknown tool name matches an installed skill command, the registry now returns a clearer correction payload so the next step is `skill_view(...)` (or `/skill-name`) instead of drifting to unrelated tools.

## Related Issue

Fixes #13263

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/registry.py` unknown-tool handling for the skill-name-as-tool case.
- Added correction fields in the error payload: `suggested_tool`, `suggested_skill`, and `hint`.
- Added a regression test in `tests/tools/test_registry.py` to lock this behavior.

## How to Test

1. Run `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/tools/test_registry.py -q`
2. Confirm `test_unknown_tool_that_matches_skill_returns_skill_hint` passes.
3. In a CLI session with an installed skill such as `text2sql`, reproduce an unknown-tool call and verify the error includes `suggested_tool=skill_view` and the matching `suggested_skill`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 (PowerShell + uv-managed Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A for this change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A for this change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A for this change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A for this change)

## Screenshots / Logs

- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/tools/test_registry.py -q` -> `32 passed`