### PR TITLE
fix(gateway): avoid threadless mirror session contamination

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -94,6 +94,8 @@ def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = Non
         origin_chat_id = str(origin.get("chat_id", ""))
         if origin_chat_id == str(chat_id):
             origin_thread_id = origin.get("thread_id")
+            if thread_id is None and origin_thread_id is not None:
+                continue
             if thread_id is not None and str(origin_thread_id or "") != str(thread_id):
                 continue
             updated = entry.get("updated_at", "")

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -77,6 +77,46 @@ class TestFindSessionId:
 
         assert result == "sess_topic_a"
 
+    def test_threadless_lookup_skips_threaded_sessions(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "topic_a": {
+                "session_id": "sess_topic_a",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "thread_id": "10"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "topic_b": {
+                "session_id": "sess_topic_b",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "thread_id": "11"},
+                "updated_at": "2026-02-01T00:00:00",
+            },
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            result = _find_session_id("telegram", "-1001")
+
+        assert result is None
+
+    def test_threadless_lookup_can_match_non_thread_session(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "group": {
+                "session_id": "sess_group",
+                "origin": {"platform": "telegram", "chat_id": "-1001"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "topic": {
+                "session_id": "sess_topic",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "thread_id": "11"},
+                "updated_at": "2026-02-01T00:00:00",
+            },
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            result = _find_session_id("telegram", "-1001")
+
+        assert result == "sess_group"
+
     def test_no_match_returns_none(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {
             "sess": {
@@ -188,6 +228,23 @@ class TestMirrorToSession:
         assert result is True
         assert (sessions_dir / "sess_topic_a.jsonl").exists()
         assert not (sessions_dir / "sess_topic_b.jsonl").exists()
+
+    def test_threadless_mirror_does_not_write_to_threaded_session(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "topic": {
+                "session_id": "sess_topic",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "thread_id": "10"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite"):
+            result = mirror_to_session("telegram", "-1001", "Hello group!", source_label="cron")
+
+        assert result is False
+        assert not (sessions_dir / "sess_topic.jsonl").exists()
 
     def test_no_matching_session(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {})


### PR DESCRIPTION
Summary:
- Skip threaded gateway sessions when delivery mirroring is called without a thread_id
- Preserve existing exact-match behavior when thread_id is provided
- Add regression coverage for threadless lookup and mirror writes

Problem:
Delivery mirroring finds a target session by platform and chat_id. For chats with multiple threaded/topic sessions, a mirror call without thread_id could match the most recently updated threaded session and append the mirror entry to the wrong transcript.

Fix:
When `_find_session_id()` is called without `thread_id`, it now ignores sessions whose origin includes `thread_id`. Non-thread sessions for the same chat can still be matched, and explicit thread_id lookups continue to disambiguate threaded sessions as before.

Tests:
- `.\.venv\Scripts\python.exe -m pytest tests\gateway\test_mirror.py -q`
