### PR TITLE
fix: guard against str model_extra in tool call normalization

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -315,7 +315,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 tc_provider_data: Dict[str, Any] = {}
                 extra = getattr(tc, "extra_content", None)
                 if extra is None and hasattr(tc, "model_extra"):
-                    extra = (tc.model_extra or {}).get("extra_content")
+                    extra = (tc.model_extra if isinstance(tc.model_extra, dict) else {}).get("extra_content")
                 if extra is not None:
                     if hasattr(extra, "model_dump"):
                         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5746,7 +5746,7 @@ class AIAgent:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)
                         if extra is None and hasattr(tc_delta, "model_extra"):
-                            extra = (tc_delta.model_extra or {}).get("extra_content")
+                            extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
                         if extra is not None:
                             if hasattr(extra, "model_dump"):
                                 extra = extra.model_dump()


### PR DESCRIPTION
## What

Fixes `AttributeError: 'str' object has no attribute 'get'` that crashes `normalize_response()` and causes every tool call to return `[error]`.

## Why

When certain OpenAI-compatible providers return a **string** for `model_extra` instead of a dict, the guard `(x or {})` fails — a non-empty string is truthy so `.get()` is called on the string and raises `AttributeError`. Observed with NVIDIA NIM + qwen3.5-397b.

## Fix

Replace falsy-fallback with explicit isinstance check in both paths:

```python
# Before
extra = (tc.model_extra or {}).get("extra_content")
# After
extra = (tc.model_extra if isinstance(tc.model_extra, dict) else {}).get("extra_content")
```

## Files changed
- `agent/transports/chat_completions.py` — non-streaming path (line 318)
- `run_agent.py` — streaming delta path (line 5749)