### PR TITLE
fix(gateway): keep visible commentary in user language

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -281,6 +281,15 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "Don't stop with a plan — execute it.\n"
 )
 
+VISIBLE_OUTPUT_LANGUAGE_GUIDANCE = (
+    "# Visible user-facing language\n"
+    "Match the user's current language for all visible user-facing text, including "
+    "final answers, interim assistant commentary, progress narration, status "
+    "updates, and error explanations. If the latest user message is in Chinese, "
+    "write visible commentary in Chinese. Do not expose raw internal planning "
+    "notes; if a brief progress note is useful, make it concise and user-facing."
+)
+
 # Model name substrings that should use the 'developer' role instead of
 # 'system' for the system prompt.  OpenAI's newer models (GPT-5, Codex)
 # give stronger instruction-following weight to the 'developer' role.

--- a/run_agent.py
+++ b/run_agent.py
@@ -96,7 +96,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, VISIBLE_OUTPUT_LANGUAGE_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -4082,6 +4082,10 @@ class AIAgent:
         if not _soul_loaded:
             # Fallback to hardcoded identity
             prompt_parts = [DEFAULT_AGENT_IDENTITY]
+
+        # Keep every user-visible message in the user's language, including
+        # mid-turn commentary that gateway platforms surface before tool calls.
+        prompt_parts.append(VISIBLE_OUTPUT_LANGUAGE_GUIDANCE)
 
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -806,6 +806,15 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt(system_message="Custom instruction")
         assert "Custom instruction" in prompt
 
+    def test_includes_visible_output_language_guidance(self, agent):
+        from agent.prompt_builder import VISIBLE_OUTPUT_LANGUAGE_GUIDANCE
+
+        prompt = agent._build_system_prompt()
+
+        assert VISIBLE_OUTPUT_LANGUAGE_GUIDANCE in prompt
+        assert "interim assistant commentary" in prompt
+        assert "Chinese" in prompt
+
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
         from agent.prompt_builder import MEMORY_GUIDANCE
 


### PR DESCRIPTION
## Summary

- Add global guidance requiring all visible user-facing text to match the user's current language
- Explicitly covers interim assistant commentary, progress narration, status updates, and errors
- Keeps raw internal planning notes out of visible chat output
- Add regression coverage that the guidance is included in the system prompt

## Motivation

Gateway chat platforms intentionally surface natural mid-turn assistant messages (from #7978). When the user is chatting in Chinese, those visible interim messages can currently appear in English because the system prompt does not explicitly steer their language.

This keeps the feature enabled while making visible commentary follow the user's language.

## Test Plan

- [x] `python -m pytest tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_includes_visible_output_language_guidance tests/run_agent/test_run_agent.py::TestBuildSystemPrompt -q -o 'addopts='`
- [x] `python -m pytest tests/agent/test_prompt_builder.py::TestGuidanceConstants tests/run_agent/test_run_agent.py::TestBuildSystemPrompt -q -o 'addopts='`
- [x] `python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts='`
