### PR TITLE
fix(cli): skip web UI rebuild when dist/ is present and sources are unchanged

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4487,6 +4487,40 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
     return default
 
 
+def _web_ui_build_needed(web_dir: Path) -> bool:
+    """Return True if the web UI dist is missing or stale.
+
+    Mirrors the staleness logic used by ``_tui_build_needed()`` for the TUI.
+    Uses the Vite manifest as the sentinel because it is written last and
+    therefore has the newest mtime of any build output.
+    """
+    sentinel = web_dir / "dist" / ".vite" / "manifest.json"
+    if not sentinel.exists():
+        sentinel = web_dir / "dist" / "index.html"
+    if not sentinel.exists():
+        return True
+    dist_mtime = sentinel.stat().st_mtime
+    skip = frozenset({"node_modules", "dist"})
+    for dirpath, dirnames, filenames in os.walk(web_dir, topdown=True):
+        dirnames[:] = [d for d in dirnames if d not in skip]
+        for fn in filenames:
+            if fn.endswith((".ts", ".tsx", ".js", ".jsx", ".css", ".html", ".vue")):
+                if os.path.getmtime(os.path.join(dirpath, fn)) > dist_mtime:
+                    return True
+    for meta in (
+        "package.json",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "vite.config.ts",
+        "vite.config.js",
+    ):
+        mp = web_dir / meta
+        if mp.exists() and mp.stat().st_mtime > dist_mtime:
+            return True
+    return False
+
+
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
@@ -4498,6 +4532,9 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     Returns True if the build succeeded or was skipped (no package.json).
     """
     if not (web_dir / "package.json").exists():
+        return True
+
+    if not _web_ui_build_needed(web_dir):
         return True
 
     npm = shutil.which("npm")

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -1,0 +1,108 @@
+"""Tests for _web_ui_build_needed — staleness check for the web UI dist."""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.main import _web_ui_build_needed, _build_web_ui
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _touch(path: Path, offset: float = 0.0) -> None:
+    """Create a file and optionally shift its mtime by offset seconds."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    if offset:
+        t = time.time() + offset
+        os.utime(path, (t, t))
+
+
+# ---------------------------------------------------------------------------
+# _web_ui_build_needed
+# ---------------------------------------------------------------------------
+
+class TestWebUIBuildNeeded:
+
+    def test_returns_true_when_dist_missing(self, tmp_path):
+        (tmp_path / "package.json").touch()
+        assert _web_ui_build_needed(tmp_path) is True
+
+    def test_returns_false_when_vite_manifest_exists_and_sources_older(self, tmp_path):
+        # Write source files first, then the manifest (newer)
+        src = tmp_path / "src" / "App.tsx"
+        _touch(src, offset=-10)
+        manifest = tmp_path / "dist" / ".vite" / "manifest.json"
+        _touch(manifest)
+
+        assert _web_ui_build_needed(tmp_path) is False
+
+    def test_returns_true_when_source_newer_than_manifest(self, tmp_path):
+        manifest = tmp_path / "dist" / ".vite" / "manifest.json"
+        _touch(manifest, offset=-10)
+        src = tmp_path / "src" / "App.tsx"
+        _touch(src)  # newer than manifest
+
+        assert _web_ui_build_needed(tmp_path) is True
+
+    def test_falls_back_to_index_html_when_manifest_missing(self, tmp_path):
+        _touch(tmp_path / "src" / "main.ts", offset=-10)
+        _touch(tmp_path / "dist" / "index.html")  # no .vite/manifest.json
+
+        assert _web_ui_build_needed(tmp_path) is False
+
+    def test_returns_true_when_package_lock_newer_than_dist(self, tmp_path):
+        _touch(tmp_path / "dist" / ".vite" / "manifest.json", offset=-10)
+        _touch(tmp_path / "package-lock.json")  # newer → rebuild
+
+        assert _web_ui_build_needed(tmp_path) is True
+
+    def test_returns_true_when_vite_config_newer_than_dist(self, tmp_path):
+        _touch(tmp_path / "dist" / ".vite" / "manifest.json", offset=-10)
+        _touch(tmp_path / "vite.config.ts")  # newer → rebuild
+
+        assert _web_ui_build_needed(tmp_path) is True
+
+    def test_ignores_files_in_node_modules_and_dist(self, tmp_path):
+        manifest = tmp_path / "dist" / ".vite" / "manifest.json"
+        _touch(manifest, offset=-10)
+        # Files inside node_modules and dist should not trigger rebuild
+        _touch(tmp_path / "node_modules" / "react" / "index.js")
+        _touch(tmp_path / "dist" / "assets" / "index.js")
+
+        assert _web_ui_build_needed(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_web_ui — skip when fresh
+# ---------------------------------------------------------------------------
+
+class TestBuildWebUISkipsWhenFresh:
+
+    def test_skips_npm_when_dist_is_fresh(self, tmp_path):
+        (tmp_path / "package.json").touch()
+        _touch(tmp_path / "dist" / ".vite" / "manifest.json")
+
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run") as mock_run:
+            result = _build_web_ui(tmp_path)
+
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_runs_npm_when_dist_is_missing(self, tmp_path):
+        (tmp_path / "package.json").touch()
+        # No dist/ — build needed
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout=b"", stderr=b"")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            result = _build_web_ui(tmp_path)
+
+        assert result is True
+        assert mock_run.call_count == 2  # npm install + npm run build


### PR DESCRIPTION
## What does this PR do?

\`_build_web_ui()\` ran \`npm install\` + \`npm run build\` unconditionally on every \`hermes dashboard\` startup. On low-memory hosts (≤1GB RAM) the Node build process peaked at ~388MB and was OOM-killed by systemd before the server could start. Docker installs hit the same root cause when overlayfs blocked \`npm install\` on a read-only layer.

Parity fix: adds \`_web_ui_build_needed()\` that mirrors the mtime-based staleness check already used by \`_tui_build_needed()\` for the TUI. The Vite manifest (\`dist/.vite/manifest.json\`) is used as the sentinel — it is written last and therefore has the newest mtime of any build artifact. Falls back to \`dist/index.html\` for older builds. Rebuild is triggered when any tracked source file (\`.ts\`, \`.tsx\`, \`.js\`, \`.jsx\`, \`.css\`, \`.html\`, \`.vue\`) or dependency manifest (\`package.json\`, \`package-lock.json\`, \`yarn.lock\`, \`pnpm-lock.yaml\`, \`vite.config.*\`) is newer than the sentinel. When \`dist/\` is absent the existing build path runs unchanged.

## Related Issue

Fixes #14898
Fixes #12243

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- \`hermes_cli/main.py\`: add \`_web_ui_build_needed(web_dir)\` (+33 lines); add early-return guard in \`_build_web_ui()\` (+2 lines)
- \`tests/hermes_cli/test_web_ui_build.py\`: 9 tests covering missing dist, stale sources, fresh dist, sentinel fallback, lockfile changes, vite config changes, node_modules exclusion, npm skip, npm run (+110 lines, new file)

## How to Test

```bash
pytest tests/hermes_cli/test_web_ui_build.py -v
```

All 9 tests pass. To verify end-to-end: run \`hermes dashboard\` once to build, then run again — the second startup should skip the npm build entirely.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_web_ui_build.py -v` and all 9 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated \`cli-config.yaml.example\` — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` — or N/A
- [x] I've considered cross-platform impact — fix uses \`os.walk\` + \`pathlib.Path\`, cross-platform safe
- [x] I've updated tool descriptions/schemas — or N/A