### PR TITLE
Fix: underscore stripping regex in gateway helpers consumes identifiers

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -157,8 +157,8 @@ class TextBatchAggregator:
 # Pre-compiled regexes for performance
 _RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 _RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
-_RE_BOLD_UNDER = re.compile(r"__(.+?)__", re.DOTALL)
-_RE_ITALIC_UNDER = re.compile(r"_(.+?)_", re.DOTALL)
+_RE_BOLD_UNDER = re.compile(r"(?<![a-zA-Z0-9])__(?=[^_\s])(.+?)(?<=[^_])__(?![a-zA-Z0-9])", re.DOTALL)
+_RE_ITALIC_UNDER = re.compile(r"(?<![a-zA-Z0-9])_(?=[^_\s])(.+?)(?<=[^_])_(?![a-zA-Z0-9])", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")
 _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)


### PR DESCRIPTION
## Problem

`gateway/platforms/helpers.py` contains the same overly-greedy Markdown underscore regex that was already fixed in `cli.py`. The `TextBatchAggregator` class uses `_RE_ITALIC_UNDER = re.compile(r"_(.+?)_", re.DOTALL)` which strips underscores from alphanumeric identifiers like `send_as_bot`, `user_id`, `my_variable`.

## Root Cause

Lines 160-161 in `gateway/platforms/helpers.py`:
```python
# Old (buggy) — matches ANY underscore pair greedily
_RE_BOLD_UNDER = re.compile(r"__(.+?)__", re.DOTALL)
_RE_ITALIC_UNDER = re.compile(r"_(.+?)_", re.DOTALL)
```

This is identical to the bug that was fixed in `cli.py`'s `_strip_markdown_syntax()` — but the `helpers.py` copy was missed.

## Fix

Replace with lookbehind/lookahead assertions that only match actual Markdown italic delimiters:
```python
# New (fixed) — requires non-alphanumeric boundaries on both sides
_RE_BOLD_UNDER = re.compile(r'(?<![a-zA-Z0-9])__(?=[^\s])(.+?)(?<=[^_])__(?![a-zA-Z0-9])', re.DOTALL)
_RE_ITALIC_UNDER = re.compile(r'(?<![a-zA-Z0-9])_(?=[^\s])(.+?)(?<=[^_])_(?![a-zA-Z0-9])', re.DOTALL)
```

## Impact

- Identifiers like `send_as_bot`, `user_id`, `my_variable` are no longer corrupted when text is stripped via `TextBatchAggregator`
- Actual Markdown italic `_text_` still correctly stripped
- Consistent with the fix already applied to `cli.py`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/helpers.py`: Fixed `_RE_BOLD_UNDER` and `_RE_ITALIC_UNDER` regex patterns (2 lines changed)

## How to Test

1. Send a message containing `send_as_bot` or `user_id` through any gateway platform
2. Verify the identifiers are preserved in the output text
3. Verify actual Markdown italic `_text_` is still correctly stripped