### PR TITLE
fix(plugins): honor pre_llm_call short_circuit_response

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -600,6 +600,7 @@ def run_conversation(
     current_turn_user_idx = _ctx.current_turn_user_idx
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
+    _plugin_short_circuit_response = _ctx.plugin_short_circuit_response
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
     # Main conversation loop counters (pure locals consumed by the loop below).
@@ -626,12 +627,26 @@ def run_conversation(
     # over instead of spinning. Reset here so each turn starts fresh. See #26080.
     agent._auth_pool_refresh_counts = {}
 
+    if agent._interrupt_requested:
+        interrupted = True
+        _turn_exit_reason = "interrupted_by_user"
+        if not agent.quiet_mode:
+            agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
+    elif _plugin_short_circuit_response is not None:
+        final_response = _plugin_short_circuit_response
+        messages.append({"role": "assistant", "content": final_response})
+        _turn_exit_reason = "plugin_short_circuit"
+
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
     # all run inside Codex). Default Hermes path is bypassed entirely.
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
-    if agent.api_mode == "codex_app_server":
+    if (
+        agent.api_mode == "codex_app_server"
+        and not interrupted
+        and _plugin_short_circuit_response is None
+    ):
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
@@ -640,7 +655,14 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while (
+        not interrupted
+        and _plugin_short_circuit_response is None
+        and (
+            (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0)
+            or agent._budget_grace_call
+        )
+    ):
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -491,8 +491,9 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     skipping the translation silently breaks every ``pre_tool_call``
     block directive.
 
-    For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    For ``pre_llm_call``, ``{"context": "..."}`` and
+    ``{"short_circuit_response": "..."}`` are passed through unchanged to
+    match the existing plugin-hook contract.
 
     Anything else returns ``None``.
     """
@@ -523,11 +524,15 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
                 return {"action": "block", "message": message}
         return None
 
+    response: Dict[str, Any] = {}
     context = data.get("context")
     if isinstance(context, str) and context.strip():
-        return {"context": context}
+        response["context"] = context
 
-    return None
+    if event == "pre_llm_call" and data.get("short_circuit_response") is not None:
+        response["short_circuit_response"] = data["short_circuit_response"]
+
+    return response or None
 
 
 # ---------------------------------------------------------------------------

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -574,8 +574,9 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     skipping the translation silently breaks every ``pre_tool_call``
     block directive.
 
-    For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    For ``pre_llm_call``, ``{"context": "..."}`` and
+    ``{"short_circuit_response": "..."}`` are passed through unchanged to
+    match the existing plugin-hook contract.
 
     Anything else returns ``None``.
     """
@@ -613,11 +614,15 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
                 return {"action": "continue", "message": message.strip()}
         return None
 
+    response: Dict[str, Any] = {}
     context = data.get("context")
     if isinstance(context, str) and context.strip():
-        return {"context": context}
+        response["context"] = context
 
-    return None
+    if event == "pre_llm_call" and data.get("short_circuit_response") is not None:
+        response["short_circuit_response"] = data["short_circuit_response"]
+
+    return response or None
 
 
 # ---------------------------------------------------------------------------

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -112,6 +112,8 @@ class TurnContext:
     should_review_memory: bool = False
     # Context contributed by ``pre_llm_call`` plugins (appended to user message).
     plugin_user_context: str = ""
+    # Optional final response supplied by a ``pre_llm_call`` plugin.
+    plugin_short_circuit_response: Optional[str] = None
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
 
@@ -477,6 +479,7 @@ def build_turn_context(
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
+    plugin_short_circuit_response: Optional[str] = None
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -506,11 +509,19 @@ def build_turn_context(
             _spill_config_cached = None
         for r in _pre_results:
             _piece: str = ""
-            if isinstance(r, dict) and r.get("context"):
-                _piece = str(r["context"])
+            if isinstance(r, dict):
+                if r.get("context"):
+                    _piece = str(r["context"])
+                if (
+                    plugin_short_circuit_response is None
+                    and r.get("short_circuit_response") is not None
+                ):
+                    plugin_short_circuit_response = str(r["short_circuit_response"])
             elif isinstance(r, str) and r.strip():
                 _piece = r
             else:
+                continue
+            if not _piece:
                 continue
             if _spill_if_oversized is not None:
                 try:
@@ -557,7 +568,11 @@ def build_turn_context(
 
     # External memory provider: prefetch once before the tool loop.
     ext_prefetch_cache = ""
-    if agent._memory_manager:
+    if (
+        agent._memory_manager
+        and not agent._interrupt_requested
+        and plugin_short_circuit_response is None
+    ):
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
@@ -575,5 +590,6 @@ def build_turn_context(
         current_turn_user_idx=current_turn_user_idx,
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
+        plugin_short_circuit_response=plugin_short_circuit_response,
         ext_prefetch_cache=ext_prefetch_cache,
     )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -151,7 +151,8 @@ def finalize_turn(
         final_response is not None
         and not failed
         and (
-            api_call_count < agent.max_iterations
+            _turn_exit_reason == "plugin_short_circuit"
+            or api_call_count < agent.max_iterations
             or normal_text_response
         )
     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -8911,9 +8911,11 @@ class AIAgent:
                         break  # Under threshold
 
         # Plugin hook: pre_llm_call
-        # Fired once per turn before the tool-calling loop.  Plugins can
-        # return a dict with a ``context`` key (or a plain string) whose
-        # value is appended to the current turn's user message.
+        # Fired once per turn before the tool-calling loop. Plugins can:
+        # - return a dict with a ``context`` key (or a plain string) whose
+        #   value is appended to the current turn's user message, and/or
+        # - return a dict with ``short_circuit_response`` to skip the model
+        #   call entirely and respond immediately.
         #
         # Context is ALWAYS injected into the user message, never the
         # system prompt.  This preserves the prompt cache prefix — the
@@ -8923,6 +8925,7 @@ class AIAgent:
         #
         # All injected context is ephemeral (not persisted to session DB).
         _plugin_user_context = ""
+        _plugin_short_circuit_response = None
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _pre_results = _invoke_hook(
@@ -8937,8 +8940,14 @@ class AIAgent:
             )
             _ctx_parts: list[str] = []
             for r in _pre_results:
-                if isinstance(r, dict) and r.get("context"):
-                    _ctx_parts.append(str(r["context"]))
+                if isinstance(r, dict):
+                    if r.get("context"):
+                        _ctx_parts.append(str(r["context"]))
+                    if (
+                        _plugin_short_circuit_response is None
+                        and r.get("short_circuit_response") is not None
+                    ):
+                        _plugin_short_circuit_response = str(r["short_circuit_response"])
                 elif isinstance(r, str) and r.strip():
                     _ctx_parts.append(r)
             if _ctx_parts:
@@ -8973,6 +8982,16 @@ class AIAgent:
             self._interrupt_message = None
             self._interrupt_thread_signal_pending = False
 
+        if self._interrupt_requested:
+            interrupted = True
+            _turn_exit_reason = "interrupted_by_user"
+            if not self.quiet_mode:
+                self._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
+        elif _plugin_short_circuit_response is not None:
+            final_response = _plugin_short_circuit_response
+            messages.append({"role": "assistant", "content": final_response})
+            _turn_exit_reason = "plugin_short_circuit"
+
         # Notify memory providers of the new turn so cadence tracking works.
         # Must happen BEFORE prefetch_all() so providers know which turn it is
         # and can gate context/dialectic refresh via contextCadence/dialecticCadence.
@@ -8988,15 +9007,17 @@ class AIAgent:
         # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
+        # Skip prefetch entirely when the turn is already interrupted or a
+        # plugin has short-circuited before any model call.
         _ext_prefetch_cache = ""
-        if self._memory_manager:
+        if self._memory_manager and not interrupted and _plugin_short_circuit_response is None:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
                 _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
 
-        while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
+        while _plugin_short_circuit_response is None and ((api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call):
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
 
@@ -11760,7 +11781,14 @@ class AIAgent:
             final_response = self._handle_max_iterations(messages, api_call_count)
         
         # Determine if conversation completed successfully
-        completed = final_response is not None and api_call_count < self.max_iterations
+        completed = (
+            final_response is not None
+            and not interrupted
+            and (
+                _turn_exit_reason == "plugin_short_circuit"
+                or api_call_count < self.max_iterations
+            )
+        )
 
         # Save trajectory if enabled.  ``user_message`` may be a multimodal
         # list of parts; the trajectory format wants a plain string.

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -87,6 +87,22 @@ class TestParseResponse:
         )
         assert r == {"context": "today is Friday"}
 
+    def test_pre_llm_call_short_circuit_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call",
+            '{"context": "today is Friday", "short_circuit_response": "Routed directly"}',
+        )
+        assert r == {
+            "context": "today is Friday",
+            "short_circuit_response": "Routed directly",
+        }
+
+    def test_pre_llm_call_short_circuit_without_context_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call", '{"short_circuit_response": "Routed directly"}',
+        )
+        assert r == {"short_circuit_response": "Routed directly"}
+
     def test_subagent_stop_context_passthrough(self):
         r = shell_hooks._parse_response(
             "subagent_stop", '{"context": "child role=leaf"}',

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -84,6 +84,22 @@ class TestParseResponse:
         )
         assert r == {"context": "today is Friday"}
 
+    def test_pre_llm_call_short_circuit_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call",
+            '{"context": "today is Friday", "short_circuit_response": "Routed directly"}',
+        )
+        assert r == {
+            "context": "today is Friday",
+            "short_circuit_response": "Routed directly",
+        }
+
+    def test_pre_llm_call_short_circuit_without_context_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call", '{"short_circuit_response": "Routed directly"}',
+        )
+        assert r == {"short_circuit_response": "Routed directly"}
+
     def test_subagent_stop_context_passthrough(self):
         r = shell_hooks._parse_response(
             "subagent_stop", '{"context": "child role=leaf"}',

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2056,6 +2056,115 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_pre_llm_hook_can_short_circuit_before_any_api_call(self, agent):
+        self._setup_agent(agent)
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when pre_llm_call short-circuits"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Routed directly"
+        assert result["api_calls"] == 0
+        assert result["completed"] is True
+        assert result["messages"][-1] == {"role": "assistant", "content": "Routed directly"}
+        agent.client.chat.completions.create.assert_not_called()
+
+    def test_pre_llm_hook_short_circuit_does_not_override_pending_interrupt(self, agent):
+        self._setup_agent(agent)
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent._interrupt_requested = True
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when the turn is already interrupted"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch("run_agent._set_interrupt"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["interrupted"] is True
+        assert result["api_calls"] == 0
+        assert not any(
+            msg.get("role") == "assistant" and msg.get("content") == "Routed directly"
+            for msg in result["messages"]
+            if isinstance(msg, dict)
+        )
+        agent.client.chat.completions.create.assert_not_called()
+
+    def test_pre_llm_hook_short_circuit_skips_memory_prefetch(self, agent):
+        self._setup_agent(agent)
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.prefetch_all.side_effect = AssertionError(
+            "Memory prefetch should not run on short-circuit"
+        )
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when pre_llm_call short-circuits"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Routed directly"
+        assert result["api_calls"] == 0
+        agent._memory_manager.on_turn_start.assert_called_once()
+        agent._memory_manager.prefetch_all.assert_not_called()
+        agent.client.chat.completions.create.assert_not_called()
+
+    def test_pre_llm_hook_short_circuit_is_completed_even_when_max_iterations_is_zero(self, agent):
+        self._setup_agent(agent)
+        agent.max_iterations = 0
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when pre_llm_call short-circuits"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Routed directly"
+        assert result["completed"] is True
+        assert result["api_calls"] == 0
+        agent.client.chat.completions.create.assert_not_called()
+
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4008,6 +4008,115 @@ class TestRunConversation:
         assert "Ollama runtime context too small for Hermes tool use" in caplog.text
         assert "runtime_context=4096" in caplog.text
 
+    def test_pre_llm_hook_can_short_circuit_before_any_api_call(self, agent):
+        self._setup_agent(agent)
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when pre_llm_call short-circuits"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Routed directly"
+        assert result["api_calls"] == 0
+        assert result["completed"] is True
+        assert result["messages"][-1] == {"role": "assistant", "content": "Routed directly"}
+        agent.client.chat.completions.create.assert_not_called()
+
+    def test_pre_llm_hook_short_circuit_does_not_override_pending_interrupt(self, agent):
+        self._setup_agent(agent)
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent._interrupt_requested = True
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when the turn is already interrupted"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch("run_agent._set_interrupt"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["interrupted"] is True
+        assert result["api_calls"] == 0
+        assert not any(
+            msg.get("role") == "assistant" and msg.get("content") == "Routed directly"
+            for msg in result["messages"]
+            if isinstance(msg, dict)
+        )
+        agent.client.chat.completions.create.assert_not_called()
+
+    def test_pre_llm_hook_short_circuit_skips_memory_prefetch(self, agent):
+        self._setup_agent(agent)
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.prefetch_all.side_effect = AssertionError(
+            "Memory prefetch should not run on short-circuit"
+        )
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when pre_llm_call short-circuits"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Routed directly"
+        assert result["api_calls"] == 0
+        agent._memory_manager.on_turn_start.assert_called_once()
+        agent._memory_manager.prefetch_all.assert_not_called()
+        agent.client.chat.completions.create.assert_not_called()
+
+    def test_pre_llm_hook_short_circuit_is_completed_even_when_max_iterations_is_zero(self, agent):
+        self._setup_agent(agent)
+        agent.max_iterations = 0
+
+        def _hook_result(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"short_circuit_response": "Routed directly"}]
+            return []
+
+        agent.client.chat.completions.create.side_effect = AssertionError(
+            "API should not be called when pre_llm_call short-circuits"
+        )
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Routed directly"
+        assert result["completed"] is True
+        assert result["api_calls"] == 0
+        agent.client.chat.completions.create.assert_not_called()
+
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")


### PR DESCRIPTION
## Summary
- supports `short_circuit_response` returned from `pre_llm_call`
- ports the behavior to the extracted conversation loop in `agent/conversation_loop.py`
- bypasses memory prefetch and the LLM/tool loop when a plugin supplies a final response
- preserves user interrupt priority over plugin short-circuit responses
- passes `short_circuit_response` through shell `pre_llm_call` hooks

## Latest main refresh
- Base: `355af2c20` (`origin/main`)
- Head: `0ffe0352d4803055dc92954e1318739c8de96d06`
- Rebuilt as one clean commit on latest main.
- Conflict resolved in `agent/conversation_loop.py` and `tests/run_agent/test_run_agent.py` by keeping latest-main failure/completion semantics (`failed`, Ollama small-context path) while preserving the plugin short-circuit completion exception and interrupt priority.

## Test Plan
- `git diff --check`
- `/home/ubuntu/.hermes/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/agent/test_shell_hooks.py tests/run_agent/test_run_agent.py -q`

Focused result: `416 passed in 127.23s`.
