### PR TITLE
fix(kimi): add X-Client-Name header for Kimi /coding endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -395,11 +395,13 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
 
     if _is_kimi_coding_endpoint(base_url):
         # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
-        # to be recognized as a valid Coding Agent. Without it, returns 403.
+        # and X-Client-Name: kimi-cli to be recognized as a valid Coding Agent.
+        # Without these headers, returns 403 / access_terminated_error.
         # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
         kwargs["api_key"] = api_key
         kwargs["default_headers"] = {
             "User-Agent": "claude-code/0.1.0",
+            "X-Client-Name": "kimi-cli",
             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
         }
     elif _requires_bearer_auth(normalized_base_url):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -864,7 +864,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                     return GeminiNativeClient(api_key=api_key, base_url=base_url), model
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
-                extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                extra["default_headers"] = {
+                    "User-Agent": "claude-code/0.1.0",
+                    "X-Client-Name": "kimi-cli",
+                }
             elif base_url_host_matches(base_url, "api.githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
@@ -890,7 +893,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 return GeminiNativeClient(api_key=api_key, base_url=base_url), model
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
-            extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            extra["default_headers"] = {
+                "User-Agent": "claude-code/0.1.0",
+                "X-Client-Name": "kimi-cli",
+            }
         elif base_url_host_matches(base_url, "api.githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
@@ -1594,7 +1600,10 @@ def _to_async_client(sync_client, model: str):
 
         async_kwargs["default_headers"] = copilot_default_headers()
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
-        async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        async_kwargs["default_headers"] = {
+            "User-Agent": "claude-code/0.1.0",
+            "X-Client-Name": "kimi-cli",
+        }
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -1783,7 +1792,10 @@ def resolve_provider_client(
             )
             extra = {}
             if base_url_host_matches(custom_base, "api.kimi.com"):
-                extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                extra["default_headers"] = {
+                    "User-Agent": "claude-code/0.1.0",
+                    "X-Client-Name": "kimi-cli",
+                }
             elif base_url_host_matches(custom_base, "api.githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
                 extra["default_headers"] = copilot_default_headers()
@@ -1926,6 +1938,7 @@ def resolve_provider_client(
         headers = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
+            headers["X-Client-Name"] = "kimi-cli"
         elif base_url_host_matches(base_url, "api.githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -981,6 +981,7 @@ def run_doctor(args):
                 }
                 if base_url_host_matches(_base, "api.kimi.com"):
                     _headers["User-Agent"] = "claude-code/0.1.0"
+                    _headers["X-Client-Name"] = "kimi-cli"
                 _resp = httpx.get(
                     _url,
                     headers=_headers,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1257,6 +1257,7 @@ class AIAgent:
                 elif base_url_host_matches(effective_base, "api.kimi.com"):
                     client_kwargs["default_headers"] = {
                         "User-Agent": "claude-code/0.1.0",
+                        "X-Client-Name": "kimi-cli",
                     }
                 elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                     client_kwargs["default_headers"] = _qwen_portal_headers()
@@ -5302,7 +5303,10 @@ class AIAgent:
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
-            self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            self._client_kwargs["default_headers"] = {
+                "User-Agent": "claude-code/0.1.0",
+                "X-Client-Name": "kimi-cli",
+            }
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1217,6 +1217,7 @@ class TestAnthropicCompatImageConversion:
         assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
 
 
+<<<<<<< HEAD
 class _AuxAuth401(Exception):
     status_code = 401
 
@@ -1413,3 +1414,44 @@ class TestAuxiliaryAuthRefreshRetry:
         mock_refresh.assert_called_once_with("anthropic")
         assert stale_client.chat.completions.create.await_count == 1
         assert fresh_client.chat.completions.create.await_count == 1
+
+
+class TestKimiCodingAuxiliaryHeaders:
+    """Auxiliary client must set Coding-Agent headers for Kimi /coding endpoint."""
+
+    def test_resolve_provider_client_sets_kimi_coding_headers(self):
+        from agent.auxiliary_client import resolve_provider_client
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials"
+        ) as mock_creds:
+            mock_creds.return_value = {
+                "api_key": "sk-kimi-test",
+                "base_url": "https://api.kimi.com/coding/v1",
+            }
+            client, model = resolve_provider_client(
+                provider="kimi-coding",
+                model="kimi-for-coding",
+            )
+
+        headers = client.default_headers
+        assert headers["User-Agent"] == "claude-code/0.1.0"
+        assert headers["X-Client-Name"] == "kimi-cli"
+
+    def test_non_kimi_provider_does_not_set_kimi_headers(self):
+        from agent.auxiliary_client import resolve_provider_client
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials"
+        ) as mock_creds:
+            mock_creds.return_value = {
+                "api_key": "sk-test",
+                "base_url": "https://api.minimax.io/anthropic",
+            }
+            client, model = resolve_provider_client(
+                provider="minimax",
+                model="MiniMax-M2.7",
+            )
+
+        headers = client.default_headers
+        assert "X-Client-Name" not in headers

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -113,3 +113,33 @@ class TestKimiCodingSkipsAnthropicThinking:
             base_url="https://api.kimi.com/v1",
         )
         assert "thinking" in kwargs
+
+
+class TestKimiCodingClientHeaders:
+    """build_anthropic_client must set Coding-Agent headers for Kimi /coding."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.kimi.com/coding",
+            "https://api.kimi.com/coding/v1",
+            "https://api.kimi.com/coding/anthropic",
+        ],
+    )
+    def test_kimi_coding_endpoint_sets_coding_agent_headers(self, base_url: str) -> None:
+        from agent.anthropic_adapter import build_anthropic_client
+
+        client = build_anthropic_client(api_key="sk-test", base_url=base_url)
+        headers = client.default_headers
+        assert headers["User-Agent"] == "claude-code/0.1.0"
+        assert headers["X-Client-Name"] == "kimi-cli"
+
+    def test_non_kimi_endpoint_does_not_set_kimi_headers(self) -> None:
+        """MiniMax and other third-party endpoints must not get Kimi headers."""
+        from agent.anthropic_adapter import build_anthropic_client
+
+        client = build_anthropic_client(
+            api_key="sk-test", base_url="https://api.minimax.io/anthropic"
+        )
+        headers = client.default_headers
+        assert "X-Client-Name" not in headers

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -81,3 +81,24 @@ def test_unknown_base_url_clears_default_headers(mock_openai):
     agent._apply_client_headers_for_base_url("https://api.example.com/v1")
 
     assert "default_headers" not in agent._client_kwargs
+
+
+@patch("run_agent.OpenAI")
+def test_kimi_coding_base_url_applies_coding_agent_headers(mock_openai):
+    """Kimi's /coding endpoint requires both User-Agent and X-Client-Name
+    to be recognized as a valid Coding Agent."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.kimi.com/coding/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"] == "claude-code/0.1.0"
+    assert headers["X-Client-Name"] == "kimi-cli"


### PR DESCRIPTION
## Problem

Kimi's `/coding` endpoint (`api.kimi.com/coding`) recently started requiring both `User-Agent: claude-code/0.1.0` **and** `X-Client-Name: kimi-cli` to recognize requests from valid Coding Agents. Without the `X-Client-Name` header, the API returns `access_terminated_error` (HTTP 403/404).

Upstream currently only sends `User-Agent: claude-code/0.1.0` to `api.kimi.com`.

## Fix

Adds `X-Client-Name: kimi-cli` to all code paths that set headers for `api.kimi.com`:

- `agent/anthropic_adapter.py` — `build_anthropic_client()` (Anthropic SDK path)
- `agent/auxiliary_client.py` — 5 locations: API key provider resolution, async client conversion, direct HTTP calls
- `hermes_cli/doctor.py` — connectivity check `GET /models`
- `run_agent.py` — `AIAgent` client construction and header refresh

Purely additive — extends existing `default_headers` dicts that already contain `User-Agent: claude-code/0.1.0`.

## Tests

- `tests/agent/test_kimi_coding_anthropic_thinking.py` — verifies `build_anthropic_client` sets both headers for `/coding`, `/coding/v1`, `/coding/anthropic` endpoints; negative case for MiniMax
- `tests/agent/test_auxiliary_client.py` — verifies `resolve_provider_client` sets both headers for `kimi-coding`; negative case for non-Kimi providers
- `tests/run_agent/test_provider_attribution_headers.py` — verifies `AIAgent._apply_client_headers_for_base_url` sets both headers for `api.kimi.com`

All new tests pass.