### PR TITLE
fix(gateway): use IMAP BODY.PEEK[] instead of RFC822 to preserve unread state

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -357,7 +357,14 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    # Use BODY.PEEK[] instead of RFC822 so polling does NOT
+                    # implicitly mark incoming messages as \Seen server-side
+                    # (per RFC 3501 §6.4.5 — any BODY[...] fetch that is not
+                    # PEEK flips the \Seen flag). Same raw bytes returned;
+                    # only the side effect differs. Without PEEK, every poll
+                    # silently "reads" the user's inbox before they open it
+                    # in their mail client.
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -811,6 +811,51 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "john@test.com")
         self.assertEqual(results[0]["sender_name"], "John Doe")
 
+    def test_fetch_uses_peek_to_preserve_unread_state(self):
+        """Fetch must use BODY.PEEK[] (not RFC822) so polling does not
+        silently mark incoming messages as \\Seen server-side.
+
+        Per RFC 3501 §6.4.5, any BODY[...] fetch that is not PEEK
+        implicitly sets the \\Seen flag. RFC822 is a synonym for BODY[]
+        and has the same side effect. Using BODY.PEEK[] returns the same
+        raw bytes without touching the flag, so the user's mail client
+        still sees them as unread until the user actually opens them.
+        """
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        fetch_specs = []
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                fetch_specs.append(args)
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            adapter._fetch_new_messages()
+
+        self.assertEqual(len(fetch_specs), 1, "Expected exactly one fetch call")
+        # fetch args: (uid, fetch_spec)
+        fetch_spec = fetch_specs[0][1]
+        self.assertEqual(
+            fetch_spec, "(BODY.PEEK[])",
+            f"Fetch spec must be (BODY.PEEK[]) to avoid \\Seen side effect, got {fetch_spec!r}",
+        )
+        self.assertNotIn(
+            "RFC822", fetch_spec,
+            "RFC822 marks messages as \\Seen — use BODY.PEEK[] instead",
+        )
+
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""


### PR DESCRIPTION
## What does this PR do?

The email gateway polls IMAP with `imap.uid("fetch", uid, "(RFC822)")`. Per [RFC 3501 §6.4.5](https://datatracker.ietf.org/doc/html/rfc3501#section-6.4.5), any `BODY[...]` fetch that is **not** PEEK implicitly sets the `\Seen` flag server-side. `RFC822` is a synonym for `BODY[]` and carries the same side effect.

Consequence: every incoming message the gateway polls is silently marked as *read* server-side before the user ever opens it in their mail client. The user's inbox ends up showing all new mail as already-read, which breaks the common "unread = needs attention" workflow and is silently destructive (the server-side flag change is visible to every client connected to the same mailbox).

The fix uses `BODY.PEEK[]` instead — same raw bytes are returned, no flag mutation. The gateway's in-memory `_seen_uids` deduplication set is orthogonal to the IMAP `\Seen` flag and keeps working identically.

## Related Issue

No pre-existing issue — discovered while investigating hermes silently marking mails as read on a Raspberry Pi deployment. Cross-checked: the sibling `email-triage-drafts` cron script in the skill catalog already uses `BODY.PEEK[]` for the same reason, so this change aligns the gateway with that existing convention.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: replace `"(RFC822)"` with `"(BODY.PEEK[])"` in `_fetch_new_messages`, plus inline comment explaining the rationale.
- `tests/gateway/test_email.py`: add `test_fetch_uses_peek_to_preserve_unread_state` regression test that asserts the fetch spec is `(BODY.PEEK[])` and explicitly checks that `RFC822` is not used.

## How to Test

```bash
uv pip install -e ".[all,dev]"
python -m pytest tests/gateway/test_email.py -v -k fetch
```

All 6 tests in `TestFetchNewMessages` pass (5 existing + 1 new).

To verify the behavior change in practice: connect the gateway to any IMAP account and send yourself a test email. Before this fix, the message appears as read in your mail client immediately after the gateway's next poll. After the fix, it stays unread until you actually open it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway/test_email.py -v` and all tests pass
- [x] I've added a regression test
- [x] I've tested on my platform: macOS 15 / Debian 12 (Raspberry Pi) with a real IMAP provider

### Documentation & Housekeeping

- [x] N/A — no user-facing config change, purely a correctness fix
- [x] N/A — no config keys touched
- [x] N/A — no architecture change
- [x] Cross-platform impact: none — pure IMAP protocol semantics, identical on all platforms
- [x] N/A — no tool schemas touched