### PR TITLE
test(matrix): mock attachment encryption dependency

### DIFF
--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1237,9 +1237,11 @@ class TestMatrixUploadAndSend:
         mock_client.send_message_event = AsyncMock(return_value="$event")
         adapter._client = mock_client
 
-        result = await adapter._upload_and_send(
-            "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
-        )
+        fake_mautrix_mods = _make_fake_mautrix()
+        with patch.dict(sys.modules, fake_mautrix_mods):
+            result = await adapter._upload_and_send(
+                "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
+            )
 
         assert result.success is True
         # Should have uploaded ciphertext, not plaintext


### PR DESCRIPTION
## Summary
- Mock the `mautrix.crypto.attachments.encrypt_attachment` import path in the encrypted Matrix upload unit test.
- Keeps the test deterministic on environments where optional Matrix E2EE dependencies are not installed.

## Why
`test_upload_encrypted_room_uses_file_payload` exercises Matrix encrypted attachment message-shape behavior, but it imported `mautrix.crypto.attachments` at runtime and failed locally with `No module named 'mautrix'`. The file already has a `_make_fake_mautrix()` helper including a fake `encrypt_attachment`; this PR uses it for that test.

## Test Plan
- `./scripts/run_tests.sh tests/gateway/test_matrix.py::TestMatrixUploadAndSend::test_upload_encrypted_room_uses_file_payload -q`
  - Result: `1 passed`
- `./scripts/run_tests.sh tests/gateway/test_matrix.py::TestMatrixUploadAndSend -q`
  - Result: `2 passed`
- `./scripts/run_tests.sh tests/gateway/test_matrix.py -q`
  - Result: `114 passed`
