### PR TITLE
fix: cap Codex GPT-5.5 context

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -126,6 +126,20 @@ DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
 # Sessions, model switches, and cron jobs should reject models below this.
 MINIMUM_CONTEXT_LENGTH = 64_000
 
+# GPT-5.5 is currently exposed through ChatGPT/Codex with a smaller effective
+# agent-usable window than the larger native/advertised GPT-5 family windows.
+# Keep compaction and preflight budgeting fail-closed until a larger window is
+# explicitly verified and configured.
+OPENAI_CODEX_GPT55_EFFECTIVE_CONTEXT = 272_000
+
+
+def _is_openai_codex_gpt55(model: str, provider: str = "", base_url: str = "") -> bool:
+    model_lower = (model or "").strip().lower()
+    if model_lower not in {"gpt-5.5", "gpt-5.5-codex"}:
+        return False
+    provider_lower = (provider or "").strip().lower()
+    return provider_lower == "openai-codex" or base_url_host_matches(base_url, "chatgpt.com")
+
 # Thin fallback defaults — only broad model family patterns.
 # These fire only when provider is unknown AND models.dev/OpenRouter/Anthropic
 # all miss. Replaced the previous 80+ entry dict.
@@ -146,8 +160,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenAI — GPT-5 family (most have 400k; specific overrides first)
     # Source: https://developers.openai.com/api/docs/models
     # GPT-5.5 (launched Apr 23 2026). 400k is the fallback for providers we
-    # can't probe live. ChatGPT Codex OAuth actually caps lower (272k as of
-    # Apr 2026) and is resolved via _resolve_codex_oauth_context_length().
+    # can't probe live. ChatGPT/Codex OAuth is guarded separately at 272k until
+    # a larger effective window is explicitly verified.
     "gpt-5.5": 400000,
     "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4-mini": 400000,           # 400k (not 1.05M like full 5.4)
@@ -1237,6 +1251,11 @@ def get_model_context_length(
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
     model = _strip_provider_prefix(model)
+
+    # GPT-5.5 on ChatGPT/Codex currently has a 272k effective cap for agent
+    # budgeting even if cache/discovery sources advertise a larger native window.
+    if _is_openai_codex_gpt55(model, provider=provider, base_url=base_url):
+        return OPENAI_CODEX_GPT55_EFFECTIVE_CONTEXT
 
     # 1. Check persistent cache (model+provider)
     if base_url:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -244,9 +244,9 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
-    def test_live_probe_overrides_fallback(self):
+    def test_live_probe_overrides_fallback_for_non_gpt55_codex_models(self):
         """When a token is provided, the live /models probe is preferred
-        and its context_window drives the result."""
+        for Codex models that do not have an explicit temporary cap."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -273,7 +273,7 @@ class TestCodexOAuthContextLength:
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx_55 == 300_000
+        assert ctx_55 == 272_000
         assert ctx_54 == 400_000
 
     def test_probe_failure_falls_back_to_hardcoded(self):
@@ -319,12 +319,10 @@ class TestCodexOAuthContextLength:
             "leaked outside openai-codex provider"
         )
 
-    def test_stale_codex_cache_over_400k_is_invalidated(self, tmp_path, monkeypatch):
-        """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
-        before the Codex-aware branch existed. Upgrading users keep that
-        stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
+    def test_stale_codex_cache_over_400k_is_bypassed_by_gpt55_cap(self, tmp_path, monkeypatch):
+        """Pre-PR builds may have cached gpt-5.5 at 1.05M from catalog
+        metadata. The explicit GPT-5.5 Codex cap must bypass both stale cache
+        and live probe metadata so compaction stays fail-closed at 272k.
         """
         from agent import model_metadata as mm
 
@@ -341,13 +339,7 @@ class TestCodexOAuthContextLength:
             other_key: 128_000,     # unrelated, must survive
         }}))
 
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.json.return_value = {
-            "models": [{"slug": "gpt-5.5", "context_window": 272_000}]
-        }
-
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+        with patch("agent.model_metadata.requests.get") as mock_get, \
              patch("agent.model_metadata.save_context_length") as mock_save:
             ctx = mm.get_model_context_length(
                 model="gpt-5.5",
@@ -356,12 +348,12 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
 
-        assert ctx == 272_000, f"Stale entry should have been re-resolved to 272k, got {ctx}"
-        # Live save was called with the fresh value
-        mock_save.assert_called_with("gpt-5.5", base_url, 272_000)
-        # The stale entry was removed from disk; unrelated entries survived
+        assert ctx == 272_000, f"Stale entry should be bypassed by GPT-5.5 cap, got {ctx}"
+        mock_get.assert_not_called()
+        mock_save.assert_not_called()
+        # The stale entry may remain on disk, but it is no longer consulted for GPT-5.5 Codex.
         remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
-        assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
+        assert remaining.get(stale_key) == 1_050_000
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
     def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
@@ -428,6 +420,25 @@ class TestGetModelContextLength:
     def test_fallback_to_defaults(self, mock_fetch):
         mock_fetch.return_value = {}
         assert get_model_context_length("anthropic/claude-sonnet-4") == 200000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.models_dev.lookup_models_dev_context")
+    @patch("agent.model_metadata.get_cached_context_length")
+    def test_gpt55_codex_uses_safe_effective_context_cap(self, mock_cache, mock_models_dev, mock_fetch):
+        """GPT-5.5 Codex must fail closed to the current 272k effective cap.
+
+        Discovery/cache sources may advertise a larger native context window;
+        compaction should not budget against that until explicitly lifted.
+        """
+        mock_cache.return_value = 1_050_000
+        mock_models_dev.return_value = 1_050_000
+        mock_fetch.return_value = {"gpt-5.5": {"context_length": 1_050_000}}
+
+        assert get_model_context_length(
+            "gpt-5.5",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        ) == 272_000
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_unknown_model_returns_first_probe_tier(self, mock_fetch):


### PR DESCRIPTION
## Summary
- fail closed to 272k effective context for GPT-5.5 on OpenAI Codex/ChatGPT routes before cached/discovered metadata can inflate it
- keep direct/provider-unknown GPT-5.5 fallback aligned with upstream metadata
- add regression coverage for stale cache/models.dev/API metadata advertising a larger window

## Test Plan
- python -m pytest tests/agent/test_model_metadata.py::TestGetModelContextLength::test_gpt55_codex_uses_safe_effective_context_cap -q -o addopts=''