### PR TITLE
fix(deepseek): preserve v4 native model ids during provider normalization

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -12,8 +12,11 @@ Different LLM providers expect model identifiers in different formats:
   model IDs, but Claude still uses hyphenated native names like
   ``claude-sonnet-4-6``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
-- **DeepSeek** only accepts two model identifiers:
-  ``deepseek-chat`` and ``deepseek-reasoner``.
+- **DeepSeek** native API accepts ``deepseek-v4-flash`` and
+  ``deepseek-v4-pro``. The legacy identifiers ``deepseek-chat`` and
+  ``deepseek-reasoner`` remain accepted for backwards compatibility and
+  map server-side to the non-thinking and thinking modes of
+  ``deepseek-v4-flash`` respectively; they will be deprecated.
 - **Custom** and remaining providers pass the name through as-is.
 
 This module centralises that translation so callers can simply write::
@@ -103,8 +106,11 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
-# DeepSeek's API only recognises exactly two model identifiers.  We map
-# common aliases and patterns to the canonical names.
+# DeepSeek's native API accepts the V4 identifiers (``deepseek-v4-flash``
+# and ``deepseek-v4-pro``) plus the legacy aliases ``deepseek-chat`` and
+# ``deepseek-reasoner``. The legacy aliases will be deprecated and
+# correspond server-side to the non-thinking and thinking modes of
+# ``deepseek-v4-flash``.
 
 _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "reasoner",
@@ -115,25 +121,27 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
 })
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
     "deepseek-chat",
     "deepseek-reasoner",
 })
 
 
 def _normalize_for_deepseek(model_name: str) -> str:
-    """Map any model input to one of DeepSeek's two accepted identifiers.
+    """Map a DeepSeek model input to an accepted API identifier.
 
     Rules:
-    - Already ``deepseek-chat`` or ``deepseek-reasoner`` -> pass through.
+    - Canonical V4 ids and legacy aliases pass through unchanged.
     - Contains any reasoner keyword (r1, think, reasoning, cot, reasoner)
-      -> ``deepseek-reasoner``.
-    - Everything else -> ``deepseek-chat``.
+      -> ``deepseek-reasoner`` (legacy thinking-mode alias).
+    - Everything else -> ``deepseek-chat`` (legacy non-thinking alias).
 
     Args:
         model_name: The bare model name (vendor prefix already stripped).
 
     Returns:
-        One of ``"deepseek-chat"`` or ``"deepseek-reasoner"``.
+        A DeepSeek API model identifier.
     """
     bare = _strip_vendor_prefix(model_name).lower()
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -164,6 +164,27 @@ class TestAggregatorProviders:
         assert result == "anthropic/claude-sonnet-4.6"
 
 
+class TestDeepSeekV4Normalization:
+    """DeepSeek native API accepts V4 ids plus legacy aliases.
+
+    Legacy aliases (deepseek-chat / deepseek-reasoner) will be deprecated
+    and map server-side to non-thinking / thinking modes of
+    deepseek-v4-flash respectively.
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("deepseek-v4-flash", "deepseek-v4-flash"),
+        ("deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek/deepseek-v4-flash", "deepseek-v4-flash"),
+        ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek-chat", "deepseek-chat"),
+        ("deepseek-reasoner", "deepseek-reasoner"),
+        ("deepseek-r1", "deepseek-reasoner"),
+    ])
+    def test_deepseek_v4_and_legacy_aliases(self, model, expected):
+        assert normalize_model_for_provider(model, "deepseek") == expected
+
+
 class TestIssue6211NativeProviderPrefixNormalization:
     @pytest.mark.parametrize("model,target_provider,expected", [
         ("zai/glm-5.1", "zai", "glm-5.1"),


### PR DESCRIPTION
## Summary

Follow-up to #14934, which added `deepseek-v4-pro` and `deepseek-v4-flash` to the DeepSeek native provider's model list — but the normalization layer was missed, so picking either V4 id from the native DeepSeek provider got silently rewritten to `deepseek-chat` before the request was sent.

### The bug, at a glance

Before this PR, `_normalize_for_deepseek` collapsed any non-reasoner-keyword input to `deepseek-chat`:

| User picks                    | Pre-PR normalize output | Post-PR normalize output |
| ----------------------------- | ----------------------- | ------------------------ |
| `deepseek-v4-pro`             | ❌ `deepseek-chat`       | ✅ `deepseek-v4-pro`      |
| `deepseek-v4-flash`           | ❌ `deepseek-chat`       | ✅ `deepseek-v4-flash`    |
| `deepseek/deepseek-v4-pro`    | ❌ `deepseek-chat`       | ✅ `deepseek-v4-pro`      |
| `deepseek-chat` (legacy)      | ✅ `deepseek-chat`       | ✅ `deepseek-chat`        |
| `deepseek-reasoner` (legacy)  | ✅ `deepseek-reasoner`   | ✅ `deepseek-reasoner`    |
| `deepseek-r1` (keyword)       | ✅ `deepseek-reasoner`   | ✅ `deepseek-reasoner`    |

### Changes

- Add the V4 ids to `_DEEPSEEK_CANONICAL_MODELS` so they pass through `_normalize_for_deepseek` unchanged.
- Document that the legacy aliases `deepseek-chat` / `deepseek-reasoner` will be deprecated and map server-side to the non-thinking / thinking modes of `deepseek-v4-flash` respectively.
- Add parametrized tests covering V4 ids, legacy aliases, vendor-prefixed forms, and the reasoner-keyword path.

**Scope:** native DeepSeek provider only. The OpenRouter / Nous Portal path was already handled by #14934.

This PR supersedes #14891 (closed); that PR was opened before #14934 landed and overlapped with the model-list additions.

## Test plan

- [x] `pytest tests/hermes_cli/test_model_normalize.py` — 62 passed locally
- [x] **Live against `api.deepseek.com`**: `normalize_model_for_provider("deepseek-v4-pro", "deepseek")` returns `"deepseek-v4-pro"`; sending that normalized id as `model=` to `chat.completions.create` returns HTTP 200 with the server echoing `model: deepseek-v4-pro` (confirming v4-pro actually reaches the server instead of being silently folded to `deepseek-chat`)