### PR TITLE
fix(gateway): abort startup during restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1981,6 +1981,39 @@ class GatewayRunner:
         task.add_done_callback(self._background_tasks.discard)
         return True
 
+    def _startup_should_abort(self) -> bool:
+        return (
+            self._restart_requested
+            or self._draining
+            or self._shutdown_event.is_set()
+        )
+
+    async def _abort_startup_if_shutdown_requested(
+        self,
+        adapter: Optional[BasePlatformAdapter] = None,
+        platform: Optional[Platform] = None,
+    ) -> bool:
+        """Clean up and exit startup when restart/shutdown begins mid-startup."""
+        if not self._startup_should_abort():
+            return False
+        if adapter is not None and platform is not None:
+            try:
+                await adapter.cancel_background_tasks()
+            except Exception as e:
+                logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
+            await self._safe_adapter_disconnect(adapter, platform)
+        stop_task = self._stop_task
+        current_task = asyncio.current_task()
+        if stop_task is not None and stop_task is not current_task:
+            await stop_task
+        elif not self._shutdown_event.is_set():
+            await self.stop(
+                restart=self._restart_requested,
+                detached_restart=self._restart_detached,
+                service_restart=self._restart_via_service,
+            )
+        return True
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -2001,6 +2034,8 @@ class GatewayRunner:
             write_runtime_status(gateway_state="starting", exit_reason=None)
         except Exception:
             pass
+        if await self._abort_startup_if_shutdown_requested():
+            return True
         
         # Warn if no user allowlists are configured and open access is not opted in
         _any_allowlist = any(
@@ -2127,6 +2162,8 @@ class GatewayRunner:
         
         # Initialize and connect each configured platform
         for platform, platform_config in self.config.platforms.items():
+            if await self._abort_startup_if_shutdown_requested():
+                return True
             if not platform_config.enabled:
                 continue
             enabled_platform_count += 1
@@ -2152,6 +2189,8 @@ class GatewayRunner:
             )
             try:
                 success = await adapter.connect()
+                if await self._abort_startup_if_shutdown_requested(adapter, platform):
+                    return True
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
@@ -2231,6 +2270,8 @@ class GatewayRunner:
                     "attempts": 1,
                     "next_retry": time.monotonic() + 30,
                 }
+            if await self._abort_startup_if_shutdown_requested():
+                return True
         
         if connected_count == 0:
             if startup_nonretryable_errors:
@@ -2256,6 +2297,8 @@ class GatewayRunner:
             logger.info("Gateway will continue running for cron job execution.")
         
         # Update delivery router with adapters
+        if await self._abort_startup_if_shutdown_requested():
+            return True
         self.delivery_router.adapters = self.adapters
         
         self._running = True
@@ -11226,6 +11269,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     if runner.should_exit_cleanly:
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
+        return True
+    if not runner._running:
+        # Startup was intentionally aborted by restart/shutdown before entering
+        # running mode; preserve that lifecycle path without starting cron.
+        await runner.wait_for_shutdown()
+        if runner.should_exit_with_failure:
+            if runner.exit_reason:
+                logger.error("Gateway exiting with failure: %s", runner.exit_reason)
+            return False
+        try:
+            from tools.mcp_tool import shutdown_mcp_servers
+            shutdown_mcp_servers()
+        except Exception:
+            pass
+        if runner.exit_code is not None:
+            raise SystemExit(runner.exit_code)
         return True
     
     # Start background cron ticker so scheduled jobs fire automatically.

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -1,0 +1,289 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.restart import (
+    DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+    GATEWAY_SERVICE_RESTART_EXIT_CODE,
+)
+
+
+class StartupRaceAdapter(BasePlatformAdapter):
+    def __init__(
+        self,
+        platform: Platform,
+        *,
+        on_connect=None,
+        wait_for_disconnect: asyncio.Event | None = None,
+    ):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self.on_connect = on_connect
+        self.wait_for_disconnect = wait_for_disconnect
+        self.connected = False
+        self.disconnected = False
+        self.background_cancelled = False
+
+    async def connect(self):
+        if self.on_connect:
+            self.on_connect()
+        if self.wait_for_disconnect is not None:
+            await self.wait_for_disconnect.wait()
+        self.connected = True
+        return True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def cancel_background_tasks(self):
+        self.background_cancelled = True
+        await super().cancel_background_tasks()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def make_startup_runner(tmp_path):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            Platform.SLACK: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner.adapters = {}
+    runner._running = False
+    runner._shutdown_event = asyncio.Event()
+    runner._exit_reason = None
+    runner._exit_code = None
+    runner._exit_cleanly = False
+    runner._exit_with_failure = False
+    runner._draining = False
+    runner._restart_requested = False
+    runner._restart_task_started = False
+    runner._restart_detached = False
+    runner._restart_via_service = False
+    runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._stop_task = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._background_tasks = set()
+    runner._failed_platforms = {}
+    runner._voice_mode = {}
+
+    runner.hooks = MagicMock()
+    runner.hooks.loaded_hooks = []
+    runner.hooks.discover_and_load = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.session_store = MagicMock()
+    runner.session_store.suspend_recently_active.return_value = 0
+    runner.delivery_router = MagicMock()
+    runner.delivery_router.adapters = {}
+
+    runner._update_runtime_status = MagicMock()
+    runner._update_platform_runtime_status = MagicMock()
+    runner._sync_voice_mode_state_to_adapter = MagicMock()
+    runner._suspend_stuck_loop_sessions = MagicMock(return_value=0)
+    runner._notify_active_sessions_of_shutdown = AsyncMock()
+    runner._drain_active_agents = AsyncMock(return_value=({}, False))
+    runner._finalize_shutdown_agents = MagicMock()
+    runner._send_update_notification = AsyncMock(return_value=False)
+    runner._schedule_update_notification_watch = MagicMock()
+    runner._send_restart_notification = AsyncMock()
+    runner.wait_for_shutdown = gateway_run.GatewayRunner.wait_for_shutdown.__get__(
+        runner, gateway_run.GatewayRunner
+    )
+
+    async def no_op_watcher(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    runner._session_expiry_watcher = no_op_watcher
+    runner._platform_reconnect_watcher = no_op_watcher
+    runner._run_process_watcher = no_op_watcher
+    runner._safe_adapter_disconnect = gateway_run.GatewayRunner._safe_adapter_disconnect.__get__(
+        runner, gateway_run.GatewayRunner
+    )
+    runner.request_restart = gateway_run.GatewayRunner.request_restart.__get__(
+        runner, gateway_run.GatewayRunner
+    )
+    runner.stop = gateway_run.GatewayRunner.stop.__get__(runner, gateway_run.GatewayRunner)
+    return runner
+
+
+def patch_startup_side_effects(monkeypatch, tmp_path):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr("agent.shell_hooks.register_from_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr("tools.process_registry.process_registry.recover_from_checkpoint", lambda: 0)
+
+
+@pytest.mark.asyncio
+async def test_startup_aborts_when_restart_requested_before_start(tmp_path, monkeypatch):
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    runner = make_startup_runner(tmp_path)
+    runner.request_restart(detached=False, via_service=True)
+    runner._create_adapter = MagicMock()
+
+    result = await asyncio.wait_for(runner.start(), timeout=2)
+
+    assert result is True
+    runner._create_adapter.assert_not_called()
+    assert runner.delivery_router.adapters == {}
+    assert runner._running is False
+    assert not any(
+        call.args[:1] == ("running",)
+        for call in runner._update_runtime_status.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_path, monkeypatch):
+    patch_startup_side_effects(monkeypatch, tmp_path)
+
+    runner = make_startup_runner(tmp_path)
+    first_disconnected = asyncio.Event()
+    telegram = StartupRaceAdapter(
+        Platform.TELEGRAM,
+        on_connect=lambda: runner.request_restart(detached=False, via_service=True),
+    )
+    slack = StartupRaceAdapter(Platform.SLACK, wait_for_disconnect=first_disconnected)
+
+    async def disconnect_and_release():
+        telegram.disconnected = True
+        first_disconnected.set()
+
+    telegram.disconnect = disconnect_and_release
+    runner._create_adapter = MagicMock(side_effect=[telegram, slack])
+
+    result = await asyncio.wait_for(runner.start(), timeout=2)
+
+    assert result is True
+    assert telegram.disconnected is True
+    assert telegram.background_cancelled is True
+    assert slack.connected is False
+    assert runner._running is False
+    assert runner.adapters == {}
+    assert runner._update_runtime_status.call_args_list[-1].args[0] == "stopped"
+    assert not any(
+        call.args[:1] == ("running",)
+        for call in runner._update_runtime_status.call_args_list
+    )
+    assert not any(
+        call.args[:2] == (Platform.SLACK.value, "connected")
+        for call in runner._update_platform_runtime_status.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_abort_waits_for_existing_stop_task(tmp_path):
+    runner = make_startup_runner(tmp_path)
+    runner._restart_requested = True
+    runner.stop = AsyncMock(side_effect=AssertionError("stop should not be called"))
+    stop_completed = asyncio.Event()
+
+    async def existing_stop():
+        await asyncio.sleep(0.01)
+        stop_completed.set()
+
+    runner._stop_task = asyncio.create_task(existing_stop())
+    adapter = StartupRaceAdapter(Platform.TELEGRAM)
+
+    result = await asyncio.wait_for(
+        runner._abort_startup_if_shutdown_requested(adapter, Platform.TELEGRAM),
+        timeout=2,
+    )
+
+    assert result is True
+    assert stop_completed.is_set()
+    assert runner._stop_task.done()
+    runner.stop.assert_not_called()
+    assert adapter.background_cancelled is True
+    assert adapter.disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_startup_aborts_after_registered_adapter_restart(tmp_path, monkeypatch):
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    runner = make_startup_runner(tmp_path)
+    telegram = StartupRaceAdapter(Platform.TELEGRAM)
+    slack = StartupRaceAdapter(Platform.SLACK)
+    runner._create_adapter = MagicMock(side_effect=[telegram, slack])
+
+    def update_platform_runtime_status(platform, platform_state, **kwargs):
+        if (platform, platform_state) == (Platform.TELEGRAM.value, "connected"):
+            runner.request_restart(detached=False, via_service=True)
+
+    runner._update_platform_runtime_status = MagicMock(side_effect=update_platform_runtime_status)
+
+    result = await asyncio.wait_for(runner.start(), timeout=2)
+
+    assert result is True
+    assert telegram.connected is True
+    assert telegram.disconnected is True
+    assert slack.connected is False
+    assert runner._running is False
+    assert runner.adapters == {}
+    assert runner._update_runtime_status.call_args_list[-1].args[0] == "stopped"
+    assert not any(
+        call.args[:1] == ("running",)
+        for call in runner._update_runtime_status.call_args_list
+    )
+    assert not any(
+        call.args[:2] == (Platform.SLACK.value, "connected")
+        for call in runner._update_platform_runtime_status.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cron_started = False
+
+    class AbortedStartupRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = False
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    def fail_if_cron_starts(*args, **kwargs):
+        nonlocal cron_started
+        cron_started = True
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+
+    with pytest.raises(SystemExit) as exc:
+        await gateway_run.start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    assert cron_started is False


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway startup/restart race where `request_restart(via_service=True)` can overlap with `GatewayRunner.start()`.

Before this change, startup could continue after `stop()` had disconnected already-connected adapters. It could then connect later platforms and write `gateway_state=running` or platform `connected`, leaving service status healthy while an adapter such as Discord was actually disconnected.

This PR adds a guarded startup-abort path that:

- Stops startup from continuing to connect later platform adapters after restart/shutdown begins.
- Coordinates with existing stop tasks instead of racing duplicate stop work.
- Cancels background tasks and disconnects a just-connected adapter during startup-abort cleanup.
- Avoids starting cron after startup was intentionally aborted before entering running mode.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Add `_startup_should_abort()` and `_abort_startup_if_shutdown_requested()`.
  - Check for startup abort after writing startup status, before each platform connect, after adapter connect, after retry bookkeeping, and before entering running mode.
  - Cancel background tasks and safely disconnect a partially-started adapter during abort cleanup.
  - Prefer awaiting an existing `_stop_task` before falling back to `stop()`.
  - Skip cron startup in `start_gateway()` when `runner.start()` returns successfully for a controlled restart/shutdown abort but `_running` is still false.
- `tests/gateway/test_startup_restart_race.py`
  - Cover restart requested before startup creates adapters.
  - Cover restart during platform connect.
  - Cover restart after an adapter has already been registered as connected.
  - Cover existing `_stop_task` coordination during startup abort.
  - Cover `start_gateway()` skipping cron and exiting with the service restart code after an aborted startup.

## How to Test

1. `uv run --extra dev pytest -q tests/gateway/test_startup_restart_race.py`
2. `uv run --extra dev pytest -q tests/gateway/test_startup_restart_race.py tests/gateway/test_restart_drain.py tests/gateway/test_clean_shutdown_marker.py tests/hermes_cli/test_gateway_service.py tests/gateway/test_runner_startup_failures.py`
3. `uv run --extra dev ruff check tests/gateway/test_startup_restart_race.py`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed:

- `uv run --extra dev pytest -q tests/gateway/test_startup_restart_race.py` (`5 passed`)
- `uv run --extra dev pytest -q tests/gateway/test_startup_restart_race.py tests/gateway/test_restart_drain.py tests/gateway/test_clean_shutdown_marker.py tests/hermes_cli/test_gateway_service.py tests/gateway/test_runner_startup_failures.py` (`139 passed`)
- `uv run --extra dev ruff check tests/gateway/test_startup_restart_race.py` (`All checks passed!`)
- `git diff --check`

CI note: the full `Tests / test` job is currently failing on unrelated baseline failures outside this gateway startup/restart patch:

- `tests/hermes_cli/test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_saved_model_still_probes_endpoint` expects `fetch_api_models` without `api_mode=None`.
- `tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig::test_no_single_field_categories` reports a singleton `prompt_caching` schema category.
- `tests/plugins/memory/test_hindsight_provider.py::TestPostSetup::test_local_embedded_setup_preserves_existing_key_when_input_left_blank` shows blank input overwriting an existing Hindsight key.
- `tests/tools/test_registry.py::TestBuiltinDiscovery::test_matches_previous_manual_builtin_tool_set` sees `tools.spotify_tool` in builtin discovery.

Note: `ruff check gateway/run.py` still reports pre-existing file-level lint violations unrelated to this patch.