### PR TITLE
fix(tools): reorder fuzzy_match strategies so indentation_flexible is reachable

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -52,6 +52,47 @@ class TestIndentDifference:
         assert "bar" in new
 
 
+
+
+class TestIndentationFlexible:
+    """Tests for the indentation_flexible strategy ordering fix (Issue #14781)."""
+
+    def test_indentation_flexible_strategy_used(self):
+        """When only indentation differs, indentation_flexible should be the matching strategy."""
+        content = "    def foo():\n        pass\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "def foo():\n    pass", "def bar():\n    return 1"
+        )
+        assert count == 1
+        assert strategy == "indentation_flexible", (
+            f"Expected indentation_flexible for indentation-only difference, "
+            f"but got {strategy}"
+        )
+        assert "bar" in new
+
+    def test_indentation_flexible_with_tabs(self):
+        """Tabs vs spaces should use indentation_flexible strategy."""
+        content = "\tdef foo():\n\t\tpass\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "def foo():\n    pass", "def bar():\n    return 1"
+        )
+        assert count == 1
+        assert strategy == "indentation_flexible", (
+            f"Expected indentation_flexible for tabs-vs-spaces, but got {strategy}"
+        )
+
+    def test_line_trimmed_for_trailing_whitespace(self):
+        """When trailing whitespace differs, line_trimmed should be used."""
+        content = "def foo(): \n    pass \n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "def foo():\n    pass", "def bar():\n    return 1"
+        )
+        assert count == 1
+        assert strategy == "line_trimmed", (
+            f"Expected line_trimmed for trailing whitespace difference, "
+            f"but got {strategy}"
+        )
+
 class TestReplaceAll:
     def test_multiple_matches_without_flag_errors(self):
         content = "aaa bbb aaa"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -8,9 +8,9 @@ in LLM-generated code.
 
 The 8-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
-2. Line-trimmed - Strip leading/trailing whitespace per line
-3. Whitespace normalized - Collapse multiple spaces/tabs to single space
-4. Indentation flexible - Ignore indentation differences entirely
+2. Indentation flexible - Ignore indentation differences entirely
+3. Line-trimmed - Strip leading/trailing whitespace per line
+4. Whitespace normalized - Collapse multiple spaces/tabs to single space
 5. Escape normalized - Convert \\n literals to actual newlines
 6. Trimmed boundary - Trim first/last line whitespace only
 7. Block anchor - Match first+last lines, use similarity for middle
@@ -72,9 +72,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
         ("exact", _strategy_exact),
+        ("indentation_flexible", _strategy_indentation_flexible),
         ("line_trimmed", _strategy_line_trimmed),
         ("whitespace_normalized", _strategy_whitespace_normalized),
-        ("indentation_flexible", _strategy_indentation_flexible),
         ("escape_normalized", _strategy_escape_normalized),
         ("trimmed_boundary", _strategy_trimmed_boundary),
         ("unicode_normalized", _strategy_unicode_normalized),


### PR DESCRIPTION
Fixes #14781

    The indentation_flexible strategy was positioned after line_trimmed in the matching chain. Since line_trimmed strips ALL whitespace from both ends of each line, it would always match before indentation_flexible (which only strips leading whitespace) could be tried, making indentation_flexible dead code.

    Changes:
    - Move indentation_flexible before line_trimmed in the strategy list
    - Update module docstring to reflect new ordering
    - Add tests to verify the fix

    Test coverage:
    - test_indentation_flexible_strategy_used: verifies indentation-only differences use indentation_flexible
    - test_indentation_flexible_with_tabs: verifies tabs-vs-spaces uses indentation_flexible
    - test_line_trimmed_for_trailing_whitespace: verifies trailing whitespace differences still use line_trimmed