### PR TITLE
fix: preserve dotted non-Claude model ids on Anthropic wire

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -912,14 +912,16 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     """Normalize a model name for the Anthropic API.
 
     - Strips 'anthropic/' prefix (OpenRouter format, case-insensitive)
-    - Converts dots to hyphens in version numbers (OpenRouter uses dots,
-      Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
-      preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+    - Converts dots to hyphens for Claude model versions only
+      (OpenRouter uses dots, Anthropic uses hyphens:
+      claude-opus-4.6 → claude-opus-4-6), unless preserve_dots is True.
+      Non-Claude model IDs on Anthropic-compatible endpoints (for example
+      qwen3.6-35B) keep their dots by default.
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
-    if not preserve_dots:
+    if not preserve_dots and model.lower().startswith("claude-"):
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.
         model = model.replace(".", "-")

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -485,6 +485,11 @@ class TestNormalizeModelName:
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
+    def test_non_claude_models_keep_dots_by_default(self):
+        """Anthropic-compatible custom endpoints can serve non-Claude IDs like Qwen."""
+        assert normalize_model_name("qwen3.6-35B") == "qwen3.6-35B"
+        assert normalize_model_name("anthropic/qwen3.6-35B") == "qwen3.6-35B"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -310,8 +310,8 @@ class TestMinimaxPreserveDots:
 
     def test_normalize_converts_without_preserve(self):
         from agent.anthropic_adapter import normalize_model_name
-        # Without preserve_dots, dots become hyphens (broken for MiniMax)
-        assert normalize_model_name("MiniMax-M2.7", preserve_dots=False) == "MiniMax-M2-7"
+        # Non-Claude model IDs now keep dots by default on Anthropic-compatible endpoints.
+        assert normalize_model_name("MiniMax-M2.7", preserve_dots=False) == "MiniMax-M2.7"
 
 
 class TestMinimaxSwitchModelCredentialGuard:


### PR DESCRIPTION
Closes #15072

## Summary

Fix Anthropic model normalization so Hermes only converts dots to hyphens for Claude model IDs.

Before this change, Anthropic wire normalization rewrote any dotted model ID, which broke Anthropic-compatible custom endpoints serving non-Claude models such as:

- `qwen3.6-35B`
- `qwen3.5-plus`
- `MiniMax-M2.7`

That produced requests like `qwen3-6-35B`, which the upstream endpoint rejected as `model_not_found`.

## Root cause

`agent.anthropic_adapter.normalize_model_name()` applied this rule globally:

- strip `anthropic/`
- replace `.` with `-`

That is correct for Claude IDs like `claude-sonnet-4.6 -> claude-sonnet-4-6`, but incorrect for non-Claude IDs on Anthropic-compatible APIs.

## Fix

Change Anthropic normalization to:

- keep stripping `anthropic/`
- only replace `.` with `-` when the bare model ID starts with `claude-`
- keep dotted non-Claude IDs unchanged by default

Examples after this patch:

- `anthropic/claude-sonnet-4.6` -> `claude-sonnet-4-6`
- `qwen3.6-35B` -> `qwen3.6-35B`
- `anthropic/qwen3.6-35B` -> `qwen3.6-35B`
- `MiniMax-M2.7` -> `MiniMax-M2.7`

## Tests

Added/updated regression coverage for:

- Qwen-style dotted model IDs staying intact on the Anthropic path
- existing Claude dot-to-hyphen behavior remaining unchanged
- MiniMax normalization expectation aligned with the new non-Claude behavior

## Validation

Passed locally:

- `pytest -o addopts='' tests/agent/test_anthropic_adapter.py`
- `pytest -o addopts='' tests/agent/test_minimax_provider.py -k 'normalize_'`

I did not run the full `test_minimax_provider.py` file in this environment because it imports `run_agent` and the local env is missing the `fire` dependency, which is unrelated to this fix.
