### PR TITLE
fix: support DeepSeek v4-flash/v4-pro thinking mode toggle and fix reasoning_content 400 error

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -100,6 +100,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_github_models: bool
             is_nvidia_nim: bool
             is_kimi: bool
+            is_deepseek: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -187,6 +188,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        is_deepseek = params.get("is_deepseek", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:
@@ -237,6 +239,18 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek thinking mode (v4-flash / v4-pro)
+        # DeepSeek uses `thinking: {"type": "enabled|disabled"}` at the top level,
+        # which is different from the `reasoning` extra_body used by OpenRouter.
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning
@@ -347,10 +361,10 @@ class ChatCompletionsTransport(ProviderTransport):
         reasoning_content = getattr(msg, "reasoning_content", None)
 
         provider_data: Dict[str, Any] = {}
-        if reasoning_content:
+        if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
         rd = getattr(msg, "reasoning_details", None)
-        if rd:
+        if rd is not None:
             provider_data["reasoning_details"] = rd
 
         return NormalizedResponse(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2831,18 +2831,17 @@ class AIAgent:
         reasoning_parts = []
         
         # Check direct reasoning field
-        if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
+        if hasattr(assistant_message, 'reasoning') and isinstance(assistant_message.reasoning, str):
             reasoning_parts.append(assistant_message.reasoning)
         
         # Check reasoning_content field (alternative name used by some providers)
-        if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
+        if hasattr(assistant_message, 'reasoning_content') and isinstance(assistant_message.reasoning_content, str):
             # Don't duplicate if same as reasoning
             if assistant_message.reasoning_content not in reasoning_parts:
                 reasoning_parts.append(assistant_message.reasoning_content)
         
         # Check reasoning_details array (OpenRouter unified format)
-        # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
-        if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+        if hasattr(assistant_message, 'reasoning_details') and isinstance(assistant_message.reasoning_details, list):
             for detail in assistant_message.reasoning_details:
                 if isinstance(detail, dict):
                     # Extract summary from reasoning detail object
@@ -7190,6 +7189,9 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = (
+            base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7258,6 +7260,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,
@@ -7300,6 +7303,7 @@ class AIAgent:
         model = (self.model or "").lower()
         reasoning_model_prefixes = (
             "deepseek/",
+            "deepseek-",
             "anthropic/",
             "openai/",
             "x-ai/",
@@ -7507,6 +7511,19 @@ class AIAgent:
         )
         if kimi_requires_reasoning and source_msg.get("tool_calls"):
             api_msg["reasoning_content"] = ""
+
+        # DeepSeek thinking mode (deepseek-v4-flash / deepseek-v4-pro) also
+        # requires `reasoning_content` on every assistant message. The streaming
+        # handler *does* capture reasoning from delta chunks into `reasoning`,
+        # but tool-call-only messages that end the stream before content arrives
+        # may have `reasoning` = None after serialization — pin a fallback empty
+        # string so DeepSeek doesn't reject the entire conversation.
+        deepseek_requires_reasoning = (
+            self.provider == "deepseek"
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+        if deepseek_requires_reasoning:
+            api_msg.setdefault("reasoning_content", "")
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:


### PR DESCRIPTION
## Summary

Two fixes for DeepSeek direct API (`api.deepseek.com`) users who use `deepseek-v4-flash` / `deepseek-v4-pro` with thinking mode.

## Changes

### 1. DeepSeek thinking mode toggle (`is_deepseek` flag + `thinking` extra_body)

DeepSeek v4-flash/v4-pro uses a different API format than OpenRouter for controlling thinking mode. While OpenRouter uses `extra_body["reasoning"] = {"enabled": true, "effort": "medium"}`, DeepSeek's native API expects:

```json
{"thinking": {"type": "enabled"}}
{"thinking": {"type": "disabled"}}
```

This PR adds an `is_deepseek` flag threaded through `run_agent.py` -> `chat_completions.py`, which injects the correct `thinking` parameter. The thinking mode is controlled by the existing `reasoning_effort` config:

| `reasoning_effort` | Result |
|---|---|
| `''` (empty) / `'medium'` | `thinking: {"type": "enabled"}` |
| `'none'` | `thinking: {"type": "disabled"}` |

### 2. Fix `reasoning_content` HTTP 400 error on multi-turn conversations

When thinking mode is enabled, DeepSeek requires `reasoning_content` on **every** assistant message, including plain-text responses. The existing `_copy_reasoning_content_for_api()` only patched tool-call messages (`source_msg.get("tool_calls")`), causing HTTP 400 errors on multi-turn conversations where the final assistant response has no tool calls.

**Fix:** Remove the `and source_msg.get("tool_calls")` condition for the DeepSeek branch, so `reasoning_content` is set (defaulting to empty string) on all assistant messages.

## Files changed

- `run_agent.py` — `_is_deepseek` flag, pass `is_deepseek` to transport, fix `_copy_reasoning_content_for_api` for all assistant messages
- `agent/transports/chat_completions.py` — accept `is_deepseek` param, inject `thinking` extra_body

## Testing

- Verified DeepSeek API accepts `thinking: {"type": "enabled"}` → returns `reasoning_content` ✅
- Verified DeepSeek API accepts `thinking: {"type": "disabled"}` → no `reasoning_content` ✅
- Verified multi-turn conversations no longer get 400 errors ✅