### PR TITLE
fix(agent): skip TCP keepalives for local endpoints to avoid HTTP 502 (#14916)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4600,9 +4600,14 @@ class AIAgent:
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
         if "http_client" not in client_kwargs:
-            keepalive_http = self._build_keepalive_http_client(client_kwargs.get("base_url", ""))
-            if keepalive_http is not None:
-                client_kwargs["http_client"] = keepalive_http
+            base_url = str(client_kwargs.get("base_url", "") or "")
+            # Skip TCP keepalives for local endpoints.  Keepalive socket options
+            # can cause HTTP 502 errors with local LLM servers (llama.cpp,
+            # Ollama, vLLM) that don't expect or handle them (#14916).
+            if not is_local_endpoint(base_url):
+                keepalive_http = self._build_keepalive_http_client()
+                if keepalive_http is not None:
+                    client_kwargs["http_client"] = keepalive_http
         client = OpenAI(**client_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",

--- a/tests/run_agent/test_create_openai_client_local_endpoint.py
+++ b/tests/run_agent/test_create_openai_client_local_endpoint.py
@@ -1,0 +1,153 @@
+"""Regression guard: _create_openai_client must skip TCP keepalives for local endpoints.
+
+Issue #14916: TCP keepalive socket options (SO_KEEPALIVE, TCP_KEEPIDLE, etc.)
+ injected via a custom httpx.HTTPTransport cause HTTP 502 errors when
+ connecting to local LLM servers (llama.cpp, Ollama, vLLM) on localhost
+ or 127.0.0.1.  Local servers typically do not expect or handle these
+ socket options, and the resulting connection behaviour manifests as
+ ``HTTP 502: Error code: 502``.
+
+The fix: before injecting the keepalive-enabled httpx.Client, check whether
+ the configured base_url points to a local endpoint.  If so, skip the
+ keepalive injection and let OpenAI use its default transport.
+
+This test pins that local endpoints do NOT receive an injected http_client,
+ while remote endpoints still do (so the dead-peer detection from #10324
+ continues to work for cloud providers).
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(base_url: str):
+    return AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+def _make_fake_openai_factory(constructed: list):
+    """Return a fake ``OpenAI`` class that records kwargs of every construction."""
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+            constructed.append(kwargs)
+
+        def close(self):
+            pass
+
+    return _FakeOpenAI
+
+
+class TestLocalEndpointSkipsKeepalive:
+    """Local endpoints must not receive the keepalive http_client injection."""
+
+    def test_localhost_skips_http_client(self):
+        constructed = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        agent = _make_agent("http://localhost:1234/v1")
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=False
+            )
+
+        assert len(constructed) == 1
+        assert constructed[0].get("http_client") is None, (
+            "Localhost endpoint should NOT receive keepalive http_client injection. "
+            "This causes HTTP 502 with local LLM servers (#14916)."
+        )
+
+    def test_127_0_0_1_skips_http_client(self):
+        constructed = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        agent = _make_agent("http://127.0.0.1:8080/v1")
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=False
+            )
+
+        assert len(constructed) == 1
+        assert constructed[0].get("http_client") is None, (
+            "127.0.0.1 endpoint should NOT receive keepalive http_client injection."
+        )
+
+    def test_0_0_0_0_skips_http_client(self):
+        constructed = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        agent = _make_agent("http://0.0.0.0:5000/v1")
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=False
+            )
+
+        assert len(constructed) == 1
+        assert constructed[0].get("http_client") is None, (
+            "0.0.0.0 endpoint should NOT receive keepalive http_client injection."
+        )
+
+
+class TestRemoteEndpointKeepsKeepalive:
+    """Remote endpoints must continue to receive the keepalive http_client injection."""
+
+    def test_openrouter_gets_http_client(self):
+        constructed = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        agent = _make_agent("https://openrouter.ai/api/v1")
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=False
+            )
+
+        assert len(constructed) == 1
+        assert constructed[0].get("http_client") is not None, (
+            "Remote endpoint (openrouter) SHOULD receive keepalive http_client "
+            "injection for dead-peer detection (#10324)."
+        )
+
+    def test_cloud_provider_gets_http_client(self):
+        constructed = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        agent = _make_agent("https://api.openai.com/v1")
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=False
+            )
+
+        assert len(constructed) == 1
+        assert constructed[0].get("http_client") is not None, (
+            "Remote endpoint (OpenAI) SHOULD receive keepalive http_client "
+            "injection for dead-peer detection (#10324)."
+        )
+
+
+class TestExplicitHttpClientPreserved:
+    """If caller explicitly passes http_client, it must be preserved regardless of endpoint."""
+
+    def test_explicit_http_client_preserved_for_localhost(self):
+        constructed = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        agent = _make_agent("http://localhost:1234/v1")
+        explicit_client = MagicMock()
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                {**agent._client_kwargs, "http_client": explicit_client},
+                reason="test",
+                shared=False,
+            )
+
+        assert len(constructed) == 1
+        assert constructed[0].get("http_client") is explicit_client, (
+            "Explicitly provided http_client should be preserved even for localhost."
+        )


### PR DESCRIPTION
 What does this PR do?

    Skip TCP keepalive socket-option injection for local endpoints (localhost, 127.0.0.1, RFC-1918 private ranges, etc.) in _create_openai_client().

    The keepalive-enabled custom httpx.Client (added in #10324 / #11277) causes HTTP 502 errors when connecting to local LLM servers such as llama.cpp, Ollama, and vLLM, because those servers do not expect or handle SO_KEEPALIVE / TCP_KEEPIDLE socket options. Remote cloud providers still receive the keepalive injection so dead-peer detection continues to work.

    Related Issue

    Fixes #14916

    Type of Change

    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

    Changes Made

    - run_agent.py (line ~4570): Added is_local_endpoint(base_url) guard before injecting the keepalive httpx.Client. Local endpoints skip injection; remote endpoints continue to receive it.
    - tests/run_agent/test_create_openai_client_local_endpoint.py: New test suite with 6 cases:
      - test_localhost_skips_http_client
      - test_127_0_0_1_skips_http_client
      - test_0_0_0_0_skips_http_client
      - test_openrouter_gets_http_client
      - test_cloud_provider_gets_http_client
      - test_explicit_http_client_preserved_for_localhost

    How to Test

    1. Run the new tests: pytest tests/run_agent/test_create_openai_client_local_endpoint.py -v
    2. Verify local endpoints skip keepalive: all 3 localhost tests should show http_client is None
    3. Verify remote endpoints keep keepalive: openrouter / OpenAI tests should show http_client is injected
    4. Run existing keepalive tests to confirm no regression: pytest tests/run_agent/test_create_openai_client_reuse.py tests/run_agent/test_create_openai_client_proxy_env.py -v

    Checklist

    Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform: macOS 15.x, Python 3.11

    Documentation & Housekeeping

    - [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
    - [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
    - [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
    - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
    - [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A