### PR TITLE
fix(telegram): gate bot-originated group messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -576,6 +576,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                if "allow_bots" in platform_cfg:
+                    bridged["allow_bots"] = platform_cfg["allow_bots"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:
@@ -673,6 +675,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["TELEGRAM_REQUIRE_MENTION"] = str(telegram_cfg["require_mention"]).lower()
                 if "mention_patterns" in telegram_cfg and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
                     os.environ["TELEGRAM_MENTION_PATTERNS"] = json.dumps(telegram_cfg["mention_patterns"])
+                if "allow_bots" in telegram_cfg and not os.getenv("TELEGRAM_ALLOW_BOTS"):
+                    os.environ["TELEGRAM_ALLOW_BOTS"] = str(telegram_cfg["allow_bots"]).lower()
                 frc = telegram_cfg.get("free_response_chats")
                 if frc is not None and not os.getenv("TELEGRAM_FREE_RESPONSE_CHATS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2347,6 +2347,62 @@ class TelegramAdapter(BasePlatformAdapter):
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
         return cleaned or text
 
+    def _is_from_bot_user(self, message: Message) -> bool:
+        user = getattr(message, "from_user", None)
+        return bool(getattr(user, "is_bot", False))
+
+    def _telegram_allow_bots_mode(self) -> str:
+        """Return how Telegram group messages from bot senders are handled.
+
+        Modes:
+        - ``none``: drop all bot-originated group messages
+        - ``signals`` (default): allow only explicit task/terminal status signals
+        - ``mentions``: allow explicit @mentions from bots, but not reply-only triggers
+        - ``all``: preserve legacy behavior and run normal group gating
+        """
+        raw = self.config.extra.get("allow_bots")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_ALLOW_BOTS", "signals")
+        raw = str(raw or "signals").strip().lower()
+        if raw in ("true", "yes", "on", "1"):
+            return "all"
+        if raw in ("false", "no", "off", "0"):
+            return "none"
+        if raw not in {"none", "signals", "mentions", "all"}:
+            logger.warning("[%s] Invalid TELEGRAM_ALLOW_BOTS value %r; using 'signals'", self.name, raw)
+            return "signals"
+        return raw
+
+    def _group_bot_message_has_work_signal(self, message: Message) -> bool:
+        """Return True for the small set of bot-originated group messages
+        that should enter an agent session in ``allow_bots=signals`` mode.
+
+        Telegram treats replies to a bot as direct triggers. In bot-to-bot
+        collaboration that creates reply loops: Bot A sends a status reply,
+        Bot B receives it as a reply-to-self trigger, answers, and the cycle
+        repeats. Only explicit task delivery or real terminal callbacks should
+        survive this gate; ACK/status/no-op chatter must be dropped before it
+        reaches the LLM.
+        """
+        text = (getattr(message, "text", None) or getattr(message, "caption", None) or "").strip()
+        if not text:
+            return False
+        if "[TASK]" in text and self._message_mentions_bot(message):
+            return True
+        if ("[DONE]" in text or "[BLOCKED]" in text) and self._message_mentions_bot(message):
+            return True
+        return False
+
+    def _should_process_bot_group_message(self, message: Message) -> bool:
+        mode = self._telegram_allow_bots_mode()
+        if mode == "all":
+            return True
+        if mode == "none":
+            return False
+        if mode == "mentions":
+            return self._message_mentions_bot(message)
+        return self._group_bot_message_has_work_signal(message)
+
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
@@ -2356,6 +2412,10 @@ class TelegramAdapter(BasePlatformAdapter):
         - the message replies to the bot
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
+
+        Bot-originated group messages are additionally gated by
+        ``allow_bots``/``TELEGRAM_ALLOW_BOTS`` to prevent bot-to-bot
+        reply/status loops. The safe default is ``signals``.
 
         When ``require_mention`` is enabled, slash commands are not given
         special treatment — they must pass the same mention/reply checks
@@ -2373,6 +2433,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     return False
             except (TypeError, ValueError):
                 logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
+        if self._is_from_bot_user(message) and not self._should_process_bot_group_message(message):
+            return False
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
             return True
         if not self._telegram_require_mention():

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
-def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None, ignored_threads=None):
+def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None, ignored_threads=None, allow_bots=None):
     from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
@@ -17,6 +17,8 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
         extra["mention_patterns"] = mention_patterns
     if ignored_threads is not None:
         extra["ignored_threads"] = ignored_threads
+    if allow_bots is not None:
+        extra["allow_bots"] = allow_bots
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -39,6 +41,7 @@ def _group_message(
     entities=None,
     caption=None,
     caption_entities=None,
+    from_bot=False,
 ):
     reply_to_message = None
     if reply_to_bot:
@@ -51,6 +54,7 @@ def _group_message(
         message_thread_id=thread_id,
         chat=SimpleNamespace(id=chat_id, type="group"),
         reply_to_message=reply_to_message,
+        from_user=SimpleNamespace(id=123, is_bot=from_bot),
     )
 
 
@@ -114,12 +118,94 @@ def test_invalid_regex_patterns_are_ignored():
     assert adapter._should_process_message(_group_message("hello everyone")) is False
 
 
+def test_bot_originated_reply_status_is_ignored_even_when_replying_to_bot(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message("不推进。等待正式 [DONE] / URL。", reply_to_bot=True, from_bot=True)
+    ) is False
+    assert adapter._should_process_message(
+        _group_message("[ACK] 收到，保持静默", reply_to_bot=True, from_bot=True)
+    ) is False
+
+
+def test_bot_originated_task_and_terminal_callbacks_are_allowed_when_mentioned(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
+    adapter = _make_adapter(require_mention=True)
+
+    task = "@hermes_bot [TASK] ShipSolo v1\n输入：x\n要求：y"
+    done = "@hermes_bot [DONE] 产物：/tmp/report.md"
+    blocked = "@hermes_bot [BLOCKED] 原因：缺少 URL"
+
+    assert adapter._should_process_message(
+        _group_message(task, entities=[_mention_entity(task)], from_bot=True)
+    ) is True
+    assert adapter._should_process_message(
+        _group_message(done, entities=[_mention_entity(done)], from_bot=True)
+    ) is True
+    assert adapter._should_process_message(
+        _group_message(blocked, entities=[_mention_entity(blocked)], from_bot=True)
+    ) is True
+
+
+def test_bot_originated_done_without_mention_is_ignored(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message("[DONE] 产物：/tmp/report.md", from_bot=True)
+    ) is False
+
+
+def test_bot_originated_mentions_mode_allows_explicit_mentions_not_replies(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "none")
+    adapter = _make_adapter(require_mention=True, allow_bots="mentions")
+
+    mention = "@hermes_bot please check this"
+    assert adapter._should_process_message(
+        _group_message(mention, entities=[_mention_entity(mention)], from_bot=True)
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("reply-only from bot", reply_to_bot=True, from_bot=True)
+    ) is False
+
+
+def test_bot_originated_all_mode_preserves_reply_to_bot_behavior(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "none")
+    adapter = _make_adapter(require_mention=True, allow_bots="all")
+
+    assert adapter._should_process_message(
+        _group_message("reply-only from bot", reply_to_bot=True, from_bot=True)
+    ) is True
+
+
+def test_bot_originated_none_mode_drops_even_explicit_mentions(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "all")
+    adapter = _make_adapter(require_mention=True, allow_bots="none")
+
+    task = "@hermes_bot [TASK] ShipSolo v1\n输入：x\n要求：y"
+    assert adapter._should_process_message(
+        _group_message(task, entities=[_mention_entity(task)], from_bot=True)
+    ) is False
+
+
+def test_telegram_allow_bots_env_used_when_config_missing(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "all")
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message("reply-only from bot", reply_to_bot=True, from_bot=True)
+    ) is True
+
+
 def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text(
         "telegram:\n"
         "  require_mention: true\n"
+        "  allow_bots: signals\n"
         "  mention_patterns:\n"
         "    - \"^\\\\s*chompy\\\\b\"\n"
         "  free_response_chats:\n"
@@ -129,6 +215,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
 
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
     monkeypatch.delenv("TELEGRAM_MENTION_PATTERNS", raising=False)
     monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_CHATS", raising=False)
 
@@ -136,6 +223,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
 
     assert config is not None
     assert __import__("os").environ["TELEGRAM_REQUIRE_MENTION"] == "true"
+    assert __import__("os").environ["TELEGRAM_ALLOW_BOTS"] == "signals"
     assert json.loads(__import__("os").environ["TELEGRAM_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
 


### PR DESCRIPTION
## Summary
- add Telegram `allow_bots` / `TELEGRAM_ALLOW_BOTS` modes for bot-originated group messages
- default to a safe `signals` mode that drops bot reply/status chatter before it reaches the agent loop
- preserve opt-in modes for `none`, explicit `mentions`, and legacy `all`
- cover the loop case where a bot replies to another bot with `[ACK]` / status text and triggers recursive responses

## Design
Telegram group gating currently treats `reply_to_bot` as a direct trigger. That is useful for humans, but unsafe once Telegram bot-to-bot delivery is enabled because bot status messages can reply-chain into another Hermes instance.

This PR keeps the human path unchanged and adds a bot-sender gate before normal mention/reply gating:

- `none`: drop all bot-originated group messages
- `signals` (default): allow only `[TASK]`, `[DONE]`, or `[BLOCKED]` messages that explicitly mention this bot
- `mentions`: allow explicit `@bot` mentions from bot senders, but not reply-only triggers
- `all`: preserve legacy behavior and run normal group gating

This keeps collaboration possible while making the default loop-safe.

## Test plan
- `python -m pytest tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_mention_boundaries.py -q -o 'addopts='`
- `python -m py_compile gateway/platforms/telegram.py gateway/config.py tests/gateway/test_telegram_group_gating.py`

Closes #13083
