### PR TITLE
fix: set empty reasoning_content for DeepSeek when tool_calls present

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7283,13 +7283,17 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
+        deepseek_requires_reasoning = (
+            self.provider in {"deepseek", "custom"}
+            and base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
         kimi_requires_reasoning = (
             self.provider in {"kimi-coding", "kimi-coding-cn"}
             or base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
-        if kimi_requires_reasoning and source_msg.get("tool_calls"):
+        if (kimi_requires_reasoning or deepseek_requires_reasoning) and source_msg.get("tool_calls"):
             api_msg["reasoning_content"] = ""
 
     @staticmethod


### PR DESCRIPTION
When the model returns `tool_calls` alongside `reasoning_content`, some DeepSeek models (e.g., deepseek-v4-flash) include non-empty `reasoning_content` which can cause downstream issues.

This PR applies the same empty-string normalization already done for Kimi models, by checking if the provider is DeepSeek (or custom pointing to api.deepseek.com) and setting `reasoning_content` to empty string when `tool_calls` are present.

Tested and verified working with deepseek-v4-flash.