### PR TITLE
fix: path traversal in signal file:// and expand dangerous command patterns

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -815,7 +815,16 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Resolve image to local path
         if image_url.startswith("file://"):
-            file_path = unquote(image_url[7:])
+            from hermes_constants import get_hermes_home
+            allowed_dir = get_hermes_home() / "media"
+            raw_path = unquote(image_url[7:])
+            local_path = Path(raw_path).expanduser().resolve()
+            try:
+                if not local_path.is_relative_to(allowed_dir.resolve()):
+                    raise PermissionError(f"file:// path outside allowed media directory: {raw_path}")
+            except ValueError:
+                raise PermissionError(f"file:// path traversal rejected: {raw_path}")
+            file_path = str(local_path)
         else:
             # Download remote image to cache
             try:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -95,7 +95,11 @@ DANGEROUS_PATTERNS = [
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
-    (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
+    (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;', "fork bomb"),
+    (r'\bsudo\s+-S\b', "sudo reading password from stdin"),
+    (r'\balias\s+\w+\s*=', "define command alias"),
+    (r'\bdisown\b', "remove job from shell's job table"),
+    (r'\bcrontab\s+(-e|-u)\b', "edit user crontab"),
     # Any shell invocation via -c or combined flags like -lc, -ic, etc.
     (r'\b(bash|sh|zsh|ksh)\s+-[^\s]*c(\s+|$)', "shell command via -c/-lc flag"),
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),


### PR DESCRIPTION
## Summary

Security fixes:
1. Path traversal in Signal file:// image handler - added is_relative_to() check
2. Missing dangerous command patterns in approval.py - added sudo -S, alias, disown, crontab -e/-u, fixed fork bomb regex

Files: gateway/platforms/signal.py, tools/approval.py