### PR TITLE
fix(config): warn when model.default is set to a pseudo-alias like 'latest' (#14963)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2819,6 +2819,13 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 # Fields that look like they should be inside custom_providers, not at root
 _CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
 
+# Pseudo-values users might guess for model.default that are NOT valid model IDs.
+# Hermes always expects a concrete provider model ID (e.g. "gpt-5.5", "claude-sonnet-4").
+_PSEUDO_MODEL_VALUES = {
+    "latest", "auto", "default", "current", "best",
+    "newest", "recommended", "stable", "preview",
+}
+
 
 @dataclass
 class ConfigIssue:
@@ -2958,6 +2965,20 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    default: your-model-name\n"
             "    base_url: https://...",
         ))
+
+    # ── model.default must not be a pseudo-alias ─────────────────────────
+    if isinstance(model_cfg, dict):
+        default_val = model_cfg.get("default", "") or ""
+        if isinstance(default_val, str) and default_val.strip().lower() in _PSEUDO_MODEL_VALUES:
+            pseudo = default_val.strip()
+            issues.append(ConfigIssue(
+                "warning",
+                f"model.default is set to '{pseudo}', which is not a valid model ID",
+                "Hermes requires a concrete provider model ID such as 'gpt-5.5' or "
+                "'anthropic/claude-sonnet-4'.  The value '" + pseudo + "' will be "
+                "passed literally to the provider and may cause an API error.\n"
+                "Run 'hermes setup' or set model.default to a real model ID.",
+            ))
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -193,6 +193,92 @@ class TestMissingModelSection:
         assert not any("no 'model' section" in i.message for i in issues)
 
 
+class TestModelDefaultPseudoValue:
+    """model.default must not be a pseudo-alias like 'latest', 'auto', etc.
+
+    Regression for #14963: a support incident where 'model.default: latest'
+    was incorrectly suggested as a valid Hermes config value.
+    """
+
+    def test_latest_warns(self):
+        """'latest' is a known pseudo-alias and should produce a warning."""
+        issues = validate_config_structure({
+            "model": {"default": "latest", "provider": "openai"},
+        })
+        pseudo_issues = [
+            i for i in issues
+            if "model.default" in i.message and "latest" in i.message
+        ]
+        assert len(pseudo_issues) == 1
+        assert pseudo_issues[0].severity == "warning"
+
+    def test_auto_warns(self):
+        issues = validate_config_structure({
+            "model": {"default": "auto"},
+        })
+        assert any(
+            "model.default" in i.message and "auto" in i.message
+            for i in issues
+        )
+
+    def test_default_warns(self):
+        issues = validate_config_structure({
+            "model": {"default": "default"},
+        })
+        assert any("model.default" in i.message for i in issues)
+
+    def test_case_insensitive(self):
+        """Pseudo-values should be detected regardless of case."""
+        for val in ("Latest", "LATEST", "Auto", "AUTO"):
+            issues = validate_config_structure({
+                "model": {"default": val},
+            })
+            assert any("model.default" in i.message for i in issues), (
+                f"Expected warning for model.default: '{val}'"
+            )
+
+    def test_concrete_model_id_no_warning(self):
+        """Real model IDs like 'gpt-5.5' must not trigger the warning."""
+        for model_id in ("gpt-5.5", "anthropic/claude-sonnet-4", "deepseek-v4-flash", "hermes-3-llama-3.1-405b"):
+            issues = validate_config_structure({
+                "model": {"default": model_id},
+            })
+            pseudo_issues = [i for i in issues if "model.default" in i.message and "not a valid model ID" in i.message]
+            assert len(pseudo_issues) == 0, (
+                f"Concrete model ID '{model_id}' should not trigger pseudo-value warning, got: {pseudo_issues}"
+            )
+
+    def test_hint_mentions_concrete_example(self):
+        """The warning hint should tell the user what to do instead."""
+        issues = validate_config_structure({
+            "model": {"default": "latest"},
+        })
+        pseudo_issues = [i for i in issues if "model.default" in i.message]
+        assert len(pseudo_issues) == 1
+        # Hint should reference 'hermes setup' or a concrete example
+        assert "hermes setup" in pseudo_issues[0].hint or "gpt-" in pseudo_issues[0].hint
+
+    def test_missing_model_section_no_crash(self):
+        """Configs without any model section should not crash the validator."""
+        issues = validate_config_structure({})
+        # No pseudo-value warning when there is no model section
+        assert not any("model.default" in i.message and "not a valid" in i.message for i in issues)
+
+    def test_model_default_empty_string_no_warning(self):
+        """Empty model.default should not trigger pseudo-value warning."""
+        issues = validate_config_structure({
+            "model": {"default": ""},
+        })
+        assert not any("not a valid model ID" in i.message for i in issues)
+
+    def test_model_default_none_no_warning(self):
+        """Null model.default should not trigger pseudo-value warning."""
+        issues = validate_config_structure({
+            "model": {"default": None},
+        })
+        assert not any("not a valid model ID" in i.message for i in issues)
+
+
 class TestConfigIssueDataclass:
     """ConfigIssue should be a proper dataclass."""
 


### PR DESCRIPTION
## Problem

A support incident (#14963) surfaced a real user pain point: `model.default: latest` looks like a valid config value but Hermes does not implement a 'latest' alias. Hermes passes the value literally to the provider, which returns an opaque API error rather than a clear config diagnostic.

The fix was requested in the issue: add config-time validation that warns when `model.default` is set to a known pseudo-alias.

## Changes

**`hermes_cli/config.py`**

Added `_PSEUDO_MODEL_VALUES` constant — a set of strings users commonly try as 'magic' model selectors:
```python
_PSEUDO_MODEL_VALUES = {
    "latest", "auto", "default", "current", "best",
    "newest", "recommended", "stable", "preview",
}
```

Added a check in `validate_config_structure()` that detects these values in `model.default` and emits a `WARNING`-level `ConfigIssue` with a clear hint:

```
⚠ model.default is set to 'latest', which is not a valid model ID
  Hermes requires a concrete provider model ID such as 'gpt-5.5' or
  'anthropic/claude-sonnet-4'. Run 'hermes setup' or set model.default
  to a real model ID.
```

Detection is case-insensitive. Empty and null values are safely handled.

## Tests

Extended `tests/hermes_cli/test_config_validation.py` with a new `TestModelDefaultPseudoValue` class (9 tests):

| Test | Verifies |
|------|---------|
| `test_latest_warns` | 'latest' produces a WARNING |
| `test_auto_warns` | 'auto' produces a WARNING |
| `test_default_warns` | 'default' produces a WARNING |
| `test_case_insensitive` | 'Latest', 'LATEST', 'Auto' all warn |
| `test_concrete_model_id_no_warning` | Real IDs (gpt-5.5, claude-sonnet-4) don't trigger |
| `test_hint_mentions_concrete_example` | Hint guides user to correct action |
| `test_missing_model_section_no_crash` | No model section → no crash |
| `test_model_default_empty_string_no_warning` | Empty string → no warning |
| `test_model_default_none_no_warning` | null value → no warning |

All 26 tests in the file pass ✅ (all prior tests unaffected)

Closes #14963