### PR TITLE
feat(models): add deepseek-v4-pro and deepseek-v4-flash

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -33,6 +33,8 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("moonshotai/kimi-k2.6",            "recommended"),
+    ("deepseek/deepseek-v4-pro",        ""),
+    ("deepseek/deepseek-v4-flash",      ""),
     ("anthropic/claude-opus-4.7",       ""),
     ("anthropic/claude-opus-4.6",       ""),
     ("anthropic/claude-sonnet-4.6",     ""),
@@ -109,6 +111,8 @@ def _codex_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "moonshotai/kimi-k2.6",
+        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
         "xiaomi/mimo-v2.5-pro",
         "xiaomi/mimo-v2.5",
         "anthropic/claude-opus-4.7",
@@ -246,6 +250,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-haiku-4-5-20251001",
     ],
     "deepseek": [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
         "deepseek-chat",
         "deepseek-reasoner",
     ],


### PR DESCRIPTION
## Summary
Adds DeepSeek V4 Pro and V4 Flash to the OpenRouter curated list, Nous Portal fallback list, and the native DeepSeek provider's static catalog.

## Changes
- `OPENROUTER_MODELS`: `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash` (load-bearing — picker filters against this)
- `_PROVIDER_MODELS["nous"]`: same two slugs (fallback-only; portal-side add still needed for authed users)
- `_PROVIDER_MODELS["deepseek"]`: bare `deepseek-v4-pro`, `deepseek-v4-flash` alongside existing entries
- Context length auto-resolves via existing `deepseek` substring entry (128K) in `DEFAULT_CONTEXT_LENGTHS`

## Validation
| | Before | After |
|---|---|---|
| DeepSeek V4 in OR picker | no | yes |
| DeepSeek V4 in Nous fallback | no | yes |
| DeepSeek V4 on direct API | no | yes |
| Targeted tests | — | 323 passed |