### PR TITLE
fix(gateway): fire on_session_finalize on idle expiry (salvage #13756)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2310,6 +2310,17 @@ class GatewayRunner:
                 for key, entry in _expired_entries:
                     try:
                         await self._async_flush_memories(entry.session_id, key)
+                        try:
+                            from hermes_cli.plugins import invoke_hook as _invoke_hook
+                            _parts = key.split(":")
+                            _platform = _parts[2] if len(_parts) > 2 else ""
+                            _invoke_hook(
+                                "on_session_finalize",
+                                session_id=entry.session_id,
+                                platform=_platform,
+                            )
+                        except Exception:
+                            pass
                         # Shut down memory provider and close tool resources
                         # on the cached agent.  Idle agents live in
                         # _agent_cache (not _running_agents), so look there.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -209,6 +209,7 @@ AUTHOR_MAP = {
     "ntconguit@gmail.com": "0xharryriddle",
     "agent@wildcat.local": "ericnicolaides",
     "georgex8001@gmail.com": "georgex8001",
+    "stefan@dimagents.ai": "dimitrovi",
     "hermes@noushq.ai": "benbarclay",
     "chinmingcock@gmail.com": "ChimingLiu",
     "openclaw@sparklab.ai": "openclaw",

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -166,3 +166,80 @@ async def test_hook_error_does_not_break_reset(mock_invoke_hook):
 
     # Should still return a success message despite hook errors
     assert "Session reset" in result or "New session" in result
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
+    """Regression test for #14981.
+
+    When ``_session_expiry_watcher`` sweeps a session that has aged past
+    its reset policy (idle timeout, scheduled reset), it must fire
+    ``on_session_finalize`` so plugin providers get the same final-pass
+    extraction opportunity they'd get from /new or CLI shutdown.  Before
+    the fix, the expiry path flushed memories and evicted the agent but
+    silently skipped the hook.
+    """
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = 0.0
+
+    session_key = "agent:main:telegram:dm:42"
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-expired",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    expired_entry.memory_flushed = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._async_flush_memories = AsyncMock()
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    # The watcher starts with `await asyncio.sleep(60)` and loops while
+    # `self._running`. Patch sleep so the 60s initial delay is instant, then
+    # flip `_running` false inside the flush call so the loop exits cleanly
+    # after one pass.
+    _orig_sleep = __import__("asyncio").sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    async def _flush_and_stop(session_id, key):
+        runner._running = False  # terminate the loop after this iteration
+
+    runner._async_flush_memories = AsyncMock(side_effect=_flush_and_stop)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    # Look for the finalize call targeting the expired session.
+    finalize_calls = [
+        c for c in mock_invoke_hook.call_args_list
+        if c[0] and c[0][0] == "on_session_finalize"
+    ]
+    session_ids = {c[1].get("session_id") for c in finalize_calls}
+    assert "sess-expired" in session_ids, (
+        f"on_session_finalize was not fired during idle expiry; "
+        f"got session_ids={session_ids} (regression of #14981)"
+    )


### PR DESCRIPTION
Salvage of #13756 by @dimitrovi onto current main with a regression test added.

Closes #14981.

## What this PR does
When `_session_expiry_watcher` sweeps a session that has aged past its reset policy (idle timeout, scheduled reset), it now fires `on_session_finalize` — matching the contract already honored by `/new`, `/reset`, CLI shutdown, and `gateway stop`. Before this PR, the expiry path flushed memories and evicted the agent silently, so plugins using `on_session_finalize` never saw their final-pass extraction opportunity for idle-expired sessions.

## How
In `_session_expiry_watcher`, right after `_async_flush_memories` completes for an expired session, invoke `hermes_cli.plugins.invoke_hook("on_session_finalize", session_id=..., platform=...)`. Platform is parsed from the session key (`agent:main:<platform>:<chat_type>:<chat_id>`). The invocation is wrapped in try/except so a misbehaving plugin can't break the expiry sweep.

## Changes
- @dimitrovi (#13756 commit): 11 lines in `gateway/run.py`
- Follow-up: AUTHOR_MAP entry for `stefan@dimagents.ai` → @dimitrovi
- Regression test: `test_idle_expiry_fires_finalize_hook` in `tests/gateway/test_session_boundary_hooks.py`

## Validation
| | Before | After |
|---|---|---|
| `/new` fires `on_session_finalize` | ✓ | ✓ |
| `/reset` fires hook | ✓ | ✓ |
| CLI shutdown fires hook | ✓ | ✓ |
| Gateway `stop()` fires hook for each active agent | ✓ | ✓ |
| **Idle expiry fires hook** | ✗ (silent) | ✓ |

Test verified as a real regression guard: fails cleanly on pre-fix code ("on_session_finalize was not fired during idle expiry"), passes with the fix applied.

- `tests/gateway/test_session_boundary_hooks.py` — 6/6 pass (1 new regression test)

## Note on parallel PR #11410
#11410 fires `MemoryProvider.on_session_end()` (a different lifecycle hook on the memory-manager layer) on expiry. That's a separate gap — distinct from the plugin-hook fix here. Leaving #11410 open for separate review.

Co-authored-by: @dimitrovi
