### PR TITLE
fix(tests): restore HERMES_HOME after branch fixture teardown

### DIFF
--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -21,12 +21,35 @@ import pytest
 @pytest.fixture
 def session_db(tmp_path):
     """Create a real SessionDB for testing."""
-    os.environ["HERMES_HOME"] = str(tmp_path / ".hermes")
-    os.makedirs(tmp_path / ".hermes", exist_ok=True)
+    hermes_home = tmp_path / ".hermes"
+    previous_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    os.makedirs(hermes_home, exist_ok=True)
     from hermes_state import SessionDB
-    db = SessionDB(db_path=tmp_path / ".hermes" / "test_sessions.db")
-    yield db
-    db.close()
+    db = SessionDB(db_path=hermes_home / "test_sessions.db")
+    try:
+        yield db
+    finally:
+        db.close()
+        if previous_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = previous_home
+
+
+def test_session_db_fixture_restores_hermes_home_after_teardown(tmp_path, monkeypatch):
+    """The session_db fixture should not leak HERMES_HOME after teardown."""
+    original_home = str(tmp_path / "original-home")
+    monkeypatch.setenv("HERMES_HOME", original_home)
+
+    fixture_gen = session_db.__wrapped__(tmp_path)
+    db = next(fixture_gen)
+    assert os.environ["HERMES_HOME"] != original_home
+
+    with pytest.raises(StopIteration):
+        next(fixture_gen)
+
+    assert os.environ.get("HERMES_HOME") == original_home
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- restore the previous `HERMES_HOME` value in `session_db` fixture teardown
- add a regression test that proves the fixture no longer leaks its temp Hermes home

## Root cause
`tests/cli/test_branch_command.py` mutated `os.environ["HERMES_HOME"]` directly and only closed the SQLite DB in teardown. Because the env var was never restored, later tests could inherit the fixture's temp Hermes home.

## Fix
Save the prior `HERMES_HOME` value before overriding it, then restore or remove it in a `finally` block after the fixture closes the DB.

## Regression coverage
- added `test_session_db_fixture_restores_hermes_home_after_teardown`

## Testing
- `scripts/run_tests.sh tests/cli/test_branch_command.py -k restores_hermes_home_after_teardown`
- `scripts/run_tests.sh tests/cli/test_branch_command.py`

Closes #14997
