### PR TITLE
docs: add Chinese project documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 # Hermes Agent ☤
 
+> **项目文档（中文）**
+> - [项目全景文档](docs/hermes-agent-overview.html) — 系统架构、核心模块、插件系统、工具系统、数据流、技能生态、配置参考
+> - [自我进化系统设计](docs/self-evolution-design.html) — 梦境整理引擎、进化提案审批、策略注入、自动回滚机制
+
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>


### PR DESCRIPTION
## Summary
Add links to Chinese documentation resources in README for broader accessibility to Chinese-speaking users.

## Test plan
- [ ] Verify links are valid and accessible
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)