### PR TITLE
fix(tools): escalate SIGTERM→SIGKILL on browser daemon + periodic orphan reap

### DIFF
--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -21,6 +21,12 @@ import pytest
 from gateway.config import Platform
 
 
+@pytest.fixture(autouse=True)
+def _isolate_gateway_locks(tmp_path, monkeypatch):
+    """Give each test its own scoped-lock directory so xdist workers don't collide."""
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "gateway-locks"))
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -82,11 +88,19 @@ def _mock_aiohttp(status=200, json_data=None, json_side_effect=None):
     return MagicMock(return_value=_AsyncCM(mock_session))
 
 
+def _mock_create_task(coro):
+    """Stand in for asyncio.create_task() without leaking unscheduled coroutines."""
+    coro.close()
+    task = MagicMock()
+    task.done.return_value = True
+    return task
+
+
 def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
     """Return a dict of common patches needed to reach the health-check loop."""
     patches = {
         "gateway.platforms.whatsapp.check_whatsapp_requirements": True,
-        "gateway.platforms.whatsapp.asyncio.create_task": MagicMock(),
+        "gateway.platforms.whatsapp.asyncio.create_task": MagicMock(side_effect=_mock_create_task),
     }
     base = [
         patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True),
@@ -96,7 +110,7 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch("subprocess.Popen", return_value=mock_proc),
         patch("builtins.open", return_value=mock_fh),
         patch("gateway.platforms.whatsapp.asyncio.sleep", new_callable=AsyncMock),
-        patch("gateway.platforms.whatsapp.asyncio.create_task"),
+        patch("gateway.platforms.whatsapp.asyncio.create_task", side_effect=_mock_create_task),
     ]
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
@@ -518,13 +532,8 @@ class TestHttpSessionLifecycle:
     async def test_poll_task_cancelled_on_disconnect(self):
         """disconnect() should cancel the poll task."""
         adapter = _make_adapter()
-        mock_task = MagicMock()
-        mock_task.done.return_value = False
-        mock_task.cancel = MagicMock()
-        mock_future = asyncio.Future()
-        mock_future.set_exception(asyncio.CancelledError())
-        mock_task.__await__ = mock_future.__await__
-        adapter._poll_task = mock_task
+        poll_task = asyncio.create_task(asyncio.sleep(100))
+        adapter._poll_task = poll_task
         adapter._http_session = None
         adapter._bridge_process = None
         adapter._running = True
@@ -532,7 +541,7 @@ class TestHttpSessionLifecycle:
 
         await adapter.disconnect()
 
-        mock_task.cancel.assert_called_once()
+        assert poll_task.cancelled()
         assert adapter._poll_task is None
 
     @pytest.mark.asyncio

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,5 +1,6 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
+import signal
 from unittest.mock import patch
 
 
@@ -64,6 +65,76 @@ class TestBrowserCleanup:
         assert "task-1" not in browser_tool._session_last_activity
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
+
+    def test_terminate_browser_daemon_escalates_to_sigkill(self):
+        browser_tool = self.browser_tool
+        kill_calls = []
+
+        def mock_kill(pid, sig):
+            kill_calls.append((pid, sig))
+
+        time_values = iter([0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2])
+
+        with (
+            patch("tools.browser_tool._pid_exists", side_effect=[True, True, False]),
+            patch("tools.browser_tool.os.kill", side_effect=mock_kill),
+            patch("tools.browser_tool.time.sleep"),
+            patch("tools.browser_tool.BROWSER_DAEMON_TERM_GRACE_SECONDS", 0.1),
+            patch("tools.browser_tool.time.time", side_effect=lambda: next(time_values)),
+        ):
+            assert browser_tool._terminate_browser_daemon(12345, "sess-1") is True
+
+        assert kill_calls == [
+            (12345, signal.SIGTERM),
+            (12345, signal.SIGKILL),
+        ]
+
+    def test_cleanup_browser_leaves_socket_dir_when_daemon_survives(self, tmp_path):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-1",
+            "bb_session_id": None,
+        }
+        browser_tool._session_last_activity["task-1"] = 123.0
+
+        socket_dir = tmp_path / "agent-browser-sess-1"
+        socket_dir.mkdir()
+        (socket_dir / "sess-1.pid").write_text("12345")
+
+        with (
+            patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)),
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True}),
+            patch("tools.browser_tool._terminate_browser_daemon", return_value=False),
+        ):
+            browser_tool.cleanup_browser("task-1")
+
+        assert "task-1" not in browser_tool._active_sessions
+        assert "task-1" not in browser_tool._session_last_activity
+        assert socket_dir.exists()
+        assert (socket_dir / "sess-1.pid").exists()
+
+    def test_cleanup_browser_removes_socket_dir_when_daemon_exits(self, tmp_path):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-1",
+            "bb_session_id": None,
+        }
+        browser_tool._session_last_activity["task-1"] = 123.0
+
+        socket_dir = tmp_path / "agent-browser-sess-1"
+        socket_dir.mkdir()
+        (socket_dir / "sess-1.pid").write_text("12345")
+
+        with (
+            patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)),
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True}),
+            patch("tools.browser_tool._terminate_browser_daemon", return_value=True),
+        ):
+            browser_tool.cleanup_browser("task-1")
+
+        assert not socket_dir.exists()
 
     def test_cleanup_camofox_managed_persistence_skips_close(self):
         """When camofox mode + managed persistence, soft_cleanup fires instead of close."""

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -80,21 +80,30 @@ class TestReapOrphanedBrowserSessions:
 
         d = _make_socket_dir(fake_tmpdir, "h_orphan12345", pid=12345)
 
-        kill_calls = []
-        original_kill = os.kill
-
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
-            if sig == 0:
-                return  # pretend process exists
-            # Don't actually kill anything
-
-        with patch("os.kill", side_effect=mock_kill):
+        with (
+            patch("tools.browser_tool._pid_exists", return_value=True),
+            patch("tools.browser_tool.os.kill", return_value=None),
+            patch("tools.browser_tool._terminate_browser_daemon", return_value=True) as mock_term,
+        ):
             _reap_orphaned_browser_sessions()
 
-        # Should have checked existence (sig 0) then killed (SIGTERM)
-        assert (12345, 0) in kill_calls
-        assert (12345, signal.SIGTERM) in kill_calls
+        mock_term.assert_called_once_with(12345, "h_orphan12345")
+        assert not d.exists()
+
+    def test_orphaned_alive_daemon_keeps_socket_dir_when_cleanup_fails(self, fake_tmpdir):
+        """If the daemon survives cleanup, keep metadata so the next reap can retry."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_orphanretry1", pid=12345)
+
+        with (
+            patch("tools.browser_tool._pid_exists", return_value=True),
+            patch("tools.browser_tool.os.kill", return_value=None),
+            patch("tools.browser_tool._terminate_browser_daemon", return_value=False),
+        ):
+            _reap_orphaned_browser_sessions()
+
+        assert d.exists()
 
     def test_tracked_session_is_not_reaped(self, fake_tmpdir):
         """Sessions tracked in _active_sessions are left alone (legacy path)."""
@@ -221,14 +230,18 @@ class TestOwnerPidCrossProcess:
         )
 
         kill_calls = []
+        daemon_alive = [True]
 
         def mock_kill(pid, sig):
             kill_calls.append((pid, sig))
             if pid == 999999999 and sig == 0:
                 raise ProcessLookupError  # owner dead
             if pid == 12345 and sig == 0:
-                return  # daemon still alive
-            # SIGTERM to daemon — noop in test
+                if daemon_alive[0]:
+                    return
+                raise ProcessLookupError
+            if pid == 12345 and sig == signal.SIGTERM:
+                daemon_alive[0] = False  # daemon honors SIGTERM
 
         with patch("os.kill", side_effect=mock_kill):
             _reap_orphaned_browser_sessions()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -537,6 +537,12 @@ _cleanup_done = False
 # Default: 5 minutes. Needs headroom for LLM reasoning between browser commands,
 # especially when subagents are doing multi-step browser tasks.
 BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+BROWSER_DAEMON_TERM_GRACE_SECONDS = float(
+    os.environ.get("BROWSER_DAEMON_TERM_GRACE_SECONDS", "2.0")
+)
+BROWSER_ORPHAN_REAP_INTERVAL_SECONDS = int(
+    os.environ.get("BROWSER_ORPHAN_REAP_INTERVAL_SECONDS", "300")
+)
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
@@ -646,6 +652,81 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
                      session_name, exc)
 
 
+def _pid_exists(pid: int) -> bool:
+    """Return True when a PID still exists and is signalable by this user."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _terminate_browser_daemon(daemon_pid: int, session_name: str) -> bool:
+    """Terminate an agent-browser daemon and confirm it exited.
+
+    Returns True only when the process is confirmed gone. If it survives the
+    grace period or cannot be signalled, returns False so the caller can leave
+    the socket dir / pid file in place for later reaping.
+    """
+    if daemon_pid <= 0:
+        return False
+
+    if not _pid_exists(daemon_pid):
+        return True
+
+    try:
+        os.kill(daemon_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError) as e:
+        logger.warning(
+            "Could not SIGTERM browser daemon PID %s for %s: %s",
+            daemon_pid,
+            session_name,
+            e,
+        )
+        return False
+
+    deadline = time.time() + max(BROWSER_DAEMON_TERM_GRACE_SECONDS, 0.1)
+    while time.time() < deadline:
+        if not _pid_exists(daemon_pid):
+            return True
+        time.sleep(0.05)
+
+    try:
+        os.kill(daemon_pid, signal.SIGKILL)
+        logger.warning(
+            "Browser daemon PID %s for %s ignored SIGTERM; escalated to SIGKILL",
+            daemon_pid,
+            session_name,
+        )
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError) as e:
+        logger.warning(
+            "Could not SIGKILL browser daemon PID %s for %s: %s",
+            daemon_pid,
+            session_name,
+            e,
+        )
+        return False
+
+    deadline = time.time() + 1.0
+    while time.time() < deadline:
+        if not _pid_exists(daemon_pid):
+            return True
+        time.sleep(0.05)
+
+    logger.warning(
+        "Browser daemon PID %s for %s survived cleanup; leaving socket dir in place",
+        daemon_pid,
+        session_name,
+    )
+    return False
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -740,27 +821,22 @@ def _reap_orphaned_browser_sessions():
             continue
 
         # Check if the daemon is still alive
-        try:
-            os.kill(daemon_pid, 0)  # signal 0 = existence check
-        except ProcessLookupError:
+        if not _pid_exists(daemon_pid):
             # Already dead, just clean up the dir
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
+        try:
+            os.kill(daemon_pid, 0)
         except PermissionError:
             # Alive but owned by someone else — leave it alone
             continue
 
         # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
-        try:
-            os.kill(daemon_pid, signal.SIGTERM)
+        if _terminate_browser_daemon(daemon_pid, session_name):
             logger.info("Reaped orphaned browser daemon PID %d (session %s)",
                         daemon_pid, session_name)
             reaped += 1
-        except (ProcessLookupError, PermissionError, OSError):
-            pass
-
-        # Clean up the socket directory
-        shutil.rmtree(socket_dir, ignore_errors=True)
+            shutil.rmtree(socket_dir, ignore_errors=True)
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
@@ -772,16 +848,15 @@ def _browser_cleanup_thread_worker():
     
     Runs every 30 seconds and checks for sessions that haven't been used
     within the BROWSER_SESSION_INACTIVITY_TIMEOUT period.
-    On first run, also reaps orphaned sessions from previous process lifetimes.
+    Periodically also reaps orphaned sessions left behind by failed cleanup.
     """
-    # One-time orphan reap on startup
-    try:
-        _reap_orphaned_browser_sessions()
-    except Exception as e:
-        logger.warning("Orphan reap error: %s", e)
+    last_orphan_reap = 0.0
 
     while _cleanup_running:
         try:
+            if time.time() - last_orphan_reap >= BROWSER_ORPHAN_REAP_INTERVAL_SECONDS:
+                _reap_orphaned_browser_sessions()
+                last_orphan_reap = time.time()
             _cleanup_inactive_browser_sessions()
         except Exception as e:
             logger.warning("Cleanup thread error: %s", e)
@@ -2420,14 +2495,23 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
             if os.path.exists(socket_dir):
                 # agent-browser writes {session}.pid in the socket dir
                 pid_file = os.path.join(socket_dir, f"{session_name}.pid")
+                remove_socket_dir = True
                 if os.path.isfile(pid_file):
                     try:
                         daemon_pid = int(Path(pid_file).read_text().strip())
-                        os.kill(daemon_pid, signal.SIGTERM)
-                        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+                        remove_socket_dir = _terminate_browser_daemon(daemon_pid, session_name)
+                        if remove_socket_dir:
+                            logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
                     except (ProcessLookupError, ValueError, PermissionError, OSError):
                         logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
-                shutil.rmtree(socket_dir, ignore_errors=True)
+                        remove_socket_dir = False
+                if remove_socket_dir:
+                    shutil.rmtree(socket_dir, ignore_errors=True)
+                else:
+                    logger.warning(
+                        "Leaving socket dir in place for session %s so orphan reaper can retry",
+                        session_name,
+                    )
         
         logger.debug("Removed task %s from active sessions", task_id)
     else:


### PR DESCRIPTION
## Summary
Builds on #11843 (owner_pid cross-process tracking). Adds:

1. `_terminate_browser_daemon()`: SIGTERM with 2s grace, escalate to SIGKILL if the daemon ignores SIGTERM. Verifies exit before returning `True`; returns `False` on survival so the socket dir is left in place for the next reap attempt.
2. `_pid_exists()`: helper that distinguishes alive / dead / foreign-owned via `os.kill(pid, 0)` + `PermissionError`.
3. Periodic orphan reap every 5 min from the cleanup thread, not just once at startup + atexit. Catches daemons orphaned mid-session.
4. Tunable via `BROWSER_DAEMON_TERM_GRACE_SECONDS` (default `2.0`) and `BROWSER_ORPHAN_REAP_INTERVAL_SECONDS` (default `300`).

## Motivation
Agent-browser daemons with SIGTERM handlers that stall in cleanup survive reap. Without SIGKILL escalation they leak indefinitely until machine reboot — observed in a long-running gateway hitting EMFILE.

## Composes with #11843 (owner_pid)
Orthogonal concerns — owner_pid decides *whether* to reap, this PR strengthens *how* the reap executes. Both live in `_reap_orphaned_browser_sessions`; conflict resolution kept both behaviors.

## Test plan
- [x] `pytest tests/tools/test_browser_cleanup.py tests/tools/test_browser_orphan_reaper.py tests/gateway/test_whatsapp_connect.py` → 49/49 pass
- [x] Updated `test_dead_owner_triggers_reap` mock to model a SIGTERM-honoring daemon (old mock modeled zombie daemon that never dies, which is now the *unhappy* path under this PR — socket dir retention is expected)
- [x] Runtime smoke: gateway restarted on this branch, no EMFILE, no orphan accumulation across reap cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)