### PR TITLE
fix(deepseek): preserve v4 model IDs

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -12,8 +12,8 @@ Different LLM providers expect model identifiers in different formats:
   model IDs, but Claude still uses hyphenated native names like
   ``claude-sonnet-4-6``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
-- **DeepSeek** only accepts two model identifiers:
-  ``deepseek-chat`` and ``deepseek-reasoner``.
+- **DeepSeek** preserves explicit public model IDs and maps legacy reasoner
+  aliases to ``deepseek-reasoner``.
 - **Custom** and remaining providers pass the name through as-is.
 
 This module centralises that translation so callers can simply write::
@@ -103,8 +103,9 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
-# DeepSeek's API only recognises exactly two model identifiers.  We map
-# common aliases and patterns to the canonical names.
+# DeepSeek's API recognises legacy aliases and explicit public model IDs. We
+# preserve exact public IDs, and map common reasoner aliases to the canonical
+# reasoner name.
 
 _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "reasoner",
@@ -117,14 +118,16 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
     "deepseek-chat",
     "deepseek-reasoner",
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
 })
 
 
 def _normalize_for_deepseek(model_name: str) -> str:
-    """Map any model input to one of DeepSeek's two accepted identifiers.
+    """Map DeepSeek model input to an accepted native identifier.
 
     Rules:
-    - Already ``deepseek-chat`` or ``deepseek-reasoner`` -> pass through.
+    - Already an accepted native ID -> pass through.
     - Contains any reasoner keyword (r1, think, reasoning, cot, reasoner)
       -> ``deepseek-reasoner``.
     - Everything else -> ``deepseek-chat``.
@@ -133,7 +136,7 @@ def _normalize_for_deepseek(model_name: str) -> str:
         model_name: The bare model name (vendor prefix already stripped).
 
     Returns:
-        One of ``"deepseek-chat"`` or ``"deepseek-reasoner"``.
+        An accepted DeepSeek native model identifier.
     """
     bare = _strip_vendor_prefix(model_name).lower()
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -146,6 +146,32 @@ class TestCopilotModelNormalization:
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
 
 
+# ── DeepSeek native model normalization (regression) ───────────────────
+
+class TestDeepSeekV4ModelPreservation:
+    """Explicit DeepSeek V4 public API model IDs must not be downgraded."""
+
+    @pytest.mark.parametrize("model,expected", [
+        ("deepseek-v4-flash", "deepseek-v4-flash"),
+        ("deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek/deepseek-v4-flash", "deepseek-v4-flash"),
+        ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek-chat", "deepseek-chat"),
+        ("deepseek-reasoner", "deepseek-reasoner"),
+    ])
+    def test_deepseek_preserves_explicit_public_model_ids(self, model, expected):
+        assert normalize_model_for_provider(model, "deepseek") == expected
+
+    @pytest.mark.parametrize("model", [
+        "deepseek-r1",
+        "deepseek/deepseek-r1",
+        "deepseek-reasoning",
+        "deepseek-think",
+    ])
+    def test_deepseek_reasoner_aliases_still_map_to_reasoner(self, model):
+        assert normalize_model_for_provider(model, "deepseek") == "deepseek-reasoner"
+
+
 # ── Aggregator providers (regression) ──────────────────────────────────
 
 class TestAggregatorProviders:


### PR DESCRIPTION
## What does this PR do?

Preserves explicit DeepSeek V4 public API model IDs during native DeepSeek model normalization.

Before this change, configuring `deepseek-v4-pro` or `deepseek-v4-flash` for the native `deepseek` provider silently normalized the model to `deepseek-chat`. That made Hermes appear to work while calling a different model than the user explicitly requested.

This keeps the change narrow: only the DeepSeek accepted-model allowlist is expanded, while legacy aliases and reasoner-style alias normalization keep their existing behavior.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_normalize.py`
  - Preserve `deepseek-v4-flash` and `deepseek-v4-pro` for the native `deepseek` provider.
  - Keep `deepseek-chat` and `deepseek-reasoner` aliases working.
  - Keep reasoner-style aliases such as `deepseek-r1`, `deepseek-reasoning`, and `deepseek-think` mapping to `deepseek-reasoner`.
  - Update the DeepSeek normalization comments/docstring to reflect the V4 public model IDs.
- `tests/hermes_cli/test_model_normalize.py`
  - Add regression tests for bare and `deepseek/`-prefixed V4 model IDs.
  - Add regression coverage that reasoner-style aliases still map to `deepseek-reasoner`.

## How to Test

1. Run the focused regression tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py::TestDeepSeekV4ModelPreservation -v --tb=short
   ```
2. Run the full model-normalization test file:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py -v --tb=short
   ```
3. Confirm expected behavior, for example:
   ```python
   normalize_model_for_provider("deepseek-v4-pro", "deepseek") == "deepseek-v4-pro"
   normalize_model_for_provider("deepseek/deepseek-v4-flash", "deepseek") == "deepseek-v4-flash"
   normalize_model_for_provider("deepseek-r1", "deepseek") == "deepseek-reasoner"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression test:

```text
scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py::TestDeepSeekV4ModelPreservation -v --tb=short
10 passed in 0.37s
```

Full model-normalization test file:

```text
scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py -v --tb=short
65 passed in 0.41s
```

Independent local review was also requested from Claude Code Opus 4.7, Kimi 2.6 via Kimi Code CLI, and DeepSeek V4 Pro. All approved with no blocking issues.
