### PR TITLE
feat(deepseek): plumb reasoning_effort and thinking toggle to V4 API

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -100,6 +100,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_github_models: bool
             is_nvidia_nim: bool
             is_kimi: bool
+            is_deepseek: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -187,6 +188,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        is_deepseek = params.get("is_deepseek", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:
@@ -218,6 +220,29 @@ class ChatCompletionsTransport(ProviderTransport):
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
+        # DeepSeek V4: top-level reasoning_effort (unless thinking disabled).
+        # Official API accepts only "high" and "max"; low/medium map to high,
+        # xhigh maps to max.  Thinking mode also forbids temperature / top_p /
+        # presence_penalty / frequency_penalty, so strip them when enabled.
+        # https://api-docs.deepseek.com/guides/thinking_mode
+        if is_deepseek:
+            _ds_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _ds_thinking_off:
+                _ds_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("max", "xhigh"):
+                        _ds_effort = "max"
+                    elif _e in ("low", "medium", "high"):
+                        _ds_effort = "high"
+                api_kwargs["reasoning_effort"] = _ds_effort
+                for _incompatible in ("temperature", "top_p", "presence_penalty", "frequency_penalty"):
+                    api_kwargs.pop(_incompatible, None)
+
         # extra_body assembly
         extra_body: Dict[str, Any] = {}
 
@@ -237,6 +262,16 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek V4 extra_body.thinking (default enabled per official docs)
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning

--- a/run_agent.py
+++ b/run_agent.py
@@ -6974,6 +6974,7 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = base_url_host_matches(self.base_url, "api.deepseek.com")
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7042,6 +7043,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -289,6 +289,106 @@ class TestChatCompletionsKimi:
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
 
+class TestChatCompletionsDeepSeek:
+    """DeepSeek V4 native provider — thinking toggle + reasoning_effort mapping.
+
+    Reference: https://api-docs.deepseek.com/guides/thinking_mode
+    """
+
+    def test_deepseek_thinking_enabled_by_default(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+        # Default effort when thinking enabled: "high"
+        assert kw["reasoning_effort"] == "high"
+
+    def test_deepseek_thinking_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek=True,
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+        # Omit reasoning_effort entirely when thinking off
+        assert "reasoning_effort" not in kw
+
+    @pytest.mark.parametrize("input_effort,expected", [
+        ("low", "high"),
+        ("medium", "high"),
+        ("high", "high"),
+        ("xhigh", "max"),
+        ("max", "max"),
+        ("MEDIUM", "high"),       # case insensitive
+        ("  high  ", "high"),     # whitespace tolerant
+    ])
+    def test_deepseek_effort_mapping(self, transport, input_effort, expected):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek=True,
+            reasoning_config={"effort": input_effort},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == expected
+
+    def test_deepseek_unknown_effort_falls_back_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek=True,
+            reasoning_config={"effort": "banana"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_deepseek_thinking_strips_incompatible_sampling_params(self, transport):
+        # Thinking mode forbids temperature/top_p/presence_penalty/
+        # frequency_penalty per the official API contract. fixed_temperature
+        # would normally set temperature; ensure it gets stripped when
+        # thinking is enabled.
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek=True,
+            fixed_temperature=0.5,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "temperature" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_deepseek_thinking_disabled_keeps_temperature(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek=True,
+            reasoning_config={"enabled": False},
+            fixed_temperature=0.5,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["temperature"] == 0.5
+
+    def test_non_deepseek_unaffected(self, transport):
+        """is_deepseek flag must be opt-in — other providers stay untouched."""
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+            reasoning_config={"effort": "high"},
+            fixed_temperature=0.5,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # No DeepSeek-specific surgery on non-deepseek calls
+        assert kw["temperature"] == 0.5
+        assert "thinking" not in kw.get("extra_body", {})
+        # reasoning_effort is only emitted by Kimi/DeepSeek branches
+        assert "reasoning_effort" not in kw
+
+
 class TestChatCompletionsValidate:
 
     def test_none(self, transport):


### PR DESCRIPTION
## Summary

Follow-up to #14934 / #14946 / #14952. With V4 ids resolvable end-to-end, the remaining gap is that `reasoning_effort` is a no-op on the native DeepSeek provider — the value never reached the request, and thinking mode was only selectable via the soon-to-be-deprecated `deepseek-reasoner` alias trick.

### Official V4 contract

DeepSeek V4 exposes thinking mode as an explicit API contract (<https://api-docs.deepseek.com/guides/thinking_mode>):

| Signal          | Location                  | Values                                       | Default                        |
| --------------- | ------------------------- | -------------------------------------------- | ------------------------------ |
| Thinking toggle | `extra_body.thinking`     | `{"type": "enabled"}` / `{"type": "disabled"}` | `enabled`                      |
| Effort level    | top-level `reasoning_effort` | `"high"` / `"max"`                         | `"high"` (auto `"max"` for complex agents) |

Thinking mode forbids `temperature`, `top_p`, `presence_penalty`, `frequency_penalty` — these must be stripped when enabled.

### Hermes → DeepSeek effort mapping

Hermes uses a 5-level vocabulary (`low`/`medium`/`high`/`xhigh` + implicit `max`). DeepSeek only accepts two values, so this PR maps:

| Hermes `reasoning_effort` | → DeepSeek `reasoning_effort` |
| ------------------------- | ----------------------------- |
| `low`                     | `high`                        |
| `medium`                  | `high`                        |
| `high`                    | `high`                        |
| `xhigh`                   | `max`                         |
| `max`                     | `max`                         |
| _(thinking disabled)_     | _omitted_                     |

This matches the "compatibility mapping" DeepSeek already documents for external clients.

### Changes

- [agent/transports/chat_completions.py](agent/transports/chat_completions.py) — new `is_deepseek` branch, effort mapping, incompatible-param strip. Structure mirrors the existing Kimi branch one screen up.
- [run_agent.py](run_agent.py) — `_is_deepseek` detection (hostname `api.deepseek.com`) + plumb through `build_kwargs`, symmetric with Kimi / OpenRouter / Nous / NVIDIA NIM detection.
- [tests/agent/transports/test_chat_completions.py](tests/agent/transports/test_chat_completions.py) — new `TestChatCompletionsDeepSeek` covering default-enabled thinking, explicit disable, effort mapping (all 5 inputs + case/whitespace tolerance), unknown-effort fallback, sampling-param stripping, temperature preservation when thinking disabled, and non-`is_deepseek` isolation.

## Test plan

- [x] `pytest tests/agent/transports/test_chat_completions.py` — 54 passed (13 new + 41 pre-existing)
- [x] **Live against `api.deepseek.com`**:
    - `deepseek-v4-pro` + `reasoning_effort=xhigh` (→ `max`) + thinking enabled → HTTP 200, `reasoning_content` populated (167 chars, thinking mode actually ran), `temperature` correctly omitted
    - `deepseek-v4-flash` + `reasoning.enabled=False` → HTTP 200, `reasoning_content` empty (thinking off), `temperature=0.5` preserved and accepted by the server