### PR TITLE
fix(install): handle non-writable shell config files gracefully

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1016,20 +1016,37 @@ setup_path() {
 
         for SHELL_CONFIG in "${SHELL_CONFIGS[@]}"; do
             if ! grep -v '^[[:space:]]*#' "$SHELL_CONFIG" 2>/dev/null | grep -qE 'PATH=.*\.local/bin'; then
-                echo "" >> "$SHELL_CONFIG"
-                echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG"
-                echo "$PATH_LINE" >> "$SHELL_CONFIG"
-                log_success "Added ~/.local/bin to PATH in $SHELL_CONFIG"
+                # Try to write, handling permission errors gracefully
+                if {
+                    echo "" >> "$SHELL_CONFIG" 2>/dev/null && \
+                    echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG" 2>/dev/null && \
+                    echo "$PATH_LINE" >> "$SHELL_CONFIG" 2>/dev/null
+                }; then
+                    log_success "Added ~/.local/bin to PATH in $SHELL_CONFIG"
+                else
+                    log_warn "Could not write to $SHELL_CONFIG (not writable?)"
+                    echo ""
+                    log_info "Add ~/.local/bin to your PATH manually:"
+                    log_info "  $PATH_LINE"
+                    echo ""
+                fi
             fi
         done
 
         # fish uses fish_add_path instead of export PATH=...
         if [ "$IS_FISH" = "true" ]; then
             if ! grep -q 'fish_add_path.*\.local/bin' "$FISH_CONFIG" 2>/dev/null; then
-                echo "" >> "$FISH_CONFIG"
-                echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$FISH_CONFIG"
-                echo 'fish_add_path "$HOME/.local/bin"' >> "$FISH_CONFIG"
-                log_success "Added ~/.local/bin to PATH in $FISH_CONFIG"
+                # Try to write, handling permission errors gracefully
+                if {
+                    echo "" >> "$FISH_CONFIG" 2>/dev/null && \
+                    echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$FISH_CONFIG" 2>/dev/null && \
+                    echo 'fish_add_path "$HOME/.local/bin"' >> "$FISH_CONFIG" 2>/dev/null
+                }; then
+                    log_success "Added ~/.local/bin to PATH in $FISH_CONFIG"
+                else
+                    log_warn "Could not write to $FISH_CONFIG"
+                    log_info "Add manually: fish_add_path \"\$HOME/.local/bin\""
+                fi
             fi
         fi
 

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -314,15 +314,23 @@ else
     fi
 
     if [ -n "$SHELL_CONFIG" ]; then
-        # Touch the file just in case it doesn't exist yet but was selected
-        touch "$SHELL_CONFIG" 2>/dev/null || true
-
         if ! echo "$PATH" | tr ':' '\n' | grep -q "^$HOME/.local/bin$"; then
             if ! grep -q '\.local/bin' "$SHELL_CONFIG" 2>/dev/null; then
-                echo "" >> "$SHELL_CONFIG"
-                echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG"
-                echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_CONFIG"
-                echo -e "${GREEN}✓${NC} Added ~/.local/bin to PATH in $SHELL_CONFIG"
+                # Try to write, handling permission errors gracefully
+                if {
+                    echo "" >> "$SHELL_CONFIG" 2>/dev/null && \
+                    echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG" 2>/dev/null && \
+                    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_CONFIG" 2>/dev/null
+                }; then
+                    echo -e "${GREEN}✓${NC} Added ~/.local/bin to PATH in $SHELL_CONFIG"
+                else
+                    echo -e "${YELLOW}⚠${NC} Could not write to $SHELL_CONFIG (not writable?)"
+                    echo ""
+                    echo -e "${CYAN}→${NC} Add ~/.local/bin to your PATH manually:"
+                    echo ""
+                    echo -e "    ${CYAN}export PATH=\"\$HOME/.local/bin:\$PATH\"${NC}"
+                    echo ""
+                fi
             else
                 echo -e "${GREEN}✓${NC} ~/.local/bin already in $SHELL_CONFIG"
             fi


### PR DESCRIPTION
## What
Fixes installer failures when shell config files (~/.zshrc, ~/.bashrc) are not writable.

## Why
The install scripts failed with "Permission denied" when trying to modify shell configs managed by nix-darwin, home-manager, or other declarative systems. These files are typically symlinked to read-only locations.

## Changes
- **setup-hermes.sh**: Wrap shell config writes with error handling
- **scripts/install.sh**: Same pattern for bash/zsh and fish configs

## Behavior now
- Attempts to write PATH export to shell config
- If write fails, shows warning with manual PATH setup instructions
- Installation continues without failing

## How to test
1. Make your shell config non-writable: `chmod -w ~/.zshrc`
2. Run install: `./setup-hermes.sh`
3. Should show warning and manual instructions instead of failing

## Platforms tested
- macOS (nix-darwin configuration)

Closes #15016

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>