### PR TITLE
fix: use custom provider context length for compression model

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -732,6 +732,82 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _custom_provider_context_length_for_model(
+    config: Dict[str, Any],
+    model: str,
+    base_url: str,
+) -> Optional[int]:
+    """Return custom_providers[].models[model].context_length for an endpoint.
+
+    Custom endpoints often expose an OpenAI-compatible ``/models`` response
+    that lists the model but omits context-window metadata. Hermes lets users
+    declare the missing value under ``custom_providers[].models``; this helper
+    resolves that override for any model using the same custom endpoint (main
+    chat model or auxiliary compression model).
+    """
+    if not isinstance(config, dict) or not model or not base_url:
+        return None
+
+    def _coerce_context_length(value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    base = str(base_url or "").strip().rstrip("/")
+    if not base:
+        return None
+
+    model_candidates = [str(model).strip()]
+    if "/" in model_candidates[0]:
+        model_candidates.append(model_candidates[0].rsplit("/", 1)[-1])
+    if ":" in model_candidates[0]:
+        prefix, suffix = model_candidates[0].split(":", 1)
+        if prefix.lower() in {"custom", "local"} and suffix.strip():
+            model_candidates.append(suffix.strip())
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        custom_providers = get_compatible_custom_providers(config)
+    except Exception:
+        custom_providers = config.get("custom_providers")
+        if not isinstance(custom_providers, list):
+            custom_providers = []
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_base = str(entry.get("base_url") or "").strip().rstrip("/")
+        if not entry_base or entry_base != base:
+            continue
+
+        models = entry.get("models")
+        if isinstance(models, dict):
+            for candidate in model_candidates:
+                model_cfg = models.get(candidate)
+                if model_cfg is None:
+                    lowered = candidate.lower()
+                    for key, value in models.items():
+                        if isinstance(key, str) and key.lower() == lowered:
+                            model_cfg = value
+                            break
+                if isinstance(model_cfg, dict):
+                    ctx = _coerce_context_length(model_cfg.get("context_length"))
+                    if ctx is not None:
+                        return ctx
+
+        ctx = _coerce_context_length(entry.get("context_length"))
+        if ctx is not None:
+            return ctx
+
+        break
+
+    return None
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -2285,11 +2361,21 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            aux_context_config = getattr(self, "_aux_compression_context_length_config", None)
+            if aux_context_config is None:
+                try:
+                    from hermes_cli.config import load_config as _load_agent_config
+                    aux_context_config = _custom_provider_context_length_for_model(
+                        _load_agent_config(), aux_model, aux_base_url
+                    )
+                except Exception:
+                    aux_context_config = None
+
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
-                config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                config_context_length=aux_context_config,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -183,6 +183,54 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     )
 
 
+def test_feasibility_check_uses_custom_provider_model_context_length():
+    """custom_providers[].models[aux_model].context_length should be used
+    for the compression model when auxiliary.compression.context_length is not
+    set. This prevents false 128K fallback warnings for custom endpoints whose
+    /models payload omits context metadata."""
+    agent = _make_agent(main_context=400_000, threshold_percent=0.95)
+    agent.provider = "custom"
+    agent.base_url = "https://example.test/v1"
+    agent.model = "gpt-5.5"
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://example.test/v1/"
+    mock_client.api_key = "sk-custom"
+    cfg = {
+        "custom_providers": [
+            {
+                "name": "Example",
+                "base_url": "https://example.test/v1",
+                "api_key": "sk-custom",
+                "model": "gpt-5.5",
+                "models": {
+                    "gpt-5.5": {"context_length": 400_000},
+                    "gpt-5.5-openai-compact": {"context_length": 400_000},
+                },
+            }
+        ]
+    }
+
+    def _ctx_len(*args, **kwargs):
+        return kwargs.get("config_context_length") or 128_000
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(mock_client, "gpt-5.5")), \
+         patch("agent.model_metadata.get_model_context_length", side_effect=_ctx_len) as mock_ctx_len:
+        agent._check_compression_model_feasibility()
+
+    assert messages == []
+    assert agent.context_compressor.threshold_tokens == 380_000
+    mock_ctx_len.assert_called_once_with(
+        "gpt-5.5",
+        base_url="https://example.test/v1/",
+        api_key="sk-custom",
+        config_context_length=400_000,
+    )
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=128_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):


### PR DESCRIPTION
## Summary
- Resolve custom provider model-level `context_length` for the auxiliary compression model during feasibility checks.
- Pass the resolved value into `get_model_context_length(..., config_context_length=...)` so OpenAI-compatible custom endpoints that omit context metadata do not fall back to 128K when the config declares a larger window.
- Add a regression test covering `custom_providers[].models[<model>].context_length` with no `auxiliary.compression.context_length` override.

## Tests
- `./venv/bin/python -m pytest tests/run_agent/test_compression_feasibility.py -q -o 'addopts='` → 17 passed
- `./venv/bin/python -m py_compile run_agent.py tests/run_agent/test_compression_feasibility.py && git diff --check` → passed
- Checked existing baseline failure on `main`: `tests/hermes_cli/test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_saved_model_still_probes_endpoint` fails because the test expects no `api_mode` kwarg while current code calls `fetch_api_models(..., api_mode=None)`. This failure is unrelated to this PR’s changed files.
