### PR TITLE
fix: preserve explicit context window on generic overflow

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -722,6 +722,33 @@ def get_next_probe_tier(current_length: int) -> Optional[int]:
     return None
 
 
+def choose_context_length_after_overflow(
+    old_ctx: int,
+    parsed_limit: Optional[int] = None,
+    config_context_length: Optional[int] = None,
+) -> Optional[int]:
+    """Choose the runtime context window after a prompt-overflow error.
+
+    If the provider reports a concrete lower limit, trust it.  Otherwise,
+    preserve an explicit user-configured context window and only compress the
+    history.  Blindly probing down from a configured 1M window to the generic
+    128K tier makes long TUI sessions appear to "lose" their context window
+    after transient/generic errors.
+    """
+    if parsed_limit and parsed_limit < old_ctx:
+        return parsed_limit
+
+    if config_context_length is not None:
+        try:
+            configured = int(config_context_length)
+        except (TypeError, ValueError):
+            configured = 0
+        if configured > 0:
+            return old_ctx
+
+    return get_next_probe_tier(old_ctx)
+
+
 def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     """Try to extract the actual context limit from an API error message.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -88,8 +88,8 @@ from agent.prompt_builder import (
 from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,
-    get_next_probe_tier, parse_context_limit_from_error,
-    parse_available_output_tokens_from_error,
+    choose_context_length_after_overflow,
+    parse_context_limit_from_error, parse_available_output_tokens_from_error,
     save_context_length, is_local_endpoint,
     query_ollama_num_ctx,
 )
@@ -10600,8 +10600,15 @@ class AIAgent:
                                 force=True,
                             )
                         else:
-                            # Step down to the next probe tier
-                            new_ctx = get_next_probe_tier(old_ctx)
+                            # Step down only for auto-detected windows.  When the
+                            # user explicitly configured model.context_length,
+                            # keep that runtime window unless the provider gave a
+                            # concrete lower parsed_limit.
+                            new_ctx = choose_context_length_after_overflow(
+                                old_ctx,
+                                parsed_limit=parsed_limit,
+                                config_context_length=getattr(self, "_config_context_length", None),
+                            )
 
                         if new_ctx and new_ctx < old_ctx:
                             compressor.update_model(

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -282,18 +282,46 @@ class TestContextNotHalvedOnOutputCapError:
         assert agent.context_compressor.context_length == old_ctx
         assert agent._ephemeral_max_output_tokens == 19_936
 
-    def test_prompt_too_long_still_triggers_probe_tier(self):
-        """Genuine prompt-too-long errors must still use get_next_probe_tier."""
+    def test_prompt_too_long_still_triggers_probe_tier_without_explicit_config(self):
+        """Genuine prompt-too-long errors may probe down only when there is no explicit config override."""
         from agent.model_metadata import parse_available_output_tokens_from_error
-        from agent.model_metadata import get_next_probe_tier
+        from agent.model_metadata import choose_context_length_after_overflow
 
         error_msg = "prompt is too long: 205000 tokens > 200000 maximum"
 
         available_out = parse_available_output_tokens_from_error(error_msg)
         assert available_out is None, "prompt-too-long must not be caught by output-cap parser"
 
-        # The old halving path is still used for this class of error
-        new_ctx = get_next_probe_tier(200_000)
+        # The old probing path is still used when the window was auto-detected.
+        new_ctx = choose_context_length_after_overflow(
+            old_ctx=200_000,
+            parsed_limit=None,
+            config_context_length=None,
+        )
+        assert new_ctx == 128_000
+
+    def test_explicit_config_context_length_prevents_probe_down_without_parsed_limit(self):
+        """If the user configured a 1M context window, generic overflow errors must not degrade it to 128K."""
+        from agent.model_metadata import choose_context_length_after_overflow
+
+        new_ctx = choose_context_length_after_overflow(
+            old_ctx=1_000_000,
+            parsed_limit=None,
+            config_context_length=1_000_000,
+        )
+
+        assert new_ctx == 1_000_000
+
+    def test_parsed_provider_limit_still_overrides_explicit_config(self):
+        """A concrete provider-reported lower limit is trusted even when config had a larger hint."""
+        from agent.model_metadata import choose_context_length_after_overflow
+
+        new_ctx = choose_context_length_after_overflow(
+            old_ctx=1_000_000,
+            parsed_limit=128_000,
+            config_context_length=1_000_000,
+        )
+
         assert new_ctx == 128_000
 
     def test_output_cap_error_safety_margin(self):


### PR DESCRIPTION
## Summary
- Preserve explicit `model.context_length` when a generic context-overflow error does not include a concrete provider limit.
- Keep trusting parsed provider-reported lower limits when present.
- Add regression coverage for explicit 1M context windows so sessions do not silently degrade to the 128K probe tier.

## Test Plan
- `python -m pytest tests/test_ctx_halving_fix.py -q -o 'addopts='`
- `python -m pytest tests/agent/test_model_metadata.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_compressor_fallback_update.py -q -o 'addopts='`

## Context
Long-running TUI sessions with an explicit 1M context configuration could fall back to the generic 128K probe tier after a generic overflow/transport error that did not report an actual lower context limit. This made the status bar suddenly show 128K even though the configured model window was still 1M.
