### PR TITLE
fix(auxiliary): use live Codex fallback models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -188,10 +188,9 @@ _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
 # Codex fallback: uses the Responses API (the only endpoint the Codex
-# OAuth token can access) with a fast model for auxiliary tasks.
-# ChatGPT-backed Codex accounts currently reject gpt-5.3-codex for these
-# auxiliary flows, while gpt-5.2-codex remains broadly available and supports
-# vision via Responses.
+# OAuth token can access). Runtime fallback must choose a model from the live
+# account catalog; this legacy constant is retained only as a preference when
+# it is explicitly present in that live catalog.
 _CODEX_AUX_MODEL = "gpt-5.2-codex"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
@@ -810,6 +809,80 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
+def _select_codex_aux_model(
+    access_token: str,
+    *,
+    requested_model: Optional[str] = None,
+) -> Optional[str]:
+    """Select a Codex auxiliary model from the live account catalog only.
+
+    Runtime fallback must not guess from hardcoded Codex defaults: stale model
+    slugs produce provider-side 400s and look like confusing model switches.
+    """
+    try:
+        from hermes_cli.codex_models import get_live_codex_model_ids
+
+        live_models = get_live_codex_model_ids(access_token)
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary client: live Codex model catalog is unavailable (%s); "
+            "skipping Codex auxiliary fallback instead of guessing a stale model",
+            exc,
+        )
+        return None
+
+    ordered_live: List[str] = []
+    for model_id in live_models or []:
+        model_id = str(model_id or "").strip()
+        if model_id and model_id not in ordered_live:
+            ordered_live.append(model_id)
+
+    if not ordered_live:
+        logger.warning(
+            "Auxiliary client: live Codex model catalog is unavailable; "
+            "skipping Codex auxiliary fallback instead of guessing a stale model"
+        )
+        return None
+
+    live_set = set(ordered_live)
+    candidates: List[tuple[str, str]] = []
+
+    def _add_candidate(label: str, model_name: Optional[str]) -> None:
+        normalized = _normalize_resolved_model(model_name, "openai-codex")
+        normalized = str(normalized or "").strip()
+        if normalized and (label, normalized) not in candidates:
+            candidates.append((label, normalized))
+
+    _add_candidate("requested", requested_model)
+    if _read_main_provider() == "openai-codex":
+        _add_candidate("main", _read_main_model())
+    _add_candidate("legacy auxiliary default", _CODEX_AUX_MODEL)
+
+    for label, candidate in candidates:
+        if candidate in live_set:
+            logger.info(
+                "Auxiliary client: Codex OAuth (%s via Responses API; "
+                "%s model from live Codex catalog)",
+                candidate,
+                label,
+            )
+            return candidate
+        logger.warning(
+            "Auxiliary client: Codex %s model %s is not in the live Codex "
+            "catalog; not using it",
+            label,
+            candidate,
+        )
+
+    selected = ordered_live[0]
+    logger.info(
+        "Auxiliary client: Codex OAuth (%s via Responses API; selected from "
+        "live Codex catalog)",
+        selected,
+    )
+    return selected
+
+
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
     """Try each API-key provider in PROVIDER_REGISTRY order.
 
@@ -1173,7 +1246,7 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     return OpenAI(api_key=custom_key, base_url=custom_base), model
 
 
-def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
+def _try_codex(requested_model: Optional[str] = None) -> Tuple[Optional[Any], Optional[str]]:
     pool_present, entry = _select_pool_entry("openai-codex")
     if pool_present:
         codex_token = _pool_runtime_api_key(entry)
@@ -1189,13 +1262,15 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
         if not codex_token:
             return None, None
         base_url = _CODEX_AUX_BASE_URL
-    logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
+    model = _select_codex_aux_model(codex_token, requested_model=requested_model)
+    if not model:
+        return None, None
     real_client = OpenAI(
         api_key=codex_token,
         base_url=base_url,
         default_headers=_codex_cloudflare_headers(codex_token),
     )
-    return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
+    return CodexAuxiliaryClient(real_client, model), model
 
 
 def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
@@ -1676,7 +1751,13 @@ def resolve_provider_client(
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")
                 return None, None
-            final_model = _normalize_resolved_model(model or _CODEX_AUX_MODEL, provider)
+            final_model = _select_codex_aux_model(codex_token, requested_model=model)
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: openai-codex requested but no "
+                    "live-supported Codex model was available"
+                )
+                return None, None
             raw_client = OpenAI(
                 api_key=codex_token,
                 base_url=_CODEX_AUX_BASE_URL,
@@ -1684,12 +1765,12 @@ def resolve_provider_client(
             )
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
-        client, default = _try_codex()
+        client, default = _try_codex(requested_model=model)
         if client is None:
             logger.warning("resolve_provider_client: openai-codex requested "
-                           "but no Codex OAuth token found (run: hermes model)")
+                           "but no Codex OAuth token or live-supported model found (run: hermes model)")
             return None, None
-        final_model = _normalize_resolved_model(model or default, provider)
+        final_model = _normalize_resolved_model(default, provider)
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
 
@@ -2332,11 +2413,26 @@ def _is_openrouter_client(client: Any) -> bool:
     return False
 
 
-def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
-    """Drop OpenRouter-format model slugs (with '/') for non-OpenRouter clients.
+def _is_codex_auxiliary_client(client: Any) -> bool:
+    return isinstance(client, (CodexAuxiliaryClient, AsyncCodexAuxiliaryClient))
 
-    Mirrors the guard in resolve_provider_client() which is skipped on cache hits.
+
+def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
+    """Return the safe effective model for a cached auxiliary client.
+
+    Cache keys intentionally omit the requested model so compatible clients can
+    be reused. That means provider-specific safety checks must run on both cache
+    hits and cold-cache returns.
     """
+    if _is_codex_auxiliary_client(client):
+        if model and cached_default and model != cached_default:
+            logger.warning(
+                "Auxiliary client: ignoring Codex model override %s; using "
+                "live-selected %s",
+                model,
+                cached_default,
+            )
+        return cached_default or model
     if model and "/" in model and not _is_openrouter_client(client):
         return cached_default
     return model or cached_default
@@ -2433,7 +2529,7 @@ def _get_cached_client(
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    return client, _compat_model(client, model, default_model)
 
 
 def _resolve_task_provider_model(

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -53,8 +53,8 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     return ordered
 
 
-def _fetch_models_from_api(access_token: str) -> List[str]:
-    """Fetch available models from the Codex API. Returns visible models sorted by priority."""
+def _fetch_live_models_from_api(access_token: str) -> List[str]:
+    """Fetch model slugs that the live Codex API says this account supports."""
     try:
         import httpx
         resp = httpx.get(
@@ -88,7 +88,12 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         sortable.append((rank, slug))
 
     sortable.sort(key=lambda x: (x[0], x[1]))
-    return _add_forward_compat_models([slug for _, slug in sortable])
+    return [slug for _, slug in sortable]
+
+
+def _fetch_models_from_api(access_token: str) -> List[str]:
+    """Fetch available models from the Codex API, including synthetic picker IDs."""
+    return _add_forward_compat_models(_fetch_live_models_from_api(access_token))
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -143,6 +148,18 @@ def _read_cache_models(codex_home: Path) -> List[str]:
         if slug not in deduped:
             deduped.append(slug)
     return deduped
+
+
+def get_live_codex_model_ids(access_token: Optional[str]) -> List[str]:
+    """Return live Codex model IDs supported by the current account.
+
+    Unlike ``get_codex_model_ids()``, this never falls back to local cache or
+    hardcoded defaults. Use it for runtime fallback decisions where guessing a
+    stale model would cause a provider-side 400.
+    """
+    if not access_token:
+        return []
+    return _fetch_live_models_from_api(access_token)
 
 
 def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -248,10 +248,14 @@ class TestAnthropicOAuthFlag:
 
 
 class TestTryCodex:
-    def test_pool_without_selected_entry_falls_back_to_auth_store(self):
+    def test_pool_without_selected_entry_uses_live_catalog_model(self, caplog):
+        caplog.set_level(logging.INFO, logger="agent.auxiliary_client")
         with (
             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
             patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"),
+            patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.5"),
+            patch("hermes_cli.codex_models.get_live_codex_model_ids", return_value=["gpt-5.5"]),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
             mock_openai.return_value = MagicMock()
@@ -260,9 +264,79 @@ class TestTryCodex:
             client, model = _try_codex()
 
         assert client is not None
-        assert model == "gpt-5.2-codex"
+        assert model == "gpt-5.5"
+        assert "live Codex catalog" in caplog.text
+        assert "gpt-5.5" in caplog.text
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+    def test_codex_aux_skips_codex_when_live_catalog_unavailable(self, caplog):
+        caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+            patch("hermes_cli.codex_models.get_live_codex_model_ids", return_value=[]),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            from agent.auxiliary_client import _try_codex
+
+            client, model = _try_codex()
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+        assert "live Codex model catalog is unavailable" in caplog.text
+
+    def test_raw_codex_client_uses_live_catalog_model(self):
+        with (
+            patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+            patch("hermes_cli.codex_models.get_live_codex_model_ids", return_value=["gpt-5.5"]),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            raw_client = MagicMock()
+            mock_openai.return_value = raw_client
+
+            client, model = resolve_provider_client(
+                "openai-codex",
+                "gpt-5.5",
+                raw_codex=True,
+            )
+
+        assert client is raw_client
+        assert model == "gpt-5.5"
+
+    def test_cached_codex_client_ignores_unsupported_requested_model(self, caplog):
+        caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+        from agent.auxiliary_client import _client_cache, _client_cache_lock, _get_cached_client
+
+        with _client_cache_lock:
+            _client_cache.clear()
+        try:
+            with (
+                patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+                patch("hermes_cli.codex_models.get_live_codex_model_ids", return_value=["gpt-5.5"]),
+                patch("agent.auxiliary_client.OpenAI") as mock_openai,
+            ):
+                mock_openai.return_value = MagicMock()
+
+                client, cold_model = _get_cached_client(
+                    "openai-codex",
+                    "gpt-5.2-codex",
+                )
+                cached_client, cached_model = _get_cached_client(
+                    "openai-codex",
+                    "gpt-5.2-codex",
+                )
+
+            assert client is not None
+            assert cached_client is client
+            assert cold_model == "gpt-5.5"
+            assert cached_model == "gpt-5.5"
+            mock_openai.assert_called_once()
+            assert "ignoring Codex model override gpt-5.2-codex" in caplog.text
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
 
 
 class TestExpiredCodexFallback:
@@ -492,6 +566,7 @@ class TestGetTextAuxiliaryClient:
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("hermes_cli.codex_models.get_live_codex_model_ids", return_value=["gpt-5.5"]),
             patch("agent.auxiliary_client.OpenAI"),
             patch("hermes_cli.auth._read_codex_tokens", side_effect=AssertionError("legacy codex store should not run")),
         ):
@@ -502,7 +577,7 @@ class TestGetTextAuxiliaryClient:
         from agent.auxiliary_client import CodexAuxiliaryClient
 
         assert isinstance(client, CodexAuxiliaryClient)
-        assert model == "gpt-5.2-codex"
+        assert model == "gpt-5.5"
 
 
 class TestNousAuxiliaryRefresh:

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
+from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids, get_live_codex_model_ids
 
 
 def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch):
@@ -105,6 +105,35 @@ def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
     assert captured["access_token"] == "codex-access-token"
     assert captured["model_ids"] == ["gpt-5.2-codex", "gpt-5.2"]
     assert captured["current_model"] == "openai/gpt-5.4"
+
+
+def test_get_live_codex_model_ids_never_uses_local_fallbacks(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "config.toml").write_text('model = "gpt-5.2-codex"\n')
+    (codex_home / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-5.4", "supported_in_api": True}]})
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_live_models_from_api",
+        lambda access_token: [],
+    )
+
+    models = get_live_codex_model_ids("codex-access-token")
+
+    assert models == []
+
+
+def test_get_live_codex_model_ids_does_not_add_forward_compat_models(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_live_models_from_api",
+        lambda access_token: ["gpt-5.2-codex"],
+    )
+
+    models = get_live_codex_model_ids("codex-access-token")
+
+    assert models == ["gpt-5.2-codex"]
 
 
 # ── Tests for _normalize_model_for_provider ──────────────────────────


### PR DESCRIPTION
## Summary

Fix the Codex auxiliary fallback path so runtime auxiliary calls do not silently try stale hardcoded Codex model IDs such as `gpt-5.2-codex` when the user's ChatGPT/Codex account no longer supports them.

This addresses the Codex stale-fallback portion of #14306.

## What changed

- Added `get_live_codex_model_ids(access_token)` for live-only Codex account catalog lookups.
- Kept the existing picker/catalog behavior separate, so model-picker flows may still use local cache/defaults/forward-compat entries.
- Updated Codex auxiliary fallback selection to:
  - prefer the requested/main Codex model only when it appears in the live account catalog
  - use the legacy auxiliary default only if it is live-supported
  - skip Codex fallback rather than guessing when the live catalog is unavailable
- Updated raw Codex and cached auxiliary paths so stale requested model overrides cannot bypass the live-selected model.
- Added regression coverage for:
  - live-catalog model selection
  - live-catalog unavailable behavior
  - raw Codex client path
  - cached Codex client cache-miss/cache-hit behavior
  - live-only catalog helper not using local/static fallbacks or synthetic forward-compat IDs

## Validation

- `python -m pytest tests/agent/test_auxiliary_client.py::TestTryCodex -q -o 'addopts='`
  - `4 passed`
- `python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py -q -o 'addopts='`
  - `100 passed`
- `python -m pytest tests/hermes_cli/test_codex_models.py::test_get_live_codex_model_ids_never_uses_local_fallbacks tests/hermes_cli/test_codex_models.py::test_get_live_codex_model_ids_does_not_add_forward_compat_models tests/hermes_cli/test_codex_models.py::test_get_codex_model_ids_adds_forward_compat_models_from_templates -q -o 'addopts='`
  - `3 passed`
- `python -m py_compile agent/auxiliary_client.py hermes_cli/codex_models.py tests/agent/test_auxiliary_client.py tests/hermes_cli/test_codex_models.py`
  - passed
- `git diff --check`
  - passed
- staged static security scan
  - no findings
- independent staged-diff review
  - passed; no security concerns or logic errors

## Notes

The normal Codex model catalog remains unchanged for model selection UX. The live-only helper is intentionally narrower and is used for runtime fallback decisions where guessing a stale model causes provider-side 400s and confusing apparent model switches.
