### PR TITLE
test(ink): add bidi regression coverage for mixed Arabic/English text

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { reorderBidi } from './bidi.js'
+
+type BidiCharacter = Parameters<typeof reorderBidi>[0][number]
+
+const charactersFrom = (text: string): BidiCharacter[] =>
+  Array.from(text, value => ({
+    value,
+    width: 1,
+    styleId: 0,
+    hyperlink: undefined
+  }))
+
+const textFrom = (characters: BidiCharacter[]) => characters.map(character => character.value).join('')
+
+const importBidiWithSoftwareReordering = async () => {
+  vi.resetModules()
+  vi.stubEnv('TERM_PROGRAM', 'vscode')
+
+  return import('./bidi.js')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('reorderBidi', () => {
+  it('leaves pure LTR text unchanged', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('hello /help gpt-5')
+    const output = reorderBidi(input)
+
+    expect(output).toBe(input)
+    expect(textFrom(output)).toBe('hello /help gpt-5')
+  })
+
+  it('detects Arabic text through the RTL reorder path', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('مرحبا')
+    const output = reorderBidi(input)
+
+    expect(output).not.toBe(input)
+    expect(textFrom(output)).toBe('ابحرم')
+  })
+
+  it('keeps an English technical token readable in mixed Arabic text', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('مرحبا gpt-5')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('gpt-5 ابحرم')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds a small tests-only regression suite for mixed Arabic/English bidi rendering in Hermes Ink.

This change does not introduce locale plumbing, translation files, or runtime behavior changes. It only documents and protects the current bidi behavior for a realistic RTL/LTR mixed-text case in the TUI layer.

## Related Issue

Refs #12375

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `ui-tui/packages/hermes-ink/src/ink/bidi.test.ts`
- Added focused regression coverage for:
  - pure LTR text remaining unchanged
  - Arabic text exercising the RTL path indirectly
  - mixed Arabic/English technical text such as `مرحبا gpt-5`

## How to Test

1. `cd ui-tui/packages/hermes-ink`
2. `npm test -- packages/hermes-ink/src/ink/bidi.test.ts`
3. Confirm the new bidi test file passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — tests-only change.