### PR TITLE
fix(copilot): token exchange + 401 auth recovery + live context + ACP HOME env

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -46,6 +46,47 @@ def _resolve_args() -> list[str]:
     return shlex.split(raw)
 
 
+def _resolve_home_dir() -> str:
+    """Return a stable HOME for child ACP processes."""
+
+    try:
+        from hermes_constants import get_subprocess_home
+
+        profile_home = get_subprocess_home()
+        if profile_home:
+            return profile_home
+    except Exception:
+        pass
+
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+
+    # Last resort: /tmp (writable on any POSIX system). Avoids crashing the
+    # subprocess with no HOME; callers can set HERMES_HOME explicitly if they
+    # need a different writable dir.
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = _resolve_home_dir()
+    return env
+
+
 def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
     return {
         "jsonrpc": "2.0",
@@ -382,6 +423,7 @@ class CopilotACPClient:
                 text=True,
                 bufsize=1,
                 cwd=self._acp_cwd,
+                env=_build_subprocess_env(),
             )
         except FileNotFoundError as exc:
             raise RuntimeError(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1066,9 +1066,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token
+            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
+                api_token = get_copilot_api_token(token)
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
                 if not _is_suppressed(provider, source_name):
                     active_sources.add(source_name)
@@ -1080,7 +1081,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         {
                             "source": source_name,
                             "auth_type": AUTH_TYPE_API_KEY,
-                            "access_token": token,
+                            "access_token": api_token,
                             "base_url": pconfig.inference_base_url if pconfig else "",
                             "label": source,
                         },

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1308,6 +1308,19 @@ def get_model_context_length(
             if inferred:
                 effective_provider = inferred
 
+    # 5a. Copilot live /models API — max_prompt_tokens from the user's account.
+    # This catches account-specific models (e.g. claude-opus-4.6-1m) that
+    # don't exist in models.dev. For models that ARE in models.dev, this
+    # returns the provider-enforced limit which is what users can actually use.
+    if effective_provider in ("copilot", "copilot-acp", "github-copilot"):
+        try:
+            from hermes_cli.models import get_copilot_model_context
+            ctx = get_copilot_model_context(model, api_key=api_key)
+            if ctx:
+                return ctx
+        except Exception:
+            pass  # Fall through to models.dev
+
     if effective_provider == "nous":
         ctx = _resolve_nous_context_length(model)
         if ctx:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -426,10 +426,10 @@ def _resolve_api_key_provider_secret(
     if provider_id == "copilot":
         # Use the dedicated copilot auth module for proper token validation
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token
+            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
-                return token, source
+                return get_copilot_api_token(token), source
         except ValueError as exc:
             logger.warning("Copilot token validation failed: %s", exc)
         except Exception:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -275,6 +275,99 @@ def copilot_device_code_login(
     return None
 
 
+# ─── Copilot Token Exchange ────────────────────────────────────────────────
+
+# Module-level cache for exchanged Copilot API tokens.
+# Maps raw_token_fingerprint -> (api_token, expires_at_epoch).
+_jwt_cache: dict[str, tuple[str, float]] = {}
+_JWT_REFRESH_MARGIN_SECONDS = 120  # refresh 2 min before expiry
+
+# Token exchange endpoint and headers (matching VS Code / Copilot CLI)
+_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
+_EDITOR_VERSION = "vscode/1.104.1"
+_EXCHANGE_USER_AGENT = "GitHubCopilotChat/0.26.7"
+
+
+def _token_fingerprint(raw_token: str) -> str:
+    """Short fingerprint of a raw token for cache keying (avoids storing full token)."""
+    import hashlib
+    return hashlib.sha256(raw_token.encode()).hexdigest()[:16]
+
+
+def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[str, float]:
+    """Exchange a raw GitHub token for a short-lived Copilot API token.
+
+    Calls ``GET https://api.github.com/copilot_internal/v2/token`` with
+    the raw GitHub token and returns ``(api_token, expires_at)``.
+
+    The returned token is a semicolon-separated string (not a standard JWT)
+    used as ``Authorization: Bearer <token>`` for Copilot API requests.
+
+    Results are cached in-process and reused until close to expiry.
+    Raises ``ValueError`` on failure.
+    """
+    import urllib.request
+
+    fp = _token_fingerprint(raw_token)
+
+    # Check cache first
+    cached = _jwt_cache.get(fp)
+    if cached:
+        api_token, expires_at = cached
+        if time.time() < expires_at - _JWT_REFRESH_MARGIN_SECONDS:
+            return api_token, expires_at
+
+    req = urllib.request.Request(
+        _TOKEN_EXCHANGE_URL,
+        method="GET",
+        headers={
+            "Authorization": f"token {raw_token}",
+            "User-Agent": _EXCHANGE_USER_AGENT,
+            "Accept": "application/json",
+            "Editor-Version": _EDITOR_VERSION,
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:
+        raise ValueError(f"Copilot token exchange failed: {exc}") from exc
+
+    api_token = data.get("token", "")
+    expires_at = data.get("expires_at", 0)
+    if not api_token:
+        raise ValueError("Copilot token exchange returned empty token")
+
+    # Convert expires_at to float if needed
+    expires_at = float(expires_at) if expires_at else time.time() + 1800
+
+    _jwt_cache[fp] = (api_token, expires_at)
+    logger.debug(
+        "Copilot token exchanged, expires_at=%s",
+        expires_at,
+    )
+    return api_token, expires_at
+
+
+def get_copilot_api_token(raw_token: str) -> str:
+    """Exchange a raw GitHub token for a Copilot API token, with fallback.
+
+    Convenience wrapper: returns the exchanged token on success, or the
+    raw token unchanged if the exchange fails (e.g. network error, unsupported
+    account type). This preserves existing behaviour for accounts that don't
+    need exchange while enabling access to internal-only models for those that do.
+    """
+    if not raw_token:
+        return raw_token
+    try:
+        api_token, _ = exchange_copilot_token(raw_token)
+        return api_token
+    except Exception as exc:
+        logger.debug("Copilot token exchange failed, using raw token: %s", exc)
+        return raw_token
+
+
 # ─── Copilot API Headers ───────────────────────────────────────────────────
 
 def copilot_request_headers(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1902,6 +1902,51 @@ def fetch_github_model_catalog(
     return None
 
 
+# ─── Copilot catalog context-window helpers ─────────────────────────────────
+
+# Module-level cache: {model_id: max_prompt_tokens}
+_copilot_context_cache: dict[str, int] = {}
+_copilot_context_cache_time: float = 0.0
+_COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
+
+
+def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
+    """Look up max_prompt_tokens for a Copilot model from the live /models API.
+
+    Results are cached in-process for 1 hour to avoid repeated API calls.
+    Returns the token limit or None if not found.
+    """
+    global _copilot_context_cache, _copilot_context_cache_time
+
+    # Serve from cache if fresh
+    if _copilot_context_cache and (time.time() - _copilot_context_cache_time < _COPILOT_CONTEXT_CACHE_TTL):
+        if model_id in _copilot_context_cache:
+            return _copilot_context_cache[model_id]
+        # Cache is fresh but model not in it — don't re-fetch
+        return None
+
+    # Fetch and populate cache
+    catalog = fetch_github_model_catalog(api_key=api_key)
+    if not catalog:
+        return None
+
+    cache: dict[str, int] = {}
+    for item in catalog:
+        mid = str(item.get("id") or "").strip()
+        if not mid:
+            continue
+        caps = item.get("capabilities") or {}
+        limits = caps.get("limits") or {}
+        max_prompt = limits.get("max_prompt_tokens")
+        if isinstance(max_prompt, int) and max_prompt > 0:
+            cache[mid] = max_prompt
+
+    _copilot_context_cache = cache
+    _copilot_context_cache_time = time.time()
+
+    return cache.get(model_id)
+
+
 def _is_github_models_base_url(base_url: Optional[str]) -> bool:
     normalized = (base_url or "").strip().rstrip("/").lower()
     return (

--- a/run_agent.py
+++ b/run_agent.py
@@ -5135,6 +5135,41 @@ class AIAgent:
 
         return True
 
+    def _try_refresh_copilot_client_credentials(self) -> bool:
+        """Refresh Copilot credentials and rebuild the shared OpenAI client.
+
+        Copilot tokens may remain the same string across refreshes (`gh auth token`
+        returns a stable OAuth token in many setups). We still rebuild the client
+        on 401 so retries recover from stale auth/client state without requiring
+        a session restart.
+        """
+        if self.provider != "copilot":
+            return False
+
+        try:
+            from hermes_cli.copilot_auth import resolve_copilot_token
+
+            new_token, token_source = resolve_copilot_token()
+        except Exception as exc:
+            logger.debug("Copilot credential refresh failed: %s", exc)
+            return False
+
+        if not isinstance(new_token, str) or not new_token.strip():
+            return False
+
+        new_token = new_token.strip()
+
+        self.api_key = new_token
+        self._client_kwargs["api_key"] = self.api_key
+        self._client_kwargs["base_url"] = self.base_url
+        self._apply_client_headers_for_base_url(str(self.base_url or ""))
+
+        if not self._replace_primary_openai_client(reason="copilot_credential_refresh"):
+            return False
+
+        logger.info("Copilot credentials refreshed from %s", token_source)
+        return True
+
     def _try_refresh_anthropic_client_credentials(self) -> bool:
         if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
             return False
@@ -9375,6 +9410,7 @@ class AIAgent:
             codex_auth_retry_attempted=False
             anthropic_auth_retry_attempted=False
             nous_auth_retry_attempted=False
+            copilot_auth_retry_attempted=False
             thinking_sig_retry_attempted = False
             has_retried_429 = False
             restart_with_compressed_messages = False
@@ -10338,6 +10374,15 @@ class AIAgent:
                         print(f"{self.log_prefix}     • Check credits / billing: https://portal.nousresearch.com")
                         print(f"{self.log_prefix}     • Verify stored credentials: {_dhh}/auth.json")
                         print(f"{self.log_prefix}     • Switch providers temporarily: /model <model> --provider openrouter")
+                    if (
+                        self.provider == "copilot"
+                        and status_code == 401
+                        and not copilot_auth_retry_attempted
+                    ):
+                        copilot_auth_retry_attempted = True
+                        if self._try_refresh_copilot_client_credentials():
+                            self._vprint(f"{self.log_prefix}🔐 Copilot credentials refreshed after 401. Retrying request...")
+                            continue
                     if (
                         self.api_mode == "anthropic_messages"
                         and status_code == 401

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -173,6 +173,8 @@ AUTHOR_MAP = {
     "mattmaximo@hotmail.com": "MattMaximo",
     "149063006+j3ffffff@users.noreply.github.com": "j3ffffff",
     "A-FdL-Prog@users.noreply.github.com": "A-FdL-Prog",
+    "l0hde@users.noreply.github.com": "l0hde",
+    "difujia@users.noreply.github.com": "difujia",
     "numman.ali@gmail.com": "nummanali",
     "rohithsaimidigudla@gmail.com": "whitehatjr1001",
     "0xNyk@users.noreply.github.com": "0xNyk",

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -144,3 +144,60 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ── HOME env propagation tests (from PR #11285) ─────────────────────
+
+from unittest.mock import patch as _patch
+import pytest
+
+
+def _make_home_client(tmp_path):
+    return CopilotACPClient(
+        api_key="copilot-acp",
+        base_url="acp://copilot",
+        acp_command="copilot",
+        acp_args=["--acp", "--stdio"],
+        acp_cwd=str(tmp_path),
+    )
+
+
+def _fake_popen_capture(captured):
+    def _fake(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        raise FileNotFoundError("copilot not found")
+    return _fake
+
+
+def test_run_prompt_prefers_profile_home_when_available(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    profile_home = hermes_home / "home"
+    profile_home.mkdir(parents=True)
+
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert captured["kwargs"]["env"]["HOME"] == str(profile_home)
+
+
+def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert "env" in captured["kwargs"]
+    assert captured["kwargs"]["env"]["HOME"]

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -1,0 +1,134 @@
+"""Tests for Copilot live /models context-window resolution."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.models import get_copilot_model_context
+
+
+# Sample catalog items mimicking the Copilot /models API response
+_SAMPLE_CATALOG = [
+    {
+        "id": "claude-opus-4.6-1m",
+        "capabilities": {
+            "type": "chat",
+            "limits": {"max_prompt_tokens": 1000000, "max_output_tokens": 64000},
+        },
+    },
+    {
+        "id": "gpt-4.1",
+        "capabilities": {
+            "type": "chat",
+            "limits": {"max_prompt_tokens": 128000, "max_output_tokens": 32768},
+        },
+    },
+    {
+        "id": "claude-sonnet-4",
+        "capabilities": {
+            "type": "chat",
+            "limits": {"max_prompt_tokens": 200000, "max_output_tokens": 64000},
+        },
+    },
+    {
+        "id": "model-without-limits",
+        "capabilities": {"type": "chat"},
+    },
+    {
+        "id": "model-zero-limit",
+        "capabilities": {
+            "type": "chat",
+            "limits": {"max_prompt_tokens": 0},
+        },
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Reset module-level cache before each test."""
+    import hermes_cli.models as mod
+
+    mod._copilot_context_cache = {}
+    mod._copilot_context_cache_time = 0.0
+    yield
+    mod._copilot_context_cache = {}
+    mod._copilot_context_cache_time = 0.0
+
+
+class TestGetCopilotModelContext:
+    """Tests for get_copilot_model_context()."""
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_returns_max_prompt_tokens(self, mock_fetch):
+        assert get_copilot_model_context("claude-opus-4.6-1m") == 1_000_000
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_returns_none_for_unknown_model(self, mock_fetch):
+        assert get_copilot_model_context("nonexistent-model") is None
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_skips_models_without_limits(self, mock_fetch):
+        assert get_copilot_model_context("model-without-limits") is None
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_skips_zero_limit(self, mock_fetch):
+        assert get_copilot_model_context("model-zero-limit") is None
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_caches_results(self, mock_fetch):
+        get_copilot_model_context("gpt-4.1")
+        get_copilot_model_context("claude-sonnet-4")
+        # Only one API call despite two lookups
+        assert mock_fetch.call_count == 1
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_cache_expires(self, mock_fetch):
+        import hermes_cli.models as mod
+
+        get_copilot_model_context("gpt-4.1")
+        assert mock_fetch.call_count == 1
+
+        # Expire the cache
+        mod._copilot_context_cache_time = time.time() - 7200
+        get_copilot_model_context("gpt-4.1")
+        assert mock_fetch.call_count == 2
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=None)
+    def test_returns_none_when_catalog_unavailable(self, mock_fetch):
+        assert get_copilot_model_context("gpt-4.1") is None
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=[])
+    def test_returns_none_for_empty_catalog(self, mock_fetch):
+        assert get_copilot_model_context("gpt-4.1") is None
+
+
+class TestModelMetadataCopilotIntegration:
+    """Test that get_model_context_length() uses Copilot live API for copilot provider."""
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_copilot_provider_uses_live_api(self, mock_fetch):
+        from agent.model_metadata import get_model_context_length
+
+        ctx = get_model_context_length("claude-opus-4.6-1m", provider="copilot")
+        assert ctx == 1_000_000
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_copilot_acp_provider_uses_live_api(self, mock_fetch):
+        from agent.model_metadata import get_model_context_length
+
+        ctx = get_model_context_length("claude-sonnet-4", provider="copilot-acp")
+        assert ctx == 200_000
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=None)
+    def test_falls_through_when_catalog_unavailable(self, mock_fetch):
+        from agent.model_metadata import get_model_context_length
+
+        # Should not raise, should fall through to models.dev or defaults
+        ctx = get_model_context_length("gpt-4.1", provider="copilot")
+        assert isinstance(ctx, int)
+        assert ctx > 0

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -1,0 +1,159 @@
+"""Tests for Copilot token exchange (raw GitHub token → Copilot API token)."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_jwt_cache():
+    """Reset the module-level JWT cache before each test."""
+    import hermes_cli.copilot_auth as mod
+    mod._jwt_cache.clear()
+    yield
+    mod._jwt_cache.clear()
+
+
+class TestExchangeCopilotToken:
+    """Tests for exchange_copilot_token()."""
+
+    def _mock_urlopen(self, token="tid=abc;exp=123;sku=copilot_individual", expires_at=None):
+        """Create a mock urlopen context manager returning a token response."""
+        if expires_at is None:
+            expires_at = time.time() + 1800
+        resp_data = json.dumps({"token": token, "expires_at": expires_at}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    @patch("urllib.request.urlopen")
+    def test_exchanges_token_successfully(self, mock_urlopen):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        mock_urlopen.return_value = self._mock_urlopen(token="tid=abc;exp=999")
+        api_token, expires_at = exchange_copilot_token("gho_test123")
+
+        assert api_token == "tid=abc;exp=999"
+        assert isinstance(expires_at, float)
+
+        # Verify request was made with correct headers
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert req.get_header("Authorization") == "token gho_test123"
+        assert "GitHubCopilotChat" in req.get_header("User-agent")
+
+    @patch("urllib.request.urlopen")
+    def test_caches_result(self, mock_urlopen):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        future = time.time() + 1800
+        mock_urlopen.return_value = self._mock_urlopen(expires_at=future)
+
+        exchange_copilot_token("gho_test123")
+        exchange_copilot_token("gho_test123")
+
+        assert mock_urlopen.call_count == 1
+
+    @patch("urllib.request.urlopen")
+    def test_refreshes_expired_cache(self, mock_urlopen):
+        from hermes_cli.copilot_auth import exchange_copilot_token, _jwt_cache, _token_fingerprint
+
+        # Seed cache with expired entry
+        fp = _token_fingerprint("gho_test123")
+        _jwt_cache[fp] = ("old_token", time.time() - 10)
+
+        mock_urlopen.return_value = self._mock_urlopen(
+            token="new_token", expires_at=time.time() + 1800
+        )
+        api_token, _ = exchange_copilot_token("gho_test123")
+
+        assert api_token == "new_token"
+        assert mock_urlopen.call_count == 1
+
+    @patch("urllib.request.urlopen")
+    def test_raises_on_empty_token(self, mock_urlopen):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        resp_data = json.dumps({"token": "", "expires_at": 0}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with pytest.raises(ValueError, match="empty token"):
+            exchange_copilot_token("gho_test123")
+
+    @patch("urllib.request.urlopen", side_effect=Exception("network error"))
+    def test_raises_on_network_error(self, mock_urlopen):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        with pytest.raises(ValueError, match="network error"):
+            exchange_copilot_token("gho_test123")
+
+
+class TestGetCopilotApiToken:
+    """Tests for get_copilot_api_token() — the fallback wrapper."""
+
+    @patch("hermes_cli.copilot_auth.exchange_copilot_token")
+    def test_returns_exchanged_token(self, mock_exchange):
+        from hermes_cli.copilot_auth import get_copilot_api_token
+
+        mock_exchange.return_value = ("exchanged_jwt", time.time() + 1800)
+        assert get_copilot_api_token("gho_raw") == "exchanged_jwt"
+
+    @patch("hermes_cli.copilot_auth.exchange_copilot_token", side_effect=ValueError("fail"))
+    def test_falls_back_to_raw_token(self, mock_exchange):
+        from hermes_cli.copilot_auth import get_copilot_api_token
+
+        assert get_copilot_api_token("gho_raw") == "gho_raw"
+
+    def test_empty_token_passthrough(self):
+        from hermes_cli.copilot_auth import get_copilot_api_token
+
+        assert get_copilot_api_token("") == ""
+
+
+class TestTokenFingerprint:
+    """Tests for _token_fingerprint()."""
+
+    def test_consistent(self):
+        from hermes_cli.copilot_auth import _token_fingerprint
+
+        fp1 = _token_fingerprint("gho_abc123")
+        fp2 = _token_fingerprint("gho_abc123")
+        assert fp1 == fp2
+
+    def test_different_tokens_different_fingerprints(self):
+        from hermes_cli.copilot_auth import _token_fingerprint
+
+        fp1 = _token_fingerprint("gho_abc123")
+        fp2 = _token_fingerprint("gho_xyz789")
+        assert fp1 != fp2
+
+    def test_length(self):
+        from hermes_cli.copilot_auth import _token_fingerprint
+
+        assert len(_token_fingerprint("gho_test")) == 16
+
+
+class TestCallerIntegration:
+    """Test that callers correctly use token exchange."""
+
+    @patch("hermes_cli.copilot_auth.resolve_copilot_token", return_value=("gho_raw", "GH_TOKEN"))
+    @patch("hermes_cli.copilot_auth.get_copilot_api_token", return_value="exchanged_jwt")
+    def test_auth_resolve_uses_exchange(self, mock_exchange, mock_resolve):
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+
+        # Create a minimal pconfig mock
+        pconfig = MagicMock()
+        token, source = _resolve_api_key_provider_secret("copilot", pconfig)
+        assert token == "exchanged_jwt"
+        assert source == "GH_TOKEN"
+        mock_exchange.assert_called_once_with("gho_raw")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -578,6 +578,36 @@ def test_run_conversation_codex_refreshes_after_401_and_retries(monkeypatch):
     assert result["final_response"] == "Recovered after refresh"
 
 
+def test_run_conversation_copilot_refreshes_after_401_and_retries(monkeypatch):
+    agent = _build_copilot_agent(monkeypatch)
+    calls = {"api": 0, "refresh": 0}
+
+    class _UnauthorizedError(RuntimeError):
+        def __init__(self):
+            super().__init__("Error code: 401 - unauthorized")
+            self.status_code = 401
+
+    def _fake_api_call(api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            raise _UnauthorizedError()
+        return _codex_message_response("Recovered after copilot refresh")
+
+    def _fake_refresh():
+        calls["refresh"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+    monkeypatch.setattr(agent, "_try_refresh_copilot_client_credentials", _fake_refresh)
+
+    result = agent.run_conversation("Say OK")
+
+    assert calls["api"] == 2
+    assert calls["refresh"] == 1
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after copilot refresh"
+
+
 def test_try_refresh_codex_client_credentials_rebuilds_client(monkeypatch):
     agent = _build_agent(monkeypatch)
     closed = {"value": False}
@@ -611,6 +641,62 @@ def test_try_refresh_codex_client_credentials_rebuilds_client(monkeypatch):
     assert rebuilt["kwargs"]["api_key"] == "new-codex-token"
     assert rebuilt["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
     assert isinstance(agent.client, _RebuiltClient)
+
+
+def test_try_refresh_copilot_client_credentials_rebuilds_client(monkeypatch):
+    agent = _build_copilot_agent(monkeypatch)
+    closed = {"value": False}
+    rebuilt = {"kwargs": None}
+
+    class _ExistingClient:
+        def close(self):
+            closed["value"] = True
+
+    class _RebuiltClient:
+        pass
+
+    def _fake_openai(**kwargs):
+        rebuilt["kwargs"] = kwargs
+        return _RebuiltClient()
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_new_token", "GH_TOKEN"),
+    )
+    monkeypatch.setattr(run_agent, "OpenAI", _fake_openai)
+
+    agent.client = _ExistingClient()
+    ok = agent._try_refresh_copilot_client_credentials()
+
+    assert ok is True
+    assert closed["value"] is True
+    assert rebuilt["kwargs"]["api_key"] == "gho_new_token"
+    assert rebuilt["kwargs"]["base_url"] == "https://api.githubcopilot.com"
+    assert rebuilt["kwargs"]["default_headers"]["Copilot-Integration-Id"] == "vscode-chat"
+    assert isinstance(agent.client, _RebuiltClient)
+
+
+def test_try_refresh_copilot_client_credentials_rebuilds_even_if_token_unchanged(monkeypatch):
+    agent = _build_copilot_agent(monkeypatch)
+    rebuilt = {"count": 0}
+
+    class _RebuiltClient:
+        pass
+
+    def _fake_openai(**kwargs):
+        rebuilt["count"] += 1
+        return _RebuiltClient()
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gh-token", "gh auth token"),
+    )
+    monkeypatch.setattr(run_agent, "OpenAI", _fake_openai)
+
+    ok = agent._try_refresh_copilot_client_credentials()
+
+    assert ok is True
+    assert rebuilt["count"] == 1
 
 
 def test_run_conversation_codex_tool_round_trip(monkeypatch):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -216,6 +216,18 @@ The Copilot API does **not** support classic Personal Access Tokens (`ghp_*`). S
 If your `gh auth token` returns a `ghp_*` token, use `hermes model` to authenticate via OAuth instead.
 :::
 
+:::info Copilot auth behavior in Hermes
+Hermes sends a supported GitHub token (`gho_*`, `github_pat_*`, or `ghu_*`) directly to `api.githubcopilot.com` and includes Copilot-specific headers (`Editor-Version`, `Copilot-Integration-Id`, `Openai-Intent`, `x-initiator`).
+
+On HTTP 401, Hermes now performs a one-shot credential recovery before fallback:
+
+1. Re-resolve token via the normal priority chain (`COPILOT_GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN` → `gh auth token`)
+2. Rebuild the shared OpenAI client with refreshed headers
+3. Retry the request once
+
+Some older community proxies use `api.github.com/copilot_internal/v2/token` exchange flows. That endpoint can be unavailable for some account types (returns 404). Hermes therefore keeps direct-token auth as the primary path and relies on runtime credential refresh + retry for robustness.
+:::
+
 **API routing**: GPT-5+ models (except `gpt-5-mini`) automatically use the Responses API. All other models (GPT-4o, Claude, Gemini, etc.) use Chat Completions. Models are auto-detected from the live Copilot catalog.
 
 **`copilot-acp` — Copilot ACP agent backend**. Spawns the local Copilot CLI as a subprocess:


### PR DESCRIPTION
## Summary
Consolidated salvage of 4 GitHub Copilot PRs — token exchange, 401 auth recovery, live context-length resolution, and HOME env propagation for ACP subprocesses. Attribution preserved via rebase-merge.

## Changes
- **`hermes_cli/copilot_auth.py` + `hermes_cli/auth.py` + `agent/credential_pool.py`** — add `exchange_copilot_token()` which calls `GET https://api.github.com/copilot_internal/v2/token` to trade a raw GitHub token for a short-lived Copilot API token (the semicolon-separated `tid=...;exp=...;sku=...` format). Previous code used the raw GitHub token as `Authorization: Bearer`, which only works for some account types. Cherry-pick from @difujia (#12876).
- **`run_agent.py`** — add `_try_refresh_copilot_client_credentials()` paralleling the existing Nous/Anthropic/Codex refresh paths. On HTTP 401 from Copilot, refresh credentials and rebuild the OpenAI client instead of failing the request. Cherry-pick from @l0hde (#10179).
- **`agent/model_metadata.py` + `hermes_cli/models.py`** — probe Copilot's live `/models` endpoint for `max_prompt_tokens` on a per-account basis. Catches account-specific models (e.g. `claude-opus-4.6-1m`) that don't exist in `models.dev`, and returns the provider-enforced limit rather than the nominal marketing number. Cached 1h in-process. Cherry-pick from @difujia (#12840).
- **`agent/copilot_acp_client.py`** — pass `HOME` env var into Copilot ACP subprocess. Without this, the subprocess inherits an empty or stale HOME and fails to locate config. Includes fallback chain: `get_subprocess_home()` → `$HOME` → `expanduser("~")` → pwd lookup → `/tmp`. Cherry-pick from @MestreY0d4-Uninter (#11285), with `/home/openclaw` hardcoded fallback replaced by `/tmp`.

## Credit
- @difujia — PRs #12876, #12840
- @l0hde — PR #10179
- @MestreY0d4-Uninter — PR #11285

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_copilot_token_exchange.py tests/hermes_cli/test_copilot_context.py tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_copilot_in_model_list.py tests/agent/test_copilot_acp_client.py tests/agent/test_credential_pool.py tests/run_agent/test_run_agent_codex_responses.py tests/hermes_cli/test_model_switch_copilot_api_mode.py` — 137/137 passing.

All four PRs cherry-picked cleanly with no conflicts against current `main`.

## Not included in this salvage
- **#7730** @emma-clawdbot — same token-exchange feature but 6500-line diff from a stale branch. #12876 is the clean equivalent.
- **#6468** @HearthCore (GHE Copilot support) — touches `auth.py`, `config.py`, `main.py`, `models.py`, `run_agent.py`. Will conflict with #12876's auth changes and needs a rebase on top of this salvage. Worth resubmitting as a focused PR after this lands.
- **#9232** @jergensturdley — forces all Copilot models through chat-completions regardless of model ID. This is a policy change (opencode's rule is that GPT-5+ uses Responses API), not a bug fix. Needs product decision.
