### PR TITLE
fix: send voice replies as Opus/OGG on Matrix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6301,11 +6301,14 @@ class GatewayRunner:
             if not tts_text:
                 return
 
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
+            # Use .ogg for platforms that require Opus voice bubbles
+            # (Telegram, Matrix); fall back to .mp3 for others.
             # The TTS tool may convert to .ogg — use file_path from result.
+            _platform = event.source.platform or ""
+            _ext = ".ogg" if _platform.lower() in ("telegram", "matrix") else ".mp3"
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}{_ext}",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -952,12 +952,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram and Matrix voice bubbles require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed).  Edge TTS
+    # always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in ("telegram", "matrix")
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## Summary

Matrix requires Opus codec in an OGG container for proper voice bubbles per [MSC3245](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3245-voice-messages.md). When sent as MP3, Matrix treats voice replies as generic file attachments — on mobile clients they appear as broken or unplayable.

Two code paths were affected:

### 1. `tools/tts_tool.py` — model-invoked `text_to_speech` tool

The `want_opus` predicate at line 960 only matched `"telegram"`, so when the model calls the TTS tool directly on a Matrix session the output was always MP3 regardless of provider capabilities.

**Fix:** Extended the check to `platform in ("telegram", "matrix")`.

### 2. `gateway/run.py` — auto voice-reply in `_send_voice_reply()`

The output path was hardcoded to `.mp3` regardless of the target platform. For providers that support native Opus output (OpenAI, ElevenLabs, Mistral, Gemini), passing `.ogg` as the extension allows the tool to request `response_format=opus` directly — no ffmpeg conversion needed.

**Fix:** Platform-aware extension selection (`.ogg` for Telegram/Matrix, `.mp3` otherwise).

## Testing

- `py_compile` passes for both modified files
- All 7 tests in `tests/gateway/test_matrix_voice.py` pass
- All TTS-related tests pass (43 passed, 3 pre-existing failures unrelated to this change)
- Broader gateway + tools test suite: 312 passed (3 pre-existing failures)

Closes #14841