### PR TITLE
fix(models): load only available models from OpenRouter

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -944,6 +944,7 @@ def list_authenticated_providers(
     from hermes_cli.models import (
         OPENROUTER_MODELS, _PROVIDER_MODELS,
         _MODELS_DEV_PREFERRED, _merge_with_models_dev, provider_model_ids,
+        model_ids as _openrouter_model_ids,
     )
 
     results: List[dict] = []
@@ -954,7 +955,7 @@ def list_authenticated_providers(
 
     # Build curated model lists keyed by hermes provider ID
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
-    curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
+    curated["openrouter"] = _openrouter_model_ids()
     # "nous" shares OpenRouter's curated list if not separately defined
     if "nous" not in curated:
         curated["nous"] = curated["openrouter"]

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -866,7 +866,12 @@ def fetch_openrouter_models(
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
+    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible.
+
+    Authenticates with ``OPENROUTER_API_KEY`` when set (required by the
+    ``/api/v1/models/user`` endpoint). Falls back to the static snapshot on
+    any network or auth failure.
+    """
     global _openrouter_catalog_cache
 
     if _openrouter_catalog_cache is not None and not force_refresh:
@@ -876,9 +881,13 @@ def fetch_openrouter_models(
     preferred_ids = [mid for mid, _ in fallback]
 
     try:
+        api_key = _resolve_openrouter_api_key()
+        headers = {"Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/models",
-            headers={"Accept": "application/json"},
+            "https://openrouter.ai/api/v1/models/user",
+            headers=headers,
         )
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -877,7 +877,7 @@ def fetch_openrouter_models(
 
     try:
         req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/models",
+            "https://openrouter.ai/api/v1/models/user",
             headers={"Accept": "application/json"},
         )
         with urllib.request.urlopen(req, timeout=timeout) as resp:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -375,6 +375,35 @@ def test_list_authenticated_providers_same_url_different_keys_disambiguated(monk
     assert models["custom:openai-2"] == ["gpt-4.6"]
 
 
+def test_list_authenticated_providers_openrouter_uses_live_model_ids(monkeypatch):
+    """OpenRouter provider row must reflect live model_ids(), not the static OPENROUTER_MODELS snapshot."""
+    live_models = [
+        ("x-ai/grok-3-mini", ""),
+        ("anthropic/claude-opus-4.6", "recommended"),
+    ]
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_models",
+        lambda **kw: live_models,
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"openrouter": {"env": ["OPENROUTER_API_KEY"]}},
+    )
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    openrouter_rows = [p for p in providers if p["slug"] == "openrouter"]
+    assert len(openrouter_rows) == 1
+    assert openrouter_rows[0]["models"] == ["x-ai/grok-3-mini", "anthropic/claude-opus-4.6"]
+
+
 def test_list_authenticated_providers_total_models_reflects_grouped_count(monkeypatch):
     """After grouping six entries into one row, total_models must reflect
     the full count, and every grouped model appears in the list."""

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -87,6 +87,65 @@ class TestFetchOpenRouterModels:
 
         assert models == OPENROUTER_MODELS
 
+    def test_fetches_from_user_endpoint(self, monkeypatch):
+        """Must use /api/v1/models/user, not the public /api/v1/models catalog."""
+        class _Resp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"data":[]}'
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=fake_urlopen):
+            fetch_openrouter_models(force_refresh=True)
+
+        assert captured["url"] == "https://openrouter.ai/api/v1/models/user"
+
+    def test_sends_authorization_header_when_api_key_set(self, monkeypatch):
+        class _Resp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"data":[{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"}}]}'
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-123")
+
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["headers"] = req.headers
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=fake_urlopen):
+            fetch_openrouter_models(force_refresh=True)
+
+        assert captured["headers"].get("Authorization") == "Bearer test-key-123"
+
+    def test_omits_authorization_header_when_no_api_key(self, monkeypatch):
+        class _Resp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"data":[{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"}}]}'
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["headers"] = req.headers
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=fake_urlopen):
+            fetch_openrouter_models(force_refresh=True)
+
+        assert "Authorization" not in captured["headers"]
+
     def test_filters_out_models_without_tool_support(self, monkeypatch):
         """Models whose supported_parameters omits 'tools' must not appear in the picker.
 


### PR DESCRIPTION
## What does this PR do?

Loads only the models available to the authenticated user from OpenRouter, instead of the full public catalog.

Previously, `hermes` fetched models from `/api/v1/models`, which returns all models regardless of the user's API key permissions, privacy settings, or access restrictions. This meant users could select a model in the picker that their key was not authorized to use, resulting in a guaranteed error at inference time.

This PR switches to the `/api/v1/models/user` endpoint, which returns only the models available to the authenticated user. It also forwards `OPENROUTER_API_KEY` as a `Bearer` token in the request (required by the user-scoped endpoint) and falls back to the static snapshot on any network or auth failure.

## Related Issue

Fixes #N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py` — Switch endpoint from `/api/v1/models` to `/api/v1/models/user`; attach `Authorization: Bearer <OPENROUTER_API_KEY>` header when the key is set; update docstring
- `hermes_cli/model_switch.py` — Replace static `OPENROUTER_MODELS` list with a call to `model_ids()` so the curated provider list reflects the live, user-scoped catalog
- `tests/hermes_cli/test_models.py` — Add tests verifying the `Authorization` header is sent when `OPENROUTER_API_KEY` is set and omitted when it is not

## How to Test

1. Set `OPENROUTER_API_KEY` to a valid key and run `hermes setup`
2. Verify only models available to your account appear in the model picker
3. Run `pytest tests/hermes_cli/test_models.py -q` — all tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->