### PR TITLE
fix: honor NO_PROXY in _build_keepalive_http_client

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4480,12 +4480,23 @@ class AIAgent:
                 _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
             # When a custom transport is provided, httpx won't auto-read proxy
             # from env vars (allow_env_proxies = trust_env and transport is None).
-            # Explicitly read proxy settings to ensure HTTP_PROXY/HTTPS_PROXY work.
+            # Use mounts= so NO_PROXY hosts get a direct transport (proxy= ignores NO_PROXY).
             _proxy = _get_proxy_from_env()
-            return _httpx.Client(
-                transport=_httpx.HTTPTransport(socket_options=_sock_opts),
-                proxy=_proxy,
-            )
+            if not _proxy:
+                return _httpx.Client(
+                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                )
+            import os as _os
+            _no_proxy = _os.environ.get('NO_PROXY', _os.environ.get('no_proxy', ''))
+            _no_proxy_hosts = [h.strip() for h in _no_proxy.split(',') if h.strip()]
+            _mounts: dict = {}
+            for _host in _no_proxy_hosts:
+                _direct = _httpx.HTTPTransport(socket_options=_sock_opts)
+                _mounts[f'http://{_host}'] = _direct
+                _mounts[f'https://{_host}'] = _direct
+            _mounts['http://'] = _httpx.HTTPTransport(proxy=_httpx.Proxy(_proxy))
+            _mounts['https://'] = _httpx.HTTPTransport(proxy=_httpx.Proxy(_proxy))
+            return _httpx.Client(mounts=_mounts)
         except Exception:
             return None
 


### PR DESCRIPTION
## Problem

When a custom `transport=` is passed to `httpx.Client`, httpx disables automatic env-var proxy handling (`allow_env_proxies` requires `transport=None`). The previous commit addressed this by reading `HTTP_PROXY` explicitly via `proxy=`, but that causes httpx to route **all** requests through the proxy — `NO_PROXY` is silently ignored when `proxy=` is set explicitly.

This breaks any LLM endpoint whose hostname appears in `NO_PROXY` (e.g. Tailscale IPs, internal addresses). The keepalive client would receive 503s from the proxy instead of connecting directly to the model server.

## Fix

Switch from `proxy=` to a `mounts=` dict:

- Each host in `NO_PROXY` gets a direct `HTTPTransport` (with keepalive socket options).
- Fall-through patterns (`http://`, `https://`) route through the proxy.
- If no proxy is configured, fall back to a plain direct client as before.

This mirrors how httpx's own env-var proxy logic works internally.

## Reproduction

On a system with `HTTP_PROXY` pointing to an outbound proxy and `NO_PROXY` containing an internal/Tailscale LLM endpoint:

- **Before**: all requests from the keepalive client go through the proxy → 503 from proxy
- **After**: NO_PROXY hosts connect directly; everything else proxied correctly