### PR TITLE
feat(browser): detect CAPTCHA / bot-challenge landing pages

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -510,3 +510,123 @@ async def test_web_crawl_blocks_redirected_final_url(monkeypatch):
     assert result["results"][0]["content"] == ""
     assert result["results"][0]["error"] == "Blocked by website policy"
     assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+
+def test_google_sorry_detected(monkeypatch):
+    """Google /sorry/ redirect should return blocked=True."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+
+    def fake_run(task_id, cmd, args, timeout=None):
+        if cmd == "open":
+            return {
+                "success": True,
+                "data": {
+                    "url": "https://www.google.com/sorry/index?continue=https://www.google.com/search%3Fq%3Dtest",
+                    "title": "Google",
+                },
+            }
+        if cmd == "snapshot":
+            return {"success": True, "data": {"snapshot": "", "refs": {}}}
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    result = json.loads(browser_tool.browser_navigate("https://www.google.com/search?q=test"))
+    assert result["success"] is False
+    assert result["blocked"] is True
+    assert result["block_reason"] == "captcha_or_bot_challenge"
+    assert result["blocked_by"] == "google.com/sorry/"
+
+
+def test_cloudflare_challenge_detected(monkeypatch):
+    """Cloudflare challenge page should return blocked=True."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+
+    def fake_run(task_id, cmd, args, timeout=None):
+        if cmd == "open":
+            return {
+                "success": True,
+                "data": {
+                    "url": "https://example.com/cdn-cgi/challenge-platform/h/b/orange/proxy/1234",
+                    "title": "Attention Required!",
+                },
+            }
+        if cmd == "snapshot":
+            return {"success": True, "data": {"snapshot": "", "refs": {}}}
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    result = json.loads(browser_tool.browser_navigate("https://example.com"))
+    assert result["success"] is False
+    assert result["blocked"] is True
+    assert result["block_reason"] == "captcha_or_bot_challenge"
+
+
+def test_normal_url_unchanged(monkeypatch):
+    """Normal navigation should return success=True, no blocked fields."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+
+    def fake_run(task_id, cmd, args, timeout=None):
+        if cmd == "open":
+            return {
+                "success": True,
+                "data": {
+                    "url": "https://example.com/article/123",
+                    "title": "Sample Article",
+                },
+            }
+        if cmd == "snapshot":
+            return {"success": True, "data": {"snapshot": "content", "refs": {"@e1": "text"}}}
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    result = json.loads(browser_tool.browser_navigate("https://example.com/article/123"))
+    assert result["success"] is True
+    assert "blocked" not in result
+    assert result["url"] == "https://example.com/article/123"
+
+
+def test_redirect_chain_terminal_url_checked(monkeypatch):
+    """Initial URL is a search query, final URL after redirect is /sorry/. Detection triggers on final URL."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+
+    def fake_run(task_id, cmd, args, timeout=None):
+        if cmd == "open":
+            return {
+                "success": True,
+                "data": {
+                    "url": "https://www.google.com/sorry/index?continue=https://www.google.com/search%3Fq%3Dsomething+specific+query",
+                    "title": "Google",
+                },
+            }
+        if cmd == "snapshot":
+            return {"success": True, "data": {"snapshot": "", "refs": {}}}
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    result = json.loads(
+        browser_tool.browser_navigate("https://www.google.com/search?q=something+specific+query")
+    )
+    assert result["success"] is False
+    assert result["blocked"] is True
+    assert result["requested_url"] == "https://www.google.com/search?q=something+specific+query"
+    assert "sorry" in result["url"]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -77,6 +77,42 @@ try:
     from tools.url_safety import is_safe_url as _is_safe_url
 except Exception:
     _is_safe_url = lambda url: False  # noqa: E731 — fail-closed: block all if safety module unavailable
+
+# Known CAPTCHA / bot-challenge / anti-bot interstitial URLs.
+# Match is: host substring AND path substring, where None means "don't care."
+BLOCK_PATTERNS: list[tuple[Optional[str], Optional[str]]] = [
+    ("google.com",       "/sorry/"),            # Google anti-bot
+    ("google.com",       "/recaptcha/"),        # Google reCAPTCHA
+    ("cloudflare.com",   "/cdn-cgi/challenge"), # Cloudflare interstitial
+    (None,               "/challenge-platform/"),# Cloudflare Turnstile
+    ("captcha.",         None),                 # Generic captcha subdomain
+    ("hcaptcha.com",     None),                 # hCaptcha standalone
+    ("datadome.co",      None),                 # DataDome block page
+    ("perimeterx.net",   None),                 # PerimeterX
+]
+
+
+def _is_captcha_url(url: str) -> Optional[tuple]:
+    """Check if a URL matches known CAPTCHA / bot-challenge patterns.
+
+    Returns the matched (host_pattern, path_pattern) tuple, or None.
+    """
+    try:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+        path = parsed.path.lower()
+    except Exception:
+        return None
+
+    for host_pat, path_pat in BLOCK_PATTERNS:
+        if host_pat is not None and host_pat not in host:
+            continue
+        if path_pat is not None and path_pat not in path:
+            continue
+        return (host_pat or "*", path_pat or "*")
+    return None
+
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
@@ -1474,6 +1510,27 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                 "success": False,
                 "error": "Blocked: redirect landed on a private/internal address",
             })
+
+         # Post-redirect CAPTCHA / bot-challenge detection.
+        # The browser succeeded in loading the page, but the final URL
+        # indicates we were redirected to a challenge page (e.g. Google
+        # /sorry/).  Return success=False so the model stops retrying.
+        captcha_match = _is_captcha_url(final_url)
+        if captcha_match is not None:
+            host_pat, path_pat = captcha_match
+            return json.dumps({
+                "success": False,
+                "blocked": True,
+                "block_reason": "captcha_or_bot_challenge",
+                "blocked_by": f"{host_pat}{path_pat}",
+                "url": final_url,
+                "requested_url": url,
+                "message": (
+                    "Destination was a bot-challenge / CAPTCHA page. "
+                    "Do not retry the same URL — try a different source or "
+                    "surface this to the user."
+                ),
+            }, ensure_ascii=False)
 
         response = {
             "success": True,


### PR DESCRIPTION
## What does this PR do?

Adds landing-page detection to `browser_navigate` for common anti-bot / CAPTCHA interstitials. When the final URL (after redirects) matches a known pattern, the tool returns `success: false, blocked: true` with structured metadata instead of the current `success: true`.

### The bug this fixes

`browser_navigate` currently reports HTTP-layer success whenever the browser loaded *something*, regardless of whether that something is the page the agent asked for. A common failure mode:

1. Agent asks for `https://www.google.com/search?q=...`
2. Google's anti-bot redirects to `https://www.google.com/sorry/index?continue=...`
3. Tool returns `{"success": true, "url": "https://www.google.com/sorry/index?..."}` — HTTP navigation did succeed
4. Model sees `success: true`, assumes the search worked, retries with the same or similar query
5. Repeat until the user interrupts

I observed 14 consecutive identical retries in a production session before the user intervened. This PR gives the model a clean signal to stop.

### What the new response shape looks like

```json
{
    "success": false,
    "blocked": true,
    "block_reason": "captcha_or_bot_challenge",
    "blocked_by": "google.com/sorry/",
    "url": "https://www.google.com/sorry/index?continue=...",
    "requested_url": "https://www.google.com/search?q=...",
    "message": "Destination was a bot-challenge / CAPTCHA page. Do not retry the same URL — try a different source or surface this to the user."
}
```

Both structured fields (`blocked`, `block_reason`, `blocked_by`) and prose (`message`) are included — structured for programmatic handling, prose as a direct instruction to the model since some models ignore structured flags but respect instructional text.

### What patterns are matched

Host + path substring pairs, either field may be `None` for "don't care":

| Host | Path | Source |
|---|---|---|
| `google.com` | `/sorry/` | Google anti-bot |
| `google.com` | `/recaptcha/` | Google reCAPTCHA |
| `cloudflare.com` | `/cdn-cgi/challenge` | Cloudflare interstitial |
| — | `/challenge-platform/` | Cloudflare Turnstile |
| `captcha.` | — | Generic CAPTCHA subdomain |
| `hcaptcha.com` | — | hCaptcha standalone |
| `datadome.co` | — | DataDome |
| `perimeterx.net` | — | PerimeterX |

Easy to extend with more vendors as they're encountered — the list is a module constant.

## Related Issue

Groundwork for #12667 ("[Feature]: forward captchas"). Forwarding can't happen without detection.

Complementary to #4008 (Camofox anti-detection browser backend): anti-detection reduces block rate, but doesn't eliminate it. Detection is the safety net when the block happens anyway.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

(Both apply — the existing `success: true` on a CAPTCHA page was arguably a reporting bug, and the new fields are additive functionality.)

## Changes Made

- **`tools/browser_tool.py`**: added `BLOCK_PATTERNS` module constant, `_is_captcha_url()` helper (case-insensitive host+path substring match via `urllib.parse.urlparse`), and a post-redirect check in `browser_navigate` immediately after the existing private-URL redirect guard.
- **`tests/tools/test_website_policy.py`**: added 4 tests covering Google `/sorry/`, Cloudflare `/cdn-cgi/challenge-platform/`, normal URL passthrough (asserts `"blocked"` field is *not* leaked on success), and redirect-chain terminal-URL matching.

Normal navigation behavior is unchanged — the block-page check only fires when a pattern matches. Tests confirm the normal success response does not gain a `blocked` field.

## How to Test

```bash
./venv/bin/python -m pytest tests/tools/test_website_policy.py -v \
  -k "google_sorry or cloudflare_challenge or normal_url_unchanged or redirect_chain_terminal"
```

All 4 new tests pass in ~2.5s locally.

Manual smoke test: trigger a Google search that hits a CAPTCHA (easiest from a throwaway VPN exit or an IP with recent heavy automated access). Observe `browser_navigate` returning the new `blocked: true` response instead of `success: true`.

## Scope / Non-goals

**Intentionally narrow** — this PR only touches `browser_navigate` in `tools/browser_tool.py`. It does NOT modify:

- `web_search_tool` / `web_extract_tool` / `web_crawl_tool` in `tools/web_tools.py`
- Other browser tools (`browser_click`, `browser_snapshot`, etc.)
- Solving / bypassing the CAPTCHA (that's #12667 territory)

These can be follow-ups if maintainers want broader coverage. I kept this PR surgical so it's easy to review.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(browser):`)
- [x] I searched for existing PRs — no open PR touches this; #4008 (Camofox, merged) is the closest related work and is complementary, not overlapping
- [x] My PR contains **only** changes related to this feature (2 files)
- [x] I've run `pytest tests/tools/test_website_policy.py -q` and all tests pass
- [x] I've added tests for my changes (4 new tests)
- [x] I've tested on my platform: Arch Linux, Python 3.11, running against local browser provider

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (response shape is additive; no public docs describe the blocked case)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string matching via `urllib.parse`, no OS-dependent code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the `browser_navigate` docstring describes the success response; a follow-up could document the blocked response if maintainers prefer, happy to add in a review round

## For New Skills

N/A — tool-level change, not a skill.

## Screenshots / Logs

Example session that motivated the fix (prior to this PR):

```
[256] assistant -> browser_navigate("https://www.google.com/search?q=best+breakfast+Bloomington")
[257] tool: {"success": true, "url": "https://www.google.com/sorry/index?continue=..."}
[258] assistant -> browser_navigate(...same URL...)
[259] tool: {"success": true, "url": "https://www.google.com/sorry/index?continue=..."}
... repeats 14x ...
[284] user: alright, looks like a loop.
```

With this PR, message 257 would be:

```json
{"success": false, "blocked": true, "block_reason": "captcha_or_bot_challenge", ...}
```

and the model sees an unambiguous signal on the first attempt.
