### PR TITLE
fix(gemini): fail fast on missing API key + surface it in hermes dump

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -801,6 +801,13 @@ class GeminiNativeClient:
         http_client: Optional[httpx.Client] = None,
         **_: Any,
     ) -> None:
+        if not (api_key or "").strip():
+            raise RuntimeError(
+                "Gemini native client requires an API key, but none was provided. "
+                "Set GOOGLE_API_KEY or GEMINI_API_KEY in your environment / ~/.hermes/.env "
+                "(get one at https://aistudio.google.com/app/apikey), or run `hermes setup` "
+                "to configure the Google provider."
+            )
         self.api_key = api_key
         normalized_base = (base_url or DEFAULT_GEMINI_BASE_URL).rstrip("/")
         if normalized_base.endswith("/openai"):

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -267,6 +267,8 @@ def run_dump(args):
         ("ANTHROPIC_API_KEY", "anthropic"),
         ("ANTHROPIC_TOKEN", "anthropic_token"),
         ("NOUS_API_KEY", "nous"),
+        ("GOOGLE_API_KEY", "google/gemini"),
+        ("GEMINI_API_KEY", "gemini"),
         ("GLM_API_KEY", "glm/zai"),
         ("ZAI_API_KEY", "zai"),
         ("KIMI_API_KEY", "kimi"),

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -234,6 +234,19 @@ def test_native_client_accepts_injected_http_client():
     assert client._http is injected
 
 
+def test_native_client_rejects_empty_api_key_with_actionable_message():
+    """Empty/whitespace api_key must raise at construction, not produce a cryptic
+    Google GFE 'Error 400 (Bad Request)!!1' HTML page on the first request."""
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    for bad in ("", "   ", None):
+        with pytest.raises(RuntimeError) as excinfo:
+            GeminiNativeClient(api_key=bad)  # type: ignore[arg-type]
+        msg = str(excinfo.value)
+        assert "GOOGLE_API_KEY" in msg and "GEMINI_API_KEY" in msg
+        assert "aistudio.google.com" in msg
+
+
 @pytest.mark.asyncio
 async def test_async_native_client_streams_without_requiring_async_iterator_from_sync_client():
     from agent.gemini_native_adapter import AsyncGeminiNativeClient


### PR DESCRIPTION
## Summary
Support report: user saw cryptic `HTTP 400 — Error 400 (Bad Request)!!1` on every `gemini-2.5-pro` request in both CLI and the Discord gateway. That string is Google's GFE HTML error page (the `!!1` is literally in Google's static template), not a real Generative Language API JSON error. Root cause: empty `GOOGLE_API_KEY` / `GEMINI_API_KEY` — the adapter stamped an empty string into `x-goog-api-key` and Google's frontend bounced it before the request ever reached the LLM.

Nothing in our output made this diagnosable, so this PR fixes both the detection and the reporting side.

## Changes
- `agent/gemini_native_adapter.py`: `GeminiNativeClient.__init__` now rejects empty/whitespace `api_key` with a `RuntimeError` pointing at `GOOGLE_API_KEY`/`GEMINI_API_KEY` and https://aistudio.google.com/app/apikey. Fails at client construction instead of on the first HTTP call.
- `hermes_cli/dump.py`: the `api_keys:` section enumerated 23 providers but omitted Google entirely. Added `GOOGLE_API_KEY` and `GEMINI_API_KEY` rows so `hermes dump` surfaces `google/gemini: not set` / `gemini: not set`.
- `tests/agent/test_gemini_native_adapter.py`: regression test for empty `''`, whitespace `'   '`, and `None` api_keys — asserts error message contains both env var names and the AI Studio URL.

## Validation
| | Before | After |
|---|---|---|
| Missing key behavior | Request hits Google, returns HTML `Error 400 (Bad Request)!!1` | `RuntimeError` at client construction with env var names and setup URL |
| `hermes dump` visibility | Google keys not listed at all | `google/gemini: set/not set` and `gemini: set/not set` shown |
| Tests | 56 passing | 57 passing (`scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py tests/hermes_cli/test_gemini_provider.py`) |