### PR TITLE
fix(packaging): include web_dist assets in sdist and improve missing-frontend error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 graft skills
 graft optional-skills
+graft hermes_cli/web_dist
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2274,7 +2274,9 @@ def mount_spa(application: FastAPI):
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
             return JSONResponse(
-                {"error": "Frontend not built. Run: cd web && npm run build"},
+                {"error": "Frontend assets not found. "
+                 "If installed via pip, try: pip install hermes-agent[web] "
+                 "For development: cd web && npm run build"},
                 status_code=404,
             )
         return


### PR DESCRIPTION
## Summary

Fixes #14880

The built wheel/sdist is missing `hermes_cli/web_dist/` frontend assets, causing the dashboard to return a 404 with an unhelpful error message when accessed.

## Root Cause

`MANIFEST.in` only grafts `skills` and `optional-skills` directories. While `pyproject.toml` declares `hermes_cli = ["web_dist/**/*"]` in `[tool.setuptools.package-data]`, the sdist tarball itself doesn't include the `web_dist` directory because `MANIFEST.in` doesn't graft it. When a wheel is built from the sdist (e.g. in CI/CD pipelines or downstream packagers), the assets are silently excluded.

## Changes

**MANIFEST.in**:
- Added `graft hermes_cli/web_dist` to ensure the frontend assets are included in sdist builds

**hermes_cli/web_server.py** — `mount_spa()`:
- Improved the no-frontend error message to suggest `pip install hermes-agent[web]` for pip users alongside the existing dev build command

## Testing

- `MANIFEST.in` graft is additive — if `web_dist/` doesn't exist at build time, the graft is a no-op (no build failure)
- The `pyproject.toml` package-data glob (`web_dist/**/*`) already handles wheel inclusion; the MANIFEST.in graft covers the sdist path
- Error message change is cosmetic — no functional regression

## Checklist

- [x] Follows Conventional Commits format
- [x] Single logical change
- [x] No breaking changes
- [x] Existing tests unaffected
