### PR TITLE
fix(email): add Date header to send_message_tool._send_email (closes #15160)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -10,9 +10,10 @@ import json
 import logging
 import os
 import re
-from typing import Dict, Optional
 import ssl
 import time
+from email.utils import formatdate
+from typing import Dict, Optional
 
 from agent.redact import redact_sensitive_text
 
@@ -1064,6 +1065,7 @@ async def _send_email(extra, chat_id, message):
         msg["From"] = address
         msg["To"] = chat_id
         msg["Subject"] = "Hermes Agent"
+        msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls(context=ssl.create_default_context())


### PR DESCRIPTION
Closes #15160

## Summary

Adds the required RFC 5322 Date header to the _send_email tool path in tools/send_message_tool.py.

Issue #15160 reported that outbound Hermes emails are bounced by mail filters with 'Missing required header field: Date'. The issue noted two affected code paths:

1. gateway/platforms/email.py - fixed by PR #15207
2. tools/send_message_tool._send_email - was NOT covered by PR #15207

The send_message tool uses _send_email for cross-channel messaging (terminal, file ops, web, code execution, etc.), so outbound emails from these tools were still missing the Date header after PR #15207.

## Fix

- Import formatdate from email.utils at module level
- Add msg['Date'] = formatdate(localtime=True) after subject header in _send_email

This mirrors the fix applied to gateway/platforms/email.py in PR #15207.

## Testing

The existing test in tests/gateway/test_email.py covers the gateway path.