### PR TITLE
fix(auth/gateway): surface Codex OAuth credential from credential_pool to /usage (#15167)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -349,6 +349,15 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
+# Provider IDs that expose account-usage APIs via agent/account_usage.py.
+# When ``/usage`` can't resolve a provider from the live/cached agent or
+# the session DB's billing row, it probes these slots in the auth
+# credential pool so users whose agent has been evicted still see their
+# plan quota (#15167).  Order matters: the first provider with a stored
+# credential wins.
+_USAGE_ACCOUNT_PROVIDERS = ("openai-codex", "anthropic")
+
+
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
@@ -7427,6 +7436,24 @@ class GatewayRunner:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
             base_url = base_url or persisted.get("billing_base_url")
+
+        # When the agent has been evicted from the in-memory cache AND no
+        # billing row exists on the session (common for a fresh-after-login
+        # user who sends /usage before their first turn), we still have
+        # OAuth credentials on disk — probe the auth pool for provider IDs
+        # that expose account-usage APIs so ``/usage`` surfaces the plan
+        # window instead of falling back to the "Session Info" stub (#15167).
+        if not provider:
+            try:
+                from hermes_cli.auth import read_credential_pool
+                for candidate in _USAGE_ACCOUNT_PROVIDERS:
+                    if read_credential_pool(candidate):
+                        provider = candidate
+                        break
+            except Exception:
+                # Auth-store probe is strictly best-effort; any failure
+                # just drops us through to the original stub message.
+                pass
 
         # Fetch account usage off the event loop so slow provider APIs don't
         # block the gateway. Failures are non-fatal -- account_lines stays [].

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2108,9 +2108,11 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
 
     The pool fallback picks the first entry with ``auth_type == "oauth"``
     that carries an access_token, and projects it onto the same
-    ``{"tokens": {...}, "last_refresh": ..., "base_url": ...}`` shape the
-    legacy slot returns so the rest of this module doesn't need to know
-    where the credential came from.
+    ``{"tokens": {...}, "last_refresh": ...}`` shape the legacy slot
+    returns so the rest of this module doesn't need to know where the
+    credential came from.  (Base URL lives on ``_resolve_custom_runtime``
+    /``resolve_codex_runtime_credentials``, not on this reader — same as
+    the legacy slot.)
     """
     if _lock:
         with _auth_store_lock():
@@ -2119,7 +2121,16 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
         auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "openai-codex")
     if not state:
-        pool_entries = (auth_store.get("credential_pool") or {}).get("openai-codex") or []
+        # Mirror ``read_credential_pool()``'s defensive typing: a corrupted
+        # ``auth.json`` where ``credential_pool`` is present but not a dict
+        # (or per-provider entries aren't a list) must not crash this
+        # reader with ``AttributeError`` — fall through to the existing
+        # ``codex_auth_missing`` path so the user gets a clean re-auth hint.
+        pool_map = auth_store.get("credential_pool")
+        if not isinstance(pool_map, dict):
+            pool_map = {}
+        raw_entries = pool_map.get("openai-codex")
+        pool_entries = raw_entries if isinstance(raw_entries, list) else []
         oauth_entry = next(
             (
                 e for e in pool_entries

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2091,9 +2091,26 @@ def _is_remote_session() -> bool:
 
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
+
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
     Raises AuthError if no Codex tokens are stored.
+
+    Reads from two slots in order of preference:
+
+    1. ``providers["openai-codex"]`` — the legacy slot written by the
+       original ``hermes auth`` Codex flow.
+    2. ``credential_pool["openai-codex"]`` — written by
+       ``hermes auth add openai-codex --type oauth`` (the newer pooled path).
+       A fresh OAuth add only populates this slot, so without the fallback
+       every consumer of Codex tokens (``_fetch_codex_account_usage``,
+       refresh flows, and downstream API calls) raised ``codex_auth_missing``
+       despite a valid OAuth credential being on disk (#15167).
+
+    The pool fallback picks the first entry with ``auth_type == "oauth"``
+    that carries an access_token, and projects it onto the same
+    ``{"tokens": {...}, "last_refresh": ..., "base_url": ...}`` shape the
+    legacy slot returns so the rest of this module doesn't need to know
+    where the credential came from.
     """
     if _lock:
         with _auth_store_lock():
@@ -2101,6 +2118,29 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     else:
         auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "openai-codex")
+    if not state:
+        pool_entries = (auth_store.get("credential_pool") or {}).get("openai-codex") or []
+        oauth_entry = next(
+            (
+                e for e in pool_entries
+                if isinstance(e, dict)
+                and e.get("auth_type") == "oauth"
+                and isinstance(e.get("access_token"), str)
+                and e.get("access_token").strip()
+            ),
+            None,
+        )
+        if oauth_entry:
+            state = {
+                "tokens": {
+                    "access_token": oauth_entry.get("access_token"),
+                    "refresh_token": oauth_entry.get("refresh_token"),
+                    "id_token": oauth_entry.get("id_token"),
+                    "account_id": oauth_entry.get("account_id"),
+                },
+                "last_refresh": oauth_entry.get("last_refresh"),
+                "base_url": oauth_entry.get("base_url"),
+            }
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -251,3 +251,161 @@ class TestUsageAccountSection:
         assert calls["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
         assert "📊 **Session Info**" in result
         assert "📈 **Account limits**" in result
+
+    @pytest.mark.asyncio
+    async def test_usage_command_probes_credential_pool_when_no_agent_and_no_billing_row(
+        self, monkeypatch,
+    ):
+        """Regression guard for #15167: a fresh-after-login user who fires
+        ``/usage`` before sending a turn has (a) no agent in cache and
+        (b) no ``billing_provider`` row on the session DB.  Before the fix,
+        the handler would emit the 'Session Info' stub and never attempt
+        to read account usage — even though an OAuth credential existed
+        on disk in ``auth.json -> credential_pool``.  The fallback probe
+        must now pick that credential up and resolve ``provider`` from it.
+        """
+        runner = _make_runner(SK)
+        runner._session_db = MagicMock()
+        # No billing row on the session — simulates a fresh session.
+        runner._session_db.get_session.return_value = {}
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-empty"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = []
+
+        calls = {}
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls["args"] = args
+            calls["kwargs"] = kwargs
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.run.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.run.render_account_usage_lines",
+            lambda snapshot, markdown=False: [
+                "📈 **Account limits**",
+                "Provider: openai-codex (Plus)",
+            ],
+        )
+
+        # Simulate an OAuth credential stored in the pool but no legacy
+        # providers row and no billing row — the state `hermes auth add
+        # openai-codex --type oauth` leaves on disk before the first turn.
+        def _fake_read_pool(provider_id=None):
+            if provider_id == "openai-codex":
+                return [{
+                    "auth_type": "oauth",
+                    "access_token": "pool-at",
+                    "refresh_token": "pool-rt",
+                }]
+            return []
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.read_credential_pool", _fake_read_pool,
+        )
+
+        event = MagicMock()
+        result = await runner._handle_usage_command(event)
+
+        assert calls.get("args") == ("openai-codex",), (
+            "gateway must probe the auth credential_pool when no agent "
+            "and no billing row resolve a provider — otherwise /usage "
+            "silently skips account-usage fetch (#15167)"
+        )
+        assert "📈 **Account limits**" in result
+
+    @pytest.mark.asyncio
+    async def test_usage_command_stops_probing_pool_on_first_hit(self, monkeypatch):
+        """The probe iterates known providers in order (currently
+        openai-codex, anthropic).  First one with a stored credential
+        wins — we don't scan the whole pool and pick arbitrarily."""
+        runner = _make_runner(SK)
+        runner._session_db = MagicMock()
+        runner._session_db.get_session.return_value = {}
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-e"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = []
+
+        calls = {}
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls["args"] = args
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.run.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.run.render_account_usage_lines",
+            lambda snapshot, markdown=False: ["📈 Account limits"],
+        )
+
+        probed = []
+
+        def _fake_read_pool(provider_id=None):
+            probed.append(provider_id)
+            # Both providers have credentials — the first probed wins.
+            return [{"auth_type": "oauth", "access_token": "x", "refresh_token": "y"}]
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.read_credential_pool", _fake_read_pool,
+        )
+
+        event = MagicMock()
+        await runner._handle_usage_command(event)
+
+        assert probed == ["openai-codex"], (
+            f"expected to stop after first hit, but probed {probed}"
+        )
+        assert calls["args"] == ("openai-codex",)
+
+    @pytest.mark.asyncio
+    async def test_usage_command_pool_probe_errors_fall_through_gracefully(
+        self, monkeypatch,
+    ):
+        """The pool probe is strictly best-effort.  If ``read_credential_pool``
+        raises (corrupted auth.json, permissions issue, etc.) the handler
+        must fall through to the no-provider path rather than bubbling the
+        exception up and breaking /usage entirely."""
+        runner = _make_runner(SK)
+        runner._session_db = MagicMock()
+        runner._session_db.get_session.return_value = {}
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-e"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = []
+
+        def _boom(provider_id=None):
+            raise RuntimeError("simulated auth.json corruption")
+
+        monkeypatch.setattr("hermes_cli.auth.read_credential_pool", _boom)
+
+        # fetch_account_usage should NOT be called, because provider is still
+        # unresolved.  Make it raise if it IS called so a silent regression
+        # fails the test loudly.
+        monkeypatch.setattr(
+            "gateway.run.fetch_account_usage",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("provider should not have been resolved")
+            ),
+        )
+
+        event = MagicMock()
+        # Must not raise — the handler swallows the pool-probe exception
+        # and falls through to its normal no-provider path.  The exact
+        # message ("Session Info" stub vs "No usage data available") depends
+        # on whether the session has transcript history; either is fine,
+        # the invariant is that the handler returned SOMETHING rather than
+        # propagating the RuntimeError.
+        result = await runner._handle_usage_command(event)
+        assert isinstance(result, str) and result, (
+            "handler must return a string even when pool probe raises"
+        )

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -75,6 +75,145 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+# ---------------------------------------------------------------------------
+# credential_pool fallback (#15167)
+#
+# ``hermes auth add openai-codex --type oauth`` writes into
+# ``auth.json -> credential_pool["openai-codex"]`` rather than the legacy
+# ``providers["openai-codex"]`` slot.  Before the fix, ``_read_codex_tokens``
+# only consulted the legacy slot, so a freshly-OAuth-logged-in user hit
+# ``codex_auth_missing`` on every consumer (``/usage``, refresh paths, the
+# account-usage fetcher) despite holding a valid credential on disk.
+# ---------------------------------------------------------------------------
+
+
+def _write_pool_only_auth_store(hermes_home: Path, entries: list) -> Path:
+    """Write an auth store where credential_pool is populated but the
+    legacy providers slot is deliberately empty — mirrors the state left
+    by ``hermes auth add ... --type oauth`` on a fresh install."""
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_store = {
+        "version": 1,
+        "providers": {},  # legacy slot deliberately empty
+        "credential_pool": {"openai-codex": entries},
+    }
+    auth_file = hermes_home / "auth.json"
+    auth_file.write_text(json.dumps(auth_store, indent=2))
+    return auth_file
+
+
+def test_read_codex_tokens_falls_back_to_credential_pool_oauth_entry(tmp_path, monkeypatch):
+    """The #15167 fix: OAuth credential in the pool is surfaced when the
+    legacy providers slot is empty."""
+    hermes_home = tmp_path / "hermes"
+    _write_pool_only_auth_store(hermes_home, [{
+        "auth_type": "oauth",
+        "access_token": "pool-access-token",
+        "refresh_token": "pool-refresh-token",
+        "id_token": "pool-id-token",
+        "account_id": "acct-123",
+        "last_refresh": "2026-04-24T12:00:00Z",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }])
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "pool-access-token"
+    assert data["tokens"]["refresh_token"] == "pool-refresh-token"
+    assert data["tokens"]["id_token"] == "pool-id-token"
+    assert data["tokens"]["account_id"] == "acct-123"
+    assert data["last_refresh"] == "2026-04-24T12:00:00Z"
+
+
+def test_read_codex_tokens_prefers_legacy_slot_over_pool(tmp_path, monkeypatch):
+    """Backward-compat guard: when BOTH slots have credentials (hybrid
+    state during migration), the legacy slot must still win so existing
+    tooling sees the same tokens it's seen before.  The pool fallback is
+    strictly a plug for the empty-legacy-slot case."""
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="legacy-at", refresh_token="legacy-rt")
+    # Mutate the file in place to add a credential_pool alongside the
+    # legacy providers slot.
+    auth_store = json.loads((hermes_home / "auth.json").read_text())
+    auth_store["credential_pool"] = {
+        "openai-codex": [{
+            "auth_type": "oauth",
+            "access_token": "pool-at",
+            "refresh_token": "pool-rt",
+        }]
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "legacy-at", (
+        "hybrid state (both slots populated) must still return the legacy "
+        "slot's credential — the pool is a fallback, not an override"
+    )
+    assert data["tokens"]["refresh_token"] == "legacy-rt"
+
+
+def test_read_codex_tokens_skips_non_oauth_pool_entries(tmp_path, monkeypatch):
+    """The pool may contain entries of other auth types (api_key, etc.).
+    The Codex token reader must only surface OAuth entries — an api_key
+    entry lacks refresh_token and would crash downstream refresh logic."""
+    hermes_home = tmp_path / "hermes"
+    _write_pool_only_auth_store(hermes_home, [
+        {"auth_type": "api_key", "access_token": "sk-...", "api_key": "sk-..."},
+    ])
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+
+def test_read_codex_tokens_skips_pool_entries_missing_access_token(tmp_path, monkeypatch):
+    """Defense-in-depth: a malformed OAuth entry that somehow lost its
+    access_token (corrupted auth.json, interrupted write, etc.) must not
+    be silently returned — better to raise codex_auth_missing so the user
+    re-runs setup and gets a clean credential."""
+    hermes_home = tmp_path / "hermes"
+    _write_pool_only_auth_store(hermes_home, [
+        {"auth_type": "oauth", "access_token": "", "refresh_token": "rt"},
+        {"auth_type": "oauth", "refresh_token": "rt-no-at"},  # missing access_token
+    ])
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+
+def test_read_codex_tokens_picks_first_valid_oauth_entry_when_multiple(tmp_path, monkeypatch):
+    """When the pool has multiple OAuth entries (user logged in twice
+    without revoking the old session, or suppressed a source), the reader
+    should pick the first one with a valid access_token — matching the
+    same 'first entry wins' convention as the rest of the pool API."""
+    hermes_home = tmp_path / "hermes"
+    _write_pool_only_auth_store(hermes_home, [
+        {"auth_type": "oauth", "access_token": "first-at", "refresh_token": "first-rt"},
+        {"auth_type": "oauth", "access_token": "second-at", "refresh_token": "second-rt"},
+    ])
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "first-at"
+
+
+def test_read_codex_tokens_empty_pool_raises_auth_error(tmp_path, monkeypatch):
+    """Both legacy slot empty AND credential_pool empty → still raises.
+    Confirms the fix doesn't silently hand back empty tokens when nothing
+    is configured — the error message is the user's cue to run setup."""
+    hermes_home = tmp_path / "hermes"
+    _write_pool_only_auth_store(hermes_home, [])
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -214,6 +214,47 @@ def test_read_codex_tokens_empty_pool_raises_auth_error(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_read_codex_tokens_survives_non_dict_credential_pool(tmp_path, monkeypatch):
+    """Defensive-typing guard flagged by Copilot on #15173: a corrupted
+    ``auth.json`` where ``credential_pool`` ended up as a list or scalar
+    (copy-paste accident, hand-edit, migration bug, ...) must not crash
+    this reader with ``AttributeError`` — fall through to the clean
+    ``codex_auth_missing`` error so the user gets a re-auth hint."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    # credential_pool is a LIST, not a dict — the truthiness check
+    # ``pool_map or {}`` wouldn't catch this.
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": ["not-a-dict-at-all"],
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+
+def test_read_codex_tokens_survives_non_list_provider_entries(tmp_path, monkeypatch):
+    """Companion to the previous test: the per-provider slot under
+    ``credential_pool["openai-codex"]`` is supposed to be a list but a
+    corrupt store could hand us a dict or string.  Same invariant — the
+    reader must not crash, it must raise ``codex_auth_missing``."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": "not-a-list"},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")


### PR DESCRIPTION
## What does this PR do?

Fixes `#15167`. When a user runs \`hermes auth add openai-codex --type oauth\`, the OAuth tokens land in \`auth.json -> credential_pool[\"openai-codex\"]\` — the newer pooled slot — *not* the legacy \`providers[\"openai-codex\"]\` slot. Two gaps then conspired to make \`/usage\` in the gateway surface nothing, even with a valid OAuth credential on disk:

**Gap 1 — \`_read_codex_tokens\` only reads the legacy slot.** Every downstream Codex consumer (\`agent/account_usage.py::_fetch_codex_account_usage\`, refresh paths) funnels through this reader. A fresh OAuth add bypasses the legacy slot, so the reader raised \`AuthError(code=codex_auth_missing)\` despite the credential existing, and \`fetch_account_usage\` silently returned \`None\`.

**Gap 2 — \`/usage\` handler only probed live/cached agent + session DB.** A fresh-after-login user whose agent has been evicted (or never instantiated yet) has neither a live \`agent.provider\` nor a \`billing_provider\` row on the session DB. The handler fell through to the \"Session Info\" stub and never even attempted the account-usage call.

Net user-visible effect: \`/usage\` shows the stub message (\`_(Detailed usage available after the first agent response)_\`) instead of the ChatGPT subscription window (5h / weekly) even though the credential is valid.

## Fix

Two surgical patches that land together:

### 1. \`hermes_cli/auth.py::_read_codex_tokens\` — fall back to credential_pool

When the legacy slot is empty, pick the first pool entry with \`auth_type == \"oauth\"\` and a non-empty \`access_token\`, then project it onto the same \`{\"tokens\": {...}, \"last_refresh\": ..., \"base_url\": ...}\` shape the legacy slot returns. The rest of the module stays unaware of where the credential came from.

Invariants preserved:
- Legacy slot still wins when both slots are populated (**backward-compat** for any hybrid state left by tooling mid-migration)
- Non-OAuth pool entries (\`auth_type: api_key\` and friends) are skipped — they lack \`refresh_token\` and would crash the refresh flow
- Malformed OAuth entries (missing \`access_token\`) fall through to the existing \`codex_auth_missing\` error path rather than being silently returned

### 2. \`gateway/run.py::_handle_usage_command\` — probe credential_pool when no provider resolved

After the existing \`live agent → cached agent → session DB billing row\` resolution chain, probe the auth \`credential_pool\` for a small allow-list of account-usage-capable providers when \`provider\` is still unset. First hit wins. Probe errors are swallowed — strictly best-effort; the handler always returns a string rather than propagating a \`RuntimeError\` from a corrupted auth.json.

The allow-list is a new module-level \`_USAGE_ACCOUNT_PROVIDERS = (\"openai-codex\", \"anthropic\")\` constant so future providers with account-usage APIs can be added in one obvious place instead of sprinkled inline.

## Verified behavior after fix

\`\`\`
📈 Account limits
Provider: openai-codex (Plus)
Session: 82% remaining (18% used) • resets in 22m
Weekly:  91% remaining (9% used)  • resets in 4d 5h
\`\`\`

Appears even when no agent is in cache.

## Test coverage (9 new tests, all green locally)

**\`tests/hermes_cli/test_auth_codex_provider.py\` — 6 cases:**
- \`test_read_codex_tokens_falls_back_to_credential_pool_oauth_entry\` — the core fix: OAuth in pool, legacy empty → pool wins
- \`test_read_codex_tokens_prefers_legacy_slot_over_pool\` — hybrid state: both populated → legacy still wins (backward-compat guard)
- \`test_read_codex_tokens_skips_non_oauth_pool_entries\` — \`auth_type: api_key\` in pool doesn't get treated as a Codex OAuth token
- \`test_read_codex_tokens_skips_pool_entries_missing_access_token\` — malformed entries don't silently pass through
- \`test_read_codex_tokens_picks_first_valid_oauth_entry_when_multiple\` — deterministic order when pool has several OAuth entries
- \`test_read_codex_tokens_empty_pool_raises_auth_error\` — both slots empty still raises, user gets the \"run hermes auth\" guidance

**\`tests/gateway/test_usage_command.py\` — 3 cases:**
- \`test_usage_command_probes_credential_pool_when_no_agent_and_no_billing_row\` — the #15167 repro end-to-end
- \`test_usage_command_stops_probing_pool_on_first_hit\` — iteration short-circuits on first provider with a stored credential
- \`test_usage_command_pool_probe_errors_fall_through_gracefully\` — handler swallows \`RuntimeError\` from a corrupted auth.json and still returns a string

## Related Issue

Fixes #15167

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Test plan

- [x] \`tests/hermes_cli/test_auth_codex_provider.py\` — **22 passed (16 pre-existing + 6 new)**
- [x] \`tests/gateway/test_usage_command.py\` — my 3 new tests pass; the pre-existing tests that fail locally (\`requests\` missing in my venv, unrelated to this PR) are green on clean \`origin/main\` per CI history
- [x] No behavioural change when the legacy \`providers\` slot is populated — hybrid-state backward-compat explicitly tested
- [x] The \`_USAGE_ACCOUNT_PROVIDERS\` tuple is a single-line extension point — adding anthropic/openrouter OAuth probe in future is a 1-char edit

## Not in scope (explicit follow-up candidates per the reporter's own notes)

- Unifying the legacy \`providers\` and \`credential_pool\` reads behind a single accessor — probably worthwhile across anthropic/openrouter/qwen too since they have the same legacy-vs-pool skew, but a much bigger surface than what this user-facing regression needs to unblock.
- The \"agent cached but \`agent.provider\` is unset\" case — not encountered in the reported repro; separate change if it turns out to be real.