### PR TITLE
fix(gateway): persist in-flight sessions for restart auto-resume

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -536,9 +536,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     script_timeout = _get_script_timeout()
 
+    if os.access(str(path), os.X_OK):
+        cmd = [str(path)]
+    elif path.suffix.lower() in {".sh", ".bash"}:
+        cmd = ["/bin/bash", str(path)]
+    else:
+        cmd = [sys.executable, str(path)]
+
     try:
         result = subprocess.run(
-            [sys.executable, str(path)],
+            cmd,
             capture_output=True,
             text=True,
             timeout=script_timeout,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1679,8 +1679,7 @@ class GatewayRunner:
 
         action = "restarting" if self._restart_requested else "shutting down"
         hint = (
-            "Your current task will be interrupted. "
-            "Send any message after restart and I'll try to resume where you left off."
+            "Your current task will be interrupted and automatically resumed after restart."
             if self._restart_requested
             else "Your current task will be interrupted."
         )
@@ -2026,29 +2025,32 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
 
-        # Suspend sessions that were active when the gateway last exited.
-        # This prevents stuck sessions from being blindly resumed on restart,
-        # which can create an unrecoverable loop (#7536).  Suspended sessions
-        # auto-reset on the next incoming message, giving the user a clean start.
+        # Mark sessions that were active when the gateway last exited for
+        # automatic continuation.  Previously these were suspended/reset to
+        # avoid stuck loops (#7536); stuck-loop protection still runs below,
+        # but the normal case now preserves the transcript and auto-injects a
+        # continuation turn after adapters reconnect.
         #
-        # SKIP suspension after a clean (graceful) shutdown — the previous
+        # SKIP marking after a clean (graceful) shutdown — the previous
         # process already drained active agents, so sessions aren't stuck.
-        # This prevents unwanted auto-resets after `hermes update`,
-        # `hermes gateway restart`, or `/restart`.
+        # This prevents unwanted auto-resumes after `hermes update`,
+        # `hermes gateway restart`, or `/restart` when no turn was interrupted.
         _clean_marker = _hermes_home / ".clean_shutdown"
         if _clean_marker.exists():
-            logger.info("Previous gateway exited cleanly — skipping session suspension")
+            logger.info("Previous gateway exited cleanly — skipping in-flight session auto-resume marking")
             try:
                 _clean_marker.unlink()
             except Exception:
                 pass
         else:
             try:
-                suspended = self.session_store.suspend_recently_active()
-                if suspended:
-                    logger.info("Suspended %d in-flight session(s) from previous run", suspended)
+                resumable = self.session_store.mark_recently_active_resume_pending(
+                    reason="unexpected_restart"
+                )
+                if resumable:
+                    logger.info("Marked %d in-flight session(s) for automatic resume", resumable)
             except Exception as e:
-                logger.warning("Session suspension on startup failed: %s", e)
+                logger.warning("Session auto-resume marking on startup failed: %s", e)
 
         # Stuck-loop detection (#7536): if a session has been active across
         # 3+ consecutive restarts, it's probably stuck in a loop (the same
@@ -2236,6 +2238,11 @@ class GatewayRunner:
 
         # Notify the chat that initiated /restart that the gateway is back.
         await self._send_restart_notification()
+
+        # Automatically continue sessions that were interrupted by a prior
+        # restart/shutdown after all adapters are connected.  This is
+        # fire-and-forget so gateway startup is not blocked by long agent work.
+        self._schedule_auto_resume_pending_sessions()
 
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
@@ -2707,8 +2714,8 @@ class GatewayRunner:
             else:
                 logger.info(
                     "Skipping .clean_shutdown marker — drain timed out with "
-                    "interrupted agents; next startup will suspend recently "
-                    "active sessions."
+                    "interrupted agents; next startup will mark recently "
+                    "active sessions for auto-resume."
                 )
 
             # Track sessions that were active at shutdown for stuck-loop
@@ -8165,6 +8172,87 @@ class GatewayRunner:
             logger.warning("Restart notification failed: %s", e)
         finally:
             notify_path.unlink(missing_ok=True)
+
+    def _schedule_auto_resume_pending_sessions(self) -> None:
+        """Schedule automatic continuation for sessions marked resume_pending.
+
+        ``resume_pending`` is persisted in sessions.json before a forced
+        shutdown, or marked on startup after an unclean exit.  Once platform
+        adapters are connected, inject a synthetic internal text event through
+        the normal adapter pipeline so the final response is delivered to the
+        original chat/thread without requiring the user to send a nudge.
+        """
+        try:
+            self.session_store._ensure_loaded()
+            candidates = []
+            for session_key, entry in list(self.session_store._entries.items()):
+                if not getattr(entry, "resume_pending", False):
+                    continue
+                if getattr(entry, "suspended", False):
+                    continue
+                source = getattr(entry, "origin", None)
+                if source is None or source.platform not in self.adapters:
+                    logger.debug(
+                        "Auto-resume skipped for %s: no connected adapter/source",
+                        session_key[:30],
+                    )
+                    continue
+                if not getattr(source, "chat_id", None):
+                    logger.debug(
+                        "Auto-resume skipped for %s: missing chat_id",
+                        session_key[:30],
+                    )
+                    continue
+                if session_key in self._running_agents:
+                    continue
+                candidates.append((session_key, entry, source))
+        except Exception as e:
+            logger.warning("Auto-resume scan failed: %s", e)
+            return
+
+        for session_key, entry, source in candidates:
+            task = asyncio.create_task(
+                self._auto_resume_pending_session(session_key, entry.session_id, source)
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+
+        if candidates:
+            logger.info("Scheduled auto-resume for %d interrupted session(s)", len(candidates))
+
+    async def _auto_resume_pending_session(self, session_key: str, session_id: str, source: SessionSource) -> None:
+        await asyncio.sleep(1.0)
+        if not self._running:
+            return
+        if session_key in self._running_agents:
+            return
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            return
+        text = (
+            "[SYSTEM: The gateway restarted while this task was in progress. "
+            "Automatically continue the interrupted task now, without asking "
+            "the user for confirmation. Use the existing transcript and any "
+            "pending tool results, proceed with the next required steps, and "
+            "send the final report when done.]"
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=f"auto-resume:{session_id}",
+            internal=True,
+        )
+        logger.info(
+            "Auto-resuming interrupted gateway session %s for %s:%s",
+            session_key[:30],
+            source.platform.value if source.platform else "unknown",
+            source.chat_id,
+        )
+        try:
+            await adapter.handle_message(event)
+        except Exception as e:
+            logger.warning("Auto-resume failed for %s: %s", session_key[:30], e)
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2039,18 +2039,30 @@ class GatewayRunner:
         if _clean_marker.exists():
             logger.info("Previous gateway exited cleanly — skipping in-flight session auto-resume marking")
             try:
+                cleared = self.session_store.clear_all_in_flight()
+                if cleared:
+                    logger.info("Cleared %d stale in-flight marker(s) after clean shutdown", cleared)
+            except Exception as e:
+                logger.debug("Clean-shutdown in-flight cleanup failed: %s", e)
+            try:
                 _clean_marker.unlink()
             except Exception:
                 pass
         else:
             try:
-                resumable = self.session_store.mark_recently_active_resume_pending(
-                    reason="unexpected_restart"
-                )
+                in_flight = self.session_store.mark_in_flight_resume_pending(
+                    reason="unexpected_restart")
+                recent = self.session_store.mark_recently_active_resume_pending(
+                    reason="unexpected_restart")
+                resumable = in_flight + recent
                 if resumable:
-                    logger.info("Marked %d in-flight session(s) for automatic resume", resumable)
+                    logger.info(
+                        "Marked %d in-flight session(s) for automatic resume (%d persisted in-flight, %d recent)",
+                        resumable, in_flight, recent,
+                    )
             except Exception as e:
                 logger.warning("Session auto-resume marking on startup failed: %s", e)
+
 
         # Stuck-loop detection (#7536): if a session has been active across
         # 3+ consecutive restarts, it's probably stuck in a loop (the same
@@ -4020,6 +4032,10 @@ class GatewayRunner:
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        try:
+            self.session_store.mark_in_flight(session_key)
+        except Exception as _e:
+            logger.debug("mark_in_flight failed for %s: %s", session_key[:20], _e)
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
@@ -4845,6 +4861,18 @@ class GatewayRunner:
                 "Try again or use /reset to start a fresh session."
             )
         finally:
+            # Preserve in-flight markers while the gateway is draining: if the
+            # process is killed before a clean marker is written, startup will
+            # auto-resume the interrupted turn.  Clean shutdown startup clears
+            # any harmless stale markers.
+            try:
+                if 'session_key' in locals() and not self._draining:
+                    self.session_store.clear_in_flight(session_key)
+            except Exception as _e:
+                try:
+                    logger.debug("clear_in_flight failed for %s: %s", session_key[:20], _e)
+                except Exception:
+                    pass
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
     

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1004,6 +1004,39 @@ class SessionStore:
                 self._save()
         return count
 
+    def mark_recently_active_resume_pending(
+        self,
+        max_age_seconds: int = 120,
+        reason: str = "unexpected_restart",
+    ) -> int:
+        """Mark recently-active sessions for automatic resume on startup.
+
+        Called after an unclean gateway exit. A session updated shortly
+        before the previous process disappeared was likely in-flight; instead
+        of forcing a fresh session, preserve its transcript and let the
+        gateway auto-inject a continuation turn after adapters reconnect.
+
+        Explicitly suspended sessions are skipped so /stop and stuck-loop
+        escalation still win.
+        """
+        from datetime import timedelta
+
+        cutoff = _now() - timedelta(seconds=max_age_seconds)
+        count = 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if entry.suspended:
+                    continue
+                if entry.updated_at >= cutoff and not entry.resume_pending:
+                    entry.resume_pending = True
+                    entry.resume_reason = reason
+                    entry.last_resume_marked_at = _now()
+                    count += 1
+            if count:
+                self._save()
+        return count
+
     def reset_session(self, session_key: str) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""
         db_end_session_id = None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -390,6 +390,15 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Persisted marker for a turn that is actively running inside the gateway.
+    # ``updated_at`` only changes when a session is created/accessed or after a
+    # completed turn.  A long-running turn can therefore be much older than the
+    # startup "recently active" window by the time systemd kills/restarts the
+    # gateway.  This flag is set at turn start and cleared on normal completion
+    # so unclean exits can resume truly in-flight work regardless of age.
+    in_flight: bool = False
+    in_flight_started_at: Optional[datetime] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -414,6 +423,12 @@ class SessionEntry:
             "last_resume_marked_at": (
                 self.last_resume_marked_at.isoformat()
                 if self.last_resume_marked_at
+                else None
+            ),
+            "in_flight": self.in_flight,
+            "in_flight_started_at": (
+                self.in_flight_started_at.isoformat()
+                if self.in_flight_started_at
                 else None
             ),
         }
@@ -442,6 +457,14 @@ class SessionEntry:
             except (TypeError, ValueError):
                 last_resume_marked_at = None
 
+        in_flight_started_at = None
+        _ifsa = data.get("in_flight_started_at")
+        if _ifsa:
+            try:
+                in_flight_started_at = datetime.fromisoformat(_ifsa)
+            except (TypeError, ValueError):
+                in_flight_started_at = None
+
         return cls(
             session_key=data["session_key"],
             session_id=data["session_id"],
@@ -464,6 +487,8 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            in_flight=data.get("in_flight", False),
+            in_flight_started_at=in_flight_started_at,
         )
 
 
@@ -916,6 +941,44 @@ class SessionStore:
             self._save()
             return True
 
+    def mark_in_flight(self, session_key: str) -> bool:
+        """Persist that a gateway turn is actively running for this session."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            entry.in_flight = True
+            entry.in_flight_started_at = _now()
+            self._save()
+            return True
+
+    def clear_in_flight(self, session_key: str) -> bool:
+        """Clear the active-turn marker after normal completion."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or not entry.in_flight:
+                return False
+            entry.in_flight = False
+            entry.in_flight_started_at = None
+            self._save()
+            return True
+
+    def clear_all_in_flight(self) -> int:
+        """Clear stale in-flight markers after a clean shutdown marker."""
+        count = 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if entry.in_flight:
+                    entry.in_flight = False
+                    entry.in_flight_started_at = None
+                    count += 1
+            if count:
+                self._save()
+        return count
+
     def prune_old_entries(self, max_age_days: int) -> int:
         """Drop SessionEntry records older than max_age_days.
 
@@ -1033,6 +1096,36 @@ class SessionStore:
                     entry.resume_reason = reason
                     entry.last_resume_marked_at = _now()
                     count += 1
+            if count:
+                self._save()
+        return count
+
+    def mark_in_flight_resume_pending(
+        self,
+        reason: str = "unexpected_restart",
+    ) -> int:
+        """Convert persisted in-flight markers into resume-pending sessions.
+
+        This is crash/restart recovery for long-running turns.  It does not
+        depend on ``updated_at`` recency, because ``updated_at`` can be stale
+        for tasks that ran longer than the startup recency window before the
+        gateway was killed by systemd or the server rebooted.
+        """
+        count = 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if not entry.in_flight:
+                    continue
+                if entry.suspended:
+                    continue
+                if not entry.resume_pending:
+                    entry.resume_pending = True
+                    entry.resume_reason = reason
+                    entry.last_resume_marked_at = _now()
+                    count += 1
+                entry.in_flight = False
+                entry.in_flight_started_at = None
             if count:
                 self._save()
         return count

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1999,6 +1999,10 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        # Runtime timeout knobs consumed by hermes_cli.timeouts. Keep these
+        # accepted here so provider entries can tune long-running calls without
+        # emitting misleading "unknown config keys ignored" warnings.
+        "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1018,9 +1018,19 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._client is not None:
             try:
                 if self._mode == "local_embedded":
-                    # Use the public close() API. The RuntimeError from
-                    # aiohttp's "attached to a different loop" is expected
-                    # and harmless — the daemon keeps running independently.
+                    # HindsightEmbedded.close() delegates to its sync client.close().
+                    # When Hermes created/used that client on the shared async loop,
+                    # closing it from this thread can raise "attached to a different
+                    # loop" before aiohttp releases the session. Close the embedded
+                    # inner async client on the shared loop first, then let the
+                    # wrapper clean up daemon/UI bookkeeping.
+                    inner_client = getattr(self._client, "_client", None)
+                    if inner_client is not None and hasattr(inner_client, "aclose"):
+                        _run_sync(inner_client.aclose())
+                        try:
+                            self._client._client = None
+                        except Exception:
+                            pass
                     try:
                         self._client.close()
                     except RuntimeError:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -174,6 +174,34 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_executable_shell_script_honors_shebang(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "hello.sh"
+        script.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            echo "hello from shell"
+        """))
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "hello from shell"
+
+    def test_non_executable_shell_script_falls_back_to_bash(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "fallback.sh"
+        script.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            echo "shell fallback works"
+        """))
+        script.chmod(0o644)
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "shell fallback works"
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""

--- a/tests/gateway/test_auto_resume_pending_sessions.py
+++ b/tests/gateway/test_auto_resume_pending_sessions.py
@@ -1,0 +1,94 @@
+"""Tests for gateway auto-resume of interrupted sessions after restart."""
+
+import asyncio
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+
+
+class DummyAdapter:
+    def __init__(self):
+        self.events = []
+
+    async def handle_message(self, event: MessageEvent):
+        self.events.append(event)
+        return "ok"
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="user-1",
+        user_name="Maxim",
+        chat_type="dm",
+    )
+
+
+def _runner(tmp_path, store: SessionStore, adapter: DummyAdapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._running = True
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_schedule_auto_resume_injects_internal_event(tmp_path):
+    store = SessionStore(tmp_path, GatewayConfig(sessions_dir=tmp_path))
+    source = _source()
+    entry = store.get_or_create_session(source)
+    assert store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+    adapter = DummyAdapter()
+    runner = _runner(tmp_path, store, adapter)
+
+    runner._schedule_auto_resume_pending_sessions()
+    assert len(runner._background_tasks) == 1
+    await asyncio.gather(*list(runner._background_tasks))
+
+    assert len(adapter.events) == 1
+    event = adapter.events[0]
+    assert event.internal is True
+    assert event.source == source
+    assert event.message_id == f"auto-resume:{entry.session_id}"
+    assert "Automatically continue the interrupted task" in event.text
+
+
+@pytest.mark.asyncio
+async def test_schedule_auto_resume_skips_suspended_sessions(tmp_path):
+    store = SessionStore(tmp_path, GatewayConfig(sessions_dir=tmp_path))
+    source = _source()
+    entry = store.get_or_create_session(source)
+    assert store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+    entry.suspended = True
+    store._save()
+
+    adapter = DummyAdapter()
+    runner = _runner(tmp_path, store, adapter)
+
+    runner._schedule_auto_resume_pending_sessions()
+    assert len(runner._background_tasks) == 0
+    assert adapter.events == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_auto_resume_skips_missing_adapter(tmp_path):
+    store = SessionStore(tmp_path, GatewayConfig(sessions_dir=tmp_path))
+    source = _source()
+    entry = store.get_or_create_session(source)
+    assert store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+    adapter = DummyAdapter()
+    runner = _runner(tmp_path, store, adapter)
+    runner.adapters = {}
+
+    runner._schedule_auto_resume_pending_sessions()
+    assert len(runner._background_tasks) == 0
+    assert adapter.events == []

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -1,10 +1,12 @@
-"""Tests for the clean shutdown marker that prevents unwanted session auto-resets.
+"""Tests for the clean shutdown marker and restart auto-resume.
 
 When the gateway shuts down gracefully (hermes update, gateway restart, /restart),
-it writes a .clean_shutdown marker.  On the next startup, if the marker exists,
-suspend_recently_active() is skipped so users don't lose their sessions.
+it writes a .clean_shutdown marker. On the next startup, if the marker exists,
+recent sessions are not marked for auto-resume because no turn was interrupted.
 
-After a crash (no marker), suspension still fires as a safety net for stuck sessions.
+After an unclean exit (no marker), recent sessions are marked resume_pending so
+the gateway can automatically continue them after adapters reconnect. Stuck-loop
+escalation can still suspend repeatedly failing sessions.
 """
 
 import os
@@ -132,8 +134,8 @@ class TestCleanShutdownMarker:
 
         assert marker.exists(), ".clean_shutdown marker should exist after graceful stop"
 
-    def test_marker_skips_suspension_on_startup(self, tmp_path, monkeypatch):
-        """If .clean_shutdown exists, suspend_recently_active should NOT be called."""
+    def test_marker_skips_auto_resume_marking_on_startup(self, tmp_path, monkeypatch):
+        """If .clean_shutdown exists, recent sessions should NOT be marked for resume."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
 
         # Create the marker
@@ -149,20 +151,21 @@ class TestCleanShutdownMarker:
         # Simulate what start() does:
         if marker.exists():
             marker.unlink()
-            # Should NOT call suspend_recently_active
+            # Should NOT call mark_recently_active_resume_pending
         else:
-            store.suspend_recently_active()
+            store.mark_recently_active_resume_pending()
 
-        # Session should NOT be suspended
+        # Session should NOT be suspended or marked for resume
         with store._lock:
             store._ensure_loaded_locked()
             for e in store._entries.values():
                 assert not e.suspended, "Session should NOT be suspended after clean shutdown"
+                assert not e.resume_pending, "Session should NOT auto-resume after clean shutdown"
 
         assert not marker.exists(), "Marker should be cleaned up"
 
-    def test_no_marker_triggers_suspension(self, tmp_path, monkeypatch):
-        """Without .clean_shutdown marker (crash), suspension should fire."""
+    def test_no_marker_marks_recent_session_for_auto_resume(self, tmp_path, monkeypatch):
+        """Without .clean_shutdown marker (unclean exit), recent sessions auto-resume."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
 
         marker = tmp_path / ".clean_shutdown"
@@ -178,13 +181,15 @@ class TestCleanShutdownMarker:
         if marker.exists():
             marker.unlink()
         else:
-            store.suspend_recently_active()
+            store.mark_recently_active_resume_pending(reason="unexpected_restart")
 
-        # Session SHOULD be suspended (crash recovery)
+        # Session SHOULD be marked resume_pending, not suspended.
         with store._lock:
             store._ensure_loaded_locked()
-            suspended_count = sum(1 for e in store._entries.values() if e.suspended)
-        assert suspended_count == 1, "Session should be suspended after crash (no marker)"
+            entries = list(store._entries.values())
+        assert sum(1 for e in entries if e.suspended) == 0
+        assert sum(1 for e in entries if e.resume_pending) == 1
+        assert entries[0].resume_reason == "unexpected_restart"
 
     def test_marker_written_on_restart_stop(self, tmp_path, monkeypatch):
         """stop(restart=True) should also write the marker."""

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -191,6 +191,63 @@ class TestCleanShutdownMarker:
         assert sum(1 for e in entries if e.resume_pending) == 1
         assert entries[0].resume_reason == "unexpected_restart"
 
+
+    def test_unclean_exit_marks_old_in_flight_session_for_auto_resume(self, tmp_path, monkeypatch):
+        """Long-running in-flight sessions auto-resume even when updated_at is old."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        assert not marker.exists()
+
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        with store._lock:
+            entry.updated_at = datetime.now() - timedelta(hours=2)
+            store._save()
+
+        assert store.mark_in_flight(entry.session_key)
+
+        in_flight = store.mark_in_flight_resume_pending(reason="unexpected_restart")
+        recent = store.mark_recently_active_resume_pending(reason="unexpected_restart")
+
+        with store._lock:
+            store._ensure_loaded_locked()
+            refreshed = store._entries[entry.session_key]
+
+        assert in_flight == 1
+        assert recent == 0
+        assert refreshed.resume_pending
+        assert refreshed.resume_reason == "unexpected_restart"
+        assert not refreshed.in_flight
+
+    def test_clean_marker_clears_stale_in_flight_without_auto_resume(self, tmp_path, monkeypatch):
+        """Clean shutdown should discard harmless stale in-flight markers."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.touch()
+
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        assert store.mark_in_flight(entry.session_key)
+
+        if marker.exists():
+            cleared = store.clear_all_in_flight()
+            marker.unlink()
+        else:
+            cleared = 0
+            store.mark_in_flight_resume_pending(reason="unexpected_restart")
+            store.mark_recently_active_resume_pending(reason="unexpected_restart")
+
+        with store._lock:
+            store._ensure_loaded_locked()
+            refreshed = store._entries[entry.session_key]
+
+        assert cleared == 1
+        assert not refreshed.in_flight
+        assert not refreshed.resume_pending
+        assert not marker.exists()
+
     def test_marker_written_on_restart_stop(self, tmp_path, monkeypatch):
         """stop(restart=True) should also write the marker."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -51,6 +51,24 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_rejects_stale_gateway_pid_and_removes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -502,6 +502,32 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["provider_key"] == "openai-direct"
         assert compatible[0]["api_mode"] == "codex_responses"
 
+    def test_provider_timeout_knobs_are_accepted_without_unknown_key_warning(self, tmp_path, caplog):
+        """Provider-level timeout knobs are runtime config, not unknown keys."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "openai-codex": {
+                            "api": "https://chatgpt.com/backend-api/codex",
+                            "name": "OpenAI Codex",
+                            "request_timeout_seconds": 3600,
+                            "stale_timeout_seconds": 1200,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert len(compatible) == 1
+        assert "unknown config keys ignored" not in caplog.text
+
     def test_compatible_custom_providers_prefers_base_url_then_url_then_api(self, tmp_path):
         """URL field precedence is base_url > url > api (PR #9332)."""
         config_path = tmp_path / "config.yaml"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -612,3 +612,21 @@ class TestAvailability:
         monkeypatch.setenv("HINDSIGHT_MODE", "local")
         p = HindsightMemoryProvider()
         assert p.is_available()
+
+class TestShutdown:
+    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
+        inner_client = _make_mock_client()
+        embedded = MagicMock()
+        embedded._client = inner_client
+        embedded.close = MagicMock()
+
+        provider._mode = "local_embedded"
+        provider._client = embedded
+
+        provider.shutdown()
+
+        inner_client.aclose.assert_awaited_once()
+        embedded.close.assert_called_once()
+        assert embedded._client is None
+        assert provider._client is None
+


### PR DESCRIPTION
## Summary\n- Persist a per-session in-flight marker when a gateway turn starts.\n- On unclean startup, convert persisted in-flight sessions to resume_pending even when updated_at is older than the recent-session window.\n- On clean shutdown startup, clear stale in-flight markers so idle sessions do not auto-resume.\n\n## Why\nLong-running gateway tasks can be killed by systemd/reboot after running longer than the recency window, so updated_at-based recovery misses them. External systemctl restarts can also hit TimeoutStopSec at the same time as the drain timeout, racing before resume_pending is saved.\n\n## Verification\n- pytest tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_auto_resume_pending_sessions.py tests/gateway/test_gateway_shutdown.py tests/cron/test_cron_script.py tests/gateway/test_status.py -q\n