### PR TITLE
fix: differentiate server overload cooldown, add error classifier rules

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -67,10 +67,15 @@ SUPPORTED_POOL_STRATEGIES = {
 }
 
 # Cooldown before retrying an exhausted credential.
-# 429 (rate-limited) and 402 (billing/quota) both cool down after 1 hour.
 # Provider-supplied reset_at timestamps override these defaults.
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+
+# Server-side overload errors (not user quota) recover much faster.
+# These are provider-specific sub-codes carried in the response body,
+# not the HTTP status code itself.
+_SERVER_OVERLOAD_CODES = frozenset({"1305", "1306", "1307", "1312", "500"})
+EXHAUSTED_TTL_SERVER_OVERLOAD_SECONDS = 3 * 60  # 3 minutes
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -187,8 +192,17 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
-def _exhausted_ttl(error_code: Optional[int]) -> int:
-    """Return cooldown seconds based on the HTTP status that caused exhaustion."""
+def _exhausted_ttl(error_code: Optional[int], error_reason: Optional[str] = None) -> int:
+    """Return cooldown seconds based on the HTTP status and provider sub-code.
+
+    Provider sub-codes (carried in the response body, e.g. ZAI's 1305/1302)
+    are passed via *error_reason* and allow finer-grained cooldowns:
+
+      - 1305/1306/1307/500: server-side overload → 3 min (recovers quickly)
+      - 1302 or plain 429:  user quota/rate-limit → 1 hour
+    """
+    if error_reason and str(error_reason) in _SERVER_OVERLOAD_CODES:
+        return EXHAUSTED_TTL_SERVER_OVERLOAD_SECONDS
     if error_code == 429:
         return EXHAUSTED_TTL_429_SECONDS
     return EXHAUSTED_TTL_DEFAULT_SECONDS
@@ -269,7 +283,7 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     if reset_at is not None:
         return reset_at
     if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
+        return entry.last_status_at + _exhausted_ttl(entry.last_error_code, entry.last_error_reason)
     return None
 
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -307,6 +307,20 @@ _SSL_TRANSIENT_PATTERNS = [
     "[ssl:",
 ]
 
+# Server overload patterns — providers (ZAI, etc.) that return HTTP 429 for
+# server-side overload instead of the standard 503/529.  These patterns
+# disambiguate server overload from user rate-limit in the 429 handler.
+_SERVER_OVERLOAD_SUBCODES = frozenset({"1305", "1306", "1307", "1312"})
+
+_SERVER_OVERLOAD_PATTERNS = [
+    "访问量过大",           # ZAI: "该模型当前访问量过大"
+    "服务器繁忙",           # Chinese providers: server busy
+    "系统负载",             # Chinese: system load overload
+    "capacity",             # English: insufficient capacity
+    "overloaded",           # English: generic overload
+    "too many concurrent",  # English: concurrency limit
+]
+
 
 # ── Classification pipeline ─────────────────────────────────────────────
 
@@ -589,6 +603,12 @@ def _classify_by_status(
         )
 
     if status_code == 429:
+        # Disambiguate: some providers (ZAI) return 429 for server overload.
+        # Check body error code and message before defaulting to rate_limit.
+        if error_code and str(error_code) in _SERVER_OVERLOAD_SUBCODES:
+            return result_fn(FailoverReason.overloaded, retryable=True)
+        if any(p in error_msg for p in _SERVER_OVERLOAD_PATTERNS):
+            return result_fn(FailoverReason.overloaded, retryable=True)
         # Already checked long_context_tier above; this is a normal rate limit
         return result_fn(
             FailoverReason.rate_limit,
@@ -775,6 +795,9 @@ def _classify_by_error_code(
             should_compress=True,
         )
 
+    if code_lower in _SERVER_OVERLOAD_SUBCODES:
+        return result_fn(FailoverReason.overloaded, retryable=True)
+
     return None
 
 
@@ -797,6 +820,11 @@ def _classify_by_message(
             retryable=True,
             should_compress=True,
         )
+
+    # Server overload — check before rate-limit patterns because overload
+    # messages might overlap with rate-limit keywords.
+    if any(p in error_msg for p in _SERVER_OVERLOAD_PATTERNS):
+        return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Usage-limit patterns need the same disambiguation as 402: some providers
     # surface "usage limit" errors without an HTTP status code.  A transient

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1128,3 +1128,97 @@ class TestRateLimitErrorWithoutStatusCode:
         e.status_code = None
         result = classify_api_error(e, provider="copilot", model="gpt-4o")
         assert result.reason != FailoverReason.rate_limit
+
+class TestOverloadedDisambiguation:
+    """ZAI returns HTTP 429 for BOTH user rate-limit AND server overload.
+
+    The classifier must distinguish these by checking the body error code
+    and message text.  Server overload must NOT trigger credential rotation.
+    """
+
+    def test_429_subcode_1305_overloaded(self):
+        """ZAI 429 with error code 1305 (server overload) → overloaded."""
+        e = MockAPIError(
+            "该模型当前访问量过大，请您稍后再试",
+            status_code=429,
+            body={"error": {"code": 1305, "message": "该模型当前访问量过大"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+        assert result.status_code == 429
+
+    def test_429_subcode_1306_overloaded(self):
+        e = MockAPIError(
+            "服务器繁忙",
+            status_code=429,
+            body={"error": {"code": "1306", "message": "服务器繁忙"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+
+    def test_429_subcode_1307_overloaded(self):
+        e = MockAPIError(
+            "系统负载过高",
+            status_code=429,
+            body={"error": {"code": "1307"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+
+    def test_429_overload_message_no_code_is_overloaded(self):
+        """429 with overload message but no structured code → overloaded."""
+        e = MockAPIError(
+            "该模型当前访问量过大，请您稍后再试",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_429_rate_limit_subcode_1302_stays_rate_limit(self):
+        """ZAI 429 with code 1302 (user rate limit) → rate_limit, NOT overloaded."""
+        e = MockAPIError(
+            "您的账户已达到速率限制",
+            status_code=429,
+            body={"error": {"code": 1302, "message": "您的账户已达到速率限制"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_429_plain_stays_rate_limit(self):
+        """Plain 429 without overload signals → rate_limit (unchanged)."""
+        e = MockAPIError("Too Many Requests", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_no_status_overload_subcode_in_body(self):
+        """Error without status code but with overload sub-code → overloaded."""
+        e = MockAPIError(
+            "server overloaded",
+            body={"error": {"code": "1305", "message": "访问量过大"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+
+    def test_no_status_overload_message_only(self):
+        """Error without status code but with overload message → overloaded."""
+        e = MockAPIError("该模型当前访问量过大")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+
+    def test_anthropic_long_context_tier_429_unchanged(self):
+        """Anthropic long-context tier 429 must still be classified correctly."""
+        e = MockAPIError(
+            "Extra usage is required for long context requests over 200k tokens",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.long_context_tier
+


### PR DESCRIPTION
## Summary
- **credential_pool**: Differentiate server overload cooldown from rate-limit cooldown for more precise backoff handling
- **error_classifier**: Add new error classification patterns to improve failover decision-making
- **tests**: Add corresponding test cases for error classifier

## Test plan
- [ ] Run `pytest tests/agent/test_error_classifier.py`
- [ ] Verify credential pool cooldown logic handles server overload vs rate-limit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)