### PR TITLE
fix(auth): apply verify= to Codex OAuth /models probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1076,6 +1076,7 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
             "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=10,
+            verify=_resolve_requests_verify(),
         )
         if resp.status_code != 200:
             logger.debug(


### PR DESCRIPTION
## Summary
Follow-up to #14533 — applies `_resolve_requests_verify()` to the one `requests.get()` site that PR missed: the Codex OAuth `chatgpt.com/backend-api/codex/models` probe in `agent/model_metadata.py` (L1053).

Keeps all seven `requests.get()` callsites in that module consistent — `HERMES_CA_BUNDLE` / `REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` are now honored everywhere, including Codex context-length probing on macOS Homebrew Python.

## Changes
- `agent/model_metadata.py`: add `verify=_resolve_requests_verify()` to the Codex `/models` probe call.

## Validation
- py_compile clean.
- `grep 'verify=_resolve_requests_verify' agent/model_metadata.py` → 5 matches (one per call site, including the shared `_verify` local covering the /v1/props + /props pair).