### PR TITLE
fix(backup): harden quick snapshot restore boundaries

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -575,6 +575,15 @@ def restore_quick_snapshot(
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
     snap_dir = root / snapshot_id
+    root_resolved = root.resolve(strict=False)
+    home_resolved = home.resolve(strict=False)
+
+    try:
+        snap_dir_resolved = snap_dir.resolve(strict=False)
+        snap_dir_resolved.relative_to(root_resolved)
+    except (OSError, ValueError):
+        logger.warning("Rejected snapshot id outside snapshot root: %s", snapshot_id)
+        return False
 
     if not snap_dir.is_dir():
         return False
@@ -593,6 +602,14 @@ def restore_quick_snapshot(
             continue
 
         dst = home / rel
+
+        try:
+            src.resolve(strict=True).relative_to(snap_dir_resolved)
+            dst.resolve(strict=False).relative_to(home_resolved)
+        except (OSError, ValueError):
+            logger.warning("Skipped unsafe snapshot restore path: %s", rel)
+            continue
+
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1127,6 +1127,54 @@ class TestQuickSnapshot:
         from hermes_cli.backup import restore_quick_snapshot
         assert restore_quick_snapshot("nonexistent", hermes_home=hermes_home) is False
 
+    def test_restore_rejects_snapshot_id_traversal(self, hermes_home, tmp_path):
+        from hermes_cli.backup import restore_quick_snapshot
+
+        outside = tmp_path / "outside-snapshot"
+        outside.mkdir()
+        (outside / "manifest.json").write_text(
+            json.dumps({"files": {"config.yaml": 1}})
+        )
+        (outside / "config.yaml").write_text("model:\n  provider: escaped\n")
+
+        result = restore_quick_snapshot("../outside-snapshot", hermes_home=hermes_home)
+
+        assert result is False
+        assert "openrouter" in (hermes_home / "config.yaml").read_text()
+
+    def test_restore_skips_manifest_path_traversal(self, hermes_home, tmp_path):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        escape_target = tmp_path / "outside.txt"
+        (hermes_home / "state-snapshots" / "outside.txt").write_text("escaped")
+        (snap_dir / "manifest.json").write_text(
+            json.dumps({"files": {"config.yaml": 1, "../outside.txt": 1}})
+        )
+
+        result = restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        assert result is True
+        assert not escape_target.exists()
+        assert "openrouter" in (hermes_home / "config.yaml").read_text()
+
+    def test_restore_skips_absolute_manifest_paths(self, hermes_home, tmp_path):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        absolute_target = tmp_path / "absolute.txt"
+        (absolute_target).write_text("do not restore")
+        (snap_dir / "manifest.json").write_text(
+            json.dumps({"files": {"config.yaml": 1, str(absolute_target): 1}})
+        )
+
+        result = restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        assert result is True
+        assert "openrouter" in (hermes_home / "config.yaml").read_text()
+
     def test_auto_prune(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot, list_quick_snapshots, _QUICK_DEFAULT_KEEP
         for i in range(_QUICK_DEFAULT_KEEP + 5):


### PR DESCRIPTION
Quick state snapshots are local recovery artifacts, but restore still needs to treat the snapshot manifest as untrusted input. Before this change, `restore_quick_snapshot()` joined both the requested snapshot id and manifest file entries directly onto trusted roots.

This tightens the restore path checks in two places:

- reject snapshot ids that resolve outside `state-snapshots/`
- skip manifest entries whose source escapes the snapshot directory or whose destination escapes `HERMES_HOME`

Normal snapshots keep the same behavior. Unsafe entries are ignored and logged instead of being restored.

Regression coverage now includes:
- `../` traversal in the snapshot id
- `../` traversal in manifest file paths
- absolute manifest file paths

Validation notes:

I ran the quick snapshot test slice on Windows with the dev test dependencies installed through `uv`:

```bash
uv run --extra dev python -m pytest tests/hermes_cli/test_backup.py::TestQuickSnapshot -q -n 4

The targeted slice passed: 16 passed.

