### PR TITLE
Clarify Windows install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Works on Linux, macOS, WSL2, and Android via Termux. The installer handles the p
 
 > **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
 >
-> **Windows:** Native Windows is not supported. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above.
+> **Windows / PowerShell / CMD:** Do **not** paste the Unix `curl ... | bash` command into PowerShell or CMD. Native Windows is not supported. Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above inside your WSL2 terminal.
 
 After installation:
 

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -30,7 +30,7 @@ Set your provider with `hermes model` or by editing `~/.hermes/.env`. See the [E
 
 ### Does it work on Windows?
 
-**Not natively.** Hermes Agent requires a Unix-like environment. On Windows, install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run Hermes from inside it. The standard install command works perfectly in WSL2:
+**Not natively.** Hermes Agent requires a Unix-like environment. On Windows, do **not** paste the Unix `curl ... | bash` command into PowerShell or CMD. Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run Hermes from inside it. The standard install command works in WSL2:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash


### PR DESCRIPTION
## Summary
- warn Windows users not to paste the Unix `curl ... | bash` installer into PowerShell or CMD
- clarify that Hermes should be installed from WSL2 on Windows
- make the Windows guidance more explicit in the README and FAQ

## Test plan
- [x] verify README wording points Windows users to WSL2
- [x] verify FAQ wording explicitly calls out PowerShell/CMD misuse
- [ ] optional follow-up: update install site pages with the same warning

🤖 Generated with [Claude Code](https://claude.com/code)