### PR TITLE
fix: preserve empty reasoning_content for DeepSeek thinking mode across turns

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -347,10 +347,10 @@ class ChatCompletionsTransport(ProviderTransport):
         reasoning_content = getattr(msg, "reasoning_content", None)
 
         provider_data: Dict[str, Any] = {}
-        if reasoning_content:
+        if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
         rd = getattr(msg, "reasoning_details", None)
-        if rd:
+        if rd is not None:
             provider_data["reasoning_details"] = rd
 
         return NormalizedResponse(

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -187,6 +187,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        is_deepseek = params.get("is_deepseek", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:
@@ -237,6 +238,18 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek thinking mode (v4-flash / v4-pro)
+        # DeepSeek uses `thinking: {"type": "enabled|disabled"}` at the top level,
+        # which is different from the `reasoning` extra_body used by OpenRouter.
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning

--- a/run_agent.py
+++ b/run_agent.py
@@ -7214,6 +7214,9 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = (
+            base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7282,6 +7285,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,
@@ -7524,18 +7528,27 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        # DeepSeek and Kimi (Moonshot) require reasoning_content (even if empty)
-        # on assistant tool-call messages when in thinking mode.
-        requires_reasoning = (
-            self.provider in {"kimi-coding", "kimi-coding-cn", "deepseek"}
+        # Kimi (Moonshot) requires reasoning_content (even if empty) on
+        # assistant tool-call messages when in thinking mode.
+        kimi_requires_reasoning = (
+            self.provider in {"kimi-coding", "kimi-coding-cn"}
             or base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
+        )
+        if kimi_requires_reasoning and source_msg.get("tool_calls"):
+            api_msg["reasoning_content"] = ""
+
+        # DeepSeek thinking mode (deepseek-v4-flash / deepseek-v4-pro) also
+        # requires reasoning_content on every assistant message, not just
+        # tool-call ones. Use setdefault so existing values are preserved.
+        deepseek_requires_reasoning = (
+            self.provider == "deepseek"
             or base_url_host_matches(self.base_url, "api.deepseek.com")
             or "deepseek" in (self.model or "").lower()
         )
-        if requires_reasoning and source_msg.get("tool_calls"):
-            api_msg["reasoning_content"] = ""
+        if deepseek_requires_reasoning:
+            api_msg.setdefault("reasoning_content", "")
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2831,14 +2831,18 @@ class AIAgent:
         reasoning_parts = []
         
         # Check direct reasoning field
-        if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
-            reasoning_parts.append(assistant_message.reasoning)
+        if hasattr(assistant_message, 'reasoning'):
+            r = getattr(assistant_message, 'reasoning')
+            if isinstance(r, str):
+                reasoning_parts.append(r)
         
         # Check reasoning_content field (alternative name used by some providers)
-        if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
-            # Don't duplicate if same as reasoning
-            if assistant_message.reasoning_content not in reasoning_parts:
-                reasoning_parts.append(assistant_message.reasoning_content)
+        if hasattr(assistant_message, 'reasoning_content'):
+            rc = getattr(assistant_message, 'reasoning_content')
+            if isinstance(rc, str):
+                # Don't duplicate if same as reasoning
+                if rc not in reasoning_parts:
+                    reasoning_parts.append(rc)
         
         # Check reasoning_details array (OpenRouter unified format)
         # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
@@ -7320,6 +7324,7 @@ class AIAgent:
         model = (self.model or "").lower()
         reasoning_model_prefixes = (
             "deepseek/",
+            "deepseek-",
             "anthropic/",
             "openai/",
             "x-ai/",
@@ -7515,17 +7520,21 @@ class AIAgent:
             return
 
         normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+        if isinstance(normalized_reasoning, str):
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        kimi_requires_reasoning = (
-            self.provider in {"kimi-coding", "kimi-coding-cn"}
+        # DeepSeek and Kimi (Moonshot) require reasoning_content (even if empty)
+        # on assistant tool-call messages when in thinking mode.
+        requires_reasoning = (
+            self.provider in {"kimi-coding", "kimi-coding-cn", "deepseek"}
             or base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+            or "deepseek" in (self.model or "").lower()
         )
-        if kimi_requires_reasoning and source_msg.get("tool_calls"):
+        if requires_reasoning and source_msg.get("tool_calls"):
             api_msg["reasoning_content"] = ""
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

Fixes HTTP 400 error from DeepSeek API: "The reasoning_content in the thinking mode must be passed back to the API."

DeepSeek v4 Flash has a "thinking mode" where the model returns `reasoning_content` in its responses. The API requires this field to be preserved and replayed in subsequent requests — even if it is an empty string during tool-call turns. Hermes was using truthy checks (`if reasoning_content:`) that silently dropped empty strings, breaking the thinking mode state across multi-turn conversations.

### Changes

- **`run_agent.py` — `_extract_reasoning`**: Replaced truthy check with `isinstance(r, str)`, so empty reasoning strings are captured.
- **`run_agent.py` — `_copy_reasoning_content_for_api`**: Removed truthy guard so empty reasoning is replayed. Expanded provider list to cover DeepSeek (by name, base URL, model prefix).
- **`agent/transports/chat_completions.py`**: Changed `if reasoning_content:` to `if reasoning_content is not None` (same for `reasoning_details`), preserving empty strings/lists.

## Type of Change

- [x] Bug fix

## How to Test

1. Configure Hermes to use `deepseek-v4-flash` (thinking mode model)
2. Start a conversation with tool calls over multiple turns
3. Previously: HTTP 400 on turn 2+ with "reasoning_content must be passed back"
4. Now: conversation continues normally

## Checklist

- [x] Conventional Commits in commit message
- [x] Only changes related to this fix
- [ ] Tested on Linux (Hermes Agent v0.11.0)
