### PR TITLE
Preserve custom headers for runtime and auxiliary requests

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1608,7 +1608,7 @@ class HermesACPAgent(acp.Agent):
         )
         if final_response and not suppress_interrupt_response:
             try:
-                from agent.title_generator import maybe_auto_title
+                from agent.title_generator import maybe_auto_title, snapshot_main_runtime
 
                 def _notify_title_update(_title: str) -> None:
                     if conn:
@@ -1628,13 +1628,7 @@ class HermesACPAgent(acp.Agent):
                     user_text,
                     final_response,
                     state.history,
-                    main_runtime={
-                        "model": getattr(state.agent, "model", None),
-                        "provider": getattr(state.agent, "provider", None),
-                        "base_url": getattr(state.agent, "base_url", None),
-                        "api_key": getattr(state.agent, "api_key", None),
-                        "api_mode": getattr(state.agent, "api_mode", None),
-                    },
+                    main_runtime=snapshot_main_runtime(state.agent),
                     runtime_validator=lambda: (
                         getattr(state.agent, "model", None) == _title_model
                         and getattr(state.agent, "provider", None) == _title_provider

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2382,6 +2382,7 @@ def set_runtime_main(
     api_key: Any = "",
     api_mode: str = "",
     auth_mode: str = "",
+    default_headers: Optional[Dict[str, Any]] = None,
 ) -> contextvars.Token:
     """Record the current context's live main runtime for auxiliary routing.
 
@@ -2403,6 +2404,12 @@ def set_runtime_main(
         "api_mode": (api_mode or "").strip(),
         "auth_mode": (auth_mode or "").strip().lower(),
     }
+    if isinstance(default_headers, dict):
+        from hermes_cli.config import normalize_extra_headers
+
+        normalized_headers = normalize_extra_headers(default_headers)
+        if normalized_headers:
+            runtime["default_headers"] = normalized_headers
     # Publish authoritative context before updating locked compatibility
     # mirrors; concurrent sessions never read those mirrors at runtime.
     token = _RUNTIME_MAIN_CONTEXT.set(runtime)
@@ -2898,7 +2905,43 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     provider = normalized.get("provider")
     if isinstance(provider, str):
         normalized["provider"] = provider.lower()
+    raw_headers = main_runtime.get("default_headers")
+    if isinstance(raw_headers, dict):
+        from hermes_cli.config import normalize_extra_headers
+
+        default_headers = normalize_extra_headers(raw_headers)
+        if default_headers:
+            normalized["default_headers"] = default_headers
     return normalized
+
+
+def _runtime_default_headers_for_provider(
+    provider: str,
+    runtime: Dict[str, Any],
+    *,
+    base_url: Optional[str] = None,
+) -> Dict[str, str]:
+    """Return runtime headers only for the provider/endpoint that produced them."""
+    headers = dict(runtime.get("default_headers") or {})
+    if not headers:
+        return {}
+    normalized_provider = _normalize_aux_provider(provider)
+    if normalized_provider == "auto":
+        return headers
+    raw_runtime_provider = str(runtime.get("provider") or "").strip().lower()
+    runtime_provider = _normalize_aux_provider(raw_runtime_provider)
+    same_provider = normalized_provider == runtime_provider
+    collapsed_custom = (
+        normalized_provider == "custom"
+        and raw_runtime_provider.startswith("custom:")
+    )
+    if not (same_provider or collapsed_custom):
+        return {}
+    runtime_base_url = str(runtime.get("base_url") or "").strip().rstrip("/")
+    requested_base_url = str(base_url or "").strip().rstrip("/")
+    if runtime_base_url and requested_base_url and runtime_base_url != requested_base_url:
+        return {}
+    return headers
 
 
 def _get_provider_chain() -> List[tuple]:
@@ -4522,6 +4565,7 @@ def _resolve_auto(
                 explicit_base_url=explicit_base_url,
                 explicit_api_key=explicit_api_key,
                 api_mode=runtime_api_mode or None,
+                main_runtime=runtime,
             )
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
@@ -4714,6 +4758,11 @@ def resolve_provider_client(
     original_provider = (provider or "").strip().lower()
     # Normalise aliases
     provider = _normalize_aux_provider(provider)
+    runtime = (
+        _normalize_main_runtime(main_runtime)
+        if isinstance(main_runtime, dict)
+        else {}
+    )
 
     # Universal model-resolution fallback for concrete providers. ``auto`` is
     # intentionally excluded: `_resolve_auto(main_runtime=...)` returns the
@@ -4935,6 +4984,9 @@ def resolve_provider_client(
                 custom_base = _main_base
                 custom_key = _main_key
         if custom_base and custom_key:
+            runtime_default_headers = _runtime_default_headers_for_provider(
+                provider, runtime, base_url=custom_base
+            )
             final_model = _normalize_resolved_model(
                 model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
                 provider,
@@ -4963,6 +5015,9 @@ def resolve_provider_client(
                 except Exception:
                     pass
             _merged_custom = _apply_user_default_headers(extra.get("default_headers"))
+            if runtime_default_headers:
+                _merged_custom = dict(_merged_custom or {})
+                _merged_custom.update(runtime_default_headers)
             if _merged_custom:
                 extra["default_headers"] = _merged_custom
             client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **extra)
@@ -5005,6 +5060,9 @@ def resolve_provider_client(
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
             custom_base = (custom_entry.get("base_url") or "").strip()
+            runtime_default_headers = _runtime_default_headers_for_provider(
+                provider, runtime, base_url=custom_base
+            )
             custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
@@ -5041,7 +5099,10 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
-                _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
+                _headers2 = _apply_user_default_headers(None)
+                if runtime_default_headers:
+                    _headers2 = dict(_headers2 or {})
+                    _headers2.update(runtime_default_headers)
                 if _headers2:
                     _extra2["default_headers"] = _headers2
                 logger.debug(
@@ -5066,7 +5127,10 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
-                        _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
+                        _fb_headers = _apply_user_default_headers(None)
+                        if runtime_default_headers:
+                            _fb_headers = dict(_fb_headers or {})
+                            _fb_headers.update(runtime_default_headers)
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
                         client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
@@ -5868,6 +5932,12 @@ def _runtime_cache_discriminator(field: str, value: Any) -> Any:
     if field == "api_key" and isinstance(value, str) and value:
         digest = hashlib.blake2b(value.encode("utf-8"), digest_size=16).digest()
         return ("api-key-digest", digest)
+    if field == "default_headers" and isinstance(value, dict) and value:
+        encoded = json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode("utf-8")
+        digest = hashlib.blake2b(encoded, digest_size=16).digest()
+        return ("default-headers-digest", digest)
     return value
 
 
@@ -5888,6 +5958,16 @@ def _client_cache_key(
         _runtime_cache_discriminator(field, runtime.get(field, ""))
         for field in _MAIN_RUNTIME_FIELDS
     ) if provider == "auto" else ()
+    runtime_headers = _runtime_default_headers_for_provider(
+        provider, runtime, base_url=base_url
+    )
+    runtime_headers_key = _runtime_cache_discriminator(
+        "default_headers", runtime_headers
+    )
+    if provider == "auto" and runtime_headers_key:
+        runtime_key = (runtime_key, runtime_headers_key)
+    elif runtime_headers_key:
+        runtime_key = (runtime_headers_key,)
     # `auto` can now resolve through task-specific or main fallback policy,
     # so the task participates in the cache key. Non-auto providers keep the
     # old cache shape because the explicit provider/model tuple is sufficient.

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -6,7 +6,7 @@ adds latency to the user-facing reply.
 
 import logging
 import threading
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from agent.auxiliary_client import call_llm
 
@@ -38,6 +38,25 @@ _TITLE_PROMPT_PINNED_LANGUAGE = (
     "Write the title in {language}. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
+
+
+def snapshot_main_runtime(agent: Any) -> Optional[dict]:
+    """Capture the live main runtime used by background title generation."""
+    if agent is None:
+        return None
+    runtime = {
+        "model": getattr(agent, "model", None),
+        "provider": getattr(agent, "provider", None),
+        "base_url": getattr(agent, "base_url", None),
+        "api_key": getattr(agent, "api_key", None),
+        "api_mode": getattr(agent, "api_mode", None),
+    }
+    default_headers = dict(
+        getattr(agent, "_client_kwargs", {}).get("default_headers") or {}
+    )
+    if default_headers:
+        runtime["default_headers"] = default_headers
+    return runtime
 
 
 def _title_language() -> str:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -164,13 +164,21 @@ def build_turn_context(
     # after primary restoration has settled the runtime.
     try:
         from agent.auxiliary_client import set_runtime_main
+        runtime_kwargs = {
+            "base_url": getattr(agent, "base_url", "") or "",
+            "api_key": getattr(agent, "api_key", "") or "",
+            "api_mode": getattr(agent, "api_mode", "") or "",
+            "auth_mode": getattr(agent, "auth_mode", "") or "",
+        }
+        runtime_headers = dict(
+            getattr(agent, "_client_kwargs", {}).get("default_headers") or {}
+        )
+        if runtime_headers:
+            runtime_kwargs["default_headers"] = runtime_headers
         set_runtime_main(
             getattr(agent, "provider", "") or "",
             getattr(agent, "model", "") or "",
-            base_url=getattr(agent, "base_url", "") or "",
-            api_key=getattr(agent, "api_key", "") or "",
-            api_mode=getattr(agent, "api_mode", "") or "",
-            auth_mode=getattr(agent, "auth_mode", "") or "",
+            **runtime_kwargs,
         )
     except Exception:
         pass

--- a/cli.py
+++ b/cli.py
@@ -12734,7 +12734,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Auto-generate session title after first exchange (non-blocking)
             if response and result and not result.get("failed") and not result.get("partial"):
                 try:
-                    from agent.title_generator import maybe_auto_title
+                    from agent.title_generator import maybe_auto_title, snapshot_main_runtime
                     # Route title-generation failures through the agent's
                     # user-visible warning channel so a depleted auxiliary
                     # provider doesn't silently leave sessions untitled
@@ -12755,13 +12755,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         response,
                         self.conversation_history,
                         failure_callback=_title_failure_cb,
-                        main_runtime={
-                            "model": self.model,
-                            "provider": self.provider,
-                            "base_url": self.base_url,
-                            "api_key": self.api_key,
-                            "api_mode": self.api_mode,
-                        },
+                        main_runtime=snapshot_main_runtime(self.agent),
                         runtime_validator=lambda: (
                             getattr(self, "model", None) == _title_model
                             and getattr(self, "provider", None) == _title_provider

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19929,7 +19929,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:
                 try:
-                    from agent.title_generator import maybe_auto_title
+                    from agent.title_generator import maybe_auto_title, snapshot_main_runtime
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
                     # In Gateway mode, auto-title failures must NOT be
                     # surfaced as user-visible messages (fixes #23246).
@@ -19949,13 +19949,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _title_provider = getattr(agent, "provider", None) if agent else None
                     maybe_auto_title_kwargs = {
                         "failure_callback": _title_failure_cb,
-                        "main_runtime": {
-                            "model": getattr(agent, "model", None),
-                            "provider": getattr(agent, "provider", None),
-                            "base_url": getattr(agent, "base_url", None),
-                            "api_key": getattr(agent, "api_key", None),
-                            "api_mode": getattr(agent, "api_mode", None),
-                        } if agent else None,
+                        "main_runtime": snapshot_main_runtime(agent),
                         "runtime_validator": (lambda: (
                             getattr(agent, "model", None) == _title_model
                             and getattr(agent, "provider", None) == _title_provider

--- a/run_agent.py
+++ b/run_agent.py
@@ -1191,9 +1191,9 @@ class AIAgent:
             detail = detail[:217].rstrip() + "..."
         self._emit_warning(f"⚠ Auxiliary {task} failed: {detail}")
 
-    def _current_main_runtime(self) -> Dict[str, str]:
+    def _current_main_runtime(self) -> Dict[str, Any]:
         """Return the live main runtime for session-scoped auxiliary routing."""
-        return {
+        runtime: Dict[str, Any] = {
             "model": getattr(self, "model", "") or "",
             "provider": getattr(self, "provider", "") or "",
             "base_url": getattr(self, "base_url", "") or "",
@@ -1201,6 +1201,12 @@ class AIAgent:
             "api_mode": getattr(self, "api_mode", "") or "",
             "auth_mode": getattr(self, "auth_mode", "") or "",
         }
+        default_headers = dict(
+            getattr(self, "_client_kwargs", {}).get("default_headers") or {}
+        )
+        if default_headers:
+            runtime["default_headers"] = default_headers
+        return runtime
 
     def _check_compression_model_feasibility(self) -> None:
         """Forwarder — see ``agent.conversation_compression.check_compression_model_feasibility``."""

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -13,6 +13,7 @@ runs when the main provider has no working client.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -278,6 +279,70 @@ class TestResolveAutoMainFirst:
         # Runtime override wins
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
+
+    def test_title_generation_inherits_effective_main_headers(self, monkeypatch):
+        """Auto title generation must reuse the main client's scoped headers."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Short title"))]
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = response
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.OpenAI", return_value=mock_client
+        ) as mock_openai:
+            from agent.auxiliary_client import call_llm, shutdown_cached_clients
+
+            shutdown_cached_clients()
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "Generate a title"}],
+                main_runtime={
+                    "provider": "custom",
+                    "model": "title-model",
+                    "base_url": "https://proxy.example.com/v1",
+                    "api_key": "proxy-key",
+                    "api_mode": "chat_completions",
+                    "default_headers": {
+                        "CF-Access-Client-Id": "client-id",
+                        "CF-Access-Client-Secret": "client-secret",
+                    },
+                },
+            )
+
+        assert result is response
+        assert mock_openai.call_args.kwargs["default_headers"] == {
+            "CF-Access-Client-Id": "client-id",
+            "CF-Access-Client-Secret": "client-secret",
+        }
+
+    def test_explicit_custom_aux_endpoint_does_not_borrow_main_headers(self):
+        """Provider-scoped headers must not leak to a different custom endpoint."""
+        with patch("agent.auxiliary_client.OpenAI", return_value=MagicMock()) as mock_openai:
+            from agent.auxiliary_client import resolve_provider_client
+
+            resolve_provider_client(
+                "custom",
+                model="aux-model",
+                explicit_base_url="https://other.example.com/v1",
+                explicit_api_key="other-key",
+                main_runtime={
+                    "provider": "custom:main-proxy",
+                    "model": "main-model",
+                    "base_url": "https://main.example.com/v1",
+                    "api_key": "main-key",
+                    "default_headers": {"CF-Access-Client-Secret": "main-secret"},
+                },
+            )
+
+        headers = mock_openai.call_args.kwargs.get("default_headers") or {}
+        assert "CF-Access-Client-Secret" not in headers
 
     def test_resolve_provider_auto_returns_runtime_model_not_stale_config_default(self):
         """Blank auto aux requests must not pair a stale config model with live fallback provider."""

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -136,6 +136,44 @@ class TestResolveProviderClientNamedCustom:
         assert model == "my-model"
         assert "beans.local" in str(client.base_url)
 
+    def test_named_custom_provider_reuses_effective_runtime_headers(self, tmp_path):
+        """The main client's provider-scoped headers keep their final precedence."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "test-model",
+                "default_headers": {"X-Scope": "global"},
+            },
+            "custom_providers": [
+                {
+                    "name": "beans",
+                    "base_url": "http://beans.local/v1",
+                    "api_key": "k",
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI", return_value=MagicMock()) as mock_openai:
+            from agent.auxiliary_client import resolve_provider_client
+
+            resolve_provider_client(
+                "beans",
+                "my-model",
+                main_runtime={
+                    "provider": "custom:beans",
+                    "model": "my-model",
+                    "base_url": "http://beans.local/v1",
+                    "api_key": "k",
+                    "default_headers": {
+                        "X-Scope": "provider",
+                        "CF-Access-Client-Secret": "scoped-secret",
+                    },
+                },
+            )
+
+        assert mock_openai.call_args.kwargs["default_headers"] == {
+            "X-Scope": "provider",
+            "CF-Access-Client-Secret": "scoped-secret",
+        }
+
     def test_named_custom_provider_default_model(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "main-model"},

--- a/tests/agent/test_auxiliary_runtime_cache_key.py
+++ b/tests/agent/test_auxiliary_runtime_cache_key.py
@@ -83,6 +83,47 @@ def test_implicit_runtime_cache_key_covers_full_connection_and_auth_surface():
     assert len(set(keys)) == len(keys)
 
 
+def test_runtime_headers_are_normalized_and_bound_to_implicit_context():
+    """Implicit auxiliary calls inherit a sanitized effective-header snapshot."""
+    runtime = _runtime("same-model")
+    aux.set_runtime_main(
+        **runtime,
+        default_headers={"X-Relay": 7, "X-Drop": None},
+    )
+
+    assert aux._normalize_main_runtime(None)["default_headers"] == {
+        "X-Relay": "7"
+    }
+
+
+@pytest.mark.parametrize("provider", ["auto", "custom"])
+def test_runtime_headers_isolate_client_cache_without_exposing_secrets(provider):
+    """Header changes rebuild clients without retaining credentials in key reprs."""
+    first_secret = "first-header-secret"
+    second_secret = "second-header-secret"
+    first = aux._client_cache_key(
+        provider,
+        async_mode=False,
+        main_runtime={
+            **_runtime("same-model"),
+            "default_headers": {"CF-Access-Client-Secret": first_secret},
+        },
+    )
+    second = aux._client_cache_key(
+        provider,
+        async_mode=False,
+        main_runtime={
+            **_runtime("same-model"),
+            "default_headers": {"CF-Access-Client-Secret": second_secret},
+        },
+    )
+
+    assert first != second
+    rendered = repr((first, second))
+    assert first_secret not in rendered
+    assert second_secret not in rendered
+
+
 def test_implicit_runtime_is_isolated_between_concurrent_session_contexts():
     """Concurrent gateway sessions must not read each other's live runtime."""
     barrier = Barrier(2)

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -293,6 +293,23 @@ def test_runtime_main_sync_happens_after_restore():
     )]
 
 
+def test_runtime_main_sync_includes_effective_default_headers():
+    agent = _FakeAgent()
+    agent._client_kwargs = {
+        "default_headers": {"CF-Access-Client-Secret": "scoped-secret"}
+    }
+    calls = []
+    with patch(
+        "agent.auxiliary_client.set_runtime_main",
+        side_effect=lambda *args, **kwargs: calls.append((args, kwargs)),
+    ):
+        _build(agent)
+
+    assert calls[0][1]["default_headers"] == {
+        "CF-Access-Client-Secret": "scoped-secret"
+    }
+
+
 def test_memory_nudge_fires_at_interval():
     agent = _FakeAgent()
     agent._memory_nudge_interval = 1
@@ -436,6 +453,7 @@ def test_preflight_still_runs_for_other_session_with_same_db(tmp_path):
     agent._compress_context.assert_called()
 
 
+
 def test_expired_cooldown_allows_preflight(tmp_path):
     agent = _make_agent_with_cooldown(
         tmp_path / "state.db",
@@ -450,4 +468,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/run_agent/test_custom_provider_extra_headers_client.py
+++ b/tests/run_agent/test_custom_provider_extra_headers_client.py
@@ -43,6 +43,7 @@ def test_custom_provider_extra_headers_applied_at_construction(mock_openai):
     headers = agent._client_kwargs["default_headers"]
     assert headers["CF-Access-Client-Id"] == "xxxx.access"
     assert headers["X-Client-Name"] == "hermes-agent"
+    assert agent._current_main_runtime()["default_headers"] == headers
 
 
 @patch("run_agent.OpenAI")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7490,6 +7490,9 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
         base_url = "https://chatgpt.example.test/backend-api/codex"
         api_key = object()
         api_mode = "codex_responses"
+        _client_kwargs = {
+            "default_headers": {"CF-Access-Client-Secret": "scoped-secret"}
+        }
 
         def run_conversation(
             self, prompt, conversation_history=None, stream_callback=None
@@ -7529,6 +7532,7 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
         "base_url": "https://chatgpt.example.test/backend-api/codex",
         "api_key": _Agent.api_key,
         "api_mode": "codex_responses",
+        "default_headers": {"CF-Access-Client-Secret": "scoped-secret"},
     }
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9698,7 +9698,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 and text.strip()
             ):
                 try:
-                    from agent.title_generator import maybe_auto_title
+                    from agent.title_generator import maybe_auto_title, snapshot_main_runtime
 
                     _title_key = session.get("session_key") or sid
                     # Snapshot the runtime identity; the validator lets the
@@ -9716,13 +9716,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         # Desktop/Webapp session. Without this, providers that
                         # rely on runtime auth (for example OpenAI Codex OAuth)
                         # are skipped and the new session remains untitled.
-                        main_runtime={
-                            "model": getattr(agent, "model", None),
-                            "provider": getattr(agent, "provider", None),
-                            "base_url": getattr(agent, "base_url", None),
-                            "api_key": getattr(agent, "api_key", None),
-                            "api_mode": getattr(agent, "api_mode", None),
-                        },
+                        main_runtime=snapshot_main_runtime(agent),
                         runtime_validator=lambda: (
                             getattr(agent, "model", None) == _title_model
                             and getattr(agent, "provider", None) == _title_provider


### PR DESCRIPTION
## Summary
- plumb custom `model.headers` and `custom_providers[].headers` through shared runtime resolution
- preserve those headers across CLI, gateway, TUI, ACP, cron, oneshot, delegation, background review, and Feishu comment entrypoints
- keep user `default_headers` merged with provider-specific headers when constructing OpenAI-compatible clients
- forward main-runtime headers into auxiliary/title-generation clients and include them in auxiliary client cache keys
- document custom provider request headers in provider/runtime docs

## Tests
- `./venv/bin/python -m pytest tests/run_agent/test_custom_default_headers.py tests/agent/test_auxiliary_client.py::TestExpiredCodexFallback::test_custom_endpoint_propagates_runtime_headers tests/agent/test_auxiliary_client.py::TestExpiredCodexFallback::test_title_generation_auto_runtime_headers_reach_codex_client tests/agent/test_auxiliary_main_first.py tests/gateway/test_fast_command.py tests/gateway/test_feishu_comment.py tests/test_empty_model_fallback.py tests/tools/test_delegate.py tests/acp/test_server.py::TestPrompt::test_prompt_auto_titles_session tests/test_tui_gateway_server.py::test_prompt_submit_auto_titles_session_on_complete -q` (204 passed)
- `git diff --check`
- local config smoke check: `resolve_runtime_provider(requested="custom")` resolves `headers` and `AIAgent.__init__` accepts `default_headers`
