### PR TITLE
fix(runtime): resolve bare custom provider to loopback or CUSTOM_BASE_URL (salvage #14719)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -36,6 +36,29 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _loopback_hostname(host: str) -> bool:
+    h = (host or "").lower().rstrip(".")
+    return h in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+
+
+def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider: str) -> bool:
+    """Decide whether ``model.base_url`` may back bare ``custom`` runtime resolution.
+
+    GitHub #14676: the model picker can select Custom while ``model.provider`` still reflects a
+    previous provider. Reject non-loopback URLs unless the YAML provider is already ``custom``,
+    so a stale OpenRouter/Z.ai base_url cannot hijack local ``custom`` sessions.
+    """
+    cfg_provider_norm = (cfg_provider or "").strip().lower()
+    bu = (cfg_base_url or "").strip()
+    if not bu:
+        return False
+    if cfg_provider_norm == "custom":
+        return True
+    if base_url_host_matches(bu, "openrouter.ai"):
+        return False
+    return _loopback_hostname(base_url_hostname(bu))
+
+
 def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     """Auto-detect api_mode from the resolved base URL.
 
@@ -472,6 +495,7 @@ def _resolve_openrouter_runtime(
     cfg_provider = cfg_provider.strip().lower()
 
     env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
+    env_custom_base_url = os.getenv("CUSTOM_BASE_URL", "").strip()
 
     # Use config base_url when available and the provider context matches.
     # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
@@ -481,11 +505,14 @@ def _resolve_openrouter_runtime(
         if requested_norm == "auto":
             if not cfg_provider or cfg_provider == "auto":
                 use_config_base_url = True
-        elif requested_norm == "custom" and cfg_provider == "custom":
+        elif requested_norm == "custom" and _config_base_url_trustworthy_for_bare_custom(
+            cfg_base_url, cfg_provider
+        ):
             use_config_base_url = True
 
     base_url = (
         (explicit_base_url or "").strip()
+        or env_custom_base_url
         or (cfg_base_url.strip() if use_config_base_url else "")
         or env_openrouter_base_url
         or OPENROUTER_BASE_URL

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -191,6 +191,7 @@ AUTHOR_MAP = {
     "reginaldasr@gmail.com": "ReginaldasR",
     "ntconguit@gmail.com": "0xharryriddle",
     "agent@wildcat.local": "ericnicolaides",
+    "georgex8001@gmail.com": "georgex8001",
     "hermes@noushq.ai": "benbarclay",
     "chinmingcock@gmail.com": "ChimingLiu",
     "openclaw@sparklab.ai": "openclaw",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -536,6 +536,72 @@ def test_custom_endpoint_explicit_custom_prefers_config_key(monkeypatch):
     assert resolved["api_key"] == "sk-vllm-key"
 
 
+def test_bare_custom_uses_loopback_model_base_url_when_provider_not_custom(monkeypatch):
+    """Regression for #14676: /model can select Custom while YAML still lists another provider."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "http://127.0.0.1:8082/v1",
+            "default": "my-local-model",
+        },
+    )
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://127.0.0.1:8082/v1"
+    assert resolved["api_key"] == "openai-key"
+
+
+def test_bare_custom_custom_base_url_env_overrides_remote_yaml(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://api.openrouter.ai/api/v1",
+        },
+    )
+    monkeypatch.setenv("CUSTOM_BASE_URL", "http://localhost:9999/v1")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://localhost:9999/v1"
+
+
+def test_bare_custom_does_not_trust_non_loopback_when_provider_not_custom(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://remote.example.com/v1",
+        },
+    )
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert "openrouter.ai" in resolved["base_url"]
+    assert "remote.example.com" not in resolved["base_url"]
+
+
 def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
Partial salvage of #14719 by @georgex8001 onto current main. Only the runtime_provider.py commit is picked; the ACP/approval contextvar refactor in the same PR is unrelated scope — worth a separate review.

Closes #14676.

## What this PR does
Two related bare-`custom` resolution fixes:
1. Consult `CUSTOM_BASE_URL` env var in runtime resolution (not just model-list display). Before, setting only `CUSTOM_BASE_URL` with bare `provider: custom` fell through to OpenRouter.
2. Protect against stale YAML state hijacking a Custom session. When `/model` switches to Custom while `model.provider` in YAML still reflects a prior cloud provider (OpenRouter, Z.AI, etc.), `model.base_url` is only trusted if it's a loopback host (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`) OR the YAML provider is already `custom`.

## How
- New `_loopback_hostname()` + `_config_base_url_trustworthy_for_bare_custom()` helpers in `hermes_cli/runtime_provider.py`
- `_resolve_openrouter_runtime` now reads `CUSTOM_BASE_URL` ahead of the OpenRouter default URLs
- `use_config_base_url` gate for bare `custom` runs through the loopback-trust check

## Cherry-pick scope
PR #14719 bundled two unrelated fixes: (a) this runtime fix, (b) an ACP approval thread-safety refactor via contextvars. Only (a) is salvaged here; (b) lives in commit `d9ef7a72` on the original PR — it can be evaluated separately.

## Changes
- @georgex8001 (#14719 commit 1): +28/-1 in `runtime_provider.py`, 66 lines of regression tests
- Follow-up: AUTHOR_MAP entry for `georgex8001@gmail.com`

## Validation
| Scenario | Before | After |
|---|---|---|
| Loopback YAML + stale `provider: openrouter`, select `custom` | hijacked → `openrouter.ai` | trusted → `localhost:8082` |
| Non-loopback YAML + stale `provider: openrouter`, select `custom` | trusted, hijacked session | falls back to OpenRouter (correct) |
| `CUSTOM_BASE_URL=http://localhost:9090/v1`, no `model.base_url` | ignored → `openrouter.ai` | honored → `localhost:9090` |
| Explicit `provider: custom` + loopback base_url | worked | still works (regression guard) |

- `tests/hermes_cli/test_runtime_provider_resolution.py` — 74/74 pass (3 new regression tests)
- E2E: all 4 scenarios above verified with real module imports

Co-authored-by: @georgex8001