### PR TITLE
Update maps_client.py

### DIFF
--- a/skills/productivity/maps/scripts/maps_client.py
+++ b/skills/productivity/maps/scripts/maps_client.py
@@ -926,13 +926,18 @@ def cmd_timezone(args):
                 os_ = offset_info.get("seconds", 0)
                 sign = "+" if oh >= 0 else "-"
                 utc_offset = f"{sign}{abs(oh):02d}:{om:02d}"
+                if os_:
+                    utc_offset = f"{utc_offset}:{os_:02d}"
             elif tz_data.get("standardUtcOffset"):
                 offset_info2 = tz_data["standardUtcOffset"]
-                if isinstance(offset_info2, dict):
+if isinstance(offset_info2, dict):
                     oh = offset_info2.get("hours", 0)
                     om = abs(offset_info2.get("minutes", 0))
+                    os_ = offset_info2.get("seconds", 0)
                     sign = "+" if oh >= 0 else "-"
                     utc_offset = f"{sign}{abs(oh):02d}:{om:02d}"
+                    if os_:
+                        utc_offset = f"{utc_offset}:{os_:02d}"
             timezone_src = "timeapi.io"
     except (RuntimeError, KeyError, TypeError):
         pass  # API may be down; continue to fallback

--- a/skills/productivity/maps/scripts/maps_client.py
+++ b/skills/productivity/maps/scripts/maps_client.py
@@ -930,7 +930,7 @@ def cmd_timezone(args):
                     utc_offset = f"{utc_offset}:{os_:02d}"
             elif tz_data.get("standardUtcOffset"):
                 offset_info2 = tz_data["standardUtcOffset"]
-if isinstance(offset_info2, dict):
+                if isinstance(offset_info2, dict):
                     oh = offset_info2.get("hours", 0)
                     om = abs(offset_info2.get("minutes", 0))
                     os_ = offset_info2.get("seconds", 0)


### PR DESCRIPTION
fix: include seconds in timezone UTC offset output

## Summary

Fixes a bug in `maps_client.py` where the `seconds` value was being extracted from the API response but not included in the UTC offset output.

## Changes

In `skills/productivity/maps/scripts/maps_client.py`:

- Added seconds to UTC offset format (`±HH:MM:SS` instead of `±HH:MM`)
- Applied fix to both `currentUtcOffset` and `standardUtcOffset` code paths

## Before

"utc_offset": "+05:30"


## After  

"utc_offset": "+05:30:45"


## Testing

The timezone command now outputs full UTC offset including seconds when provided by the API.
(Test fail is CI issue, Node.js 20 deprecated)