### PR TITLE
fix(tools): schema-aware MCP normalization preserves property names

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -266,6 +266,89 @@ class TestSchemaConversion:
 
         assert schema["properties"]["items"]["items"]["properties"] == {}
 
+    def test_property_named_properties_is_not_treated_as_schema_node(self):
+        """A parameter literally named ``properties`` must not make the
+        normalizer treat the property-map as an object schema and inject a
+        stray ``type`` sibling. Anthropic rejects that as invalid against
+        draft 2020-12 (``'object' is not of type 'object', 'boolean'``)
+        because every value inside ``properties`` must itself be a schema.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "parent_page_id": {"type": "string"},
+                "title": {"type": "string"},
+                "properties": {"type": "string"},
+            },
+            "required": ["parent_page_id", "title", "properties"],
+            "additionalProperties": False,
+        })
+
+        # The property-map only contains the three declared parameters —
+        # no stray ``type``, ``required``, or other schema keyword.
+        assert set(schema["properties"].keys()) == {
+            "parent_page_id",
+            "title",
+            "properties",
+        }
+        assert schema["properties"]["properties"] == {"type": "string"}
+
+    def test_property_named_required_is_not_treated_as_schema_node(self):
+        """Same trap, different keyword: a parameter named ``required`` must
+        not be pruned or otherwise rewritten as if it were a ``required`` list.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "required": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Names of required fields",
+                },
+                "optional": {"type": "array", "items": {"type": "string"}},
+            },
+        })
+
+        assert schema["properties"]["required"] == {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Names of required fields",
+        }
+
+    def test_property_named_definitions_is_not_renamed_to_defs(self):
+        """The ``definitions`` → ``$defs`` rewrite applies to the JSON-Schema
+        keyword, not to a user-defined property that happens to share its name.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "definitions": {"type": "string", "description": "Glossary text"},
+            },
+        })
+
+        assert "definitions" in schema["properties"]
+        assert "$defs" not in schema["properties"]
+
+    def test_additionalproperties_false_is_preserved(self):
+        """``additionalProperties: false`` is a boolean schema and must survive
+        normalization unchanged (common in strict MCP server schemas).
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "additionalProperties": False,
+        })
+
+        assert schema["additionalProperties"] is False
+
     def test_convert_mcp_schema_survives_missing_inputschema_attribute(self):
         """A Tool object without .inputSchema must not crash registration."""
         import types

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2133,66 +2133,108 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
 
     All repairs are provider-agnostic and ideally produce a schema valid on
     OpenAI, Anthropic, Gemini, and Moonshot in one pass.
+
+    Traversal is *schema-aware*: we recurse only into positions that hold JSON
+    Schema values (``items``, values of ``properties``, members of ``oneOf``,
+    etc.), never into positions that hold arbitrary user data (the
+    ``properties`` map itself, whose keys are tool-author-chosen field names).
+    A structure-blind walk would misfire whenever a parameter happens to share
+    a name with a JSON Schema keyword — e.g. a Notion tool with a parameter
+    literally named ``properties`` would trigger the "looks like an object
+    schema" heuristic on the property map itself and inject a stray
+    ``"type": "object"`` sibling into it, producing a schema that Anthropic
+    rejects as invalid against draft 2020-12.
     """
     if not schema:
         return {"type": "object", "properties": {}}
 
-    def _rewrite_local_refs(node):
-        if isinstance(node, dict):
-            normalized = {}
-            for key, value in node.items():
-                out_key = "$defs" if key == "definitions" else key
-                normalized[out_key] = _rewrite_local_refs(value)
-            ref = normalized.get("$ref")
-            if isinstance(ref, str) and ref.startswith("#/definitions/"):
-                normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
-            return normalized
-        if isinstance(node, list):
-            return [_rewrite_local_refs(item) for item in node]
-        return node
+    # JSON Schema keywords that hold schema-typed values, classified by shape.
+    # Anything not listed here is a leaf (e.g. `type`, `required`, `enum`,
+    # `description`, `const`) and must not be recursed into as a schema.
+    _SINGLE_SCHEMA_KEYS = frozenset({
+        "additionalItems",         # draft-07 (deprecated in 2020-12)
+        "additionalProperties",    # schema or bool
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",                   # schema, or list (tuple-validation in draft-07)
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    })
+    _LIST_SCHEMA_KEYS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+    _MAP_SCHEMA_KEYS = frozenset({
+        "$defs",
+        "definitions",             # renamed to $defs below
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    })
 
-    def _repair_object_shape(node):
-        """Recursively repair object-shaped nodes: fill type, prune required."""
-        if isinstance(node, list):
-            return [_repair_object_shape(item) for item in node]
+    def _walk_schema(node):
+        """Recurse into ``node`` treating it as a JSON Schema."""
+        if isinstance(node, bool):
+            # Boolean schemas (``true``/``false``) are legal under draft 2019-09+.
+            return node
         if not isinstance(node, dict):
             return node
 
-        repaired = {k: _repair_object_shape(v) for k, v in node.items()}
+        walked: dict = {}
+        for key, value in node.items():
+            out_key = "$defs" if key == "definitions" else key
+            if key in _SINGLE_SCHEMA_KEYS:
+                # ``items`` (draft-07) and a couple of other keywords permit a
+                # list of schemas for tuple-style validation.
+                if isinstance(value, list):
+                    walked[out_key] = [_walk_schema(v) for v in value]
+                else:
+                    walked[out_key] = _walk_schema(value)
+            elif key in _LIST_SCHEMA_KEYS and isinstance(value, list):
+                walked[out_key] = [_walk_schema(v) for v in value]
+            elif key in _MAP_SCHEMA_KEYS and isinstance(value, dict):
+                walked[out_key] = {k: _walk_schema(v) for k, v in value.items()}
+            else:
+                # Leaf keyword (type, required, enum, description, …) or an
+                # unrecognized keyword: copy verbatim without descending.
+                walked[out_key] = value
 
-        # Coerce missing / null type when the shape is clearly an object
-        # (has properties or required but no type).
-        if not repaired.get("type") and (
-            "properties" in repaired or "required" in repaired
+        # Rewrite local ``$ref`` pointers: #/definitions/... -> #/$defs/...
+        ref = walked.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/definitions/"):
+            walked["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
+
+        # Coerce missing / null ``type`` when the shape is clearly an object
+        # (has ``properties`` or ``required`` but no ``type``).
+        if not walked.get("type") and (
+            "properties" in walked or "required" in walked
         ):
-            repaired["type"] = "object"
+            walked["type"] = "object"
 
-        if repaired.get("type") == "object":
-            # Ensure properties exists so required can reference it safely
-            if "properties" not in repaired or not isinstance(
-                repaired.get("properties"), dict
-            ):
-                repaired["properties"] = {} if "properties" not in repaired else repaired["properties"]
-                if not isinstance(repaired.get("properties"), dict):
-                    repaired["properties"] = {}
+        if walked.get("type") == "object":
+            # Ensure ``properties`` exists so ``required`` entries can resolve.
+            if not isinstance(walked.get("properties"), dict):
+                walked["properties"] = {}
 
-            # Prune required to only include names that exist in properties
-            required = repaired.get("required")
+            # Prune ``required`` to names that exist in ``properties``;
+            # otherwise Gemini 400s with "property is not defined".
+            required = walked.get("required")
             if isinstance(required, list):
-                props = repaired.get("properties") or {}
+                props = walked.get("properties") or {}
                 valid = [r for r in required if isinstance(r, str) and r in props]
                 if len(valid) != len(required):
                     if valid:
-                        repaired["required"] = valid
+                        walked["required"] = valid
                     else:
-                        repaired.pop("required", None)
+                        walked.pop("required", None)
 
-        return repaired
+        return walked
 
-    normalized = _rewrite_local_refs(schema)
-    normalized = _repair_object_shape(normalized)
+    normalized = _walk_schema(schema)
 
-    # Ensure top-level is a well-formed object schema
+    # Ensure top-level is a well-formed object schema.
     if not isinstance(normalized, dict):
         return {"type": "object", "properties": {}}
     if normalized.get("type") == "object" and "properties" not in normalized:


### PR DESCRIPTION
## What changed and why

`_normalize_mcp_input_schema` in `tools/mcp_tool.py` recursed blindly into every dict, treating the `properties` map itself as a schema node. When a tool parameter happens to share a name with a JSON Schema keyword — `properties`, `required`, or `definitions` — the heuristics misfire. The most visible symptom: Anthropic 400s on tool-use requests with

```
tools.N.custom.input_schema: JSON schema is invalid.
It must match JSON Schema draft 2020-12.
('object' is not of type 'object', 'boolean')
```

because Hermes had injected a stray `"type": "object"` sibling into the `properties` map. The existing check

```python
if not repaired.get("type") and ("properties" in repaired or "required" in repaired):
    repaired["type"] = "object"
```

was meant to say "this node looks like an object schema" but triggers equally on a property-map whose **keys** happen to include `properties` or `required`. Similarly the `definitions → $defs` rewrite applied to a user-named property rather than only the JSON Schema keyword.

The fix replaces the two structure-blind passes (`_rewrite_local_refs` + `_repair_object_shape`) with a single schema-aware walk that recurses only into positions holding JSON Schema values:

- **Single schema**: `items`, `additionalProperties`, `contains`, `not`, `if`/`then`/`else`, `propertyNames`, `unevaluatedItems`/`unevaluatedProperties`, `contentSchema`, `additionalItems` (draft-07 compat).
- **List of schemas**: `allOf`, `anyOf`, `oneOf`, `prefixItems`.
- **Map of name→schema**: `properties`, `patternProperties`, `dependentSchemas`, `$defs`, `definitions`.

Everything else (including `type`, `required`, `enum`, `const`, `description`, and unknown keywords) is treated as a leaf and copied verbatim. Boolean schemas (`true`, `additionalProperties: false`) pass through unchanged. No public API change; return shape is identical and walk order is still post-order.

## Repro

Trivial with any Notion-shaped MCP server. The official `@notionhq/notion-mcp-server` defines tools like `API_post_page` / `API_patch_page` / `API_create_a_data_source` / `API_update_a_data_source` whose schemas include a top-level `properties` field mirroring the Notion REST API. User-authored Notion MCP servers (anywhere with `z.object({ ..., properties: z.string() })`) hit the same trap. In my local setup, 7 tools across two Notion MCP servers all produced schemas Anthropic rejected before this fix.

## How to test it

```
./venv/bin/pytest tests/tools/test_mcp_tool.py -q -k "schema or normali or definitions_refs or missing_type or null_type or required_pruned or required_removed or nested_objects or array_items or property_named or additionalproperties"
```

New regression tests cover:

- Parameter literally named `properties` — property-map stays clean (no injected `type`).
- Parameter named `required` — not pruned / not rewritten.
- Parameter named `definitions` — not renamed to `$defs`.
- `additionalProperties: false` preserved.

## Platforms tested

- macOS 15 (Darwin 25.4.0, arm64), Python 3.11.13
- Full `tests/tools/test_mcp_tool.py`: 177 of 178 pass. The one failure (`TestShutdown::test_shutdown_is_parallel`) is a pre-existing timing-flake unrelated to this change.
- End-to-end: live 138-tool payload (including previously-broken Notion tools) validates clean via `jsonschema.Draft202012Validator.check_schema` for every tool, and a real `claude-opus-4-7` request with the full tools list returns successfully.

No platform-specific code paths are touched — the change is pure Python dict/list manipulation — so Linux impact is expected to be identical.

## Related issues

- Related to #14927 / #14870: same function, adjacent but distinct root cause. That issue concerns an MCP server emitting a malformed `additionalProperties: "object"` string shorthand; this PR concerns a Hermes-side heuristic misfire on a valid server schema. The two fixes do not overlap textually and can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)