### PR TITLE
feat(cron): add [PAUSE] marker for self-pausing cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -238,12 +238,46 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim, pause_job
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+PAUSE_MARKER = "[PAUSE]"
+_CRON_PAUSE_TOKENS = frozenset({"[PAUSE]", "PAUSE"})
+
+def _is_cron_pause_response(text: str) -> bool:
+    """Return True when a cron final response should trigger auto-pause.
+
+    Follows the same strict-matching contract as ``_is_cron_silence_response``:
+    whole-response token, first line, last line, or ``[PAUSE]`` same-line
+    prefix.  Mid-sentence mentions are treated as real content and *not*
+    paused.
+    """
+    if not isinstance(text, str):
+        return False
+    stripped = text.strip()
+    if not stripped:
+        return False
+
+    def _is_token(line: str) -> bool:
+        return " ".join(line.strip().upper().split()) in _CRON_PAUSE_TOKENS
+
+    # Whole response is exactly a token.
+    if _is_token(stripped):
+        return True
+    # Marker on its own first or last line.
+    lines = [ln for ln in stripped.splitlines() if ln.strip()]
+    if lines and (_is_token(lines[0]) or _is_token(lines[-1])):
+        return True
+    # Bracketed sentinel used as a same-line prefix — "[PAUSE] Monitor
+    # complete, auto-closing."
+    upper = stripped.upper()
+    if upper.startswith("[PAUSE]"):
+        return True
+    return False
+
 
 # Canonical silence tokens recognized in cron output.  Cron's contract is
 # intentionally looser than the gateway's exact-whole-response rule: the cron
@@ -3507,6 +3541,17 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             if should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
+
+            # Auto-pause if agent returned [PAUSE] marker.
+            # Uses the same strict-matching contract as _is_cron_silence_response
+            # to avoid false positives from mid-sentence mentions of "[PAUSE]".
+            if success and _is_cron_pause_response(deliver_content):
+                logger.info("Job '%s': agent returned %s — auto-pausing", job["id"], PAUSE_MARKER)
+                try:
+                    pause_job(job["id"], reason="Auto-paused: agent returned [PAUSE]")
+                    _notify_provider_jobs_changed()
+                except Exception as pe:
+                    logger.warning("Failed to auto-pause job %s: %s", job["id"], pe)
 
             if should_deliver:
                 try:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -113,6 +113,7 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+PAUSE_MARKER = "[PAUSE]"
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
@@ -1237,6 +1238,18 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+
+                # Auto-pause: if the agent returned [PAUSE], pause the job
+                # so it won't fire again until manually resumed.  Works with
+                # or without [SILENT] — agent can deliver a final message
+                # then self-pause, or suppress delivery AND pause.
+                if success and PAUSE_MARKER in deliver_content.strip().upper():
+                    logger.info("Job '%s': agent returned %s — pausing job", job["id"], PAUSE_MARKER)
+                    try:
+                        from cron.jobs import pause_job
+                        pause_job(job["id"], reason="Auto-paused: agent returned [PAUSE]")
+                    except Exception as pause_err:
+                        logger.error("Failed to auto-pause job %s: %s", job["id"], pause_err)
                 return True
 
             except Exception as e:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2587,6 +2587,43 @@ class TestSilentDelivery:
         assert not sil("")
         assert not sil("   \n\t ")
 
+    def test_is_cron_pause_response_contract(self):
+        """Direct behavior contract for the cron pause matcher.
+
+        Mirrors the silence matcher: whole-response token, first line, last
+        line, or ``[PAUSE]`` same-line prefix.  Mid-sentence mentions are
+        treated as real content and NOT paused.
+        """
+        from cron.scheduler import _is_cron_pause_response as pau
+        # Pause: bare/bracketed/bracketless tokens, prefix, trailing-line.
+        assert pau("[PAUSE]")
+        assert pau("[pause] monitor complete, auto-closing.")
+        assert pau("[PAUSE] Printer offline, stopping monitor.")
+        assert pau("3 pages printed.\n\n[PAUSE]")
+        assert pau("PAUSE")
+        assert pau("Summary.\nPAUSE")
+        # Deliver (do NOT pause): real content, mid-sentence quotes, bare words, junk.
+        assert not pau("The system hit [PAUSE] but recovered: 2 tasks done.")
+        assert not pau("Paused retry succeeded after 2 attempts.")
+        assert not pau("[PAUSE")  # malformed open-bracket is not the sentinel
+        assert not pau("")
+        assert not pau("   \n\t ")
+
+    def test_silent_and_pause_combined(self):
+        """[SILENT] [PAUSE] on separate lines: pauses (last line wins)."""
+        from cron.scheduler import _is_cron_silence_response as sil
+        from cron.scheduler import _is_cron_pause_response as pau
+        combined = "2 items found.\n\n[SILENT]\n[PAUSE]"
+        # [SILENT] is not the last line (it's followed by [PAUSE]), so silence
+        # is NOT triggered — this is by design: mid-content tokens are content.
+        assert not sil(combined)
+        # But [PAUSE] IS the last line, so pause fires.
+        assert pau(combined)
+        # Reverse order: [PAUSE] then [SILENT] — silence fires (last line).
+        reversed_order = "2 items found.\n\n[PAUSE]\n[SILENT]"
+        assert sil(reversed_order)
+        assert not pau(reversed_order)
+
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \


### PR DESCRIPTION
## Summary

Extends the existing `[SILENT]` marker pattern with a new `[PAUSE]` marker that allows cron agents to automatically pause themselves.

## Problem

Cron agents (especially when using smaller/cheaper models) cannot reliably call the `cronjob` tool to pause themselves. An agent may report that it has paused, but never actually execute the tool call — the job remains `enabled: true` and continues firing on schedule.

This was observed with a 3D printer monitoring job that should stop once the printer goes offline or completes a print. The agent would output text like "Monitor auto-closed" but the job kept running every 15 minutes.

## Solution

Follow the same pattern as the existing `[SILENT]` marker:

1. Added `PAUSE_MARKER = "[PAUSE]"` constant alongside `SILENT_MARKER`
2. After job execution and delivery, check if the agent's response contains `[PAUSE]`
3. If found, call `pause_job()` to pause the job with reason `"Auto-paused: agent returned [PAUSE]"`

### Usage

Cron job prompts can instruct the agent to output `[PAUSE]` on its last line when a stopping condition is met:

```
If the printer is offline, idle (printing complete), or in error state,
output [PAUSE] on your last line to auto-pause this job.
```

Works alongside `[SILENT]`:
- `[PAUSE]` alone → deliver final message, then pause
- `[SILENT] [PAUSE]` → suppress delivery AND pause

## Testing

Tested with a Printer Monitor cron job (GLM-4.7 model, `*/15 * * * *` schedule):
1. Resumed the paused job
2. Agent ran, detected printer offline, delivered notification
3. Agent output `[PAUSE]` on last line
4. Scheduler auto-paused the job ✅

## Files Changed

- `cron/scheduler.py` — Added `PAUSE_MARKER` constant + auto-pause logic (13 lines)