### PR TITLE
feat: add gateway footer slash command

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    "response_footer": False,
 }
 
 # ---------------------------------------------------------------------------
@@ -50,6 +51,7 @@ _TIER_HIGH = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,  # follow global
+    "response_footer": False,
 }
 
 _TIER_MEDIUM = {
@@ -182,7 +184,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in ("show_reasoning", "streaming"):
+    if setting in ("show_reasoning", "streaming", "response_footer"):
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3745,6 +3745,9 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical == "footer":
+            return await self._handle_footer_command(event)
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
@@ -4664,6 +4667,13 @@ class GatewayRunner:
                     else:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+
+            response = self._maybe_append_response_footer(
+                response,
+                agent_result,
+                source,
+                session_key,
+            )
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -5976,6 +5986,146 @@ class GatewayRunner:
         if hasattr(raw, "guild") and raw.guild:
             return raw.guild.id
         return None
+
+    @staticmethod
+    def _format_response_footer_enabled(enabled: bool) -> str:
+        return "ON" if enabled else "OFF"
+
+    def _response_footer_reasoning_label(self, session_key: str | None) -> str:
+        reasoning_config = None
+        session_overrides = getattr(self, "_session_reasoning_overrides", None)
+        if session_key and isinstance(session_overrides, dict):
+            reasoning_config = session_overrides.get(session_key)
+        if reasoning_config is None:
+            resolver = getattr(self, "_resolve_reasoning_config", None)
+            if callable(resolver):
+                reasoning_config = resolver(session_key)
+        if reasoning_config is None:
+            reasoning_config = getattr(self, "_reasoning_config", None)
+        if not reasoning_config:
+            return "default"
+        if reasoning_config.get("enabled") is False:
+            return "none"
+        return str(reasoning_config.get("effort") or "medium")
+
+    def _maybe_append_response_footer(
+        self,
+        response: Optional[str],
+        agent_result: Optional[Dict[str, Any]],
+        source: SessionSource,
+        session_key: str | None,
+    ) -> Optional[str]:
+        if not response or not isinstance(agent_result, dict):
+            return response
+
+        user_config = _load_gateway_config()
+        platform_key = _platform_config_key(source.platform)
+        try:
+            from gateway.display_config import resolve_display_setting
+
+            footer_enabled = bool(
+                resolve_display_setting(user_config, platform_key, "response_footer", False)
+            )
+        except Exception:
+            footer_enabled = False
+        if not footer_enabled:
+            return response
+
+        input_tokens = agent_result.get("turn_input_tokens")
+        if input_tokens is None:
+            input_tokens = agent_result.get("input_tokens")
+        output_tokens = agent_result.get("turn_output_tokens")
+        if output_tokens is None:
+            output_tokens = agent_result.get("output_tokens")
+        total_tokens = agent_result.get("turn_total_tokens")
+        if total_tokens is None:
+            total_tokens = agent_result.get("total_tokens")
+
+        try:
+            input_tokens = int(input_tokens or 0)
+            output_tokens = int(output_tokens or 0)
+            total_tokens = int(total_tokens or 0)
+        except (TypeError, ValueError):
+            return response
+
+        if total_tokens <= 0 and input_tokens <= 0 and output_tokens <= 0:
+            return response
+        if total_tokens <= 0:
+            total_tokens = input_tokens + output_tokens
+
+        model_name = (
+            str(agent_result.get("model") or "").strip()
+            or _resolve_gateway_model(user_config)
+            or "unknown"
+        )
+        reasoning_label = self._response_footer_reasoning_label(session_key)
+        footer = (
+            "---\n"
+            f"model: `{model_name}`\n"
+            f"reasoning: `{reasoning_label}`\n"
+            f"tokens: `in {input_tokens:,} / out {output_tokens:,} / total {total_tokens:,}`"
+        )
+        return f"{response.rstrip()}\n\n{footer}"
+
+    async def _handle_footer_command(self, event: MessageEvent) -> str:
+        """Handle /footer [on|off|status] — toggle per-platform response footer."""
+        import yaml
+        from gateway.display_config import resolve_display_setting
+
+        args = (event.get_command_args() or "").strip().lower()
+        config_path = _hermes_home / "config.yaml"
+        platform_key = _platform_config_key(event.source.platform)
+
+        try:
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            if not isinstance(user_config, dict):
+                user_config = {}
+        except Exception as e:
+            logger.error("Failed to load footer config: %s", e)
+            return f"❌ Failed to read config.yaml: {e}"
+
+        current = bool(resolve_display_setting(user_config, platform_key, "response_footer", False))
+
+        if args == "status":
+            return (
+                f"🧾 Response footer for **{platform_key}** is **{self._format_response_footer_enabled(current)}**.\n"
+                "Includes model, reasoning, and per-reply token usage when available."
+            )
+        if args in ("", "toggle"):
+            new_value = not current
+        elif args == "on":
+            new_value = True
+        elif args == "off":
+            new_value = False
+        else:
+            return "Usage: /footer [on|off|status]"
+
+        display_cfg = user_config.get("display")
+        if not isinstance(display_cfg, dict):
+            display_cfg = {}
+            user_config["display"] = display_cfg
+        platforms_cfg = display_cfg.get("platforms")
+        if not isinstance(platforms_cfg, dict):
+            platforms_cfg = {}
+            display_cfg["platforms"] = platforms_cfg
+        platform_cfg = platforms_cfg.get(platform_key)
+        if not isinstance(platform_cfg, dict):
+            platform_cfg = {}
+            platforms_cfg[platform_key] = platform_cfg
+
+        platform_cfg["response_footer"] = new_value
+        try:
+            atomic_yaml_write(config_path, user_config)
+        except Exception as e:
+            logger.error("Failed to save footer config: %s", e)
+            return f"❌ Failed to save config.yaml: {e}"
+        return (
+            f"🧾 Response footer for **{platform_key}** is now **{self._format_response_footer_enabled(new_value)}**.\n"
+            f"_(saved to `display.platforms.{platform_key}.response_footer`; applies to the next reply with usage data)_"
+        )
 
     async def _handle_voice_command(self, event: MessageEvent) -> str:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
@@ -10105,6 +10255,9 @@ class GatewayRunner:
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            _pre_input_toks = getattr(agent, "session_input_tokens", 0) or 0
+            _pre_output_toks = getattr(agent, "session_output_tokens", 0) or 0
+            _pre_total_toks = getattr(agent, "session_total_tokens", 0) or (_pre_input_toks + _pre_output_toks)
             try:
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
@@ -10115,7 +10268,7 @@ class GatewayRunner:
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()
-            
+
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
 
@@ -10123,12 +10276,19 @@ class GatewayRunner:
             _last_prompt_toks = 0
             _input_toks = 0
             _output_toks = 0
+            _total_toks = 0
             _agent = agent_holder[0]
             if _agent and hasattr(_agent, "context_compressor"):
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
-                _input_toks = getattr(_agent, "session_prompt_tokens", 0)
-                _output_toks = getattr(_agent, "session_completion_tokens", 0)
-            _resolved_model = getattr(_agent, "model", None) if _agent else None
+                _input_toks = getattr(_agent, "session_input_tokens", 0) or 0
+                _output_toks = getattr(_agent, "session_output_tokens", 0) or 0
+                _total_toks = getattr(_agent, "session_total_tokens", 0) or (_input_toks + _output_toks)
+            _resolved_model = getattr(_agent, "model", turn_route["model"]) if _agent else turn_route["model"]
+            _turn_input_toks = max(0, _input_toks - _pre_input_toks)
+            _turn_output_toks = max(0, _output_toks - _pre_output_toks)
+            _turn_total_toks = max(0, _total_toks - _pre_total_toks)
+            if _turn_total_toks == 0 and (_turn_input_toks or _turn_output_toks):
+                _turn_total_toks = _turn_input_toks + _turn_output_toks
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
@@ -10143,9 +10303,13 @@ class GatewayRunner:
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
+                    "total_tokens": _total_toks,
+                    "turn_input_tokens": _turn_input_toks,
+                    "turn_output_tokens": _turn_output_toks,
+                    "turn_total_tokens": _turn_total_toks,
                     "model": _resolved_model,
                 }
-            
+
             # Scan tool results for MEDIA:<path> tags that need to be delivered
             # as native audio/file attachments.  The TTS tool embeds MEDIA: tags
             # in its JSON response, but the model's final text reply usually
@@ -10232,6 +10396,10 @@ class GatewayRunner:
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
+                "total_tokens": _total_toks,
+                "turn_input_tokens": _turn_input_toks,
+                "turn_output_tokens": _turn_output_toks,
+                "turn_total_tokens": _turn_total_toks,
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -126,6 +126,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[name]"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+    CommandDef("footer", "Toggle per-platform response footer (model / reasoning / tokens)", "Configuration",
+               gateway_only=True, args_hint="[on|off|status]",
+               subcommands=("on", "off", "status")),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -83,6 +83,22 @@ class TestSlashCommands:
         assert "verbose" in response_text.lower() or "tool_progress" in response_text
 
     @pytest.mark.asyncio
+    async def test_footer_responds(self, adapter, platform, tmp_path, monkeypatch):
+        import gateway.run as gateway_run
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("display: {}\n", encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        send = await send_and_capture(adapter, "/footer status", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "footer" in response_text.lower()
+        assert "telegram" in response_text.lower() or "discord" in response_text.lower() or "slack" in response_text.lower()
+
+    @pytest.mark.asyncio
     async def test_personality_lists_options(self, adapter, platform):
         send = await send_and_capture(adapter, "/personality", platform)
 

--- a/tests/gateway/test_footer_command.py
+++ b/tests/gateway/test_footer_command.py
@@ -1,0 +1,142 @@
+"""Tests for gateway /footer command."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/footer", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._session_reasoning_overrides = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+class TestFooterCommand:
+    @pytest.mark.asyncio
+    async def test_status_uses_platform_default(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("display: {}\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer status"))
+
+        assert "OFF" in result
+        assert "telegram" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_on_saves_platform_override(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("display: {}\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer on"))
+
+        assert "ON" in result
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["platforms"]["telegram"]["response_footer"] is True
+
+    @pytest.mark.asyncio
+    async def test_off_saves_platform_override(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n  platforms:\n    telegram:\n      response_footer: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer off"))
+
+        assert "OFF" in result
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["platforms"]["telegram"]["response_footer"] is False
+
+    @pytest.mark.asyncio
+    async def test_toggle_flips_current_value(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("display: {}\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        first = await runner._handle_footer_command(_make_event("/footer"))
+        second = await runner._handle_footer_command(_make_event("/footer"))
+
+        assert "ON" in first
+        assert "OFF" in second
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["platforms"]["telegram"]["response_footer"] is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_arg_returns_usage(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("display: {}\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer maybe"))
+
+        assert "Usage:" in result
+        assert "/footer [on|off|status]" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_yaml_returns_read_error(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("display: [\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer status"))
+
+        assert "Failed to read config.yaml" in result
+
+    def test_footer_is_in_gateway_known_commands(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+        assert "footer" in GATEWAY_KNOWN_COMMANDS

--- a/tests/gateway/test_response_footer.py
+++ b/tests/gateway/test_response_footer.py
@@ -1,0 +1,140 @@
+"""Tests for response footer rendering on gateway replies."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _make_source(platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._session_reasoning_overrides = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+class TestResponseFooter:
+    @pytest.mark.asyncio
+    async def test_footer_appended_when_enabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n  platforms:\n    telegram:\n      response_footer: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        runner._session_reasoning_overrides["sess-1"] = {"enabled": True, "effort": "high"}
+        source = _make_source()
+        result = runner._maybe_append_response_footer(
+            "done",
+            {
+                "model": "gpt-5.4",
+                "input_tokens": 1234,
+                "output_tokens": 318,
+                "total_tokens": 1552,
+            },
+            source,
+            "sess-1",
+        )
+
+        assert result.startswith("done\n\n---")
+        assert "model: `gpt-5.4`" in result
+        assert "reasoning: `high`" in result
+        assert "tokens: `in 1,234 / out 318 / total 1,552`" in result
+
+    @pytest.mark.asyncio
+    async def test_footer_skipped_when_disabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("display: {}\n", encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        source = _make_source()
+        result = runner._maybe_append_response_footer(
+            "done",
+            {"model": "gpt-5.4", "input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+            source,
+            "sess-1",
+        )
+
+        assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_none_when_disabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "display:\n  platforms:\n    telegram:\n      response_footer: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        runner._session_reasoning_overrides["sess-1"] = {"enabled": False}
+        source = _make_source()
+        result = runner._maybe_append_response_footer(
+            "done",
+            {"model": "gpt-5.4", "input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+            source,
+            "sess-1",
+        )
+
+        assert "reasoning: `none`" in result
+
+    @pytest.mark.asyncio
+    async def test_footer_skipped_without_usage(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n  platforms:\n    telegram:\n      response_footer: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        source = _make_source()
+        result = runner._maybe_append_response_footer(
+            "done",
+            {"model": "gpt-5.4", "input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            source,
+            "sess-1",
+        )
+
+        assert result == "done"
+
+    def test_resolve_display_setting_supports_response_footer(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"response_footer": True}}}}
+        assert resolve_display_setting(config, "telegram", "response_footer") is True
+        assert resolve_display_setting({}, "telegram", "response_footer") is False


### PR DESCRIPTION
## Summary
- add a gateway-only `/footer [on|off|status]` slash command for per-platform response footer control
- store the footer toggle in `display.platforms.<platform>.response_footer` and render the footer after final response assembly
- append model / reasoning / per-reply token usage only when the footer is enabled and usage metadata exists
- compute per-turn token deltas in gateway agent results so footer counts do not drift upward across a session
- add focused gateway + e2e coverage for command routing, footer rendering, and invalid `config.yaml` handling

## Test Plan
- [x] `scripts/run_tests.sh tests/gateway/test_footer_command.py tests/gateway/test_response_footer.py tests/e2e/test_platform_commands.py tests/gateway/test_display_config.py tests/gateway/test_verbose_command.py tests/gateway/test_fast_command.py tests/gateway/test_reasoning_command.py`
- [x] `git diff --check`
- [x] `git diff --cached --check`

## Notes
- `/footer` persists per platform (for example Telegram-only) instead of changing global display behavior.
- malformed `config.yaml` now returns a user-facing error for `/footer` instead of crashing the command.
