### PR TITLE
fix(agent): guard switch_model when fallback chain is unset

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2107,8 +2107,15 @@ class AIAgent:
             })
 
         # ── Reset fallback state ──
+        # Some tests and lightweight callers construct an agent via __new__()
+        # and invoke switch_model() without running the full __init__ path.
+        # Normalize the legacy fallback attributes here before pruning so the
+        # model switch logic stays robust for those call sites too.
+        fallback_chain = list(getattr(self, "_fallback_chain", []) or [])
+        self._fallback_chain = fallback_chain
         self._fallback_activated = False
         self._fallback_index = 0
+        self._fallback_model = fallback_chain[0] if fallback_chain else None
 
         # When the user deliberately swaps primary providers (e.g. openrouter
         # → anthropic), drop any fallback entries that target the OLD primary


### PR DESCRIPTION
## Summary\n- normalize fallback state at the start of AIAgent.switch_model()\n- avoid crashing when lightweight callers or tests invoke switch_model() without the full __init__ path\n- preserve existing fallback-pruning behavior when switching primary providers\n\n## Why\nRecent CI failures across authored PRs include tests/agent/test_minimax_provider.py::TestMinimaxSwitchModelCredentialGuard::test_switch_to_minimax_does_not_resolve_anthropic_token, which crashes with an AttributeError before the actual credential guard can be verified.\n\nThis patch keeps switch_model() robust for those direct-call paths and removes one shared test failure from the current PR backlog.\n\n## Verification\n- python3.12 direct repro of the failing MiniMax switch_model path now passes without _fallback_chain present\n- python3.12 direct repro of fallback-pruning compatibility still passes