### PR TITLE
test(gateway): make systemd refresh tests hermetic with user D-Bus preflight

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -52,6 +52,7 @@ class TestSystemdServiceRefresh:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_start()
 
@@ -75,6 +76,7 @@ class TestSystemdServiceRefresh:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_restart()
 
@@ -502,6 +504,7 @@ class TestGatewaySystemServiceRouting:
             raise AssertionError(f"Unexpected systemctl call: {cmd}")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_subprocess_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         # get_running_pid returns new PID after restart
         pid_calls = [0]
         def fake_get_pid():
@@ -555,6 +558,7 @@ class TestGatewaySystemServiceRouting:
             raise AssertionError(f"Unexpected command: {cmd}")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_subprocess_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 999 if started["value"] else None,


### PR DESCRIPTION
## Summary
Fixes a test regression introduced by user D-Bus preflight checks in systemd user-scope commands.

This keeps runtime behavior unchanged and makes the affected unit tests hermetic again by stubbing `_preflight_user_systemd` where tests are specifically validating command sequencing / refresh behavior.

### Changes
- Add `monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)` in:
  - `TestSystemdServiceRefresh::test_systemd_start_refreshes_outdated_unit`
  - `TestSystemdServiceRefresh::test_systemd_restart_refreshes_outdated_unit`
  - `TestGatewaySystemServiceRouting::test_systemd_restart_self_requests_graceful_restart_and_waits`
  - `TestGatewaySystemServiceRouting::test_systemd_restart_recovers_failed_planned_restart`

## Why
`systemd_start()` and `systemd_restart()` now call `_preflight_user_systemd()` before the mocked `subprocess.run` path. In non-systemd environments, those tests fail early with `UserSystemdUnavailableError` and never reach their intended assertions.

## Validation
- `pytest -q -n 0 tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_systemd_start_refreshes_outdated_unit tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_systemd_restart_refreshes_outdated_unit tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_systemd_restart_self_requests_graceful_restart_and_waits tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_systemd_restart_recovers_failed_planned_restart`
- `pytest -q -n 0 tests/hermes_cli/test_gateway_service.py`

Closes #15187
