### PR TITLE
feat(memory): add Membase provider

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8115,7 +8115,7 @@ Examples:
         description=(
             "Set up and manage external memory provider plugins.\n\n"
             "Available providers: honcho, openviking, mem0, hindsight,\n"
-            "holographic, retaindb, byterover.\n\n"
+            "holographic, retaindb, byterover, supermemory, membase.\n\n"
             "Only one external provider can be active at a time.\n"
             "Built-in memory (MEMORY.md/USER.md) is always active."
         ),

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -55,6 +56,23 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
+_IMPORT_NAMES = {
+    "honcho-ai": "honcho",
+    "mem0ai": "mem0",
+    "hindsight-client": "hindsight_client",
+    "hindsight-all": "hindsight",
+    "hermes-membase": "membase_hermes",
+}
+
+
+def _import_name_for_dependency(dep: str) -> str:
+    """Return the import name that should satisfy a pip requirement string."""
+    requirement = str(dep).split(";", 1)[0].strip()
+    base = re.split(r"[<>=!~]", requirement, 1)[0].strip()
+    base = base.split("[", 1)[0].strip()
+    return _IMPORT_NAMES.get(base, base.replace("-", "_"))
+
+
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
@@ -78,18 +96,10 @@ def _install_dependencies(provider_name: str) -> None:
     if not pip_deps:
         return
 
-    # pip name → import name mapping for packages where they differ
-    _IMPORT_NAMES = {
-        "honcho-ai": "honcho",
-        "mem0ai": "mem0",
-        "hindsight-client": "hindsight_client",
-        "hindsight-all": "hindsight",
-    }
-
     # Check which packages are missing
     missing = []
     for dep in pip_deps:
-        import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
+        import_name = _import_name_for_dependency(dep)
         try:
             __import__(import_name)
         except ImportError:
@@ -110,7 +120,7 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         subprocess.run(
-            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + missing,
+            [uv_path, "pip", "install", "--no-config", "--python", sys.executable, "--quiet"] + missing,
             check=True, timeout=120,
             capture_output=True,
         )

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -244,7 +244,7 @@ TIPS = [
     # --- Plugins ---
     "Three plugin types: general (tools/hooks), memory providers, and context engines.",
     "hermes plugins install owner/repo installs plugins directly from GitHub.",
-    "8 external memory providers available: Honcho, OpenViking, Mem0, Hindsight, and more.",
+    "9 external memory providers available: Honcho, OpenViking, Mem0, Hindsight, Membase, and more.",
     "Plugin hooks include pre/post_tool_call, pre/post_llm_call, and transform_terminal_output for output canonicalization.",
 
     # --- Miscellaneous ---
@@ -344,5 +344,4 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-
 

--- a/plugins/memory/membase/README.md
+++ b/plugins/memory/membase/README.md
@@ -1,0 +1,108 @@
+# Membase Memory Provider
+
+Persistent long-term memory for Hermes Agent using Membase's hybrid vector
+search, knowledge graph, and wiki retrieval.
+
+The implementation lives in the
+[`hermes-membase`](https://pypi.org/project/hermes-membase/) package. This
+directory is a thin Hermes shim that registers the provider and installs the
+package through `hermes memory setup`.
+
+## Requirements
+
+- Python 3.11+
+- `hermes-membase>=0.1.5`
+- Membase OAuth login
+
+## Setup
+
+```bash
+hermes memory setup    # select "membase"
+hermes membase login   # OAuth PKCE login
+```
+
+Or configure manually:
+
+```bash
+uv pip install --python "$(which python)" "hermes-membase>=0.1.5"
+hermes config set memory.provider membase
+hermes membase login
+```
+
+## Config
+
+Config file: `$HERMES_HOME/membase.json`
+
+Credentials file: `$HERMES_HOME/credentials/membase.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `apiUrl` | `https://api.membase.so` | Membase API URL. Override for self-hosted deployments. |
+| `tokenFile` | `$HERMES_HOME/credentials/membase.json` | OAuth token cache path. |
+| `autoRecall` | `false` | Inject relevant memories before each response. |
+| `autoWikiRecall` | `false` | Inject relevant wiki documents before each response. |
+| `autoCapture` | `true` | Automatically store conversations in Membase. |
+| `mirrorBuiltin` | `true` | Mirror Hermes built-in `MEMORY.md` writes into Membase. |
+| `maxRecallChars` | `4000` | Max characters of recalled context per turn. |
+| `debug` | `false` | Enable verbose debug logging. |
+
+## CLI Commands
+
+```bash
+hermes membase login
+hermes membase logout
+hermes membase status
+hermes membase resync
+hermes membase resync --dry-run
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `membase_search` | Search memories by semantic similarity with optional date and source filters. |
+| `membase_store` | Save important conversational context to long-term memory. |
+| `membase_forget` | Delete a memory through a confirmation flow. |
+| `membase_profile` | Retrieve user profile context and related memories. |
+| `membase_search_wiki` | Search wiki documents and return full document content. |
+| `membase_add_wiki` | Create a wiki document from markdown content. |
+| `membase_update_wiki` | Update an existing wiki document. |
+| `membase_delete_wiki` | Delete a wiki document through a confirmation flow. |
+
+## Behavior
+
+When enabled, Hermes can:
+
+- prefetch relevant memory and wiki context before turns
+- expose explicit tools for memory and wiki search/write/delete operations
+- capture user conversation context asynchronously
+- mirror built-in `MEMORY.md` writes to Membase in the background
+
+## Troubleshooting
+
+If `hermes membase` is unavailable, make sure the provider is active:
+
+```bash
+hermes config set memory.provider membase
+```
+
+If Hermes says Membase is disconnected, run:
+
+```bash
+hermes membase login
+```
+
+If the provider loads but the implementation package is missing, install it:
+
+```bash
+uv pip install --python "$(which python)" "hermes-membase>=0.1.5"
+```
+
+Then restart Hermes so the real provider implementation is imported.
+
+## Links
+
+- [Membase](https://membase.so)
+- [Hermes connector docs](https://docs.membase.so/connectors/hermes)
+- [hermes-membase source](https://github.com/aristoapp/hermes-membase)
+- [hermes-membase on PyPI](https://pypi.org/project/hermes-membase/)

--- a/plugins/memory/membase/__init__.py
+++ b/plugins/memory/membase/__init__.py
@@ -1,0 +1,130 @@
+"""Membase memory provider shim.
+
+The provider implementation lives in the ``hermes-membase`` PyPI package.
+This bundled shim keeps Hermes discovery light while allowing
+``hermes memory setup`` to install the package on demand.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+try:
+    from membase_hermes.provider import MembaseMemoryProvider as _MembaseMemoryProvider
+except ModuleNotFoundError as exc:
+    if exc.name != "membase_hermes":
+        raise
+    _MembaseMemoryProvider = None
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class _MembaseSetupProvider(MemoryProvider):
+    """Minimal setup-time provider used before hermes-membase is installed."""
+
+    @property
+    def name(self) -> str:
+        return "membase"
+
+    def is_available(self) -> bool:
+        # Keep the provider visible in `hermes memory setup`; credentials are
+        # handled by OAuth after setup via `hermes membase login`.
+        return True
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "apiUrl",
+                "description": "Membase API URL (press enter to accept default)",
+                "required": False,
+                "default": "https://api.membase.so",
+                "secret": False,
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        home = Path(hermes_home).expanduser()
+        config_path = home / "membase.json"
+        token_path = home / "credentials" / "membase.json"
+        mirror_index_path = home / "plugins" / "membase" / "mirror_index.json"
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        mirror_index_path.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: Dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                raw = json.loads(config_path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    existing = raw
+            except Exception:
+                existing = {}
+
+        api_url = str(values.get("apiUrl", existing.get("apiUrl", "https://api.membase.so"))).strip()
+        existing.update(
+            {
+                "apiUrl": api_url or "https://api.membase.so",
+                "clientId": existing.get("clientId", ""),
+                "tokenFile": str(token_path),
+                "autoRecall": _as_bool(existing.get("autoRecall"), False),
+                "autoWikiRecall": _as_bool(existing.get("autoWikiRecall"), False),
+                "autoCapture": _as_bool(existing.get("autoCapture"), True),
+                "mirrorBuiltin": _as_bool(existing.get("mirrorBuiltin"), True),
+                "maxRecallChars": _as_int(existing.get("maxRecallChars"), 4000),
+                "debug": _as_bool(existing.get("debug"), False),
+            }
+        )
+        config_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        if not token_path.exists():
+            token_path.write_text('{"accessToken": "", "refreshToken": ""}\n', encoding="utf-8")
+        if not mirror_index_path.exists():
+            mirror_index_path.write_text("{}\n", encoding="utf-8")
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        return None
+
+    def system_prompt_block(self) -> str:
+        return (
+            "<membase-notice>\n"
+            "Membase requires the `hermes-membase` package. Run `hermes memory setup` "
+            "or `uv pip install --python $(which python) \"hermes-membase>=0.1.5\"`, "
+            "then run `hermes membase login`.\n"
+            "</membase-notice>"
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        return "Membase requires hermes-membase>=0.1.5. Run `hermes memory setup` and `hermes membase login`."
+
+
+MembaseMemoryProvider = _MembaseMemoryProvider or _MembaseSetupProvider
+
+
+def register(ctx: Any) -> None:
+    if hasattr(ctx, "register_memory_provider"):
+        ctx.register_memory_provider(MembaseMemoryProvider())

--- a/plugins/memory/membase/cli.py
+++ b/plugins/memory/membase/cli.py
@@ -1,0 +1,30 @@
+"""CLI shim for the Membase memory provider."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+try:
+    from membase_hermes.plugin.cli import membase_command, register_cli
+except ModuleNotFoundError as exc:
+    if exc.name != "membase_hermes":
+        raise
+
+    def register_cli(subparser: argparse.ArgumentParser) -> None:
+        subparser.description = (
+            "Membase CLI is available after installing hermes-membase. "
+            "Run `hermes memory setup` first."
+        )
+        subparser.set_defaults(func=membase_command)
+
+    def membase_command(args: argparse.Namespace) -> None:
+        raise SystemExit(
+            "Membase requires hermes-membase>=0.1.5. "
+            "Run `hermes memory setup` to install dependencies, then `hermes membase login`."
+        )
+
+
+def register(ctx: Any) -> None:
+    """Compat shim for plugin hosts that call cli.register(ctx) directly."""
+    return None

--- a/plugins/memory/membase/plugin.yaml
+++ b/plugins/memory/membase/plugin.yaml
@@ -1,0 +1,5 @@
+name: membase
+version: 1.0.0
+description: "Membase - persistent memory with OAuth, memory/wiki recall, auto-capture, and built-in memory mirroring."
+pip_dependencies:
+  - "hermes-membase>=0.1.5"

--- a/tests/hermes_cli/test_memory_setup_dependencies.py
+++ b/tests/hermes_cli/test_memory_setup_dependencies.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from hermes_cli.memory_setup import _import_name_for_dependency, _install_dependencies
+
+
+def test_import_name_for_dependency_handles_versioned_requirements():
+    assert _import_name_for_dependency("hindsight-client>=0.4.22") == "hindsight_client"
+    assert _import_name_for_dependency("hermes-membase>=0.1.5") == "membase_hermes"
+
+
+def test_import_name_for_dependency_handles_extras_and_plain_names():
+    assert _import_name_for_dependency("some-package[extra]>=1.2") == "some_package"
+    assert _import_name_for_dependency("supermemory") == "supermemory"
+    assert _import_name_for_dependency("marker-package; python_version >= '3.11'") == "marker_package"
+
+
+def test_install_dependencies_ignores_repo_uv_config(tmp_path, monkeypatch):
+    plugin_dir = tmp_path / "membase"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        "pip_dependencies:\n"
+        "  - example-missing-package>=1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("plugins.memory.find_provider_dir", lambda name: plugin_dir)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    _install_dependencies("membase")
+
+    cmd, kwargs = calls[0]
+    assert cmd[:4] == ["/usr/bin/uv", "pip", "install", "--no-config"]
+    assert "--python" in cmd
+    assert "example-missing-package>=1" in cmd
+    assert kwargs["check"] is True

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -76,7 +76,7 @@ Speech-to-text supports three providers: local Whisper (free, runs on-device), G
 ## Memory & Personalization
 
 - **[Built-in Memory](/docs/user-guide/features/memory)** — Persistent, curated memory via `MEMORY.md` and `USER.md` files. The agent maintains bounded stores of personal notes and user profile data that survive across sessions.
-- **[Memory Providers](/docs/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Seven providers are supported: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), and ByteRover (CLI-based).
+- **[Memory Providers](/docs/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Nine providers are supported: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), Supermemory (cloud memory), and Membase (memory + wiki retrieval).
 
 ## Messaging Platforms
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -56,6 +56,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes pairing` | Approve or revoke messaging pairing codes. |
 | `hermes skills` | Browse, install, publish, audit, and configure skills. |
 | `hermes honcho` | Manage Honcho cross-session memory integration. |
+| `hermes membase` | Manage Membase memory provider OAuth, status, and mirror resync. |
 | `hermes memory` | Configure external memory provider. |
 | `hermes acp` | Run Hermes as an ACP server for editor integration. |
 | `hermes mcp` | Manage MCP server configurations and run Hermes as an MCP server. |
@@ -622,13 +623,30 @@ Subcommands:
 | `sync` | Sync Honcho config to all existing profiles (creates missing host blocks). |
 | `migrate` | Step-by-step migration guide from openclaw-honcho to Hermes Honcho. |
 
+## `hermes membase`
+
+```bash
+hermes membase <subcommand>
+```
+
+Manage the Membase memory provider. This command is provided by the Membase memory provider plugin and is only available when `memory.provider` is set to `membase` in your config.
+
+Subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `login [--api-url URL] [--port PORT]` | Login to Membase with OAuth PKCE. |
+| `logout` | Remove stored Membase OAuth tokens. |
+| `status` | Check Membase API connectivity and profile status. |
+| `resync [--memory-file PATH] [--mirror-index PATH] [--dry-run]` | Rebuild the local mirror index from `MEMORY.md`; `--dry-run` previews without writing. |
+
 ## `hermes memory`
 
 ```bash
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory, membase. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
 
 Subcommands:
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Membase"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, membase
 ```
 
 ## How It Works
@@ -522,6 +522,61 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 ---
 
+### Membase
+
+Persistent long-term memory with OAuth login, hybrid vector search, knowledge graph extraction, wiki retrieval, auto-capture, and built-in `MEMORY.md` mirroring.
+
+| | |
+|---|---|
+| **Best for** | Users who want memory and wiki retrieval across Hermes and other agents with OAuth-based setup |
+| **Requires** | `hermes-membase>=0.1.5` + Membase OAuth login |
+| **Data storage** | Membase Cloud or self-hosted |
+| **Cost** | Membase pricing / self-hosted |
+
+**Tools (8):** `membase_search` (semantic memory search with date/source filters), `membase_store` (save explicit memories), `membase_forget` (delete memories with confirmation), `membase_profile` (profile + related memories), `membase_search_wiki` (search wiki docs), `membase_add_wiki` (create wiki docs), `membase_update_wiki` (update wiki docs), `membase_delete_wiki` (delete wiki docs with confirmation)
+
+**Setup:**
+```bash
+hermes memory setup    # select "membase"
+hermes membase login   # OAuth PKCE login
+```
+
+Or manually:
+
+```bash
+uv pip install --python "$(which python)" "hermes-membase>=0.1.5"
+hermes config set memory.provider membase
+hermes membase login
+```
+
+**Config:** `$HERMES_HOME/membase.json`
+
+**Credentials:** `$HERMES_HOME/credentials/membase.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `apiUrl` | `https://api.membase.so` | Membase API URL. Override for self-hosted deployments. |
+| `tokenFile` | `$HERMES_HOME/credentials/membase.json` | OAuth token cache path. |
+| `autoRecall` | `false` | Inject relevant memories before each response. |
+| `autoWikiRecall` | `false` | Inject relevant wiki documents before each response. |
+| `autoCapture` | `true` | Automatically store conversations in Membase. |
+| `mirrorBuiltin` | `true` | Mirror Hermes built-in memory writes into Membase. |
+| `maxRecallChars` | `4000` | Max characters of recalled context per turn. |
+| `debug` | `false` | Enable verbose debug logging. |
+
+**Environment variables:** none required. Membase uses OAuth 2.0 with PKCE and stores rotating tokens in `$HERMES_HOME/credentials/membase.json`.
+
+**Key features:**
+- Hybrid vector search plus knowledge graph extraction
+- Memory and wiki tools in one provider
+- Background auto-capture with short-message filtering
+- Built-in `MEMORY.md` mirroring for cross-session persistence
+- OAuth setup with no API keys to copy into `.env`
+
+**Support:** [Membase docs](https://docs.membase.so/connectors/hermes) · [GitHub](https://github.com/aristoapp/hermes-membase)
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -534,13 +589,14 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **Membase** | Cloud/Self-hosted | Membase pricing / self-hosted | 8 | `hermes-membase` | Memory + wiki retrieval + built-in memory mirroring |
 
 ## Profile Isolation
 
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory, Membase) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -209,7 +209,7 @@ memory:
 
 ## External Memory Providers
 
-For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 8 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, and Supermemory.
+For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 9 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, and Membase.
 
 External providers run **alongside** built-in memory (never replacing it) and add capabilities like knowledge graphs, semantic search, automatic fact extraction, and cross-session user modeling.
 

--- a/website/docs/user-guide/features/overview.md
+++ b/website/docs/user-guide/features/overview.md
@@ -39,7 +39,7 @@ Hermes Agent includes a rich set of capabilities that extend far beyond basic ch
 - **[Provider Routing](provider-routing.md)** — Fine-grained control over which AI providers handle your requests. Optimize for cost, speed, or quality with sorting, whitelists, blacklists, and priority ordering.
 - **[Fallback Providers](fallback-providers.md)** — Automatic failover to backup LLM providers when your primary model encounters errors, including independent fallback for auxiliary tasks like vision and compression.
 - **[Credential Pools](credential-pools.md)** — Distribute API calls across multiple keys for the same provider. Automatic rotation on rate limits or failures.
-- **[Memory Providers](memory-providers.md)** — Plug in external memory backends (Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover) for cross-session user modeling and personalization beyond the built-in memory system.
+- **[Memory Providers](memory-providers.md)** — Plug in external memory backends (Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Membase) for cross-session user modeling and personalization beyond the built-in memory system.
 - **[API Server](api-server.md)** — Expose Hermes as an OpenAI-compatible HTTP endpoint. Connect any frontend that speaks the OpenAI format — Open WebUI, LobeChat, LibreChat, and more.
 - **[IDE Integration (ACP)](acp.md)** — Use Hermes inside ACP-compatible editors such as VS Code, Zed, and JetBrains. Chat, tool activity, file diffs, and terminal commands render inside your editor.
 - **[RL Training](rl-training.md)** — Generate trajectory data from agent sessions for reinforcement learning and model fine-tuning.


### PR DESCRIPTION
## What does this PR do?

Adds a bundled Membase memory provider shim for Hermes.

The actual provider implementation lives in the [`hermes-membase`](https://pypi.org/project/hermes-membase/) PyPI package. This keeps the upstream Hermes integration lightweight while allowing `hermes memory setup` to discover Membase, install `hermes-membase>=0.1.5`, register the provider, expose the `hermes membase` CLI, and document setup/usage.

Links:
- Membase: https://membase.so
- Hermes connector docs: https://docs.membase.so/connectors/hermes
- Provider implementation source: https://github.com/aristoapp/hermes-membase
- PyPI package: https://pypi.org/project/hermes-membase/

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `plugins/memory/membase/` with provider registration shim, CLI shim, `plugin.yaml`, and README.
- Add dependency import-name handling for versioned pip requirements such as `hermes-membase>=0.1.5`.
- Install memory plugin dependencies with `uv pip install --no-config` so repo-level uv settings such as `exclude-newer` do not block newly released provider packages.
- Add Membase to memory provider docs, CLI docs, feature overview, integrations overview, and provider counts.
- Add tests for dependency import-name parsing and install command behavior.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_memory_setup_dependencies.py -q`
2. `python -m py_compile hermes_cli/memory_setup.py plugins/memory/membase/__init__.py plugins/memory/membase/cli.py`
3. `npm run build` in `website/`
4. Manual smoke:
   - verify `hermes memory --help` lists `membase`
   - verify the missing-package fallback provider loads before `hermes-membase` is installed
   - verify dependency install installs `hermes-membase>=0.1.5`
   - verify `load_memory_provider("membase")` returns `membase 8`
   - verify `hermes membase --help` and `hermes membase status`

Full suite was attempted locally on macOS, but unrelated existing/platform failures remain outside this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
