### PR TITLE
feat(gateway): optionally auto-delete progress messages

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -32,6 +32,7 @@ from typing import Any
 
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
+    "progress_auto_delete": False,
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
@@ -47,6 +48,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
 
 _TIER_HIGH = {
     "tool_progress": "all",
+    "progress_auto_delete": False,
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,  # follow global
@@ -54,6 +56,7 @@ _TIER_HIGH = {
 
 _TIER_MEDIUM = {
     "tool_progress": "new",
+    "progress_auto_delete": False,
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,
@@ -61,6 +64,7 @@ _TIER_MEDIUM = {
 
 _TIER_LOW = {
     "tool_progress": "off",
+    "progress_auto_delete": False,
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": False,
@@ -68,6 +72,7 @@ _TIER_LOW = {
 
 _TIER_MINIMAL = {
     "tool_progress": "off",
+    "progress_auto_delete": False,
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": False,
@@ -121,7 +126,8 @@ def resolve_display_setting(
         Platform config key (e.g. ``"telegram"``, ``"slack"``).  Use
         ``_platform_config_key(source.platform)`` from gateway/run.py.
     setting : str
-        Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
+        Display setting name (e.g. ``"tool_progress"``, ``"progress_auto_delete"``,
+        ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
 
@@ -182,7 +188,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in ("show_reasoning", "streaming"):
+    if setting in ("progress_auto_delete", "show_reasoning", "streaming"):
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1127,6 +1127,14 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
+        """
+        Delete a previously sent message. Optional — platforms that don't
+        support deletion return success=False without logging so callers can
+        safely probe this capability.
+        """
+        return SendResult(success=False, error="Not supported")
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
         Send a typing indicator.

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1299,6 +1299,21 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
+        """Delete a previously sent Discord message."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[%s] Failed to delete Discord message %s: %s", self.name, message_id, e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     async def _send_file_attachment(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -485,6 +485,11 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _adapter_supports_delete_message(adapter: BasePlatformAdapter) -> bool:
+    """Return True when an adapter overrides the optional message delete API."""
+    return type(adapter).delete_message is not BasePlatformAdapter.delete_message
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error."""
     try:
@@ -9369,6 +9374,10 @@ class GatewayRunner:
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )
+        progress_auto_delete_requested = is_truthy_value(
+            resolve_display_setting(user_config, platform_key, "progress_auto_delete", False),
+            default=False,
+        )
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
@@ -9467,6 +9476,27 @@ class GatewayRunner:
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _progress_msg_ids: list[str] = []
+        _progress_auto_delete_active = [False]
+
+        def _remember_progress_result(result) -> None:
+            if not getattr(result, "success", False):
+                return
+
+            message_ids: list[str] = []
+            raw_response = getattr(result, "raw_response", None)
+            if isinstance(raw_response, dict):
+                raw_message_ids = raw_response.get("message_ids")
+                if isinstance(raw_message_ids, (list, tuple)):
+                    message_ids.extend(str(msg_id) for msg_id in raw_message_ids if msg_id)
+
+            message_id = getattr(result, "message_id", None)
+            if message_id:
+                message_ids.append(str(message_id))
+
+            for message_id in message_ids:
+                if message_id not in _progress_msg_ids:
+                    _progress_msg_ids.append(message_id)
 
         async def send_progress_messages():
             if not progress_queue:
@@ -9475,6 +9505,10 @@ class GatewayRunner:
             adapter = self.adapters.get(source.platform)
             if not adapter:
                 return
+            _progress_auto_delete_active[0] = (
+                progress_auto_delete_requested
+                and _adapter_supports_delete_message(adapter)
+            )
 
             # Skip tool progress for platforms that don't support message
             # editing (e.g. iMessage/BlueBubbles) — each progress update
@@ -9550,7 +9584,9 @@ class GatewayRunner:
                                     adapter.name,
                                 )
                             can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            if result.success:
+                                _remember_progress_result(result)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
@@ -9561,6 +9597,8 @@ class GatewayRunner:
                             result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
+                        if result.success:
+                            _remember_progress_result(result)
 
                     _last_edit_ts = time.monotonic()
 
@@ -9584,6 +9622,8 @@ class GatewayRunner:
                                 progress_lines.append(raw)
                         except Exception:
                             break
+                    if _progress_auto_delete_active[0]:
+                        return
                     # Final edit with all remaining tools (only if editing works)
                     if can_edit and progress_lines and progress_msg_id:
                         full_text = "\n".join(progress_lines)
@@ -9599,6 +9639,35 @@ class GatewayRunner:
                 except Exception as e:
                     logger.error("Progress message error: %s", e)
                     await asyncio.sleep(1)
+
+        async def delete_progress_messages():
+            if not progress_auto_delete_requested or not _progress_msg_ids:
+                return
+
+            adapter = self.adapters.get(source.platform)
+            if not adapter or not _adapter_supports_delete_message(adapter):
+                return
+
+            for message_id in list(_progress_msg_ids):
+                try:
+                    result = await adapter.delete_message(
+                        chat_id=source.chat_id,
+                        message_id=message_id,
+                    )
+                    if not result.success:
+                        logger.debug(
+                            "[%s] Progress message delete skipped for %s: %s",
+                            adapter.name,
+                            message_id,
+                            getattr(result, "error", "") or "unsupported",
+                        )
+                except Exception:
+                    logger.debug(
+                        "[%s] Progress message delete failed for %s",
+                        adapter.name,
+                        message_id,
+                        exc_info=True,
+                    )
         
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance
@@ -10844,6 +10913,8 @@ class GatewayRunner:
                         await task
                     except asyncio.CancelledError:
                         pass
+
+            await delete_progress_messages()
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -618,6 +618,7 @@ DEFAULT_CONFIG = {
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "progress_auto_delete": False,  # Gateway: delete transient tool-progress messages after a run finishes, when supported
         "platforms": {},  # Per-platform display overrides: {"telegram": {"tool_progress": "all"}, "slack": {"tool_progress": "off"}}
     },
 

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -54,6 +54,30 @@ class TestResolveDisplaySetting:
         # Unknown platform, no config → global default "all"
         assert resolve_display_setting(config, "unknown_platform", "tool_progress") == "all"
 
+    def test_progress_auto_delete_defaults_off(self):
+        """Progress auto-delete is opt-in globally and per platform."""
+        from gateway.display_config import resolve_display_setting
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["display"]["progress_auto_delete"] is False
+        assert resolve_display_setting({}, "discord", "progress_auto_delete") is False
+        assert resolve_display_setting({}, "unknown_platform", "progress_auto_delete") is False
+
+    def test_progress_auto_delete_platform_override(self):
+        """display.platforms.<plat>.progress_auto_delete overrides the global setting."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "progress_auto_delete": False,
+                "platforms": {
+                    "discord": {"progress_auto_delete": True},
+                },
+            }
+        }
+        assert resolve_display_setting(config, "discord", "progress_auto_delete") is True
+        assert resolve_display_setting(config, "telegram", "progress_auto_delete") is False
+
     def test_fallback_parameter_used_last(self):
         """Explicit fallback is used when nothing else matches."""
         from gateway.display_config import resolve_display_setting

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -58,6 +58,45 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         return {"id": chat_id}
 
 
+class ProgressDeleteCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.DISCORD):
+        super().__init__(platform=platform)
+        self.deletes = []
+
+    async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
+        self.deletes.append({"chat_id": chat_id, "message_id": message_id})
+        return SendResult(success=True, message_id=message_id)
+
+
+class ProgressEditFailureDeleteCaptureAdapter(ProgressDeleteCaptureAdapter):
+    def __init__(self, platform=Platform.DISCORD):
+        super().__init__(platform=platform)
+        self._send_count = 0
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self._send_count += 1
+        message_id = f"progress-{self._send_count}"
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(success=False, error="edit failed")
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
@@ -103,6 +142,23 @@ class DelayedProgressAgent:
         time.sleep(0.45)
         self.tool_progress_callback("tool.started", "terminal", "second command", {})
         time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class EditFailureFallbackProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "first command", {})
+        time.sleep(1.8)
+        self.tool_progress_callback("tool.started", "terminal", "second command", {})
+        time.sleep(0.8)
         return {
             "final_response": "done",
             "messages": [],
@@ -502,6 +558,7 @@ async def _run_with_agent(
     chat_id="-1001",
     chat_type="group",
     thread_id="17585",
+    adapter_cls=ProgressCaptureAdapter,
 ):
     if config_data:
         import yaml
@@ -516,7 +573,7 @@ async def _run_with_agent(
     fake_run_agent.AIAgent = agent_cls
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
-    adapter = ProgressCaptureAdapter(platform=platform)
+    adapter = adapter_cls(platform=platform)
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
@@ -549,6 +606,93 @@ async def _run_with_agent(
         session_key=session_key,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_progress_auto_delete_deletes_progress_when_supported(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FakeAgent,
+        session_id="sess-progress-auto-delete",
+        config_data={"display": {"tool_progress": "all", "progress_auto_delete": True}},
+        platform=Platform.DISCORD,
+        chat_id="dm-delete",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=ProgressDeleteCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert adapter.deletes == [{"chat_id": "dm-delete", "message_id": "progress-1"}]
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_progress_auto_delete_deletes_edit_failure_fallback_send(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        EditFailureFallbackProgressAgent,
+        session_id="sess-progress-auto-delete-edit-fallback",
+        config_data={"display": {"tool_progress": "all", "progress_auto_delete": True}},
+        platform=Platform.DISCORD,
+        chat_id="dm-edit-fallback-delete",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=ProgressEditFailureDeleteCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits
+    assert adapter.edits[0]["message_id"] == "progress-1"
+    assert any("first command" in call["content"] for call in adapter.sent)
+    assert any("second command" in call["content"] for call in adapter.sent)
+    assert adapter.deletes == [
+        {"chat_id": "dm-edit-fallback-delete", "message_id": "progress-1"},
+        {"chat_id": "dm-edit-fallback-delete", "message_id": "progress-2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_progress_auto_delete_default_keeps_final_progress_edit(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FakeAgent,
+        session_id="sess-progress-auto-delete-default-off",
+        config_data={"display": {"tool_progress": "all"}},
+        platform=Platform.DISCORD,
+        chat_id="dm-keep",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=ProgressDeleteCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.deletes == []
+    assert adapter.edits
+    assert "browser_navigate" in adapter.edits[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_progress_auto_delete_unsupported_adapter_keeps_final_progress_edit(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FakeAgent,
+        session_id="sess-progress-auto-delete-unsupported",
+        config_data={"display": {"tool_progress": "all", "progress_auto_delete": True}},
+        platform=Platform.TELEGRAM,
+        chat_id="dm-unsupported",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits
+    assert "browser_navigate" in adapter.edits[-1]["content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an opt-in `display.progress_auto_delete` gateway display setting (default `false`)
- add optional platform message deletion support with a Discord implementation
- delete transient progress messages after runs only when the option is enabled and the adapter supports deletion
- keep the existing final progress edit behavior by default and for unsupported adapters

## Why
Some chat deployments prefer tool-progress updates to be transient so the final answer remains uncluttered, but changing the default would be disruptive. This makes the behavior configurable and default-off.

## Tests
- `python -m pytest -o addopts="" tests/gateway/test_run_progress_topics.py::test_progress_auto_delete_deletes_progress_when_supported tests/gateway/test_run_progress_topics.py::test_progress_auto_delete_deletes_edit_failure_fallback_send tests/gateway/test_run_progress_topics.py::test_progress_auto_delete_default_keeps_final_progress_edit tests/gateway/test_run_progress_topics.py::test_progress_auto_delete_unsupported_adapter_keeps_final_progress_edit tests/gateway/test_display_config.py::TestResolveDisplaySetting::test_progress_auto_delete_defaults_off tests/gateway/test_display_config.py::TestResolveDisplaySetting::test_progress_auto_delete_platform_override -vv -s`
- `python -m pytest tests/hermes_cli/test_model_validation.py -q`
- `git diff --check`

## Compatibility
Default behavior is unchanged unless `display.progress_auto_delete: true` is configured. Unsupported adapters skip deletion and keep the existing final progress edit behavior.