### PR TITLE
fix(update): honor protected local workflows

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -17,6 +17,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import stat
 import subprocess
 import sys
@@ -113,9 +114,143 @@ def get_managed_update_command() -> Optional[str]:
     return None
 
 
+_PROTECTED_UPDATE_BYPASS_ENV = "HERMES_ALLOW_PROTECTED_BRANCH_UPDATE"
+_PROTECTED_UPDATE_BRANCH_ENV = "HERMES_PROTECTED_UPDATE_BRANCH"
+_PROTECTED_UPDATE_COMMAND_ENV = "HERMES_PROTECTED_UPDATE_COMMAND"
+_PROTECTED_UPDATE_HELPER_ENV = "HERMES_PROTECTED_UPDATE_HELPER"
+_PROTECTED_UPDATE_REBASE_COMMAND_ENV = "HERMES_PROTECTED_UPDATE_REBASE_COMMAND"
+
+
+def get_protected_update_context(project_root: Optional[Path] = None) -> Optional[Dict[str, str]]:
+    """Return protected local update details for this install, if configured.
+
+    Some source checkouts intentionally carry local commits or tracked edits on
+    top of upstream Hermes (for example customized dashboard installs).  A raw
+    ``hermes update`` always follows the stock update path and can stash those
+    local changes, switch/pull upstream ``main``, and leave the running app
+    looking as if the local customization disappeared.  This opt-in guard lets
+    such installs advertise their safer local update controller instead.
+    """
+    raw_bypass = os.getenv(_PROTECTED_UPDATE_BYPASS_ENV, "").strip().lower()
+    if raw_bypass in _MANAGED_TRUE_VALUES:
+        return None
+
+    protected_branch = os.getenv(_PROTECTED_UPDATE_BRANCH_ENV, "").strip()
+    command = os.getenv(_PROTECTED_UPDATE_COMMAND_ENV, "").strip()
+    helper_raw = os.getenv(_PROTECTED_UPDATE_HELPER_ENV, "").strip()
+    helper_command = os.getenv(_PROTECTED_UPDATE_REBASE_COMMAND_ENV, "").strip()
+
+    if not (protected_branch or command or helper_raw):
+        return None
+
+    repo = (project_root or get_project_root()).expanduser().resolve()
+    helper_path = ""
+    warnings: List[str] = []
+
+    if helper_raw and not command:
+        helper = Path(helper_raw).expanduser()
+        if not helper.is_absolute():
+            helper = get_hermes_home() / helper
+        helper = helper.resolve()
+        helper_path = str(helper)
+        if helper.is_file():
+            command_parts = [
+                "python3",
+                shlex.quote(str(helper)),
+                "--repo",
+                shlex.quote(str(repo)),
+            ]
+            if protected_branch:
+                command_parts.extend(["--branch", shlex.quote(protected_branch)])
+            command = " ".join(command_parts)
+        else:
+            warnings.append(f"Configured protected update helper was not found: {helper}")
+
+    if protected_branch:
+        try:
+            branch_check = subprocess.run(
+                ["git", "rev-parse", "--verify", f"refs/heads/{protected_branch}"],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+            )
+            if branch_check.returncode != 0:
+                warnings.append(f"Configured protected branch was not found: {protected_branch}")
+        except Exception as exc:
+            warnings.append(f"Could not verify protected branch {protected_branch!r}: {exc}")
+
+    current_branch = None
+    try:
+        current = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        if current.returncode == 0:
+            current_branch = current.stdout.strip() or None
+    except Exception:
+        current_branch = None
+
+    return {
+        "repo": str(repo),
+        "protected_branch": protected_branch,
+        "current_branch": current_branch or "unknown",
+        "command": command,
+        "helper_path": helper_path,
+        "helper_command": helper_command,
+        "warning": "\n".join(warnings),
+    }
+
+
+def format_protected_update_message(
+    context: Dict[str, str],
+    action: str = "update Hermes Agent",
+) -> str:
+    """Build a user-facing error for protected local update workflows."""
+    repo = context.get("repo", "")
+    protected_branch = context.get("protected_branch", "")
+    current_branch = context.get("current_branch", "unknown")
+    command = context.get("command", "")
+    helper_command = context.get("helper_command", "")
+    warning = context.get("warning", "")
+    lines = [
+        f"Cannot {action} with raw 'hermes update': this repo uses a protected local update workflow.",
+    ]
+    if repo:
+        lines.append(f"Repo: {repo}")
+    if protected_branch:
+        lines.append(f"Protected branch: {protected_branch}")
+    lines.extend([
+        f"Current branch: {current_branch}",
+        "Raw update can stash tracked local customizations and make dashboard/UI changes appear lost.",
+    ])
+    if warning:
+        lines.extend(["Warning:", warning])
+    if command:
+        lines.extend(["Use instead:", f"  {command}"])
+    else:
+        lines.append(
+            f"Set {_PROTECTED_UPDATE_COMMAND_ENV} to the protected update command for this install."
+        )
+    if helper_command:
+        lines.extend(["Manual rebase helper:", f"  {helper_command}"])
+    lines.append(
+        f"Set {_PROTECTED_UPDATE_BYPASS_ENV}=1 only if you intentionally want to bypass this guard."
+    )
+    return "\n".join(lines)
+
+
 def recommended_update_command() -> str:
     """Return the best update command for the current installation."""
-    return get_managed_update_command() or "hermes update"
+    managed_command = get_managed_update_command()
+    if managed_command:
+        return managed_command
+    protected_context = get_protected_update_context()
+    if protected_context:
+        return protected_context.get("command") or "protected local update workflow"
+    return "hermes update"
+
 
 
 def format_managed_message(action: str = "modify this Hermes installation") -> str:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5429,10 +5429,26 @@ def cmd_update(args):
     runs the update, then restores stdio on the way out (even on
     ``sys.exit`` or unhandled exceptions).
     """
-    from hermes_cli.config import is_managed, managed_error
+    from hermes_cli.config import (
+        format_protected_update_message,
+        get_protected_update_context,
+        is_managed,
+        managed_error,
+    )
 
     if is_managed():
         managed_error("update Hermes Agent")
+        return
+
+    protected_update = get_protected_update_context(PROJECT_ROOT)
+    if protected_update:
+        print(
+            format_protected_update_message(
+                protected_update,
+                action="update Hermes Agent",
+            ),
+            file=sys.stderr,
+        )
         return
 
     gateway_mode = getattr(args, "gateway", False)

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -3,11 +3,27 @@ from unittest.mock import patch
 
 from hermes_cli.config import (
     format_managed_message,
+    format_protected_update_message,
     get_managed_system,
+    get_protected_update_context,
     recommended_update_command,
 )
 from hermes_cli.main import cmd_update
 from tools.skills_hub import OptionalSkillSource
+
+
+_PROTECTED_UPDATE_ENVS = (
+    "HERMES_ALLOW_PROTECTED_BRANCH_UPDATE",
+    "HERMES_PROTECTED_UPDATE_BRANCH",
+    "HERMES_PROTECTED_UPDATE_COMMAND",
+    "HERMES_PROTECTED_UPDATE_HELPER",
+    "HERMES_PROTECTED_UPDATE_REBASE_COMMAND",
+)
+
+
+def _clear_protected_update_env(monkeypatch):
+    for name in _PROTECTED_UPDATE_ENVS:
+        monkeypatch.delenv(name, raising=False)
 
 
 def test_get_managed_system_homebrew(monkeypatch):
@@ -28,8 +44,147 @@ def test_format_managed_message_homebrew(monkeypatch):
 
 def test_recommended_update_command_defaults_to_hermes_update(monkeypatch):
     monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    _clear_protected_update_env(monkeypatch)
 
     assert recommended_update_command() == "hermes update"
+
+
+def test_get_protected_update_context_uses_configured_command(monkeypatch, tmp_path):
+    _clear_protected_update_env(monkeypatch)
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_BRANCH", "local/custom-dashboard")
+    monkeypatch.setenv(
+        "HERMES_PROTECTED_UPDATE_COMMAND",
+        "python3 /tmp/protected-update.py --repo /tmp/hermes-agent --branch local/custom-dashboard",
+    )
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_REBASE_COMMAND", "python3 /tmp/rebase-helper.py")
+
+    def fake_run(args, **kwargs):
+        if args == ["git", "rev-parse", "--verify", "refs/heads/local/custom-dashboard"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if args == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="local/custom-dashboard\n", stderr="")
+        raise AssertionError(f"unexpected subprocess call: {args!r}")
+
+    monkeypatch.setattr("hermes_cli.config.subprocess.run", fake_run)
+
+    context = get_protected_update_context(tmp_path)
+
+    assert context is not None
+    assert context["repo"] == str(tmp_path.resolve())
+    assert context["protected_branch"] == "local/custom-dashboard"
+    assert context["current_branch"] == "local/custom-dashboard"
+    assert context["command"].startswith("python3 /tmp/protected-update.py")
+    assert context["helper_command"] == "python3 /tmp/rebase-helper.py"
+
+
+def test_get_protected_update_context_builds_helper_command(monkeypatch, tmp_path):
+    _clear_protected_update_env(monkeypatch)
+    helper = tmp_path / "protected update.py"
+    helper.write_text("# helper\n")
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_BRANCH", "local/custom-dashboard")
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_HELPER", str(helper))
+
+    def fake_run(args, **kwargs):
+        if args == ["git", "rev-parse", "--verify", "refs/heads/local/custom-dashboard"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if args == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="local/custom-dashboard\n", stderr="")
+        raise AssertionError(f"unexpected subprocess call: {args!r}")
+
+    monkeypatch.setattr("hermes_cli.config.subprocess.run", fake_run)
+
+    context = get_protected_update_context(tmp_path)
+
+    assert context is not None
+    assert context["helper_path"] == str(helper.resolve())
+    assert "protected update.py" in context["command"]
+    assert f"--repo {tmp_path.resolve()}" in context["command"]
+    assert "--branch local/custom-dashboard" in context["command"]
+    assert context["warning"] == ""
+
+
+def test_get_protected_update_context_fails_closed_when_branch_missing(monkeypatch, tmp_path):
+    _clear_protected_update_env(monkeypatch)
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_BRANCH", "local/custom-dashboard")
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_COMMAND", "python3 /tmp/protected-update.py")
+
+    def fake_run(args, **kwargs):
+        if args == ["git", "rev-parse", "--verify", "refs/heads/local/custom-dashboard"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="missing")
+        if args == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        raise AssertionError(f"unexpected subprocess call: {args!r}")
+
+    monkeypatch.setattr("hermes_cli.config.subprocess.run", fake_run)
+
+    context = get_protected_update_context(tmp_path)
+
+    assert context is not None
+    assert context["command"] == "python3 /tmp/protected-update.py"
+    assert "Configured protected branch was not found" in context["warning"]
+
+
+def test_get_protected_update_context_honors_bypass(monkeypatch, tmp_path):
+    _clear_protected_update_env(monkeypatch)
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_BRANCH", "local/custom-dashboard")
+    monkeypatch.setenv("HERMES_PROTECTED_UPDATE_COMMAND", "python3 /tmp/protected-update.py")
+    monkeypatch.setenv("HERMES_ALLOW_PROTECTED_BRANCH_UPDATE", "1")
+
+    with patch("hermes_cli.config.subprocess.run") as mock_run:
+        assert get_protected_update_context(tmp_path) is None
+
+    assert not mock_run.called
+
+
+def test_recommended_update_command_prefers_protected_update_controller(monkeypatch):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_protected_update_context",
+        lambda project_root=None: {
+            "repo": "/tmp/hermes-agent",
+            "protected_branch": "local/custom-dashboard",
+            "current_branch": "main",
+            "command": "python3 /tmp/protected-update.py --repo /tmp/hermes-agent --branch local/custom-dashboard",
+            "helper_path": "/tmp/protected-update.py",
+        },
+    )
+
+    assert recommended_update_command() == (
+        "python3 /tmp/protected-update.py --repo /tmp/hermes-agent --branch local/custom-dashboard"
+    )
+
+
+def test_format_protected_update_message_mentions_protected_branch():
+    message = format_protected_update_message(
+        {
+            "repo": "/tmp/hermes-agent",
+            "protected_branch": "local/custom-dashboard",
+            "current_branch": "main",
+            "command": "python3 /tmp/protected-update.py --repo /tmp/hermes-agent --branch local/custom-dashboard",
+            "helper_path": "/tmp/protected-update.py",
+        },
+        action="update Hermes Agent",
+    )
+
+    assert "protected local update workflow" in message
+    assert "/tmp/hermes-agent" in message
+    assert "local/custom-dashboard" in message
+    assert "python3 /tmp/protected-update.py" in message
+
+
+def test_recommended_update_command_avoids_raw_update_when_protected_context_has_no_command(monkeypatch):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_protected_update_context",
+        lambda project_root=None: {
+            "repo": "/tmp/hermes-agent",
+            "protected_branch": "local/custom-dashboard",
+            "current_branch": "main",
+            "command": "",
+        },
+    )
+
+    assert recommended_update_command() == "protected local update workflow"
 
 
 def test_cmd_update_blocks_managed_homebrew(monkeypatch, capsys):
@@ -42,6 +197,30 @@ def test_cmd_update_blocks_managed_homebrew(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "managed by Homebrew" in captured.err
     assert "brew upgrade hermes-agent" in captured.err
+
+
+def test_cmd_update_blocks_protected_update_workflow(monkeypatch, capsys):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_protected_update_context",
+        lambda project_root=None: {
+            "repo": "/tmp/hermes-agent",
+            "protected_branch": "local/custom-dashboard",
+            "current_branch": "main",
+            "command": "python3 /tmp/protected-update.py --repo /tmp/hermes-agent --branch local/custom-dashboard",
+            "helper_path": "/tmp/protected-update.py",
+        },
+    )
+
+    with patch("hermes_cli.main.subprocess.run") as mock_run:
+        cmd_update(SimpleNamespace(gateway=False))
+
+    assert not mock_run.called
+    captured = capsys.readouterr()
+    assert "protected local update workflow" in captured.err
+    assert "local/custom-dashboard" in captured.err
+    assert "python3 /tmp/protected-update.py" in captured.err
 
 
 def test_optional_skill_source_honors_env_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Adds an opt-in protected local update workflow guard for source checkouts that intentionally carry local commits or tracked customizations on top of upstream Hermes, such as customized dashboard installs.

When configured via environment variables, Hermes now:

- exposes the protected update controller from `recommended_update_command()` instead of telling users to run raw `hermes update`;
- blocks raw `hermes update` before the stock update/autostash path runs;
- prints the repo, protected branch, current branch, safer controller command, optional manual helper, and bypass instructions;
- fails closed with warnings if a configured protected branch/helper cannot be verified;
- preserves existing managed-install behavior and the default unconfigured `hermes update` path.

This addresses the dashboard/customization persistence class of failures discussed in #3523 and the update-command UX concern in #6357.

## Configuration

Opt-in environment variables:

- `HERMES_PROTECTED_UPDATE_COMMAND`: command to show/run for the protected update workflow.
- `HERMES_PROTECTED_UPDATE_BRANCH`: optional local branch name to verify and display.
- `HERMES_PROTECTED_UPDATE_HELPER`: optional helper script path; if no command is configured, Hermes builds a `python3 <helper> --repo <repo> --branch <branch>` command.
- `HERMES_PROTECTED_UPDATE_REBASE_COMMAND`: optional manual rebase/helper command shown in the block message.
- `HERMES_ALLOW_PROTECTED_BRANCH_UPDATE=1`: explicit escape hatch to bypass the guard.

## Validation

- `git diff --check --cached`
- `python -m py_compile hermes_cli/config.py hermes_cli/main.py tests/hermes_cli/test_managed_installs.py`
- `python -m pytest tests/hermes_cli/test_managed_installs.py -q -o 'addopts='` → `13 passed`
- Static scan of added lines for hardcoded secrets, shell injection, eval/exec, unsafe deserialization, and SQL-injection patterns → no findings
- Independent staged-diff review → passed after fixing the initial helper-path `shlex` import/test gap and branch-verification fail-open risk
