### PR TITLE
feat(tui): default /details to expanded

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2775,13 +2775,13 @@ def _(rid, params: dict) -> dict:
         allowed_dm = frozenset({"hidden", "collapsed", "expanded"})
         raw = (
             str(
-                _load_cfg().get("display", {}).get("details_mode", "collapsed")
-                or "collapsed"
+                _load_cfg().get("display", {}).get("details_mode", "expanded")
+                or "expanded"
             )
             .strip()
             .lower()
         )
-        nv = raw if raw in allowed_dm else "collapsed"
+        nv = raw if raw in allowed_dm else "expanded"
         return _ok(rid, {"value": nv})
     if key == "thinking_mode":
         allowed_tm = frozenset({"collapsed", "truncated", "full"})
@@ -2792,8 +2792,8 @@ def _(rid, params: dict) -> dict:
         else:
             dm = (
                 str(
-                    cfg.get("display", {}).get("details_mode", "collapsed")
-                    or "collapsed"
+                    cfg.get("display", {}).get("details_mode", "expanded")
+                    or "expanded"
                 )
                 .strip()
                 .lower()

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -78,14 +78,14 @@ describe('createSlashHandler', () => {
   it('cycles details mode and persists it', async () => {
     const ctx = buildCtx()
 
-    expect(getUiState().detailsMode).toBe('collapsed')
-    expect(createSlashHandler(ctx)('/details toggle')).toBe(true)
     expect(getUiState().detailsMode).toBe('expanded')
+    expect(createSlashHandler(ctx)('/details toggle')).toBe(true)
+    expect(getUiState().detailsMode).toBe('hidden')
     expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
       key: 'details_mode',
-      value: 'expanded'
+      value: 'hidden'
     })
-    expect(ctx.transcript.sys).toHaveBeenCalledWith('details: expanded')
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('details: hidden')
   })
 
   it('shows tool enable usage when names are missing', () => {

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -9,7 +9,7 @@ const buildUiState = (): UiState => ({
   bgTasks: new Set(),
   busy: false,
   compact: false,
-  detailsMode: 'collapsed',
+  detailsMode: 'expanded',
   info: null,
   inlineDiffs: true,
   showCost: false,

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -21,6 +21,6 @@ export const resolveDetailsMode = (d?: { details_mode?: unknown; thinking_mode?:
       .trim()
       .toLowerCase()
   ] ??
-  'collapsed'
+  'expanded'
 
 export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!


### PR DESCRIPTION
## Summary
TUI now shows Thinking + Tool calls + Spawn tree inline during streaming by default instead of hiding them behind `▸`. Matches what users actually want from `--tui` out of the box; `/details collapsed` still works for the old behavior.

## Changes
- `ui-tui/src/app/uiStore.ts` — initial `detailsMode: 'expanded'`
- `ui-tui/src/domain/details.ts` — `resolveDetailsMode()` fallback is `'expanded'`
- `tui_gateway/server.py` — backend `config.get('details_mode')` default returns `'expanded'` (2 sites)
- `ui-tui/src/__tests__/createSlashHandler.test.ts` — `/details toggle` now cycles `expanded → hidden`

## Validation
- Targeted vitest suites: 25/25 pass (`createSlashHandler`, `useConfigSync`)
- `/details` cycle order unchanged (`hidden → collapsed → expanded`), just starts at a different point