### PR TITLE
fix(providers): register alibaba-coding-plan as a first-class provider (salvage #14961)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -224,6 +224,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("DASHSCOPE_API_KEY",),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
+    "alibaba-coding-plan": ProviderConfig(
+        id="alibaba-coding-plan",
+        name="Alibaba Cloud (Coding Plan)",
+        auth_type="api_key",
+        inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+        api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
+        base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
+    ),
     "minimax-cn": ProviderConfig(
         id="minimax-cn",
         name="MiniMax (China)",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1032,6 +1032,8 @@ def resolve_provider(
         "step": "stepfun", "stepfun-coding-plan": "stepfun",
         "arcee-ai": "arcee", "arceeai": "arcee",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
+        "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
+        "alibaba_coding_plan": "alibaba-coding-plan",
         "claude": "anthropic", "claude-code": "anthropic",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -116,6 +116,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
+    "alibaba-coding-plan": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
+    ),
     "vercel": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -259,6 +263,9 @@ ALIASES: Dict[str, str] = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "alibaba_coding": "alibaba-coding-plan",
+    "alibaba-coding": "alibaba-coding-plan",
+    "alibaba_coding_plan": "alibaba-coding-plan",
 
     # google-gemini-cli (OAuth + Code Assist)
     "gemini-cli": "google-gemini-cli",


### PR DESCRIPTION
Salvage of #14961 by @ygd58 onto current main, with a follow-up fix.

Closes #14940.

## What this PR does
Registers `alibaba-coding-plan` (endpoint `coding-intl.dashscope.aliyuncs.com/v1`) as a first-class provider so users can set `provider: alibaba_coding` in config.yaml without falling through to OpenRouter.

## Changes
- @ygd58 (#14961): adds `ProviderConfig` in `hermes_cli/auth.py`, `HermesOverlay` in `hermes_cli/providers.py`, three aliases (`alibaba_coding`, `alibaba-coding`, `alibaba_coding_plan`).
- Follow-up: mirrors the three aliases into `auth.py::resolve_provider()::_PROVIDER_ALIASES`. Without this, the issue's exact repro (`provider: alibaba_coding`) still raised `Unknown provider` because `resolve_provider` has its own alias table separate from `providers.py::ALIASES`.

## Validation
| | Before | After |
|---|---|---|
| `resolve_provider('alibaba_coding')` | AuthError: Unknown provider | `'alibaba-coding-plan'` |
| `resolve_provider('alibaba-coding-plan')` | AuthError: Unknown provider | `'alibaba-coding-plan'` |
| PROVIDER_REGISTRY endpoint | missing | `coding-intl.dashscope.aliyuncs.com/v1` |

`tests/hermes_cli/test_runtime_provider_resolution.py`, `test_api_key_providers.py`, `test_auth_provider_gate.py` — 215/215 pass.

Co-authored-by: @ygd58