### PR TITLE
fix(gateway): resolve custom providers in TUI model switch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -362,6 +362,89 @@ def test_config_set_model_global_persists(monkeypatch):
     assert saved["model"]["base_url"] == "https://api.anthropic.com"
 
 
+def test_config_set_model_resolves_custom_provider_without_global(monkeypatch):
+    class _Agent:
+        provider = "openrouter"
+        model = "old/model"
+        base_url = ""
+        api_key = "sk-old"
+
+        def __init__(self):
+            self.switched = {}
+
+        def switch_model(self, **kwargs):
+            self.switched.update(kwargs)
+
+    agent = _Agent()
+    cfg = {
+        "providers": {},
+        "custom_providers": [
+            {
+                "name": "voyager",
+                "base_url": "http://localhost:8080/v1",
+                "api_key": "sk-voyager",
+                "model": "qwen3.6-27b",
+            }
+        ],
+    }
+    persisted = []
+
+    def _runtime_provider(requested=None, target_model=None):
+        assert requested == "custom:voyager"
+        assert target_model == "qwen3.6-27b"
+        return {
+            "provider": "custom:voyager",
+            "api_key": "sk-voyager",
+            "base_url": "http://localhost:8080/v1",
+            "api_mode": "chat_completions",
+        }
+
+    server._sessions["sid"] = _session(agent=agent)
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(
+        server, "_persist_model_switch", lambda result: persisted.append(result)
+    )
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {"accepted": True, "persist": True},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_info",
+        lambda *args, **kwargs: None,
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "qwen3.6-27b --provider custom:voyager",
+            },
+        }
+    )
+
+    assert resp["result"]["value"] == "qwen3.6-27b"
+    assert agent.switched["new_model"] == "qwen3.6-27b"
+    assert agent.switched["new_provider"] == "custom:voyager"
+    assert agent.switched["api_key"] == "sk-voyager"
+    assert agent.switched["base_url"] == "http://localhost:8080/v1"
+    assert os.environ["HERMES_INFERENCE_PROVIDER"] == "custom:voyager"
+    assert persisted == []
+
+
 def test_config_set_model_syncs_inference_provider_env(monkeypatch):
     """After an explicit provider switch, HERMES_INFERENCE_PROVIDER must
     reflect the user's choice so ambient re-resolution (credential pool

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -654,6 +654,14 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
     if not model_input:
         raise ValueError("model value required")
 
+    cfg = _load_cfg()
+    cfg_providers = cfg.get("providers")
+    cfg_custom_providers = cfg.get("custom_providers")
+    user_providers = cfg_providers if isinstance(cfg_providers, dict) else {}
+    custom_providers = (
+        cfg_custom_providers if isinstance(cfg_custom_providers, list) else []
+    )
+
     agent = session.get("agent")
     if agent:
         current_provider = getattr(agent, "provider", "") or ""
@@ -675,6 +683,8 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
         current_api_key=current_api_key,
         is_global=persist_global,
         explicit_provider=explicit_provider,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
     )
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")


### PR DESCRIPTION
  ## What does this PR do?

  Fixes TUI current-session model switching for named custom providers such as `custom:my-provider`.

  The TUI model picker can surface saved custom providers, but `_apply_model_switch()` called the shared model switch path without passing configured `providers` and `custom_providers`. As a result, a selected
  provider like `custom:voyager` could be treated as unknown even though it exists in `config.yaml`.

  This threads the configured provider data into `switch_model()` for the TUI gateway path while preserving the existing behavior that changes are session-scoped unless `--global` is supplied.

  ## Related Issue

  No issue filed.

  Related but not duplicate:
  - #14571 handles picker provider filtering.
  - #15088 handles preserving custom endpoint credentials during `/model` switches.
  - #3115 handles displaying named custom providers in CLI `/model` output.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Updated `tui_gateway/server.py` so `_apply_model_switch()` loads configured `providers` and `custom_providers` and passes them into `switch_model()`.
  - Added regression coverage in `tests/test_tui_gateway_server.py` for switching to `qwen3.6-27b` with `--provider custom:voyager` without persisting global config changes.

  ## How to Test

  1. Configure a saved custom provider named `voyager` with model `qwen3.6-27b`.
  2. Start `hermes --tui`.
  3. Switch models with `/model qwen3.6-27b --provider custom:voyager`.
  4. Confirm the current TUI session switches to provider `custom:voyager` and model `qwen3.6-27b`.
  5. Confirm `config.yaml` is not updated unless `--global` is supplied.

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; this only
  threads existing config data through the TUI gateway model switch path
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

  ## Screenshots / Logs

  Focused test:

  ```text
  scripts/run_tests.sh tests/test_tui_gateway_server.py -q
  56 passed
```

  Full suite via the repo test wrapper currently has unrelated failures outside this change area:

```text
  scripts/run_tests.sh -q
  26 failed, 15438 passed, 66 skipped
```

The failures are in existing delegate/subagent provider config, Hindsight setup, web schema, custom-provider model switch assertion, gateway service timeout, and Signal config isolation tests