### PR TITLE
fix(gateway): wire up message_timestamp config pipeline

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -67,6 +67,7 @@ class Platform(Enum):
     WEIXIN = "weixin"
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
+    YUANBAO = "yuanbao"
 
 
 @dataclass
@@ -195,6 +196,14 @@ class StreamingConfig:
     edit_interval: float = 1.0    # Seconds between message edits (Telegram rate-limits at ~1/s)
     buffer_threshold: int = 40    # Chars before forcing an edit
     cursor: str = " ▉"           # Cursor shown during streaming
+    # Ported from openclaw/openclaw#72038.  When >0, the final edit for
+    # a long-running streamed response is delivered as a fresh message
+    # if the original preview has been visible for at least this many
+    # seconds, so the platform's visible timestamp reflects completion
+    # time instead of the preview creation time.  Currently applied to
+    # Telegram only (other platforms ignore the setting).  Default 60s
+    # matches the OpenClaw rollout.  Set to 0 to disable.
+    fresh_final_after_seconds: float = 60.0
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -203,6 +212,7 @@ class StreamingConfig:
             "edit_interval": self.edit_interval,
             "buffer_threshold": self.buffer_threshold,
             "cursor": self.cursor,
+            "fresh_final_after_seconds": self.fresh_final_after_seconds,
         }
 
     @classmethod
@@ -215,6 +225,9 @@ class StreamingConfig:
             edit_interval=float(data.get("edit_interval", 1.0)),
             buffer_threshold=int(data.get("buffer_threshold", 40)),
             cursor=data.get("cursor", " ▉"),
+            fresh_final_after_seconds=float(
+                data.get("fresh_final_after_seconds", 60.0)
+            ),
         )
 
 
@@ -265,6 +278,9 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Timestamp injection for inbound messages
+    message_timestamp: Dict[str, Any] = field(default_factory=lambda: {"enabled": False})
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -313,6 +329,9 @@ class GatewayConfig:
                 connected.append(platform)
             # QQBot uses extra dict for app credentials
             elif platform == Platform.QQBOT and config.extra.get("app_id") and config.extra.get("client_secret"):
+                connected.append(platform)
+            # Yuanbao uses extra dict for app credentials
+            elif platform == Platform.YUANBAO and config.extra.get("app_id") and config.extra.get("app_secret"):
                 connected.append(platform)
             # DingTalk uses client_id/client_secret from config.extra or env vars
             elif platform == Platform.DINGTALK and (
@@ -442,6 +461,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            message_timestamp=data.get("message_timestamp", {"enabled": False}),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -528,6 +548,10 @@ def load_gateway_config() -> GatewayConfig:
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
 
+            mt_cfg = yaml_cfg.get("message_timestamp")
+            if isinstance(mt_cfg, dict):
+                gw_data["message_timestamp"] = mt_cfg
+
             if "unauthorized_dm_behavior" in yaml_cfg:
                 gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(
                     yaml_cfg.get("unauthorized_dm_behavior"),
@@ -570,6 +594,8 @@ def load_gateway_config() -> GatewayConfig:
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
+                if "reply_in_thread" in platform_cfg:
+                    bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
@@ -584,7 +610,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_policy"] = platform_cfg["group_policy"]
                 if "group_allow_from" in platform_cfg:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
-                if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
+                if plat in (Platform.DISCORD, Platform.SLACK) and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
@@ -609,6 +635,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(slack_cfg, dict):
                 if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
                     os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
+                if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):
+                    os.environ["SLACK_STRICT_MENTION"] = str(slack_cfg["strict_mention"]).lower()
                 if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
                     os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
                 frc = slack_cfg.get("free_response_channels")
@@ -918,8 +946,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:
         if Platform.SLACK not in config.platforms:
+            # No yaml config for Slack — env-only setup, enable it
             config.platforms[Platform.SLACK] = PlatformConfig()
-        config.platforms[Platform.SLACK].enabled = True
+            config.platforms[Platform.SLACK].enabled = True
+        # If yaml config exists, respect its enabled flag (don't override
+        # explicit enabled: false). Token is still stored so skills that
+        # send Slack messages can use it without activating the gateway adapter.
         config.platforms[Platform.SLACK].token = slack_token
     slack_home = os.getenv("SLACK_HOME_CHANNEL")
     if slack_home and Platform.SLACK in config.platforms:
@@ -1275,6 +1307,48 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 chat_id=qq_home,
                 name=os.getenv("QQBOT_HOME_CHANNEL_NAME") or os.getenv(qq_home_name_env, "Home"),
             )
+
+    # Yuanbao — YUANBAO_APP_ID preferred
+    yuanbao_app_id = os.getenv("YUANBAO_APP_ID") or os.getenv("YUANBAO_APP_KEY")
+    yuanbao_app_secret = os.getenv("YUANBAO_APP_SECRET")
+    if yuanbao_app_id and yuanbao_app_secret:
+        if Platform.YUANBAO not in config.platforms:
+            config.platforms[Platform.YUANBAO] = PlatformConfig()
+        config.platforms[Platform.YUANBAO].enabled = True
+        extra = config.platforms[Platform.YUANBAO].extra
+        extra["app_id"] = yuanbao_app_id
+        extra["app_secret"] = yuanbao_app_secret
+        yuanbao_bot_id = os.getenv("YUANBAO_BOT_ID")
+        if yuanbao_bot_id:
+            extra["bot_id"] = yuanbao_bot_id
+        yuanbao_ws_url = os.getenv("YUANBAO_WS_URL")
+        if yuanbao_ws_url:
+            extra["ws_url"] = yuanbao_ws_url
+        yuanbao_api_domain = os.getenv("YUANBAO_API_DOMAIN")
+        if yuanbao_api_domain:
+            extra["api_domain"] = yuanbao_api_domain
+        yuanbao_route_env = os.getenv("YUANBAO_ROUTE_ENV")
+        if yuanbao_route_env:
+            extra["route_env"] = yuanbao_route_env
+        yuanbao_home = os.getenv("YUANBAO_HOME_CHANNEL")
+        if yuanbao_home:
+            config.platforms[Platform.YUANBAO].home_channel = HomeChannel(
+                platform=Platform.YUANBAO,
+                chat_id=yuanbao_home,
+                name=os.getenv("YUANBAO_HOME_CHANNEL_NAME", "Home"),
+            )
+        yuanbao_dm_policy = os.getenv("YUANBAO_DM_POLICY")
+        if yuanbao_dm_policy:
+            extra["dm_policy"] = yuanbao_dm_policy.strip().lower()
+        yuanbao_dm_allow_from = os.getenv("YUANBAO_DM_ALLOW_FROM")
+        if yuanbao_dm_allow_from:
+            extra["dm_allow_from"] = yuanbao_dm_allow_from
+        yuanbao_group_policy = os.getenv("YUANBAO_GROUP_POLICY")
+        if yuanbao_group_policy:
+            extra["group_policy"] = yuanbao_group_policy.strip().lower()
+        yuanbao_group_allow_from = os.getenv("YUANBAO_GROUP_ALLOW_FROM")
+        if yuanbao_group_allow_from:
+            extra["group_allow_from"] = yuanbao_group_allow_from
 
     # Session settings
     idle_minutes = os.getenv("SESSION_IDLE_MINUTES")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3962,7 +3962,7 @@ class GatewayRunner:
         #     enabled: true           # default: false
         #     format: "%m-%d %H:%M"   # strftime format (default shown)
         # Uses the `timezone` from config.yaml / HERMES_TIMEZONE env var.
-        _ts_cfg = (self.config or {}).get("message_timestamp", {})
+        _ts_cfg = getattr(self.config, "message_timestamp", {}) if self.config else {}
         if isinstance(_ts_cfg, dict) and _ts_cfg.get("enabled", False):
             try:
                 from datetime import datetime as _dt, timezone as _tz

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3956,6 +3956,30 @@ class GatewayRunner:
         history = history or []
         message_text = event.text or ""
 
+        # Prepend a local timestamp so the agent knows when the message
+        # was sent.  Controlled by config.yaml `message_timestamp` setting:
+        #   message_timestamp:
+        #     enabled: true           # default: false
+        #     format: "%m-%d %H:%M"   # strftime format (default shown)
+        # Uses the `timezone` from config.yaml / HERMES_TIMEZONE env var.
+        _ts_cfg = (self.config or {}).get("message_timestamp", {})
+        if isinstance(_ts_cfg, dict) and _ts_cfg.get("enabled", False):
+            try:
+                from datetime import datetime as _dt, timezone as _tz
+                _tz_name = os.environ.get("HERMES_TIMEZONE", "")
+                _tz_obj = _tz.utc
+                if _tz_name:
+                    try:
+                        from zoneinfo import ZoneInfo
+                        _tz_obj = ZoneInfo(_tz_name)
+                    except Exception:
+                        pass
+                _fmt = _ts_cfg.get("format", "%m-%d %H:%M")
+                _ts_str = _dt.now(_tz_obj).strftime(_fmt)
+                message_text = f"[{_ts_str}] {message_text}"
+            except Exception:
+                pass  # Non-fatal — skip timestamp on error
+
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -700,7 +700,14 @@ DEFAULT_CONFIG = {
             "device": "cpu",  # cpu, cuda, or mps
         },
     },
-    
+
+    # Prepend a local timestamp to inbound gateway messages so the agent
+    # knows when each message was sent.  Uses the top-level `timezone` setting.
+    "message_timestamp": {
+        "enabled": False,           # Set true to enable
+        "format": "%m-%d %H:%M",    # strftime format string
+    },
+
     "stt": {
         "enabled": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)


### PR DESCRIPTION
## Summary

Fix the `message_timestamp` config pipeline so that the existing timestamp injection code in `_prepare_inbound_message_text` actually reads from config.yaml.

## Problem

Commit b4193b63 added timestamp injection code to `gateway/run.py` that prepends `[MM-DD HH:MM]` to inbound messages, controlled by a `message_timestamp` config section. However, the config pipeline was never wired up:

1. `GatewayConfig` dataclass has no `message_timestamp` field
2. `from_dict()` does not map the key into the constructor
3. `load_gateway_config()` does not read it from YAML

Result: timestamps are silently disabled even when config.yaml has the setting. Additionally, `.get()` on the dataclass caused AttributeError crashes.

## Solution

- config.py: dataclass field + from_dict() + load_gateway_config() pipeline (3 fixes)
- run.py: .get() on dataclass -> getattr()

## Testing

Verified [MM-DD HH:MM] prefix on Telegram inbound messages with config: `message_timestamp: {enabled: true, format: "%m-%d %H:%M"}`

## Files Changed

- gateway/config.py - GatewayConfig field + from_dict + yaml reader pipeline
- gateway/run.py - getattr fix, removed debug log