### PR TITLE
fix(google-workspace): defer PEP 604 unions so setup.py runs on Py3.9 (#14688)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -3,6 +3,14 @@
 Import-safe module with no dependencies — can be imported from anywhere
 without risk of circular imports.
 """
+# ``from __future__ import annotations`` (PEP 563) defers annotation
+# evaluation so PEP 604 unions (``X | None``) don't fire at import time on
+# Python 3.9.  This module is intentionally kept import-safe: skill scripts
+# (google-workspace ``setup.py``, others) invoke it via whatever ``python3``
+# the agent's terminal tool picks up, and macOS ships ``/usr/bin/python3`` =
+# 3.9 by default.  Without this, ``def f(x: Path | None = None)`` crashed
+# the skill setup flow (#14688).
+from __future__ import annotations
 
 import os
 from pathlib import Path

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -19,6 +19,11 @@ Usage:
   python google_api.py sheets append SHEET_ID RANGE --values '[[...]]'
   python google_api.py docs get DOC_ID
 """
+# ``from __future__ import annotations`` (PEP 563) defers annotation
+# evaluation so PEP 604 unions (``X | None``) don't fire at import time on
+# Python 3.9.  The agent's terminal tool routinely invokes this script via
+# the plain system ``python3``, which on macOS is still 3.9 (#14688).
+from __future__ import annotations
 
 import argparse
 import base64

--- a/tests/skills/test_py39_compat_google_workspace.py
+++ b/tests/skills/test_py39_compat_google_workspace.py
@@ -1,0 +1,158 @@
+"""Regression guard for #14688.
+
+macOS ships ``/usr/bin/python3`` = 3.9.  Agents' terminal tools routinely
+invoke ``python3 setup.py --check`` (the google-workspace skill's auth
+entry-point) via that system interpreter rather than Hermes' venv python,
+because ``SKILL.md`` hints are not always honoured by smaller local models.
+
+Before this guard, three files — ``hermes_constants.py`` (imported
+transitively) and the two skill scripts — declared annotations using PEP 604
+unions (``X | None``).  On Python 3.9 that syntax is evaluated at
+function-def time and raises ``TypeError: unsupported operand type(s) for |:
+'type' and 'NoneType'`` BEFORE the script ever reaches its try/except
+fallbacks.  Net effect: the agent saw a crash and interpreted it as "auth
+broken", ran setup from scratch, and looped.
+
+Fix: each of the affected files starts with ``from __future__ import
+annotations`` (PEP 563).  That converts every annotation in the file into a
+string, so ``Path | None`` never fires at import time and the module loads
+cleanly on Python 3.9 the same way it does on 3.10+.
+
+This test fails if a future edit drops the pragma from any of the three
+files — which would silently re-break macOS users with system-``python3``
+toolchains.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Files that MUST carry ``from __future__ import annotations`` so Python 3.9
+# (still the default interpreter on macOS) can import them without firing on
+# a PEP 604 union at def-time.  Keep this list pinned — expanding it should
+# be a deliberate act that updates this docstring too.
+_PY39_COMPAT_FILES = (
+    REPO_ROOT / "hermes_constants.py",
+    REPO_ROOT / "skills/productivity/google-workspace/scripts/setup.py",
+    REPO_ROOT / "skills/productivity/google-workspace/scripts/google_api.py",
+)
+
+
+def _has_future_annotations_import(path: Path) -> bool:
+    """Return True iff the module starts with ``from __future__ import annotations``.
+
+    Uses ``ast`` rather than a substring scan — a string literal mentioning
+    the pragma inside a docstring would otherwise pass the check.
+    """
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+        # ``from __future__`` imports must precede all non-docstring,
+        # non-import statements.  A missing import by the time we hit real
+        # code means the file is not protected.
+        if isinstance(node, (ast.Expr,)) and isinstance(node.value, ast.Constant):
+            # Module docstring — keep looking.
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module != "__future__":
+            return False
+        if isinstance(node, ast.Import):
+            return False
+    return False
+
+
+@pytest.mark.parametrize("path", _PY39_COMPAT_FILES, ids=lambda p: p.name)
+def test_file_has_future_annotations_import(path: Path) -> None:
+    assert path.exists(), f"missing file: {path}"
+    assert _has_future_annotations_import(path), (
+        f"{path.relative_to(REPO_ROOT)} dropped ``from __future__ import "
+        f"annotations``.  Python 3.9 users will hit TypeError on any PEP 604 "
+        f"union at module-load time — see #14688."
+    )
+
+
+@pytest.mark.parametrize("path", _PY39_COMPAT_FILES, ids=lambda p: p.name)
+def test_file_uses_pep_604_unions(path: Path) -> None:
+    """The future-import guard is only meaningful if the file actually uses
+    ``X | None`` style unions.  If every annotation is plain, the guard would
+    just be cosmetic and we'd prefer to know — update the pinned list above.
+    """
+    src = path.read_text()
+    # Syntactic check: any ``| None`` or ``| str`` etc. in annotation-ish
+    # context.  A dumb substring scan is fine here — we just want to confirm
+    # the module has SOMETHING worth deferring.  This prevents the pinned
+    # list from going stale if someone removes all unions from a file.
+    has_union_annotation = any(
+        token in src
+        for token in (" | None", " | str", " | Path", " | dict", " | list", " | int", " | bool")
+    )
+    assert has_union_annotation, (
+        f"{path.relative_to(REPO_ROOT)} no longer uses PEP 604 unions.  The "
+        f"future-annotations pragma is still harmless, but the pinned list "
+        f"in this test should be re-evaluated — does this file still need "
+        f"Py3.9 compat?"
+    )
+
+
+def test_hermes_constants_module_loads_and_behaves() -> None:
+    """End-to-end smoke: import the module and exercise the functions that
+    previously crashed at import time under Python 3.9.  Under 3.11 this
+    mostly proves we didn't break anything — the real 3.9 check is
+    ``test_file_has_future_annotations_import`` above, since CI does not
+    have a 3.9 runner.
+    """
+    import hermes_constants
+
+    # get_optional_skills_dir has the annotation from the original #14688
+    # traceback (``Path | None``).  It must still be callable with and
+    # without an argument.
+    result_none = hermes_constants.get_optional_skills_dir()
+    assert isinstance(result_none, Path)
+
+    override = Path("/tmp/hermes-test-skills")
+    result_override = hermes_constants.get_optional_skills_dir(default=override)
+    assert result_override == override
+
+    # parse_reasoning_effort also had a ``dict | None`` return annotation.
+    assert hermes_constants.parse_reasoning_effort("") is None
+    assert hermes_constants.parse_reasoning_effort("none") == {"enabled": False}
+    assert hermes_constants.parse_reasoning_effort("high") == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+
+@pytest.mark.parametrize("path", _PY39_COMPAT_FILES, ids=lambda p: p.name)
+def test_file_parses_as_python_3_9(path: Path) -> None:
+    """Each guarded file must parse under Python 3.9 grammar.
+
+    ``ast.parse(..., feature_version=(3, 9))`` tells the Python parser to
+    reject syntax introduced after 3.9 — match/case, ``except*``, PEP 695
+    type params, etc.  Without this, using ``py_compile`` under the CI
+    interpreter (3.11) would pass even for files that crash on a macOS
+    system ``python3`` (still 3.9) — which is exactly the class of bug
+    #14688 reported.
+
+    Note: PEP 604 ``X | None`` in an annotation is *valid 3.9 grammar* —
+    the crash is at runtime when the annotation is evaluated.  So this
+    check is intentionally paired with ``test_file_has_future_annotations_import``:
+    the parser guards against Py3.10+ syntax that the pragma can't save,
+    the AST import-check guards against the pragma being removed.
+
+    Credit: @Copilot flagged on #15158 that the prior ``py_compile``-only
+    version gave a false sense of 3.9 safety.
+    """
+    source = path.read_text()
+    try:
+        ast.parse(source, filename=str(path), feature_version=(3, 9))
+    except SyntaxError as e:
+        pytest.fail(
+            f"{path.relative_to(REPO_ROOT)} is not valid Python 3.9 syntax "
+            f"(would crash on macOS /usr/bin/python3): {e}"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes `#14688`: on macOS, the agent's terminal tool invokes `python3 scripts/setup.py --check` (the google-workspace skill's auth entry-point) via the system interpreter `/usr/bin/python3` = 3.9.  The script crashes at import time on `def get_optional_skills_dir(default: Path | None = None)` with:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

PEP 604 union syntax evaluates at function-def time on Py3.9 — the `try/except ModuleNotFoundError` fallback in `setup.py` never runs.  The agent sees the crash, interprets it as "auth broken", and re-runs setup from scratch in a loop.

SKILL.md does tell agents to use `$HERMES_HOME/hermes-agent/venv/bin/python`, but smaller local models (e.g. Qwen3.5-35B-A3B-4bit) routinely simplify that down to plain `python3`, reproducing the bug on every call.

## Fix

Add `from __future__ import annotations` (PEP 563) to the three affected files.  This converts every annotation to a string so the PEP 604 unions never fire at module-load time.  Py3.10+ behavior is unchanged.

**Why this file set** (grep'd exhaustively for PEP 604 syntax):
- `hermes_constants.py` — shared infra with 5 `X | None` sites, including two module-level assignments (`_wsl_detected: bool | None = None`, `_container_detected: bool | None = None`) that evaluate eagerly even without the future import.
- `skills/productivity/google-workspace/scripts/setup.py` — direct crash site; also uses `tuple[str, str | None]` at line 239.
- `skills/productivity/google-workspace/scripts/google_api.py` — imported during `setup.py --check`; uses `str | None` and `dict | None` on `_gws_binary`/`_run_gws` (called out by @thedavidweng in the issue comments).

`gws_bridge.py` has no PEP 604 syntax — verified via AST-level scan, no pragma needed.

## Related Issue

Fixes #14688

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `from __future__ import annotations` to `hermes_constants.py`, `skills/productivity/google-workspace/scripts/setup.py`, and `skills/productivity/google-workspace/scripts/google_api.py` with an inline comment linking back to #14688 so a future refactor doesn't drop the pragma without thinking.
- New regression test file `tests/skills/test_py39_compat_google_workspace.py` with 4 classes of assertion:
  1. **AST check** that each file starts with `from __future__ import annotations`.  Uses `ast.parse` walk rather than a substring scan — a docstring mentioning the pragma wouldn't pass.
  2. **PEP 604 usage check** — each file still contains at least one `X | None` style annotation.  If a future edit strips them all, the pragma becomes cosmetic and the pinned list should be re-evaluated; the test will flag that.
  3. **Smoke test** that `hermes_constants` imports cleanly and the two functions whose annotations were problematic (`get_optional_skills_dir`, `parse_reasoning_effort`) still return expected values.
  4. **py_compile** on each file — catches Py3.10+-only syntax beyond PEP 604 (e.g. match/case) that the pragma wouldn't cover.

All 8 new tests pass.  All 14 existing `tests/skills/test_google_oauth_setup.py` + `test_google_workspace_api.py` tests still pass — no runtime behavior change under Py3.11+.

## Verification

```bash
$ python3 -m pytest tests/skills/test_py39_compat_google_workspace.py tests/skills/test_google_oauth_setup.py tests/skills/test_google_workspace_api.py -v
...
================== 22 passed, 1 warning in 0.09s ==================
```

Proof that the pragma does what it claims (annotations become strings rather than being evaluated eagerly):

```python
# WITH `from __future__ import annotations`
ann = get_optional_skills_dir.__annotations__
# {'default': 'Path | None', 'return': 'Path'} — strings, never evaluated

# WITHOUT the future import (the pre-fix state)
# __annotations__['default'] is a UnionType object, which requires
# Py3.10+ to even CONSTRUCT — hence the TypeError on 3.9.
```

## Why not the reporter's second proposed fix (parents[4] path)?

The reporter diagnosed two root causes; I only applied the real one.

Their claim was that `Path(__file__).resolve().parents[4]` in `setup.py`'s fallback resolves to `~/.hermes/` when `hermes_constants.py` actually lives at `~/.hermes/hermes-agent/hermes_constants.py`, so the fallback `sys.path.insert` points at the wrong directory.

Verified locally this is **not** the case: for `hermes-agent/skills/productivity/google-workspace/scripts/setup.py`, `parents[0..4]` resolves to `scripts/ → google-workspace/ → productivity/ → skills/ → hermes-agent/` — exactly the directory containing `hermes_constants.py`.  The reporter's own traceback shows `hermes_constants.py` **being found** at the expected path before crashing with `TypeError` at line 60; that's inconsistent with a misrouted fallback.  The crash is purely the Py3.9 type-evaluation failure.

Adding a needless `/ \"hermes-agent\"` suffix would break the fallback on other installation layouts.  Leaving that code path alone.

## Out of scope for this PR (possible follow-ups)

- **Auto-reexec into the Hermes venv python** when Py<3.10 is detected at script entry — ergonomic defense-in-depth.  The current fix makes the crash go away for the reported case; reexec would also handle files that grow non-annotation Py3.10+ syntax in future (e.g. `match/case`).  Separate change.
- **Broader sweep** of other skills for the same `X | None` pattern — this PR ships the narrow google-workspace fix.

## Test plan

- [x] New tests pass
- [x] Existing google-workspace tests pass (14 tests)
- [x] py_compile succeeds on all three modified files
- [x] Proved PEP 563 deferral is active: `get_optional_skills_dir.__annotations__['default']` is the string `'Path | None'`, not a `UnionType`
- [x] `hermes_constants.get_optional_skills_dir()` and `parse_reasoning_effort()` still return expected values