### PR TITLE
fix(docker): HERMES_UID permission handling + docker-compose.yml (salvage #13483)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,15 @@ COPY --chown=hermes:hermes . .
 # Build web dashboard (Vite outputs to hermes_cli/web_dist/)
 RUN cd web && npm run build
 
+# ---------- Permissions ----------
+# Make install dir world-readable so any HERMES_UID can read it at runtime.
+# The venv needs to be traversable too.
+USER root
+RUN chmod -R a+rX /opt/hermes
+# Start as root so the entrypoint can usermod/groupmod + gosu.
+# If HERMES_UID is unset, the entrypoint drops to the default hermes user (10000).
+
 # ---------- Python virtualenv ----------
-RUN chown hermes:hermes /opt/hermes
-USER hermes
 RUN uv venv && \
     uv pip install --no-cache-dir -e ".[all]"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  gateway:
+    build: .
+    image: hermes-agent
+    container_name: hermes
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-1001}
+      - HERMES_GID=${HERMES_GID:-1001}
+      # Uncomment to expose API server beyond localhost (requires API_SERVER_KEY):
+      # - API_SERVER_HOST=0.0.0.0
+      # - API_SERVER_KEY=${API_SERVER_KEY}
+    command: ["gateway", "run"]
+
+  dashboard:
+    image: hermes-agent
+    container_name: hermes-dashboard
+    restart: unless-stopped
+    network_mode: host
+    depends_on:
+      - gateway
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-1001}
+      - HERMES_GID=${HERMES_GID:-1001}
+    command: ["dashboard", "--host", "0.0.0.0", "--insecure"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,23 @@
+#
+# docker-compose.yml for Hermes Agent
+#
+# Usage:
+#   HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d
+#
+# Set HERMES_UID / HERMES_GID to the host user that owns ~/.hermes so
+# files created inside the container stay readable/writable on the host.
+# The entrypoint remaps the internal `hermes` user to these values via
+# usermod/groupmod + gosu.
+#
+# Security notes:
+#   - The dashboard service binds to 127.0.0.1 by default. It stores API
+#     keys; exposing it on LAN without auth is unsafe. If you want remote
+#     access, use an SSH tunnel or put it behind a reverse proxy that
+#     adds authentication — do NOT pass --insecure --host 0.0.0.0.
+#   - The gateway's API server is off unless you uncomment API_SERVER_KEY
+#     and API_SERVER_HOST. See docs/user-guide/api-server.md before doing
+#     this on an internet-facing host.
+#
 services:
   gateway:
     build: .
@@ -8,9 +28,10 @@ services:
     volumes:
       - ~/.hermes:/opt/data
     environment:
-      - HERMES_UID=${HERMES_UID:-1001}
-      - HERMES_GID=${HERMES_GID:-1001}
-      # Uncomment to expose API server beyond localhost (requires API_SERVER_KEY):
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+      # To expose the OpenAI-compatible API server beyond localhost,
+      # uncomment BOTH lines (API_SERVER_KEY is mandatory for auth):
       # - API_SERVER_HOST=0.0.0.0
       # - API_SERVER_KEY=${API_SERVER_KEY}
     command: ["gateway", "run"]
@@ -25,6 +46,7 @@ services:
     volumes:
       - ~/.hermes:/opt/data
     environment:
-      - HERMES_UID=${HERMES_UID:-1001}
-      - HERMES_GID=${HERMES_GID:-1001}
-    command: ["dashboard", "--host", "0.0.0.0", "--insecure"]
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    # Localhost-only. For remote access, tunnel via `ssh -L 9119:localhost:9119`.
+    command: ["dashboard", "--host", "127.0.0.1", "--no-open"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,9 +22,18 @@ if [ "$(id -u)" = "0" ]; then
         groupmod -o -g "$HERMES_GID" hermes 2>/dev/null || true
     fi
 
+    # Fix ownership of the data volume. When HERMES_UID remaps the hermes user,
+    # files created by previous runs (under the old UID) become inaccessible.
+    # Always chown -R when UID was remapped; otherwise only if top-level is wrong.
     actual_hermes_uid=$(id -u hermes)
-    if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
-        echo "$HERMES_HOME is not owned by $actual_hermes_uid, fixing"
+    needs_chown=false
+    if [ -n "$HERMES_UID" ] && [ "$HERMES_UID" != "10000" ]; then
+        needs_chown=true
+    elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+        needs_chown=true
+    fi
+    if [ "$needs_chown" = true ]; then
+        echo "Fixing ownership of $HERMES_HOME to hermes ($actual_hermes_uid)"
         # In rootless Podman the container's "root" is mapped to an unprivileged
         # host UID — chown will fail.  That's fine: the volume is already owned
         # by the mapped user on the host side.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -78,6 +78,7 @@ AUTHOR_MAP = {
     "77628552+raulvidis@users.noreply.github.com": "raulvidis",
     "145567217+Aum08Desai@users.noreply.github.com": "Aum08Desai",
     "256820943+kshitij-eliza@users.noreply.github.com": "kshitij-eliza",
+    "jiechengwu@pony.ai": "Jason2031",
     "44278268+shitcoinsherpa@users.noreply.github.com": "shitcoinsherpa",
     "104278804+Sertug17@users.noreply.github.com": "Sertug17",
     "112503481+caentzminger@users.noreply.github.com": "caentzminger",


### PR DESCRIPTION
Salvages PR #13483 by @Jason2031 onto current main.

## What this lands
- `docker/entrypoint.sh`: always chown -R when HERMES_UID is remapped from 10000 (was only when top-level dir owner mismatched) — fixes stale-UID files in an existing volume becoming inaccessible after a UID change.
- `Dockerfile`: build as root, `chmod -R a+rX /opt/hermes` so a remapped HERMES_UID can read/traverse the venv. Dropped `USER hermes` is safe — the entrypoint does gosu drop at runtime.
- `docker-compose.yml` added, with our follow-up tightening defaults: UID/GID default to 10000 (matches Dockerfile's `useradd -u 10000` and the entrypoint's default) instead of 1001; dashboard binds to `127.0.0.1 --no-open` (not `--host 0.0.0.0 --insecure`, which the dashboard's own help text flags as DANGEROUS since it stores API keys); header comments document HERMES_UID usage and how to expose the API server safely.
- `scripts/release.py`: AUTHOR_MAP entry for jiechengwu@pony.ai → Jason2031.

## Not included from the original PR
- `.gitignore` `.hermes` entry — skipped per maintainer preference.

## Validation
| | Before | After |
|---|---|---|
| HERMES_UID=1001, volume pre-populated by UID 10000 | files unreadable after usermod | chown -R fires, files accessible |
| HERMES_UID unset, fresh volume | top-level owner check → skip chown | unchanged |
| Remapped UID reading /opt/hermes venv | permission denied | world-readable/traversable via `a+rX` |
| docker-compose dashboard default | `0.0.0.0 --insecure` (unsafe) | `127.0.0.1 --no-open` |

- bash harness across 5 UID/ownership scenarios — all needs_chown branches return the intended value.
- `docker buildx build --check` passes with no warnings.
- `git diff origin/main` confirms `openssh-client docker-cli` (#4009f2edd, #5fbb69989) and `ENV PATH="/opt/data/.local/bin:..."` (#8db5517b4) are preserved through the 3-way merge.

## Credit
Core permissions fix and compose file authored by @Jason2031 (commit authorship preserved via rebase-merge). Our follow-up commits tighten compose defaults and add the AUTHOR_MAP entry.

Closes #13483