### PR TITLE
fix: keep compression reachable at 64k context

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -314,10 +314,7 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        self.threshold_tokens = self._compute_threshold_tokens(context_length)
 
     def __init__(
         self,
@@ -350,14 +347,7 @@ class ContextCompressor(ContextEngine):
             config_context_length=config_context_length,
             provider=provider,
         )
-        # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        self.threshold_tokens = self._compute_threshold_tokens(self.context_length)
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context
@@ -378,7 +368,6 @@ class ContextCompressor(ContextEngine):
                 provider or "none", base_url or "none",
             )
         self._context_probed = False  # True after a step-down from context error
-
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
 
@@ -391,6 +380,19 @@ class ContextCompressor(ContextEngine):
         self._ineffective_compression_count: int = 0
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
+
+    def _compute_threshold_tokens(self, context_length: int) -> int:
+        """Return a compression threshold that never disables compression.
+
+        The 64K floor prevents premature compression on large-context models,
+        but for models at the floor itself it would otherwise push the
+        threshold to 100% and make compression unreachable.
+        """
+        percentage_threshold = int(context_length * self.threshold_percent)
+        threshold_tokens = max(percentage_threshold, MINIMUM_CONTEXT_LENGTH)
+        if threshold_tokens >= context_length:
+            return percentage_threshold
+        return threshold_tokens
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -685,6 +685,28 @@ class TestSummaryTargetRatio:
         # 50% of 200K = 100K, which is above the 64K floor
         assert c.threshold_tokens == 100_000
 
+    def test_threshold_uses_percentage_at_exact_minimum_context(self):
+        """64K models must still compress before hitting the hard context limit."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=64_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                threshold_percent=0.70,
+            )
+        assert c.threshold_tokens == 44_800
+
+    def test_update_model_uses_percentage_at_exact_minimum_context(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                threshold_percent=0.70,
+            )
+
+        c.update_model("test", 64_000)
+
+        assert c.threshold_tokens == 44_800
+
     def test_default_protect_last_n_is_20(self):
         """Default protect_last_n should be 20."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):


### PR DESCRIPTION
## Summary
- keep ContextCompressor threshold percentage-based when the 64K floor would otherwise push it to the full context window
- reuse the same threshold calculation in __init__ and update_model
- add regression tests for exact-64K initialization and model-update paths

## Testing
- python3 -m pytest -o addopts= tests/agent/test_context_compressor.py -k threshold

Closes #14690