### PR TITLE
fix(cli): merge prompt_caching config category into agent

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -330,6 +330,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "cron": "agent",
     "network": "agent",
     "checkpoints": "agent",
+    "prompt_caching": "agent",
     "approvals": "security",
     "human_delay": "display",
     "dashboard": "display",


### PR DESCRIPTION
## Summary
- merge the standalone `prompt_caching` schema category into `agent`
- remove the last single-field dashboard config category
- keep the change scoped to web config schema generation only

## Why
The shared `Tests / test` backlog is red on `tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig::test_no_single_field_categories` because `prompt_caching` is still emitted as its own one-field category.

## Verification
- `python3 - <<"PY" ...` checked `CONFIG_SCHEMA` category counts
- confirmed `prompt_caching` count is gone and no category has fewer than 2 fields
