### PR TITLE
fix(memory): preserve embedded hindsight key on blank input

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -589,12 +589,31 @@ class HindsightMemoryProvider(MemoryProvider):
             val = input(f"  LLM model [{default_model}]: ").strip()
             provider_config["llm_model"] = val or default_model
 
-            sys.stdout.write("  LLM API key: ")
+            existing_llm_key = os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+            if not existing_llm_key:
+                existing_llm_key = _load_simple_env(Path(hermes_home) / ".env").get(
+                    "HINDSIGHT_LLM_API_KEY",
+                    "",
+                )
+            if not existing_llm_key:
+                existing_profile_config = dict(self._config or {})
+                existing_llm_key = _load_simple_env(
+                    _embedded_profile_env_path(existing_profile_config)
+                ).get("HINDSIGHT_API_LLM_API_KEY", "")
+
+            if existing_llm_key:
+                masked = f"...{existing_llm_key[-4:]}" if len(existing_llm_key) > 4 else "set"
+                sys.stdout.write(f"  LLM API key (current: {masked}, blank to keep): ")
+            else:
+                sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
             llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
-            # Always write explicitly (including empty) so the provider sees ""
-            # rather than a missing variable.  The daemon reads from .env at
-            # startup and fails when HINDSIGHT_LLM_API_KEY is unset.
+            if not llm_key and existing_llm_key:
+                llm_key = existing_llm_key
+            # Always write explicitly so the provider sees a concrete value.
+            # Preserve an existing key when the user leaves the prompt blank;
+            # otherwise keep the legacy empty-string fallback instead of an
+            # unset variable.
             env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
 
         # Step 4: Save everything


### PR DESCRIPTION
## Summary
- preserve the existing embedded Hindsight LLM key when setup is rerun and the API-key prompt is left blank
- load the current key from env, profile `.env`, or embedded profile env before prompting so the blank input can intentionally keep it
- keep the existing explicit empty-string fallback when no prior key exists

## Testing
- python3 -m pytest -o addopts="" tests/plugins/memory/test_hindsight_provider.py -k preserves_existing_key_when_input_left_blank
