### PR TITLE
fix(cron): skip AI call when script produces no output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -659,10 +659,8 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     f"{prompt}"
                 )
             else:
-                prompt = (
-                    "[Script ran successfully but produced no output.]\n\n"
-                    f"{prompt}"
-                )
+                # Script produced no output — nothing to report, skip AI call.
+                return None
         else:
             prompt = (
                 "## Script Error\n"
@@ -774,6 +772,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             return True, silent_doc, SILENT_MARKER, None
 
     prompt = _build_job_prompt(job, prerun_script=prerun_script)
+    if prompt is None:
+        logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 


### PR DESCRIPTION
## Problem

When a cron job has a pre-run script that runs successfully but produces no output (e.g., an email checker with an empty inbox), the scheduler injects `[Script ran successfully but produced no output.]` into the prompt and **still calls the AI model**. For jobs running every 5 minutes, that's 288 API calls/day of pure waste — burning tokens even when there is genuinely nothing to report.

## Fix

- `_build_job_prompt()` now returns `None` when the script succeeds with empty output
- `run_job()` checks for `None` and short-circuits with `(True, "", SILENT_MARKER, None)` — returning the standard 4-tuple with a silent response
- The existing `[SILENT]` delivery suppression path handles the rest
- **Zero API calls when there is nothing to report**

## Example

An email checker script that prints nothing when there are no new emails:
- **Before:** AI called every 5 min → tokens burned → AI generates `[SILENT]` → delivery suppressed (but tokens already spent)
- **After:** Script prints nothing → scheduler returns early → no AI call at all

## Edge Cases

- **Script errors** are unaffected — they still get reported to the AI as before
- **Script with output** works exactly as before — output gets prepended to the prompt
- **Script gate (`wakeAgent=false`)** already had its own early-return; this is separate

Fixes: N/A (new issue discovered in production use)