### PR TITLE
fix(gateway): restore Mattermost command prefix wording

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -24,6 +24,42 @@ from utils import normalize_proxy_url
 logger = logging.getLogger(__name__)
 
 
+TEXT_COMMAND_PREFIXES = ("/", "!", "oc_")
+
+
+def extract_command_parts(text: str) -> tuple[str, str, str] | None:
+    """Return ``(prefix, command, args)`` for supported text command forms."""
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+
+    parts = stripped.split(maxsplit=1)
+    token = parts[0]
+    args = parts[1] if len(parts) > 1 else ""
+
+    if token.startswith("/"):
+        prefix = "/"
+        raw = token[1:]
+    elif token.startswith("!"):
+        prefix = "!"
+        raw = token[1:]
+    elif token.lower().startswith("oc_"):
+        prefix = "oc_"
+        raw = token[3:]
+    else:
+        return None
+
+    raw = raw.lower()
+    if raw and "@" in raw:
+        raw = raw.split("@", 1)[0]
+    # Reject file paths: valid command names never contain /
+    if raw and "/" in raw:
+        return None
+    if prefix != "/" and not raw:
+        return None
+    return prefix, raw, args
+
+
 def utf16_len(s: str) -> int:
     """Count UTF-16 code units in *s*.
 
@@ -731,28 +767,19 @@ class MessageEvent:
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        return self.text.startswith("/")
+        return extract_command_parts(self.text) is not None
     
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""
-        if not self.is_command():
-            return None
-        # Split on space and get first word, strip the /
-        parts = self.text.split(maxsplit=1)
-        raw = parts[0][1:].lower() if parts else None
-        if raw and "@" in raw:
-            raw = raw.split("@", 1)[0]
-        # Reject file paths: valid command names never contain /
-        if raw and "/" in raw:
-            return None
-        return raw
+        parsed = extract_command_parts(self.text)
+        return parsed[1] if parsed else None
     
     def get_command_args(self) -> str:
         """Get the arguments after a command."""
-        if not self.is_command():
+        parsed = extract_command_parts(self.text)
+        if not parsed:
             return self.text
-        parts = self.text.split(maxsplit=1)
-        args = parts[1] if len(parts) > 1 else ""
+        args = parsed[2]
         # iOS auto-corrects -- to — (em dash) and - to – (en dash)
         args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
         return args

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -28,6 +28,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    extract_command_parts,
 )
 
 logger = logging.getLogger(__name__)
@@ -616,6 +617,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Config (env vars):
         #   MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
         #   MATTERMOST_FREE_RESPONSE_CHANNELS: Channel IDs where bot responds without mention
+        parsed_command = extract_command_parts(message_text)
         if channel_type_raw != "D":
             require_mention = os.getenv(
                 "MATTERMOST_REQUIRE_MENTION", "true"
@@ -634,7 +636,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 for pattern in mention_patterns
             )
 
-            if require_mention and not is_free_channel and not has_mention:
+            if require_mention and not is_free_channel and not has_mention and not parsed_command:
                 logger.debug(
                     "Mattermost: skipping non-DM message without @mention (channel=%s)",
                     channel_id,
@@ -658,7 +660,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT
-        if message_text.startswith("/"):
+        if extract_command_parts(message_text):
             msg_type = MessageType.COMMAND
 
         # Download file attachments immediately (URLs require auth headers

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -288,6 +288,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    extract_command_parts,
     merge_pending_message_event,
 )
 from gateway.restart import (
@@ -430,6 +431,14 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
         return False
     normalized = " ".join(str(message).strip().split()).lower()
     return normalized in _CONTROL_INTERRUPT_MESSAGES
+
+
+def _preferred_command_prefix(source_or_event=None) -> str:
+    """Return the command prefix to show users for this gateway source."""
+    source = getattr(source_or_event, "source", source_or_event)
+    if getattr(source, "platform", None) == Platform.MATTERMOST:
+        return "!"
+    return "/"
 
 
 def _check_unavailable_skill(command_name: str) -> str | None:
@@ -3448,9 +3457,10 @@ class GatewayRunner:
             # silently discarded by the slash-command safety net,
             # producing a zero-char response. See #5057, #6252, #10370.
             if _cmd_def_inner:
+                command_prefix = _preferred_command_prefix(source)
                 return (
-                    f"⏳ Agent is running — `/{_cmd_def_inner.name}` can't run "
-                    f"mid-turn. Wait for the current response or `/stop` first."
+                    f"⏳ Agent is running — `{command_prefix}{_cmd_def_inner.name}` can't run "
+                    f"mid-turn. Wait for the current response or `{command_prefix}stop` first."
                 )
 
             if event.message_type == MessageType.PHOTO:
@@ -3837,16 +3847,18 @@ class GatewayRunner:
                     # built-ins (command may be an alias target set by the
                     # quick-command block above, so _cmd_def can be stale).
                     if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                        command_prefix = _preferred_command_prefix(source)
                         logger.warning(
-                            "Unrecognized slash command /%s from %s — "
+                            "Unrecognized command %s%s from %s — "
                             "replying with unknown-command notice",
+                            command_prefix,
                             command,
                             source.platform.value if source.platform else "?",
                         )
                         return (
-                            f"Unknown command `/{command}`. "
-                            f"Type /commands to see what's available, "
-                            f"or resend without the leading slash to send "
+                            f"Unknown command `{command_prefix}{command}`. "
+                            f"Type {command_prefix}commands to see what's available, "
+                            f"or resend without the leading command prefix to send "
                             f"as a regular message."
                         )
             except Exception as e:
@@ -3939,16 +3951,20 @@ class GatewayRunner:
                     _stt_meta = {"thread_id": source.thread_id} if source.thread_id else None
                     if _stt_adapter:
                         try:
+                            command_prefix = _preferred_command_prefix(source)
                             _stt_msg = (
                                 "🎤 I received your voice message but can't transcribe it — "
                                 "no speech-to-text provider is configured.\n\n"
                                 "To enable voice: install faster-whisper "
                                 "(`pip install faster-whisper` in the Hermes venv) "
                                 "and set `stt.enabled: true` in config.yaml, "
-                                "then /restart the gateway."
+                                f"then {command_prefix}restart the gateway."
                             )
                             if self._has_setup_skill():
-                                _stt_msg += "\n\nFor full setup instructions, type: `/skill hermes-agent-setup`"
+                                _stt_msg += (
+                                    "\n\nFor full setup instructions, type: "
+                                    f"`{command_prefix}skill hermes-agent-setup`"
+                                )
                             await _stt_adapter.send(
                                 source.chat_id,
                                 _stt_msg,
@@ -4437,9 +4453,10 @@ class GatewayRunner:
 
         # First-message onboarding -- only on the very first interaction ever
         if not history and not self.session_store.has_any_sessions():
+            command_prefix = _preferred_command_prefix(source)
             context_prompt += (
                 "\n\n[System note: This is the user's very first message ever. "
-                "Briefly introduce yourself and mention that /help shows available commands. "
+                f"Briefly introduce yourself and mention that {command_prefix}help shows available commands. "
                 "Keep the introduction concise -- one or two sentences max.]"
             )
         
@@ -5378,21 +5395,26 @@ class GatewayRunner:
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
         from hermes_cli.commands import gateway_help_lines
+        command_prefix = _preferred_command_prefix(event)
         lines = [
             "📖 **Hermes Commands**\n",
-            *gateway_help_lines(),
+            *gateway_help_lines(prefix=command_prefix),
         ]
         try:
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
             if skill_cmds:
                 lines.append(f"\n⚡ **Skill Commands** ({len(skill_cmds)} active):")
-                # Show first 10, then point to /commands for the rest
+                # Show first 10, then point to the commands list for the rest.
                 sorted_cmds = sorted(skill_cmds)
                 for cmd in sorted_cmds[:10]:
-                    lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
+                    display_cmd = f"{command_prefix}{cmd.lstrip('/')}"
+                    lines.append(f"`{display_cmd}` — {skill_cmds[cmd]['description']}")
                 if len(sorted_cmds) > 10:
-                    lines.append(f"\n... and {len(sorted_cmds) - 10} more. Use `/commands` for the full paginated list.")
+                    lines.append(
+                        f"\n... and {len(sorted_cmds) - 10} more. "
+                        f"Use `{command_prefix}commands` for the full paginated list."
+                    )
         except Exception:
             pass
         return "\n".join(lines)
@@ -5401,17 +5423,18 @@ class GatewayRunner:
         """Handle /commands [page] - paginated list of all commands and skills."""
         from hermes_cli.commands import gateway_help_lines
 
+        command_prefix = _preferred_command_prefix(event)
         raw_args = event.get_command_args().strip()
         if raw_args:
             try:
                 requested_page = int(raw_args)
             except ValueError:
-                return "Usage: `/commands [page]`"
+                return f"Usage: `{command_prefix}commands [page]`"
         else:
             requested_page = 1
 
         # Build combined entry list: built-in commands + skill commands
-        entries = list(gateway_help_lines())
+        entries = list(gateway_help_lines(prefix=command_prefix))
         try:
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
@@ -5420,7 +5443,8 @@ class GatewayRunner:
                 entries.append("⚡ **Skill Commands**:")
                 for cmd in sorted(skill_cmds):
                     desc = skill_cmds[cmd].get("description", "").strip() or "Skill command"
-                    entries.append(f"`{cmd}` — {desc}")
+                    display_cmd = f"{command_prefix}{cmd.lstrip('/')}"
+                    entries.append(f"`{display_cmd}` — {desc}")
         except Exception:
             pass
 
@@ -5442,9 +5466,9 @@ class GatewayRunner:
         if total_pages > 1:
             nav_parts = []
             if page > 1:
-                nav_parts.append(f"`/commands {page - 1}` ← prev")
+                nav_parts.append(f"`{command_prefix}commands {page - 1}` ← prev")
             if page < total_pages:
-                nav_parts.append(f"next → `/commands {page + 1}`")
+                nav_parts.append(f"next → `{command_prefix}commands {page + 1}`")
             lines.extend(["", " | ".join(nav_parts)])
         if page != requested_page:
             lines.append(f"_(Requested page {requested_page} was out of range, showing page {page}.)_")
@@ -10647,16 +10671,17 @@ class GatewayRunner:
             # as user input.  The primary fix is in base.py (commands bypass the
             # active-session guard), but this catches edge cases where command
             # text leaks through the interrupt_message fallback.
-            if pending and pending.strip().startswith("/"):
-                _pending_parts = pending.strip().split(None, 1)
-                _pending_cmd_word = _pending_parts[0][1:].lower() if _pending_parts else ""
+            _pending_cmd = extract_command_parts(pending or "")
+            if _pending_cmd:
+                _pending_cmd_word = _pending_cmd[1]
                 if _pending_cmd_word:
                     try:
                         from hermes_cli.commands import resolve_command as _rc_pending
                         if _rc_pending(_pending_cmd_word):
                             logger.info(
-                                "Discarding command '/%s' from pending queue — "
+                                "Discarding command '%s%s' from pending queue — "
                                 "commands must not be passed as agent input",
+                                _pending_cmd[0],
                                 _pending_cmd_word,
                             )
                             pending_event = None

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -372,7 +372,7 @@ def _is_gateway_available(cmd: CommandDef, config_overrides: set[str] | None = N
     return False
 
 
-def gateway_help_lines() -> list[str]:
+def gateway_help_lines(prefix: str = "/") -> list[str]:
     """Generate gateway help text lines from the registry."""
     overrides = _resolve_config_gates()
     lines: list[str] = []
@@ -385,9 +385,9 @@ def gateway_help_lines() -> list[str]:
             # Skip internal aliases like reload_mcp (underscore variant)
             if a.replace("-", "_") == cmd.name.replace("-", "_") and a != cmd.name:
                 continue
-            alias_parts.append(f"`/{a}`")
+            alias_parts.append(f"`{prefix}{a}`")
         alias_note = f" (alias: {', '.join(alias_parts)})" if alias_parts else ""
-        lines.append(f"`/{cmd.name}{args}` -- {cmd.description}{alias_note}")
+        lines.append(f"`{prefix}{cmd.name}{args}` -- {cmd.description}{alias_note}")
     return lines
 
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -280,6 +280,31 @@ class TestMattermostWebSocketParsing:
         assert msg_event.message_id == "post_abc"
 
     @pytest.mark.asyncio
+    async def test_bang_prefixed_command_is_marked_as_command(self):
+        from gateway.platforms.base import MessageType
+
+        post_data = {
+            "id": "post_cmd",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "!model",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "model"
+
+    @pytest.mark.asyncio
     async def test_ignore_own_messages(self):
         """Messages from the bot's own user_id should be ignored."""
         post_data = {

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -8,6 +8,7 @@ from gateway.platforms.base import (
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    extract_command_parts,
     safe_url_for_log,
     utf16_len,
     _prefix_within_utf16_limit,
@@ -68,6 +69,14 @@ class TestMessageEventIsCommand:
         event = MessageEvent(text="/")
         assert event.is_command() is True
 
+    def test_bang_prefix_command(self):
+        event = MessageEvent(text="!help")
+        assert event.is_command() is True
+
+    def test_openclaw_prefix_command(self):
+        event = MessageEvent(text="oc_model gpt-5.5")
+        assert event.is_command() is True
+
 
 class TestMessageEventGetCommand:
     def test_simple_command(self):
@@ -102,6 +111,18 @@ class TestMessageEventGetCommand:
         event = MessageEvent(text="/RESET@TigerNanoBot")
         assert event.get_command() == "reset"
 
+    def test_bang_prefix_command(self):
+        event = MessageEvent(text="!help")
+        assert event.get_command() == "help"
+
+    def test_bang_prefix_command_with_args(self):
+        event = MessageEvent(text="!model gpt-5.5")
+        assert event.get_command() == "model"
+
+    def test_openclaw_prefix_command(self):
+        event = MessageEvent(text="oc_Model gpt-5.5")
+        assert event.get_command() == "model"
+
 
 class TestMessageEventGetCommandArgs:
     def test_command_with_args(self):
@@ -115,6 +136,25 @@ class TestMessageEventGetCommandArgs:
     def test_not_a_command_returns_full_text(self):
         event = MessageEvent(text="hello world")
         assert event.get_command_args() == "hello world"
+
+    def test_bang_prefix_command_with_args(self):
+        event = MessageEvent(text="!new session id 123")
+        assert event.get_command_args() == "session id 123"
+
+    def test_openclaw_prefix_command_with_args(self):
+        event = MessageEvent(text="oc_new session id 123")
+        assert event.get_command_args() == "session id 123"
+
+
+class TestExtractCommandParts:
+    def test_rejects_empty_bang_command(self):
+        assert extract_command_parts("!") is None
+
+    def test_rejects_slash_path_like_token(self):
+        assert extract_command_parts("/tmp/file.txt") is None
+
+    def test_returns_prefix_command_and_args(self):
+        assert extract_command_parts("!model gpt-5.5") == ("!", "model", "gpt-5.5")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -16,9 +16,9 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
-def _make_source() -> SessionSource:
+def _make_source(platform: Platform = Platform.TELEGRAM) -> SessionSource:
     return SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=platform,
         user_id="u1",
         chat_id="c1",
         user_name="tester",
@@ -26,20 +26,20 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str) -> MessageEvent:
-    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+def _make_event(text: str, platform: Platform = Platform.TELEGRAM) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(platform), message_id="m1")
 
 
-def _make_runner():
+def _make_runner(platform: Platform = Platform.TELEGRAM):
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        platforms={platform: PlatformConfig(enabled=True, token="***")}
     )
     adapter = MagicMock()
     adapter.send = AsyncMock()
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(
         emit=AsyncMock(),
@@ -48,11 +48,11 @@ def _make_runner():
     )
 
     session_entry = SessionEntry(
-        session_key=build_session_key(_make_source()),
+        session_key=build_session_key(_make_source(platform)),
         session_id="sess-1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
-        platform=Platform.TELEGRAM,
+        platform=platform,
         chat_type="dm",
     )
     runner.session_store = MagicMock()
@@ -105,6 +105,76 @@ async def test_unknown_slash_command_returns_guidance(monkeypatch):
     assert "/definitely-not-a-command" in result
     assert "/commands" in result
     runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mattermost_unknown_command_returns_bang_guidance(monkeypatch):
+    """Mattermost should render user-facing command guidance with !commands."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner(Platform.MATTERMOST)
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError(
+            "unknown Mattermost command leaked through to the agent"
+        )
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(
+        _make_event("!definitely-not-a-command", Platform.MATTERMOST)
+    )
+
+    assert result is not None
+    assert "Unknown command" in result
+    assert "!definitely-not-a-command" in result
+    assert "!commands" in result
+    assert "/commands" not in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mattermost_help_renders_bang_prefixed_commands(monkeypatch):
+    """Mattermost help should advertise ! commands, including skills."""
+    from agent import skill_commands
+
+    runner = _make_runner(Platform.MATTERMOST)
+    event = _make_event("!help", Platform.MATTERMOST)
+    monkeypatch.setattr(
+        skill_commands,
+        "get_skill_commands",
+        lambda: {"/example-skill": {"description": "Example skill"}},
+    )
+
+    result = await runner._handle_help_command(event)
+
+    assert "`!help" in result
+    assert "`!commands" in result
+    assert "`!example-skill`" in result
+    assert "`/example-skill`" not in result
+
+
+@pytest.mark.asyncio
+async def test_non_mattermost_help_keeps_slash_prefix(monkeypatch):
+    """Non-Mattermost help should keep the existing slash wording."""
+    from agent import skill_commands
+
+    runner = _make_runner(Platform.TELEGRAM)
+    event = _make_event("/help", Platform.TELEGRAM)
+    monkeypatch.setattr(
+        skill_commands,
+        "get_skill_commands",
+        lambda: {"/example-skill": {"description": "Example skill"}},
+    )
+
+    result = await runner._handle_help_command(event)
+
+    assert "`/help" in result
+    assert "`/commands" in result
+    assert "`/example-skill`" in result
+    assert "`!example-skill`" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -202,6 +202,14 @@ class TestGatewayHelpLines:
         assert len(bg_line) == 1
         assert "/bg" in bg_line[0]
 
+    def test_uses_custom_prefix_for_gateway_help(self):
+        lines = gateway_help_lines(prefix="!")
+        joined = "\n".join(lines)
+        help_line = [line for line in lines if line.startswith("`!help")]
+        assert len(help_line) == 1
+        assert "`!background" in joined
+        assert "`!bg`" in joined
+
 
 class TestTelegramBotCommands:
     def test_returns_list_of_tuples(self):


### PR DESCRIPTION
## Summary
- Restore Mattermost-facing command guidance to advertise `!` commands such as `!help` and `!commands`.
- Preserve non-Mattermost slash-command wording.
- Keep restored command parsing for `/`, `!`, and `oc_` prefixes.
- Add focused tests for Mattermost bang-prefixed command handling and unknown-command guidance.

## Test Plan
- `python -m pytest tests/gateway/test_platform_base.py tests/gateway/test_mattermost.py tests/gateway/test_unknown_command.py tests/hermes_cli/test_commands.py -q -o "addopts="`
- `python -m py_compile gateway/platforms/base.py gateway/platforms/mattermost.py gateway/run.py hermes_cli/commands.py`
- `git diff --check`
