### PR TITLE
fix(wecom): pad base64 aeskey before decoding in media decrypt

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1010,7 +1010,9 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
-        key = base64.b64decode(aes_key)
+        # Pad base64 key if needed (WeCom AI Bot omits trailing = in aeskey)
+        padded_key = aes_key + "=" * (4 - len(aes_key) % 4) if len(aes_key) % 4 else aes_key
+        key = base64.b64decode(padded_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")
 


### PR DESCRIPTION
## Problem

WeCom AI Bot WebSocket (`aibot_msg_callback`) delivers inbound image/file messages with an `aeskey` field that is base64-encoded but **omits trailing `=` padding** — for example:

```
+bTGvcNgTiGO/w6rwhrgQYvfBP43z0+pkpBish3+i0U   (43 chars, needs 1 pad)
ylMgROx2SpyfFWBujd3cBFN/nEAjoEzRqvwT2djNp6Q   (43 chars, needs 1 pad)
```

`base64.b64decode()` raises `Incorrect padding` when the input length is not a multiple of 4, causing `_decrypt_file_bytes` to fail silently. The image/file downloads successfully but is never cached, so `_extract_media` returns an empty list and the message is dropped as "Empty WeCom message skipped".

## Root Cause

`_decrypt_file_bytes` in `gateway/platforms/wecom.py` calls `base64.b64decode(aes_key)` without padding normalization.

## Fix

Add standard base64 padding before decoding:

```python
# Before
key = base64.b64decode(aes_key)

# After
padded_key = aes_key + "=" * (4 - len(aes_key) % 4) if len(aes_key) % 4 else aes_key
key = base64.b64decode(padded_key)
```

## Testing

Tested with WeCom AI Bot in production:
- Before: all inbound image messages fail with "Failed to decrypt image: Incorrect padding"
- After: images download, decrypt, cache, and reach the agent successfully

OpenClaw's wecom-openclaw-plugin handles the same aeskey format via `wsClient.downloadFile(url, aeskey)` which pads internally — confirming this is the expected format from WeCom's API.

## Affected Versions

v0.10.0, v0.11.0 (and likely all versions since WeCom media decrypt was added)