### PR TITLE
fix(redact): honor security.redact_secrets from config.yaml

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -166,6 +166,27 @@ from hermes_cli.env_loader import load_hermes_dotenv
 
 load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
 
+# Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
+# var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
+# module-import time). Without this, config.yaml's toggle is ignored because
+# the setup_logging() call below imports agent.redact, which reads the env var
+# exactly once. Env var in .env still wins — this is config.yaml fallback only.
+try:
+    if "HERMES_REDACT_SECRETS" not in os.environ:
+        import yaml as _yaml_early
+        _cfg_path = get_hermes_home() / "config.yaml"
+        if _cfg_path.exists():
+            with open(_cfg_path, encoding="utf-8") as _f:
+                _early_sec_cfg = (_yaml_early.safe_load(_f) or {}).get("security", {})
+            if isinstance(_early_sec_cfg, dict):
+                _early_redact = _early_sec_cfg.get("redact_secrets")
+                if _early_redact is not None:
+                    os.environ["HERMES_REDACT_SECRETS"] = str(_early_redact).lower()
+            del _early_sec_cfg
+        del _cfg_path
+except Exception:
+    pass  # best-effort — redaction stays at default (enabled) on config errors
+
 # Initialize centralized file logging early — all `hermes` subcommands
 # (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
 try:

--- a/tests/hermes_cli/test_redact_config_bridge.py
+++ b/tests/hermes_cli/test_redact_config_bridge.py
@@ -1,0 +1,151 @@
+"""Regression test for config.yaml `security.redact_secrets: false` toggle.
+
+Bug: `agent/redact.py` snapshots `_REDACT_ENABLED` from the env var
+`HERMES_REDACT_SECRETS` at module-import time. `hermes_cli/main.py` at
+line ~174 calls `setup_logging(mode="cli")` which transitively imports
+`agent.redact` — BEFORE any config bridge ran. So if a user set
+`security.redact_secrets: false` in config.yaml (instead of as an env var
+in .env), the toggle was silently ignored in both `hermes chat` and
+`hermes gateway run`.
+
+Fix: bridge `security.redact_secrets` from config.yaml → `HERMES_REDACT_SECRETS`
+env var in `hermes_cli/main.py` BEFORE the `setup_logging()` call.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_redact_secrets_false_in_config_yaml_is_honored(tmp_path):
+    """Setting `security.redact_secrets: false` in config.yaml must disable
+    redaction — even though it's set in YAML, not as an env var."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    # Write a config.yaml with redact_secrets: false
+    (hermes_home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            security:
+              redact_secrets: false
+            """
+        )
+    )
+    # Empty .env so nothing else sets the env var
+    (hermes_home / ".env").write_text("")
+
+    # Spawn a fresh Python process that imports hermes_cli.main and checks
+    # _REDACT_ENABLED. Must be a subprocess — we need a clean module state.
+    probe = textwrap.dedent(
+        """\
+        import sys, os
+        # Make absolutely sure the env var is not pre-set
+        os.environ.pop("HERMES_REDACT_SECRETS", None)
+        sys.path.insert(0, %r)
+        import hermes_cli.main  # triggers the bridge + setup_logging
+        import agent.redact
+        print(f"REDACT_ENABLED={agent.redact._REDACT_ENABLED}")
+        print(f"ENV_VAR={os.environ.get('HERMES_REDACT_SECRETS', '<unset>')}")
+        """
+    ) % str(REPO_ROOT)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_REDACT_SECRETS", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr}"
+    assert "REDACT_ENABLED=False" in result.stdout, (
+        f"Config toggle not honored.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "ENV_VAR=false" in result.stdout
+
+
+def test_redact_secrets_default_true_when_unset(tmp_path):
+    """Without the config key, redaction stays on by default."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("{}\n")  # empty config
+    (hermes_home / ".env").write_text("")
+
+    probe = textwrap.dedent(
+        """\
+        import sys, os
+        os.environ.pop("HERMES_REDACT_SECRETS", None)
+        sys.path.insert(0, %r)
+        import hermes_cli.main
+        import agent.redact
+        print(f"REDACT_ENABLED={agent.redact._REDACT_ENABLED}")
+        """
+    ) % str(REPO_ROOT)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_REDACT_SECRETS", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr}"
+    assert "REDACT_ENABLED=True" in result.stdout
+
+
+def test_dotenv_redact_secrets_beats_config_yaml(tmp_path):
+    """.env HERMES_REDACT_SECRETS takes precedence over config.yaml."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            security:
+              redact_secrets: false
+            """
+        )
+    )
+    # .env force-enables redaction
+    (hermes_home / ".env").write_text("HERMES_REDACT_SECRETS=true\n")
+
+    probe = textwrap.dedent(
+        """\
+        import sys, os
+        os.environ.pop("HERMES_REDACT_SECRETS", None)
+        sys.path.insert(0, %r)
+        import hermes_cli.main
+        import agent.redact
+        print(f"REDACT_ENABLED={agent.redact._REDACT_ENABLED}")
+        print(f"ENV_VAR={os.environ.get('HERMES_REDACT_SECRETS', '<unset>')}")
+        """
+    ) % str(REPO_ROOT)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_REDACT_SECRETS", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr}"
+    # .env value wins
+    assert "REDACT_ENABLED=True" in result.stdout
+    assert "ENV_VAR=true" in result.stdout


### PR DESCRIPTION
## Summary
`security.redact_secrets: false` in config.yaml now actually disables redaction. Previously the toggle was silently ignored because `agent/redact.py` snapshots `_REDACT_ENABLED` from the env var at module-import time, and `hermes_cli/main.py:174` (`setup_logging(mode="cli")`) transitively imports `agent.redact` **before** any config→env bridge runs.

Reported by @teknium1 during live gateway use — `security.redact_secrets: false` was configured but tool output and env-var values were still being masked to `***`.

## Root cause
Startup ordering in `hermes_cli/main.py`:
1. `load_hermes_dotenv()` — loads `.env` (no `HERMES_REDACT_SECRETS` there)
2. `setup_logging(mode="cli")` — imports `hermes_logging` → imports `agent.redact` → **snapshots `_REDACT_ENABLED=True`**
3. (much later) `gateway/run.py` or `cli.py` reads config.yaml and bridges `security.redact_secrets` → `HERMES_REDACT_SECRETS` — too late, snapshot is already frozen

Affects both `hermes chat` and `hermes gateway run`.

## Fix
Bridge `security.redact_secrets` from config.yaml → `HERMES_REDACT_SECRETS` env var in `hermes_cli/main.py` BEFORE the `setup_logging()` call. `.env` still wins (only set env when unset) — config.yaml is the fallback.

## Changes
- `hermes_cli/main.py`: 21-line early config-bridge block inserted after `load_hermes_dotenv()`, before `setup_logging()`.
- `tests/hermes_cli/test_redact_config_bridge.py`: 3 regression tests using subprocess probes:
  - `redact_secrets: false` in config.yaml disables redaction (would fail without the fix)
  - default (key absent) leaves redaction enabled
  - `.env HERMES_REDACT_SECRETS=true` overrides config.yaml `false`

## Validation
```
$ scripts/run_tests.sh tests/hermes_cli/test_redact_config_bridge.py tests/agent/test_redact.py
3 + 161 passed in 0.4s
```

Before fix (fresh subprocess with only config.yaml `redact_secrets: false`):
```
REDACT_ENABLED=True
ENV_VAR=<unset>
```
After fix:
```
REDACT_ENABLED=False
ENV_VAR=false
```

## Deployment note
Gateway/CLI restart required for the fix to take effect in an already-running process (the env-var snapshot happens at Python interpreter startup).
