### PR TITLE
fix(normalize): lowercase Xiaomi model IDs for case-insensitive config

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -100,6 +100,15 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "custom",
 })
 
+# Providers whose APIs require lowercase model IDs.  Xiaomi's
+# ``api.xiaomimimo.com`` rejects mixed-case names like ``MiMo-V2.5-Pro``
+# that users might copy from marketing docs — it only accepts
+# ``mimo-v2.5-pro``.  After stripping a matching provider prefix, these
+# providers also get ``.lower()`` applied.
+_LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
+    "xiaomi",
+})
+
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
@@ -347,6 +356,9 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
         >>> normalize_model_for_provider("claude-sonnet-4.6", "zai")
         'claude-sonnet-4.6'
+
+        >>> normalize_model_for_provider("MiMo-V2.5-Pro", "xiaomi")
+        'mimo-v2.5-pro'
     """
     name = (model_input or "").strip()
     if not name:
@@ -410,7 +422,12 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Direct providers: repair matching provider prefixes only ---
     if provider in _MATCHING_PREFIX_STRIP_PROVIDERS:
-        return _strip_matching_provider_prefix(name, provider)
+        result = _strip_matching_provider_prefix(name, provider)
+        # Some providers require lowercase model IDs (e.g. Xiaomi's API
+        # rejects "MiMo-V2.5-Pro" but accepts "mimo-v2.5-pro").
+        if provider in _LOWERCASE_MODEL_PROVIDERS:
+            result = result.lower()
+        return result
 
     # --- Authoritative native providers: preserve user-facing slugs as-is ---
     if provider in _AUTHORITATIVE_NATIVE_PROVIDERS:

--- a/tests/hermes_cli/test_xiaomi_provider.py
+++ b/tests/hermes_cli/test_xiaomi_provider.py
@@ -195,6 +195,26 @@ class TestXiaomiNormalization:
         from hermes_cli.model_normalize import _MATCHING_PREFIX_STRIP_PROVIDERS
         assert "xiaomi" in _MATCHING_PREFIX_STRIP_PROVIDERS
 
+    def test_lowercase_model_provider(self):
+        """Xiaomi must be in _LOWERCASE_MODEL_PROVIDERS."""
+        from hermes_cli.model_normalize import _LOWERCASE_MODEL_PROVIDERS
+        assert "xiaomi" in _LOWERCASE_MODEL_PROVIDERS
+
+    def test_lowercase_subset_of_matching_prefix(self):
+        """_LOWERCASE_MODEL_PROVIDERS must be a subset of _MATCHING_PREFIX_STRIP_PROVIDERS.
+
+        Otherwise the .lower() code path is unreachable dead code — the
+        provider check at line 422 gates entry to the block.
+        """
+        from hermes_cli.model_normalize import (
+            _LOWERCASE_MODEL_PROVIDERS,
+            _MATCHING_PREFIX_STRIP_PROVIDERS,
+        )
+        assert _LOWERCASE_MODEL_PROVIDERS.issubset(_MATCHING_PREFIX_STRIP_PROVIDERS), (
+            f"_LOWERCASE_MODEL_PROVIDERS has entries not in _MATCHING_PREFIX_STRIP_PROVIDERS: "
+            f"{_LOWERCASE_MODEL_PROVIDERS - _MATCHING_PREFIX_STRIP_PROVIDERS}"
+        )
+
     def test_normalize_strips_provider_prefix(self):
         from hermes_cli.model_normalize import normalize_model_for_provider
         result = normalize_model_for_provider("xiaomi/mimo-v2-pro", "xiaomi")
@@ -204,6 +224,40 @@ class TestXiaomiNormalization:
         from hermes_cli.model_normalize import normalize_model_for_provider
         result = normalize_model_for_provider("mimo-v2-pro", "xiaomi")
         assert result == "mimo-v2-pro"
+
+    @pytest.mark.parametrize("empty_input", ["", None, "   "])
+    def test_normalize_empty_and_none(self, empty_input):
+        """None, empty, and whitespace-only inputs return empty string."""
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        result = normalize_model_for_provider(empty_input, "xiaomi")
+        assert result == ""
+
+    @pytest.mark.parametrize("input_name,expected", [
+        ("MiMo-V2.5-Pro", "mimo-v2.5-pro"),
+        ("MIMO-V2.5-PRO", "mimo-v2.5-pro"),
+        ("MiMo-v2.5-pro", "mimo-v2.5-pro"),
+        ("mimo-v2.5-pro", "mimo-v2.5-pro"),     # already lowercase
+        ("MiMo-V2-Pro", "mimo-v2-pro"),
+        ("MiMo-V2-Omni", "mimo-v2-omni"),
+        ("MiMo-V2-Flash", "mimo-v2-flash"),
+        ("MiMo-V2.5", "mimo-v2.5"),
+    ])
+    def test_normalize_lowercases_mixed_case(self, input_name, expected):
+        """Xiaomi's API requires lowercase model IDs — mixed case from docs must be lowered."""
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        result = normalize_model_for_provider(input_name, "xiaomi")
+        assert result == expected
+
+    @pytest.mark.parametrize("input_name,expected", [
+        ("xiaomi/MiMo-V2.5-Pro", "mimo-v2.5-pro"),
+        ("xiaomi/MIMO-V2.5-PRO", "mimo-v2.5-pro"),
+        ("xiaomi/mimo-v2.5-pro", "mimo-v2.5-pro"),
+    ])
+    def test_normalize_strips_prefix_and_lowercases(self, input_name, expected):
+        """Provider prefix stripping AND lowercasing must both work together."""
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        result = normalize_model_for_provider(input_name, "xiaomi")
+        assert result == expected
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Xiaomi's API (`api.xiaomimimo.com`) requires lowercase model IDs like `mimo-v2.5-pro` but rejects mixed-case names like `MiMo-V2.5-Pro`. Users naturally copy the marketing-style case from docs and the ProviderEntry description (`MiMo-V2.5 and V2 models — pro, omni, flash`), then hit unrecognized model errors.

## Problem

`normalize_model_for_provider()` for the `xiaomi` provider (in `_MATCHING_PREFIX_STRIP_PROVIDERS`) only strips the `xiaomi/` prefix but does **not** normalize case. So:

| User config | Sent to API | Result |
|---|---|---|
| `mimo-v2.5-pro` | `mimo-v2.5-pro` | ✅ Works |
| `MiMo-V2.5-Pro` | `MiMo-V2.5-Pro` | ❌ API rejects |
| `xiaomi/MiMo-V2.5-Pro` | `MiMo-V2.5-Pro` | ❌ API rejects |

## Fix

- Add `_LOWERCASE_MODEL_PROVIDERS` frozenset (currently just `xiaomi`) in `model_normalize.py`
- Apply `.lower()` after prefix stripping for providers in this set
- Other providers (minimax, zai, etc.) are **not affected** — their APIs accept mixed case

## After fix

| User config | Sent to API | Result |
|---|---|---|
| `mimo-v2.5-pro` | `mimo-v2.5-pro` | ✅ Works |
| `MiMo-V2.5-Pro` | `mimo-v2.5-pro` | ✅ Works |
| `xiaomi/MiMo-V2.5-Pro` | `mimo-v2.5-pro` | ✅ Works |
| `MIMO-V2.5-PRO` | `mimo-v2.5-pro` | ✅ Works |

## Test plan

- 15 new tests in `test_xiaomi_provider.py`:
  - 8 parametrized tests for mixed-case bare names (all model variants)
  - 3 parametrized tests for prefix+case combos
  - 3 parametrized edge-case tests (None, empty, whitespace)
  - 1 invariant test: `_LOWERCASE_MODEL_PROVIDERS ⊆ _MATCHING_PREFIX_STRIP_PROVIDERS`
- All 52 Xiaomi provider tests pass
- All 55 model normalization tests pass
- 317 total tests across related suites — 0 new failures
- Cross-provider non-regression verified: minimax, zai, kimi-coding, alibaba, arcee all preserve case
- Aggregator paths (openrouter, nous) unaffected

## Files changed

- `hermes_cli/model_normalize.py` — add `_LOWERCASE_MODEL_PROVIDERS`, apply `.lower()` in the direct-provider normalization path, add docstring example
- `tests/hermes_cli/test_xiaomi_provider.py` — 15 new tests for case-insensitive normalization + invariant + edge cases