### PR TITLE
fix(tests): skip skill symlink tests when symlinks are unavailable

### DIFF
--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_plan_path,

--- a/tests/agent/test_skill_commands_symlink_skip.py
+++ b/tests/agent/test_skill_commands_symlink_skip.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+import tests.agent.test_skill_commands as skill_command_tests
+
+
+def test_symlink_category_skips_when_symlinks_unavailable(tmp_path, monkeypatch):
+    def _raise_oserror(self, target, target_is_directory=False):
+        raise OSError("no symlink")
+
+    monkeypatch.setattr(Path, "symlink_to", _raise_oserror)
+
+    with pytest.raises(pytest.skip.Exception, match="symlinks unavailable"):
+        skill_command_tests._symlink_category(
+            tmp_path / "skills",
+            tmp_path / "repo",
+            "linked",
+        )


### PR DESCRIPTION
## Summary
- import `pytest` in `tests/agent/test_skill_commands.py` so the symlink-unavailable fallback can actually skip
- add a focused regression test that forces `Path.symlink_to()` to raise and asserts `_symlink_category()` emits a pytest skip instead of crashing

## Root cause
`_symlink_category()` already called `pytest.skip(...)` in its fallback path, but the module never imported `pytest`. When symlink creation failed, the helper raised `NameError` instead of skipping.

## Fix
- add the missing `import pytest`
- cover the failure path with a dedicated regression test

## Regression coverage
- `tests/agent/test_skill_commands_symlink_skip.py::test_symlink_category_skips_when_symlinks_unavailable`
- `tests/agent/test_skill_commands.py`

## Testing
- `scripts/run_tests.sh tests/agent/test_skill_commands_symlink_skip.py::test_symlink_category_skips_when_symlinks_unavailable` (RED before fix, GREEN after fix)
- `scripts/run_tests.sh tests/agent/test_skill_commands.py`
- `scripts/run_tests.sh tests/agent/test_skill_commands_symlink_skip.py tests/agent/test_skill_commands.py`

Closes #14995
