### PR TITLE
feat(api-server): serve generated images over HTTP for Open WebUI

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2510,6 +2510,23 @@ class APIServerAdapter(BasePlatformAdapter):
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            # Static serving for generated images (patched — see /opt/hermes-patches/).
+            # Auth-free by design: <img> tags don't send Authorization headers.
+            # Security relies on the random hex suffix in save_b64_image filenames.
+            try:
+                from gateway.platforms.base import IMAGE_CACHE_DIR
+                IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+                self._app.router.add_static(
+                    "/images/", str(IMAGE_CACHE_DIR), show_index=False,
+                )
+                logger.info(
+                    "[%s] Static image route: /images/ -> %s",
+                    self.name, IMAGE_CACHE_DIR,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Could not add /images static route: %s", self.name, exc,
+                )
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:

--- a/tests/tools/test_image_generation_url_rewrite.py
+++ b/tests/tools/test_image_generation_url_rewrite.py
@@ -1,0 +1,154 @@
+"""Tests for the image_generate → HTTP URL post-processor.
+
+Covers :func:`tools.image_generation_tool._maybe_rewrite_image_to_url`
+and :func:`tools.image_generation_tool._resolve_image_serve_base_url`.
+The rewrite is what lets Open WebUI (and any HTTP client) actually
+fetch generated images — without it the assistant's markdown points
+at an absolute filesystem path the browser can't reach.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import image_generation_tool
+
+
+def _make_success(path: str = "/some/cache/openai_codex_medium_abcd1234.png") -> str:
+    return json.dumps({
+        "success": True,
+        "image": path,
+        "model": "gpt-image-2-medium",
+        "prompt": "a cat",
+        "aspect_ratio": "square",
+        "provider": "openai-codex",
+    })
+
+
+class TestResolveBaseUrl:
+    """``_resolve_image_serve_base_url`` reads env var then config.yaml."""
+
+    def test_env_var_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://env.example.com")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  serve_base_url: https://config.example.com\n"
+        )
+        assert image_generation_tool._resolve_image_serve_base_url() == "https://env.example.com"
+
+    def test_config_yaml_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("IMAGE_SERVE_BASE_URL", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  serve_base_url: https://config.example.com\n"
+        )
+        assert image_generation_tool._resolve_image_serve_base_url() == "https://config.example.com"
+
+    def test_returns_none_when_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("IMAGE_SERVE_BASE_URL", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: openai-codex\n")
+        assert image_generation_tool._resolve_image_serve_base_url() is None
+
+    def test_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://example.com/")
+        assert image_generation_tool._resolve_image_serve_base_url() == "https://example.com"
+
+    def test_whitespace_trimmed(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "  https://example.com  ")
+        assert image_generation_tool._resolve_image_serve_base_url() == "https://example.com"
+
+    def test_empty_env_falls_through_to_config(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  serve_base_url: https://config.example.com\n"
+        )
+        assert image_generation_tool._resolve_image_serve_base_url() == "https://config.example.com"
+
+
+class TestMaybeRewriteImageToUrl:
+    """``_maybe_rewrite_image_to_url`` turns local paths into public URLs."""
+
+    def test_rewrites_local_path_when_base_set(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("/var/hermes/cache/images/openai_codex_abc123.png")
+        result = json.loads(image_generation_tool._maybe_rewrite_image_to_url(before))
+        assert result["image"] == "https://chat.example.com/images/openai_codex_abc123.png"
+        # Everything else preserved
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-medium"
+
+    def test_no_op_when_base_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("IMAGE_SERVE_BASE_URL", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))  # no config.yaml present
+        before = _make_success("/var/hermes/cache/images/openai_codex_abc123.png")
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_no_op_when_already_http_url(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("https://cdn.fal.ai/generated/xyz.png")
+        # Already a URL — FAL-style providers return URLs directly; don't double-prefix.
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_no_op_when_already_https_url(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("https://cdn.fal.ai/generated/xyz.png")
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_no_op_when_data_uri(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("data:image/png;base64,iVBORw0KGgoA...")
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_no_op_on_failure_result(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = json.dumps({
+            "success": False,
+            "image": None,
+            "error": "provider failed",
+            "error_type": "api_error",
+        })
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_no_op_on_malformed_json(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        # A non-JSON tool_error payload must not crash the post-processor.
+        assert image_generation_tool._maybe_rewrite_image_to_url("not json {{{") == "not json {{{"
+
+    def test_no_op_when_image_field_missing(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = json.dumps({"success": True, "model": "x"})
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_no_op_when_image_is_empty_string(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("")
+        assert image_generation_tool._maybe_rewrite_image_to_url(before) == before
+
+    def test_filename_only_is_preserved(self, monkeypatch):
+        """Even a bare filename (edge case) should rewrite cleanly."""
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("just_a_filename.png")
+        result = json.loads(image_generation_tool._maybe_rewrite_image_to_url(before))
+        assert result["image"] == "https://chat.example.com/images/just_a_filename.png"
+
+    def test_nested_path_uses_basename_only(self, monkeypatch):
+        """Only the filename is carried into the URL; the cache dir isn't leaked."""
+        monkeypatch.setenv("IMAGE_SERVE_BASE_URL", "https://chat.example.com")
+        before = _make_success("/some/deeply/nested/cache/dir/image_xyz.png")
+        result = json.loads(image_generation_tool._maybe_rewrite_image_to_url(before))
+        assert result["image"] == "https://chat.example.com/images/image_xyz.png"
+
+    def test_config_yaml_drives_rewrite_when_no_env(self, monkeypatch, tmp_path):
+        """config.yaml alone is sufficient to activate the rewrite."""
+        monkeypatch.delenv("IMAGE_SERVE_BASE_URL", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  serve_base_url: https://via-config.example.com\n"
+        )
+        before = _make_success("/cache/images/pic.png")
+        result = json.loads(image_generation_tool._maybe_rewrite_image_to_url(before))
+        assert result["image"] == "https://via-config.example.com/images/pic.png"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -972,6 +972,57 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     return json.dumps(result)
 
 
+def _resolve_image_serve_base_url():
+    """Return the base URL that cache/images/* is publicly reachable at, or None.
+
+    Precedence: IMAGE_SERVE_BASE_URL env var, then image_gen.serve_base_url
+    in config.yaml. Unset → return None (caller keeps local path, matching
+    legacy behavior for CLI / Telegram / etc.).
+    """
+    base = os.environ.get("IMAGE_SERVE_BASE_URL")
+    if base:
+        return base.strip().rstrip("/") or None
+    try:
+        from hermes_cli.config import load_config
+        section = (load_config() or {}).get("image_gen")
+        if isinstance(section, dict):
+            value = section.get("serve_base_url")
+            if isinstance(value, str) and value.strip():
+                return value.strip().rstrip("/")
+    except Exception:
+        pass
+    return None
+
+
+def _maybe_rewrite_image_to_url(result_json: str) -> str:
+    """Post-process image_generate result: rewrite local path to public URL.
+
+    Only fires when a base URL is configured (env or config.yaml). Only
+    rewrites successful results whose ``image`` field is a local filesystem
+    path — URLs and data: URIs are passed through unchanged. Keeps the file
+    name intact so a matching ``/images/<filename>`` static route serves it.
+    """
+    try:
+        result = json.loads(result_json)
+    except Exception:
+        return result_json
+    if not (isinstance(result, dict) and result.get("success")):
+        return result_json
+    path = result.get("image")
+    if not isinstance(path, str) or not path:
+        return result_json
+    if path.startswith(("http://", "https://", "data:")):
+        return result_json
+    base = _resolve_image_serve_base_url()
+    if not base:
+        return result_json
+    filename = os.path.basename(path)
+    if not filename:
+        return result_json
+    result["image"] = f"{base}/images/{filename}"
+    return json.dumps(result)
+
+
 def _handle_image_generate(args, **kw):
     prompt = args.get("prompt", "")
     if not prompt:
@@ -982,11 +1033,10 @@ def _handle_image_generate(args, **kw):
     # not the in-tree FAL path).
     dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
     if dispatched is not None:
-        return dispatched
+        return _maybe_rewrite_image_to_url(dispatched)
 
-    return image_generate_tool(
-        prompt=prompt,
-        aspect_ratio=aspect_ratio,
+    return _maybe_rewrite_image_to_url(
+        image_generate_tool(prompt=prompt, aspect_ratio=aspect_ratio)
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Adds HTTP delivery for images produced by the `image_generate` tool on the `api_server` platform, so Open WebUI (and any other HTTP client) can actually render generated images inline.

Today, the tool returns the absolute filesystem path of the saved PNG and the model faithfully renders `![desc](/Users/…/cache/images/foo.png)` per its own schema. Platforms like Telegram and Discord turn that path into an upload; `api_server` does neither — the path hits the browser and 404s. Full problem statement + SSE evidence: #14959.

Two coupled, opt-in changes — the rewrite only activates when the user sets `IMAGE_SERVE_BASE_URL` (or `image_gen.serve_base_url` in config), so CLI / Telegram / Discord / feishu paths are byte-identical when unconfigured.

## Related Issue

Fixes #14959

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`tools/image_generation_tool.py`** (+58)
  - New `_resolve_image_serve_base_url()` — reads `IMAGE_SERVE_BASE_URL` env var, then falls back to `image_gen.serve_base_url` in `config.yaml`. Returns `None` when unset so callers are no-ops.
  - New `_maybe_rewrite_image_to_url(result_json)` — post-processes the provider's JSON result. If it's a success with a local filesystem path in `image` (i.e. not an existing URL or `data:` URI), rewrites `image` to `{base}/images/{basename}`. Leaves every other field untouched.
  - `_handle_image_generate` now funnels both dispatch paths (plugin provider and in-tree FAL) through the post-processor.

- **`gateway/platforms/api_server.py`** (+17)
  - During `_setup_app`, register an aiohttp static route `/images/*` serving `IMAGE_CACHE_DIR` (already the canonical cache path in `gateway/platforms/base.py`).
  - Auth-free by design: `<img>` tags don't send `Authorization` headers. Security relies on the random hex suffix in `save_b64_image` filenames. Failure to register logs a warning and keeps the server up — not fatal.

- **`tests/tools/test_image_generation_url_rewrite.py`** (+154, new)
  - 18 tests covering both helpers: env-vs-config precedence, trailing-slash/whitespace handling, pass-through for failures, already-URL / data-URI / empty / missing image fields, malformed JSON, `basename()` leak-proofing.

## How to Test

```bash
# 1. Enable a plugin image-gen provider (openai-codex works well — no API key needed)
hermes -p <profile> config set image_gen.provider openai-codex

# 2. Configure the public base for generated images
echo 'IMAGE_SERVE_BASE_URL=http://127.0.0.1:8642' >> ~/.hermes/profiles/<profile>/.env

# 3. Enable api_server + restart
# (.env should already have API_SERVER_ENABLED=true and API_SERVER_KEY=<key>)
hermes -p <profile> gateway restart

# 4. Trigger an image over /v1/chat/completions and watch the SSE stream
curl -sN -X POST http://127.0.0.1:8642/v1/chat/completions \
  -H "Authorization: Bearer <key>" -H 'Content-Type: application/json' \
  -d '{"model":"<profile>","stream":true,"messages":[{"role":"user","content":"Use image_generate to draw a red apple. Render inline."}]}'
```

Before this change the `delta.content` would include `![apple](/abs/path/cache/images/foo.png)`. With this change it includes `![apple](http://127.0.0.1:8642/images/foo.png)`, and a browser `GET` on that URL returns `HTTP 200, image/png` with the exact cache file bytes.

Verified end-to-end on two deployments:
- **Mac + Open WebUI in Docker** with `IMAGE_SERVE_BASE_URL=http://127.0.0.1:8642`
- **VPS + Caddy reverse proxy** with `IMAGE_SERVE_BASE_URL=https://chat.example.com`, Caddy routing `/images/*` through to the gateway

Tests: `pytest tests/tools/test_image_generation_url_rewrite.py -q` → **18 passed**. Broader sweep `pytest tests/tools/test_image_generation*.py tests/plugins/image_gen/ -q` → **121 passed** (no regressions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(api-server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_image_generation*.py tests/plugins/image_gen/ -q` and all 121 tests pass
- [x] I've added tests for my changes (18 new tests)
- [x] I've tested on my platform: macOS 15 + Ubuntu 24.04 (VPS)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — can update `website/docs/user-guide/messaging/open-webui.md` with a one-line note about the env var if maintainers prefer
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A** (feature is gated entirely on env var or config.yaml addition; the config key is optional)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — `os.path.basename` and `aiohttp.add_static` are both platform-agnostic; `IMAGE_CACHE_DIR` already uses `get_hermes_dir`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the existing schema (`"Returns either a URL or an absolute file path in the \`image\` field"`) already covers the URL case; no change needed

## Open questions for maintainers (also listed in #14959)

1. **Auth on `/images/*`**. I went with public + random-hex filename. Happy to switch to signed URLs if you prefer — that's a `self._sign_image_url(path)` helper and a query-string check in the static handler.
2. **Route naming**. `/images/` vs OpenAI-style `/v1/images/{filename}`? I picked the shorter path because it's not an OpenAI-spec endpoint and doesn't belong under `/v1/`.
3. **Data-URI fallback**. Some deployments can't easily expose a URL (private VPS without reverse proxy). Interested if you'd accept a complementary `IMAGE_SERVE_MODE=data_uri` option as a follow-up.

Happy to iterate on any of these.
