### PR TITLE
fix(providers): register alibaba-coding-plan as a first-class provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -210,6 +210,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("DASHSCOPE_API_KEY",),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
+    "alibaba-coding-plan": ProviderConfig(
+        id="alibaba-coding-plan",
+        name="Alibaba Cloud (Coding Plan)",
+        auth_type="api_key",
+        inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+        api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
+        base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
+    ),
     "minimax-cn": ProviderConfig(
         id="minimax-cn",
         name="MiniMax (China)",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -110,6 +110,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
+    "alibaba-coding-plan": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
+    ),
     "vercel": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -249,6 +253,9 @@ ALIASES: Dict[str, str] = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "alibaba_coding": "alibaba-coding-plan",
+    "alibaba-coding": "alibaba-coding-plan",
+    "alibaba_coding_plan": "alibaba-coding-plan",
 
     # google-gemini-cli (OAuth + Code Assist)
     "gemini-cli": "google-gemini-cli",


### PR DESCRIPTION
## Problem

The `alibaba-coding-plan` provider (`coding-intl.dashscope.aliyuncs.com/v1`) was not registered in `providers.py` or `auth.py`. When users set `provider: alibaba_coding` or `provider: alibaba-coding-plan` in `config.yaml`, Hermes could not resolve credentials and fell back to OpenRouter (HTTP 402) or rejected with HTTP 401.

## Fix

- `providers.py`: add `HermesOverlay` for `alibaba-coding-plan` + aliases (`alibaba_coding`, `alibaba-coding`, `alibaba_coding_plan`)
- `auth.py`: add `ProviderConfig` with correct endpoint (`coding-intl.dashscope.aliyuncs.com/v1`) and env vars (`ALIBABA_CODING_PLAN_API_KEY`, `DASHSCOPE_API_KEY`)

Fixes #14940