### PR TITLE
fix: eliminate duplicate checkpoint entries and JSON-unsafe coercion

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -951,13 +951,9 @@ class BatchRunner:
                     root_logger.setLevel(original_level)
         
         # Aggregate all batch statistics and update checkpoint
-        all_completed_prompts = list(completed_prompts_set)
         total_reasoning_stats = {"total_assistant_turns": 0, "turns_with_reasoning": 0, "turns_without_reasoning": 0}
-        
+
         for batch_result in results:
-            # Add newly completed prompts
-            all_completed_prompts.extend(batch_result.get("completed_prompts", []))
-            
             # Aggregate tool stats
             for tool_name, stats in batch_result.get("tool_stats", {}).items():
                 if tool_name not in total_tool_stats:
@@ -977,7 +973,7 @@ class BatchRunner:
         
         # Save final checkpoint (best-effort; incremental writes already happened)
         try:
-            checkpoint_data["completed_prompts"] = all_completed_prompts
+            checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
             print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")

--- a/model_tools.py
+++ b/model_tools.py
@@ -427,9 +427,9 @@ def _coerce_number(value: str, integer_only: bool = False):
         f = float(value)
     except (ValueError, OverflowError):
         return value
-    # Guard against inf/nan before int() conversion
+    # Guard against inf/nan — not JSON-serializable, keep original string
     if f != f or f == float("inf") or f == float("-inf"):
-        return f
+        return value
     # If it looks like an integer (no fractional part), return int
     if f == int(f):
         return int(f)


### PR DESCRIPTION
## Summary
- **`batch_runner.py`**: `completed_prompts_set` is fully populated via incremental updates during result collection, so the subsequent `extend()` over `results` re-added every completed prompt index a second time. Removed the redundant variable and `extend` call; the final checkpoint now writes `sorted(completed_prompts_set)` directly.
- **`model_tools.py`**: `_coerce_number` returned Python `float('inf')` / `float('nan')` for inf/nan strings instead of the original string. `json.dumps` raises `ValueError` for these values, so any tool call where the model emitted `"inf"` or `"nan"` for a numeric parameter would crash at serialization. Changed the guard to return the original string, matching the function's documented contract.

## Test plan
- [ ] `pytest tests/test_batch_runner_checkpoint.py` — all checkpoint read/write tests pass
- [ ] `pytest tests/test_model_tools.py tests/test_model_tools_async_bridge.py` — all tool coercion and dispatch tests pass
- [ ] Manually confirm batch runner resume no longer produces duplicate indices in checkpoint file after a multi-batch run
- [ ] Confirm that passing `"inf"` / `"nan"` as a numeric tool argument no longer raises `ValueError` during JSON serialization

