### PR TITLE
fix(cli): handle missing compressor in /usage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7081,11 +7081,11 @@ class HermesCLI:
         completion = agent.session_completion_tokens
         total = agent.session_total_tokens
 
-        compressor = agent.context_compressor
-        last_prompt = compressor.last_prompt_tokens
-        ctx_len = compressor.context_length
+        compressor = getattr(agent, "context_compressor", None)
+        last_prompt = getattr(compressor, "last_prompt_tokens", 0) or 0
+        ctx_len = getattr(compressor, "context_length", 0) or 0
         pct = min(100, (last_prompt / ctx_len * 100)) if ctx_len else 0
-        compressions = compressor.compression_count
+        compressions = getattr(compressor, "compression_count", 0) or 0
 
         msg_count = len(self.conversation_history)
         cost_result = estimate_usage_cost(

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -268,6 +268,32 @@ class TestCLIStatusBar:
 
 
 class TestCLIUsageReport:
+    def test_show_usage_handles_missing_context_compressor(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj.agent = SimpleNamespace(
+            model=cli_obj.model,
+            provider="anthropic",
+            base_url="",
+            session_input_tokens=10,
+            session_output_tokens=2,
+            session_cache_read_tokens=0,
+            session_cache_write_tokens=0,
+            session_prompt_tokens=12,
+            session_completion_tokens=2,
+            session_total_tokens=14,
+            session_api_calls=1,
+            get_rate_limit_state=lambda: None,
+            context_compressor=None,
+        )
+        cli_obj.verbose = False
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Session Token Usage" in output
+        assert "Current context:  0 / 0 (0%)" in output
+        assert "Compressions:     0" in output
+
     def test_show_usage_includes_estimated_cost(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(),


### PR DESCRIPTION
## Summary
- guard /usage against a missing context_compressor
- default context/compression metrics to zero when the compressor is absent
- add a CLI regression test covering context_compressor=None

Closes #14715

## Testing
- python3 -m pytest -o addopts= tests/cli/test_cli_status_bar.py
