### PR TITLE
fix(context-compressor): accept Anthropic-style usage keys as fallback

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -391,9 +391,16 @@ class ContextCompressor(ContextEngine):
         self._summary_failure_cooldown_until: float = 0.0
 
     def update_from_response(self, usage: Dict[str, Any]):
-        """Update tracked token usage from API response."""
-        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
-        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        """Update tracked token usage from API response.
+
+        Accepts both OpenAI-style keys (prompt_tokens/completion_tokens) and
+        Anthropic-style keys (input_tokens/output_tokens) so that plugin authors
+        and OpenAI-compat local servers (e.g. mlx_vlm, NVIDIA NIM) that emit
+        Anthropic-shaped usage dicts don't silently produce zero token counts.
+        OpenAI-style keys take priority when both are present.
+        """
+        self.last_prompt_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens") or usage.get("output_tokens", 0)
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -53,6 +53,26 @@ class TestUpdateFromResponse:
         compressor.update_from_response({})
         assert compressor.last_prompt_tokens == 0
 
+    def test_anthropic_style_keys(self, compressor):
+        # OpenAI-compat servers (mlx_vlm, NVIDIA NIM) may return Anthropic-shaped usage
+        compressor.update_from_response({
+            "input_tokens": 4000,
+            "output_tokens": 800,
+        })
+        assert compressor.last_prompt_tokens == 4000
+        assert compressor.last_completion_tokens == 800
+
+    def test_openai_keys_take_priority(self, compressor):
+        # When both key styles are present, OpenAI-style wins
+        compressor.update_from_response({
+            "prompt_tokens": 5000,
+            "completion_tokens": 1000,
+            "input_tokens": 4000,
+            "output_tokens": 800,
+        })
+        assert compressor.last_prompt_tokens == 5000
+        assert compressor.last_completion_tokens == 1000
+
 
 
 class TestCompress:


### PR DESCRIPTION
update_from_response() previously only recognised OpenAI-style field names (prompt_tokens/completion_tokens).  OpenAI-compatible local servers such as mlx_vlm and NVIDIA NIM can return Anthropic-shaped usage dicts (input_tokens/output_tokens), causing last_prompt_tokens and last_completion_tokens to silently stay at zero.  This broke the context progress bar and disabled auto-compression for those providers.

OpenAI-style keys still take priority when both are present.

Closes #14687
Related: #14686

## What does this PR do?

  ContextCompressor.update_from_response() now falls back to Anthropic-style usage
   keys (input_tokens/output_tokens) when OpenAI-style keys
  (prompt_tokens/completion_tokens) are absent. This is the correct fix because   
  OpenAI-compatible servers like NVIDIA NIM and mlx_vlm can return
  Anthropic-shaped usage objects, causing token counts to silently read as zero —
  which breaks the context progress bar and prevents auto-compression from ever
  triggering.



## Related Issue

Fixes #14687                                                                    
Related: #14686, companion to #14698 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- agent/context_compressor.py — update_from_response(): fall back to            
  input_tokens/output_tokens when OpenAI-style keys are absent; OpenAI-style takes
   priority when both present                                                     
- tests/agent/test_context_compressor.py — two regression tests added to
  TestUpdateFromResponse 

## How to Test

  1. Configure Hermes with an OpenAI-compatible local server that returns         
  Anthropic-style usage fields (e.g. mlx_vlm or NVIDIA NIM via
  integrate.api.nvidia.com)                                                       
  2. Run a multi-turn session and observe the context progress bar — it should now
   reflect actual token usage instead of staying at 0%                            
  3. Run uv run --extra dev pytest tests/agent/test_context_compressor.py -v — all
   52 tests pass including the two new regression tests

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 Apple Silicon

### Documentation & Housekeeping

- I've updated relevant documentation (README, docs/, docstrings) — updated     
  docstring on update_from_response()
- I've updated cli-config.yaml.example if I added/changed config keys — N/A     
- I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or        
  workflows — N/A
- I've considered cross-platform impact (Windows, macOS) per the                
  https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-pla
  tform-compatibility — N/A, pure Python dict key lookup
- I've updated tool descriptions/schemas if I changed tool behavior — N/A 

## Screenshots / Logs

- tests/agent/test_context_compressor.py::TestUpdateFromResponse::test_updates_fields PASSED
- tests/agent/test_context_compressor.py::TestUpdateFromResponse::test_missing_fields_default_zero PASSED                                                         
- tests/agent/test_context_compressor.py::TestUpdateFromResponse::test_anthropic_style_keys PASSED                                                                
- tests/agent/test_context_compressor.py::TestUpdateFromResponse::test_openai_keys_take_priority PASSED  

