### PR TITLE
feat: add DeepSeek V4 model identifiers

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -12,8 +12,11 @@ Different LLM providers expect model identifiers in different formats:
   model IDs, but Claude still uses hyphenated native names like
   ``claude-sonnet-4-6``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
-- **DeepSeek** only accepts two model identifiers:
-  ``deepseek-chat`` and ``deepseek-reasoner``.
+- **DeepSeek** accepts V4 API identifiers:
+  ``deepseek-v4-flash`` and ``deepseek-v4-pro``. Legacy names
+  ``deepseek-chat`` and ``deepseek-reasoner`` remain compatible but are
+  deprecated; they map to non-thinking and thinking modes of
+  ``deepseek-v4-flash`` respectively.
 - **Custom** and remaining providers pass the name through as-is.
 
 This module centralises that translation so callers can simply write::
@@ -103,8 +106,10 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
-# DeepSeek's API only recognises exactly two model identifiers.  We map
-# common aliases and patterns to the canonical names.
+# DeepSeek supports V4 model identifiers while keeping legacy aliases for
+# backwards compatibility.  ``deepseek-chat`` and ``deepseek-reasoner`` are
+# deprecated names that correspond to non-thinking and thinking modes of
+# ``deepseek-v4-flash`` respectively.
 
 _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "reasoner",
@@ -115,25 +120,27 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
 })
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
     "deepseek-chat",
     "deepseek-reasoner",
 })
 
 
 def _normalize_for_deepseek(model_name: str) -> str:
-    """Map any model input to one of DeepSeek's two accepted identifiers.
+    """Map DeepSeek model aliases to supported API identifiers.
 
     Rules:
-    - Already ``deepseek-chat`` or ``deepseek-reasoner`` -> pass through.
+    - V4 and legacy API IDs pass through unchanged.
     - Contains any reasoner keyword (r1, think, reasoning, cot, reasoner)
-      -> ``deepseek-reasoner``.
-    - Everything else -> ``deepseek-chat``.
+      -> ``deepseek-reasoner`` for legacy compatibility.
+    - Everything else -> ``deepseek-v4-flash``.
 
     Args:
         model_name: The bare model name (vendor prefix already stripped).
 
     Returns:
-        One of ``"deepseek-chat"`` or ``"deepseek-reasoner"``.
+        A DeepSeek API model identifier.
     """
     bare = _strip_vendor_prefix(model_name).lower()
 
@@ -145,7 +152,7 @@ def _normalize_for_deepseek(model_name: str) -> str:
         if keyword in bare:
             return "deepseek-reasoner"
 
-    return "deepseek-chat"
+    return "deepseek-v4-flash"
 
 
 # ---------------------------------------------------------------------------
@@ -336,8 +343,8 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         >>> normalize_model_for_provider("minimax-m2.5-free", "opencode-zen")
         'minimax-m2.5-free'
 
-        >>> normalize_model_for_provider("deepseek-v3", "deepseek")
-        'deepseek-chat'
+        >>> normalize_model_for_provider("deepseek-v4", "deepseek")
+        'deepseek-v4-flash'
 
         >>> normalize_model_for_provider("deepseek-r1", "deepseek")
         'deepseek-reasoner'

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -14,8 +14,8 @@ Different LLM providers expect model identifiers in different formats:
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
 - **DeepSeek** accepts V4 API identifiers:
   ``deepseek-v4-flash`` and ``deepseek-v4-pro``. Legacy names
-  ``deepseek-chat`` and ``deepseek-reasoner`` remain compatible but are
-  deprecated; they map to non-thinking and thinking modes of
+  ``deepseek-chat`` and ``deepseek-reasoner`` remain compatible until
+  2026-07-24; they map to non-thinking and thinking modes of
   ``deepseek-v4-flash`` respectively.
 - **Custom** and remaining providers pass the name through as-is.
 
@@ -108,8 +108,8 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
 # ---------------------------------------------------------------------------
 # DeepSeek supports V4 model identifiers while keeping legacy aliases for
 # backwards compatibility.  ``deepseek-chat`` and ``deepseek-reasoner`` are
-# deprecated names that correspond to non-thinking and thinking modes of
-# ``deepseek-v4-flash`` respectively.
+# deprecated after 2026-07-24 and correspond to non-thinking and thinking
+# modes of ``deepseek-v4-flash`` respectively.
 
 _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "reasoner",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -246,6 +246,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-haiku-4-5-20251001",
     ],
     "deepseek": [
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
         "deepseek-chat",
         "deepseek-reasoner",
     ],
@@ -704,7 +706,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
-    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
+    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V4 Flash/Pro — direct API; legacy chat/reasoner aliases supported)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
     ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -164,6 +164,23 @@ class TestAggregatorProviders:
         assert result == "anthropic/claude-sonnet-4.6"
 
 
+class TestDeepSeekV4Normalization:
+    """DeepSeek direct API supports V4 model IDs plus legacy aliases."""
+
+    @pytest.mark.parametrize("model,expected", [
+        ("deepseek-v4-flash", "deepseek-v4-flash"),
+        ("deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek/deepseek-v4-flash", "deepseek-v4-flash"),
+        ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek-chat", "deepseek-chat"),
+        ("deepseek-reasoner", "deepseek-reasoner"),
+        ("deepseek-v4", "deepseek-v4-flash"),
+        ("deepseek-r1", "deepseek-reasoner"),
+    ])
+    def test_deepseek_v4_and_legacy_aliases(self, model, expected):
+        assert normalize_model_for_provider(model, "deepseek") == expected
+
+
 class TestIssue6211NativeProviderPrefixNormalization:
     @pytest.mark.parametrize("model,target_provider,expected", [
         ("zai/glm-5.1", "zai", "glm-5.1"),


### PR DESCRIPTION
## Summary
- Add DeepSeek V4 API model IDs: `deepseek-v4-flash` and `deepseek-v4-pro`
- Keep legacy `deepseek-chat` and `deepseek-reasoner` available for compatibility until 2026-07-24
- Update DeepSeek provider description and normalization docs/tests

## Source
- DeepSeek Models & Pricing: https://api-docs.deepseek.com/quick_start/pricing
- The pricing page notes that `deepseek-chat` and `deepseek-reasoner` are deprecated compatibility aliases for `deepseek-v4-flash` non-thinking/thinking modes.

## Verification
- `python -m pytest tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_models.py -q`
- 120 passed