### PR TITLE
docs: add explicit PowerShell warning to install pages

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -34,7 +34,20 @@ The installer detects Termux automatically and switches to a tested Android flow
 If you want the fully explicit path, follow the dedicated [Termux guide](./termux.md).
 
 :::warning Windows
-Native Windows is **not supported**. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run Hermes Agent from there. The install command above works inside WSL2.
+Native Windows is **not supported**.
+
+Do **not** paste the Unix `curl ... | bash` command into **PowerShell** or **CMD** — it is meant for a Unix shell (Linux, macOS, WSL2, Git Bash, or Termux).
+
+If you're on Windows:
+- install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)
+- open your **WSL2 terminal**
+- run the Linux install command there
+
+If you specifically need the Windows PowerShell installer script, use:
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
 :::
 
 ### What the Installer Does

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -22,7 +22,15 @@ If you're installing on a phone, see the dedicated [Termux guide](./termux.md) f
 :::
 
 :::tip Windows Users
+Do **not** run `curl ... | bash` in **PowerShell** or **CMD**.
+
 Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) first, then run the command above inside your WSL2 terminal.
+
+If you specifically want the Windows PowerShell installer script, use:
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
 :::
 
 After it finishes, reload your shell:


### PR DESCRIPTION
## Summary
Follow-up to #15142. Updates the `getting-started/installation` and `getting-started/quickstart` pages to explicitly warn Windows users against pasting the Unix `curl ... | bash` command into PowerShell or CMD. 

This prevents the UX confusion where users paste a Unix pipeline into PowerShell, which hangs or behaves unexpectedly because it is not a Unix shell.

## Test plan
- [x] verified updated text in installation docs
- [x] verified updated text in quickstart docs

🤖 Generated with [Claude Code](https://claude.com/code)