### PR TITLE
feat: configurable prompt_caching.cache_ttl (5m default, 1h opt-in) — salvage #12659

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -327,6 +327,16 @@ compression:
   # auxiliary section below (auxiliary.compression.provider / model).
 
 # =============================================================================
+# Anthropic prompt caching TTL
+# =============================================================================
+# When prompt caching is active (Claude via OpenRouter or native Anthropic),
+# Anthropic supports two TTL tiers for cached prefixes: "5m" (default) and
+# "1h". Other values are ignored and "5m" is used.
+#
+prompt_caching:
+  cache_ttl: "5m" # use "1h" for long sessions with pauses between turns
+
+# =============================================================================
 # Auxiliary Models (Advanced — Experimental)
 # =============================================================================
 # Hermes uses lightweight "auxiliary" models for side tasks: image analysis,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -521,6 +521,12 @@ DEFAULT_CONFIG = {
 
     },
 
+    # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
+    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    "prompt_caching": {
+        "cache_ttl": "5m",
+    },
+
     # AWS Bedrock provider configuration.
     # Only used when model.provider is "bedrock".
     "bedrock": {

--- a/run_agent.py
+++ b/run_agent.py
@@ -1036,8 +1036,21 @@ class AIAgent:
         self._use_prompt_caching, self._use_native_cache_layout = (
             self._anthropic_prompt_cache_policy()
         )
-        self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
-        
+        # Anthropic supports "5m" (default) and "1h" cache TTL tiers. Read from
+        # config.yaml under prompt_caching.cache_ttl; unknown values keep "5m".
+        # 1h tier costs 2x on write vs 1.25x for 5m, but amortizes across long
+        # sessions with >5-minute pauses between turns (#14971).
+        self._cache_ttl = "5m"
+        try:
+            from hermes_cli.config import load_config as _load_pc_cfg
+
+            _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
+            _ttl = _pc_cfg.get("cache_ttl", "5m")
+            if _ttl in ("5m", "1h"):
+                self._cache_ttl = _ttl
+        except Exception:
+            pass
+
         # Iteration budget: the LLM is only notified when it actually exhausts
         # the iteration budget (api_call_count >= max_iterations).  At that
         # point we inject ONE message, allow one final API call, and if the

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -190,6 +190,7 @@ AUTHOR_MAP = {
     "hermes@nousresearch.com": "NousResearch",
     "reginaldasr@gmail.com": "ReginaldasR",
     "ntconguit@gmail.com": "0xharryriddle",
+    "agent@wildcat.local": "ericnicolaides",
     "hermes@noushq.ai": "benbarclay",
     "chinmingcock@gmail.com": "ChimingLiu",
     "openclaw@sparklab.ai": "openclaw",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -685,6 +685,66 @@ class TestInit:
             assert a.api_mode == "anthropic_messages"
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_cache_ttl_defaults_without_config(self):
+        """cache_ttl stays 5m when prompt_caching is absent from config."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value={}),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "5m"
+
+    def test_prompt_caching_cache_ttl_custom_1h(self):
+        """prompt_caching.cache_ttl 1h is applied when present in config."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"cache_ttl": "1h"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "1h"
+
+    def test_prompt_caching_cache_ttl_invalid_falls_back(self):
+        """Non-Anthropic TTL values keep default 5m without raising."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"cache_ttl": "30m"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "5m"
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -332,9 +332,9 @@ Prompt caching is automatically enabled when:
 - The provider supports `cache_control` (native Anthropic API or OpenRouter)
 
 ```yaml
-# config.yaml — TTL is configurable
-model:
-  cache_ttl: "5m"   # "5m" or "1h"
+# config.yaml — TTL is configurable (must be "5m" or "1h")
+prompt_caching:
+  cache_ttl: "5m"
 ```
 
 The CLI shows caching status at startup:


### PR DESCRIPTION
Salvage of #12659 by @ericnicolaides onto current main. Chosen over parallel PRs #14812 (env-var only, violates '.env for secrets only') and #3082 (threads kwarg through gateway + session + state DB — unnecessarily heavy for a 2-value config).

Closes #14971.

## What this PR does
Exposes Anthropic's 1h prompt-cache TTL tier as a config option. Default remains `5m` — zero behavior change for existing users.

```yaml
# ~/.hermes/config.yaml
prompt_caching:
  cache_ttl: "1h"   # opt-in; default is "5m"
```

Motivated by #14971 cost data: on a $246 Anthropic workload, 56.5% of spend was `input_cache_write_5m` — the cache was rewriting more than reading because the 5m TTL kept expiring between turns. The 1h tier costs 2x on write (vs 1.25x for 5m) but amortizes across a full session. The 1h path has been supported inside `apply_anthropic_cache_control()` since it landed; this PR just exposes it.

## How
`AIAgent.__init__` reads `prompt_caching.cache_ttl` via `hermes_cli.config.load_config()`. Validates against `{"5m", "1h"}`; anything else falls back to `"5m"` without raising. `DEFAULT_CONFIG` gets a `prompt_caching` section so the merge resolves cleanly for upgraders. Same conflict resolution applied to match current main's `_anthropic_prompt_cache_policy()` helper refactor.

## Changes
- @ericnicolaides (#12659 commit 1): config wiring + run_agent.py lookup + 3 unit tests + developer guide fix
- @ericnicolaides (#12659 commit 2): `cli-config.yaml.example` documentation block
- Follow-up: AUTHOR_MAP entry for `agent@wildcat.local` (Cursor agent commit email) → @ericnicolaides

## Validation
| Config | Expected `_cache_ttl` | Got |
|---|---|---|
| (no `prompt_caching` section) | `5m` | `5m` ✓ |
| `cache_ttl: "1h"` | `1h` | `1h` ✓ |
| `cache_ttl: "30m"` (invalid) | `5m` (fallback) | `5m` ✓ |
| `cache_ttl: "5m"` (explicit) | `5m` | `5m` ✓ |
| `prompt_caching: {}` (empty) | `5m` | `5m` ✓ |

- `tests/run_agent/test_run_agent.py -k cache_ttl` — 3/3 pass (new tests)
- `tests/agent/test_prompt_caching.py` — 14/14 pass (regression guard)
- E2E: 5 scenarios above verified with real config.yaml + AIAgent instantiation

Co-authored-by: @ericnicolaides