### PR TITLE
fix(model): only strip /v1 from OpenCode URLs on fresh provider resolution

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -859,11 +859,17 @@ def switch_model(
     # without it, /model switches into an anthropic_messages-routed OpenCode
     # model (e.g. `/model minimax-m2.7` on opencode-go, `/model claude-sonnet-4-6`
     # on opencode-zen) hit a double /v1 and returned OpenCode's website 404 page.
+    #
+    # Only strip when the URL was freshly resolved via resolve_runtime_provider
+    # (provider_changed or explicit_provider).  When the user switches models
+    # on the same provider, the base_url is already correct from a prior
+    # resolution and stripping /v1 breaks endpoints that need it (#14879).
     if (
         api_mode == "anthropic_messages"
         and target_provider in {"opencode-zen", "opencode-go"}
         and isinstance(base_url, str)
         and base_url
+        and (provider_changed or explicit_provider)
     ):
         base_url = re.sub(r"/v1/?$", "", base_url)
 


### PR DESCRIPTION
## Summary

Fixes #14879

The `/model` command unconditionally strips `/v1` from OpenCode base URLs when `api_mode == "anthropic_messages"`, but this breaks models that need `/v1` in the URL when the user switches models on the same provider (where the URL was already correct from a prior resolution).

## Root Cause

In `switch_model()`, the `/v1` stripping regex runs whenever:
1. `api_mode == "anthropic_messages"`
2. Provider is `opencode-zen` or `opencode-go`

But it didn't check whether the URL was freshly resolved or was carried over from the current session. When a user on `opencode-go` switches from one model to another (same provider), the `base_url` is already in the correct form and stripping `/v1` corrupts it.

## Changes

**hermes_cli/model_switch.py** — `switch_model()`:
- Added `(provider_changed or explicit_provider)` to the `/v1` strip condition
- `/v1` is now only stripped when the URL was freshly resolved via `resolve_runtime_provider()` (i.e., the provider changed or was explicitly specified)
- When switching models on the same provider, the `base_url` is left as-is
- Updated the comment block to document this behavior

## Testing

- **Provider switch** (e.g., `openrouter` → `opencode-go`): `provider_changed=True` → `/v1` stripped as before
- **Same-provider model switch** (e.g., model A → model B on `opencode-go`): `provider_changed=False, explicit_provider=""` → `/v1` preserved (bug fixed)
- **Explicit provider** (e.g., `/model sonnet --provider opencode-go`): `explicit_provider="opencode-go"` → `/v1` stripped correctly
- Non-OpenCode providers: condition short-circuits at `target_provider` check → no change

## Checklist

- [x] Follows Conventional Commits format
- [x] Single logical change
- [x] No breaking changes
- [x] Existing tests unaffected
