### PR TITLE
fix(tui): harden terminal dimming and multiplexer copy

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/Text.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/components/Text.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldUseAnsiDim } from './Text.js'
+
+describe('shouldUseAnsiDim', () => {
+  it('disables ANSI dim on VTE terminals by default', () => {
+    expect(shouldUseAnsiDim({ VTE_VERSION: '7603' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+
+  it('keeps ANSI dim enabled elsewhere by default', () => {
+    expect(shouldUseAnsiDim({ TERM: 'xterm-256color' } as NodeJS.ProcessEnv)).toBe(true)
+  })
+
+  it('honors explicit env override', () => {
+    expect(shouldUseAnsiDim({ HERMES_TUI_DIM: '1', VTE_VERSION: '7603' } as NodeJS.ProcessEnv)).toBe(true)
+    expect(shouldUseAnsiDim({ HERMES_TUI_DIM: '0' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/components/Text.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/Text.tsx
@@ -3,6 +3,9 @@ import React from 'react'
 import { c as _c } from 'react/compiler-runtime'
 
 import type { Color, Styles } from '../styles.js'
+
+const ENV_ON_RE = /^(?:1|true|yes|on)$/i
+const ENV_OFF_RE = /^(?:0|false|no|off)$/i
 type BaseProps = {
   /**
    * Change text color. Accepts a raw color value (rgb, hex, ansi).
@@ -61,6 +64,20 @@ type WeightProps =
       bold?: never
     }
 export type Props = BaseProps & WeightProps
+
+export function shouldUseAnsiDim(env: NodeJS.ProcessEnv = process.env): boolean {
+  const override = (env.HERMES_TUI_DIM ?? '').trim()
+
+  if (ENV_ON_RE.test(override)) {
+    return true
+  }
+
+  if (ENV_OFF_RE.test(override)) {
+    return false
+  }
+
+  return !env.VTE_VERSION
+}
 
 const memoizedStylesForWrap: Record<NonNullable<Styles['textWrap']>, Styles> = {
   wrap: {
@@ -143,6 +160,7 @@ export default function Text(t0: Props) {
   const strikethrough = t3 === undefined ? false : t3
   const inverse = t4 === undefined ? false : t4
   const wrap = t5 === undefined ? 'wrap' : t5
+  const effectiveDim = dim && shouldUseAnsiDim()
 
   if (children === undefined || children === null) {
     return null
@@ -174,11 +192,11 @@ export default function Text(t0: Props) {
 
   let t8
 
-  if ($[4] !== dim) {
-    t8 = dim && {
-      dim
+  if ($[4] !== effectiveDim) {
+    t8 = effectiveDim && {
+      dim: effectiveDim
     }
-    $[4] = dim
+    $[4] = effectiveDim
     $[5] = t8
   } else {
     t8 = $[5]

--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldEmitClipboardSequence } from './osc.js'
+
+describe('shouldEmitClipboardSequence', () => {
+  it('suppresses local multiplexer clipboard OSC by default', () => {
+    expect(shouldEmitClipboardSequence({ TMUX: '/tmp/tmux-1/default,1,0' } as NodeJS.ProcessEnv)).toBe(false)
+    expect(shouldEmitClipboardSequence({ STY: '1234.pts-0.host' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+
+  it('keeps OSC enabled for remote or plain local terminals', () => {
+    expect(shouldEmitClipboardSequence({ SSH_CONNECTION: '1', TMUX: '/tmp/tmux-1/default,1,0' } as NodeJS.ProcessEnv)).toBe(
+      true
+    )
+    expect(shouldEmitClipboardSequence({ TERM: 'xterm-256color' } as NodeJS.ProcessEnv)).toBe(true)
+  })
+
+  it('honors explicit env override', () => {
+    expect(shouldEmitClipboardSequence({ HERMES_TUI_CLIPBOARD_OSC52: '1', TMUX: '/tmp/tmux-1/default,1,0' } as NodeJS.ProcessEnv)).toBe(
+      true
+    )
+    expect(shouldEmitClipboardSequence({ HERMES_TUI_COPY_OSC52: '0', TERM: 'xterm-256color' } as NodeJS.ProcessEnv)).toBe(
+      false
+    )
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
@@ -11,6 +11,8 @@ import { BEL, ESC, ESC_TYPE, SEP } from './ansi.js'
 import type { Action, Color, TabStatusAction } from './types.js'
 
 export const OSC_PREFIX = ESC + String.fromCharCode(ESC_TYPE.OSC)
+const ENV_ON_RE = /^(?:1|true|yes|on)$/i
+const ENV_OFF_RE = /^(?:0|false|no|off)$/i
 
 /** String Terminator (ESC \) - alternative to BEL for terminating OSC */
 export const ST = ESC + '\\'
@@ -79,6 +81,20 @@ export function getClipboardPath(): ClipboardPath {
   }
 
   return 'osc52'
+}
+
+export function shouldEmitClipboardSequence(env: NodeJS.ProcessEnv = process.env): boolean {
+  const override = (env.HERMES_TUI_CLIPBOARD_OSC52 ?? env.HERMES_TUI_COPY_OSC52 ?? '').trim()
+
+  if (ENV_ON_RE.test(override)) {
+    return true
+  }
+
+  if (ENV_OFF_RE.test(override)) {
+    return false
+  }
+
+  return !!env['SSH_CONNECTION'] || (!env['TMUX'] && !env['STY'])
 }
 
 /**
@@ -152,6 +168,7 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
 export async function setClipboard(text: string): Promise<string> {
   const b64 = Buffer.from(text, 'utf8').toString('base64')
   const raw = osc(OSC.CLIPBOARD, 'c', b64)
+  const emitSequence = shouldEmitClipboardSequence(process.env)
 
   // Native safety net — fire FIRST, before the tmux await, so a quick
   // focus-switch after selecting doesn't race pbcopy. Previously this ran
@@ -170,10 +187,10 @@ export async function setClipboard(text: string): Promise<string> {
   // Inner OSC uses BEL directly (not osc()) — ST's ESC would need doubling
   // too, and BEL works everywhere for OSC 52.
   if (tmuxBufferLoaded) {
-    return tmuxPassthrough(`${ESC}]52;c;${b64}${BEL}`)
+    return emitSequence ? tmuxPassthrough(`${ESC}]52;c;${b64}${BEL}`) : ''
   }
 
-  return raw
+  return emitSequence ? raw : ''
 }
 
 // Linux clipboard tool: undefined = not yet probed, null = none available.


### PR DESCRIPTION
## Summary
- disable ANSI dim by default on VTE terminals so reasoning text and accent colors stay readable on dark backgrounds, with an env override for terminals that want the old behavior
- stop emitting local multiplexer OSC52 copy sequences by default so copy actions do not boomerang back into the TUI as repeated paste events, while keeping remote passthrough and opt-in override support
- add regression coverage for both compatibility decisions in the shared hermes-ink layer

## Test plan
- [x] `cd ui-tui && ./node_modules/.bin/vitest run`
- [ ] `cd ui-tui && ./node_modules/.bin/tsc --noEmit -p tsconfig.json` *(currently fails on pre-existing `packages/hermes-ink/src/ink/dom.ts` error unrelated to this PR)*
- [ ] Manual check in a VTE terminal dark theme and a local tmux/cmux session