### PR TITLE
Fix Feishu group mention config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -582,6 +582,12 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allow_from"] = platform_cfg["allow_from"]
                 if "group_policy" in platform_cfg:
                     bridged["group_policy"] = platform_cfg["group_policy"]
+                if "require_group_mention" in platform_cfg:
+                    bridged["require_group_mention"] = platform_cfg["require_group_mention"]
+                if "default_group_policy" in platform_cfg:
+                    bridged["default_group_policy"] = platform_cfg["default_group_policy"]
+                if "group_rules" in platform_cfg:
+                    bridged["group_rules"] = platform_cfg["group_rules"]
                 if "group_allow_from" in platform_cfg:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -387,6 +387,7 @@ class FeishuAdapterSettings:
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
+    require_group_mention: bool = True
 
 
 @dataclass
@@ -498,6 +499,23 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Coerce common config/env boolean representations."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
 
 
 # ---------------------------------------------------------------------------
@@ -1408,6 +1426,7 @@ class FeishuAdapter(BasePlatformAdapter):
             bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
             bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
             bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
+            require_group_mention=_coerce_bool(extra.get("require_group_mention"), default=True),
             dedup_cache_size=max(
                 32,
                 int(os.getenv("HERMES_FEISHU_DEDUP_CACHE_SIZE", str(_DEFAULT_DEDUP_CACHE_SIZE))),
@@ -1460,6 +1479,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
         self._group_rules = settings.group_rules
+        self._require_group_mention = settings.require_group_mention
         self._bot_open_id = settings.bot_open_id
         self._bot_user_id = settings.bot_user_id
         self._bot_name = settings.bot_name
@@ -3629,6 +3649,9 @@ class FeishuAdapter(BasePlatformAdapter):
         """Require an explicit @mention before group messages enter the agent."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        # When require_group_mention is False, accept all group messages
+        if not self._require_group_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -299,6 +299,26 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_bridges_feishu_group_reply_settings_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n"
+            "  require_group_mention: false\n"
+            "  default_group_policy: open\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "test_secret")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.FEISHU].extra["require_group_mention"] is False
+        assert config.platforms[Platform.FEISHU].extra["default_group_policy"] == "open"
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -703,6 +703,17 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertFalse(adapter._should_accept_group_message(message_with_mention, sender_id, ""))
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_message_accepts_unmentioned_when_require_group_mention_string_false(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_group_mention": "false"}))
+        message = SimpleNamespace(mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_message_with_other_user_mention_is_rejected_when_bot_identity_unknown(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
Fixes #15226

## Summary

- Bridge Feishu group reply settings from `config.yaml` into runtime `PlatformConfig.extra`.
- Add `require_group_mention` support in the Feishu adapter with a secure default of `true`.
- Coerce common boolean representations so string values like `"false"` work as expected.
- Add regression tests for config bridging and unmentioned group message routing.

## Verification

```text
pytest tests/gateway/test_feishu.py tests/gateway/test_config.py -q
218 passed
```

## Notes

This keeps group policy checks in place before accepting unmentioned group messages. Disabling mention requirements only routes messages when the existing sender/chat policy allows them.
