### PR TITLE
feat(handoff): structured Code Crab completion callback handler

### DIFF
--- a/gateway/handoffs.py
+++ b/gateway/handoffs.py
@@ -1,0 +1,243 @@
+"""Hermes handoff record persistence and validation.
+
+Manages small handoff/run records for Hermes <-> Code Crab coordination.
+Records are stored as individual JSON files in ~/.hermes/handoffs/.
+
+Each record tracks: handoff_id, origin metadata, requester, request summary,
+acceptance criteria, queued next action, and status lifecycle.
+"""
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+HANDOFFS_DIR = "handoffs"
+
+# Valid status values and allowed transitions
+VALID_STATUSES = {"requested", "in_progress", "done", "blocked", "failed"}
+VALID_TRANSITIONS: Dict[str, set] = {
+    "requested": {"in_progress", "blocked", "failed"},
+    "in_progress": {"done", "blocked", "failed"},
+    # Terminal states allow re-entry for idempotent callbacks
+    "done": {"done"},
+    "blocked": {"blocked", "in_progress"},
+    "failed": {"failed", "in_progress"},
+}
+
+
+def _handoffs_dir() -> Path:
+    """Return the handoffs storage directory, creating it if needed."""
+    d = get_hermes_home() / HANDOFFS_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _record_path(handoff_id: str) -> Path:
+    """Return the file path for a handoff record."""
+    # Sanitize ID to prevent path traversal
+    safe_id = handoff_id.replace("/", "_").replace("..", "_")
+    return _handoffs_dir() / f"{safe_id}.json"
+
+
+def create_handoff(
+    handoff_id: str,
+    origin_platform: str = "",
+    origin_channel_id: str = "",
+    origin_thread_id: str = "",
+    origin_message_id: str = "",
+    requestor: str = "",
+    request_summary: str = "",
+    acceptance_criteria: str = "",
+    done_when: str = "",
+    next_action: str = "",
+    next_action_safe: bool = False,
+    callback_contract: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Create and persist a new handoff record.
+
+    Raises ValueError if a record with this handoff_id already exists.
+    """
+    path = _record_path(handoff_id)
+    if path.exists():
+        raise ValueError(f"Handoff record already exists: {handoff_id}")
+
+    record = {
+        "handoff_id": handoff_id,
+        "status": "requested",
+        "origin": {
+            "platform": origin_platform,
+            "channel_id": origin_channel_id,
+            "thread_id": origin_thread_id,
+            "message_id": origin_message_id,
+        },
+        "requestor": requestor,
+        "request_summary": request_summary,
+        "acceptance_criteria": acceptance_criteria,
+        "done_when": done_when,
+        "next_action": next_action,
+        "next_action_safe": next_action_safe,
+        "callback_contract": callback_contract or {},
+        "callback_received": None,
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "return_message_id": None,
+    }
+
+    _write_record(path, record)
+    logger.info("[handoffs] Created handoff record: %s", handoff_id)
+    return record
+
+
+def get_handoff(handoff_id: str) -> Optional[Dict[str, Any]]:
+    """Load a handoff record by ID. Returns None if not found."""
+    path = _record_path(handoff_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error("[handoffs] Failed to read %s: %s", handoff_id, e)
+        return None
+
+
+def validate_status_transition(current: str, proposed: str) -> bool:
+    """Check if a status transition is valid."""
+    if current not in VALID_TRANSITIONS:
+        return False
+    return proposed in VALID_TRANSITIONS[current]
+
+
+def update_handoff_status(
+    handoff_id: str,
+    new_status: str,
+    callback_payload: Optional[Dict[str, Any]] = None,
+    return_message_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update a handoff record's status and optionally store callback data.
+
+    Raises ValueError if handoff_id is unknown or transition is invalid.
+    Idempotent: re-applying the same terminal status is a no-op.
+    """
+    record = get_handoff(handoff_id)
+    if record is None:
+        raise ValueError(f"Unknown handoff_id: {handoff_id}")
+
+    current = record["status"]
+
+    if not validate_status_transition(current, new_status):
+        raise ValueError(
+            f"Invalid status transition: {current} -> {new_status} "
+            f"(allowed: {VALID_TRANSITIONS.get(current, set())})"
+        )
+
+    # Idempotent: same terminal status with existing callback = no-op
+    if current == new_status and record.get("callback_received") is not None:
+        logger.info(
+            "[handoffs] Idempotent callback for %s (already %s)",
+            handoff_id,
+            current,
+        )
+        return record
+
+    record["status"] = new_status
+    record["updated_at"] = time.time()
+    if callback_payload is not None:
+        record["callback_received"] = callback_payload
+    if return_message_id is not None:
+        record["return_message_id"] = return_message_id
+
+    _write_record(_record_path(handoff_id), record)
+    logger.info(
+        "[handoffs] Updated %s: %s -> %s", handoff_id, current, new_status
+    )
+    return record
+
+
+def list_handoffs(status_filter: Optional[str] = None) -> List[Dict[str, Any]]:
+    """List all handoff records, optionally filtered by status."""
+    records = []
+    handoffs_dir = _handoffs_dir()
+    for path in sorted(handoffs_dir.glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if status_filter is None or record.get("status") == status_filter:
+                records.append(record)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return records
+
+
+def render_origin_message(record: Dict[str, Any]) -> str:
+    """Render a concise return message for the origin thread/channel.
+
+    Includes status, summary, key artifacts, and verification results
+    so Kevin (or whoever is watching the thread) can trust the outcome.
+    """
+    cb = record.get("callback_received") or {}
+    status = record.get("status", "unknown")
+    summary = cb.get("summary", record.get("request_summary", ""))
+
+    parts = [f"**Handoff {record['handoff_id']}** — status: **{status}**"]
+
+    if summary:
+        parts.append(f"\n{summary}")
+
+    # Artifacts
+    artifacts = cb.get("artifacts", {})
+    artifact_lines = []
+    if artifacts.get("pr"):
+        artifact_lines.append(f"PR: {artifacts['pr']}")
+    if artifacts.get("branch"):
+        artifact_lines.append(f"Branch: `{artifacts['branch']}`")
+    if artifacts.get("commit"):
+        artifact_lines.append(f"Commit: `{artifacts['commit'][:12]}`")
+    if artifact_lines:
+        parts.append("\n**Artifacts:** " + " | ".join(artifact_lines))
+
+    # Verification
+    verification = cb.get("verification", {})
+    if verification.get("results"):
+        parts.append(f"\n**Verification:** {verification['results']}")
+
+    # Next action
+    if cb.get("needs_kevin"):
+        parts.append(
+            f"\n:warning: **Needs Kevin** — {cb.get('next_recommended_action', 'review required')}"
+        )
+    elif cb.get("next_recommended_action"):
+        parts.append(
+            f"\n**Next:** {cb['next_recommended_action']}"
+        )
+
+    return "\n".join(parts)
+
+
+def should_auto_resume(record: Dict[str, Any]) -> bool:
+    """Determine if Hermes should auto-resume the queued next action.
+
+    Auto-resume only when:
+    - status is 'done'
+    - needs_kevin is false
+    - next_action is set and marked safe
+    """
+    cb = record.get("callback_received") or {}
+    return (
+        record.get("status") == "done"
+        and not cb.get("needs_kevin", True)
+        and bool(record.get("next_action"))
+        and record.get("next_action_safe", False)
+    )
+
+
+def _write_record(path: Path, record: Dict[str, Any]) -> None:
+    """Atomic write: temp file + rename to prevent partial reads."""
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    os.replace(str(tmp), str(path))

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -340,6 +340,12 @@ class WebhookAdapter(BasePlatformAdapter):
                     {"error": "Cannot parse body"}, status=400
                 )
 
+        # ── Built-in route: code-crab-completion ────────────────
+        # Structured handoff callback from Code Crab — handled inline
+        # (does NOT go through the normal agent processing flow).
+        if route_name == "code-crab-completion":
+            return await self._handle_code_crab_completion(payload)
+
         # Check event type filter
         event_type = (
             request.headers.get("X-GitHub-Event", "")
@@ -475,6 +481,149 @@ class WebhookAdapter(BasePlatformAdapter):
                 "delivery_id": delivery_id,
             },
             status=202,
+        )
+
+    # ------------------------------------------------------------------
+    # Built-in handler: Code Crab completion callback
+    # ------------------------------------------------------------------
+
+    async def _handle_code_crab_completion(
+        self, payload: dict
+    ) -> "web.Response":
+        """Handle a structured handoff completion callback from Code Crab.
+
+        Validates the payload, updates the handoff record, posts a concise
+        return message to the origin thread/channel, and optionally triggers
+        auto-resume for safe queued actions.
+
+        This bypasses the normal agent processing flow entirely — no prompt
+        rendering, no skill loading, no agent run.
+        """
+        from gateway.handoffs import (
+            get_handoff,
+            render_origin_message,
+            should_auto_resume,
+            update_handoff_status,
+            validate_status_transition,
+        )
+
+        handoff_id = payload.get("handoff_id")
+        status = payload.get("status")
+
+        # Validate required fields
+        if not handoff_id or not isinstance(handoff_id, str):
+            return web.json_response(
+                {"error": "Missing or invalid handoff_id"}, status=400
+            )
+        if status not in ("done", "blocked", "failed"):
+            return web.json_response(
+                {"error": f"Invalid status: {status}"}, status=400
+            )
+
+        # Look up handoff record
+        record = get_handoff(handoff_id)
+        if record is None:
+            logger.warning(
+                "[webhook] Unknown handoff_id in completion callback: %s",
+                handoff_id,
+            )
+            return web.json_response(
+                {"error": f"Unknown handoff_id: {handoff_id}"}, status=404
+            )
+
+        # Validate status transition
+        current_status = record.get("status", "requested")
+        if not validate_status_transition(current_status, status):
+            return web.json_response(
+                {
+                    "error": f"Invalid transition: {current_status} -> {status}",
+                    "current_status": current_status,
+                },
+                status=409,
+            )
+
+        # Update handoff record
+        try:
+            record = update_handoff_status(
+                handoff_id, status, callback_payload=payload
+            )
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=409)
+
+        # Post return message to origin thread/channel
+        return_message_id = None
+        origin = record.get("origin", {})
+        origin_platform = origin.get("platform", "")
+        origin_channel_id = origin.get("channel_id", "")
+
+        if origin_platform and origin_channel_id and self.gateway_runner:
+            message = render_origin_message(record)
+            try:
+                target_platform = Platform(origin_platform)
+                adapter = self.gateway_runner.adapters.get(target_platform)
+                if adapter:
+                    metadata = None
+                    if origin.get("thread_id"):
+                        metadata = {"thread_id": origin["thread_id"]}
+                    result = await adapter.send(
+                        origin_channel_id, message, metadata=metadata
+                    )
+                    if result.success:
+                        return_message_id = getattr(
+                            result, "message_id", None
+                        )
+                        logger.info(
+                            "[webhook] Posted handoff return message to %s/%s",
+                            origin_platform,
+                            origin_channel_id,
+                        )
+                    else:
+                        logger.error(
+                            "[webhook] Failed to post return message: %s",
+                            result.error,
+                        )
+                else:
+                    logger.warning(
+                        "[webhook] Origin platform %s not connected",
+                        origin_platform,
+                    )
+            except Exception as e:
+                logger.error(
+                    "[webhook] Error posting return message: %s", e
+                )
+
+        # Store return message ID
+        if return_message_id:
+            try:
+                update_handoff_status(
+                    handoff_id,
+                    status,
+                    return_message_id=str(return_message_id),
+                )
+            except ValueError:
+                pass  # Already at terminal status, ignore
+
+        # Check auto-resume
+        auto_resume = should_auto_resume(record)
+        if auto_resume:
+            logger.info(
+                "[webhook] Auto-resume eligible for %s: %s",
+                handoff_id,
+                record.get("next_action", ""),
+            )
+            # Auto-resume is logged but not executed inline — the gateway
+            # supervisor or a separate scheduler should pick this up.
+            # For now we include it in the response so callers know.
+
+        return web.json_response(
+            {
+                "status": "accepted",
+                "handoff_id": handoff_id,
+                "new_status": status,
+                "return_message_posted": return_message_id is not None,
+                "return_message_id": return_message_id,
+                "auto_resume_eligible": auto_resume,
+            }
         )
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_handoffs.py
+++ b/tests/gateway/test_handoffs.py
@@ -1,0 +1,272 @@
+"""Tests for gateway/handoffs.py — handoff record persistence and validation."""
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Patch HERMES_HOME to use a temp directory for all tests
+_TEMP_DIR = None
+
+
+@pytest.fixture(autouse=True)
+def temp_hermes_home(tmp_path):
+    """Redirect handoffs storage to a temp directory for each test."""
+    global _TEMP_DIR
+    _TEMP_DIR = tmp_path
+    with mock.patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+from gateway.handoffs import (
+    VALID_TRANSITIONS,
+    create_handoff,
+    get_handoff,
+    list_handoffs,
+    render_origin_message,
+    should_auto_resume,
+    update_handoff_status,
+    validate_status_transition,
+)
+
+
+# ── create / get ─────────────────────────────────────────────
+
+
+class TestCreateAndGet:
+    def test_create_persists_record(self, tmp_path):
+        record = create_handoff(
+            handoff_id="hc_test_001",
+            origin_platform="discord",
+            origin_channel_id="123",
+            origin_thread_id="456",
+            origin_message_id="789",
+            requestor="Kevin",
+            request_summary="Fix the auth bug",
+            done_when="Tests pass",
+        )
+        assert record["handoff_id"] == "hc_test_001"
+        assert record["status"] == "requested"
+        assert record["requestor"] == "Kevin"
+        assert record["origin"]["channel_id"] == "123"
+        assert record["origin"]["thread_id"] == "456"
+
+        # Verify it's actually on disk
+        loaded = get_handoff("hc_test_001")
+        assert loaded is not None
+        assert loaded["handoff_id"] == "hc_test_001"
+
+    def test_create_rejects_duplicate(self, tmp_path):
+        create_handoff(handoff_id="hc_dup_001")
+        with pytest.raises(ValueError, match="already exists"):
+            create_handoff(handoff_id="hc_dup_001")
+
+    def test_get_returns_none_for_unknown(self, tmp_path):
+        assert get_handoff("hc_nonexistent") is None
+
+
+# ── status transitions ───────────────────────────────────────
+
+
+class TestStatusTransitions:
+    def test_valid_transitions(self):
+        assert validate_status_transition("requested", "in_progress")
+        assert validate_status_transition("requested", "blocked")
+        assert validate_status_transition("requested", "failed")
+        assert validate_status_transition("in_progress", "done")
+        assert validate_status_transition("in_progress", "blocked")
+        assert validate_status_transition("in_progress", "failed")
+        # Idempotent terminal states
+        assert validate_status_transition("done", "done")
+        assert validate_status_transition("blocked", "blocked")
+        assert validate_status_transition("failed", "failed")
+        # Recovery from blocked/failed
+        assert validate_status_transition("blocked", "in_progress")
+        assert validate_status_transition("failed", "in_progress")
+
+    def test_invalid_transitions(self):
+        assert not validate_status_transition("requested", "done")
+        assert not validate_status_transition("done", "in_progress")
+        assert not validate_status_transition("done", "failed")
+        assert not validate_status_transition("done", "blocked")
+
+    def test_update_status(self, tmp_path):
+        create_handoff(handoff_id="hc_trans_001")
+        record = update_handoff_status("hc_trans_001", "in_progress")
+        assert record["status"] == "in_progress"
+
+        record = update_handoff_status(
+            "hc_trans_001",
+            "done",
+            callback_payload={"summary": "All fixed"},
+        )
+        assert record["status"] == "done"
+        assert record["callback_received"]["summary"] == "All fixed"
+
+    def test_update_rejects_invalid_transition(self, tmp_path):
+        create_handoff(handoff_id="hc_invalid_001")
+        with pytest.raises(ValueError, match="Invalid status transition"):
+            update_handoff_status("hc_invalid_001", "done")
+
+    def test_update_rejects_unknown_id(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown handoff_id"):
+            update_handoff_status("hc_ghost", "done")
+
+    def test_idempotent_callback(self, tmp_path):
+        create_handoff(handoff_id="hc_idem_001")
+        update_handoff_status("hc_idem_001", "in_progress")
+        update_handoff_status(
+            "hc_idem_001",
+            "done",
+            callback_payload={"summary": "First"},
+        )
+        # Second callback with same status should be idempotent
+        record = update_handoff_status(
+            "hc_idem_001",
+            "done",
+            callback_payload={"summary": "Second"},
+        )
+        # Should still have the first callback (idempotent = no-op)
+        assert record["callback_received"]["summary"] == "First"
+
+
+# ── list ─────────────────────────────────────────────────────
+
+
+class TestListHandoffs:
+    def test_list_all(self, tmp_path):
+        create_handoff(handoff_id="hc_list_001")
+        create_handoff(handoff_id="hc_list_002")
+        records = list_handoffs()
+        assert len(records) == 2
+
+    def test_list_with_filter(self, tmp_path):
+        create_handoff(handoff_id="hc_filter_001")
+        create_handoff(handoff_id="hc_filter_002")
+        update_handoff_status("hc_filter_002", "in_progress")
+        assert len(list_handoffs("requested")) == 1
+        assert len(list_handoffs("in_progress")) == 1
+        assert len(list_handoffs("done")) == 0
+
+
+# ── render_origin_message ────────────────────────────────────
+
+
+class TestRenderOriginMessage:
+    def test_basic_done_message(self, tmp_path):
+        create_handoff(handoff_id="hc_render_001", request_summary="Fix auth")
+        update_handoff_status("hc_render_001", "in_progress")
+        record = update_handoff_status(
+            "hc_render_001",
+            "done",
+            callback_payload={
+                "summary": "Fixed the auth middleware",
+                "artifacts": {
+                    "pr": "https://github.com/example/repo/pull/42",
+                    "branch": "fix/auth",
+                },
+                "verification": {"results": "All 15 tests pass"},
+                "needs_kevin": False,
+            },
+        )
+
+        msg = render_origin_message(record)
+        assert "hc_render_001" in msg
+        assert "done" in msg
+        assert "Fixed the auth middleware" in msg
+        assert "pull/42" in msg
+        assert "fix/auth" in msg
+        assert "All 15 tests pass" in msg
+
+    def test_blocked_needs_kevin(self, tmp_path):
+        create_handoff(handoff_id="hc_render_002")
+        update_handoff_status("hc_render_002", "in_progress")
+        record = update_handoff_status(
+            "hc_render_002",
+            "blocked",
+            callback_payload={
+                "summary": "Missing API key",
+                "needs_kevin": True,
+                "next_recommended_action": "Provide staging API key",
+            },
+        )
+
+        msg = render_origin_message(record)
+        assert "blocked" in msg
+        assert "Needs Kevin" in msg
+        assert "Provide staging API key" in msg
+
+
+# ── should_auto_resume ───────────────────────────────────────
+
+
+class TestAutoResume:
+    def test_auto_resume_when_safe(self, tmp_path):
+        create_handoff(
+            handoff_id="hc_resume_001",
+            next_action="Deploy to staging",
+            next_action_safe=True,
+        )
+        update_handoff_status("hc_resume_001", "in_progress")
+        record = update_handoff_status(
+            "hc_resume_001",
+            "done",
+            callback_payload={"needs_kevin": False},
+        )
+        assert should_auto_resume(record) is True
+
+    def test_no_resume_when_needs_kevin(self, tmp_path):
+        create_handoff(
+            handoff_id="hc_resume_002",
+            next_action="Deploy to prod",
+            next_action_safe=True,
+        )
+        update_handoff_status("hc_resume_002", "in_progress")
+        record = update_handoff_status(
+            "hc_resume_002",
+            "done",
+            callback_payload={"needs_kevin": True},
+        )
+        assert should_auto_resume(record) is False
+
+    def test_no_resume_when_blocked(self, tmp_path):
+        create_handoff(
+            handoff_id="hc_resume_003",
+            next_action="Continue",
+            next_action_safe=True,
+        )
+        update_handoff_status("hc_resume_003", "in_progress")
+        record = update_handoff_status(
+            "hc_resume_003",
+            "blocked",
+            callback_payload={"needs_kevin": False},
+        )
+        assert should_auto_resume(record) is False
+
+    def test_no_resume_when_action_unsafe(self, tmp_path):
+        create_handoff(
+            handoff_id="hc_resume_004",
+            next_action="Deploy to prod",
+            next_action_safe=False,
+        )
+        update_handoff_status("hc_resume_004", "in_progress")
+        record = update_handoff_status(
+            "hc_resume_004",
+            "done",
+            callback_payload={"needs_kevin": False},
+        )
+        assert should_auto_resume(record) is False
+
+    def test_no_resume_when_no_action(self, tmp_path):
+        create_handoff(handoff_id="hc_resume_005")
+        update_handoff_status("hc_resume_005", "in_progress")
+        record = update_handoff_status(
+            "hc_resume_005",
+            "done",
+            callback_payload={"needs_kevin": False},
+        )
+        assert should_auto_resume(record) is False


### PR DESCRIPTION
## Summary
- add handoff record persistence for Hermes ↔ Code Crab coordination
- add built-in webhook route for Code Crab completion callbacks
- post rendered completion results back to the stored origin channel/thread
- add tests for handoff lifecycle, idempotency, rendering, and auto-resume eligibility

## Verification
- source venv/bin/activate && python -m pytest tests/gateway/test_handoffs.py -q