### PR TITLE
fix(tui): keep FloatingOverlays visible when input is blocked

### DIFF
--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -185,56 +185,58 @@ const ComposerPane = memo(function ComposerPane({
 
       <StatusRulePane at="top" composer={composer} status={status} />
 
-      {!isBlocked && (
-        <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
-          <FloatingOverlays
-            cols={composer.cols}
-            compIdx={composer.compIdx}
-            completions={composer.completions}
-            onModelSelect={actions.onModelSelect}
-            onPickerSelect={actions.resumeById}
-            pagerPageSize={composer.pagerPageSize}
-          />
+      <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
+        <FloatingOverlays
+          cols={composer.cols}
+          compIdx={composer.compIdx}
+          completions={composer.completions}
+          onModelSelect={actions.onModelSelect}
+          onPickerSelect={actions.resumeById}
+          pagerPageSize={composer.pagerPageSize}
+        />
 
-          {composer.inputBuf.map((line, i) => (
-            <Box key={i}>
-              <Box width={3}>
-                <Text color={ui.theme.color.dim}>{i === 0 ? `${ui.theme.brand.prompt} ` : '  '}</Text>
+        {!isBlocked && (
+          <>
+            {composer.inputBuf.map((line, i) => (
+              <Box key={i}>
+                <Box width={3}>
+                  <Text color={ui.theme.color.dim}>{i === 0 ? `${ui.theme.brand.prompt} ` : '  '}</Text>
+                </Box>
+
+                <Text color={ui.theme.color.cornsilk}>{line || ' '}</Text>
+              </Box>
+            ))}
+
+            <Box position="relative">
+              <Box width={pw}>
+                {sh ? (
+                  <Text color={ui.theme.color.shellDollar}>$ </Text>
+                ) : (
+                  <Text bold color={ui.theme.color.prompt}>
+                    {composer.inputBuf.length ? '  ' : `${ui.theme.brand.prompt} `}
+                  </Text>
+                )}
               </Box>
 
-              <Text color={ui.theme.color.cornsilk}>{line || ' '}</Text>
-            </Box>
-          ))}
+              <Box flexGrow={1} position="relative">
+                {/* subtract NoSelect paddingX={1} (2 cols) + pw so wrap-ansi and cursorLayout agree */}
+                <TextInput
+                  columns={Math.max(20, composer.cols - pw - 2)}
+                  onChange={composer.updateInput}
+                  onPaste={composer.handleTextPaste}
+                  onSubmit={composer.submit}
+                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  value={composer.input}
+                />
 
-          <Box position="relative">
-            <Box width={pw}>
-              {sh ? (
-                <Text color={ui.theme.color.shellDollar}>$ </Text>
-              ) : (
-                <Text bold color={ui.theme.color.prompt}>
-                  {composer.inputBuf.length ? '  ' : `${ui.theme.brand.prompt} `}
-                </Text>
-              )}
-            </Box>
-
-            <Box flexGrow={1} position="relative">
-              {/* subtract NoSelect paddingX={1} (2 cols) + pw so wrap-ansi and cursorLayout agree */}
-              <TextInput
-                columns={Math.max(20, composer.cols - pw - 2)}
-                onChange={composer.updateInput}
-                onPaste={composer.handleTextPaste}
-                onSubmit={composer.submit}
-                placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
-                value={composer.input}
-              />
-
-              <Box position="absolute" right={0}>
-                <GoodVibesHeart t={ui.theme} tick={status.goodVibesTick} />
+                <Box position="absolute" right={0}>
+                  <GoodVibesHeart t={ui.theme} tick={status.goodVibesTick} />
+                </Box>
               </Box>
             </Box>
-          </Box>
-        </Box>
-      )}
+          </>
+        )}
+      </Box>
 
       {!composer.empty && !ui.sid && <Text color={ui.theme.color.dim}>⚕ {ui.status}</Text>}
 


### PR DESCRIPTION
## What does this PR do?

Fixes a structural regression where FloatingOverlays (SessionPicker, ModelPicker, SkillsHub, pager, completions) was nested inside the !isBlocked guard in ComposerPane. When any overlay opened, $isBlocked became true, which removed the entire composer box from the tree — including the overlay that was trying to render. This made /resume with no args appear to do nothing (the input line vanished and no picker appeared), and also broke /history, /logs, /model, /skills, and the completion dropdown.




Since 99d859ce (feat: refactor by splitting up app and doing proper state), isBlocked gated only the text input lines so that approval/clarify prompts and pickers rendered above a hidden composer. The regression happened in 408fc893 (fix(tui): tighten composer — status sits directly above input, overlays anchor to input) when FloatingOverlays was moved into the input row for anchoring but accidentally kept inside the !isBlocked guard.



This PR restores the original architecture: FloatingOverlays is rendered outside the !isBlocked guard inside the same position:relative Box, so overlays stay visible even when text input is hidden. Only the actual input buffer lines and TextInput remain gated.

this is a better fix than https://github.com/NousResearch/hermes-agent/pull/14509 because if u moved picker out::

• composer completions woukd still trigger underneath the session picker (cause useCompletion gets isBlocked)
• typin/enter/arrows in the main handler would still try 2 navigate history or submit messages while the overlay is up
• youd have to add special cases in useInputHandlers to ignore keys when overlay.picker is true,, which is just isBlocked with extra steps

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #14467

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

• ui-tui/src/components/appLayout.tsx: Moved FloatingOverlays outside the !isBlocked conditional so overlays render even when $isBlocked is true. Only composer.inputBuf and TextInput remain gated by !isBlocked.

## How to Test

1. Start the TUI: hermes --tui
2. Without a session active, type /resume and press Enter
3. Observe that the SessionPicker overlay appears and the input line does not vanish
4. Navigate with arrow keys and press Enter to resume a session, or press Esc to cancel

without this PR, you can see /resume just hides the input line and doesn't show the box

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS + GhosTTY + fish

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A