### PR TITLE
feat(model): surface free OpenRouter models in model picker

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1336,11 +1336,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 label = f"{p['name']} ({count})"
                 if p.get("is_current"):
                     label = f"✓ {label}"
-                # Compact callback data: mp:<index>  (max 64 bytes).
-                # The picker can include multiple UX groups with the same real
-                # provider slug (for example OpenRouter and OpenRouter free
-                # models). Use the row index for Telegram navigation, while
-                # still passing the real provider slug to switch_model later.
                 buttons.append(
                     InlineKeyboardButton(label, callback_data=f"mp:{idx}")
                 )
@@ -1451,8 +1446,6 @@ class TelegramAdapter(BasePlatformAdapter):
             if 0 <= provider_idx < len(state["providers"]):
                 provider = state["providers"][provider_idx]
             else:
-                # Backward compatibility with any older in-flight pickers that
-                # used mp:<slug> callback data.
                 provider = next(
                     (p for p in state["providers"] if p["slug"] == provider_ref),
                     None,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1331,14 +1331,18 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             # Build provider buttons — 2 per row
             buttons: list = []
-            for p in providers:
+            for idx, p in enumerate(providers):
                 count = p.get("total_models", len(p.get("models", [])))
                 label = f"{p['name']} ({count})"
                 if p.get("is_current"):
                     label = f"✓ {label}"
-                # Compact callback data: mp:<slug>  (max 64 bytes)
+                # Compact callback data: mp:<index>  (max 64 bytes).
+                # The picker can include multiple UX groups with the same real
+                # provider slug (for example OpenRouter and OpenRouter free
+                # models). Use the row index for Telegram navigation, while
+                # still passing the real provider slug to switch_model later.
                 buttons.append(
-                    InlineKeyboardButton(label, callback_data=f"mp:{p['slug']}")
+                    InlineKeyboardButton(label, callback_data=f"mp:{idx}")
                 )
 
             rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
@@ -1438,17 +1442,31 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if data.startswith("mp:"):
             # --- Provider selected: show model buttons (page 0) ---
-            provider_slug = data[3:]
-            provider = next(
-                (p for p in state["providers"] if p["slug"] == provider_slug),
-                None,
-            )
+            provider_ref = data[3:]
+            provider = None
+            try:
+                provider_idx = int(provider_ref)
+            except ValueError:
+                provider_idx = -1
+            if 0 <= provider_idx < len(state["providers"]):
+                provider = state["providers"][provider_idx]
+            else:
+                # Backward compatibility with any older in-flight pickers that
+                # used mp:<slug> callback data.
+                provider = next(
+                    (p for p in state["providers"] if p["slug"] == provider_ref),
+                    None,
+                )
             if not provider:
                 await query.answer(text="Provider not found.")
                 return
 
+            provider_slug = provider.get("slug", provider_ref)
             models = provider.get("models", [])
             state["selected_provider"] = provider_slug
+            state["selected_provider_index"] = (
+                provider_idx if 0 <= provider_idx < len(state["providers"]) else None
+            )
             state["selected_provider_name"] = provider.get("name", provider_slug)
             state["model_list"] = models
             state["model_page"] = 0
@@ -1486,10 +1504,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
             pname = state.get("selected_provider_name", "")
             provider_slug = state.get("selected_provider", "")
-            provider = next(
-                (p for p in state["providers"] if p["slug"] == provider_slug),
-                None,
-            )
+            provider_idx = state.get("selected_provider_index")
+            provider = None
+            if isinstance(provider_idx, int) and 0 <= provider_idx < len(state["providers"]):
+                provider = state["providers"][provider_idx]
+            if provider is None:
+                provider = next(
+                    (p for p in state["providers"] if p["slug"] == provider_slug),
+                    None,
+                )
             total = provider.get("total_models", len(models)) if provider else len(models)
             shown = len(models)
             extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
@@ -1557,13 +1580,13 @@ class TelegramAdapter(BasePlatformAdapter):
         elif data == "mb":
             # --- Back to provider list ---
             buttons = []
-            for p in state["providers"]:
+            for idx, p in enumerate(state["providers"]):
                 count = p.get("total_models", len(p.get("models", [])))
                 label = f"{p['name']} ({count})"
                 if p.get("is_current"):
                     label = f"✓ {label}"
                 buttons.append(
-                    InlineKeyboardButton(label, callback_data=f"mp:{p['slug']}")
+                    InlineKeyboardButton(label, callback_data=f"mp:{idx}")
                 )
 
             rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1192,9 +1192,6 @@ def list_authenticated_providers(
         })
         seen_slugs.add(_cp.slug.lower())
 
-    # --- 2c. OpenRouter free model shortcut group ---
-    # UX-only grouping: selecting any entry still routes through provider
-    # "openrouter". Do not introduce a real/fake provider named "free".
     if any(p.get("slug") == "openrouter" for p in results):
         try:
             from hermes_cli.models import fetch_openrouter_free_models

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1192,6 +1192,27 @@ def list_authenticated_providers(
         })
         seen_slugs.add(_cp.slug.lower())
 
+    # --- 2c. OpenRouter free model shortcut group ---
+    # UX-only grouping: selecting any entry still routes through provider
+    # "openrouter". Do not introduce a real/fake provider named "free".
+    if any(p.get("slug") == "openrouter" for p in results):
+        try:
+            from hermes_cli.models import fetch_openrouter_free_models
+            free_models = fetch_openrouter_free_models(timeout=3.0)
+        except Exception:
+            free_models = []
+        if free_models:
+            top_free = free_models[:max_models]
+            results.append({
+                "slug": "openrouter",
+                "name": "OpenRouter free models",
+                "is_current": current_provider == "openrouter",
+                "is_user_defined": False,
+                "models": top_free,
+                "total_models": len(free_models),
+                "source": "openrouter-free",
+            })
+
     # --- 3. User-defined endpoints from config ---
     # Track (name, base_url) of what section 3 emits so section 4 can skip
     # any overlapping ``custom_providers:`` entries.  Callers typically pass

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -973,7 +973,6 @@ def fetch_openrouter_free_models(
         mid = str(item.get("id") or "").strip()
         if not mid:
             continue
-        # First pass intentionally avoids adding NVIDIA-specific free models.
         if mid.lower().startswith("nvidia/"):
             continue
         if not _openrouter_model_supports_tools(item):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -70,6 +70,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
+_openrouter_live_catalog_cache: list[dict[str, Any]] | None = None
 
 
 # Fallback Vercel AI Gateway snapshot used when the live catalog is unavailable.
@@ -827,11 +828,13 @@ def get_default_model_for_provider(provider: str) -> str:
 
 
 def _openrouter_model_is_free(pricing: Any) -> bool:
-    """Return True when both prompt and completion pricing are zero."""
+    """Return True when both prompt and completion pricing are explicitly zero."""
     if not isinstance(pricing, dict):
         return False
+    if pricing.get("prompt") is None or pricing.get("completion") is None:
+        return False
     try:
-        return float(pricing.get("prompt", "0")) == 0 and float(pricing.get("completion", "0")) == 0
+        return float(pricing["prompt"]) == 0 and float(pricing["completion"]) == 0
     except (TypeError, ValueError):
         return False
 
@@ -861,6 +864,44 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     return "tools" in params
 
 
+def _fetch_openrouter_catalog_items(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> Optional[list[dict[str, Any]]]:
+    """Fetch and cache raw OpenRouter catalog items for picker helpers."""
+    global _openrouter_live_catalog_cache
+
+    if _openrouter_live_catalog_cache is not None and not force_refresh:
+        return list(_openrouter_live_catalog_cache)
+
+    try:
+        req = urllib.request.Request(
+            "https://openrouter.ai/api/v1/models",
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+    live_items = payload.get("data", []) if isinstance(payload, dict) else []
+    if not isinstance(live_items, list):
+        return None
+
+    parsed: list[dict[str, Any]] = []
+    for item in live_items:
+        if not isinstance(item, dict):
+            continue
+        mid = str(item.get("id") or "").strip()
+        if not mid:
+            continue
+        parsed.append(item)
+
+    _openrouter_live_catalog_cache = parsed
+    return list(parsed)
+
+
 def fetch_openrouter_models(
     timeout: float = 8.0,
     *,
@@ -875,28 +916,15 @@ def fetch_openrouter_models(
     fallback = list(OPENROUTER_MODELS)
     preferred_ids = [mid for mid, _ in fallback]
 
-    try:
-        req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/models",
-            headers={"Accept": "application/json"},
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
-    except Exception:
+    live_items = _fetch_openrouter_catalog_items(timeout=timeout, force_refresh=force_refresh)
+    if live_items is None:
         return list(_openrouter_catalog_cache or fallback)
 
-    live_items = payload.get("data", [])
-    if not isinstance(live_items, list):
-        return list(_openrouter_catalog_cache or fallback)
-
-    live_by_id: dict[str, dict[str, Any]] = {}
-    for item in live_items:
-        if not isinstance(item, dict):
-            continue
-        mid = str(item.get("id") or "").strip()
-        if not mid:
-            continue
-        live_by_id[mid] = item
+    live_by_id = {
+        str(item.get("id") or "").strip(): item
+        for item in live_items
+        if str(item.get("id") or "").strip()
+    }
 
     curated: list[tuple[str, str]] = []
     for preferred_id in preferred_ids:
@@ -918,6 +946,47 @@ def fetch_openrouter_models(
     curated[0] = (first_id, "recommended")
     _openrouter_catalog_cache = curated
     return list(curated)
+
+
+def _openrouter_free_model_sort_key(model_id: str) -> tuple[int, str]:
+    lowered = model_id.lower()
+    if lowered == "openrouter/free":
+        return (0, lowered)
+    if lowered.endswith(":free"):
+        return (1, lowered)
+    return (2, lowered)
+
+
+def fetch_openrouter_free_models(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> list[str]:
+    """Return zero-priced, tool-capable OpenRouter model IDs for the free picker group."""
+    live_items = _fetch_openrouter_catalog_items(timeout=timeout, force_refresh=force_refresh)
+    if live_items is None:
+        return []
+
+    free_ids: list[str] = []
+    seen: set[str] = set()
+    for item in live_items:
+        mid = str(item.get("id") or "").strip()
+        if not mid:
+            continue
+        # First pass intentionally avoids adding NVIDIA-specific free models.
+        if mid.lower().startswith("nvidia/"):
+            continue
+        if not _openrouter_model_supports_tools(item):
+            continue
+        if not _openrouter_model_is_free(item.get("pricing")):
+            continue
+        key = mid.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        free_ids.append(mid)
+
+    return sorted(free_ids, key=_openrouter_free_model_sort_key)
 
 
 def model_ids(*, force_refresh: bool = False) -> list[str]:

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class _FakeBot:
+    def __init__(self):
+        self.sent_messages = []
+
+    async def send_message(self, **kwargs):
+        self.sent_messages.append(kwargs)
+        return SimpleNamespace(message_id=123)
+
+
+class _FakeQuery:
+    def __init__(self):
+        self.edits = []
+        self.answers = []
+
+    async def edit_message_text(self, **kwargs):
+        self.edits.append(kwargs)
+
+    async def answer(self, **kwargs):
+        self.answers.append(kwargs)
+
+
+class _FakeInlineKeyboardButton:
+    def __init__(self, text, callback_data=None):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class _FakeInlineKeyboardMarkup:
+    def __init__(self, inline_keyboard):
+        self.inline_keyboard = inline_keyboard
+
+
+def _install_fake_telegram_keyboard(monkeypatch):
+    import gateway.platforms.telegram as telegram
+
+    monkeypatch.setattr(telegram, "InlineKeyboardButton", _FakeInlineKeyboardButton)
+    monkeypatch.setattr(telegram, "InlineKeyboardMarkup", _FakeInlineKeyboardMarkup)
+
+
+def _make_adapter():
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="test-token")
+    adapter._bot = _FakeBot()
+    adapter._model_picker_state = {}
+    return adapter
+
+
+def _button_callback_data(markup):
+    return [button.callback_data for row in markup.inline_keyboard for button in row]
+
+
+@pytest.mark.asyncio
+async def test_model_picker_provider_callbacks_distinguish_duplicate_provider_slugs(monkeypatch):
+    """Telegram picker entries may share a provider slug for UX groupings.
+
+    The OpenRouter free-model group intentionally uses slug ``openrouter`` so
+    selection resolves through the real provider. Telegram callback data must
+    therefore identify the picker row, not just the provider slug, otherwise the
+    free group opens the regular OpenRouter model list.
+    """
+    _install_fake_telegram_keyboard(monkeypatch)
+    adapter = _make_adapter()
+    providers = [
+        {
+            "name": "OpenRouter",
+            "slug": "openrouter",
+            "models": ["anthropic/claude-sonnet-4"],
+            "total_models": 1,
+            "is_current": False,
+        },
+        {
+            "name": "OpenRouter free models",
+            "slug": "openrouter",
+            "models": ["meta-llama/llama-3.3-8b-instruct:free"],
+            "total_models": 1,
+            "is_current": False,
+        },
+    ]
+
+    selected = {}
+
+    async def on_model_selected(chat_id, model_id, provider_slug):
+        selected.update({"chat_id": chat_id, "model_id": model_id, "provider_slug": provider_slug})
+        return "ok"
+
+    result = await adapter.send_model_picker(
+        chat_id="123",
+        providers=providers,
+        current_model="anthropic/claude-sonnet-4",
+        current_provider="openrouter",
+        session_key="telegram:123",
+        on_model_selected=on_model_selected,
+    )
+
+    assert result.success
+    markup = adapter._bot.sent_messages[0]["reply_markup"]
+    callback_data = _button_callback_data(markup)
+    assert callback_data[:3] == ["mp:0", "mp:1", "mx"], repr(markup)
+    provider_callbacks = [value for value in callback_data if value and value.startswith("mp:")]
+    assert provider_callbacks == ["mp:0", "mp:1"]
+
+    query = _FakeQuery()
+    await adapter._handle_model_picker_callback(query, "mp:1", "123")
+
+    assert adapter._model_picker_state["123"]["selected_provider"] == "openrouter"
+    assert adapter._model_picker_state["123"]["selected_provider_name"] == "OpenRouter free models"
+    assert adapter._model_picker_state["123"]["model_list"] == [
+        "meta-llama/llama-3.3-8b-instruct:free"
+    ]
+
+    await adapter._handle_model_picker_callback(_FakeQuery(), "mm:0", "123")
+
+    assert selected == {
+        "chat_id": "123",
+        "model_id": "meta-llama/llama-3.3-8b-instruct:free",
+        "provider_slug": "openrouter",
+    }

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -6,6 +6,7 @@ from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
     is_nous_free_tier, partition_nous_models_by_tier,
     check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    fetch_openrouter_free_models,
 )
 import hermes_cli.models as _models_mod
 
@@ -86,6 +87,102 @@ class TestFetchOpenRouterModels:
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == OPENROUTER_MODELS
+
+    def test_missing_pricing_is_not_marked_free(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0","completion":"0"}},'
+                    b'{"id":"qwen/qwen3.6-plus","pricing":{"prompt":"0"}},'
+                    b'{"id":"minimax/minimax-m2.5:free","pricing":null}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+            models = dict(fetch_openrouter_models(force_refresh=True))
+
+        assert models["anthropic/claude-opus-4.6"] == "recommended"
+        assert models["qwen/qwen3.6-plus"] == ""
+        assert models["minimax/minimax-m2.5:free"] == ""
+
+
+class TestFetchOpenRouterFreeModels:
+    def test_detects_zero_priced_free_models_and_excludes_paid_unknown_and_nvidia(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-paid","name":"Claude Paid",'
+                    b'"pricing":{"prompt":"0.000015","completion":"0.000075"},'
+                    b'"supported_parameters":["tools"]},'
+                    b'{"id":"meta-llama/llama-3:free","name":"Llama Free",'
+                    b'"pricing":{"prompt":"0","completion":"0.000000"},'
+                    b'"supported_parameters":["tools","temperature"]},'
+                    b'{"id":"qwen/qwen-zero","name":"Qwen Zero",'
+                    b'"pricing":{"prompt":0,"completion":0},'
+                    b'"supported_parameters":["tools"]},'
+                    b'{"id":"missing/pricing","name":"Missing Pricing",'
+                    b'"pricing":{"prompt":"0"},'
+                    b'"supported_parameters":["tools"]},'
+                    b'{"id":"image/free","name":"Image Free",'
+                    b'"pricing":{"prompt":"0","completion":"0"},'
+                    b'"supported_parameters":["response_format"]},'
+                    b'{"id":"nvidia/nemotron-test:free","name":"Nemotron Free",'
+                    b'"pricing":{"prompt":"0","completion":"0"},'
+                    b'"supported_parameters":["tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+            assert fetch_openrouter_free_models(force_refresh=True) == [
+                "meta-llama/llama-3:free",
+                "qwen/qwen-zero",
+            ]
+
+    def test_orders_openrouter_free_then_tagged_then_other_zero_priced(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"zeta/zero","pricing":{"prompt":"0","completion":"0"},"supported_parameters":["tools"]},'
+                    b'{"id":"openrouter/free","pricing":{"prompt":"0","completion":"0"},"supported_parameters":["tools"]},'
+                    b'{"id":"alpha/model:free","pricing":{"prompt":"0","completion":"0"},"supported_parameters":["tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+            assert fetch_openrouter_free_models(force_refresh=True) == [
+                "openrouter/free",
+                "alpha/model:free",
+                "zeta/zero",
+            ]
+
+    def test_failure_returns_empty_list(self, monkeypatch):
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=OSError("boom")):
+            assert fetch_openrouter_free_models(force_refresh=True) == []
 
     def test_filters_out_models_without_tool_support(self, monkeypatch):
         """Models whose supported_parameters omits 'tools' must not appear in the picker.

--- a/tests/hermes_cli/test_openrouter_free_model_picker.py
+++ b/tests/hermes_cli/test_openrouter_free_model_picker.py
@@ -1,0 +1,50 @@
+"""Tests for surfacing free OpenRouter models in the /model picker."""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers, switch_model
+
+
+@patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}, clear=True)
+def test_free_openrouter_group_appears_without_fake_provider():
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models.fetch_openrouter_free_models", return_value=["openrouter/free", "meta-llama/model:free"]):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    free_group = next((p for p in providers if p.get("source") == "openrouter-free"), None)
+    assert free_group is not None
+    assert free_group["slug"] == "openrouter"
+    assert free_group["name"] == "OpenRouter free models"
+    assert free_group["models"] == ["openrouter/free", "meta-llama/model:free"]
+    assert "free" not in {p["slug"] for p in providers}
+
+
+@patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}, clear=True)
+def test_free_openrouter_group_omitted_when_discovery_fails_or_empty():
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models.fetch_openrouter_free_models", return_value=[]):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    assert not any(p.get("source") == "openrouter-free" for p in providers)
+
+
+def test_selecting_free_openrouter_model_resolves_to_openrouter_provider():
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+               return_value={"api_key": "test-key", "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions"}), \
+         patch("hermes_cli.models.validate_requested_model", return_value={"accepted": True, "persist": True, "recognized": True, "message": None}), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+        result = switch_model(
+            raw_input="meta-llama/model:free",
+            current_provider="openai-codex",
+            current_model="gpt-5.3-codex",
+            explicit_provider="openrouter",
+        )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "meta-llama/model:free"


### PR DESCRIPTION
## What does this PR do?

Adds a dedicated “OpenRouter free models” group to the `/model` picker.

This is intentionally scoped to the picker UX layer. It reuses existing OpenRouter catalog/pricing metadata and does not introduce a fake `free` provider. Selecting a free model still resolves internally as:

- provider: `openrouter`
- model: selected OpenRouter model id

This preserves existing `/model` behaviour and does not change the default model.

The PR also fixes Telegram model picker callback handling so multiple picker groups can share the same real provider slug. This is needed because both “OpenRouter” and “OpenRouter free models” resolve to provider `openrouter`.

## Related Issue

Related to #9474.

This PR does not attempt to replace canonical OpenRouter catalog discovery work. If #9474 lands first, this can be rebased to consume its canonical helper.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Adds OpenRouter free-model detection based on explicit zero prompt and completion pricing.
- Treats missing, null, or unknown pricing as not free.
- Preserves `:free` OpenRouter model IDs.
- Adds an “OpenRouter free models” group to `/model`.
- Keeps selected free models under provider `openrouter`.
- Preserves the existing normal OpenRouter picker group.
- Updates Telegram picker callbacks to use provider row indices rather than provider slug callback data, while still resolving to the real provider slug internally.
- Adds mocked tests for free/paid/unknown pricing, picker behaviour, provider resolution, and Telegram duplicate-slug handling.

## How to Test

Focused tests:

```bash
venv/bin/python -m pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_openrouter_free_model_picker.py tests/hermes_cli/test_model_switch_variant_tags.py tests/gateway/test_telegram_model_picker.py -q -n 4
```

Result:

```text
passed
```

Lint on touched files:

```bash
venv/bin/python -m ruff check --extend-ignore E402 gateway/platforms/telegram.py tests/gateway/test_telegram_model_picker.py hermes_cli/model_switch.py hermes_cli/models.py tests/hermes_cli/test_openrouter_free_model_picker.py tests/hermes_cli/test_models.py
```

Result:

```text
All checks passed!
```

Manual testing:

1. Run Hermes locally.
2. Open `/model`.
3. Confirm the normal provider/model picker still works.
4. Confirm “OpenRouter free models” appears when OpenRouter is configured.
5. Select a free OpenRouter model.
6. Confirm selected model uses provider `openrouter`.
7. In Telegram, run `/model` and confirm both normal OpenRouter and OpenRouter free models can be selected correctly.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behaviour — N/A
