### PR TITLE
fix(env): safely quote ~/ subpaths in wrapped cd commands

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -60,6 +60,22 @@ class TestWrapCommand:
         assert "cd ~" in wrapped
         assert "cd '~'" not in wrapped
 
+    def test_tilde_subpath_with_spaces_uses_home_and_quotes_suffix(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("ls", "~/my repo")
+
+        assert "cd $HOME/'my repo'" in wrapped
+        assert "cd ~/my repo" not in wrapped
+
+    def test_tilde_slash_maps_to_home(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("ls", "~/")
+
+        assert "cd $HOME" in wrapped
+        assert "cd ~/" not in wrapped
+
     def test_cd_failure_exit_126(self):
         env = _TestableEnv()
         env._snapshot_ready = True

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -368,6 +368,17 @@ class BaseEnvironment(ABC):
     # Command wrapping
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _quote_cwd_for_cd(cwd: str) -> str:
+        """Quote a ``cd`` target while preserving ``~`` expansion."""
+        if cwd == "~":
+            return cwd
+        if cwd == "~/":
+            return "$HOME"
+        if cwd.startswith("~/"):
+            return f"$HOME/{shlex.quote(cwd[2:])}"
+        return shlex.quote(cwd)
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -379,10 +390,9 @@ class BaseEnvironment(ABC):
         if self._snapshot_ready:
             parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
 
-        # cd to working directory — let bash expand ~ natively
-        quoted_cwd = (
-            shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
-        )
+        # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
+        # ``$HOME`` so suffixes with spaces remain a single shell word.
+        quoted_cwd = self._quote_cwd_for_cd(cwd)
         parts.append(f"builtin cd {quoted_cwd} || exit 126")
 
         # Run the actual command


### PR DESCRIPTION
## Summary

`BaseEnvironment._wrap_command()` intentionally left `~/...` paths unquoted so the shell could expand `~`. That worked for a bare `~`, but it broke subpaths containing spaces.

Before this change, a cwd like `~/my repo` was emitted as:


builtin cd ~/my repo || exit 126

which the shell parses as multiple arguments.

This patch keeps bare ~ behavior intact, but rewrites ~/... paths through $HOME with a safely quoted suffix so values like ~/my repo stay a single shell word.

## What changed
added a small _quote_cwd_for_cd() helper in BaseEnvironment
preserved raw ~ handling
mapped ~/ to $HOME
mapped ~/subpath to $HOME/<quoted suffix>
added regression coverage for:
~/my repo
~/

## Why this matters
This is a small but broadly useful cross-platform fix in the shared environment wrapper used by terminal backends. Any user-configured cwd/workdir under the home directory with spaces could fail deterministically before this patch.

## Testing

uv run --extra dev pytest tests/tools/test_base_environment.py -q

## Result

17 passed

