### PR TITLE
fix(gateway): guard /compress against pluggable context engines

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7102,17 +7102,36 @@ class GatewayRunner:
                 tmp_agent._print_fn = lambda *a, **kw: None
 
                 compressor = tmp_agent.context_compressor
-                compress_start = compressor.protect_first_n
-                compress_start = compressor._align_boundary_forward(msgs, compress_start)
-                compress_end = compressor._find_tail_cut_by_tokens(msgs, compress_start)
-                if compress_start >= compress_end:
-                    return "Nothing to compress yet (the transcript is still all protected context)."
+
+                # Guard against pluggable context engines (e.g. LCMEngine)
+                # that don't expose legacy ContextCompressor internals.
+                _has_legacy_api = (
+                    hasattr(compressor, '_align_boundary_forward')
+                    and hasattr(compressor, '_find_tail_cut_by_tokens')
+                )
+
+                if _has_legacy_api:
+                    compress_start = compressor.protect_first_n
+                    compress_start = compressor._align_boundary_forward(msgs, compress_start)
+                    compress_end = compressor._find_tail_cut_by_tokens(msgs, compress_start)
+                    if compress_start >= compress_end:
+                        return "Nothing to compress yet (the transcript is still all protected context)."
 
                 loop = asyncio.get_running_loop()
-                compressed, _ = await loop.run_in_executor(
-                    None,
-                    lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
-                )
+
+                if _has_legacy_api:
+                    compressed, _ = await loop.run_in_executor(
+                        None,
+                        lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
+                    )
+                else:
+                    # Pluggable engine: use the public compress() API
+                    compressed = await loop.run_in_executor(
+                        None,
+                        lambda: compressor.compress(msgs, current_tokens=approx_tokens, focus_topic=focus_topic)
+                    )
+                    if compressed == msgs or len(compressed) >= len(msgs):
+                        return "Nothing to compress yet (the transcript is still all protected context)."
 
                 # _compress_context already calls end_session() on the old session
                 # (preserving its full transcript in SQLite) and creates a new


### PR DESCRIPTION
## Summary

Fixes #14886

The gateway `/compress` command crashes with an `AttributeError` when a pluggable context engine (e.g. `LCMEngine`) is used instead of the legacy `ContextCompressor`, because it directly calls private methods `_align_boundary_forward()` and `_find_tail_cut_by_tokens()` that only exist on the legacy class.

## Root Cause

In `_handle_compress_command()`, lines 7104-7107:
```python
compressor = tmp_agent.context_compressor
compress_start = compressor.protect_first_n
compress_start = compressor._align_boundary_forward(msgs, compress_start)
compress_end = compressor._find_tail_cut_by_tokens(msgs, compress_start)
```

These are private methods specific to `ContextCompressor`. Pluggable engines like `LCMEngine` don't expose them.

## Changes

**gateway/run.py** — `_handle_compress_command()`:
- Added `hasattr` guards to detect whether the compressor has the legacy private API
- When legacy API is available: existing code path runs unchanged (zero behavioral change)
- When legacy API is missing: falls back to the public `compressor.compress()` API that all engines must implement
- Added `len(compressed) >= len(msgs)` check for the fallback path to detect no-op compression

## Testing

- **Legacy compressor**: `hasattr` returns `True` for both methods → existing path runs unchanged → all existing tests pass
- **LCM engine**: `hasattr` returns `False` → public `compress()` API used → no crash
- MagicMock (used in existing tests) auto-creates attributes, so `hasattr` returns `True` → existing test fixtures work

## Checklist

- [x] Follows Conventional Commits format
- [x] Single logical change
- [x] No breaking changes
- [x] Existing tests unaffected (MagicMock preserves hasattr behavior)
