### PR TITLE
fix(email): add required Date header to outbound mail

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -28,6 +28,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
+from email.utils import formatdate
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -504,6 +505,7 @@ class EmailAdapter(BasePlatformAdapter):
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
 
+        msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
@@ -586,6 +588,7 @@ class EmailAdapter(BasePlatformAdapter):
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
 
+        msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -488,6 +488,7 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["Subject"], "Re: Project question")
             self.assertEqual(send_call["In-Reply-To"], "<original@test.com>")
             self.assertEqual(send_call["References"], "<original@test.com>")
+            self.assertIn("Date", send_call)
 
     def test_reply_does_not_double_re(self):
         """If subject already has Re:, don't add another."""
@@ -519,6 +520,7 @@ class TestThreadContext(unittest.TestCase):
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
+            self.assertIn("Date", send_call)
 
 
 class TestSendMethods(unittest.TestCase):
@@ -889,6 +891,11 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertEqual(result["platform"], "email")
             _, kwargs = mock_server.starttls.call_args
             self.assertIsInstance(kwargs["context"], ssl.SSLContext)
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Hermes Agent")
+            self.assertIn("Date", send_call)
+            self.assertEqual(send_call["To"], "user@test.com")
+            self.assertEqual(send_call["From"], "hermes@test.com")
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1047,6 +1047,7 @@ async def _send_email(extra, chat_id, message):
     """Send via SMTP (one-shot, no persistent connection needed)."""
     import smtplib
     from email.mime.text import MIMEText
+    from email.utils import formatdate
 
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")
@@ -1064,6 +1065,7 @@ async def _send_email(extra, chat_id, message):
         msg["From"] = address
         msg["To"] = chat_id
         msg["Subject"] = "Hermes Agent"
+        msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls(context=ssl.create_default_context())


### PR DESCRIPTION
## What does this PR do?

Outbound Hermes emails could appear to send successfully via SMTP but never reach the recipient. The receiving mail filter later bounced them with:

> Undeliverable mail, invalid header section — missing required header field: "Date"

The three outbound code paths in the email gateway and `send_message_tool` built `MIMEMultipart` / `MIMEText` messages without ever setting a `Date` header. SMTP accepted the message locally (so the send looked successful), but the downstream filter rejected it during validation. RFC 5322 requires a `Date` header.

This PR sets `msg["Date"] = email.utils.formatdate(localtime=True)` in the three affected outbound paths. `Message-ID` was already being set, so it is not touched.

## Related Issue

Fixes #15160

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/email.py`: set `msg["Date"]` in both `EmailAdapter._send_email` paths (text reply and attachment send). Added `from email.utils import formatdate`.
- `tools/send_message_tool.py`: set `msg["Date"]` in the standalone `_send_email` function.
- `tests/gateway/test_email.py`: added `assertIn("Date", send_call)` to the three affected send tests.

## How to Test

1. Configure the email platform (`EMAIL_ADDRESS`, `EMAIL_PASSWORD`, `EMAIL_SMTP_HOST`, `EMAIL_IMAP_HOST`) and run the gateway.
2. Trigger an outbound reply from Hermes — confirm the outgoing message has a `Date` header and is delivered (no postmaster bounce).
3. Trigger an outbound send with an attachment (e.g. a generated voice message) — confirm the same.
4. Run the targeted test suite: `uv run pytest tests/gateway/test_email.py -q` — 54 passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Linux, kernel 5.14.0), Python 3.13.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (stdlib `email.utils` only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — the bug evidence (postmaster bounce) is attached to the linked issue #15160.
