### PR TITLE
fix(tools): backfill read tracker timestamp state

### DIFF
--- a/tests/tools/test_accretion_caps.py
+++ b/tests/tools/test_accretion_caps.py
@@ -129,6 +129,27 @@ class TestReadTrackerCaps:
             assert len(td["dedup"]) <= 3
             assert len(td["read_timestamps"]) <= 3
 
+    def test_live_read_backfills_missing_timestamp_container(self, tmp_path):
+        """A pre-cap tracker entry without read_timestamps stays compatible."""
+        from tools import file_tools as ft
+
+        p = tmp_path / "compat.txt"
+        p.write_text("compat\n" * 10)
+
+        with ft._read_tracker_lock:
+            ft._read_tracker["compat-task"] = {
+                "last_key": None,
+                "consecutive": 0,
+                "read_history": set(),
+                "dedup": {},
+            }
+
+        ft.read_file_tool(path=str(p), task_id="compat-task")
+
+        with ft._read_tracker_lock:
+            td = ft._read_tracker["compat-task"]
+            assert str(p) in td["read_timestamps"]
+
 
 class TestCompletionConsumedPrune:
     def test_prune_drops_completion_entry_with_expired_session(self):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -428,7 +428,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
-                "read_history": set(), "dedup": {},
+                "read_history": set(), "dedup": {}, "read_timestamps": {},
             })
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
@@ -499,6 +499,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             # Ensure "dedup" key exists (backward compat with old tracker state)
             if "dedup" not in task_data:
                 task_data["dedup"] = {}
+            if "read_history" not in task_data:
+                task_data["read_history"] = set()
+            if "read_timestamps" not in task_data:
+                task_data["read_timestamps"] = {}
             task_data["read_history"].add((path, offset, limit))
             if task_data["last_key"] == read_key:
                 task_data["consecutive"] += 1


### PR DESCRIPTION
## Summary
- backfill missing `read_timestamps` state when `read_file_tool` resumes from older `_read_tracker` entries
- initialize new per-task tracker entries with `read_timestamps` so live reads always have a consistent schema
- add a regression test covering a pre-cap tracker entry that only has the older keys

## Testing
- python3 -m pytest -o addopts="" tests/tools/test_accretion_caps.py -q
