### PR TITLE
fix(copilot): switch to VS Code client ID and derive enterprise base URL

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -751,7 +751,7 @@ def init_agent(
                 client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)
             elif base_url_host_matches(effective_base, "api.routermint.com"):
                 client_kwargs["default_headers"] = _ra()._routermint_headers()
-            elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
+            elif base_url_host_matches(effective_base, "githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
                 client_kwargs["default_headers"] = copilot_default_headers()

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1473,7 +1473,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-            elif base_url_host_matches(base_url, "api.githubcopilot.com"):
+            elif base_url_host_matches(base_url, "githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
@@ -1513,7 +1513,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-        elif base_url_host_matches(base_url, "api.githubcopilot.com"):
+        elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
@@ -2699,7 +2699,7 @@ def _recoverable_pool_provider(
         return "nous"
     if base_url_host_matches(base, "api.anthropic.com"):
         return "anthropic"
-    if base_url_host_matches(base, "api.githubcopilot.com"):
+    if base_url_host_matches(base, "githubcopilot.com"):
         return "copilot"
     if base_url_host_matches(base, "api.kimi.com"):
         return "kimi-coding"
@@ -3291,7 +3291,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     sync_base_url = str(sync_client.base_url)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()
-    elif base_url_host_matches(sync_base_url, "api.githubcopilot.com"):
+    elif base_url_host_matches(sync_base_url, "githubcopilot.com"):
         from hermes_cli.copilot_auth import copilot_request_headers
 
         async_kwargs["default_headers"] = copilot_request_headers(
@@ -3588,7 +3588,7 @@ def resolve_provider_client(
                 extra["default_query"] = _dq
             if base_url_host_matches(custom_base, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-            elif base_url_host_matches(custom_base, "api.githubcopilot.com"):
+            elif base_url_host_matches(custom_base, "githubcopilot.com"):
                 from hermes_cli.copilot_auth import copilot_request_headers
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
@@ -3841,7 +3841,7 @@ def resolve_provider_client(
         headers = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
-        elif base_url_host_matches(base_url, "api.githubcopilot.com"):
+        elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.copilot_auth import copilot_request_headers
 
             headers.update(copilot_request_headers(
@@ -4312,9 +4312,14 @@ def auxiliary_max_tokens_param(value: int) -> dict:
     or_key = os.getenv("OPENROUTER_API_KEY")
     # Use max_completion_tokens for direct OpenAI-compatible providers that reject
     # max_tokens on newer GPT-4o/o-series/GPT-5-style models.
+    _custom_host = base_url_hostname(custom_base) or ""
     if (not or_key
             and _read_nous_auth() is None
-            and base_url_hostname(custom_base) in {"api.openai.com", "api.githubcopilot.com"}):
+            and (
+                _custom_host == "api.openai.com"
+                or _custom_host == "api.githubcopilot.com"
+                or _custom_host.endswith(".githubcopilot.com")
+            )):
         return {"max_completion_tokens": value}
     return {"max_tokens": value}
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -569,7 +569,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _ct = agent._get_transport()
         is_github_responses = (
             base_url_host_matches(agent.base_url, "models.github.ai")
-            or base_url_host_matches(agent.base_url, "api.githubcopilot.com")
+            or base_url_host_matches(agent.base_url, "githubcopilot.com")
         )
         is_codex_backend = (
             agent.provider == "openai-codex"
@@ -639,7 +639,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     _is_or = agent._is_openrouter_url()
     _is_gh = (
         base_url_host_matches(agent._base_url_lower, "models.github.ai")
-        or base_url_host_matches(agent._base_url_lower, "api.githubcopilot.com")
+        or base_url_host_matches(agent._base_url_lower, "githubcopilot.com")
     )
     _is_nous = "nousresearch" in agent._base_url_lower
     _is_nvidia = "integrate.api.nvidia.com" in agent._base_url_lower

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1781,11 +1781,16 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
-                api_token = get_copilot_api_token(token)
+                api_token, enterprise_base_url = get_copilot_api_token(token)
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
                 if not _is_suppressed(provider, source_name):
                     active_sources.add(source_name)
                     pconfig = PROVIDER_REGISTRY.get(provider)
+                    # Use enterprise base URL from token exchange if available,
+                    # otherwise fall back to the provider's default.
+                    effective_base_url = enterprise_base_url or (
+                        pconfig.inference_base_url if pconfig else ""
+                    )
                     changed |= _upsert_entry(
                         entries,
                         provider,
@@ -1794,7 +1799,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                             "source": source_name,
                             "auth_type": AUTH_TYPE_API_KEY,
                             "access_token": api_token,
-                            "base_url": pconfig.inference_base_url if pconfig else "",
+                            "base_url": effective_base_url,
                             "label": source,
                         },
                     )

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1173,11 +1173,16 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
-                api_token = get_copilot_api_token(token)
+                api_token, enterprise_base_url = get_copilot_api_token(token)
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
                 if not _is_suppressed(provider, source_name):
                     active_sources.add(source_name)
                     pconfig = PROVIDER_REGISTRY.get(provider)
+                    # Use enterprise base URL from token exchange if available,
+                    # otherwise fall back to the provider's default.
+                    effective_base_url = enterprise_base_url or (
+                        pconfig.inference_base_url if pconfig else ""
+                    )
                     changed |= _upsert_entry(
                         entries,
                         provider,
@@ -1186,7 +1191,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                             "source": source_name,
                             "auth_type": AUTH_TYPE_API_KEY,
                             "access_token": api_token,
-                            "base_url": pconfig.inference_base_url if pconfig else "",
+                            "base_url": effective_base_url,
                             "label": source,
                         },
                     )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -364,6 +364,10 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
+    # Enterprise Copilot endpoints look like api.enterprise.githubcopilot.com,
+    # api.business.githubcopilot.com, etc.  Match the suffix so context-window
+    # resolution works for enterprise accounts too.
+    ".githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
     # GitHub Models free tier (Azure-hosted prototyping endpoint) — same
     # canonical provider as the Copilot API.  Hard per-request token cap

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -570,7 +570,8 @@ def _resolve_api_key_provider_secret(
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
-                return get_copilot_api_token(token), source
+                api_token, _base_url = get_copilot_api_token(token)
+                return api_token, source
         except ValueError as exc:
             logger.warning("Copilot token validation failed: %s", exc)
         except Exception:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -452,7 +452,8 @@ def _resolve_api_key_provider_secret(
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
-                return get_copilot_api_token(token), source
+                api_token, _base_url = get_copilot_api_token(token)
+                return api_token, source
         except ValueError as exc:
             logger.warning("Copilot token validation failed: %s", exc)
         except Exception:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -29,8 +29,14 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# OAuth device code flow constants (same client ID as opencode/Copilot CLI)
-COPILOT_OAUTH_CLIENT_ID = "Ov23li8tweQw6odWQebz"
+# OAuth device code flow constants — VS Code's GitHub App client ID.
+# The previous opencode OAuth App ID (Ov23li8tweQw6odWQebz) produces gho_*
+# tokens that cannot be exchanged for Copilot API JWTs (404 on
+# /copilot_internal/v2/token). VS Code's App ID produces ghu_* tokens
+# that support exchange, which is required to access internal-only models
+# (e.g. claude-opus-4.6-1m) and enterprise endpoints.
+# Tested on Individual and Enterprise accounts.
+COPILOT_OAUTH_CLIENT_ID = "Iv1.b507a08c87ecfe98"
 # Token type prefixes
 _CLASSIC_PAT_PREFIX = "ghp_"
 _SUPPORTED_PREFIXES = ("gho_", "github_pat_", "ghu_")
@@ -278,8 +284,8 @@ def copilot_device_code_login(
 # ─── Copilot Token Exchange ────────────────────────────────────────────────
 
 # Module-level cache for exchanged Copilot API tokens.
-# Maps raw_token_fingerprint -> (api_token, expires_at_epoch).
-_jwt_cache: dict[str, tuple[str, float]] = {}
+# Maps raw_token_fingerprint -> (api_token, expires_at_epoch, base_url).
+_jwt_cache: dict[str, tuple[str, float, Optional[str]]] = {}
 _JWT_REFRESH_MARGIN_SECONDS = 120  # refresh 2 min before expiry
 
 # Token exchange endpoint and headers (matching VS Code / Copilot CLI)
@@ -294,14 +300,16 @@ def _token_fingerprint(raw_token: str) -> str:
     return hashlib.sha256(raw_token.encode()).hexdigest()[:16]
 
 
-def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[str, float]:
+def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[str, float, Optional[str]]:
     """Exchange a raw GitHub token for a short-lived Copilot API token.
 
     Calls ``GET https://api.github.com/copilot_internal/v2/token`` with
-    the raw GitHub token and returns ``(api_token, expires_at)``.
+    the raw GitHub token and returns ``(api_token, expires_at, base_url)``.
 
     The returned token is a semicolon-separated string (not a standard JWT)
     used as ``Authorization: Bearer <token>`` for Copilot API requests.
+    If the token contains a ``proxy-ep`` field (enterprise accounts), the
+    derived API base URL is returned; otherwise ``base_url`` is None.
 
     Results are cached in-process and reused until close to expiry.
     Raises ``ValueError`` on failure.
@@ -313,9 +321,9 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     # Check cache first
     cached = _jwt_cache.get(fp)
     if cached:
-        api_token, expires_at = cached
+        api_token, expires_at, base_url = cached
         if time.time() < expires_at - _JWT_REFRESH_MARGIN_SECONDS:
-            return api_token, expires_at
+            return api_token, expires_at, base_url
 
     req = urllib.request.Request(
         _TOKEN_EXCHANGE_URL,
@@ -342,30 +350,71 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     # Convert expires_at to float if needed
     expires_at = float(expires_at) if expires_at else time.time() + 1800
 
-    _jwt_cache[fp] = (api_token, expires_at)
+    # Derive enterprise base URL from proxy-ep in the token.
+    # The token is semicolon-separated: "tid=xxx;exp=xxx;proxy-ep=proxy.enterprise.githubcopilot.com;..."
+    # Replace leading "proxy." with "api." to get the API base URL.
+    base_url = _derive_base_url_from_proxy_ep(api_token)
+
+    _jwt_cache[fp] = (api_token, expires_at, base_url)
     logger.debug(
-        "Copilot token exchanged, expires_at=%s",
+        "Copilot token exchanged, expires_at=%s, base_url=%s",
         expires_at,
+        base_url,
     )
-    return api_token, expires_at
+    return api_token, expires_at, base_url
 
 
-def get_copilot_api_token(raw_token: str) -> str:
+def _derive_base_url_from_proxy_ep(token: str) -> Optional[str]:
+    """Derive the Copilot API base URL from a proxy-ep field in the token.
+
+    The exchanged Copilot token is a semicolon-separated string like
+    ``tid=xxx;exp=xxx;proxy-ep=proxy.enterprise.githubcopilot.com;...``.
+    This extracts ``proxy-ep`` and converts it to an API base URL by
+    replacing the leading ``proxy.`` with ``api.``.
+
+    Returns ``https://{api_hostname}`` or None if proxy-ep is absent.
+    """
+    import re
+    m = re.search(r'(?:^|;)\s*proxy-ep=([^;\s]+)', token)
+    if not m:
+        return None
+
+    proxy_ep = m.group(1)
+    # Strip scheme if present
+    for prefix in ("https://", "http://"):
+        if proxy_ep.startswith(prefix):
+            proxy_ep = proxy_ep[len(prefix):]
+            break
+    proxy_ep = proxy_ep.rstrip("/")
+
+    # Replace leading "proxy." with "api."
+    if proxy_ep.startswith("proxy."):
+        api_host = "api." + proxy_ep[len("proxy."):]
+    else:
+        api_host = proxy_ep
+
+    return f"https://{api_host}"
+
+
+def get_copilot_api_token(raw_token: str) -> tuple[str, Optional[str]]:
     """Exchange a raw GitHub token for a Copilot API token, with fallback.
 
-    Convenience wrapper: returns the exchanged token on success, or the
-    raw token unchanged if the exchange fails (e.g. network error, unsupported
+    Convenience wrapper: returns ``(api_token, base_url)`` on success, or
+    ``(raw_token, None)`` if the exchange fails (e.g. network error, unsupported
     account type). This preserves existing behaviour for accounts that don't
     need exchange while enabling access to internal-only models for those that do.
+
+    ``base_url`` is the enterprise API endpoint derived from the token's
+    ``proxy-ep`` field, or None for individual accounts.
     """
     if not raw_token:
-        return raw_token
+        return raw_token, None
     try:
-        api_token, _ = exchange_copilot_token(raw_token)
-        return api_token
+        api_token, _, base_url = exchange_copilot_token(raw_token)
+        return api_token, base_url
     except Exception as exc:
         logger.debug("Copilot token exchange failed, using raw token: %s", exc)
-        return raw_token
+        return raw_token, None
 
 
 # ─── Copilot API Headers ───────────────────────────────────────────────────

--- a/run_agent.py
+++ b/run_agent.py
@@ -1070,7 +1070,9 @@ class AIAgent:
             hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
                 getattr(self, "_base_url_lower", "")
             )
-        return hostname == "api.githubcopilot.com"
+        if not hostname:
+            return False
+        return hostname == "api.githubcopilot.com" or hostname.endswith(".githubcopilot.com")
 
     def _resolved_api_call_timeout(self) -> float:
         """Resolve the effective per-call request timeout in seconds.
@@ -3519,7 +3521,7 @@ class AIAgent:
         # unaffected (they don't go through here).
         request_kwargs["max_retries"] = 0
         if (
-            base_url_host_matches(str(request_kwargs.get("base_url", "")), "api.githubcopilot.com")
+            base_url_host_matches(str(request_kwargs.get("base_url", "")), "githubcopilot.com")
             and self._api_kwargs_have_image_parts(api_kwargs or {})
         ):
             request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
@@ -3781,7 +3783,7 @@ class AIAgent:
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)
         elif base_url_host_matches(base_url, "api.routermint.com"):
             self._client_kwargs["default_headers"] = _routermint_headers()
-        elif base_url_host_matches(base_url, "api.githubcopilot.com"):
+        elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
@@ -4651,7 +4653,7 @@ class AIAgent:
             return True
         if (
             base_url_host_matches(self._base_url_lower, "models.github.ai")
-            or base_url_host_matches(self._base_url_lower, "api.githubcopilot.com")
+            or base_url_host_matches(self._base_url_lower, "githubcopilot.com")
         ):
             try:
                 from hermes_cli.models import github_model_reasoning_efforts

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -37,10 +37,11 @@ class TestExchangeCopilotToken:
         from hermes_cli.copilot_auth import exchange_copilot_token
 
         mock_urlopen.return_value = self._mock_urlopen(token="tid=abc;exp=999")
-        api_token, expires_at = exchange_copilot_token("gho_test123")
+        api_token, expires_at, base_url = exchange_copilot_token("gho_test123")
 
         assert api_token == "tid=abc;exp=999"
         assert isinstance(expires_at, float)
+        assert base_url is None  # no proxy-ep in this token
 
         # Verify request was made with correct headers
         call_args = mock_urlopen.call_args
@@ -66,12 +67,12 @@ class TestExchangeCopilotToken:
 
         # Seed cache with expired entry
         fp = _token_fingerprint("gho_test123")
-        _jwt_cache[fp] = ("old_token", time.time() - 10)
+        _jwt_cache[fp] = ("old_token", time.time() - 10, None)
 
         mock_urlopen.return_value = self._mock_urlopen(
             token="new_token", expires_at=time.time() + 1800
         )
-        api_token, _ = exchange_copilot_token("gho_test123")
+        api_token, _, _ = exchange_copilot_token("gho_test123")
 
         assert api_token == "new_token"
         assert mock_urlopen.call_count == 1
@@ -105,19 +106,25 @@ class TestGetCopilotApiToken:
     def test_returns_exchanged_token(self, mock_exchange):
         from hermes_cli.copilot_auth import get_copilot_api_token
 
-        mock_exchange.return_value = ("exchanged_jwt", time.time() + 1800)
-        assert get_copilot_api_token("gho_raw") == "exchanged_jwt"
+        mock_exchange.return_value = ("exchanged_jwt", time.time() + 1800, None)
+        api_token, base_url = get_copilot_api_token("gho_raw")
+        assert api_token == "exchanged_jwt"
+        assert base_url is None
 
     @patch("hermes_cli.copilot_auth.exchange_copilot_token", side_effect=ValueError("fail"))
     def test_falls_back_to_raw_token(self, mock_exchange):
         from hermes_cli.copilot_auth import get_copilot_api_token
 
-        assert get_copilot_api_token("gho_raw") == "gho_raw"
+        api_token, base_url = get_copilot_api_token("gho_raw")
+        assert api_token == "gho_raw"
+        assert base_url is None
 
     def test_empty_token_passthrough(self):
         from hermes_cli.copilot_auth import get_copilot_api_token
 
-        assert get_copilot_api_token("") == ""
+        api_token, base_url = get_copilot_api_token("")
+        assert api_token == ""
+        assert base_url is None
 
 
 class TestTokenFingerprint:
@@ -147,7 +154,7 @@ class TestCallerIntegration:
     """Test that callers correctly use token exchange."""
 
     @patch("hermes_cli.copilot_auth.resolve_copilot_token", return_value=("gho_raw", "GH_TOKEN"))
-    @patch("hermes_cli.copilot_auth.get_copilot_api_token", return_value="exchanged_jwt")
+    @patch("hermes_cli.copilot_auth.get_copilot_api_token", return_value=("exchanged_jwt", None))
     def test_auth_resolve_uses_exchange(self, mock_exchange, mock_resolve):
         from hermes_cli.auth import _resolve_api_key_provider_secret
 
@@ -157,3 +164,65 @@ class TestCallerIntegration:
         assert token == "exchanged_jwt"
         assert source == "GH_TOKEN"
         mock_exchange.assert_called_once_with("gho_raw")
+
+
+class TestDeriveBaseUrlFromProxyEp:
+    """Tests for _derive_base_url_from_proxy_ep()."""
+
+    def test_extracts_enterprise_url(self):
+        from hermes_cli.copilot_auth import _derive_base_url_from_proxy_ep
+
+        token = "tid=abc;exp=999;proxy-ep=proxy.enterprise.githubcopilot.com;sku=copilot_enterprise"
+        assert _derive_base_url_from_proxy_ep(token) == "https://api.enterprise.githubcopilot.com"
+
+    def test_returns_none_without_proxy_ep(self):
+        from hermes_cli.copilot_auth import _derive_base_url_from_proxy_ep
+
+        token = "tid=abc;exp=999;sku=copilot_individual"
+        assert _derive_base_url_from_proxy_ep(token) is None
+
+    def test_handles_https_prefix(self):
+        from hermes_cli.copilot_auth import _derive_base_url_from_proxy_ep
+
+        token = "proxy-ep=https://proxy.enterprise.githubcopilot.com/"
+        assert _derive_base_url_from_proxy_ep(token) == "https://api.enterprise.githubcopilot.com"
+
+    def test_no_proxy_prefix(self):
+        from hermes_cli.copilot_auth import _derive_base_url_from_proxy_ep
+
+        token = "proxy-ep=custom.copilot.example.com"
+        assert _derive_base_url_from_proxy_ep(token) == "https://custom.copilot.example.com"
+
+    @patch("urllib.request.urlopen")
+    def test_exchange_returns_enterprise_base_url(self, mock_urlopen, _clear_jwt_cache):
+        """exchange_copilot_token returns base_url from proxy-ep."""
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        token_with_ep = "tid=abc;exp=999;proxy-ep=proxy.enterprise.githubcopilot.com"
+        expires_at = time.time() + 1800
+        resp_data = json.dumps({"token": token_with_ep, "expires_at": expires_at}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        api_token, _, base_url = exchange_copilot_token("gho_test")
+        assert base_url == "https://api.enterprise.githubcopilot.com"
+
+    @patch("urllib.request.urlopen")
+    def test_exchange_returns_none_base_url_for_individual(self, mock_urlopen, _clear_jwt_cache):
+        """exchange_copilot_token returns None base_url for individual accounts."""
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        token_no_ep = "tid=abc;exp=999;sku=copilot_individual"
+        expires_at = time.time() + 1800
+        resp_data = json.dumps({"token": token_no_ep, "expires_at": expires_at}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        api_token, _, base_url = exchange_copilot_token("gho_test")
+        assert base_url is None

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -295,3 +295,31 @@ def test_openrouter_headers_no_cache_when_disabled(mock_openai):
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
     assert "X-OpenRouter-Cache" not in headers
     assert "X-OpenRouter-Cache-TTL" not in headers
+
+
+@patch("run_agent.OpenAI")
+def test_copilot_enterprise_base_url_applies_copilot_default_headers(mock_openai):
+    """Enterprise Copilot endpoints (api.<tenant>.githubcopilot.com) must apply
+    the same default_headers — including Copilot-Integration-Id: vscode-chat —
+    as the default api.githubcopilot.com endpoint. Without this, the upstream
+    sees the request as integrator 'zed' or 'copilot-language-server' and
+    rejects it with a 400 error for many models (regression seen May 2026)."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.enterprise.githubcopilot.com",
+        model="claude-opus-4.6-1m",
+        provider="copilot",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.enterprise.githubcopilot.com")
+
+    headers = agent._client_kwargs.get("default_headers", {})
+    # Lookup is case-insensitive — normalize for the assertion.
+    lc = {k.lower(): v for k, v in headers.items()}
+    assert lc.get("copilot-integration-id") == "vscode-chat", (
+        f"enterprise Copilot endpoint must carry Copilot-Integration-Id=vscode-chat; got {headers}"
+    )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5056,6 +5056,13 @@ class TestMaxTokensParam:
         result = agent._max_tokens_param(4096)
         assert result == {"max_completion_tokens": 4096}
 
+    def test_returns_max_completion_tokens_for_enterprise_copilot(self, agent):
+        """Enterprise Copilot endpoints (api.<tenant>.githubcopilot.com) must
+        share the same max_tokens behavior as the default endpoint."""
+        agent.base_url = "https://api.enterprise.githubcopilot.com"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_completion_tokens": 4096}
+
 
 class TestGpt5ApiModeRouting:
     """Verify provider-specific GPT-5 API-mode routing."""


### PR DESCRIPTION
Fixes #6455
Refs #7731 (parts 3 and 4), completing the Copilot auth improvements.


## Changes

### Part 3: Switch OAuth client ID
The opencode OAuth App ID (`Ov23li8tweQw6odWQebz`) produces `gho_*` tokens that return **404** on `/copilot_internal/v2/token`, making the token exchange (landed in d7ad07d6) non-functional. VS Code's GitHub App ID (`Iv1.b507a08c87ecfe98`) produces `ghu_*` tokens that support exchange.

One-line change: `COPILOT_OAUTH_CLIENT_ID` in `hermes_cli/copilot_auth.py`.

### Part 4: Derive enterprise base URL from proxy-ep
Enterprise Copilot accounts get exchanged tokens containing a `proxy-ep` field (e.g. `proxy-ep=proxy.enterprise.githubcopilot.com`). This is now parsed and converted to an API base URL (`https://api.enterprise.githubcopilot.com`) which is stored in the credential pool.

- `exchange_copilot_token()` now returns `(api_token, expires_at, base_url)`
- `get_copilot_api_token()` now returns `(api_token, base_url)`
- `credential_pool.py` uses the enterprise base URL when available, falls back to default
- `COPILOT_API_BASE_URL` env var still works as a user escape hatch
- Individual accounts (no proxy-ep) are unaffected

## Test matrix (Individual × Enterprise × Client ID)

| Account | Client ID | Token type | Device flow | Token exchange | Models (raw) | Models (JWT) | Enterprise base URL |
|---|---|---|---|---|---|---|---|
| Individual¹ | opencode `Ov23li...` | `gho_*` | ✅ | ❌ 404 | 31 | N/A | N/A |
| Individual¹ | VS Code `Iv1.b5...` | `ghu_*` | ✅ | ✅ | 31 | 39 | None (individual) |
| Enterprise | opencode `Ov23li...` | `gho_*` | ✅ | ❌ 404 | 31 | N/A | N/A |
| Enterprise | VS Code `Iv1.b5...` | `ghu_*` | ✅ | ✅ | 31 | 39 | ✅ derived from proxy-ep |

¹ The Individual account tested has an Enterprise Copilot seat linked, so its model catalog matches Enterprise (both show 39 models after exchange). A pure Individual account without Enterprise linkage may see fewer models — the important signal is that device flow and token exchange work correctly on both account types.

Key findings:
- `gho_*` tokens (opencode ID) **never** support exchange, regardless of account type
- `ghu_*` tokens (VS Code ID) support exchange on **both** Individual and Enterprise
- After exchange, 8 additional models appear including `claude-opus-4.6-1m` (936K prompt tokens)
- `gpt-4.1` context jumps from 64K → 128K after exchange
- Enterprise tokens contain `proxy-ep` for base URL derivation; Individual tokens do not

216 existing tests pass. 6 new tests for proxy-ep parsing and enterprise base URL derivation.

**Note:** Existing users will need to re-run `copilot login` / `hermes model` to get a new `ghu_*` token.