### PR TITLE
fix: handle EOFError in stash restore prompt during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3255,7 +3255,13 @@ def _restore_stashed_changes(
         if input_fn is not None:
             response = input_fn("Restore local changes now? [Y/n]", "y")
         else:
-            response = input().strip().lower()
+            try:
+                response = input().strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                # stdin closed or Ctrl-C — skip restore so update completes.
+                # Stash is preserved for manual recovery.
+                print()
+                response = "n"
         if response not in ("", "y", "yes"):
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")


### PR DESCRIPTION
## Summary

- Wraps bare `input()` call in `_restore_stashed_changes()` with `try/except (EOFError, KeyboardInterrupt)`
- Defaults to skipping restore when stdin is unavailable (stash is preserved for manual recovery)
- Fixes crash during `hermes update` in non-interactive environments (Docker containers, process launchers like Teleost)

## Problem

When `hermes update` detects local changes, it stashes them and prompts "Restore local changes now? [Y/n]". If stdin is closed (common in Docker/managed deployments), the bare `input()` throws `EOFError`, causing the update to crash with exit code 1 — even though the code update itself succeeded.

## Fix

```python
# Before
response = input().strip().lower()

# After
try:
    response = input().strip().lower()
except (EOFError, KeyboardInterrupt):
    print()
    response = "n"
```

The `isatty()` guard at the call site was supposed to prevent this, but some process launchers (e.g. Teleost via Fly.io) allocate a pseudo-TTY that reports `isatty()=True` while stdin is effectively closed.