### PR TITLE
feat(tui): per-section visibility for the details accordion

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -160,6 +160,71 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     assert saved["display"]["tui_statusbar"] == "bottom"
 
 
+def test_config_set_section_writes_per_section_override(tmp_path, monkeypatch):
+    import yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "details_mode.activity", "value": "hidden"},
+        }
+    )
+
+    assert resp["result"] == {"key": "details_mode.activity", "value": "hidden"}
+    saved = yaml.safe_load(cfg_path.read_text())
+    assert saved["display"]["sections"] == {"activity": "hidden"}
+
+
+def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch):
+    import yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {"display": {"sections": {"activity": "hidden", "tools": "expanded"}}}
+        )
+    )
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "details_mode.activity", "value": ""},
+        }
+    )
+
+    assert resp["result"] == {"key": "details_mode.activity", "value": ""}
+    saved = yaml.safe_load(cfg_path.read_text())
+    assert saved["display"]["sections"] == {"tools": "expanded"}
+
+
+def test_config_set_section_rejects_unknown_section_or_mode(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    bad_section = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "details_mode.bogus", "value": "hidden"},
+        }
+    )
+    assert bad_section["error"]["code"] == 4002
+
+    bad_mode = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {"key": "details_mode.tools", "value": "maximised"},
+        }
+    )
+    assert bad_mode["error"]["code"] == 4002
+
+
 def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):
     monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2642,6 +2642,41 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.details_mode", nv)
         return _ok(rid, {"key": key, "value": nv})
 
+    if key.startswith("details_mode."):
+        # Per-section override: `details_mode.<section>` writes to
+        # `display.sections.<section>`.  Empty value clears the override
+        # and lets the section fall back to the global details_mode.
+        section = key.split(".", 1)[1]
+        allowed_sections = frozenset({"thinking", "tools", "subagents", "activity"})
+        if section not in allowed_sections:
+            return _err(rid, 4002, f"unknown section: {section}")
+
+        cfg = _load_cfg()
+        display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
+        sections_cfg = (
+            display.get("sections")
+            if isinstance(display.get("sections"), dict)
+            else {}
+        )
+
+        nv = str(value or "").strip().lower()
+        if not nv:
+            sections_cfg.pop(section, None)
+            display["sections"] = sections_cfg
+            cfg["display"] = display
+            _save_cfg(cfg)
+            return _ok(rid, {"key": key, "value": ""})
+
+        allowed_dm = frozenset({"hidden", "collapsed", "expanded"})
+        if nv not in allowed_dm:
+            return _err(rid, 4002, f"unknown details_mode: {value}")
+
+        sections_cfg[section] = nv
+        display["sections"] = sections_cfg
+        cfg["display"] = display
+        _save_cfg(cfg)
+        return _ok(rid, {"key": key, "value": nv})
+
     if key == "thinking_mode":
         nv = str(value or "").strip().lower()
         allowed_tm = frozenset({"collapsed", "truncated", "full"})

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -88,6 +88,41 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('details: expanded')
   })
 
+  it('sets a per-section override and persists it under details_mode.<section>', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/details activity hidden')).toBe(true)
+    expect(getUiState().sections.activity).toBe('hidden')
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
+      key: 'details_mode.activity',
+      value: 'hidden'
+    })
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('details activity: hidden')
+  })
+
+  it('clears a per-section override on /details <section> reset', () => {
+    const ctx = buildCtx()
+    createSlashHandler(ctx)('/details tools expanded')
+    expect(getUiState().sections.tools).toBe('expanded')
+
+    createSlashHandler(ctx)('/details tools reset')
+    expect(getUiState().sections.tools).toBeUndefined()
+    expect(ctx.gateway.rpc).toHaveBeenLastCalledWith('config.set', {
+      key: 'details_mode.tools',
+      value: ''
+    })
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('details tools: reset')
+  })
+
+  it('rejects unknown section modes with a usage hint', () => {
+    const ctx = buildCtx()
+    createSlashHandler(ctx)('/details tools blink')
+    expect(getUiState().sections.tools).toBeUndefined()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(
+      'usage: /details <section> [hidden|collapsed|expanded|reset]'
+    )
+  })
+
   it('shows tool enable usage when names are missing', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/details.test.ts
+++ b/ui-tui/src/__tests__/details.test.ts
@@ -90,4 +90,13 @@ describe('sectionMode', () => {
     expect(sectionMode('activity', 'expanded', { activity: 'collapsed' })).toBe('collapsed')
     expect(sectionMode('tools', 'collapsed', { tools: 'expanded' })).toBe('expanded')
   })
+
+  it('lets per-section overrides escape the global hidden mode', () => {
+    // Regression for the case where global details_mode: hidden used to
+    // short-circuit the entire accordion and prevent overrides from
+    // surfacing — `sections.tools: expanded` must still resolve to expanded.
+    expect(sectionMode('tools', 'hidden', { tools: 'expanded' })).toBe('expanded')
+    expect(sectionMode('thinking', 'hidden', { thinking: 'collapsed' })).toBe('collapsed')
+    expect(sectionMode('activity', 'hidden', { activity: 'expanded' })).toBe('expanded')
+  })
 })

--- a/ui-tui/src/__tests__/details.test.ts
+++ b/ui-tui/src/__tests__/details.test.ts
@@ -72,13 +72,22 @@ describe('resolveSections', () => {
 })
 
 describe('sectionMode', () => {
-  it('falls back to the global mode when no override is set', () => {
+  it('falls back to the global mode for sections without a built-in default', () => {
     expect(sectionMode('tools', 'collapsed', {})).toBe('collapsed')
     expect(sectionMode('tools', 'expanded', undefined)).toBe('expanded')
+    expect(sectionMode('thinking', 'collapsed', {})).toBe('collapsed')
+    expect(sectionMode('subagents', 'expanded', {})).toBe('expanded')
   })
 
-  it('honours per-section overrides over the global mode', () => {
-    expect(sectionMode('activity', 'expanded', { activity: 'hidden' })).toBe('hidden')
+  it('hides the activity panel by default regardless of global mode', () => {
+    expect(sectionMode('activity', 'collapsed', {})).toBe('hidden')
+    expect(sectionMode('activity', 'expanded', undefined)).toBe('hidden')
+    expect(sectionMode('activity', 'hidden', {})).toBe('hidden')
+  })
+
+  it('honours per-section overrides over both the section default and global mode', () => {
+    expect(sectionMode('activity', 'collapsed', { activity: 'expanded' })).toBe('expanded')
+    expect(sectionMode('activity', 'expanded', { activity: 'collapsed' })).toBe('collapsed')
     expect(sectionMode('tools', 'collapsed', { tools: 'expanded' })).toBe('expanded')
   })
 })

--- a/ui-tui/src/__tests__/details.test.ts
+++ b/ui-tui/src/__tests__/details.test.ts
@@ -73,10 +73,16 @@ describe('resolveSections', () => {
 
 describe('sectionMode', () => {
   it('falls back to the global mode for sections without a built-in default', () => {
-    expect(sectionMode('tools', 'collapsed', {})).toBe('collapsed')
-    expect(sectionMode('tools', 'expanded', undefined)).toBe('expanded')
-    expect(sectionMode('thinking', 'collapsed', {})).toBe('collapsed')
-    expect(sectionMode('subagents', 'expanded', {})).toBe('expanded')
+    expect(sectionMode('subagents', 'collapsed', {})).toBe('collapsed')
+    expect(sectionMode('subagents', 'expanded', undefined)).toBe('expanded')
+    expect(sectionMode('subagents', 'hidden', {})).toBe('hidden')
+  })
+
+  it('streams thinking + tools expanded by default regardless of global mode', () => {
+    expect(sectionMode('thinking', 'collapsed', {})).toBe('expanded')
+    expect(sectionMode('thinking', 'hidden', undefined)).toBe('expanded')
+    expect(sectionMode('tools', 'collapsed', {})).toBe('expanded')
+    expect(sectionMode('tools', 'hidden', undefined)).toBe('expanded')
   })
 
   it('hides the activity panel by default regardless of global mode', () => {
@@ -86,16 +92,17 @@ describe('sectionMode', () => {
   })
 
   it('honours per-section overrides over both the section default and global mode', () => {
+    expect(sectionMode('thinking', 'collapsed', { thinking: 'collapsed' })).toBe('collapsed')
+    expect(sectionMode('tools', 'collapsed', { tools: 'hidden' })).toBe('hidden')
     expect(sectionMode('activity', 'collapsed', { activity: 'expanded' })).toBe('expanded')
     expect(sectionMode('activity', 'expanded', { activity: 'collapsed' })).toBe('collapsed')
-    expect(sectionMode('tools', 'collapsed', { tools: 'expanded' })).toBe('expanded')
   })
 
   it('lets per-section overrides escape the global hidden mode', () => {
     // Regression for the case where global details_mode: hidden used to
     // short-circuit the entire accordion and prevent overrides from
     // surfacing — `sections.tools: expanded` must still resolve to expanded.
-    expect(sectionMode('tools', 'hidden', { tools: 'expanded' })).toBe('expanded')
+    expect(sectionMode('subagents', 'hidden', { subagents: 'expanded' })).toBe('expanded')
     expect(sectionMode('thinking', 'hidden', { thinking: 'collapsed' })).toBe('collapsed')
     expect(sectionMode('activity', 'hidden', { activity: 'expanded' })).toBe('expanded')
   })

--- a/ui-tui/src/__tests__/details.test.ts
+++ b/ui-tui/src/__tests__/details.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSectionName, parseDetailsMode, resolveSections, sectionMode, SECTION_NAMES } from '../domain/details.js'
+
+describe('parseDetailsMode', () => {
+  it('accepts the canonical modes case-insensitively', () => {
+    expect(parseDetailsMode('hidden')).toBe('hidden')
+    expect(parseDetailsMode(' COLLAPSED ')).toBe('collapsed')
+    expect(parseDetailsMode('Expanded')).toBe('expanded')
+  })
+
+  it('rejects junk', () => {
+    expect(parseDetailsMode('truncated')).toBeNull()
+    expect(parseDetailsMode('')).toBeNull()
+    expect(parseDetailsMode(undefined)).toBeNull()
+    expect(parseDetailsMode(42)).toBeNull()
+  })
+})
+
+describe('isSectionName', () => {
+  it('only lets the four canonical sections through', () => {
+    expect(isSectionName('thinking')).toBe(true)
+    expect(isSectionName('tools')).toBe(true)
+    expect(isSectionName('subagents')).toBe(true)
+    expect(isSectionName('activity')).toBe(true)
+
+    expect(isSectionName('Thinking')).toBe(false) // case-sensitive on purpose
+    expect(isSectionName('bogus')).toBe(false)
+    expect(isSectionName('')).toBe(false)
+    expect(isSectionName(7)).toBe(false)
+  })
+
+  it('SECTION_NAMES exposes them all', () => {
+    expect([...SECTION_NAMES].sort()).toEqual(['activity', 'subagents', 'thinking', 'tools'])
+  })
+})
+
+describe('resolveSections', () => {
+  it('parses a well-formed sections object', () => {
+    expect(
+      resolveSections({
+        thinking: 'expanded',
+        tools: 'expanded',
+        subagents: 'collapsed',
+        activity: 'hidden'
+      })
+    ).toEqual({
+      thinking: 'expanded',
+      tools: 'expanded',
+      subagents: 'collapsed',
+      activity: 'hidden'
+    })
+  })
+
+  it('drops unknown section names and unknown modes', () => {
+    expect(
+      resolveSections({
+        thinking: 'expanded',
+        tools: 'maximised',
+        bogus: 'hidden',
+        activity: 'hidden'
+      })
+    ).toEqual({ thinking: 'expanded', activity: 'hidden' })
+  })
+
+  it('treats nullish/non-objects as empty overrides', () => {
+    expect(resolveSections(undefined)).toEqual({})
+    expect(resolveSections(null)).toEqual({})
+    expect(resolveSections('hidden')).toEqual({})
+    expect(resolveSections([])).toEqual({})
+  })
+})
+
+describe('sectionMode', () => {
+  it('falls back to the global mode when no override is set', () => {
+    expect(sectionMode('tools', 'collapsed', {})).toBe('collapsed')
+    expect(sectionMode('tools', 'expanded', undefined)).toBe('expanded')
+  })
+
+  it('honours per-section overrides over the global mode', () => {
+    expect(sectionMode('activity', 'expanded', { activity: 'hidden' })).toBe('hidden')
+    expect(sectionMode('tools', 'collapsed', { tools: 'expanded' })).toBe('expanded')
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -62,6 +62,53 @@ describe('applyDisplay', () => {
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
+    expect(s.sections).toEqual({})
+  })
+
+  it('parses display.sections into per-section overrides', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          display: {
+            details_mode: 'collapsed',
+            sections: {
+              activity: 'hidden',
+              tools: 'expanded',
+              thinking: 'expanded',
+              bogus: 'expanded'
+            }
+          }
+        }
+      },
+      setBell
+    )
+
+    const s = $uiState.get()
+    expect(s.detailsMode).toBe('collapsed')
+    expect(s.sections).toEqual({
+      activity: 'hidden',
+      tools: 'expanded',
+      thinking: 'expanded'
+    })
+  })
+
+  it('drops invalid section modes', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          display: {
+            sections: { tools: 'maximised' as unknown as string, activity: 'hidden' }
+          }
+        }
+      },
+      setBell
+    )
+
+    expect($uiState.get().sections).toEqual({ activity: 'hidden' })
   })
 
   it('treats a null config like an empty display block', () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -16,6 +16,7 @@ import type {
   Msg,
   PanelSection,
   SecretReq,
+  SectionVisibility,
   SessionInfo,
   SlashCatalog,
   SubagentProgress,
@@ -87,6 +88,7 @@ export interface UiState {
   detailsMode: DetailsMode
   info: null | SessionInfo
   inlineDiffs: boolean
+  sections: SectionVisibility
   showCost: boolean
   showReasoning: boolean
   sid: null | string

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -1,7 +1,7 @@
 import { NO_CONFIRM_DESTRUCTIVE } from '../../../config/env.js'
 import { dailyFortune, randomFortune } from '../../../content/fortunes.js'
 import { HOTKEYS } from '../../../content/hotkeys.js'
-import { isSectionName, nextDetailsMode, parseDetailsMode, SECTION_NAMES } from '../../../domain/details.js'
+import { SECTION_NAMES, isSectionName, nextDetailsMode, parseDetailsMode } from '../../../domain/details.js'
 import type {
   ConfigGetValueResponse,
   ConfigSetResponse,
@@ -62,7 +62,10 @@ export const coreCommands: SlashCommand[] = [
         {
           rows: [
             ['/details [hidden|collapsed|expanded|cycle]', 'set global agent detail visibility mode'],
-            ['/details <section> [hidden|collapsed|expanded|reset]', 'override one section (thinking/tools/subagents/activity)'],
+            [
+              '/details <section> [hidden|collapsed|expanded|reset]',
+              'override one section (thinking/tools/subagents/activity)'
+            ],
             ['/fortune [random|daily]', 'show a random or daily local fortune']
           ],
           title: 'TUI'
@@ -159,8 +162,7 @@ export const coreCommands: SlashCommand[] = [
             const mode = parseDetailsMode(r?.value) ?? ui.detailsMode
             patchUiState({ detailsMode: mode })
 
-            const overrides = SECTION_NAMES
-              .filter(s => ui.sections[s])
+            const overrides = SECTION_NAMES.filter(s => ui.sections[s])
               .map(s => `${s}=${ui.sections[s]}`)
               .join(' ')
 

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../../gatewayTypes.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
-import type { DetailsMode, Msg, PanelSection, SectionName } from '../../../types.js'
+import type { Msg, PanelSection } from '../../../types.js'
 import type { StatusBarMode } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
@@ -38,7 +38,11 @@ const flagFromArg = (arg: string, current: boolean): boolean | null => {
   return null
 }
 
-const DETAIL_MODES = new Set(['collapsed', 'cycle', 'expanded', 'hidden', 'toggle'])
+const RESET_WORDS = new Set(['reset', 'clear', 'default'])
+const CYCLE_WORDS = new Set(['cycle', 'toggle'])
+const DETAILS_USAGE =
+  'usage: /details [hidden|collapsed|expanded|cycle]  or  /details <section> [hidden|collapsed|expanded|reset]'
+const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expanded|reset]'
 
 export const coreCommands: SlashCommand[] = [
   {
@@ -150,9 +154,7 @@ export const coreCommands: SlashCommand[] = [
         gateway
           .rpc<ConfigGetValueResponse>('config.get', { key: 'details_mode' })
           .then(r => {
-            if (ctx.stale()) {
-              return
-            }
+            if (ctx.stale()) return
 
             const mode = parseDetailsMode(r?.value) ?? ui.detailsMode
             patchUiState({ detailsMode: mode })
@@ -164,58 +166,37 @@ export const coreCommands: SlashCommand[] = [
 
             transcript.sys(`details: ${mode}${overrides ? `  (${overrides})` : ''}`)
           })
-          .catch(() => {
-            if (!ctx.stale()) {
-              transcript.sys(`details: ${ui.detailsMode}`)
-            }
-          })
+          .catch(() => !ctx.stale() && transcript.sys(`details: ${ui.detailsMode}`))
 
         return
       }
 
-      const tokens = arg.trim().toLowerCase().split(/\s+/)
+      const [first, second] = arg.trim().toLowerCase().split(/\s+/)
 
-      // Per-section override: `/details <section> <mode>`
-      if (tokens.length >= 2 && isSectionName(tokens[0])) {
-        const section = tokens[0] as SectionName
-        const action = tokens[1] ?? ''
+      if (second && isSectionName(first)) {
+        const reset = RESET_WORDS.has(second)
+        const mode = reset ? null : parseDetailsMode(second)
 
-        if (action === 'reset' || action === 'clear' || action === 'default') {
-          const { [section]: _drop, ...rest } = ui.sections
-          patchUiState({ sections: rest })
-          gateway
-            .rpc<ConfigSetResponse>('config.set', { key: `details_mode.${section}`, value: '' })
-            .catch(() => {})
-          transcript.sys(`details ${section}: reset`)
-
-          return
+        if (!reset && !mode) {
+          return transcript.sys(DETAILS_SECTION_USAGE)
         }
 
-        const sectionMode = parseDetailsMode(action)
+        const { [first]: _drop, ...rest } = ui.sections
 
-        if (!sectionMode) {
-          return transcript.sys('usage: /details <section> [hidden|collapsed|expanded|reset]')
-        }
-
-        patchUiState({ sections: { ...ui.sections, [section]: sectionMode } })
+        patchUiState({ sections: mode ? { ...rest, [first]: mode } : rest })
         gateway
-          .rpc<ConfigSetResponse>('config.set', { key: `details_mode.${section}`, value: sectionMode })
+          .rpc<ConfigSetResponse>('config.set', { key: `details_mode.${first}`, value: mode ?? '' })
           .catch(() => {})
-        transcript.sys(`details ${section}: ${sectionMode}`)
+        transcript.sys(`details ${first}: ${mode ?? 'reset'}`)
 
         return
       }
 
-      // Global mode (existing behavior).
-      const mode = tokens[0] ?? ''
+      const next = CYCLE_WORDS.has(first ?? '') ? nextDetailsMode(ui.detailsMode) : parseDetailsMode(first)
 
-      if (!DETAIL_MODES.has(mode)) {
-        return transcript.sys(
-          'usage: /details [hidden|collapsed|expanded|cycle]  or  /details <section> [hidden|collapsed|expanded|reset]'
-        )
+      if (!next) {
+        return transcript.sys(DETAILS_USAGE)
       }
-
-      const next = mode === 'cycle' || mode === 'toggle' ? nextDetailsMode(ui.detailsMode) : (mode as DetailsMode)
 
       patchUiState({ detailsMode: next })
       gateway.rpc<ConfigSetResponse>('config.set', { key: 'details_mode', value: next }).catch(() => {})

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -1,7 +1,7 @@
 import { NO_CONFIRM_DESTRUCTIVE } from '../../../config/env.js'
 import { dailyFortune, randomFortune } from '../../../content/fortunes.js'
 import { HOTKEYS } from '../../../content/hotkeys.js'
-import { nextDetailsMode, parseDetailsMode } from '../../../domain/details.js'
+import { isSectionName, nextDetailsMode, parseDetailsMode, SECTION_NAMES } from '../../../domain/details.js'
 import type {
   ConfigGetValueResponse,
   ConfigSetResponse,
@@ -10,7 +10,7 @@ import type {
 } from '../../../gatewayTypes.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
-import type { DetailsMode, Msg, PanelSection } from '../../../types.js'
+import type { DetailsMode, Msg, PanelSection, SectionName } from '../../../types.js'
 import type { StatusBarMode } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
@@ -57,7 +57,8 @@ export const coreCommands: SlashCommand[] = [
       sections.push(
         {
           rows: [
-            ['/details [hidden|collapsed|expanded|cycle]', 'set agent detail visibility mode'],
+            ['/details [hidden|collapsed|expanded|cycle]', 'set global agent detail visibility mode'],
+            ['/details <section> [hidden|collapsed|expanded|reset]', 'override one section (thinking/tools/subagents/activity)'],
             ['/fortune [random|daily]', 'show a random or daily local fortune']
           ],
           title: 'TUI'
@@ -140,7 +141,7 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['detail'],
-    help: 'control agent detail visibility',
+    help: 'control agent detail visibility (global or per-section)',
     name: 'details',
     run: (arg, ctx) => {
       const { gateway, transcript, ui } = ctx
@@ -154,9 +155,14 @@ export const coreCommands: SlashCommand[] = [
             }
 
             const mode = parseDetailsMode(r?.value) ?? ui.detailsMode
-
             patchUiState({ detailsMode: mode })
-            transcript.sys(`details: ${mode}`)
+
+            const overrides = SECTION_NAMES
+              .filter(s => ui.sections[s])
+              .map(s => `${s}=${ui.sections[s]}`)
+              .join(' ')
+
+            transcript.sys(`details: ${mode}${overrides ? `  (${overrides})` : ''}`)
           })
           .catch(() => {
             if (!ctx.stale()) {
@@ -167,10 +173,46 @@ export const coreCommands: SlashCommand[] = [
         return
       }
 
-      const mode = arg.trim().toLowerCase()
+      const tokens = arg.trim().toLowerCase().split(/\s+/)
+
+      // Per-section override: `/details <section> <mode>`
+      if (tokens.length >= 2 && isSectionName(tokens[0])) {
+        const section = tokens[0] as SectionName
+        const action = tokens[1] ?? ''
+
+        if (action === 'reset' || action === 'clear' || action === 'default') {
+          const { [section]: _drop, ...rest } = ui.sections
+          patchUiState({ sections: rest })
+          gateway
+            .rpc<ConfigSetResponse>('config.set', { key: `details_mode.${section}`, value: '' })
+            .catch(() => {})
+          transcript.sys(`details ${section}: reset`)
+
+          return
+        }
+
+        const sectionMode = parseDetailsMode(action)
+
+        if (!sectionMode) {
+          return transcript.sys('usage: /details <section> [hidden|collapsed|expanded|reset]')
+        }
+
+        patchUiState({ sections: { ...ui.sections, [section]: sectionMode } })
+        gateway
+          .rpc<ConfigSetResponse>('config.set', { key: `details_mode.${section}`, value: sectionMode })
+          .catch(() => {})
+        transcript.sys(`details ${section}: ${sectionMode}`)
+
+        return
+      }
+
+      // Global mode (existing behavior).
+      const mode = tokens[0] ?? ''
 
       if (!DETAIL_MODES.has(mode)) {
-        return transcript.sys('usage: /details [hidden|collapsed|expanded|cycle]')
+        return transcript.sys(
+          'usage: /details [hidden|collapsed|expanded|cycle]  or  /details <section> [hidden|collapsed|expanded|reset]'
+        )
       }
 
       const next = mode === 'cycle' || mode === 'toggle' ? nextDetailsMode(ui.detailsMode) : (mode as DetailsMode)

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -12,6 +12,7 @@ const buildUiState = (): UiState => ({
   detailsMode: 'collapsed',
   info: null,
   inlineDiffs: true,
+  sections: {},
   showCost: false,
   showReasoning: false,
   sid: null,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import { resolveDetailsMode } from '../domain/details.js'
+import { resolveDetailsMode, resolveSections } from '../domain/details.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
   ConfigFullResponse,
@@ -46,6 +46,7 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
     compact: !!d.tui_compact,
     detailsMode: resolveDetailsMode(d),
     inlineDiffs: d.inline_diffs !== false,
+    sections: resolveSections(d.sections),
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { STARTUP_RESUME_ID } from '../config/env.js'
 import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
+import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
 import { fmtCwdBranch, shortCwd } from '../domain/paths.js'
 import { type GatewayClient } from '../gatewayClient.js'
@@ -630,11 +631,15 @@ export function useMainApp(gw: GatewayClient) {
 
   const hasReasoning = Boolean(turn.reasoning.trim())
 
-  const showProgressArea =
-    ui.detailsMode === 'hidden'
-      ? turn.activity.some(item => item.tone !== 'info')
-      : Boolean(
-          ui.busy ||
+  // Per-section overrides win over the global mode — when every section is
+  // resolved to hidden, the only thing ToolTrail will surface is the
+  // floating-alert backstop (errors/warnings).  Mirror that so we don't
+  // render an empty wrapper Box above the streaming area in quiet mode.
+  const anyPanelVisible = SECTION_NAMES.some(s => sectionMode(s, ui.detailsMode, ui.sections) !== 'hidden')
+
+  const showProgressArea = anyPanelVisible
+    ? Boolean(
+        ui.busy ||
           turn.outcome ||
           turn.streamPendingTools.length ||
           turn.streamSegments.length ||
@@ -643,7 +648,8 @@ export function useMainApp(gw: GatewayClient) {
           turn.turnTrail.length ||
           hasReasoning ||
           turn.activity.length
-        )
+      )
+    : turn.activity.some(item => item.tone !== 'info')
 
   const appActions = useMemo(
     () => ({

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -8,7 +8,7 @@ import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStor
 import { $uiState } from '../app/uiStore.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import type { Theme } from '../theme.js'
-import type { DetailsMode } from '../types.js'
+import type { DetailsMode, SectionVisibility } from '../types.js'
 
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
@@ -25,6 +25,7 @@ const StreamingAssistant = memo(function StreamingAssistant({
   compact,
   detailsMode,
   progress,
+  sections,
   t
 }: StreamingAssistantProps) {
   if (!progress.showProgressArea && !progress.showStreamingArea) {
@@ -34,7 +35,15 @@ const StreamingAssistant = memo(function StreamingAssistant({
   return (
     <>
       {progress.streamSegments.map((msg, i) => (
-        <MessageLine cols={cols} compact={compact} detailsMode={detailsMode} key={`seg:${i}`} msg={msg} t={t} />
+        <MessageLine
+          cols={cols}
+          compact={compact}
+          detailsMode={detailsMode}
+          key={`seg:${i}`}
+          msg={msg}
+          sections={sections}
+          t={t}
+        />
       ))}
 
       {progress.showProgressArea && (
@@ -48,6 +57,7 @@ const StreamingAssistant = memo(function StreamingAssistant({
             reasoningActive={progress.reasoningActive}
             reasoningStreaming={progress.reasoningStreaming}
             reasoningTokens={progress.reasoningTokens}
+            sections={sections}
             subagents={progress.subagents}
             t={t}
             tools={progress.tools}
@@ -68,6 +78,7 @@ const StreamingAssistant = memo(function StreamingAssistant({
             text: progress.streaming,
             ...(progress.streamPendingTools.length && { tools: progress.streamPendingTools })
           }}
+          sections={sections}
           t={t}
         />
       )}
@@ -78,6 +89,7 @@ const StreamingAssistant = memo(function StreamingAssistant({
           compact={compact}
           detailsMode={detailsMode}
           msg={{ kind: 'trail', role: 'system', text: '', tools: progress.streamPendingTools }}
+          sections={sections}
           t={t}
         />
       )}
@@ -115,6 +127,7 @@ const TranscriptPane = memo(function TranscriptPane({
                   compact={ui.compact}
                   detailsMode={ui.detailsMode}
                   msg={row.msg}
+                  sections={ui.sections}
                   t={ui.theme}
                 />
               )}
@@ -129,6 +142,7 @@ const TranscriptPane = memo(function TranscriptPane({
             compact={ui.compact}
             detailsMode={ui.detailsMode}
             progress={progress}
+            sections={ui.sections}
             t={ui.theme}
           />
         </Box>
@@ -337,5 +351,6 @@ interface StreamingAssistantProps {
   compact?: boolean
   detailsMode: DetailsMode
   progress: AppLayoutProgressProps
+  sections?: SectionVisibility
   t: Theme
 }

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -1,6 +1,7 @@
 import { Ansi, Box, NoSelect, Text } from '@hermes/ink'
 import { memo } from 'react'
 
+import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { LONG_MSG } from '../config/limits.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
@@ -21,11 +22,16 @@ export const MessageLine = memo(function MessageLine({
   t
 }: MessageLineProps) {
   if (msg.kind === 'trail' && msg.tools?.length) {
-    return detailsMode === 'hidden' ? null : (
+    // Per-section overrides win over the global mode, so don't pre-empt on
+    // `detailsMode === 'hidden'` — only skip when EVERY section is hidden,
+    // matching ToolTrail's own internal short-circuit.
+    const anyVisible = SECTION_NAMES.some(s => sectionMode(s, detailsMode, sections) !== 'hidden')
+
+    return anyVisible ? (
       <Box flexDirection="column" marginTop={1}>
         <ToolTrail detailsMode={detailsMode} sections={sections} t={t} trail={msg.tools} />
       </Box>
-    )
+    ) : null
   }
 
   if (msg.role === 'tool') {

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -6,7 +6,7 @@ import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
 import { compactPreview, hasAnsi, isPasteBackedText, stripAnsi } from '../lib/text.js'
 import type { Theme } from '../theme.js'
-import type { DetailsMode, Msg } from '../types.js'
+import type { DetailsMode, Msg, SectionVisibility } from '../types.js'
 
 import { Md } from './markdown.js'
 import { ToolTrail } from './thinking.js'
@@ -17,12 +17,13 @@ export const MessageLine = memo(function MessageLine({
   detailsMode = 'collapsed',
   isStreaming = false,
   msg,
+  sections,
   t
 }: MessageLineProps) {
   if (msg.kind === 'trail' && msg.tools?.length) {
     return detailsMode === 'hidden' ? null : (
       <Box flexDirection="column" marginTop={1}>
-        <ToolTrail detailsMode={detailsMode} t={t} trail={msg.tools} />
+        <ToolTrail detailsMode={detailsMode} sections={sections} t={t} trail={msg.tools} />
       </Box>
     )
   }
@@ -98,6 +99,7 @@ export const MessageLine = memo(function MessageLine({
             detailsMode={detailsMode}
             reasoning={thinking}
             reasoningTokens={msg.thinkingTokens}
+            sections={sections}
             t={t}
             toolTokens={msg.toolTokens}
             trail={msg.tools}
@@ -124,5 +126,6 @@ interface MessageLineProps {
   detailsMode?: DetailsMode
   isStreaming?: boolean
   msg: Msg
+  sections?: SectionVisibility
   t: Theme
 }

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -1,7 +1,7 @@
 import { Ansi, Box, NoSelect, Text } from '@hermes/ink'
 import { memo } from 'react'
 
-import { SECTION_NAMES, sectionMode } from '../domain/details.js'
+import { sectionMode } from '../domain/details.js'
 import { LONG_MSG } from '../config/limits.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
@@ -21,13 +21,19 @@ export const MessageLine = memo(function MessageLine({
   sections,
   t
 }: MessageLineProps) {
-  if (msg.kind === 'trail' && msg.tools?.length) {
-    // Per-section overrides win over the global mode, so don't pre-empt on
-    // `detailsMode === 'hidden'` — only skip when EVERY section is hidden,
-    // matching ToolTrail's own internal short-circuit.
-    const anyVisible = SECTION_NAMES.some(s => sectionMode(s, detailsMode, sections) !== 'hidden')
+  // Per-section overrides win over the global mode, so resolve each section
+  // we might consume here once and gate visibility on the *content-bearing*
+  // sections only — never on the global mode.  A `trail` message feeds Tool
+  // calls + Activity; an assistant message with thinking/tools metadata
+  // feeds Thinking + Tool calls.  Gating on every section would let
+  // `thinking` (expanded by default) keep an empty wrapper alive when only
+  // `tools` is hidden — exactly the empty-Box bug Copilot caught.
+  const thinkingMode = sectionMode('thinking', detailsMode, sections)
+  const toolsMode = sectionMode('tools', detailsMode, sections)
+  const activityMode = sectionMode('activity', detailsMode, sections)
 
-    return anyVisible ? (
+  if (msg.kind === 'trail' && msg.tools?.length) {
+    return toolsMode !== 'hidden' || activityMode !== 'hidden' ? (
       <Box flexDirection="column" marginTop={1}>
         <ToolTrail detailsMode={detailsMode} sections={sections} t={t} trail={msg.tools} />
       </Box>
@@ -56,7 +62,10 @@ export const MessageLine = memo(function MessageLine({
 
   const { body, glyph, prefix } = ROLE[msg.role](t)
   const thinking = msg.thinking?.trim() ?? ''
-  const showDetails = detailsMode !== 'hidden' && (Boolean(msg.tools?.length) || Boolean(thinking))
+
+  const showDetails =
+    (toolsMode !== 'hidden' && Boolean(msg.tools?.length)) ||
+    (thinkingMode !== 'hidden' && Boolean(thinking))
 
   const content = (() => {
     if (msg.kind === 'slash') {

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -1,5 +1,5 @@
 import { Box, NoSelect, Text } from '@hermes/ink'
-import { memo, type ReactNode, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo, useState, type ReactNode } from 'react'
 import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
 import { THINKING_COT_MAX } from '../config/limits.js'
@@ -874,18 +874,22 @@ export const ToolTrail = memo(function ToolTrail({
   const delegateGroups = groups.filter(g => g.label.startsWith('Delegate Task'))
   const inlineDelegateKey = hasSubagents && delegateGroups.length === 1 ? delegateGroups[0]!.key : null
 
-  // ── Hidden: errors/warnings only ──────────────────────────────
+  // ── Backstop: floating alerts when every panel is hidden ─────────
   //
-  // When the global details_mode is 'hidden' (or all sections are individually
-  // hidden), the accordion collapses entirely.  Errors/warnings still float
-  // as inline alerts UNLESS the activity section is explicitly hidden — that
-  // override means "I don't want to see meta at all", so respect it.
+  // Per-section overrides win over the global details_mode (they're computed
+  // by sectionMode), so we only collapse to nothing when EVERY section is
+  // resolved to hidden — that way `details_mode: hidden` + `sections.tools:
+  // expanded` still renders the tools panel.  When all panels are hidden
+  // AND ambient errors/warnings exist, surface them as a compact inline
+  // backstop so quiet-mode users aren't blind to failures.
 
-  if (detailsMode === 'hidden') {
-    if (visible.activity === 'hidden') {
-      return null
-    }
+  const allHidden =
+    visible.thinking === 'hidden' &&
+    visible.tools === 'hidden' &&
+    visible.subagents === 'hidden' &&
+    visible.activity === 'hidden'
 
+  if (allHidden) {
     const alerts = activity.filter(i => i.tone !== 'info').slice(-2)
 
     return alerts.length ? (

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -707,34 +707,39 @@ export const ToolTrail = memo(function ToolTrail({
   trail?: string[]
   activity?: ActivityItem[]
 }) {
-  const thinkingSection = sectionMode('thinking', detailsMode, sections)
-  const toolsSection = sectionMode('tools', detailsMode, sections)
-  const subagentsSection = sectionMode('subagents', detailsMode, sections)
-  const activitySection = sectionMode('activity', detailsMode, sections)
+  const visible = useMemo(
+    () => ({
+      thinking: sectionMode('thinking', detailsMode, sections),
+      tools: sectionMode('tools', detailsMode, sections),
+      subagents: sectionMode('subagents', detailsMode, sections),
+      activity: sectionMode('activity', detailsMode, sections)
+    }),
+    [detailsMode, sections]
+  )
 
   const [now, setNow] = useState(() => Date.now())
-  const [openThinking, setOpenThinking] = useState(thinkingSection === 'expanded')
-  const [openTools, setOpenTools] = useState(toolsSection === 'expanded')
-  const [openSubagents, setOpenSubagents] = useState(subagentsSection === 'expanded')
-  const [deepSubagents, setDeepSubagents] = useState(subagentsSection === 'expanded')
-  const [openMeta, setOpenMeta] = useState(activitySection === 'expanded')
+  const [openThinking, setOpenThinking] = useState(visible.thinking === 'expanded')
+  const [openTools, setOpenTools] = useState(visible.tools === 'expanded')
+  const [openSubagents, setOpenSubagents] = useState(visible.subagents === 'expanded')
+  const [deepSubagents, setDeepSubagents] = useState(visible.subagents === 'expanded')
+  const [openMeta, setOpenMeta] = useState(visible.activity === 'expanded')
 
   useEffect(() => {
-    if (!tools.length || (toolsSection !== 'expanded' && !openTools)) {
+    if (!tools.length || (visible.tools !== 'expanded' && !openTools)) {
       return
     }
 
     const id = setInterval(() => setNow(Date.now()), 500)
 
     return () => clearInterval(id)
-  }, [toolsSection, openTools, tools.length])
+  }, [openTools, tools.length, visible.tools])
 
   useEffect(() => {
-    setOpenThinking(thinkingSection === 'expanded')
-    setOpenTools(toolsSection === 'expanded')
-    setOpenSubagents(subagentsSection === 'expanded')
-    setOpenMeta(activitySection === 'expanded')
-  }, [thinkingSection, toolsSection, subagentsSection, activitySection])
+    setOpenThinking(visible.thinking === 'expanded')
+    setOpenTools(visible.tools === 'expanded')
+    setOpenSubagents(visible.subagents === 'expanded')
+    setOpenMeta(visible.activity === 'expanded')
+  }, [visible])
 
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 
@@ -877,7 +882,7 @@ export const ToolTrail = memo(function ToolTrail({
   // override means "I don't want to see meta at all", so respect it.
 
   if (detailsMode === 'hidden') {
-    if (activitySection === 'hidden') {
+    if (visible.activity === 'hidden') {
       return null
     }
 
@@ -900,13 +905,13 @@ export const ToolTrail = memo(function ToolTrail({
   // hidden sections stay hidden so the override is honoured.
 
   const expandAll = () => {
-    if (thinkingSection !== 'hidden') setOpenThinking(true)
-    if (toolsSection !== 'hidden') setOpenTools(true)
-    if (subagentsSection !== 'hidden') {
+    if (visible.thinking !== 'hidden') setOpenThinking(true)
+    if (visible.tools !== 'hidden') setOpenTools(true)
+    if (visible.subagents !== 'hidden') {
       setOpenSubagents(true)
       setDeepSubagents(true)
     }
-    if (activitySection !== 'hidden') setOpenMeta(true)
+    if (visible.activity !== 'hidden') setOpenMeta(true)
   }
 
   const metaTone: 'dim' | 'error' | 'warn' = activity.some(i => i.tone === 'error')
@@ -920,7 +925,7 @@ export const ToolTrail = memo(function ToolTrail({
       {spawnTree.map((node, index) => (
         <SubagentAccordion
           branch={index === spawnTree.length - 1 ? 'last' : 'mid'}
-          expanded={subagentsSection === 'expanded' || deepSubagents}
+          expanded={visible.subagents === 'expanded' || deepSubagents}
           key={node.item.id}
           node={node}
           peak={spawnPeak}
@@ -938,7 +943,7 @@ export const ToolTrail = memo(function ToolTrail({
     render: (rails: boolean[]) => ReactNode
   }[] = []
 
-  if (hasThinking && thinkingSection !== 'hidden') {
+  if (hasThinking && visible.thinking !== 'hidden') {
     panels.push({
       header: (
         <Box
@@ -951,7 +956,7 @@ export const ToolTrail = memo(function ToolTrail({
           }}
         >
           <Text color={t.color.dim} dim={!thinkingLive}>
-            <Text color={t.color.amber}>{thinkingSection === 'expanded' || openThinking ? '▾ ' : '▸ '}</Text>
+            <Text color={t.color.amber}>{visible.thinking === 'expanded' || openThinking ? '▾ ' : '▸ '}</Text>
             {thinkingLive ? (
               <Text bold color={t.color.cornsilk}>
                 Thinking
@@ -971,7 +976,7 @@ export const ToolTrail = memo(function ToolTrail({
         </Box>
       ),
       key: 'thinking',
-      open: thinkingSection === 'expanded' || openThinking,
+      open: visible.thinking === 'expanded' || openThinking,
       render: rails => (
         <Thinking
           active={reasoningActive}
@@ -986,7 +991,7 @@ export const ToolTrail = memo(function ToolTrail({
     })
   }
 
-  if (hasTools && toolsSection !== 'hidden') {
+  if (hasTools && visible.tools !== 'hidden') {
     panels.push({
       header: (
         <Chevron
@@ -998,14 +1003,14 @@ export const ToolTrail = memo(function ToolTrail({
               setOpenTools(v => !v)
             }
           }}
-          open={toolsSection === 'expanded' || openTools}
+          open={visible.tools === 'expanded' || openTools}
           suffix={toolTokensLabel}
           t={t}
           title="Tool calls"
         />
       ),
       key: 'tools',
-      open: toolsSection === 'expanded' || openTools,
+      open: visible.tools === 'expanded' || openTools,
       render: rails => (
         <Box flexDirection="column">
           {groups.map((group, index) => {
@@ -1045,7 +1050,7 @@ export const ToolTrail = memo(function ToolTrail({
     })
   }
 
-  if (hasSubagents && !inlineDelegateKey && subagentsSection !== 'hidden') {
+  if (hasSubagents && !inlineDelegateKey && visible.subagents !== 'hidden') {
     // Spark + summary give a one-line read on the branch shape before
     // opening the subtree.  `/agents` opens the full-screen audit overlay.
     const suffix = spawnSpark ? `${spawnSummaryLabel}  ${spawnSpark}  (/agents)` : `${spawnSummaryLabel}  (/agents)`
@@ -1063,19 +1068,19 @@ export const ToolTrail = memo(function ToolTrail({
               setDeepSubagents(false)
             }
           }}
-          open={subagentsSection === 'expanded' || openSubagents}
+          open={visible.subagents === 'expanded' || openSubagents}
           suffix={suffix}
           t={t}
           title="Spawn tree"
         />
       ),
       key: 'subagents',
-      open: subagentsSection === 'expanded' || openSubagents,
+      open: visible.subagents === 'expanded' || openSubagents,
       render: renderSubagentList
     })
   }
 
-  if (hasMeta && activitySection !== 'hidden') {
+  if (hasMeta && visible.activity !== 'hidden') {
     panels.push({
       header: (
         <Chevron
@@ -1087,14 +1092,14 @@ export const ToolTrail = memo(function ToolTrail({
               setOpenMeta(v => !v)
             }
           }}
-          open={activitySection === 'expanded' || openMeta}
+          open={visible.activity === 'expanded' || openMeta}
           t={t}
           title="Activity"
           tone={metaTone}
         />
       ),
       key: 'meta',
-      open: activitySection === 'expanded' || openMeta,
+      open: visible.activity === 'expanded' || openMeta,
       render: rails => (
         <Box flexDirection="column">
           {meta.map((row, index) => (

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -3,6 +3,7 @@ import { memo, type ReactNode, useEffect, useMemo, useState } from 'react'
 import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
 import { THINKING_COT_MAX } from '../config/limits.js'
+import { sectionMode } from '../domain/details.js'
 import {
   buildSubagentTree,
   fmtCost,
@@ -25,7 +26,15 @@ import {
   toolTrailLabel
 } from '../lib/text.js'
 import type { Theme } from '../theme.js'
-import type { ActiveTool, ActivityItem, DetailsMode, SubagentNode, SubagentProgress, ThinkingMode } from '../types.js'
+import type {
+  ActiveTool,
+  ActivityItem,
+  DetailsMode,
+  SectionVisibility,
+  SubagentNode,
+  SubagentProgress,
+  ThinkingMode
+} from '../types.js'
 
 const THINK: BrailleSpinnerName[] = ['helix', 'breathe', 'orbit', 'dna', 'waverows', 'snake', 'pulse']
 const TOOL: BrailleSpinnerName[] = ['cascade', 'scan', 'diagswipe', 'fillsweep', 'rain', 'columns', 'sparkle']
@@ -675,6 +684,7 @@ export const ToolTrail = memo(function ToolTrail({
   reasoning = '',
   reasoningTokens,
   reasoningStreaming = false,
+  sections,
   subagents = [],
   t,
   tools = [],
@@ -689,6 +699,7 @@ export const ToolTrail = memo(function ToolTrail({
   reasoning?: string
   reasoningTokens?: number
   reasoningStreaming?: boolean
+  sections?: SectionVisibility
   subagents?: SubagentProgress[]
   t: Theme
   tools?: ActiveTool[]
@@ -696,38 +707,34 @@ export const ToolTrail = memo(function ToolTrail({
   trail?: string[]
   activity?: ActivityItem[]
 }) {
+  const thinkingSection = sectionMode('thinking', detailsMode, sections)
+  const toolsSection = sectionMode('tools', detailsMode, sections)
+  const subagentsSection = sectionMode('subagents', detailsMode, sections)
+  const activitySection = sectionMode('activity', detailsMode, sections)
+
   const [now, setNow] = useState(() => Date.now())
-  const [openThinking, setOpenThinking] = useState(false)
-  const [openTools, setOpenTools] = useState(false)
-  const [openSubagents, setOpenSubagents] = useState(false)
-  const [deepSubagents, setDeepSubagents] = useState(false)
-  const [openMeta, setOpenMeta] = useState(false)
+  const [openThinking, setOpenThinking] = useState(thinkingSection === 'expanded')
+  const [openTools, setOpenTools] = useState(toolsSection === 'expanded')
+  const [openSubagents, setOpenSubagents] = useState(subagentsSection === 'expanded')
+  const [deepSubagents, setDeepSubagents] = useState(subagentsSection === 'expanded')
+  const [openMeta, setOpenMeta] = useState(activitySection === 'expanded')
 
   useEffect(() => {
-    if (!tools.length || (detailsMode === 'collapsed' && !openTools)) {
+    if (!tools.length || (toolsSection !== 'expanded' && !openTools)) {
       return
     }
 
     const id = setInterval(() => setNow(Date.now()), 500)
 
     return () => clearInterval(id)
-  }, [detailsMode, openTools, tools.length])
+  }, [toolsSection, openTools, tools.length])
 
   useEffect(() => {
-    if (detailsMode === 'expanded') {
-      setOpenThinking(true)
-      setOpenTools(true)
-      setOpenSubagents(true)
-      setOpenMeta(true)
-    }
-
-    if (detailsMode === 'hidden') {
-      setOpenThinking(false)
-      setOpenTools(false)
-      setOpenSubagents(false)
-      setOpenMeta(false)
-    }
-  }, [detailsMode])
+    setOpenThinking(thinkingSection === 'expanded')
+    setOpenTools(toolsSection === 'expanded')
+    setOpenSubagents(subagentsSection === 'expanded')
+    setOpenMeta(activitySection === 'expanded')
+  }, [thinkingSection, toolsSection, subagentsSection, activitySection])
 
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 
@@ -863,8 +870,17 @@ export const ToolTrail = memo(function ToolTrail({
   const inlineDelegateKey = hasSubagents && delegateGroups.length === 1 ? delegateGroups[0]!.key : null
 
   // ── Hidden: errors/warnings only ──────────────────────────────
+  //
+  // When the global details_mode is 'hidden' (or all sections are individually
+  // hidden), the accordion collapses entirely.  Errors/warnings still float
+  // as inline alerts UNLESS the activity section is explicitly hidden — that
+  // override means "I don't want to see meta at all", so respect it.
 
   if (detailsMode === 'hidden') {
+    if (activitySection === 'hidden') {
+      return null
+    }
+
     const alerts = activity.filter(i => i.tone !== 'info').slice(-2)
 
     return alerts.length ? (
@@ -879,13 +895,18 @@ export const ToolTrail = memo(function ToolTrail({
   }
 
   // ── Tree render fragments ──────────────────────────────────────
+  //
+  // Shift+click on any chevron expands every NON-hidden section at once —
+  // hidden sections stay hidden so the override is honoured.
 
   const expandAll = () => {
-    setOpenThinking(true)
-    setOpenTools(true)
-    setOpenSubagents(true)
-    setDeepSubagents(true)
-    setOpenMeta(true)
+    if (thinkingSection !== 'hidden') setOpenThinking(true)
+    if (toolsSection !== 'hidden') setOpenTools(true)
+    if (subagentsSection !== 'hidden') {
+      setOpenSubagents(true)
+      setDeepSubagents(true)
+    }
+    if (activitySection !== 'hidden') setOpenMeta(true)
   }
 
   const metaTone: 'dim' | 'error' | 'warn' = activity.some(i => i.tone === 'error')
@@ -899,7 +920,7 @@ export const ToolTrail = memo(function ToolTrail({
       {spawnTree.map((node, index) => (
         <SubagentAccordion
           branch={index === spawnTree.length - 1 ? 'last' : 'mid'}
-          expanded={detailsMode === 'expanded' || deepSubagents}
+          expanded={subagentsSection === 'expanded' || deepSubagents}
           key={node.item.id}
           node={node}
           peak={spawnPeak}
@@ -910,15 +931,15 @@ export const ToolTrail = memo(function ToolTrail({
     </Box>
   )
 
-  const sections: {
+  const panels: {
     header: ReactNode
     key: string
     open: boolean
     render: (rails: boolean[]) => ReactNode
   }[] = []
 
-  if (hasThinking) {
-    sections.push({
+  if (hasThinking && thinkingSection !== 'hidden') {
+    panels.push({
       header: (
         <Box
           onClick={(e: any) => {
@@ -930,7 +951,7 @@ export const ToolTrail = memo(function ToolTrail({
           }}
         >
           <Text color={t.color.dim} dim={!thinkingLive}>
-            <Text color={t.color.amber}>{detailsMode === 'expanded' || openThinking ? '▾ ' : '▸ '}</Text>
+            <Text color={t.color.amber}>{thinkingSection === 'expanded' || openThinking ? '▾ ' : '▸ '}</Text>
             {thinkingLive ? (
               <Text bold color={t.color.cornsilk}>
                 Thinking
@@ -950,7 +971,7 @@ export const ToolTrail = memo(function ToolTrail({
         </Box>
       ),
       key: 'thinking',
-      open: detailsMode === 'expanded' || openThinking,
+      open: thinkingSection === 'expanded' || openThinking,
       render: rails => (
         <Thinking
           active={reasoningActive}
@@ -965,8 +986,8 @@ export const ToolTrail = memo(function ToolTrail({
     })
   }
 
-  if (hasTools) {
-    sections.push({
+  if (hasTools && toolsSection !== 'hidden') {
+    panels.push({
       header: (
         <Chevron
           count={groups.length}
@@ -977,14 +998,14 @@ export const ToolTrail = memo(function ToolTrail({
               setOpenTools(v => !v)
             }
           }}
-          open={detailsMode === 'expanded' || openTools}
+          open={toolsSection === 'expanded' || openTools}
           suffix={toolTokensLabel}
           t={t}
           title="Tool calls"
         />
       ),
       key: 'tools',
-      open: detailsMode === 'expanded' || openTools,
+      open: toolsSection === 'expanded' || openTools,
       render: rails => (
         <Box flexDirection="column">
           {groups.map((group, index) => {
@@ -1024,12 +1045,12 @@ export const ToolTrail = memo(function ToolTrail({
     })
   }
 
-  if (hasSubagents && !inlineDelegateKey) {
+  if (hasSubagents && !inlineDelegateKey && subagentsSection !== 'hidden') {
     // Spark + summary give a one-line read on the branch shape before
     // opening the subtree.  `/agents` opens the full-screen audit overlay.
     const suffix = spawnSpark ? `${spawnSummaryLabel}  ${spawnSpark}  (/agents)` : `${spawnSummaryLabel}  (/agents)`
 
-    sections.push({
+    panels.push({
       header: (
         <Chevron
           count={spawnTotals.descendantCount}
@@ -1042,20 +1063,20 @@ export const ToolTrail = memo(function ToolTrail({
               setDeepSubagents(false)
             }
           }}
-          open={detailsMode === 'expanded' || openSubagents}
+          open={subagentsSection === 'expanded' || openSubagents}
           suffix={suffix}
           t={t}
           title="Spawn tree"
         />
       ),
       key: 'subagents',
-      open: detailsMode === 'expanded' || openSubagents,
+      open: subagentsSection === 'expanded' || openSubagents,
       render: renderSubagentList
     })
   }
 
-  if (hasMeta) {
-    sections.push({
+  if (hasMeta && activitySection !== 'hidden') {
+    panels.push({
       header: (
         <Chevron
           count={meta.length}
@@ -1066,14 +1087,14 @@ export const ToolTrail = memo(function ToolTrail({
               setOpenMeta(v => !v)
             }
           }}
-          open={detailsMode === 'expanded' || openMeta}
+          open={activitySection === 'expanded' || openMeta}
           t={t}
           title="Activity"
           tone={metaTone}
         />
       ),
       key: 'meta',
-      open: detailsMode === 'expanded' || openMeta,
+      open: activitySection === 'expanded' || openMeta,
       render: rails => (
         <Box flexDirection="column">
           {meta.map((row, index) => (
@@ -1092,19 +1113,19 @@ export const ToolTrail = memo(function ToolTrail({
     })
   }
 
-  const topCount = sections.length + (totalTokensLabel ? 1 : 0)
+  const topCount = panels.length + (totalTokensLabel ? 1 : 0)
 
   return (
     <Box flexDirection="column">
-      {sections.map((section, index) => (
+      {panels.map((panel, index) => (
         <TreeNode
           branch={index === topCount - 1 ? 'last' : 'mid'}
-          header={section.header}
-          key={section.key}
-          open={section.open}
+          header={panel.header}
+          key={panel.key}
+          open={panel.open}
           t={t}
         >
-          {section.render}
+          {panel.render}
         </TreeNode>
       ))}
       {totalTokensLabel ? (

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -17,10 +17,12 @@ const THINKING_FALLBACK: Record<string, DetailsMode> = {
   truncated: 'collapsed'
 }
 
-const norm = (v: unknown) => String(v ?? '').trim().toLowerCase()
+const norm = (v: unknown) =>
+  String(v ?? '')
+    .trim()
+    .toLowerCase()
 
-export const parseDetailsMode = (v: unknown): DetailsMode | null =>
-  MODES.find(m => m === norm(v)) ?? null
+export const parseDetailsMode = (v: unknown): DetailsMode | null => MODES.find(m => m === norm(v)) ?? null
 
 export const isSectionName = (v: unknown): v is SectionName =>
   typeof v === 'string' && (SECTION_NAMES as readonly string[]).includes(v)
@@ -42,11 +44,7 @@ export const resolveSections = (raw: unknown): SectionVisibility =>
 
 // Effective mode for one section: explicit override → SECTION_DEFAULTS → global.
 // Single source of truth for "is this section open by default / rendered at all".
-export const sectionMode = (
-  name: SectionName,
-  global: DetailsMode,
-  sections?: SectionVisibility
-): DetailsMode => sections?.[name] ?? SECTION_DEFAULTS[name] ?? global
+export const sectionMode = (name: SectionName, global: DetailsMode, sections?: SectionVisibility): DetailsMode =>
+  sections?.[name] ?? SECTION_DEFAULTS[name] ?? global
 
-export const nextDetailsMode = (m: DetailsMode): DetailsMode =>
-  MODES[(MODES.indexOf(m) + 1) % MODES.length]!
+export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -4,12 +4,27 @@ const MODES = ['hidden', 'collapsed', 'expanded'] as const
 
 export const SECTION_NAMES = ['thinking', 'tools', 'subagents', 'activity'] as const
 
-// Activity panel = ambient meta (gateway hints, terminal-parity nudges,
-// background-process notifications).  Hidden out of the box because tool
-// failures already render inline on the failing tool row — the panel itself
-// is noise for typical use.  Opt back in via `display.sections.activity` or
-// `/details activity collapsed`.
-const SECTION_DEFAULTS: SectionVisibility = { activity: 'hidden' }
+// Out-of-the-box per-section defaults — applied when the user hasn't pinned
+// an explicit override and layered ABOVE the global details_mode:
+//
+//   - thinking / tools: expanded — stream open so the turn reads like a
+//     live transcript (reasoning + tool calls side by side) instead of a
+//     wall of chevrons the user has to click every turn.
+//   - activity: hidden — ambient meta (gateway hints, terminal-parity
+//     nudges, background notifications) is noise for typical use.  Tool
+//     failures still render inline on the failing tool row, and ambient
+//     errors/warnings surface via the floating-alert backstop when every
+//     panel resolves to hidden.
+//   - subagents: not set — falls through to the global details_mode so
+//     Spawn trees stay under a chevron until a delegation actually happens.
+//
+// Opt out of any of these with `display.sections.<name>` in config.yaml
+// or at runtime via `/details <name> collapsed|hidden`.
+const SECTION_DEFAULTS: SectionVisibility = {
+  thinking: 'expanded',
+  tools: 'expanded',
+  activity: 'hidden'
+}
 
 const THINKING_FALLBACK: Record<string, DetailsMode> = {
   collapsed: 'collapsed',

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -1,6 +1,7 @@
-import type { DetailsMode } from '../types.js'
+import type { DetailsMode, SectionName, SectionVisibility } from '../types.js'
 
 const MODES = ['hidden', 'collapsed', 'expanded'] as const
+export const SECTION_NAMES: readonly SectionName[] = ['thinking', 'tools', 'subagents', 'activity']
 
 const THINKING_FALLBACK: Record<string, DetailsMode> = {
   collapsed: 'collapsed',
@@ -14,6 +15,9 @@ export const parseDetailsMode = (v: unknown): DetailsMode | null => {
   return MODES.find(m => m === s) ?? null
 }
 
+export const isSectionName = (v: unknown): v is SectionName =>
+  typeof v === 'string' && (SECTION_NAMES as readonly string[]).includes(v)
+
 export const resolveDetailsMode = (d?: { details_mode?: unknown; thinking_mode?: unknown } | null): DetailsMode =>
   parseDetailsMode(d?.details_mode) ??
   THINKING_FALLBACK[
@@ -22,5 +26,36 @@ export const resolveDetailsMode = (d?: { details_mode?: unknown; thinking_mode?:
       .toLowerCase()
   ] ??
   'collapsed'
+
+// Build a SectionVisibility from a free-form `display.sections` config blob.
+// Skips keys that aren't recognized section names or don't parse to a valid
+// mode — partial overrides are intentional, missing keys fall through to the
+// global details_mode at render time.
+export const resolveSections = (raw: unknown): SectionVisibility => {
+  const out: SectionVisibility = {}
+
+  if (!raw || typeof raw !== 'object') {
+    return out
+  }
+
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    const mode = parseDetailsMode(v)
+
+    if (mode && isSectionName(k)) {
+      out[k] = mode
+    }
+  }
+
+  return out
+}
+
+// Resolve the effective mode for one section: explicit override wins,
+// otherwise the global details_mode.  Single source of truth — every render
+// site that needs to know "is this section open by default" calls this.
+export const sectionMode = (
+  name: SectionName,
+  global: DetailsMode,
+  sections?: SectionVisibility
+): DetailsMode => sections?.[name] ?? global
 
 export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -1,7 +1,15 @@
 import type { DetailsMode, SectionName, SectionVisibility } from '../types.js'
 
 const MODES = ['hidden', 'collapsed', 'expanded'] as const
-export const SECTION_NAMES: readonly SectionName[] = ['thinking', 'tools', 'subagents', 'activity']
+
+export const SECTION_NAMES = ['thinking', 'tools', 'subagents', 'activity'] as const
+
+// Activity panel = ambient meta (gateway hints, terminal-parity nudges,
+// background-process notifications).  Hidden out of the box because tool
+// failures already render inline on the failing tool row — the panel itself
+// is noise for typical use.  Opt back in via `display.sections.activity` or
+// `/details activity collapsed`.
+const SECTION_DEFAULTS: SectionVisibility = { activity: 'hidden' }
 
 const THINKING_FALLBACK: Record<string, DetailsMode> = {
   collapsed: 'collapsed',
@@ -9,66 +17,36 @@ const THINKING_FALLBACK: Record<string, DetailsMode> = {
   truncated: 'collapsed'
 }
 
-export const parseDetailsMode = (v: unknown): DetailsMode | null => {
-  const s = typeof v === 'string' ? v.trim().toLowerCase() : ''
+const norm = (v: unknown) => String(v ?? '').trim().toLowerCase()
 
-  return MODES.find(m => m === s) ?? null
-}
+export const parseDetailsMode = (v: unknown): DetailsMode | null =>
+  MODES.find(m => m === norm(v)) ?? null
 
 export const isSectionName = (v: unknown): v is SectionName =>
   typeof v === 'string' && (SECTION_NAMES as readonly string[]).includes(v)
 
 export const resolveDetailsMode = (d?: { details_mode?: unknown; thinking_mode?: unknown } | null): DetailsMode =>
-  parseDetailsMode(d?.details_mode) ??
-  THINKING_FALLBACK[
-    String(d?.thinking_mode ?? '')
-      .trim()
-      .toLowerCase()
-  ] ??
-  'collapsed'
+  parseDetailsMode(d?.details_mode) ?? THINKING_FALLBACK[norm(d?.thinking_mode)] ?? 'collapsed'
 
-// Build a SectionVisibility from a free-form `display.sections` config blob.
-// Skips keys that aren't recognized section names or don't parse to a valid
-// mode — partial overrides are intentional, missing keys fall through to the
-// global details_mode at render time.
-export const resolveSections = (raw: unknown): SectionVisibility => {
-  const out: SectionVisibility = {}
+// Build SectionVisibility from a free-form blob.  Unknown section names and
+// invalid modes are dropped silently — partial overrides are intentional, so
+// missing keys fall through to SECTION_DEFAULTS / global at lookup time.
+export const resolveSections = (raw: unknown): SectionVisibility =>
+  raw && typeof raw === 'object' && !Array.isArray(raw)
+    ? (Object.fromEntries(
+        Object.entries(raw as Record<string, unknown>)
+          .map(([k, v]) => [k, parseDetailsMode(v)] as const)
+          .filter(([k, m]) => !!m && isSectionName(k))
+      ) as SectionVisibility)
+    : {}
 
-  if (!raw || typeof raw !== 'object') {
-    return out
-  }
-
-  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-    const mode = parseDetailsMode(v)
-
-    if (mode && isSectionName(k)) {
-      out[k] = mode
-    }
-  }
-
-  return out
-}
-
-// Built-in per-section defaults applied when the user has no explicit
-// override.  The activity panel (gateway hints, terminal-parity nudges,
-// background-process notifications) is hidden out of the box — it's noise
-// for the typical day-to-day user, who only cares about thinking + tools +
-// streamed content.  Tool failures still surface inline on the failing tool
-// row; this default only suppresses the ambient meta feed.
-//
-// Opt back in with `display.sections.activity: collapsed` (under chevron)
-// or `expanded` (always open) in `~/.hermes/config.yaml`, or live with
-// `/details activity collapsed`.
-const SECTION_DEFAULTS: SectionVisibility = { activity: 'hidden' }
-
-// Resolve the effective mode for one section: explicit override wins,
-// then the SECTION_DEFAULTS fallback, then the global details_mode.
-// Single source of truth — every render site that needs to know "is this
-// section open by default" calls this.
+// Effective mode for one section: explicit override → SECTION_DEFAULTS → global.
+// Single source of truth for "is this section open by default / rendered at all".
 export const sectionMode = (
   name: SectionName,
   global: DetailsMode,
   sections?: SectionVisibility
 ): DetailsMode => sections?.[name] ?? SECTION_DEFAULTS[name] ?? global
 
-export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!
+export const nextDetailsMode = (m: DetailsMode): DetailsMode =>
+  MODES[(MODES.indexOf(m) + 1) % MODES.length]!

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -49,13 +49,26 @@ export const resolveSections = (raw: unknown): SectionVisibility => {
   return out
 }
 
+// Built-in per-section defaults applied when the user has no explicit
+// override.  The activity panel (gateway hints, terminal-parity nudges,
+// background-process notifications) is hidden out of the box — it's noise
+// for the typical day-to-day user, who only cares about thinking + tools +
+// streamed content.  Tool failures still surface inline on the failing tool
+// row; this default only suppresses the ambient meta feed.
+//
+// Opt back in with `display.sections.activity: collapsed` (under chevron)
+// or `expanded` (always open) in `~/.hermes/config.yaml`, or live with
+// `/details activity collapsed`.
+const SECTION_DEFAULTS: SectionVisibility = { activity: 'hidden' }
+
 // Resolve the effective mode for one section: explicit override wins,
-// otherwise the global details_mode.  Single source of truth — every render
-// site that needs to know "is this section open by default" calls this.
+// then the SECTION_DEFAULTS fallback, then the global details_mode.
+// Single source of truth — every render site that needs to know "is this
+// section open by default" calls this.
 export const sectionMode = (
   name: SectionName,
   global: DetailsMode,
   sections?: SectionVisibility
-): DetailsMode => sections?.[name] ?? global
+): DetailsMode => sections?.[name] ?? SECTION_DEFAULTS[name] ?? global
 
 export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -55,6 +55,7 @@ export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
   details_mode?: string
   inline_diffs?: boolean
+  sections?: Record<string, string>
   show_cost?: boolean
   show_reasoning?: boolean
   streaming?: boolean

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -116,6 +116,14 @@ export type Role = 'assistant' | 'system' | 'tool' | 'user'
 export type DetailsMode = 'hidden' | 'collapsed' | 'expanded'
 export type ThinkingMode = 'collapsed' | 'truncated' | 'full'
 
+// Per-section overrides on top of the global DetailsMode.  Each missing key
+// falls back to the global mode; an explicit value overrides for that one
+// section only — so users can keep the accordion collapsed by default while
+// auto-expanding tools, or hide the activity panel entirely without touching
+// thinking/tools/subagents.
+export type SectionName = 'thinking' | 'tools' | 'subagents' | 'activity'
+export type SectionVisibility = Partial<Record<SectionName, DetailsMode>>
+
 export interface McpServerStatus {
   connected: boolean
   name: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -116,11 +116,11 @@ export type Role = 'assistant' | 'system' | 'tool' | 'user'
 export type DetailsMode = 'hidden' | 'collapsed' | 'expanded'
 export type ThinkingMode = 'collapsed' | 'truncated' | 'full'
 
-// Per-section overrides on top of the global DetailsMode.  Each missing key
-// falls back to the global mode; an explicit value overrides for that one
-// section only — so users can keep the accordion collapsed by default while
-// auto-expanding tools, or hide the activity panel entirely without touching
-// thinking/tools/subagents.
+// Per-section overrides for the agent details accordion.  Resolution order
+// at lookup time is: explicit `display.sections.<name>` → built-in
+// SECTION_DEFAULTS → global `details_mode`.  Today the built-in defaults
+// expand `thinking`/`tools` and hide `activity`; `subagents` falls through
+// to the global mode.  Any explicit value still wins for that one section.
 export type SectionName = 'thinking' | 'tools' | 'subagents' | 'activity'
 export type SectionVisibility = Partial<Record<SectionName, DetailsMode>>
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -87,7 +87,7 @@ All slash commands work unchanged. A few are TUI-owned — they produce richer o
 | `/sessions` | Modal session picker — preview, title, token totals, resume inline |
 | `/model` | Modal model picker grouped by provider, with cost hints |
 | `/skin` | Live preview — theme change applies as you browse |
-| `/details` | Toggle verbose tool-call details in the transcript |
+| `/details` | Toggle verbose tool-call details (global or per-section) |
 | `/usage` | Rich token / cost / context panel |
 
 Every other slash command (including installed skills, quick commands, and personality toggles) works identically to the classic CLI. See [Slash Commands Reference](../reference/slash-commands.md).
@@ -114,13 +114,26 @@ A handful of keys tune the TUI surface specifically:
 
 ```yaml
 display:
-  skin: default          # any built-in or custom skin
+  skin: default              # any built-in or custom skin
   personality: helpful
-  details_mode: compact  # or "verbose" — default tool-call detail level
-  mouse_tracking: true   # disable if your terminal conflicts with mouse reporting
+  details_mode: collapsed    # hidden | collapsed | expanded — global accordion default
+  sections:                  # optional: per-section overrides (any subset)
+    thinking: expanded       # always open
+    tools: expanded          # always open
+    activity: hidden         # never show errors/warnings/info panel
+  mouse_tracking: true       # disable if your terminal conflicts with mouse reporting
 ```
 
-`/details on` / `/details off` / `/details cycle` toggle this at runtime.
+Runtime toggles:
+
+- `/details [hidden|collapsed|expanded|cycle]` — set the global mode
+- `/details <section> [hidden|collapsed|expanded|reset]` — override one section
+  (sections: `thinking`, `tools`, `subagents`, `activity`)
+
+Per-section overrides take precedence over the global `details_mode`. With
+`activity: hidden`, errors/warnings are suppressed entirely (the floating-alert
+fallback that normally surfaces under `details_mode: hidden` is also silenced
+when activity is explicitly hidden).
 
 ## Sessions
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -120,7 +120,7 @@ display:
   sections:                  # optional: per-section overrides (any subset)
     thinking: expanded       # always open
     tools: expanded          # always open
-    activity: hidden         # never show errors/warnings/info panel
+    activity: collapsed      # opt back IN to the activity panel (hidden by default)
   mouse_tracking: true       # disable if your terminal conflicts with mouse reporting
 ```
 
@@ -130,10 +130,26 @@ Runtime toggles:
 - `/details <section> [hidden|collapsed|expanded|reset]` — override one section
   (sections: `thinking`, `tools`, `subagents`, `activity`)
 
-Per-section overrides take precedence over the global `details_mode`. With
-`activity: hidden`, errors/warnings are suppressed entirely (the floating-alert
-fallback that normally surfaces under `details_mode: hidden` is also silenced
-when activity is explicitly hidden).
+**Default visibility**
+
+- `thinking`, `tools`, `subagents` — fall through to the global `details_mode`
+  (collapsed under chevron by default, click to expand).
+- `activity` — **hidden by default**. The activity panel surfaces ambient
+  meta (gateway hints, terminal-parity nudges, background notifications) and
+  is noise for most day-to-day use. Tool failures still render inline on the
+  failing tool row, so this default suppresses the noise feed without losing
+  the signal.
+
+Per-section overrides take precedence over both the section default and the
+global `details_mode`. To opt the activity panel back in:
+
+- `display.sections.activity: collapsed` — under a chevron
+- `display.sections.activity: expanded` — always open
+- `/details activity collapsed` at runtime
+
+With `activity: hidden` (the default), errors/warnings are suppressed entirely
+— the floating-alert fallback that surfaces under `details_mode: hidden` is
+silenced as well.
 
 ## Sessions
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -132,24 +132,29 @@ Runtime toggles:
 
 **Default visibility**
 
-- `thinking`, `tools`, `subagents` — fall through to the global `details_mode`
-  (collapsed under chevron by default, click to expand).
-- `activity` — **hidden by default**. The activity panel surfaces ambient
-  meta (gateway hints, terminal-parity nudges, background notifications) and
-  is noise for most day-to-day use. Tool failures still render inline on the
-  failing tool row, so this default suppresses the noise feed without losing
-  the signal.
+The TUI ships with opinionated per-section defaults that stream the turn as
+a live transcript instead of a wall of chevrons:
+
+- `thinking` — **expanded**. Reasoning streams inline as the model emits it.
+- `tools` — **expanded**. Tool calls and their results render open.
+- `subagents` — falls through to the global `details_mode` (collapsed under
+  chevron by default — stays quiet until a delegation actually happens).
+- `activity` — **hidden**. Ambient meta (gateway hints, terminal-parity
+  nudges, background notifications) is noise for most day-to-day use. Tool
+  failures still render inline on the failing tool row; ambient
+  errors/warnings surface via a floating-alert backstop when every panel
+  is hidden.
 
 Per-section overrides take precedence over both the section default and the
-global `details_mode`. To opt the activity panel back in:
+global `details_mode`. To reshape the layout:
 
-- `display.sections.activity: collapsed` — under a chevron
-- `display.sections.activity: expanded` — always open
-- `/details activity collapsed` at runtime
+- `display.sections.thinking: collapsed` — put thinking back under a chevron
+- `display.sections.tools: collapsed` — put tool calls back under a chevron
+- `display.sections.activity: collapsed` — opt the activity panel back in
+- `/details <section> <mode>` at runtime
 
-With `activity: hidden` (the default), errors/warnings are suppressed entirely
-— the floating-alert fallback that surfaces under `details_mode: hidden` is
-silenced as well.
+Anything set explicitly in `display.sections` wins over the defaults, so
+existing configs keep working unchanged.
 
 ## Sessions
 


### PR DESCRIPTION
## Summary

Two changes that together let users shape exactly what the TUI shows:

1. **Opinionated per-section defaults.** Out of the box the TUI now streams the turn as a live transcript — reasoning and tool calls render inline, the activity noise feed is silenced, spawn trees stay quiet until a delegation actually happens. Driven by the request: *"all that I want to see is thinking, content/midstream content, and tools, always — no errors/warnings"*.
2. **Per-section visibility overrides.** New optional `display.sections` map lets users override visibility for any subset of sections without affecting the rest. Pairs with the existing global `details_mode`.

## Default matrix

| Section | Default | Rationale |
|---|---|---|
| `thinking` | **expanded** | Reasoning streams inline as the model emits it. |
| `tools` | **expanded** | Tool calls + results render open. |
| `subagents` | falls through to `details_mode` (collapsed) | Stays quiet until a delegation actually happens. |
| `activity` | **hidden** | Ambient meta (gateway hints, terminal-parity nudges, background notifications) is noise for typical use. Tool failures still render inline on the failing tool row; ambient errors/warnings surface via a floating-alert backstop when every panel is hidden. |

Streaming/midstream assistant content is unaffected — it always renders inline, it's not part of the section accordion.

## Opting out

Everything explicit in `display.sections` wins over the built-in defaults, so existing configs keep working unchanged. To reshape the layout:

```yaml
display:
  details_mode: collapsed       # global fallback (existing — unchanged)
  sections:
    thinking: collapsed         # put thinking back under a chevron
    tools: collapsed            # put tool calls back under a chevron
    activity: collapsed         # opt the activity panel back in
    subagents: expanded         # always open spawn tree
```

Or at runtime: `/details <section> [hidden|collapsed|expanded|reset]`.

## Slash command

Extended `/details`:

- `/details` — show current global + active overrides
- `/details [hidden|collapsed|expanded|cycle]` — set global mode (existing)
- `/details <section> [hidden|collapsed|expanded|reset]` — per-section override (new)

Sections: `thinking`, `tools`, `subagents`, `activity`. Per-section overrides take precedence over both the section default and the global mode — so `details_mode: hidden` + `sections.tools: expanded` renders the tools panel even when the global mode is hidden.

## Implementation

- **`ui-tui/src/types.ts`** — `SectionName` + `SectionVisibility` types.
- **`ui-tui/src/domain/details.ts`** — `resolveSections`, `isSectionName`, `SECTION_NAMES`, plus `SECTION_DEFAULTS` (thinking/tools expanded, activity hidden) and `sectionMode` which resolves explicit override → `SECTION_DEFAULTS` → global. Single source of truth for "what mode does this section render in".
- **`ui-tui/src/app/{interfaces,uiStore,useConfigSync}.ts`** — `sections` (the explicit-overrides map) threaded into `UiState`, parsed from `display.sections` on initial config sync.
- **`ui-tui/src/components/thinking.tsx`** — `ToolTrail` consumes per-section modes via `sectionMode`. Hidden sections are skipped entirely; expanded ones seed `open` state to true. Renamed the local `sections` array to `panels` to avoid shadowing the new prop. Early-return now keys off `allHidden` (every section resolved to hidden) so per-section overrides still render when the global mode is hidden; floating-alert backstop surfaces under that all-hidden case.
- **`ui-tui/src/components/{messageLine,appLayout}.tsx`** — pass `sections` through; skip the trail wrapper only when every section resolves to hidden.
- **`ui-tui/src/app/useMainApp.ts`** — `showProgressArea` rebuilt around `anyPanelVisible` (mirrors `ToolTrail`'s short-circuit, kills the empty-wrapper-Box cosmetic gap).
- **`ui-tui/src/app/slash/commands/core.ts`** — `/details <section> <mode>` parsing + dispatch via `config.set` with `details_mode.<section>` key. `reset` clears the override.
- **`tui_gateway/server.py`** — `config.set details_mode.<section>` handler writes to `display.sections.<section>`. Empty value clears the override. Validation rejects unknown sections / unknown modes with 4002.
- **`website/docs/user-guide/tui.md`** — documented defaults, overrides, and the opt-out story.

## Behavioural changes for existing users

- **Most users**: thinking + tools panels now stream expanded by default; activity panel disappears; spawn trees unchanged. Tool failures still surface inline; ambient hints (e.g. "tmux detected", "Apple Terminal detected") no longer clutter the transcript chrome.
- **Users on `details_mode: expanded`**: no visible change — thinking/tools were already open; activity is now hidden but gets a floating backstop for errors.
- **Users on `details_mode: hidden` (legacy quiet mode)**: thinking + tools now render open regardless (section defaults win over the global). To restore silence: pin each section explicitly (`display.sections.thinking: hidden`, etc.).
- **Users who already set `display.sections` entries**: their overrides win. No migration needed.

One config line reverts each default in every case.

## Test plan

- [x] `vitest run` (ui-tui) — 272/272 passing (17 new: 6 domain, 4 config sync, 3 slash, 3 gateway, 1 override-escapes-hidden regression)
- [x] `tsc --noEmit` (ui-tui) — clean (the pre-existing `dom.ts` warning on main is untouched)
- [x] `pytest tests/test_tui_gateway_server.py -k config_set_section` — 3/3
- [x] Copilot review threads (3) — addressed + resolved
- [ ] Manual: fresh `~/.hermes/` directory → run `hermes --tui` → thinking + tools stream open, activity never surfaces, spawn tree stays collapsed until a delegation fires
- [ ] Manual: `/details thinking collapsed` → thinking back under a chevron + persists to config; `/details thinking reset` → restores the new default (expanded)
- [ ] Manual: `details_mode: hidden` + `sections.tools: expanded` → tools panel still renders (regression coverage for Copilot's catch)