### PR TITLE
feat(agent): add actor runtime state

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,183 @@
+"""Match-based model routing via ``model.routes``.
+
+A pure helper that lets callers pick a model + provider bundle based on a
+context dict describing the turn (``platform``, ``source_kind``, etc.).
+The router iterates ``model.routes`` — a list of ``{match, model, provider,
+api_key, base_url, ...}`` entries — and applies the first route whose
+``match`` predicates are all satisfied by the context.
+
+Two legacy shorthand forms are supported for backwards compatibility and
+config ergonomics (the ``routes`` list is canonical; shims synthesize
+entries from them at match time):
+
+    model.platforms.<name>:       routes by platform (pre-unify shorthand)
+    model.by_source.<kind>:       routes by source identity (owner /
+                                  hub_peer / stranger / cron)
+
+Example config::
+
+    model:
+      default: my-fast-model
+      routes:
+        - match: { source_kind: owner }
+          model: my-strong-model
+          api_key: sk-owner
+        - match: { platform: hub }
+          model: my-fast-model
+        - match: { source_kind: cron }
+          model: my-fast-model
+        - match: { platform: discord, source_kind: stranger }
+          model: some-other
+
+Explicit ``routes`` always evaluate first; legacy shims run last, so a new
+``routes:`` block always takes priority over an equivalent legacy entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+
+SOURCE_KIND_OWNER = "owner"
+SOURCE_KIND_HUB_PEER = "hub_peer"
+SOURCE_KIND_STRANGER = "stranger"
+SOURCE_KIND_CRON = "cron"
+KNOWN_SOURCE_KINDS = frozenset({
+    SOURCE_KIND_OWNER,
+    SOURCE_KIND_HUB_PEER,
+    SOURCE_KIND_STRANGER,
+    SOURCE_KIND_CRON,
+})
+
+_OVERRIDE_RUNTIME_KEYS = ("api_key", "base_url", "provider", "api_mode", "command", "args")
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_routes(model_config: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collect the effective ordered route list from ``model_config``.
+
+    Precedence (first match wins during lookup):
+
+    1. Explicit ``routes:`` list as declared in config.
+    2. Legacy ``platforms.<name>`` entries (synthesized as
+       ``{match: {platform: <name>}, ...}``).
+    3. Legacy ``by_source.<kind>`` entries (synthesized as
+       ``{match: {source_kind: <kind>}, ...}``).
+    """
+    if not isinstance(model_config, dict):
+        return []
+
+    routes: List[Dict[str, Any]] = []
+
+    explicit = model_config.get("routes")
+    if isinstance(explicit, list):
+        for item in explicit:
+            if isinstance(item, dict) and isinstance(item.get("match"), dict):
+                routes.append(item)
+
+    platforms = model_config.get("platforms")
+    if isinstance(platforms, dict):
+        for name, override in platforms.items():
+            if isinstance(override, str) and override:
+                routes.append({"match": {"platform": str(name)}, "model": override})
+            elif isinstance(override, dict) and override:
+                routes.append({"match": {"platform": str(name)}, **override})
+
+    by_source = model_config.get("by_source")
+    if isinstance(by_source, dict):
+        for kind, override in by_source.items():
+            if isinstance(override, dict) and override:
+                routes.append({"match": {"source_kind": str(kind)}, **override})
+
+    return routes
+
+
+def _route_matches(match_spec: Dict[str, Any], context: Dict[str, Any]) -> bool:
+    """Return True when every key in ``match_spec`` equals the context value.
+
+    Missing keys in ``context`` never match (empty context satisfies empty
+    match only). String comparison is case-sensitive.
+    """
+    if not isinstance(match_spec, dict) or not match_spec:
+        return False
+    for key, expected in match_spec.items():
+        actual = context.get(key)
+        if actual is None:
+            return False
+        if str(actual) != str(expected):
+            return False
+    return True
+
+
+def apply_route(
+    model: str,
+    runtime_kwargs: Dict[str, Any],
+    model_config: Optional[Dict[str, Any]],
+    context: Optional[Dict[str, Any]],
+) -> Tuple[str, Dict[str, Any]]:
+    """Apply the first matching ``model.routes`` entry to ``(model, runtime_kwargs)``.
+
+    ``context`` is a dict describing the turn. Current recognised keys:
+
+    * ``platform``   — inbound platform string ("telegram", "hub", "cli", ...)
+    * ``source_kind`` — ``"owner"`` / ``"hub_peer"`` / ``"stranger"`` /
+                        ``"cron"`` as classified by the caller.
+
+    Callers may add additional keys (e.g. ``user_id``); routes that don't
+    reference them are unaffected.
+
+    Each route entry has shape::
+
+        {
+          "match": { "platform": "hub", "source_kind": "stranger", ... },
+          "model": "my-model",            # optional; preserves base when missing
+          "provider": "custom",           # optional
+          "api_key": "sk-...",
+          "base_url": "https://...",
+          "api_mode": "chat_completions",
+          "command": [...],  "args": [...]
+        }
+
+    Partial overrides are supported — any field not set on the matched route
+    keeps its base value. First match wins; no match leaves inputs unchanged.
+    """
+    if not context:
+        return model, runtime_kwargs
+    routes = _normalize_routes(model_config)
+    if not routes:
+        return model, runtime_kwargs
+
+    for entry in routes:
+        match_spec = entry.get("match")
+        if not isinstance(match_spec, dict):
+            continue
+        if not _route_matches(match_spec, context):
+            continue
+
+        new_model = model
+        new_runtime = dict(runtime_kwargs or {})
+        applied = []
+
+        if entry.get("model"):
+            new_model = str(entry["model"])
+            applied.append("model")
+        for key in _OVERRIDE_RUNTIME_KEYS:
+            val = entry.get(key)
+            if val in (None, "", []):
+                continue
+            if key == "args":
+                new_runtime[key] = list(val)
+            else:
+                new_runtime[key] = val
+            applied.append(key)
+
+        if applied:
+            logger.info(
+                "model.routes matched: context=%s fields=%s model=%s provider=%s",
+                context, applied, new_model, new_runtime.get("provider"),
+            )
+        return new_model, new_runtime
+
+    return model, runtime_kwargs

--- a/cli.py
+++ b/cli.py
@@ -3187,21 +3187,40 @@ class HermesCLI:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from agent.smart_model_routing import apply_route
 
-        runtime = {
+        # CLI is always the owner (operator-driven). Apply ``model.routes``
+        # (or legacy ``model.by_source.owner`` / ``model.platforms.cli``)
+        # before building the route dict.
+        _cli_model = self.model
+        _cli_runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,
             "provider": self.provider,
             "api_mode": self.api_mode,
             "command": self.acp_command,
             "args": list(self.acp_args or []),
+        }
+        _cli_model_config = CLI_CONFIG.get("model") if isinstance(CLI_CONFIG, dict) else None
+        if not isinstance(_cli_model_config, dict):
+            _cli_model_config = None
+        try:
+            _cli_model, _cli_runtime = apply_route(
+                _cli_model, _cli_runtime, _cli_model_config,
+                {"platform": "cli", "source_kind": "owner"},
+            )
+        except Exception as _exc:
+            logger.debug("apply_route failed in CLI (ignored): %s", _exc)
+
+        runtime = {
+            **_cli_runtime,
             "credential_pool": getattr(self, "_credential_pool", None),
         }
         route = {
-            "model": self.model,
+            "model": _cli_model,
             "runtime": runtime,
             "signature": (
-                self.model,
+                _cli_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -882,6 +882,34 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
+        # Apply ``model.routes`` for this cron fire. Context is always
+        # ``{platform: cron, source_kind: cron}`` — cron jobs don't carry
+        # per-source identity. Silent fallback on exception.
+        try:
+            from agent.smart_model_routing import apply_route
+            _cron_runtime = {
+                "api_key": runtime.get("api_key"),
+                "base_url": runtime.get("base_url"),
+                "provider": runtime.get("provider"),
+                "api_mode": runtime.get("api_mode"),
+                "command": runtime.get("command"),
+                "args": list(runtime.get("args") or []),
+            }
+            _cron_model_config = _cfg.get("model") if isinstance(_cfg, dict) else None
+            if not isinstance(_cron_model_config, dict):
+                _cron_model_config = None
+            model, _cron_runtime = apply_route(
+                model, _cron_runtime, _cron_model_config,
+                {"platform": "cron", "source_kind": "cron"},
+            )
+            # Fold any routed overrides back into the shared ``runtime`` dict
+            # so downstream AIAgent construction picks them up.
+            for _k in ("api_key", "base_url", "provider", "api_mode", "command", "args"):
+                if _cron_runtime.get(_k) is not None:
+                    runtime[_k] = _cron_runtime[_k]
+        except Exception as _exc:
+            logger.debug("Job '%s': apply_route failed (ignored): %s", job_id, _exc)
+
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -402,6 +402,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             delivery_errors.append(msg)
             continue
 
+        try:
+            from gateway.agent_actor import evaluate_send_message_policy
+
+            decision = evaluate_send_message_policy(
+                target_platform=platform_name,
+                target_chat_id=chat_id,
+                target_thread_id=thread_id or "",
+                message=cleaned_delivery_content,
+            )
+            if not decision.allowed:
+                msg = f"delivery blocked by {decision.policy}: {decision.reason}"
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
+        except Exception as e:
+            logger.debug("Job '%s': outbound policy check failed open: %s", job["id"], e)
+
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)

--- a/gateway/agent_actor.py
+++ b/gateway/agent_actor.py
@@ -317,14 +317,37 @@ def _format_runtime_event_line(event: Dict[str, Any]) -> str:
     )
 
 
-def _visible_recent_events(db, *, authority: str, session_key: str, person_id: str) -> list[Dict[str, Any]]:
+def _visible_recent_events(
+    db,
+    *,
+    authority: str,
+    session_key: str,
+    person_id: str,
+    platform: str = "",
+    platform_chat_id: str = "",
+) -> list[Dict[str, Any]]:
     if authority in {"owner", "trusted"}:
         return db.list_recent_agent_events(limit=8)
     events = db.list_recent_agent_events(session_key=session_key, limit=5)
     if person_id:
         by_person = db.list_recent_agent_events(person_id=person_id, limit=5)
         events = list({event["event_id"]: event for event in events + by_person}.values())
-    return events[:8]
+    # Cross-session outbound activity targeting the current audience. Without
+    # this, the agent cannot see its own attempts (delivered or blocked) to
+    # send to this same chat from autonomous/cron sessions, and confabulates
+    # "must be a different session" when challenged. Blocked events are
+    # explicitly included — they are the strongest signal of "I have been
+    # trying to push content into this audience."
+    if platform and platform_chat_id:
+        by_audience = db.list_recent_agent_events(
+            event_type="outbound",
+            platform=platform,
+            platform_chat_id=platform_chat_id,
+            limit=5,
+        )
+        events = list({event["event_id"]: event for event in events + by_audience}.values())
+    events.sort(key=lambda e: e.get("seq") or 0, reverse=True)
+    return events[:10]
 
 
 def build_state_packet(
@@ -356,6 +379,8 @@ def build_state_packet(
             authority=authority,
             session_key=session_key,
             person_id=person_id,
+            platform=platform,
+            platform_chat_id=chat_id,
         )
     except Exception:
         recent_events = []

--- a/gateway/agent_actor.py
+++ b/gateway/agent_actor.py
@@ -1,0 +1,584 @@
+"""Agent-level runtime state for gateway sessions.
+
+Sessions remain transcript windows. This module adds a small actor layer above
+them: per-platform identity, append-only events, active directives, structured
+state packets, and outbound policy checks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+
+from gateway.session_context import get_session_env
+
+
+_PUBLIC_PLATFORM_NAMES = {
+    "discord",
+    "slack",
+    "telegram",
+    "matrix",
+    "mattermost",
+    "feishu",
+    "dingtalk",
+    "wecom",
+    "wecom_callback",
+    "weixin",
+    "qqbot",
+}
+
+_AUTONOMOUS_SOURCE_NAMES = {
+    "cron",
+    "hub",
+    "webhook",
+    "homeassistant",
+    "api_server",
+}
+
+_STOP_WORD_RE = re.compile(
+    r"\b(stop|turn\s+this\s+off|turn\s+off|disable|pause|shut\s+off|kill)\b",
+    re.IGNORECASE,
+)
+_PUBLIC_BROADCAST_RE = re.compile(
+    r"\b(post(?:ing)?|broadcast(?:ing)?|send(?:ing)?|digest|market|alpha|cron|general|channel|public)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class GateDecision:
+    allowed: bool
+    reason: str = ""
+    policy: str = ""
+    event_id: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "policy": self.policy,
+            "event_id": self.event_id,
+        }
+
+
+def _platform_value(value: Any) -> str:
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value or "")
+
+
+def _source_to_payload(source: Any) -> Dict[str, Any]:
+    try:
+        return source.to_dict()
+    except Exception:
+        return {}
+
+
+def _preview(text: Any, limit: int = 500) -> str:
+    s = str(text or "").replace("\r", " ").replace("\n", " ").strip()
+    if len(s) <= limit:
+        return s
+    return s[: limit - 3].rstrip() + "..."
+
+
+def _load_db(db=None):
+    if db is not None:
+        return db, False
+    from hermes_state import SessionDB
+
+    return SessionDB(), True
+
+
+def _split_identifier_csv(raw: str) -> set[str]:
+    return {part.strip() for part in str(raw or "").split(",") if part.strip()}
+
+
+def owner_user_ids_for_platform(platform: str) -> set[str]:
+    """Return owner user IDs for a trusted platform.
+
+    The provisioner-owned identity should eventually be emitted as env/config.
+    Until then, SOUL.md is the generated local source available on agent VMs.
+    Keep this narrowly scoped: only the explicit "Your owner" block is parsed.
+    """
+    platform = str(platform or "").strip().lower()
+    ids: set[str] = set()
+    ids.update(_split_identifier_csv(os.getenv("GATEWAY_OWNER_USER_IDS", "")))
+    if platform:
+        prefix = platform.upper()
+        ids.update(_split_identifier_csv(os.getenv(f"{prefix}_OWNER_USER_ID", "")))
+        ids.update(_split_identifier_csv(os.getenv(f"{prefix}_OWNER_USER_IDS", "")))
+    if ids or platform != "discord":
+        return ids
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        soul = get_hermes_home() / "SOUL.md"
+        text = soul.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ids
+
+    owner_match = re.search(r"(?ms)^## Your owner\b(?P<body>.*?)(?:^## |\Z)", text)
+    if not owner_match:
+        return ids
+    body = owner_match.group("body")
+    for pattern in (
+        r"Discord:\s*`?@?[^`\n]*`?\s*\(user_id\s*`?(\d{5,})`?\)",
+        r"\buser_id\s*`?(\d{5,})`?",
+    ):
+        ids.update(re.findall(pattern, body))
+    return ids
+
+
+def infer_platform_authority(source: Any) -> str:
+    """Best-effort v1 authority without cross-platform person unification."""
+    platform = _platform_value(getattr(source, "platform", ""))
+    user_id = str(getattr(source, "user_id", "") or "")
+    chat_type = str(getattr(source, "chat_type", "") or "")
+    if not platform or not user_id:
+        return "system"
+    check_ids = {user_id}
+    if "@" in user_id:
+        check_ids.add(user_id.split("@", 1)[0])
+    owner_ids = owner_user_ids_for_platform(platform)
+
+    platform_allowlist_env = {
+        "telegram": "TELEGRAM_ALLOWED_USERS",
+        "discord": "DISCORD_ALLOWED_USERS",
+        "whatsapp": "WHATSAPP_ALLOWED_USERS",
+        "slack": "SLACK_ALLOWED_USERS",
+        "signal": "SIGNAL_ALLOWED_USERS",
+        "email": "EMAIL_ALLOWED_USERS",
+        "sms": "SMS_ALLOWED_USERS",
+        "mattermost": "MATTERMOST_ALLOWED_USERS",
+        "matrix": "MATRIX_ALLOWED_USERS",
+        "dingtalk": "DINGTALK_ALLOWED_USERS",
+        "feishu": "FEISHU_ALLOWED_USERS",
+        "wecom": "WECOM_ALLOWED_USERS",
+        "wecom_callback": "WECOM_CALLBACK_ALLOWED_USERS",
+        "weixin": "WEIXIN_ALLOWED_USERS",
+        "bluebubbles": "BLUEBUBBLES_ALLOWED_USERS",
+        "qqbot": "QQ_ALLOWED_USERS",
+        "hub": "HUB_ALLOWED_USERS",
+    }
+    if owner_ids and check_ids & owner_ids:
+        return "owner"
+    platform_allow_all_env = f"{platform.upper()}_ALLOW_ALL_USERS"
+    if os.getenv(platform_allow_all_env, "").strip().lower() in {"1", "true", "yes"}:
+        return "user"
+
+    allowed_raw = ",".join(
+        part
+        for part in (
+            os.getenv(platform_allowlist_env.get(platform, ""), ""),
+            os.getenv("GATEWAY_ALLOWED_USERS", ""),
+        )
+        if part
+    )
+    allowed = {p.strip() for p in allowed_raw.split(",") if p.strip()}
+    if "*" in allowed:
+        return "trusted"
+    if allowed and check_ids & allowed:
+        return "trusted"
+    if chat_type == "dm":
+        return "known"
+    return "user"
+
+
+def resolve_identity(db, source: Any, authority: str = "") -> str:
+    platform = _platform_value(getattr(source, "platform", ""))
+    user_id = str(getattr(source, "user_id", "") or "")
+    if not platform or not user_id:
+        return ""
+    authority = authority or infer_platform_authority(source)
+    return db.upsert_agent_identity(
+        platform=platform,
+        platform_user_id=user_id,
+        display_name=str(getattr(source, "user_name", "") or ""),
+        authority=authority,
+        payload={
+            "chat_id": str(getattr(source, "chat_id", "") or ""),
+            "chat_type": str(getattr(source, "chat_type", "") or ""),
+            "thread_id": str(getattr(source, "thread_id", "") or ""),
+        },
+    )
+
+
+def record_inbound_event(
+    db,
+    *,
+    source: Any,
+    session_id: str,
+    session_key: str,
+    text: str,
+    message_id: str = "",
+    platform_update_id: str = "",
+    authority: str = "",
+) -> tuple[str, str]:
+    """Record one inbound MessageEvent and return (event_id, person_id)."""
+    person_id = resolve_identity(db, source, authority=authority)
+    platform = _platform_value(getattr(source, "platform", ""))
+    chat_type = str(getattr(source, "chat_type", "") or "")
+    event_id = db.append_agent_event(
+        event_type="inbound",
+        event_subtype="message",
+        status="received",
+        session_id=session_id,
+        session_key=session_key,
+        actor_id="main",
+        actor_kind="user" if person_id else "system",
+        source=platform,
+        person_id=person_id,
+        sender_user_id=str(getattr(source, "user_id", "") or ""),
+        sender_name=str(getattr(source, "user_name", "") or ""),
+        chat_type=chat_type,
+        audience_type="private" if chat_type == "dm" else "shared",
+        platform=platform,
+        platform_chat_id=str(getattr(source, "chat_id", "") or ""),
+        platform_thread_id=str(getattr(source, "thread_id", "") or ""),
+        platform_message_id=str(message_id or ""),
+        platform_update_id=str(platform_update_id or ""),
+        content=_preview(text, 1000),
+        payload={
+            "source": _source_to_payload(source),
+            "authority": authority or infer_platform_authority(source),
+        },
+    )
+    return event_id, person_id
+
+
+def detect_public_broadcast_stop_directive(text: str) -> Optional[Dict[str, Any]]:
+    """Conservative v1 detector for owner/trusted stop-broadcast directives."""
+    if not text:
+        return None
+    if not _STOP_WORD_RE.search(text):
+        return None
+    if not _PUBLIC_BROADCAST_RE.search(text):
+        return None
+    return {
+        "text": _preview(text, 1000),
+        "target": "public_broadcasts",
+        "behavior": "suppress",
+        "reason": "trusted sender asked the agent to stop/disable public broadcast behavior",
+    }
+
+
+def maybe_record_directive_from_inbound(
+    db,
+    *,
+    source: Any,
+    session_id: str,
+    session_key: str,
+    inbound_event_id: str,
+    person_id: str,
+    text: str,
+    authority: str,
+) -> Optional[str]:
+    """Persist a durable directive extracted from an inbound trusted message."""
+    if authority not in {"trusted", "owner"}:
+        return None
+    directive = detect_public_broadcast_stop_directive(text)
+    if not directive:
+        return None
+    platform = _platform_value(getattr(source, "platform", ""))
+    return db.create_or_replace_agent_directive(
+        directive_scope="actor",
+        directive_key="public-broadcast-suppression",
+        directive_type="suppress_public_broadcasts",
+        payload={**directive, "source_event_id": inbound_event_id},
+        session_id=session_id,
+        session_key="",
+        actor_id="main",
+        issuer_person_id=person_id,
+        issuer_platform=platform,
+        issuer_user_id=str(getattr(source, "user_id", "") or ""),
+        priority=100,
+    )
+
+
+def _format_directive_line(directive: Dict[str, Any]) -> str:
+    payload = directive.get("payload") or {}
+    text = payload.get("text") or directive.get("directive_type") or directive.get("directive_key")
+    return f"- {directive.get('directive_type')}: {_preview(text, 220)}"
+
+
+def _format_runtime_event_line(event: Dict[str, Any]) -> str:
+    who = event.get("person_id") or event.get("sender_name") or event.get("sender_user_id") or "unknown"
+    target = event.get("platform_chat_id") or "unknown"
+    session = event.get("session_key") or "unknown-session"
+    return (
+        f"- {event.get('event_type') or '?'}:{event.get('event_subtype') or '?'} "
+        f"{event.get('status') or 'unknown'} platform={event.get('platform') or event.get('source') or '?'} "
+        f"chat={target} chat_type={event.get('chat_type') or '?'} "
+        f"person={who} session={session} content={_preview(event.get('content'), 180)!r}"
+    )
+
+
+def _visible_recent_events(db, *, authority: str, session_key: str, person_id: str) -> list[Dict[str, Any]]:
+    if authority in {"owner", "trusted"}:
+        return db.list_recent_agent_events(limit=8)
+    events = db.list_recent_agent_events(session_key=session_key, limit=5)
+    if person_id:
+        by_person = db.list_recent_agent_events(person_id=person_id, limit=5)
+        events = list({event["event_id"]: event for event in events + by_person}.values())
+    return events[:8]
+
+
+def build_state_packet(
+    db,
+    *,
+    source: Any,
+    session_id: str,
+    session_key: str,
+    inbound_event_id: str = "",
+    person_id: str = "",
+    authority: str = "",
+) -> str:
+    """Build an ephemeral structured system prefix for this exact event."""
+    platform = _platform_value(getattr(source, "platform", ""))
+    chat_id = str(getattr(source, "chat_id", "") or "")
+    chat_type = str(getattr(source, "chat_type", "") or "")
+    user_id = str(getattr(source, "user_id", "") or "")
+    user_name = str(getattr(source, "user_name", "") or "")
+    authority = authority or infer_platform_authority(source)
+    person_id = person_id or (f"{platform}:{user_id}" if platform and user_id else "")
+
+    try:
+        directives = db.list_active_agent_directives(actor_id="main", limit=8)
+    except Exception:
+        directives = []
+    try:
+        recent_events = _visible_recent_events(
+            db,
+            authority=authority,
+            session_key=session_key,
+            person_id=person_id,
+        )
+    except Exception:
+        recent_events = []
+
+    lines = [
+        "## Agent Runtime State",
+        "",
+        "This packet is ephemeral runtime state, not conversation history.",
+        "Use it for behavior and policy. Do not reveal private cross-session details unless the current sender is authorized and disclosure is needed.",
+        "",
+        "**Current Sender:**",
+        f"- person_id: {person_id or 'unknown'}",
+        f"- platform_user_id: {user_id or 'unknown'}",
+        f"- display_name: {user_name or 'unknown'}",
+        f"- authority: {authority}",
+        "",
+        "**Current Audience:**",
+        f"- platform: {platform or 'unknown'}",
+        f"- chat_id: {chat_id or 'unknown'}",
+        f"- chat_type: {chat_type or 'unknown'}",
+        f"- session_key: {session_key}",
+        f"- inbound_event_id: {inbound_event_id or 'unknown'}",
+    ]
+
+    if directives:
+        lines.extend(["", "**Active Agent Directives:**"])
+        lines.extend(_format_directive_line(d) for d in directives)
+    else:
+        lines.extend(["", "**Active Agent Directives:**", "- none"])
+
+    if recent_events:
+        lines.extend(["", "**Recent Runtime Events:**"])
+        lines.extend(_format_runtime_event_line(event) for event in recent_events)
+    else:
+        lines.extend(["", "**Recent Runtime Events:**", "- none"])
+
+    lines.extend([
+        "",
+        "**Broadcast Policy Reminder:**",
+        "- A cron, Hub, webhook, or other autonomous inbound must not be rebroadcast to a public channel unless the current event contains explicit trusted authorization.",
+        "- If an action is blocked by policy, explain the causal source instead of trying another public target.",
+    ])
+    return "\n".join(lines)
+
+
+def _iter_directive_payloads(db) -> Iterable[Dict[str, Any]]:
+    try:
+        directives = db.list_active_agent_directives(
+            actor_id="main",
+            directive_type="suppress_public_broadcasts",
+            limit=20,
+        )
+    except Exception:
+        directives = []
+    for directive in directives:
+        yield directive.get("payload") or {}
+
+
+def _event_content_for_current_context(db) -> str:
+    event_id = get_session_env("HERMES_AGENT_EVENT_ID", "")
+    if not event_id:
+        return ""
+    try:
+        event = db.get_agent_event(event_id)
+    except Exception:
+        event = None
+    return str((event or {}).get("content") or "")
+
+
+def _is_publicish_cross_session_target(
+    *,
+    target_platform: str,
+    target_chat_id: str,
+    source_platform: str,
+    source_chat_id: str,
+) -> bool:
+    if target_platform not in _PUBLIC_PLATFORM_NAMES:
+        return False
+    if not source_platform or target_platform != source_platform:
+        return True
+    return bool(target_chat_id and source_chat_id and target_chat_id != source_chat_id)
+
+
+def evaluate_send_message_policy(
+    *,
+    target_platform: str,
+    target_chat_id: str,
+    target_thread_id: str = "",
+    message: str = "",
+    db=None,
+) -> GateDecision:
+    """Gate model/tool initiated cross-channel sends."""
+    db, should_close = _load_db(db)
+    try:
+        source_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        source_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+        source_session_key = get_session_env("HERMES_SESSION_KEY", "").strip()
+        target_platform = str(target_platform or "").strip().lower()
+        target_chat_id = str(target_chat_id or "").strip()
+        target_thread_id = str(target_thread_id or "").strip()
+        message = str(message or "")
+        risky_public_target = _is_publicish_cross_session_target(
+            target_platform=target_platform,
+            target_chat_id=target_chat_id,
+            source_platform=source_platform,
+            source_chat_id=source_chat_id,
+        )
+
+        active_stop = any(_iter_directive_payloads(db))
+        if active_stop and risky_public_target:
+            event_id = db.append_agent_event(
+                event_type="outbound",
+                event_subtype="send_message",
+                status="blocked",
+                session_key=source_session_key,
+                actor_id="main",
+                actor_kind="tool",
+                source=source_platform or "tool",
+                person_id=get_session_env("HERMES_AGENT_PERSON_ID", ""),
+                sender_user_id=get_session_env("HERMES_SESSION_USER_ID", ""),
+                sender_name=get_session_env("HERMES_SESSION_USER_NAME", ""),
+                parent_event_id=get_session_env("HERMES_AGENT_EVENT_ID", ""),
+                platform=target_platform,
+                platform_chat_id=target_chat_id,
+                platform_thread_id=target_thread_id,
+                tool_name="send_message",
+                content=_preview(message, 1000),
+                payload={"decision": "deny", "source_platform": source_platform},
+            )
+            return GateDecision(
+                allowed=False,
+                reason="Active directive suppresses public/cross-session broadcasts.",
+                policy="suppress_public_broadcasts",
+                event_id=event_id,
+            )
+
+        inbound_content = _event_content_for_current_context(db)
+        cron_like = inbound_content.lower().startswith("cronjob response:")
+        autonomous_source = source_platform in _AUTONOMOUS_SOURCE_NAMES
+        if risky_public_target and (cron_like or autonomous_source):
+            event_id = db.append_agent_event(
+                event_type="outbound",
+                event_subtype="send_message",
+                status="blocked",
+                session_key=source_session_key,
+                actor_id="main",
+                actor_kind="tool",
+                source=source_platform or "tool",
+                person_id=get_session_env("HERMES_AGENT_PERSON_ID", ""),
+                sender_user_id=get_session_env("HERMES_SESSION_USER_ID", ""),
+                sender_name=get_session_env("HERMES_SESSION_USER_NAME", ""),
+                parent_event_id=get_session_env("HERMES_AGENT_EVENT_ID", ""),
+                platform=target_platform,
+                platform_chat_id=target_chat_id,
+                platform_thread_id=target_thread_id,
+                tool_name="send_message",
+                content=_preview(message, 1000),
+                payload={
+                    "decision": "deny",
+                    "source_platform": source_platform,
+                    "cron_like": cron_like,
+                    "autonomous_source": autonomous_source,
+                },
+            )
+            return GateDecision(
+                allowed=False,
+                reason="Autonomous cron/Hub/webhook context cannot rebroadcast to public/cross-session targets without explicit trusted authorization.",
+                policy="autonomous_public_rebroadcast_guard",
+                event_id=event_id,
+            )
+
+        return GateDecision(allowed=True)
+    finally:
+        if should_close:
+            db.close()
+
+
+def record_send_message_outbound(
+    *,
+    target_platform: str,
+    target_chat_id: str,
+    target_thread_id: str = "",
+    message: str = "",
+    status: str = "succeeded",
+    result: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Best-effort event log write after an allowed send attempt."""
+    db = None
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        db.append_agent_event(
+            event_type="outbound",
+            event_subtype="send_message",
+            status=status,
+            session_key=get_session_env("HERMES_SESSION_KEY", ""),
+            actor_id="main",
+            actor_kind="tool",
+            source=get_session_env("HERMES_SESSION_PLATFORM", "tool"),
+            person_id=get_session_env("HERMES_AGENT_PERSON_ID", ""),
+            sender_user_id=get_session_env("HERMES_SESSION_USER_ID", ""),
+            sender_name=get_session_env("HERMES_SESSION_USER_NAME", ""),
+            parent_event_id=get_session_env("HERMES_AGENT_EVENT_ID", ""),
+            platform=target_platform,
+            platform_chat_id=target_chat_id,
+            platform_thread_id=target_thread_id,
+            tool_name="send_message",
+            content=_preview(message, 1000),
+            payload={"result": result or {}},
+        )
+    except Exception:
+        pass
+    finally:
+        if db is not None:
+            db.close()
+
+
+def blocked_tool_result(decision: GateDecision) -> str:
+    return json.dumps({
+        "success": False,
+        "blocked": True,
+        "policy": decision.policy,
+        "reason": decision.reason,
+        "event_id": decision.event_id,
+    }, ensure_ascii=False)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1073,6 +1073,14 @@ class GatewayRunner:
             pass
 
         try:
+            from gateway.agent_actor import infer_platform_authority
+
+            if infer_platform_authority(source) == "owner":
+                return "owner"
+        except Exception:
+            pass
+
+        try:
             cfg = getattr(self, "config", None)
             get_hc = getattr(cfg, "get_home_channel", None) if cfg is not None else None
             if callable(get_hc):
@@ -4151,9 +4159,49 @@ class GatewayRunner:
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
+
+        inbound_event_id = ""
+        inbound_person_id = ""
+        inbound_authority = ""
+        if self._session_db is not None:
+            try:
+                from gateway.agent_actor import (
+                    build_state_packet,
+                    infer_platform_authority,
+                    maybe_record_directive_from_inbound,
+                    record_inbound_event,
+                )
+
+                inbound_authority = infer_platform_authority(source)
+                inbound_event_id, inbound_person_id = record_inbound_event(
+                    self._session_db,
+                    source=source,
+                    session_id=session_entry.session_id,
+                    session_key=session_key,
+                    text=event.text or "",
+                    message_id=getattr(event, "message_id", "") or "",
+                    platform_update_id=str(getattr(event, "platform_update_id", "") or ""),
+                    authority=inbound_authority,
+                )
+                maybe_record_directive_from_inbound(
+                    self._session_db,
+                    source=source,
+                    session_id=session_entry.session_id,
+                    session_key=session_key,
+                    inbound_event_id=inbound_event_id,
+                    person_id=inbound_person_id,
+                    text=event.text or "",
+                    authority=inbound_authority,
+                )
+            except Exception as _actor_exc:
+                logger.debug("Agent actor inbound recording failed: %s", _actor_exc)
         
         # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        _session_env_tokens = self._set_session_env(
+            context,
+            agent_event_id=inbound_event_id,
+            person_id=inbound_person_id,
+        )
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -4167,6 +4215,21 @@ class GatewayRunner:
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+        if self._session_db is not None:
+            try:
+                from gateway.agent_actor import build_state_packet
+
+                context_prompt += "\n\n" + build_state_packet(
+                    self._session_db,
+                    source=source,
+                    session_id=session_entry.session_id,
+                    session_key=session_key,
+                    inbound_event_id=inbound_event_id,
+                    person_id=inbound_person_id,
+                    authority=inbound_authority,
+                )
+            except Exception as _actor_exc:
+                logger.debug("Agent actor state packet failed: %s", _actor_exc)
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
@@ -4874,6 +4937,33 @@ class GatewayRunner:
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
+
+            if response and response.strip() != "NO_REPLY" and self._session_db is not None:
+                try:
+                    self._session_db.append_agent_event(
+                        event_type="outbound",
+                        event_subtype="reply",
+                        status="prepared",
+                        session_id=session_entry.session_id,
+                        session_key=session_key,
+                        actor_id="main",
+                        actor_kind="agent",
+                        source=source.platform.value if source.platform else "",
+                        person_id=inbound_person_id,
+                        sender_user_id=str(source.user_id or ""),
+                        sender_name=str(source.user_name or ""),
+                        parent_event_id=inbound_event_id,
+                        platform=source.platform.value if source.platform else "",
+                        platform_chat_id=str(source.chat_id or ""),
+                        platform_thread_id=str(source.thread_id or ""),
+                        content=(response or "").replace("\r", " ").replace("\n", " ")[:1000],
+                        payload={
+                            "api_calls": _api_calls,
+                            "response_time_seconds": round(_response_time, 3),
+                        },
+                    )
+                except Exception as _actor_exc:
+                    logger.debug("Agent actor outbound reply recording failed: %s", _actor_exc)
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
@@ -8288,7 +8378,13 @@ class GatewayRunner:
         finally:
             notify_path.unlink(missing_ok=True)
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(
+        self,
+        context: SessionContext,
+        *,
+        agent_event_id: str = "",
+        person_id: str = "",
+    ) -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -8302,10 +8398,13 @@ class GatewayRunner:
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
+            chat_type=context.source.chat_type or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            agent_event_id=agent_event_id,
+            person_id=person_id,
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4163,10 +4163,10 @@ class GatewayRunner:
         inbound_event_id = ""
         inbound_person_id = ""
         inbound_authority = ""
+        actor_state_packet = ""
         if self._session_db is not None:
             try:
                 from gateway.agent_actor import (
-                    build_state_packet,
                     infer_platform_authority,
                     maybe_record_directive_from_inbound,
                     record_inbound_event,
@@ -4219,7 +4219,7 @@ class GatewayRunner:
             try:
                 from gateway.agent_actor import build_state_packet
 
-                context_prompt += "\n\n" + build_state_packet(
+                actor_state_packet = build_state_packet(
                     self._session_db,
                     source=source,
                     session_id=session_entry.session_id,
@@ -4227,7 +4227,7 @@ class GatewayRunner:
                     inbound_event_id=inbound_event_id,
                     person_id=inbound_person_id,
                     authority=inbound_authority,
-                )
+                ).strip()
             except Exception as _actor_exc:
                 logger.debug("Agent actor state packet failed: %s", _actor_exc)
         
@@ -4664,6 +4664,7 @@ class GatewayRunner:
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
+                ephemeral_user_context=actor_state_packet or None,
                 history=history,
                 source=source,
                 session_id=session_entry.session_id,
@@ -9211,6 +9212,7 @@ class GatewayRunner:
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        ephemeral_user_context: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -9272,7 +9274,10 @@ class GatewayRunner:
             if role in ("user", "assistant") and content:
                 api_messages.append({"role": role, "content": content})
 
-        api_messages.append({"role": "user", "content": message})
+        current_message = message
+        if ephemeral_user_context:
+            current_message = f"{ephemeral_user_context.strip()}\n\n{message}"
+        api_messages.append({"role": "user", "content": current_message})
 
         # HTTP headers ---------------------------------------------------
         headers: Dict[str, str] = {"Content-Type": "application/json"}
@@ -9489,6 +9494,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        ephemeral_user_context: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -9507,6 +9513,7 @@ class GatewayRunner:
             return await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,
+                ephemeral_user_context=ephemeral_user_context,
                 history=history,
                 source=source,
                 session_id=session_id,
@@ -10331,7 +10338,13 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                run_kwargs = {
+                    "conversation_history": agent_history,
+                    "task_id": session_id,
+                }
+                if ephemeral_user_context:
+                    run_kwargs["ephemeral_user_context"] = ephemeral_user_context
+                result = agent.run_conversation(message, **run_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1047,6 +1047,59 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _classify_source_kind(self, source) -> str:
+        """Classify an inbound source for ``model.routes`` ``source_kind`` match.
+
+        Returns one of ``"owner"``, ``"hub_peer"``, ``"stranger"``, or ``""``
+        when the source is absent/unclassifiable. Classification is coarse —
+        detail lives in config, not here.
+
+        * ``owner`` — DM whose chat_id matches a configured home channel.
+        * ``hub_peer`` — any inbound from the ``hub`` platform (detected by
+          platform-value string so no hard dependency on a ``Platform.HUB``
+          enum member).
+        * ``stranger`` — any other inbound.
+        """
+        if source is None:
+            return ""
+        platform = getattr(source, "platform", None)
+        if platform is None:
+            return ""
+
+        try:
+            if str(getattr(platform, "value", "")).lower() == "hub":
+                return "hub_peer"
+        except Exception:
+            pass
+
+        try:
+            cfg = getattr(self, "config", None)
+            get_hc = getattr(cfg, "get_home_channel", None) if cfg is not None else None
+            if callable(get_hc):
+                hc = get_hc(platform)
+                if hc is not None and getattr(source, "chat_type", None) == "dm":
+                    if str(getattr(source, "chat_id", "")) == str(getattr(hc, "chat_id", "")):
+                        return "owner"
+        except Exception:
+            pass
+
+        return "stranger"
+
+    def _build_routing_context(self, source) -> Dict[str, Any]:
+        """Build the context dict passed to ``apply_route`` for this source."""
+        if source is None:
+            return {}
+        platform = getattr(source, "platform", None)
+        platform_value = ""
+        try:
+            platform_value = str(getattr(platform, "value", "")).lower() if platform is not None else ""
+        except Exception:
+            platform_value = ""
+        return {
+            "platform": platform_value,
+            "source_kind": self._classify_source_kind(source),
+        }
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -1118,6 +1171,25 @@ class GatewayRunner:
                     )
             except Exception:
                 pass
+
+        # Apply ``model.routes`` as the final layer. Stacks below session
+        # /model overrides (already applied above) and above base config.
+        # Supports legacy ``model.platforms.*`` and ``model.by_source.*``
+        # shorthand via the normalizer inside ``apply_route``. Silent
+        # fallback on exception — never blocks a turn.
+        try:
+            from agent.smart_model_routing import apply_route
+            model_config = None
+            if isinstance(user_config, dict):
+                _m = user_config.get("model")
+                if isinstance(_m, dict):
+                    model_config = _m
+            context = self._build_routing_context(source)
+            model, runtime_kwargs = apply_route(
+                model, runtime_kwargs, model_config, context,
+            )
+        except Exception as _exc:
+            logger.debug("apply_route failed (ignored): %s", _exc)
 
         return model, runtime_kwargs
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1085,6 +1085,12 @@ class GatewayRunner:
 
         return "stranger"
 
+    # Transports where inbound events carry caller-supplied fields and the
+    # platform doesn't enforce sender identity — user_id is suppressed from
+    # the routing context for these so a spoofed value can't match a
+    # ``match: {user_id: ...}`` route.
+    _ROUTING_CTX_UNTRUSTED_IDENTITY = frozenset({"webhook", "api_server"})
+
     def _build_routing_context(self, source) -> Dict[str, Any]:
         """Build the context dict passed to ``apply_route`` for this source."""
         if source is None:
@@ -1095,10 +1101,17 @@ class GatewayRunner:
             platform_value = str(getattr(platform, "value", "")).lower() if platform is not None else ""
         except Exception:
             platform_value = ""
-        return {
+        context: Dict[str, Any] = {
             "platform": platform_value,
             "source_kind": self._classify_source_kind(source),
         }
+        # Expose user_id so routes can match on per-sender identity — but
+        # only for trusted-identity transports (see class attribute above).
+        if platform_value and platform_value not in self._ROUTING_CTX_UNTRUSTED_IDENTITY:
+            uid = getattr(source, "user_id", None)
+            if uid:
+                context["user_id"] = str(uid)
+        return context
 
     def _resolve_session_agent_runtime(
         self,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -241,6 +241,19 @@ def build_session_context_prompt(
     if context.source.chat_topic:
         lines.append(f"**Channel Topic:** {context.source.chat_topic}")
 
+    lines.append("")
+    lines.append("**Runtime self-awareness:** Conversation sessions are isolated, but you have a shared runtime.")
+    lines.append(
+        "When the user asks what you are doing, why you posted or messaged something, "
+        "what sessions are active, or whether a cron or another session caused behavior, "
+        "call `self_state` before answering."
+    )
+    lines.append(
+        "`self_state` is the first source for this runtime evidence. Do not inspect "
+        "~/.hermes files, session DBs, logs, or cron files with terminal as a substitute "
+        "until after `self_state` has been tried and found insufficient."
+    )
+
     # User identity.
     # In shared multi-user sessions (shared threads OR shared non-thread groups
     # when group_sessions_per_user=False), multiple users contribute to the same

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -51,10 +51,13 @@ _UNSET: Any = object()
 _SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
 _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
+_AGENT_EVENT_ID: ContextVar = ContextVar("HERMES_AGENT_EVENT_ID", default=_UNSET)
+_AGENT_PERSON_ID: ContextVar = ContextVar("HERMES_AGENT_PERSON_ID", default=_UNSET)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
@@ -66,10 +69,13 @@ _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
+    "HERMES_AGENT_EVENT_ID": _AGENT_EVENT_ID,
+    "HERMES_AGENT_PERSON_ID": _AGENT_PERSON_ID,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -80,10 +86,13 @@ def set_session_vars(
     platform: str = "",
     chat_id: str = "",
     chat_name: str = "",
+    chat_type: str = "",
     thread_id: str = "",
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
+    agent_event_id: str = "",
+    person_id: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -97,10 +106,13 @@ def set_session_vars(
         _SESSION_PLATFORM.set(platform),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
+        _AGENT_EVENT_ID.set(agent_event_id),
+        _AGENT_PERSON_ID.set(person_id),
     ]
     return tokens
 
@@ -120,10 +132,13 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_PLATFORM,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,
+        _AGENT_EVENT_ID,
+        _AGENT_PERSON_ID,
     ):
         var.set("")
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -60,6 +60,7 @@ CONFIGURABLE_TOOLSETS = [
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
+    ("self_state",      "🧭 Self State",                "inspect sessions, recent activity, and local crons"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1453,6 +1453,8 @@ class SessionDB:
         event_type: str = "",
         session_key: str = "",
         person_id: str = "",
+        platform: str = "",
+        platform_chat_id: str = "",
         limit: int = 20,
     ) -> List[Dict[str, Any]]:
         """Return recent agent events ordered newest-first."""
@@ -1467,6 +1469,12 @@ class SessionDB:
         if person_id:
             clauses.append("person_id = ?")
             params.append(person_id)
+        if platform:
+            clauses.append("platform = ?")
+            params.append(platform)
+        if platform_chat_id:
+            clauses.append("platform_chat_id = ?")
+            params.append(platform_chat_id)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         params.append(int(limit))
         with self._lock:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
@@ -31,7 +32,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -91,10 +92,115 @@ CREATE TABLE IF NOT EXISTS state_meta (
     value TEXT
 );
 
+CREATE TABLE IF NOT EXISTS agent_identities (
+    person_id TEXT PRIMARY KEY,
+    platform TEXT NOT NULL,
+    platform_user_id TEXT NOT NULL,
+    display_name TEXT,
+    authority TEXT,
+    payload_json TEXT,
+    first_seen_at REAL NOT NULL,
+    last_seen_at REAL NOT NULL,
+    UNIQUE(platform, platform_user_id)
+);
+
+CREATE TABLE IF NOT EXISTS agent_events (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    session_id TEXT,
+    session_key TEXT,
+    actor_id TEXT,
+    actor_kind TEXT,
+    source TEXT,
+    person_id TEXT,
+    sender_user_id TEXT,
+    sender_name TEXT,
+    chat_type TEXT,
+    audience_type TEXT,
+    event_type TEXT NOT NULL,
+    event_subtype TEXT,
+    status TEXT,
+    parent_event_id TEXT,
+    root_event_id TEXT,
+    correlation_id TEXT,
+    platform TEXT,
+    platform_chat_id TEXT,
+    platform_thread_id TEXT,
+    platform_message_id TEXT,
+    platform_update_id TEXT,
+    tool_name TEXT,
+    tool_call_id TEXT,
+    directive_id TEXT,
+    supersedes_directive_id TEXT,
+    content TEXT,
+    payload_json TEXT,
+    error_json TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL
+);
+
+CREATE TABLE IF NOT EXISTS agent_event_links (
+    from_event_id TEXT NOT NULL,
+    to_event_id TEXT NOT NULL,
+    link_type TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (from_event_id, to_event_id, link_type)
+);
+
+CREATE TABLE IF NOT EXISTS agent_directives (
+    directive_id TEXT PRIMARY KEY,
+    directive_scope TEXT NOT NULL,
+    directive_key TEXT NOT NULL,
+    session_id TEXT,
+    session_key TEXT,
+    actor_id TEXT,
+    issuer_person_id TEXT,
+    issuer_platform TEXT,
+    issuer_user_id TEXT,
+    status TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_event_id TEXT NOT NULL,
+    supersedes_directive_id TEXT,
+    superseded_by_directive_id TEXT,
+    directive_type TEXT,
+    priority INTEGER DEFAULT 0,
+    payload_json TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    superseded_at REAL,
+    completed_at REAL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_agent_identities_platform_user
+ON agent_identities(platform, platform_user_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_session_seq
+ON agent_events(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_agent_events_session_type_created
+ON agent_events(session_id, event_type, created_at);
+CREATE INDEX IF NOT EXISTS idx_agent_events_correlation
+ON agent_events(correlation_id, seq);
+CREATE INDEX IF NOT EXISTS idx_agent_events_parent
+ON agent_events(parent_event_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_root
+ON agent_events(root_event_id, seq);
+CREATE INDEX IF NOT EXISTS idx_agent_events_platform_message
+ON agent_events(platform, platform_chat_id, platform_thread_id, platform_message_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_tool_call
+ON agent_events(tool_call_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_directive
+ON agent_events(directive_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_person
+ON agent_events(person_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_agent_event_links_to
+ON agent_event_links(to_event_id, link_type);
+CREATE INDEX IF NOT EXISTS idx_agent_directives_scope
+ON agent_directives(directive_scope, directive_key, active);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_directives_one_active
+ON agent_directives(directive_scope, directive_key, COALESCE(session_key, ''), COALESCE(actor_id, ''))
+WHERE active = 1;
 """
 
 FTS_SQL = """
@@ -356,6 +462,11 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 8")
+            if current_version < 9:
+                # v9: additive agent-actor event log. Tables and indexes are
+                # created by SCHEMA_SQL above; the version bump records that
+                # this database supports the actor/directive APIs.
+                cursor.execute("UPDATE schema_version SET version = 9")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -1019,6 +1130,383 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    # =========================================================================
+    # Agent actor event log
+    # =========================================================================
+
+    @staticmethod
+    def _json_dumps_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        try:
+            return json.dumps(value, ensure_ascii=False, default=str)
+        except Exception:
+            return json.dumps(str(value), ensure_ascii=False)
+
+    def upsert_agent_identity(
+        self,
+        *,
+        platform: str,
+        platform_user_id: str,
+        display_name: str = "",
+        authority: str = "",
+        payload: Optional[Dict[str, Any]] = None,
+        person_id: Optional[str] = None,
+    ) -> str:
+        """Create/update a per-platform identity and return its person_id."""
+        platform = str(platform or "").strip()
+        platform_user_id = str(platform_user_id or "").strip()
+        if not platform or not platform_user_id:
+            raise ValueError("platform and platform_user_id are required")
+        person_id = person_id or f"{platform}:{platform_user_id}"
+        now = time.time()
+        payload_json = self._json_dumps_or_none(payload)
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO agent_identities
+                   (person_id, platform, platform_user_id, display_name, authority,
+                    payload_json, first_seen_at, last_seen_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(platform, platform_user_id) DO UPDATE SET
+                     display_name = excluded.display_name,
+                     authority = excluded.authority,
+                     payload_json = excluded.payload_json,
+                     last_seen_at = excluded.last_seen_at""",
+                (
+                    person_id,
+                    platform,
+                    platform_user_id,
+                    display_name,
+                    authority,
+                    payload_json,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                "SELECT person_id FROM agent_identities WHERE platform = ? AND platform_user_id = ?",
+                (platform, platform_user_id),
+            ).fetchone()
+            return row["person_id"] if isinstance(row, sqlite3.Row) else row[0]
+
+        return self._execute_write(_do)
+
+    def append_agent_event(
+        self,
+        *,
+        event_type: str,
+        event_subtype: str = "",
+        status: str = "",
+        event_id: Optional[str] = None,
+        session_id: str = "",
+        session_key: str = "",
+        actor_id: str = "main",
+        actor_kind: str = "agent",
+        source: str = "",
+        person_id: str = "",
+        sender_user_id: str = "",
+        sender_name: str = "",
+        chat_type: str = "",
+        audience_type: str = "",
+        parent_event_id: str = "",
+        root_event_id: str = "",
+        correlation_id: str = "",
+        platform: str = "",
+        platform_chat_id: str = "",
+        platform_thread_id: str = "",
+        platform_message_id: str = "",
+        platform_update_id: str = "",
+        tool_name: str = "",
+        tool_call_id: str = "",
+        directive_id: str = "",
+        supersedes_directive_id: str = "",
+        content: str = "",
+        payload: Optional[Dict[str, Any]] = None,
+        error: Optional[Dict[str, Any]] = None,
+        created_at: Optional[float] = None,
+    ) -> str:
+        """Append one durable agent-level event. Duplicate event_id is idempotent."""
+        event_id = event_id or uuid.uuid4().hex
+        created_at = float(created_at or time.time())
+        root_event_id = root_event_id or parent_event_id or event_id
+        payload_json = self._json_dumps_or_none(payload)
+        error_json = self._json_dumps_or_none(error)
+
+        def _do(conn):
+            conn.execute(
+                """INSERT OR IGNORE INTO agent_events (
+                    event_id, session_id, session_key, actor_id, actor_kind, source,
+                    person_id, sender_user_id, sender_name, chat_type, audience_type,
+                    event_type, event_subtype, status, parent_event_id, root_event_id,
+                    correlation_id, platform, platform_chat_id, platform_thread_id,
+                    platform_message_id, platform_update_id, tool_name, tool_call_id,
+                    directive_id, supersedes_directive_id, content, payload_json,
+                    error_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    event_id,
+                    session_id or None,
+                    session_key or None,
+                    actor_id or None,
+                    actor_kind or None,
+                    source or None,
+                    person_id or None,
+                    sender_user_id or None,
+                    sender_name or None,
+                    chat_type or None,
+                    audience_type or None,
+                    event_type,
+                    event_subtype or None,
+                    status or None,
+                    parent_event_id or None,
+                    root_event_id or None,
+                    correlation_id or None,
+                    platform or None,
+                    platform_chat_id or None,
+                    platform_thread_id or None,
+                    platform_message_id or None,
+                    platform_update_id or None,
+                    tool_name or None,
+                    tool_call_id or None,
+                    directive_id or None,
+                    supersedes_directive_id or None,
+                    content or None,
+                    payload_json,
+                    error_json,
+                    created_at,
+                    created_at,
+                ),
+            )
+            return event_id
+
+        return self._execute_write(_do)
+
+    def link_agent_events(self, from_event_id: str, to_event_id: str, link_type: str) -> None:
+        """Record a causal relationship between two agent events."""
+        if not from_event_id or not to_event_id or not link_type:
+            return
+
+        def _do(conn):
+            conn.execute(
+                """INSERT OR IGNORE INTO agent_event_links
+                   (from_event_id, to_event_id, link_type, created_at)
+                   VALUES (?, ?, ?, ?)""",
+                (from_event_id, to_event_id, link_type, time.time()),
+            )
+
+        self._execute_write(_do)
+
+    def create_or_replace_agent_directive(
+        self,
+        *,
+        directive_scope: str,
+        directive_key: str,
+        directive_type: str,
+        payload: Dict[str, Any],
+        session_id: str = "",
+        session_key: str = "",
+        actor_id: str = "main",
+        issuer_person_id: str = "",
+        issuer_platform: str = "",
+        issuer_user_id: str = "",
+        created_event_id: str = "",
+        priority: int = 0,
+    ) -> str:
+        """Create an active directive, superseding any active equivalent."""
+        directive_id = uuid.uuid4().hex
+        created_event_id = created_event_id or uuid.uuid4().hex
+        now = time.time()
+        payload_json = self._json_dumps_or_none(payload) or "{}"
+
+        def _do(conn):
+            old = conn.execute(
+                """SELECT directive_id, created_event_id FROM agent_directives
+                   WHERE directive_scope = ? AND directive_key = ?
+                     AND COALESCE(session_key, '') = COALESCE(?, '')
+                     AND COALESCE(actor_id, '') = COALESCE(?, '')
+                     AND active = 1
+                   ORDER BY created_at DESC LIMIT 1""",
+                (directive_scope, directive_key, session_key or None, actor_id or None),
+            ).fetchone()
+            old_id = old["directive_id"] if old else None
+            old_event_id = old["created_event_id"] if old else None
+
+            conn.execute(
+                """INSERT OR IGNORE INTO agent_events (
+                    event_id, session_id, session_key, actor_id, actor_kind, source,
+                    person_id, sender_user_id, event_type, event_subtype, status,
+                    platform, directive_id, supersedes_directive_id, content,
+                    payload_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    created_event_id,
+                    session_id or None,
+                    session_key or None,
+                    actor_id or None,
+                    "user",
+                    issuer_platform or None,
+                    issuer_person_id or None,
+                    issuer_user_id or None,
+                    "directive",
+                    "create" if old_id is None else "supersede",
+                    "active",
+                    issuer_platform or None,
+                    directive_id,
+                    old_id,
+                    payload.get("text") if isinstance(payload, dict) else None,
+                    payload_json,
+                    now,
+                    now,
+                ),
+            )
+
+            if old_id:
+                conn.execute(
+                    """UPDATE agent_directives
+                       SET active = 0, status = 'superseded',
+                           superseded_by_directive_id = ?, superseded_at = ?
+                       WHERE directive_id = ?""",
+                    (directive_id, now, old_id),
+                )
+                if old_event_id:
+                    conn.execute(
+                        """INSERT OR IGNORE INTO agent_event_links
+                           (from_event_id, to_event_id, link_type, created_at)
+                           VALUES (?, ?, 'supersedes', ?)""",
+                        (created_event_id, old_event_id, now),
+                    )
+
+            conn.execute(
+                """INSERT INTO agent_directives (
+                    directive_id, directive_scope, directive_key, session_id,
+                    session_key, actor_id, issuer_person_id, issuer_platform,
+                    issuer_user_id, status, active, created_event_id,
+                    supersedes_directive_id, directive_type, priority,
+                    payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?, ?, ?, ?, ?)""",
+                (
+                    directive_id,
+                    directive_scope,
+                    directive_key,
+                    session_id or None,
+                    session_key or None,
+                    actor_id or None,
+                    issuer_person_id or None,
+                    issuer_platform or None,
+                    issuer_user_id or None,
+                    created_event_id,
+                    old_id,
+                    directive_type,
+                    int(priority or 0),
+                    payload_json,
+                    now,
+                ),
+            )
+            return directive_id
+
+        return self._execute_write(_do)
+
+    def list_active_agent_directives(
+        self,
+        *,
+        actor_id: str = "main",
+        directive_type: str = "",
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Return active directives for state packet/action policy use."""
+        with self._lock:
+            if directive_type:
+                cursor = self._conn.execute(
+                    """SELECT * FROM agent_directives
+                       WHERE active = 1
+                         AND COALESCE(actor_id, '') = COALESCE(?, '')
+                         AND directive_type = ?
+                       ORDER BY priority DESC, created_at DESC LIMIT ?""",
+                    (actor_id or None, directive_type, int(limit)),
+                )
+            else:
+                cursor = self._conn.execute(
+                    """SELECT * FROM agent_directives
+                       WHERE active = 1
+                         AND COALESCE(actor_id, '') = COALESCE(?, '')
+                       ORDER BY priority DESC, created_at DESC LIMIT ?""",
+                    (actor_id or None, int(limit)),
+                )
+            rows = cursor.fetchall()
+        directives = []
+        for row in rows:
+            item = dict(row)
+            if item.get("payload_json"):
+                try:
+                    item["payload"] = json.loads(item["payload_json"])
+                except Exception:
+                    item["payload"] = {}
+            directives.append(item)
+        return directives
+
+    def list_recent_agent_events(
+        self,
+        *,
+        event_type: str = "",
+        session_key: str = "",
+        person_id: str = "",
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Return recent agent events ordered newest-first."""
+        clauses = []
+        params: List[Any] = []
+        if event_type:
+            clauses.append("event_type = ?")
+            params.append(event_type)
+        if session_key:
+            clauses.append("session_key = ?")
+            params.append(session_key)
+        if person_id:
+            clauses.append("person_id = ?")
+            params.append(person_id)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(int(limit))
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM agent_events {where} ORDER BY seq DESC LIMIT ?",
+                params,
+            )
+            rows = cursor.fetchall()
+        events = []
+        for row in rows:
+            item = dict(row)
+            for key in ("payload_json", "error_json"):
+                if item.get(key):
+                    try:
+                        item[key[:-5]] = json.loads(item[key])
+                    except Exception:
+                        pass
+            events.append(item)
+        return events
+
+    def get_agent_event(self, event_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch one agent event by id."""
+        if not event_id:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM agent_events WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        if not row:
+            return None
+        item = dict(row)
+        for key in ("payload_json", "error_json"):
+            if item.get(key):
+                try:
+                    item[key[:-5]] = json.loads(item[key])
+                except Exception:
+                    pass
+        return item
+
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by timestamp."""
         with self._lock:
@@ -1588,4 +2076,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/run_agent.py
+++ b/run_agent.py
@@ -8635,6 +8635,7 @@ class AIAgent:
         task_id: str = None,
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
+        ephemeral_user_context: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -8649,8 +8650,10 @@ class AIAgent:
                 When None (default), API calls use the standard non-streaming path.
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
-                synthetic prefixes.
-                    or queuing follow-up prefetch work.
+                synthetic prefixes or queued follow-up prefetch work.
+            ephemeral_user_context: API-only context prepended to the current
+                user turn. It is not persisted and does not alter the cached
+                system prompt.
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -8676,6 +8679,8 @@ class AIAgent:
             user_message = _sanitize_surrogates(user_message)
         if isinstance(persist_user_message, str):
             persist_user_message = _sanitize_surrogates(persist_user_message)
+        if isinstance(ephemeral_user_context, str):
+            ephemeral_user_context = _sanitize_surrogates(ephemeral_user_context).strip()
 
         # Strip leaked <memory-context> blocks from user input.  When Honcho's
         # saveMessages persists a turn that included injected context, the block
@@ -8686,6 +8691,8 @@ class AIAgent:
             user_message = sanitize_context(user_message)
         if isinstance(persist_user_message, str):
             persist_user_message = sanitize_context(persist_user_message)
+        if isinstance(ephemeral_user_context, str):
+            ephemeral_user_context = sanitize_context(ephemeral_user_context).strip()
 
         # Store stream callback for _interruptible_api_call to pick up
         self._stream_callback = stream_callback
@@ -9117,22 +9124,26 @@ class AIAgent:
                 api_msg = msg.copy()
 
                 # Inject ephemeral context into the current turn's user message.
-                # Sources: memory manager prefetch + plugin pre_llm_call hooks
-                # with target="user_message" (the default).  Both are
+                # Sources: gateway runtime state, memory manager prefetch,
+                # and plugin pre_llm_call hooks. All are
                 # API-call-time only — the original message in `messages` is
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
-                    _injections = []
+                    _prefix_injections = []
+                    _suffix_injections = []
+                    if ephemeral_user_context:
+                        _prefix_injections.append(ephemeral_user_context)
                     if _ext_prefetch_cache:
                         _fenced = build_memory_context_block(_ext_prefetch_cache)
                         if _fenced:
-                            _injections.append(_fenced)
+                            _suffix_injections.append(_fenced)
                     if _plugin_user_context:
-                        _injections.append(_plugin_user_context)
-                    if _injections:
+                        _suffix_injections.append(_plugin_user_context)
+                    if _prefix_injections or _suffix_injections:
                         _base = api_msg.get("content", "")
                         if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                            _parts = _prefix_injections + [_base] + _suffix_injections
+                            api_msg["content"] = "\n\n".join(part for part in _parts if part)
 
                 # For ALL assistant messages, pass reasoning back to the API
                 # This ensures multi-turn reasoning context is preserved

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,0 +1,130 @@
+from agent.smart_model_routing import apply_route
+
+
+# ----- apply_route (match-based model.routes) -----
+
+def test_apply_route_no_op_when_context_empty():
+    cfg = {"routes": [{"match": {"platform": "hub"}, "model": "hub-model"}]}
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {})
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_apply_route_no_op_when_no_routes():
+    m, r = apply_route("base-model", {"api_key": "k1"}, {"default": "base-model"}, {"platform": "hub"})
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_apply_route_matches_by_platform():
+    cfg = {
+        "routes": [
+            {"match": {"platform": "hub"}, "model": "hub-model", "api_key": "sk-hub"},
+        ],
+    }
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {"platform": "hub", "source_kind": "hub_peer"})
+    assert m == "hub-model"
+    assert r["api_key"] == "sk-hub"
+
+
+def test_apply_route_matches_by_source_kind():
+    cfg = {
+        "routes": [
+            {"match": {"source_kind": "owner"}, "model": "strong-model"},
+        ],
+    }
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {"platform": "telegram", "source_kind": "owner"})
+    assert m == "strong-model"
+    assert r == {"api_key": "k1"}  # base runtime preserved
+
+
+def test_apply_route_requires_all_match_keys():
+    # Compound match: both platform AND source_kind must match
+    cfg = {
+        "routes": [
+            {"match": {"platform": "discord", "source_kind": "stranger"}, "model": "edge-case-model"},
+        ],
+    }
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "discord", "source_kind": "owner"})
+    assert m == "base-model"  # source_kind mismatched → no match
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "telegram", "source_kind": "stranger"})
+    assert m == "base-model"  # platform mismatched → no match
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "discord", "source_kind": "stranger"})
+    assert m == "edge-case-model"  # both matched → route fires
+
+
+def test_apply_route_first_match_wins():
+    cfg = {
+        "routes": [
+            {"match": {"source_kind": "owner"}, "model": "first-route-model"},
+            {"match": {"source_kind": "owner"}, "model": "second-route-model"},
+        ],
+    }
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "telegram", "source_kind": "owner"})
+    assert m == "first-route-model"
+
+
+def test_apply_route_legacy_platforms_shim_string():
+    # ``model.platforms.hub: "hub-model"`` is legacy shorthand
+    cfg = {"platforms": {"hub": "hub-model"}}
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "hub"})
+    assert m == "hub-model"
+
+
+def test_apply_route_legacy_platforms_shim_dict():
+    cfg = {"platforms": {"hub": {"model": "hub-model", "base_url": "https://hub.example/v1"}}}
+    m, r = apply_route("base-model", {}, cfg, {"platform": "hub"})
+    assert m == "hub-model"
+    assert r["base_url"] == "https://hub.example/v1"
+
+
+def test_apply_route_legacy_by_source_shim():
+    cfg = {"by_source": {"owner": {"model": "strong-model", "api_key": "sk-owner"}}}
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {"source_kind": "owner"})
+    assert m == "strong-model"
+    assert r["api_key"] == "sk-owner"
+
+
+def test_apply_route_explicit_routes_beat_legacy():
+    # Explicit routes come first in the effective list → they match before legacy shims.
+    cfg = {
+        "routes": [{"match": {"source_kind": "owner"}, "model": "new-explicit"}],
+        "by_source": {"owner": {"model": "old-legacy"}},
+    }
+    m, _ = apply_route("base-model", {}, cfg, {"source_kind": "owner"})
+    assert m == "new-explicit"
+
+
+def test_apply_route_partial_override_preserves_base_runtime():
+    cfg = {"routes": [{"match": {"source_kind": "cron"}, "model": "cheap-model"}]}
+    m, r = apply_route(
+        "base-model",
+        {"api_key": "k1", "base_url": "https://base.example/v1", "provider": "custom"},
+        cfg,
+        {"source_kind": "cron"},
+    )
+    assert m == "cheap-model"
+    assert r == {"api_key": "k1", "base_url": "https://base.example/v1", "provider": "custom"}
+
+
+def test_apply_route_empty_fields_dont_overwrite():
+    cfg = {"routes": [{"match": {"source_kind": "owner"}, "api_key": "", "base_url": None, "args": []}]}
+    m, r = apply_route(
+        "base-model",
+        {"api_key": "k1", "base_url": "https://base.example/v1"},
+        cfg,
+        {"source_kind": "owner"},
+    )
+    # Route matched but all fields are empty/nullish → inputs preserved
+    assert m == "base-model"
+    assert r["api_key"] == "k1"
+    assert r["base_url"] == "https://base.example/v1"
+
+
+def test_apply_route_context_missing_match_key_does_not_match():
+    cfg = {"routes": [{"match": {"source_kind": "owner"}, "model": "strong-model"}]}
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "telegram"})  # no source_kind in context
+    assert m == "base-model"
+
+
+def test_apply_route_null_model_config():
+    m, r = apply_route("base-model", {"api_key": "k1"}, None, {"source_kind": "owner"})
+    assert m == "base-model" and r == {"api_key": "k1"}

--- a/tests/gateway/test_agent_actor.py
+++ b/tests/gateway/test_agent_actor.py
@@ -132,6 +132,68 @@ def test_owner_state_packet_includes_recent_cross_session_events(tmp_path):
     db.close()
 
 
+def test_user_state_packet_surfaces_cross_session_outbounds_to_same_audience(tmp_path):
+    """A non-trusted sender's state packet must reveal the agent's own
+    cross-session attempts (delivered or blocked) targeting the current
+    audience. Without this, the agent confabulates "must be a different
+    session" when challenged about messages it actually authored from
+    autonomous/cron sessions to the same chat.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    # A blocked rebroadcast attempt to discord:general from a hub-DM session,
+    # before the user's inbound. Different session_key, different person_id —
+    # the existing per-session and per-person filters would both miss it.
+    db.append_agent_event(
+        event_type="outbound",
+        event_subtype="send_message",
+        status="blocked",
+        session_key="agent:main:hub:dm:hub:sal",
+        actor_id="main",
+        actor_kind="tool",
+        source="hub",
+        platform="discord",
+        platform_chat_id="general",
+        tool_name="send_message",
+        content="autonomous hub rebroadcast attempt",
+        payload={"decision": "deny"},
+    )
+
+    user_source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="general",
+        chat_type="group",
+        user_id="999",
+        user_name="adam",
+    )
+    inbound_event_id, person_id = record_inbound_event(
+        db,
+        source=user_source,
+        session_id="group-sid",
+        session_key="agent:main:discord:group:general:999",
+        text="why am I getting pinged about this stuff?",
+        authority="user",
+    )
+
+    packet = build_state_packet(
+        db,
+        source=user_source,
+        session_id="group-sid",
+        session_key="agent:main:discord:group:general:999",
+        inbound_event_id=inbound_event_id,
+        person_id=person_id,
+        authority="user",
+    )
+
+    assert "authority: user" in packet
+    assert "autonomous hub rebroadcast attempt" in packet, (
+        "user-authority state packet must include outbound activity targeting "
+        "the same platform_chat_id, even from other sessions"
+    )
+    assert "blocked" in packet
+    db.close()
+
+
 def test_directive_blocks_public_cross_session_send(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     source = SessionSource(

--- a/tests/gateway/test_agent_actor.py
+++ b/tests/gateway/test_agent_actor.py
@@ -1,0 +1,222 @@
+import json
+
+from gateway.agent_actor import (
+    build_state_packet,
+    detect_public_broadcast_stop_directive,
+    evaluate_send_message_policy,
+    infer_platform_authority,
+    maybe_record_directive_from_inbound,
+    owner_user_ids_for_platform,
+    record_inbound_event,
+)
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.session_context import clear_session_vars, set_session_vars
+from hermes_state import SessionDB
+
+
+def test_detects_public_broadcast_stop_directive():
+    directive = detect_public_broadcast_stop_directive("Is this a cron? Turn this off")
+
+    assert directive is not None
+    assert directive["behavior"] == "suppress"
+
+
+def test_state_packet_is_sender_scoped(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="149",
+        chat_type="group",
+        user_id="141",
+        user_name="hands",
+    )
+    event_id, person_id = record_inbound_event(
+        db,
+        source=source,
+        session_id="sid",
+        session_key="agent:main:discord:group:149:141",
+        text="hello",
+        authority="trusted",
+    )
+
+    packet = build_state_packet(
+        db,
+        source=source,
+        session_id="sid",
+        session_key="agent:main:discord:group:149:141",
+        inbound_event_id=event_id,
+        person_id=person_id,
+        authority="trusted",
+    )
+
+    assert "person_id: discord:141" in packet
+    assert "authority: trusted" in packet
+    assert "session_key: agent:main:discord:group:149:141" in packet
+    db.close()
+
+
+def test_owner_authority_uses_generated_soul_owner_block(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "SOUL.md").write_text(
+        "## Your owner\n"
+        "- Discord: `@handsdiff` (user_id `1417636184355766305`)\n"
+        "\n## Peer roster\n"
+        "- Someone else user_id `999999999999999999`\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    monkeypatch.delenv("DISCORD_OWNER_USER_ID", raising=False)
+    monkeypatch.delenv("DISCORD_OWNER_USER_IDS", raising=False)
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="1495468809216327702",
+        chat_type="group",
+        user_id="1417636184355766305",
+        user_name="hands",
+    )
+
+    assert owner_user_ids_for_platform("discord") == {"1417636184355766305"}
+    assert infer_platform_authority(source) == "owner"
+
+
+def test_owner_state_packet_includes_recent_cross_session_events(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    group_source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="general",
+        chat_type="group",
+        user_id="141",
+        user_name="hands",
+    )
+    record_inbound_event(
+        db,
+        source=group_source,
+        session_id="group-sid",
+        session_key="agent:main:discord:group:general:141",
+        text="hey from general",
+        authority="owner",
+    )
+    dm_source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="dm",
+        chat_type="dm",
+        user_id="141",
+        user_name="hands",
+    )
+    dm_event_id, person_id = record_inbound_event(
+        db,
+        source=dm_source,
+        session_id="dm-sid",
+        session_key="agent:main:discord:dm:dm",
+        text="do you see general?",
+        authority="owner",
+    )
+
+    packet = build_state_packet(
+        db,
+        source=dm_source,
+        session_id="dm-sid",
+        session_key="agent:main:discord:dm:dm",
+        inbound_event_id=dm_event_id,
+        person_id=person_id,
+        authority="owner",
+    )
+
+    assert "authority: owner" in packet
+    assert "Recent Runtime Events" in packet
+    assert "hey from general" in packet
+    db.close()
+
+
+def test_directive_blocks_public_cross_session_send(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="general",
+        chat_type="group",
+        user_id="141",
+        user_name="hands",
+    )
+    event_id, person_id = record_inbound_event(
+        db,
+        source=source,
+        session_id="sid",
+        session_key="agent:main:discord:group:general:141",
+        text="Is this a cron? Turn this off",
+        authority="trusted",
+    )
+    maybe_record_directive_from_inbound(
+        db,
+        source=source,
+        session_id="sid",
+        session_key="agent:main:discord:group:general:141",
+        inbound_event_id=event_id,
+        person_id=person_id,
+        text="Is this a cron? Turn this off",
+        authority="trusted",
+    )
+
+    tokens = set_session_vars(
+        platform="hub",
+        chat_id="hub:speculator",
+        chat_type="dm",
+        user_id="speculator",
+        user_name="speculator",
+        session_key="agent:main:hub:dm:hub:speculator",
+        agent_event_id=event_id,
+        person_id="hub:speculator",
+    )
+    try:
+        decision = evaluate_send_message_policy(
+            target_platform="discord",
+            target_chat_id="general",
+            message="Market digest",
+            db=db,
+        )
+    finally:
+        clear_session_vars(tokens)
+        db.close()
+
+    assert decision.allowed is False
+    assert decision.policy == "suppress_public_broadcasts"
+
+
+def test_cron_like_hub_inbound_blocks_public_rebroadcast(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    event_id = db.append_agent_event(
+        event_type="inbound",
+        event_subtype="message",
+        status="received",
+        session_key="agent:main:hub:dm:hub:speculator",
+        source="hub",
+        platform="hub",
+        platform_chat_id="hub:speculator",
+        content="Cronjob Response: synthetic market digest",
+    )
+    tokens = set_session_vars(
+        platform="hub",
+        chat_id="hub:speculator",
+        chat_type="dm",
+        user_id="speculator",
+        user_name="speculator",
+        session_key="agent:main:hub:dm:hub:speculator",
+        agent_event_id=event_id,
+        person_id="hub:speculator",
+    )
+    try:
+        decision = evaluate_send_message_policy(
+            target_platform="discord",
+            target_chat_id="1495468809216327702",
+            message="Synthetic market digest",
+            db=db,
+        )
+    finally:
+        clear_session_vars(tokens)
+        db.close()
+
+    assert decision.allowed is False
+    assert decision.policy == "autonomous_public_rebroadcast_guard"

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -36,12 +36,27 @@ from gateway.session import SessionSource
 
 class _CapturingAgent:
     last_init = None
+    last_run = None
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
         self.tools = []
 
-    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message=None,
+        ephemeral_user_context=None,
+    ):
+        type(self).last_run = {
+            "user_message": user_message,
+            "conversation_history": conversation_history,
+            "task_id": task_id,
+            "persist_user_message": persist_user_message,
+            "ephemeral_user_context": ephemeral_user_context,
+        }
         return {
             "final_response": "ok",
             "messages": [],
@@ -255,4 +270,52 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["ephemeral_system_prompt"] == (
         "Context prompt\n\nChannel prompt\n\nGlobal prompt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_actor_state_as_ephemeral_user_context(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("agent:\n  system_prompt: Global prompt\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    _CapturingAgent.last_run = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        ephemeral_user_context="## Runtime State\ninbound_event_id: evt-1",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:discord:thread:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["ephemeral_system_prompt"] == (
+        "Context prompt\n\nGlobal prompt"
+    )
+    assert _CapturingAgent.last_run["user_message"] == "hi"
+    assert _CapturingAgent.last_run["ephemeral_user_context"] == (
+        "## Runtime State\ninbound_event_id: evt-1"
     )

--- a/tests/gateway/test_routing_context_user_id.py
+++ b/tests/gateway/test_routing_context_user_id.py
@@ -1,0 +1,112 @@
+"""``_build_routing_context`` must expose ``user_id`` so ``model.routes`` can
+route per-sender on trusted-identity platforms — not just per ``source_kind``.
+
+This lets an agent owner whose messages land outside the strict DM home
+channel (e.g. @mentions in a shared Discord channel) still route to their
+preferred model by matching on user_id directly.
+
+Untrusted-identity transports (webhook, api_server) must NOT expose user_id;
+their inbound events can carry spoofed fields, and allowing a route match on
+them would let an attacker impersonate the owner for model selection.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_dotenv(monkeypatch):
+    fake = types.ModuleType("dotenv")
+    fake.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(get_home_channel=lambda _p: None)
+    return runner
+
+
+def _src(platform_value: str, *, user_id: str = "99", chat_id: str = "111",
+         chat_type: str = "group", thread_id=None):
+    plat = SimpleNamespace(value=platform_value)
+    return SimpleNamespace(
+        platform=plat, user_id=user_id, chat_id=chat_id,
+        chat_type=chat_type, thread_id=thread_id,
+    )
+
+
+class TestRoutingContextUserId:
+    def test_discord_group_exposes_user_id(self):
+        from gateway.run import GatewayRunner
+        runner = _make_runner()
+        ctx = GatewayRunner._build_routing_context(
+            runner, _src("discord", user_id="1417636184355766305")
+        )
+        assert ctx["user_id"] == "1417636184355766305"
+        assert ctx["platform"] == "discord"
+
+    def test_telegram_dm_exposes_user_id(self):
+        from gateway.run import GatewayRunner
+        runner = _make_runner()
+        ctx = GatewayRunner._build_routing_context(
+            runner, _src("telegram", user_id="42", chat_type="dm")
+        )
+        assert ctx["user_id"] == "42"
+
+    def test_webhook_suppresses_user_id(self):
+        from gateway.run import GatewayRunner
+        runner = _make_runner()
+        ctx = GatewayRunner._build_routing_context(
+            runner, _src("webhook", user_id="spoofed")
+        )
+        assert "user_id" not in ctx
+        assert ctx["platform"] == "webhook"
+
+    def test_api_server_suppresses_user_id(self):
+        from gateway.run import GatewayRunner
+        runner = _make_runner()
+        ctx = GatewayRunner._build_routing_context(
+            runner, _src("api_server", user_id="spoofed")
+        )
+        assert "user_id" not in ctx
+
+    def test_missing_user_id_is_not_in_context(self):
+        from gateway.run import GatewayRunner
+        runner = _make_runner()
+        ctx = GatewayRunner._build_routing_context(
+            runner, _src("discord", user_id="")
+        )
+        assert "user_id" not in ctx
+
+    def test_none_source_returns_empty(self):
+        from gateway.run import GatewayRunner
+        runner = _make_runner()
+        assert GatewayRunner._build_routing_context(runner, None) == {}
+
+    def test_user_id_route_fires_end_to_end(self):
+        """Integration: a Discord group message from the owner's user_id
+        matches a ``user_id`` route even though ``source_kind`` is stranger."""
+        from agent.smart_model_routing import apply_route
+        from gateway.run import GatewayRunner
+
+        runner = _make_runner()
+        src = _src("discord", user_id="1417636184355766305", chat_type="group")
+        ctx = GatewayRunner._build_routing_context(runner, src)
+
+        cfg = {
+            "default": "slate-1",
+            "routes": [
+                {"match": {"source_kind": "owner"}, "model": "slate-3"},
+                {"match": {"platform": "discord", "user_id": "1417636184355766305"},
+                 "model": "slate-3", "base_url": "https://litellm-3.int.exe.xyz/v1"},
+            ],
+        }
+        model, runtime = apply_route("slate-1", {}, cfg, ctx)
+        assert model == "slate-3"
+        assert runtime.get("base_url") == "https://litellm-3.int.exe.xyz/v1"

--- a/tests/gateway/test_routing_context_user_id.py
+++ b/tests/gateway/test_routing_context_user_id.py
@@ -51,6 +51,15 @@ class TestRoutingContextUserId:
         assert ctx["user_id"] == "1417636184355766305"
         assert ctx["platform"] == "discord"
 
+    def test_discord_group_owner_user_id_logs_owner_source_kind(self, monkeypatch):
+        from gateway.run import GatewayRunner
+        monkeypatch.setenv("DISCORD_OWNER_USER_ID", "1417636184355766305")
+        runner = _make_runner()
+        ctx = GatewayRunner._build_routing_context(
+            runner, _src("discord", user_id="1417636184355766305")
+        )
+        assert ctx["source_kind"] == "owner"
+
     def test_telegram_dm_exposes_user_id(self):
         from gateway.run import GatewayRunner
         runner = _make_runner()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3096,6 +3096,34 @@ class TestConversationHistoryNotMutated:
         assert len(result["messages"]) > original_len
 
 
+class TestEphemeralUserContext:
+    def test_injected_into_current_user_message_not_system_or_history(self, agent):
+        agent.ephemeral_system_prompt = "Stable gateway context"
+        resp = _mock_response(content="ok", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "hello",
+                ephemeral_user_context="## Runtime State\ninbound_event_id: evt-1",
+            )
+
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        system_msg = next(msg for msg in sent_messages if msg["role"] == "system")
+        user_msg = next(msg for msg in sent_messages if msg["role"] == "user")
+
+        assert "Stable gateway context" in system_msg["content"]
+        assert "Runtime State" not in system_msg["content"]
+        assert user_msg["content"].startswith("## Runtime State\ninbound_event_id: evt-1\n\nhello")
+
+        persisted_user = next(msg for msg in result["messages"] if msg["role"] == "user")
+        assert persisted_user["content"] == "hello"
+
+
 # ---------------------------------------------------------------------------
 # _max_tokens_param consistency
 # ---------------------------------------------------------------------------

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1169,11 +1169,15 @@ class TestSchemaInit:
         assert "sessions" in tables
         assert "messages" in tables
         assert "schema_version" in tables
+        assert "agent_events" in tables
+        assert "agent_event_links" in tables
+        assert "agent_directives" in tables
+        assert "agent_identities" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 8
+        assert version == 9
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1229,12 +1233,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v8
+        # Open with SessionDB — should migrate to current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 8
+        assert cursor.fetchone()[0] == 9
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1253,6 +1257,79 @@ class TestSchemaInit:
         assert session["title"] == "Migrated Title"
 
         migrated_db.close()
+
+
+class TestAgentActorEventLog:
+    def test_identity_upsert_is_per_platform(self, db):
+        p1 = db.upsert_agent_identity(
+            platform="discord",
+            platform_user_id="123",
+            display_name="A",
+            authority="trusted",
+        )
+        p2 = db.upsert_agent_identity(
+            platform="telegram",
+            platform_user_id="123",
+            display_name="A",
+            authority="trusted",
+        )
+
+        assert p1 == "discord:123"
+        assert p2 == "telegram:123"
+        assert p1 != p2
+
+    def test_append_and_fetch_agent_event(self, db):
+        event_id = db.append_agent_event(
+            event_id="evt-1",
+            event_type="inbound",
+            event_subtype="message",
+            status="received",
+            session_id="sid",
+            session_key="agent:main:discord:group:1:123",
+            platform="discord",
+            platform_chat_id="1",
+            sender_user_id="123",
+            person_id="discord:123",
+            content="hello",
+            payload={"authority": "trusted"},
+        )
+
+        assert event_id == "evt-1"
+        event = db.get_agent_event("evt-1")
+        assert event["event_type"] == "inbound"
+        assert event["payload"]["authority"] == "trusted"
+        assert db.list_recent_agent_events(event_type="inbound")[0]["event_id"] == "evt-1"
+
+    def test_directive_supersession(self, db):
+        first = db.create_or_replace_agent_directive(
+            directive_scope="actor",
+            directive_key="public-broadcast-suppression",
+            directive_type="suppress_public_broadcasts",
+            payload={"text": "stop posting digests"},
+            actor_id="main",
+            issuer_person_id="discord:1",
+            issuer_platform="discord",
+            issuer_user_id="1",
+        )
+        second = db.create_or_replace_agent_directive(
+            directive_scope="actor",
+            directive_key="public-broadcast-suppression",
+            directive_type="suppress_public_broadcasts",
+            payload={"text": "turn this off"},
+            actor_id="main",
+            issuer_person_id="discord:1",
+            issuer_platform="discord",
+            issuer_user_id="1",
+        )
+
+        active = db.list_active_agent_directives(actor_id="main")
+        assert [d["directive_id"] for d in active] == [second]
+        old = db._conn.execute(
+            "SELECT active, superseded_by_directive_id FROM agent_directives WHERE directive_id = ?",
+            (first,),
+        ).fetchone()
+        assert old["active"] == 0
+        assert old["superseded_by_directive_id"] == second
 
 
 class TestTitleUniqueness:
@@ -1911,4 +1988,3 @@ class TestAutoMaintenance:
         assert marker is not None
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
-

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -308,6 +308,7 @@ class TestBuiltinDiscovery:
             "tools.process_registry",
             "tools.rl_training_tool",
             "tools.send_message_tool",
+            "tools.self_state_tool",
             "tools.session_search_tool",
             "tools.skill_manager_tool",
             "tools.skills_tool",

--- a/tests/tools/test_self_state_tool.py
+++ b/tests/tools/test_self_state_tool.py
@@ -1,0 +1,124 @@
+import json
+import sys
+from types import SimpleNamespace
+
+from tools.self_state_tool import self_state_tool
+from tools.registry import registry
+from toolsets import resolve_toolset
+
+
+def test_self_state_lists_sessions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "sessions.json").write_text(json.dumps({
+        "agent:main:discord:group:123": {
+            "session_id": "20260423_120000_abcd",
+            "platform": "discord",
+            "chat_type": "group",
+            "display_name": "#general",
+            "updated_at": "2026-04-23T12:03:00",
+            "created_at": "2026-04-23T12:00:00",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "123",
+                "chat_name": "#general",
+                "user_id": "u1",
+                "user_name": "hands",
+            },
+        }
+    }), encoding="utf-8")
+
+    result = self_state_tool(action="sessions")
+
+    assert result["action"] == "sessions"
+    assert result["sessions"][0]["session_id"] == "20260423_120000_abcd"
+    assert result["sessions"][0]["platform"] == "discord"
+    assert result["sessions"][0]["chat_name"] == "#general"
+
+
+def test_self_state_lists_local_crons(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir()
+    (cron_dir / "jobs.json").write_text(json.dumps({
+        "jobs": [{
+            "id": "job-1",
+            "name": "Market monitor",
+            "enabled": True,
+            "deliver": "origin",
+            "schedule": {"display": "every 10m"},
+            "origin": {"platform": "hub", "chat_id": "hub:sal"},
+            "next_run": "2026-04-23T12:10:00",
+        }]
+    }), encoding="utf-8")
+
+    result = self_state_tool(action="crons")
+
+    assert result["action"] == "crons"
+    assert result["crons"][0]["id"] == "job-1"
+    assert result["crons"][0]["deliver"] == "origin"
+    assert result["crons"][0]["origin"]["chat_id"] == "hub:sal"
+
+
+def test_self_state_recent_activity_uses_session_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "sessions.json").write_text(json.dumps({
+        "agent:main:hub:dm:hub:codex-cron": {
+            "session_id": "sid-1",
+            "platform": "hub",
+            "chat_type": "dm",
+            "updated_at": "2026-04-23T12:03:00",
+            "origin": {
+                "platform": "hub",
+                "chat_id": "hub:codex-cron",
+                "user_id": "codex-cron",
+                "user_name": "codex-cron",
+            },
+        }
+    }), encoding="utf-8")
+
+    class FakeDB:
+        def list_sessions_rich(self, **_kwargs):
+            return [{"id": "sid-1", "source": "hub", "last_active": 1}]
+
+        def get_messages(self, session_id):
+            assert session_id == "sid-1"
+            return [
+                {
+                    "timestamp": 1,
+                    "role": "assistant",
+                    "content": "Posting an update to #general",
+                    "tool_calls": [{"function": {"name": "send_message"}}],
+                }
+            ]
+
+        def close(self):
+            pass
+
+    monkeypatch.setitem(sys.modules, "hermes_state", SimpleNamespace(SessionDB=FakeDB))
+
+    result = self_state_tool(action="recent_activity", session_filter="codex-cron")
+
+    assert result["activity"][0]["session_id"] == "sid-1"
+    assert result["activity"][0]["source"] == "hub:codex-cron"
+    assert result["activity"][0]["tool_calls"] == ["send_message"]
+
+
+def test_self_state_registry_dispatch_returns_json_string(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "sessions.json").write_text(json.dumps({}), encoding="utf-8")
+
+    result = registry.dispatch("self_state", {"action": "sessions"})
+
+    assert isinstance(result, str)
+    assert json.loads(result)["action"] == "sessions"
+
+
+def test_self_state_is_in_core_toolsets():
+    assert "self_state" in resolve_toolset("hermes-cli")
+    assert "self_state" in resolve_toolset("hermes-discord")

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -65,6 +65,38 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+    def test_policy_block_skips_send(self):
+        discord_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.DISCORD: discord_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        from gateway.agent_actor import GateDecision
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.agent_actor.evaluate_send_message_policy", return_value=GateDecision(
+                 allowed=False,
+                 policy="autonomous_public_rebroadcast_guard",
+                 reason="blocked",
+                 event_id="evt-blocked",
+             )), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "discord:1495468809216327702",
+                        "message": "market digest",
+                    }
+                )
+            )
+
+        assert result["blocked"] is True
+        assert result["policy"] == "autonomous_public_rebroadcast_guard"
+        send_mock.assert_not_awaited()
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()

--- a/tools/self_state_tool.py
+++ b/tools/self_state_tool.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Self-state introspection tool.
+
+Gives the agent a compact, factual view of its own runtime state across
+isolated gateway sessions. This is intentionally read-only: it helps the
+model diagnose "what am I doing?" without mutating crons, memory, or sessions.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+
+
+def _clamp_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    try:
+        if not path.exists():
+            return default
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def _format_ts(ts: Any) -> Optional[str]:
+    if ts in (None, ""):
+        return None
+    try:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(float(ts)))
+    except (TypeError, ValueError, OSError):
+        return str(ts)
+
+
+def _preview(text: Any, limit: int = 240) -> str:
+    if text is None:
+        return ""
+    s = str(text).replace("\r", " ").replace("\n", " ").strip()
+    if len(s) <= limit:
+        return s
+    return s[: limit - 3].rstrip() + "..."
+
+
+def _session_entries(limit: int) -> List[Dict[str, Any]]:
+    sessions_path = get_hermes_home() / "sessions" / "sessions.json"
+    data = _load_json(sessions_path, {})
+    if not isinstance(data, dict):
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for key, raw in data.items():
+        if not isinstance(raw, dict):
+            continue
+        origin = raw.get("origin") if isinstance(raw.get("origin"), dict) else {}
+        entries.append({
+            "session_key": key,
+            "session_id": raw.get("session_id", ""),
+            "platform": raw.get("platform") or origin.get("platform", ""),
+            "chat_type": raw.get("chat_type") or origin.get("chat_type", ""),
+            "chat_id": origin.get("chat_id", ""),
+            "chat_name": origin.get("chat_name") or raw.get("display_name", ""),
+            "user_id": origin.get("user_id", ""),
+            "user_name": origin.get("user_name", ""),
+            "thread_id": origin.get("thread_id"),
+            "updated_at": raw.get("updated_at", ""),
+            "created_at": raw.get("created_at", ""),
+        })
+
+    entries.sort(key=lambda e: str(e.get("updated_at") or ""), reverse=True)
+    return entries[:limit]
+
+
+def _session_index_by_id() -> Dict[str, Dict[str, Any]]:
+    entries = _session_entries(1000)
+    return {
+        str(entry.get("session_id")): entry
+        for entry in entries
+        if entry.get("session_id")
+    }
+
+
+def _recent_activity_from_db(limit: int, session_filter: str = "") -> List[Dict[str, Any]]:
+    try:
+        from hermes_state import SessionDB
+    except Exception:
+        return []
+
+    db = None
+    try:
+        db = SessionDB()
+        session_index = _session_index_by_id()
+        filter_text = session_filter.lower()
+        sessions = db.list_sessions_rich(limit=max(limit * 3, limit), include_children=True)
+        rows: List[Dict[str, Any]] = []
+        for session in sessions:
+            session_id = session.get("id") or session.get("session_id")
+            if not session_id:
+                continue
+            index_entry = session_index.get(str(session_id), {})
+            session_haystack = " ".join(
+                str(value or "")
+                for value in (
+                    session_id,
+                    session.get("source", ""),
+                    index_entry.get("session_key", ""),
+                    index_entry.get("platform", ""),
+                    index_entry.get("chat_id", ""),
+                    index_entry.get("chat_name", ""),
+                    index_entry.get("user_id", ""),
+                    index_entry.get("user_name", ""),
+                )
+            ).lower()
+            if filter_text and filter_text not in session_haystack:
+                continue
+            try:
+                messages = db.get_messages(session_id)
+            except Exception:
+                continue
+            for msg in messages[-8:]:
+                role = msg.get("role")
+                tool_calls = msg.get("tool_calls") or []
+                tool_names = _tool_names(tool_calls)
+                tool_details = _tool_call_details(tool_calls)
+                content = msg.get("content")
+                if role not in ("user", "assistant", "tool") and not tool_names:
+                    continue
+                row = {
+                    "timestamp": _format_ts(msg.get("timestamp")),
+                    "session_id": session_id,
+                    "session_key": index_entry.get("session_key", ""),
+                    "source": index_entry.get("chat_id") or session.get("source", ""),
+                    "platform": index_entry.get("platform") or session.get("source", ""),
+                    "user_name": index_entry.get("user_name", ""),
+                    "role": role,
+                    "tool_name": msg.get("tool_name"),
+                    "tool_calls": tool_names,
+                    "content_preview": _preview(content),
+                }
+                if tool_details:
+                    row["tool_call_details"] = tool_details
+                rows.append(row)
+        rows.sort(key=lambda r: str(r.get("timestamp") or ""), reverse=True)
+        return rows[:limit]
+    except Exception:
+        return []
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _tool_names(tool_calls: Any) -> List[str]:
+    if not isinstance(tool_calls, list):
+        return []
+    names: List[str] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        name = call.get("name")
+        if not name and isinstance(call.get("function"), dict):
+            name = call["function"].get("name")
+        if name:
+            names.append(str(name))
+    return names
+
+
+def _tool_call_details(tool_calls: Any) -> List[Dict[str, Any]]:
+    if not isinstance(tool_calls, list):
+        return []
+    details: List[Dict[str, Any]] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function") if isinstance(call.get("function"), dict) else {}
+        name = call.get("name") or function.get("name")
+        if not name:
+            continue
+        raw_args = call.get("arguments")
+        if raw_args is None:
+            raw_args = function.get("arguments")
+        args_summary: Dict[str, Any] = {}
+        if isinstance(raw_args, str) and raw_args.strip():
+            try:
+                parsed = json.loads(raw_args)
+            except (TypeError, ValueError):
+                args_summary["arguments_preview"] = _preview(raw_args)
+            else:
+                if isinstance(parsed, dict):
+                    for key in ("action", "target", "message", "query", "job_id"):
+                        if key in parsed:
+                            args_summary[key] = _preview(parsed.get(key), 180)
+                else:
+                    args_summary["arguments_preview"] = _preview(parsed)
+        elif isinstance(raw_args, dict):
+            for key in ("action", "target", "message", "query", "job_id"):
+                if key in raw_args:
+                    args_summary[key] = _preview(raw_args.get(key), 180)
+        details.append({"name": str(name), **args_summary})
+    return details
+
+
+def _jobs_iter(data: Any) -> Iterable[Dict[str, Any]]:
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                yield item
+        return
+    if isinstance(data, dict):
+        raw_jobs = data.get("jobs")
+        if isinstance(raw_jobs, list):
+            for item in raw_jobs:
+                if isinstance(item, dict):
+                    yield item
+        else:
+            for item in data.values():
+                if isinstance(item, dict):
+                    yield item
+
+
+def _cron_jobs(limit: int) -> List[Dict[str, Any]]:
+    jobs_path = get_hermes_home() / "cron" / "jobs.json"
+    data = _load_json(jobs_path, [])
+    jobs: List[Dict[str, Any]] = []
+    for job in _jobs_iter(data):
+        origin = job.get("origin") if isinstance(job.get("origin"), dict) else {}
+        schedule = job.get("schedule") if isinstance(job.get("schedule"), dict) else {}
+        jobs.append({
+            "id": job.get("id", ""),
+            "name": job.get("name", ""),
+            "enabled": bool(job.get("enabled", True)),
+            "deliver": job.get("deliver", "local"),
+            "origin": {
+                "platform": origin.get("platform"),
+                "chat_id": origin.get("chat_id"),
+                "chat_name": origin.get("chat_name"),
+                "thread_id": origin.get("thread_id"),
+            } if origin else None,
+            "schedule": job.get("schedule_display") or schedule.get("display") or job.get("schedule"),
+            "next_run": job.get("next_run"),
+            "last_run": job.get("last_run"),
+        })
+    jobs.sort(key=lambda j: (not j.get("enabled", False), str(j.get("next_run") or "")))
+    return jobs[:limit]
+
+
+def _outbound_events(limit: int) -> List[Dict[str, Any]]:
+    rows = _recent_activity_from_db(limit=limit * 4)
+    events: List[Dict[str, Any]] = []
+    for row in rows:
+        tool_calls = row.get("tool_calls") or []
+        if "send_message" not in tool_calls:
+            continue
+        events.append({
+            "timestamp": row.get("timestamp"),
+            "session_id": row.get("session_id"),
+            "source": row.get("source"),
+            "kind": "send_message_tool_call",
+            "content_preview": row.get("content_preview", ""),
+            "tool_calls": tool_calls,
+            "tool_call_details": row.get("tool_call_details", []),
+        })
+        if len(events) >= limit:
+            break
+    if len(events) < limit:
+        events.extend(_mirror_events_from_jsonl(limit - len(events)))
+    events.sort(key=lambda r: str(r.get("timestamp") or ""), reverse=True)
+    return events[:limit]
+
+
+def _active_directives(limit: int) -> List[Dict[str, Any]]:
+    try:
+        from hermes_state import SessionDB
+    except Exception:
+        return []
+    db = None
+    try:
+        db = SessionDB()
+        rows = db.list_active_agent_directives(actor_id="main", limit=limit)
+        result = []
+        for row in rows:
+            payload = row.get("payload") or {}
+            result.append({
+                "directive_id": row.get("directive_id"),
+                "directive_type": row.get("directive_type"),
+                "directive_key": row.get("directive_key"),
+                "priority": row.get("priority"),
+                "created_at": _format_ts(row.get("created_at")),
+                "issuer": row.get("issuer_person_id") or row.get("issuer_user_id"),
+                "text": payload.get("text", ""),
+            })
+        return result
+    except Exception:
+        return []
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _agent_events(limit: int) -> List[Dict[str, Any]]:
+    try:
+        from hermes_state import SessionDB
+    except Exception:
+        return []
+    db = None
+    try:
+        db = SessionDB()
+        rows = db.list_recent_agent_events(limit=limit)
+        return [
+            {
+                "event_id": row.get("event_id"),
+                "event_type": row.get("event_type"),
+                "event_subtype": row.get("event_subtype"),
+                "status": row.get("status"),
+                "source": row.get("source"),
+                "person_id": row.get("person_id"),
+                "platform": row.get("platform"),
+                "chat_id": row.get("platform_chat_id"),
+                "session_key": row.get("session_key"),
+                "created_at": _format_ts(row.get("created_at")),
+                "content_preview": _preview(row.get("content")),
+            }
+            for row in rows
+        ]
+    except Exception:
+        return []
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _mirror_events_from_jsonl(limit: int) -> List[Dict[str, Any]]:
+    if limit <= 0:
+        return []
+    sessions_path = get_hermes_home() / "sessions"
+    entries = _session_entries(50)
+    events: List[Dict[str, Any]] = []
+    for entry in entries:
+        session_id = entry.get("session_id")
+        if not session_id:
+            continue
+        transcript = sessions_path / f"{session_id}.jsonl"
+        if not transcript.exists():
+            continue
+        try:
+            lines = transcript.read_text(encoding="utf-8").splitlines()
+        except Exception:
+            continue
+        for line in reversed(lines[-100:]):
+            try:
+                msg = json.loads(line)
+            except Exception:
+                continue
+            if not isinstance(msg, dict) or not msg.get("mirror"):
+                continue
+            events.append({
+                "timestamp": msg.get("timestamp"),
+                "session_id": session_id,
+                "source": entry.get("platform", ""),
+                "kind": "delivery_mirror",
+                "mirror_source": msg.get("mirror_source", ""),
+                "content_preview": _preview(msg.get("content")),
+            })
+            if len(events) >= limit:
+                return events
+    return events
+
+
+def self_state_tool(action: str = "summary", limit: int = 10, session_filter: str = "", **_) -> Dict[str, Any]:
+    """Return a read-only snapshot of the agent's runtime state."""
+    action = (action or "summary").strip().lower()
+    limit = _clamp_int(limit, default=10, minimum=1, maximum=50)
+    session_filter = str(session_filter or "").strip()
+
+    if action == "sessions":
+        return {
+            "action": "sessions",
+            "sessions": _session_entries(limit),
+            "note": "These are separate conversation contexts for the same agent runtime.",
+        }
+    if action == "recent_activity":
+        return {
+            "action": "recent_activity",
+            "activity": _recent_activity_from_db(limit, session_filter=session_filter),
+            "note": "Use this to inspect what the agent recently saw or did across sessions.",
+        }
+    if action == "crons":
+        return {
+            "action": "crons",
+            "crons": _cron_jobs(limit),
+            "note": "This only lists cron jobs on this VM. Jobs delegated to other agents live on their VMs.",
+        }
+    if action == "outbounds":
+        return {
+            "action": "outbounds",
+            "outbounds": _outbound_events(limit),
+            "note": "Best-effort view based on persisted assistant/tool-call history.",
+        }
+    if action == "directives":
+        return {
+            "action": "directives",
+            "directives": _active_directives(limit),
+            "note": "Active agent-level directives are shared across isolated sessions.",
+        }
+    if action == "events":
+        return {
+            "action": "events",
+            "events": _agent_events(limit),
+            "note": "Recent agent-level runtime events across sessions.",
+        }
+    if action != "summary":
+        return {
+            "error": f"Unknown action {action!r}. Use summary, sessions, recent_activity, crons, outbounds, directives, or events.",
+        }
+
+    return {
+        "action": "summary",
+        "sessions": _session_entries(min(limit, 10)),
+        "recent_activity": _recent_activity_from_db(min(limit, 12), session_filter=session_filter),
+        "crons": _cron_jobs(min(limit, 12)),
+        "outbounds": _outbound_events(min(limit, 8)),
+        "directives": _active_directives(min(limit, 8)),
+        "agent_events": _agent_events(min(limit, 8)),
+        "notes": [
+            "Sessions are isolated for prompt context, but this tool provides a shared runtime view.",
+            "Remote agents' local crons are not visible here unless they report through your sessions.",
+        ],
+    }
+
+
+SELF_STATE_SCHEMA = {
+    "name": "self_state",
+    "description": (
+        "Inspect your own runtime across isolated sessions. Use this when the user asks "
+        "what you are doing, why you posted or messaged something, what sessions/channels "
+        "are active, what local crons exist, or whether recent behavior came from another "
+        "conversation context. Prefer this before terminal, session_search, logs, or cron "
+        "tools for runtime self-awareness. Read-only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["summary", "sessions", "recent_activity", "crons", "outbounds", "directives", "events"],
+                "description": "Which self-state view to return. Use summary first unless you need a narrower view.",
+                "default": "summary",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum entries per section, 1-50.",
+                "default": 10,
+            },
+            "session_filter": {
+                "type": "string",
+                "description": "Optional substring filter for session id/source/chat/user in recent_activity.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _check_self_state_requirements() -> bool:
+    return get_hermes_home().exists()
+
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="self_state",
+    toolset="self_state",
+    schema=SELF_STATE_SCHEMA,
+    handler=lambda args, **kw: json.dumps(
+        self_state_tool(
+            action=args.get("action", "summary"),
+            limit=args.get("limit", 10),
+            session_filter=args.get("session_filter", ""),
+        ),
+        ensure_ascii=False,
+    ),
+    check_fn=_check_self_state_requirements,
+    emoji="",
+)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -169,6 +169,31 @@ def _handle_send(args):
     else:
         is_explicit = False
 
+    try:
+        from gateway.agent_actor import (
+            blocked_tool_result,
+            evaluate_send_message_policy,
+            record_send_message_outbound,
+        )
+    except Exception:
+        blocked_tool_result = None
+        evaluate_send_message_policy = None
+        record_send_message_outbound = None
+
+    def _policy_decision(current_chat_id, current_message):
+        if not evaluate_send_message_policy:
+            return None
+        try:
+            return evaluate_send_message_policy(
+                target_platform=platform_name,
+                target_chat_id=current_chat_id,
+                target_thread_id=thread_id or "",
+                message=current_message,
+            )
+        except Exception:
+            logger.debug("send_message policy evaluation failed", exc_info=True)
+            return None
+
     # Resolve human-friendly channel names to numeric IDs
     if target_ref and not is_explicit:
         try:
@@ -190,6 +215,19 @@ def _handle_send(args):
     from tools.interrupt import is_interrupted
     if is_interrupted():
         return tool_error("Interrupted")
+
+    policy_checked = False
+    if chat_id:
+        duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
+        if duplicate_skip:
+            return json.dumps(duplicate_skip)
+
+        if blocked_tool_result:
+            decision = _policy_decision(chat_id, message)
+            if decision and not decision.allowed:
+                return blocked_tool_result(decision)
+            if decision:
+                policy_checked = True
 
     try:
         from gateway.config import load_gateway_config, Platform
@@ -271,6 +309,29 @@ def _handle_send(args):
     if duplicate_skip:
         return json.dumps(duplicate_skip)
 
+    if not policy_checked and blocked_tool_result:
+        decision = _policy_decision(chat_id, cleaned_message)
+        if decision and not decision.allowed:
+            return blocked_tool_result(decision)
+
+    try:
+        from gateway.agent_actor import (
+            blocked_tool_result,
+            evaluate_send_message_policy,
+            record_send_message_outbound,
+        )
+
+        decision = evaluate_send_message_policy(
+            target_platform=platform_name,
+            target_chat_id=chat_id,
+            target_thread_id=thread_id or "",
+            message=cleaned_message,
+        )
+        if not decision.allowed:
+            return blocked_tool_result(decision)
+    except Exception:
+        record_send_message_outbound = None
+
     try:
         from model_tools import _run_async
         result = _run_async(
@@ -285,6 +346,19 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+
+        if record_send_message_outbound:
+            try:
+                record_send_message_outbound(
+                    target_platform=platform_name,
+                    target_chat_id=chat_id,
+                    target_thread_id=thread_id or "",
+                    message=cleaned_message,
+                    status="succeeded" if isinstance(result, dict) and result.get("success") else "failed",
+                    result=result if isinstance(result, dict) else {"result": result},
+                )
+            except Exception:
+                pass
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:

--- a/toolsets.py
+++ b/toolsets.py
@@ -48,6 +48,8 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     # Planning & memory
     "todo", "memory",
+    # Runtime self-inspection across isolated sessions
+    "self_state",
     # Session history search
     "session_search",
     # Clarifying questions
@@ -167,6 +169,12 @@ TOOLSETS = {
         "tools": ["memory"],
         "includes": []
     },
+
+    "self_state": {
+        "description": "Read-only runtime self-inspection across sessions, local crons, and recent activity",
+        "tools": ["self_state"],
+        "includes": []
+    },
     
     "session_search": {
         "description": "Search and recall past conversations with summarization",
@@ -250,7 +258,7 @@ TOOLSETS = {
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
-            "todo", "memory",
+            "todo", "memory", "self_state",
             "session_search",
             "execute_code", "delegate_task",
         ],
@@ -276,7 +284,7 @@ TOOLSETS = {
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
             # Planning & memory
-            "todo", "memory",
+            "todo", "memory", "self_state",
             # Session history search
             "session_search",
             # Code execution + delegation


### PR DESCRIPTION
## Summary

Adds an actor/runtime state layer so an agent can reason across isolated sessions without collapsing identity boundaries.

- records inbound, outbound, directive, and cron-related runtime events in `state.db`
- resolves per-platform actor identity/authority, including owner turns outside owner DMs
- injects an ephemeral self-state packet into gateway turns
- adds `self_state` for read-only runtime introspection
- gates public outbound sends against recent owner directives and unsafe cross-session broadcasts

## Stack

Depends on:

- #12234 (`feat/model-routing`)
- #14883 (`feat/routing-context-user-id`)

## Verification

- Focused actor/routing/state regression suite: `319 passed, 1 warning`
- Broader gateway/tooling/cron regression suite with optional extras: `527 passed, 4 warnings`
- Integration rebuild: same broader suite passed with `527 passed, 4 warnings`
- Canary focused regression suite: `307 passed, 4 warnings`
- Owner group-source sanity: `authority=owner`; routing context includes `source_kind: owner` and owner `user_id`
