### PR TITLE
fix(runtime_provider): strip trailing /v1 for kimi-coding anthropic_messages mode

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -868,7 +868,7 @@ def switch_model(
     # on opencode-zen) hit a double /v1 and returned OpenCode's website 404 page.
     if (
         api_mode == "anthropic_messages"
-        and target_provider in {"opencode-zen", "opencode-go"}
+        and target_provider in {"opencode-zen", "opencode-go", "kimi-coding"}
         and isinstance(base_url, str)
         and base_url
     ):

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -251,7 +251,7 @@ def _resolve_runtime_from_pool_entry(
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
     # trailing /v1 so the SDK constructs the correct path (e.g.
     # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go", "kimi-coding"):
         base_url = re.sub(r"/v1/?$", "", base_url)
 
     return {
@@ -1057,7 +1057,7 @@ def resolve_runtime_provider(
                 if detected:
                     api_mode = detected
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
-        if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+        if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go", "kimi-coding"):
             base_url = re.sub(r"/v1/?$", "", base_url)
         return {
             "provider": provider,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1991,7 +1991,7 @@ class AIAgent:
         # tests) can't reintroduce the double-/v1 404 bug.
         if (
             api_mode == "anthropic_messages"
-            and new_provider in ("opencode-zen", "opencode-go")
+            and new_provider in ("opencode-zen", "opencode-go", "kimi-coding")
             and isinstance(base_url, str)
             and base_url
         ):

--- a/tests/hermes_cli/test_determine_api_mode_hostname.py
+++ b/tests/hermes_cli/test_determine_api_mode_hostname.py
@@ -41,3 +41,23 @@ class TestAnthropicHostHardening:
         # proxies) expose the Anthropic protocol under a ``/anthropic`` suffix.
         # That convention must still resolve to anthropic_messages.
         assert determine_api_mode("", "https://api.minimax.io/anthropic") == "anthropic_messages"
+
+
+class TestKimiCodingHostDetection:
+    """Kimi /coding endpoint must resolve to anthropic_messages."""
+
+    def test_kimi_coding_url_is_anthropic_messages(self):
+        assert determine_api_mode("", "https://api.kimi.com/coding") == "anthropic_messages"
+
+    def test_kimi_coding_v1_url_is_anthropic_messages(self):
+        assert determine_api_mode("", "https://api.kimi.com/coding/v1") == "anthropic_messages"
+
+    def test_kimi_coding_anthropic_url_is_anthropic_messages(self):
+        assert determine_api_mode("", "https://api.kimi.com/coding/anthropic") == "anthropic_messages"
+
+    def test_kimi_plain_v1_is_chat_completions(self):
+        # Plain api.kimi.com/v1 (without /coding) is OpenAI-compatible
+        assert determine_api_mode("", "https://api.kimi.com/v1") == "chat_completions"
+
+    def test_kimi_host_suffix_is_not_anthropic(self):
+        assert determine_api_mode("", "https://api.kimi.com.example/v1") == "chat_completions"

--- a/tests/hermes_cli/test_model_switch_kimi_coding.py
+++ b/tests/hermes_cli/test_model_switch_kimi_coding.py
@@ -1,0 +1,112 @@
+"""Regression tests for Kimi /v1 stripping during /model switch.
+
+When switching to an Anthropic-routed Kimi model mid-session
+(``/model kimi-for-coding`` on kimi-coding), the resolved base_url must
+have its trailing ``/v1`` stripped before being handed to the Anthropic SDK.
+
+Without the strip, the SDK prepends its own ``/v1/messages`` path and
+requests hit ``https://api.kimi.com/coding/v1/v1/messages`` — a double
+``/v1`` that returns Kimi's 404 error.
+
+``hermes_cli.runtime_provider.resolve_runtime_provider`` already strips
+``/v1`` at fresh agent init, but the ``/model`` mid-session switch path in
+``hermes_cli.model_switch.switch_model`` was missing the same logic.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _run_kimi_switch(
+    raw_input: str,
+    current_provider: str,
+    current_model: str,
+    current_base_url: str,
+    explicit_provider: str = "",
+    runtime_base_url: str = "",
+):
+    """Run switch_model with Kimi mocks and return the result."""
+    effective_runtime_base = runtime_base_url or current_base_url
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "sk-kimi-fake",
+                "base_url": effective_runtime_base,
+                "api_mode": "anthropic_messages",
+            },
+        ),
+        patch(
+            "hermes_cli.models.validate_requested_model",
+            return_value=_MOCK_VALIDATION,
+        ),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model=current_model,
+            current_base_url=current_base_url,
+            current_api_key="sk-kimi-fake",
+            explicit_provider=explicit_provider,
+        )
+
+
+class TestKimiCodingV1Strip:
+    """kimi-coding: ``/model kimi-for-coding`` must strip /v1."""
+
+    def test_switch_to_kimi_for_coding_strips_v1(self):
+        """OpenRouter → Kimi: base_url loses trailing /v1."""
+        result = _run_kimi_switch(
+            raw_input="kimi-for-coding",
+            current_provider="kimi-coding",
+            current_model="kimi-for-coding",
+            current_base_url="https://api.kimi.com/coding/v1",
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+        assert result.api_mode == "anthropic_messages"
+        assert result.base_url == "https://api.kimi.com/coding", (
+            f"Expected /v1 stripped for anthropic_messages; got {result.base_url}"
+        )
+
+    def test_switch_to_kimi_k2_turbo_strips_v1(self):
+        """Same behavior for kimi-k2-turbo-preview."""
+        result = _run_kimi_switch(
+            raw_input="kimi-k2-turbo-preview",
+            current_provider="kimi-coding",
+            current_model="kimi-for-coding",
+            current_base_url="https://api.kimi.com/coding/v1",
+        )
+
+        assert result.success
+        assert result.api_mode == "anthropic_messages"
+        assert result.base_url == "https://api.kimi.com/coding"
+
+    def test_trailing_slash_also_stripped(self):
+        """``/v1/`` with trailing slash is also stripped cleanly."""
+        result = _run_kimi_switch(
+            raw_input="kimi-for-coding",
+            current_provider="kimi-coding",
+            current_model="kimi-for-coding",
+            current_base_url="https://api.kimi.com/coding/v1/",
+        )
+
+        assert result.success
+        assert result.api_mode == "anthropic_messages"
+        assert result.base_url == "https://api.kimi.com/coding"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1565,3 +1565,82 @@ class TestOllamaUrlSubstringLeak:
         resolved = rp.resolve_runtime_provider(requested="custom")
 
         assert resolved["api_key"] == "ol-legit-key"
+
+
+class TestKimiCodingV1Strip:
+    """Kimi /coding endpoints must have trailing /v1 stripped for anthropic_messages.
+
+    The Anthropic SDK appends its own /v1/messages path to the base_url.
+    If the base_url already ends in /v1 (e.g. from KIMI_BASE_URL env override),
+    the SDK requests /coding/v1/v1/messages — a double-/v1 404.
+    """
+
+    def test_kimi_coding_explicit_with_v1_suffix_strips_it(self, monkeypatch):
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {
+                "provider": "kimi-coding",
+                "default": "kimi-for-coding",
+                "base_url": "https://api.kimi.com/coding/v1",
+            },
+        )
+        monkeypatch.setenv("KIMI_API_KEY", "sk-kimi-test")
+        monkeypatch.delenv("KIMI_BASE_URL", raising=False)
+
+        resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+        assert resolved["provider"] == "kimi-coding"
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+    def test_kimi_coding_without_v1_suffix_unchanged(self, monkeypatch):
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {
+                "provider": "kimi-coding",
+                "default": "kimi-for-coding",
+                "base_url": "https://api.kimi.com/coding",
+            },
+        )
+        monkeypatch.setenv("KIMI_API_KEY", "sk-kimi-test")
+        monkeypatch.delenv("KIMI_BASE_URL", raising=False)
+
+        resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+        assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+    def test_kimi_coding_pool_entry_with_v1_suffix_strips_it(self, monkeypatch):
+        class _Entry:
+            access_token = "pool-kimi-token"
+            source = "manual"
+            base_url = "https://api.kimi.com/coding/v1"
+            runtime_api_key = "pool-kimi-token"
+            runtime_base_url = "https://api.kimi.com/coding/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {
+                "provider": "kimi-coding",
+                "default": "kimi-for-coding",
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+        assert resolved["provider"] == "kimi-coding"
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"] == "https://api.kimi.com/coding"


### PR DESCRIPTION
## Problem

Kimi's `/coding` endpoint (`api.kimi.com/coding`) speaks the Anthropic Messages protocol. When a user configures `base_url: https://api.kimi.com/coding/v1` (e.g. via `KIMI_BASE_URL` env override), the Anthropic SDK appends its own `/v1/messages` path to the base URL. This produces `https://api.kimi.com/coding/v1/v1/messages` — a double `/v1` that returns HTTP 404.

The code already strips trailing `/v1` for OpenCode providers (`opencode-zen`, `opencode-go`) in the same scenario, but `kimi-coding` was missing from that logic.

## Fix

Add `kimi-coding` to the existing `/v1` strip conditions in three locations:

- `hermes_cli/runtime_provider.py` — `resolve_runtime_provider()` and `_resolve_runtime_from_pool_entry()`
- `hermes_cli/model_switch.py` — `switch_model()` (mid-session `/model` switch path)
- `run_agent.py` — `AIAgent.switch_model()` (defense-in-depth guard)

## Tests

- `tests/hermes_cli/test_determine_api_mode_hostname.py` — verifies `api.kimi.com/coding/*` resolves to `anthropic_messages`
- `tests/hermes_cli/test_runtime_provider_resolution.py` — verifies `/v1` stripped for explicit config and pool entries
- `tests/hermes_cli/test_model_switch_kimi_coding.py` — verifies `/v1` stripped during `/model` switch

All 18 new tests pass.