### PR TITLE
fix(auth): clear stale OpenAI Codex provider state on logout

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -946,10 +946,12 @@ def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
             del pool[target]
             cleared = True
 
-        if not cleared:
-            return False
         if auth_store.get("active_provider") == target:
             auth_store["active_provider"] = None
+            cleared = True
+
+        if not cleared:
+            return False
         _save_auth_store(auth_store)
     return True
 
@@ -2796,6 +2798,46 @@ def _update_config_for_provider(
     return config_path
 
 
+def _get_config_provider() -> Optional[str]:
+    """Return model.provider from config.yaml, normalized, if present."""
+    try:
+        config = read_raw_config()
+    except Exception:
+        return None
+    if not config:
+        return None
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return None
+    provider = model.get("provider")
+    if not isinstance(provider, str):
+        return None
+    provider = provider.strip().lower()
+    return provider or None
+
+
+def _config_provider_matches(provider_id: Optional[str]) -> bool:
+    """Return True when config.yaml currently selects *provider_id*."""
+    if not provider_id:
+        return False
+    return _get_config_provider() == provider_id.strip().lower()
+
+
+def _logout_default_provider_from_config() -> Optional[str]:
+    """Fallback logout target when auth.json has no active provider.
+
+    `hermes logout` historically keyed off auth.json.active_provider only.
+    That left users stuck when auth state had already been cleared but
+    config.yaml still selected an OAuth provider such as openai-codex for the
+    agent model: there was no active auth provider to target, so logout printed
+    "No provider is currently logged in" and never reset model.provider.
+    """
+    provider = _get_config_provider()
+    if provider in {"nous", "openai-codex"}:
+        return provider
+    return None
+
+
 def _reset_config_provider() -> Path:
     """Reset config.yaml provider back to auto after logout."""
     config_path = get_config_path()
@@ -3494,15 +3536,16 @@ def logout_command(args) -> None:
         raise SystemExit(1)
 
     active = get_active_provider()
-    target = provider_id or active
+    target = provider_id or active or _logout_default_provider_from_config()
 
     if not target:
         print("No provider is currently logged in.")
         return
 
     provider_name = PROVIDER_REGISTRY[target].name if target in PROVIDER_REGISTRY else target
+    config_matches = _config_provider_matches(target)
 
-    if clear_provider_auth(target):
+    if clear_provider_auth(target) or config_matches:
         _reset_config_provider()
         print(f"Logged out of {provider_name}.")
         if os.getenv("OPENROUTER_API_KEY"):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -504,6 +504,91 @@ def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch
     assert "openrouter" in payload.get("credential_pool", {})
 
 
+def test_logout_resets_codex_config_when_auth_state_already_cleared(tmp_path, monkeypatch, capsys):
+    """`hermes logout --provider openai-codex` must still clear model.provider.
+
+    Users can end up with auth.json already cleared but config.yaml still set to
+    openai-codex.  Previously logout reported no auth state and left the agent
+    pinned to the Codex provider.
+    """
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}, "credential_pool": {}})
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-5.3-codex\n"
+        "  provider: openai-codex\n"
+        "  base_url: https://chatgpt.com/backend-api/codex\n"
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth import logout_command
+
+    logout_command(SimpleNamespace(provider="openai-codex"))
+
+    out = capsys.readouterr().out
+    assert "Logged out of OpenAI Codex." in out
+    config_text = (hermes_home / "config.yaml").read_text()
+    assert "provider: auto" in config_text
+    assert "base_url: https://openrouter.ai/api/v1" in config_text
+
+
+def test_logout_defaults_to_configured_codex_when_no_active_provider(tmp_path, monkeypatch, capsys):
+    """Bare `hermes logout` should target configured Codex if auth has no active provider."""
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}, "credential_pool": {}})
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-5.3-codex\n"
+        "  provider: openai-codex\n"
+        "  base_url: https://chatgpt.com/backend-api/codex\n"
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth import logout_command
+
+    logout_command(SimpleNamespace(provider=None))
+
+    out = capsys.readouterr().out
+    assert "Logged out of OpenAI Codex." in out
+    config_text = (hermes_home / "config.yaml").read_text()
+    assert "provider: auto" in config_text
+
+
+def test_logout_clears_stale_active_codex_without_provider_credentials(tmp_path, monkeypatch, capsys):
+    """Logout must clear active_provider even when provider credential payloads are gone."""
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {},
+            "credential_pool": {},
+        },
+    )
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-5.3-codex\n"
+        "  provider: openai-codex\n"
+        "  base_url: https://chatgpt.com/backend-api/codex\n"
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth import logout_command
+
+    logout_command(SimpleNamespace(provider=None))
+
+    out = capsys.readouterr().out
+    assert "Logged out of OpenAI Codex." in out
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    assert auth_payload.get("active_provider") is None
+    config_text = (hermes_home / "config.yaml").read_text()
+    assert "provider: auto" in config_text
+
+
 def test_auth_list_does_not_call_mutating_select(monkeypatch, capsys):
     from hermes_cli.auth_commands import auth_list_command
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a logout edge case where Hermes can remain pinned to the OpenAI Codex provider even after the user has attempted to log out.

Previously, `hermes logout` relied primarily on `auth.json.active_provider` or an explicitly provided `--provider` value to decide which provider should be logged out. That created a stale-state failure mode:

1. OpenAI Codex auth/provider state was already removed or partially cleared from `auth.json`.
2. `config.yaml` still contained `model.provider: openai-codex`.
3. Running `hermes logout` could report that no provider was currently logged in.
4. Hermes would continue using the OpenAI Codex agent model provider because the config remained pinned to `openai-codex`.

This PR fixes that by making logout also inspect the configured model provider when auth state has no active provider. If `config.yaml` is still pinned to a logout-capable OAuth provider such as `openai-codex` or `nous`, logout now treats that as valid stale provider state and resets the configured provider back to `auto`.

The PR also tightens stale auth cleanup by making `clear_provider_auth()` treat clearing a matching `active_provider` as a successful cleanup, even when provider credential payloads were already missing.

This approach is intentionally narrow and backward-compatible:

- Preserves existing logout behavior when normal auth state exists.
- Does not broaden logout to arbitrary providers.
- Only adds fallback behavior for providers currently supported by the logout CLI path: `nous` and `openai-codex`.
- Adds regression tests for stale Codex states that caused the bug.

---

## Related Issue

Fixes #15013

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

---

## Changes Made

### Updated `hermes_cli/auth.py`

- Added `_get_config_provider()` to safely read and normalize `model.provider` from `config.yaml`.
- Added `_config_provider_matches()` to check whether the current config provider matches the logout target.
- Added `_logout_default_provider_from_config()` to provide a fallback logout target when `auth.json` has no active provider but `config.yaml` is still pinned to a known logout-capable provider.
- Updated `logout_command()` so bare `hermes logout` can recover from stale config-only state.
- Updated `logout_command()` so `hermes logout --provider openai-codex` resets config even if provider credentials were already removed from `auth.json`.
- Updated `clear_provider_auth()` so clearing a stale matching `active_provider` counts as a successful mutation.

### Updated `tests/hermes_cli/test_auth_commands.py`

- Added `test_logout_resets_codex_config_when_auth_state_already_cleared`
  - Covers `hermes logout --provider openai-codex` when `auth.json` has no Codex provider state but `config.yaml` is still pinned to Codex.
- Added `test_logout_defaults_to_configured_codex_when_no_active_provider`
  - Covers bare `hermes logout` when there is no active provider in auth state but `config.yaml` still selects `openai-codex`.
- Added `test_logout_clears_stale_active_codex_without_provider_credentials`
  - Covers stale `active_provider: openai-codex` when provider credential payloads are already missing.

---

## How to Test

1. **Run focused regression tests**
   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_auth_commands.py::test_logout_resets_codex_config_when_auth_state_already_cleared \
     tests/hermes_cli/test_auth_commands.py::test_logout_defaults_to_configured_codex_when_no_active_provider \
     tests/hermes_cli/test_auth_commands.py::test_logout_clears_stale_active_codex_without_provider_credentials \
     -v --tb=long
```

Expected:

```text
3 passed
```

2. **Run full related auth tests**

   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_auth_commands.py \
     tests/hermes_cli/test_auth_codex_provider.py
   ```

   Expected:

   ```text
   54 passed
   ```

3. **Manual reproduction (before fix)**

   * Ensure:

     * `auth.json` has no Codex credentials
     * `auth.json.active_provider` is empty or missing
     * `config.yaml` contains:

       ```yaml
       model:
         provider: openai-codex
         base_url: https://chatgpt.com/backend-api/codex
       ```
   * Run:

     ```bash
     hermes logout
     ```
   * Observe:

     ```text
     No provider is currently logged in.
     ```
   * Config remains pinned to Codex

4. **Manual verification (after fix)**

   * With the same stale state, run:

     ```bash
     hermes logout
     ```

     or:

     ```bash
     hermes logout --provider openai-codex
     ```
   * Expected output:

     ```text
     Logged out of OpenAI Codex.
     ```
   * Expected config:

     ```yaml
     model:
       provider: auto
     ```
   * If Codex base URL was set:

     ```yaml
     model:
       base_url: https://openrouter.ai/api/v1
     ```

---

## Checklist

### Code

* [ ] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [ ] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
* [ ] I searched for existing PRs to make sure this isn't a duplicate
* [ ] My PR contains **only** changes related to this fix/feature
* [ ] I've run `pytest tests/ -q` and all tests pass
* [ ] I've added tests for my changes
* [ ] I've tested on my platform

### Documentation & Housekeeping

* [ ] I've updated relevant documentation — or N/A
* [ ] I've updated `cli-config.yaml.example` — or N/A
* [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
* [ ] I've considered cross-platform impact — or N/A
* [ ] I've updated tool descriptions/schemas — or N/A

---

## Screenshots / Logs

```text
$ scripts/run_tests.sh \
  tests/hermes_cli/test_auth_commands.py::test_logout_resets_codex_config_when_auth_state_already_cleared \
  tests/hermes_cli/test_auth_commands.py::test_logout_defaults_to_configured_codex_when_no_active_provider \
  tests/hermes_cli/test_auth_commands.py::test_logout_clears_stale_active_codex_without_provider_credentials \
  -v --tb=long

3 passed
```

```text
$ scripts/run_tests.sh \
  tests/hermes_cli/test_auth_commands.py \
  tests/hermes_cli/test_auth_codex_provider.py

54 passed
```

```
```