### PR TITLE
fix(environments): handle remote POSIX paths on Windows hosts

### DIFF
--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -2,12 +2,18 @@
 
 import os
 import time
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tools.environments.file_sync import FileSyncManager, _FORCE_SYNC_ENV
+from tools.environments import file_sync as file_sync_mod
+from tools.environments.file_sync import (
+    FileSyncManager,
+    _FORCE_SYNC_ENV,
+    remote_parent_dir,
+    unique_parent_dirs,
+)
 
 
 @pytest.fixture
@@ -309,3 +315,22 @@ class TestBulkUpload:
         mgr.sync(force=True)
         bulk_upload.assert_called_once()
         assert len(bulk_upload.call_args[0][0]) == 3
+
+
+class TestRemotePathHandling:
+    """Remote sandbox paths must stay POSIX even on Windows hosts."""
+
+    def test_remote_parent_dir_uses_posix_semantics(self):
+        assert remote_parent_dir("/home/user/.hermes/skills/a.py") == "/home/user/.hermes/skills"
+
+    def test_unique_parent_dirs_not_host_os_dependent(self, monkeypatch):
+        monkeypatch.setattr(file_sync_mod, "Path", PureWindowsPath)
+        files = [
+            (r"C:\Users\me\.hermes\skills\a.py", "/home/user/.hermes/skills/a.py"),
+            (r"C:\Users\me\.hermes\credentials\b.json", "/home/user/.hermes/credentials/b.json"),
+        ]
+
+        assert unique_parent_dirs(files) == [
+            "/home/user/.hermes/credentials",
+            "/home/user/.hermes/skills",
+        ]

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,16 +1,20 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-import fcntl
 import io
 import logging
 import os
 import signal
 import tarfile
 import time
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -18,6 +22,7 @@ from tools.environments.file_sync import (
     _SYNC_BACK_BACKOFF,
     _SYNC_BACK_MAX_RETRIES,
 )
+from tools.environments import file_sync as file_sync_mod
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +312,7 @@ class TestPushedHashesPopulated:
 class TestSyncBackFileLock:
     """Verify that fcntl.flock is used during sync-back."""
 
+    @pytest.mark.skipif(fcntl is None, reason="fcntl is not available on this platform")
     @patch("tools.environments.file_sync.fcntl.flock")
     def test_sync_back_file_lock(self, mock_flock, tmp_path):
         download_fn = _make_download_fn({})
@@ -376,6 +382,21 @@ class TestInferHostPath:
         )
         expected = str(tmp_path / "host" / "skills" / "b.py")
         assert result == expected
+
+    def test_infer_uses_posix_remote_prefix_on_windows_host(self, monkeypatch):
+        """Remote path prefix matching must not depend on the host pathlib flavor."""
+        monkeypatch.setattr(file_sync_mod, "Path", PureWindowsPath)
+        mapping = [
+            (r"C:\Users\me\.hermes\skills\a.py", "/root/.hermes/skills/a.py"),
+        ]
+
+        mgr = _make_manager(Path("/tmp"), file_mapping=mapping)
+        result = mgr._infer_host_path(
+            "/root/.hermes/skills/b.py",
+            file_mapping=mapping,
+        )
+
+        assert result == r"C:\Users\me\.hermes\skills\b.py"
 
 
 class TestSyncBackSIGINT:

--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -2,7 +2,7 @@
 
 import os
 import subprocess
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +51,25 @@ class TestSSHBulkUpload:
             mock_run.assert_not_called()
             mock_popen.assert_not_called()
 
+    def test_single_upload_uses_posix_parent_on_windows_host(self, mock_env, monkeypatch, tmp_path):
+        """Single-file scp upload must mkdir the POSIX remote parent."""
+        monkeypatch.setattr(ssh_env, "Path", PureWindowsPath)
+        src = tmp_path / "a.txt"
+        src.write_text("aaa")
+
+        run_calls = []
+
+        def capture_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return subprocess.CompletedProcess([], 0)
+
+        with patch.object(subprocess, "run", side_effect=capture_run):
+            mock_env._scp_upload(str(src), "/home/testuser/.hermes/skills/a.txt")
+
+        mkdir_cmd = " ".join(run_calls[0])
+        assert "mkdir -p /home/testuser/.hermes/skills" in mkdir_cmd
+        assert "\\home\\testuser" not in mkdir_cmd
+
     def test_mkdir_batched_into_single_call(self, mock_env, tmp_path):
         """All parent directories should be created in one SSH call."""
         # Create test files
@@ -90,8 +109,8 @@ class TestSSHBulkUpload:
         assert "/home/testuser/.hermes/skills" in mkdir_str
         assert "/home/testuser/.hermes/credentials" in mkdir_str
 
-    def test_staging_symlinks_mirror_remote_layout(self, mock_env, tmp_path):
-        """Symlinks in staging dir should mirror the remote path structure."""
+    def test_staging_files_mirror_remote_layout(self, mock_env, tmp_path):
+        """Staging entries should mirror the remote path structure."""
         f1 = tmp_path / "local_a.txt"
         f1.write_text("content a")
 
@@ -111,8 +130,11 @@ class TestSSHBulkUpload:
                     staging_dir, "home/testuser/.hermes/skills/my_skill.md"
                 )
                 staging_paths.append(expected)
-                assert os.path.islink(expected), f"Expected symlink at {expected}"
-                assert os.readlink(expected) == os.path.abspath(str(f1))
+                if os.path.islink(expected):
+                    assert os.readlink(expected) == os.path.abspath(str(f1))
+                else:
+                    assert os.path.isfile(expected), f"Expected staged file at {expected}"
+                    assert Path(expected).read_text() == "content a"
 
             mock = MagicMock()
             mock.stdout = MagicMock()
@@ -129,6 +151,40 @@ class TestSSHBulkUpload:
             mock_env._ssh_bulk_upload(files)
 
         assert len(staging_paths) == 1, "tar command should have been called"
+
+    def test_staging_falls_back_to_copy_when_symlink_unavailable(self, mock_env, tmp_path):
+        """Windows without Developer Mode should still stage files for tar."""
+        f1 = tmp_path / "local_a.txt"
+        f1.write_text("content a")
+        files = [(str(f1), "/home/testuser/.hermes/skills/my_skill.md")]
+        staged_files = []
+
+        def capture_tar_cmd(cmd, **kwargs):
+            if cmd[0] == "tar":
+                c_idx = cmd.index("-C")
+                staged = os.path.join(
+                    cmd[c_idx + 1], "home/testuser/.hermes/skills/my_skill.md"
+                )
+                staged_files.append(staged)
+                assert os.path.isfile(staged)
+                assert Path(staged).read_text() == "content a"
+
+            mock = MagicMock()
+            mock.stdout = MagicMock()
+            mock.returncode = 0
+            mock.poll.return_value = 0
+            mock.communicate.return_value = (b"", b"")
+            mock.stderr = MagicMock()
+            mock.stderr.read.return_value = b""
+            return mock
+
+        with patch.object(subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)), \
+             patch.object(os, "symlink", side_effect=OSError("symlink denied")), \
+             patch.object(subprocess, "Popen", side_effect=capture_tar_cmd):
+            mock_env._ssh_bulk_upload(files)
+
+        assert len(staged_files) == 1
 
     def test_tar_pipe_commands(self, mock_env, tmp_path):
         """Verify tar and SSH commands are wired correctly."""

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -10,7 +10,6 @@ import math
 import os
 import shlex
 import threading
-from pathlib import Path
 
 from tools.environments.base import (
     BaseEnvironment,
@@ -21,6 +20,7 @@ from tools.environments.file_sync import (
     iter_sync_files,
     quoted_mkdir_command,
     quoted_rm_command,
+    remote_parent_dir,
     unique_parent_dirs,
 )
 
@@ -142,7 +142,7 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _daytona_upload(self, host_path: str, remote_path: str) -> None:
         """Upload a single file via Daytona SDK."""
-        parent = str(Path(remote_path).parent)
+        parent = remote_parent_dir(remote_path)
         self._sandbox.process.exec(f"mkdir -p {parent}")
         self._sandbox.fs.upload_file(host_path, remote_path)
 

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -13,7 +13,6 @@ import shlex
 import shutil
 import signal
 import tarfile
-import tempfile
 import threading
 import time
 
@@ -21,7 +20,7 @@ try:
     import fcntl
 except ImportError:
     fcntl = None  # Windows — file locking skipped
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Callable
 
 from hermes_constants import get_hermes_home
@@ -79,9 +78,19 @@ def quoted_mkdir_command(dirs: list[str]) -> str:
     return "mkdir -p " + " ".join(shlex.quote(d) for d in dirs)
 
 
+def remote_parent_dir(remote_path: str) -> str:
+    """Return the POSIX parent directory for a remote sandbox path.
+
+    Remote execution backends always use POSIX paths, even when Hermes runs
+    on a Windows host.  ``Path(remote_path)`` is host-OS dependent and turns
+    ``/root/.hermes/x`` into a backslash path on Windows.
+    """
+    return str(PurePosixPath(remote_path).parent)
+
+
 def unique_parent_dirs(files: list[tuple[str, str]]) -> list[str]:
     """Extract sorted unique parent directories from (host, remote) pairs."""
-    return sorted({str(Path(remote).parent) for _, remote in files})
+    return sorted({remote_parent_dir(remote) for _, remote in files})
 
 
 def _sha256_file(path: str) -> str:
@@ -91,6 +100,30 @@ def _sha256_file(path: str) -> str:
         for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _safe_extract_regular_files(tar: tarfile.TarFile, destination: Path) -> None:
+    """Extract regular files while rejecting path traversal and links."""
+    destination.mkdir(parents=True, exist_ok=True)
+    for member in tar.getmembers():
+        posix_path = PurePosixPath(member.name)
+        if posix_path.is_absolute() or ".." in posix_path.parts:
+            logger.warning("sync_back: skipping unsafe tar member %s", member.name)
+            continue
+        if member.isdir():
+            destination.joinpath(*posix_path.parts).mkdir(parents=True, exist_ok=True)
+            continue
+        if not member.isfile():
+            logger.debug("sync_back: skipping non-regular tar member %s", member.name)
+            continue
+
+        src = tar.extractfile(member)
+        if src is None:
+            continue
+        target = destination.joinpath(*posix_path.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with src, open(target, "wb") as dst:
+            shutil.copyfileobj(src, dst)
 
 
 _SYNC_BACK_MAX_RETRIES = 3
@@ -276,17 +309,17 @@ class FileSyncManager:
         """Sync-back under file lock (serializes concurrent gateways)."""
         if fcntl is None:
             # Windows: no flock — run without serialization
-            self._sync_back_impl()
+            self._sync_back_impl(temp_parent=lock_path.parent)
             return
         lock_fd = open(lock_path, "w")
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            self._sync_back_impl()
+            self._sync_back_impl(temp_parent=lock_path.parent)
         finally:
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
             lock_fd.close()
 
-    def _sync_back_impl(self) -> None:
+    def _sync_back_impl(self, temp_parent: Path | None = None) -> None:
         """Download, diff, and apply remote changes to host."""
         if self._bulk_download_fn is None:
             raise RuntimeError("_sync_back_impl called without bulk_download_fn")
@@ -297,13 +330,19 @@ class FileSyncManager:
         except Exception:
             file_mapping = []
 
-        with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
-            self._bulk_download_fn(Path(tf.name))
+        temp_dir = temp_parent or get_hermes_home()
+        temp_dir.mkdir(parents=True, exist_ok=True)
+
+        nonce = f"{os.getpid()}-{time.monotonic_ns()}"
+        tmp_tar_path = temp_dir / f"hermes-sync-back-{nonce}.tar"
+        staging_path = temp_dir / f"hermes-sync-back-{nonce}"
+        try:
+            self._bulk_download_fn(tmp_tar_path)
 
             # Defensive size cap: a misbehaving sandbox could produce an
             # arbitrarily large tar. Refuse to extract if it exceeds the cap.
             try:
-                tar_size = os.path.getsize(tf.name)
+                tar_size = os.path.getsize(tmp_tar_path)
             except OSError:
                 tar_size = 0
             if tar_size > _SYNC_BACK_MAX_BYTES:
@@ -313,16 +352,17 @@ class FileSyncManager:
                 )
                 return
 
-            with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
-                with tarfile.open(tf.name) as tar:
-                    tar.extractall(staging, filter="data")
+            staging_path.mkdir(parents=True, exist_ok=False)
+            try:
+                with tarfile.open(tmp_tar_path) as tar:
+                    _safe_extract_regular_files(tar, staging_path)
 
                 applied = 0
-                for dirpath, _dirnames, filenames in os.walk(staging):
+                for dirpath, _dirnames, filenames in os.walk(staging_path):
                     for fname in filenames:
                         staged_file = os.path.join(dirpath, fname)
-                        rel = os.path.relpath(staged_file, staging)
-                        remote_path = "/" + rel
+                        rel_parts = Path(staged_file).relative_to(staging_path).parts
+                        remote_path = "/" + "/".join(rel_parts)
 
                         pushed_hash = self._pushed_hashes.get(remote_path)
 
@@ -363,6 +403,13 @@ class FileSyncManager:
                     logger.info("sync_back: applied %d changed file(s)", applied)
                 else:
                     logger.debug("sync_back: no remote changes detected")
+            finally:
+                shutil.rmtree(staging_path, ignore_errors=True)
+        finally:
+            try:
+                tmp_tar_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.debug("sync_back: failed to remove temp tar %s: %s", tmp_tar_path, exc)
 
     def _resolve_host_path(self, remote_path: str,
                            file_mapping: list[tuple[str, str]] | None = None) -> str | None:
@@ -385,9 +432,8 @@ class FileSyncManager:
         """
         mapping = file_mapping if file_mapping is not None else []
         for host, remote in mapping:
-            remote_dir = str(Path(remote).parent)
+            remote_dir = remote_parent_dir(remote)
             if remote_path.startswith(remote_dir + "/"):
-                host_dir = str(Path(host).parent)
                 suffix = remote_path[len(remote_dir):]
-                return host_dir + suffix
+                return str(Path(host).parent / suffix.lstrip("/"))
         return None

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -26,6 +26,7 @@ from tools.environments.file_sync import (
     iter_sync_files,
     quoted_mkdir_command,
     quoted_rm_command,
+    remote_parent_dir,
     unique_parent_dirs,
 )
 
@@ -278,7 +279,7 @@ class ModalEnvironment(BaseEnvironment):
         """Upload a single file via base64 piped through stdin."""
         content = Path(host_path).read_bytes()
         b64 = base64.b64encode(content).decode("ascii")
-        container_dir = str(Path(remote_path).parent)
+        container_dir = remote_parent_dir(remote_path)
         cmd = (
             f"mkdir -p {shlex.quote(container_dir)} && "
             f"base64 -d > {shlex.quote(remote_path)}"

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -15,6 +15,7 @@ from tools.environments.file_sync import (
     iter_sync_files,
     quoted_mkdir_command,
     quoted_rm_command,
+    remote_parent_dir,
     unique_parent_dirs,
 )
 
@@ -136,7 +137,7 @@ class SSHEnvironment(BaseEnvironment):
 
     def _scp_upload(self, host_path: str, remote_path: str) -> None:
         """Upload a single file via scp over ControlMaster."""
-        parent = str(Path(remote_path).parent)
+        parent = remote_parent_dir(remote_path)
         mkdir_cmd = self._build_ssh_command()
         mkdir_cmd.append(f"mkdir -p {shlex.quote(parent)}")
         subprocess.run(mkdir_cmd, capture_output=True, text=True, timeout=10)
@@ -178,7 +179,13 @@ class SSHEnvironment(BaseEnvironment):
             for host_path, remote_path in files:
                 staged = os.path.join(staging, remote_path.lstrip("/"))
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
-                os.symlink(os.path.abspath(host_path), staged)
+                try:
+                    os.symlink(os.path.abspath(host_path), staged)
+                except OSError:
+                    # Windows requires Developer Mode or elevated privileges
+                    # for symlinks. Falling back to a copy preserves the
+                    # archive layout and keeps SSH bulk upload usable.
+                    shutil.copy2(host_path, staged)
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()


### PR DESCRIPTION
## Summary

Fixes Windows-host compatibility issues in remote environment file sync for SSH, Modal, and Daytona backends.

Remote sandbox paths are always POSIX-style paths, but parts of the sync code were using host-dependent `Path(...)` parsing. On Windows this could turn remote paths such as `/root/.hermes/skills/a.py` into backslash paths, breaking remote mkdir commands and sync-back path inference.

This also fixes two Windows-specific sync paths found during testing:
- SSH bulk upload now falls back to copying staged files when `os.symlink()` is unavailable without Developer Mode/admin privileges.
- sync-back no longer relies on Windows-sensitive `NamedTemporaryFile`, `TemporaryDirectory`, or `tar.extractall(..., filter="data")` behavior. It uses Hermes-local temp paths and extracts only regular files with explicit traversal/link rejection.

## Changes

- Add POSIX-only remote path parent handling via `PurePosixPath`
- Use the POSIX remote parent helper in SSH, Modal, and Daytona upload paths
- Normalize sync-back inferred remote paths to POSIX separators
- Add a safe regular-file tar extractor for sync-back
- Add Windows-host regression coverage for remote path handling and SSH symlink fallback
- Skip `fcntl` lock assertion on platforms where `fcntl` is unavailable

## Tests

Result: 57 passed, 1 skipped.

uv run --extra dev pytest tests\tools\test_file_sync.py tests\tools\test_file_sync_back.py tests\tools\test_ssh_bulk_upload.py
