### PR TITLE
fix(deepseek): bump V4 family context window to 1M tokens

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -142,7 +142,17 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gemma-4-31b": 256000,
     "gemma-3": 131072,
     "gemma": 8192,  # fallback for older gemma models
-    # DeepSeek
+    # DeepSeek — V4 family ships with a 1M context window. The legacy
+    # aliases ``deepseek-chat`` / ``deepseek-reasoner`` are server-side
+    # mapped to the non-thinking / thinking modes of ``deepseek-v4-flash``
+    # and inherit the same 1M window. The ``deepseek`` substring entry
+    # below remains as a 128K fallback for older / unknown DeepSeek model
+    # ids (e.g. via custom endpoints).
+    # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
+    "deepseek-v4-pro": 1_000_000,
+    "deepseek-v4-flash": 1_000_000,
+    "deepseek-chat": 1_000_000,
+    "deepseek-reasoner": 1_000_000,
     "deepseek": 128000,
     # Meta
     "llama": 131072,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -192,6 +192,43 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_deepseek_v4_models_1m_context(self):
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        expected_keys = {
+            "deepseek-v4-pro": 1_000_000,
+            "deepseek-v4-flash": 1_000_000,
+            "deepseek-chat": 1_000_000,
+            "deepseek-reasoner": 1_000_000,
+        }
+        for key, value in expected_keys.items():
+            assert key in DEFAULT_CONTEXT_LENGTHS, f"{key} missing"
+            assert DEFAULT_CONTEXT_LENGTHS[key] == value, (
+                f"{key} should be {value}, got {DEFAULT_CONTEXT_LENGTHS[key]}"
+            )
+
+        # Longest-first substring matching must resolve both the bare V4
+        # ids (native DeepSeek) and the vendor-prefixed forms (OpenRouter
+        # / Nous Portal) to 1M without probing down to the legacy 128K
+        # ``deepseek`` substring fallback.
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            cases = [
+                ("deepseek-v4-pro", 1_000_000),
+                ("deepseek-v4-flash", 1_000_000),
+                ("deepseek/deepseek-v4-pro", 1_000_000),
+                ("deepseek/deepseek-v4-flash", 1_000_000),
+                ("deepseek-chat", 1_000_000),
+                ("deepseek-reasoner", 1_000_000),
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected_ctx, (
+                    f"{model_id}: expected {expected_ctx}, got {actual}"
+                )
+
     def test_all_values_positive(self):
         for key, value in DEFAULT_CONTEXT_LENGTHS.items():
             assert value > 0, f"{key} has non-positive context length"


### PR DESCRIPTION
## Summary

Follow-up to #14934, which added `deepseek-v4-pro` / `deepseek-v4-flash` to the DeepSeek native provider's model list. The context-window lookup in `agent/model_metadata.py` still falls back to the existing `"deepseek"` substring entry (128K) — but DeepSeek V4 ships with a **1M** context window, so callers relying on `get_model_context_length()` for pre-flight token budgeting (compression triggers, context warnings) under-count by ~8x.

Adds explicit lowercase entries for the four DeepSeek model ids that share the 1M window:

- `deepseek-v4-pro` — 1M
- `deepseek-v4-flash` — 1M
- `deepseek-chat` — 1M (legacy alias, server-side maps to v4-flash non-thinking)
- `deepseek-reasoner` — 1M (legacy alias, server-side maps to v4-flash thinking)

Longest-key-first substring matching means these explicit entries also resolve the vendor-prefixed forms (`deepseek/deepseek-v4-pro` on OpenRouter / Nous Portal) without regressing the existing 128K fallback for older / unknown DeepSeek model ids on custom endpoints.

Source: <https://api-docs.deepseek.com/quick_start/pricing>

Pairs with #14946 (the normalization-side fix). The two PRs are independent — either one can land first.

### Note for reviewers (out of scope, just flagging)

The pre-existing `"deepseek-ai/DeepSeek-V3.2": 65536` override at [model_metadata.py:185](https://github.com/NousResearch/hermes-agent/blob/main/agent/model_metadata.py#L185) is effectively dead — its key contains uppercase letters but the lookup at line 1290 checks `if default_model in model_lower` against a lowercased input. Not addressed in this PR to keep the diff scoped, happy to follow up separately if useful.

## Test plan

- [x] `pytest tests/agent/test_model_metadata.py::TestDefaultContextLengths` — 9 passed
- [x] New test `test_deepseek_v4_models_1m_context` covers bare ids, vendor-prefixed forms, and legacy aliases
- [x] **End-to-end resolution** (fallback table isolated via mocks): `get_model_context_length()` returns 1,000,000 for all of `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek-chat`, `deepseek-reasoner`; the `deepseek` substring fallback stays at 128K (no regression for unknown deepseek-* ids on custom endpoints)