### PR TITLE
fix(/branch): redirect session_log_file and expose branch sessions in sessions list

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4829,6 +4829,12 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = new_session_id
             self.agent.session_start = now
+            # Redirect the JSON session log to the new branch session file so
+            # messages written after branching land in the correct file.
+            if hasattr(self.agent, "session_log_file") and hasattr(self.agent, "logs_dir"):
+                self.agent.session_log_file = (
+                    self.agent.logs_dir / f"session_{new_session_id}.json"
+                )
             self.agent.reset_session_state()
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -822,7 +822,18 @@ class SessionDB:
         params = []
 
         if not include_children:
-            where_clauses.append("s.parent_session_id IS NULL")
+            # Show root sessions and branch sessions (whose parent ended with
+            # end_reason='branched' before the child was created), while still
+            # hiding sub-agent runs and compression continuations (which also
+            # carry a parent_session_id but were spawned while the parent was
+            # still live — i.e., started_at < parent.ended_at).
+            where_clauses.append(
+                "(s.parent_session_id IS NULL"
+                " OR EXISTS (SELECT 1 FROM sessions p"
+                "            WHERE p.id = s.parent_session_id"
+                "            AND p.end_reason = 'branched'"
+                "            AND s.started_at >= p.ended_at))"
+            )
 
         if source:
             where_clauses.append("s.source = ?")

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -160,6 +160,30 @@ class TestBranchCommandCLI:
         assert agent.reset_session_state.called
         assert agent._last_flushed_db_idx == 4  # len(conversation_history)
 
+    def test_branch_updates_agent_session_log_file(self, cli_instance, session_db, tmp_path):
+        """Branching must redirect the agent's session_log_file to the new session's path."""
+        from cli import HermesCLI
+        from pathlib import Path
+
+        logs_dir = tmp_path / "sessions"
+        logs_dir.mkdir()
+
+        agent = MagicMock()
+        agent._last_flushed_db_idx = 0
+        agent.logs_dir = logs_dir
+        agent.session_log_file = logs_dir / f"session_{cli_instance.session_id}.json"
+        cli_instance.agent = agent
+
+        old_log_file = agent.session_log_file
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        new_session_id = cli_instance.session_id
+        expected_log = logs_dir / f"session_{new_session_id}.json"
+        assert agent.session_log_file == expected_log, (
+            "session_log_file must point to the branch session, not the original"
+        )
+        assert agent.session_log_file != old_log_file
+
     def test_branch_sets_resumed_flag(self, cli_instance, session_db):
         """Branch should set _resumed=True to prevent auto-title generation."""
         from cli import HermesCLI

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1458,6 +1458,48 @@ class TestListSessionsRich:
         assert "\n" not in sessions[0]["preview"]
         assert "Line one Line two" in sessions[0]["preview"]
 
+    def test_branch_session_visible_in_list(self, db):
+        """Branch sessions (parent ended with 'branched') must appear in list_sessions_rich."""
+        db.create_session("parent", "cli")
+        db.end_session("parent", "branched")
+        db.create_session("branch", "cli", parent_session_id="parent")
+        db.append_message("branch", "user", "Exploring the alternative approach")
+
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "branch" in ids, "Branch session should be visible in default list"
+
+    def test_subagent_session_still_hidden(self, db):
+        """Sub-agent children (parent NOT ended with 'branched') remain hidden."""
+        db.create_session("root", "cli")
+        db.create_session("delegate", "cli", parent_session_id="root")
+
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "delegate" not in ids, "Delegate sub-agent should not appear in default list"
+        assert "root" in ids
+
+    def test_compression_child_still_hidden(self, db):
+        """Compression continuation sessions remain hidden (parent ended with 'compression')."""
+        import time as _time
+        t0 = _time.time()
+        db.create_session("root", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root"))
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+            (t0 + 1800, "root"),
+        )
+        db._conn.commit()
+        db.create_session("continuation", "cli", parent_session_id="root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1801, "continuation")
+        )
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(project_compression_tips=False)
+        ids = [s["id"] for s in sessions]
+        assert "continuation" not in ids, "Compression continuation should stay hidden"
+
 
 class TestCompressionChainProjection:
     """Tests for lineage-aware list_sessions_rich — compressed conversations


### PR DESCRIPTION
Fixes #14854

## Problem

Two bugs when using `/branch`:

1. **JSON session log not created for the branch** — `_handle_branch_command` updates `self.agent.session_id` to the new session ID but never updates `self.agent.session_log_file`. All messages written after branching still go to the *original* session's `session_<id>.json`, and the branch session never gets its own JSON log on disk.

2. **Branch session invisible in `sessions list` / `sessions browse`** — `list_sessions_rich` filters out every session with `parent_session_id IS NOT NULL` to hide sub-agent runs and compression continuations. Branch sessions set `parent_session_id` too, so they are silently excluded from `hermes sessions list` and `hermes sessions browse`, making it easy to lose the branch.

## Solution

**Fix 1 (`cli.py`):** Mirror the compression-split path in `run_agent.py` (line 7579) — immediately after updating `agent.session_id`, also update `agent.session_log_file` to `logs_dir / f"session_{new_session_id}.json"`.

**Fix 2 (`hermes_state.py`):** Expand the `list_sessions_rich` filter to also include branch sessions — those whose parent ended with `end_reason='branched'` *and* whose `started_at >= parent.ended_at` (the same timing condition `get_compression_tip` uses to distinguish compression continuations from live-spawned sub-agents). Sub-agent runs (spawned while the parent is still live) and compression continuations (parent `end_reason='compression'`) remain hidden.

## Testing

Added two new test cases:
- `tests/cli/test_branch_command.py::test_branch_updates_agent_session_log_file` — verifies `agent.session_log_file` is redirected to the new branch path
- `tests/test_hermes_state.py::TestListSessionsRich::test_branch_session_visible_in_list` — verifies branch sessions appear in the list
- `tests/test_hermes_state.py::TestListSessionsRich::test_subagent_session_still_hidden` — verifies sub-agent children are still excluded
- `tests/test_hermes_state.py::TestListSessionsRich::test_compression_child_still_hidden` — verifies compression continuations are still excluded

All three scenarios verified manually:
```
branch visible: True       # was False before fix
subagent hidden: True      # unchanged
compression continuation hidden: True  # unchanged
```