### PR TITLE
fix(send_message): route media attachments through Feishu adapter

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -528,11 +528,28 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu: native attachment support via adapter (image/video/audio/document) ---
+    if platform == Platform.FEISHU and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, and signal; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -540,7 +557,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, and signal"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, and feishu"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary

`_send_feishu()` in `tools/send_message_tool.py` already supports `media_files` — it routes PDFs/docs to `adapter.send_document()`, images to `send_image_file()`, and audio/video to `send_voice()`/`send_video()`, mirroring how Telegram is wired.

However, `_send_to_platform()` never gave Feishu a dedicated branch. Feishu messages fell into the generic "Non-media platforms" loop at L566, which calls `_send_feishu(pconfig, chat_id, chunk, thread_id=...)` **without** passing `media_files`. Any `MEDIA:/path/...` tag emitted by the model (or media supplied by the caller) triggered the warning at L542:

> MEDIA attachments were omitted for feishu; native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, and signal

…and only text was delivered, even though the adapter had full file-upload support.

### Change

- Add a `Platform.FEISHU` branch next to the existing Signal/Matrix/Discord/Telegram branches that passes `media_files` to `_send_feishu()` on the last chunk.
- Update the omitted-media warning and the text-less media error string to list Feishu alongside the other supported platforms.

No new dependencies; reuses `_send_feishu()`'s existing media path. Non-Feishu platforms are unaffected.

## Repro before the fix

Any Hermes agent running on Feishu that tries `send_message` with `MEDIA:/some/file.pdf` in the text — the file is dropped and the delivery result includes the "MEDIA attachments were omitted" warning.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('tools/send_message_tool.py').read())"` passes.
- [x] Verified locally (patched install) that crypto Feishu agent can deliver a PDF via `MEDIA:/root/.hermes/profiles/crypto/cache/documents/onsite_report.pdf` — before the patch only the text was sent with an omitted-media warning; after the patch the PDF is uploaded and attached to the chat as a document.
- [ ] Maintainers: please run the existing `tests/gateway/test_feishu.py` suite to confirm no regression; the patch only adds a dispatch branch and does not touch adapter behavior.