### PR TITLE
docs(google-workspace): add troubleshooting entry for missing pip in venv

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -270,6 +270,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 | `HttpError 403: Insufficient Permission` | Missing API scope — `$GSETUP --revoke` then redo Steps 3-5 |
 | `HttpError 403: Access Not Configured` | API not enabled — user needs to enable it in Google Cloud Console |
 | `ModuleNotFoundError` | Run `$GSETUP --install-deps` |
+| `No module named pip` (venv pip missing) | Bootstrap with `venv/bin/python -m ensurepip --upgrade --default-pip`, then retry `--install-deps` |
 | Advanced Protection blocks auth | Workspace admin must allowlist the OAuth client ID |
 
 ## Revoking Access


### PR DESCRIPTION
## Summary

When the Hermes venv is created without pip (e.g., on a fresh macOS install where the venv's pip wrapper is absent), `$GSETUP --install-deps` fails with `No module named pip`. The existing troubleshooting table covers `ModuleNotFoundError` (which is the symptom _after_ pip is present but a google-auth module is missing), but not this prior case.

This PR adds a single row to the troubleshooting table in `skills/productivity/google-workspace/SKILL.md`:

```
| `No module named pip` (venv pip missing) | Bootstrap with `venv/bin/python -m ensurepip --upgrade --default-pip`, then retry `--install-deps` |
```

## Context

Discovered in practice during Google Workspace skill setup on a fresh Mac mini install of Hermes Agent v0.10.0 (and re-surfaced after upgrade to v0.11.0). My Hermes instance's local venv at `~/src/hermes-agent/venv/` didn't have pip available even though uv-managed; running `$GSETUP --install-deps` then relied on `sys.executable -m pip install ...` which failed immediately. Bootstrapping via `ensurepip` recovered cleanly.

Documented the fix in my own skill copy when I encountered it; this PR upstreams the entry so future users get it without having to figure it out themselves.

## Test plan

- [x] Row renders in the existing Markdown table without disrupting alignment
- [x] Fix text is accurate (verified `venv/bin/python -m ensurepip --upgrade --default-pip` recovers a pip-less venv)
- [x] No other content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)