### PR TITLE
feat(browser): expose chrome_args config for Chrome launch flags

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -349,6 +349,7 @@ def load_cli_config() -> Dict[str, Any]:
         "browser": {
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
             "record_sessions": False,  # Auto-record browser sessions as WebM videos
+            "chrome_args": "",  # Extra Chrome launch args (e.g. "--no-sandbox" for containers)
         },
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit

--- a/tests/tools/test_browser_chrome_args.py
+++ b/tests/tools/test_browser_chrome_args.py
@@ -1,0 +1,167 @@
+"""Tests for browser.chrome_args config and AGENT_BROWSER_ARGS env injection.
+
+Covers the config -> env var wiring that lets users pass --no-sandbox and
+other Chrome launch flags when running in containers/VMs.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+import tools.browser_tool as browser_tool
+
+
+class TestGetChromeArgs:
+    """Tests for the _get_chrome_args() config reader."""
+
+    def setup_method(self):
+        # Clear the module-level cache before each test
+        browser_tool._cached_chrome_args = None
+        browser_tool._chrome_args_resolved = False
+
+    def teardown_method(self):
+        browser_tool._cached_chrome_args = None
+        browser_tool._chrome_args_resolved = False
+
+    def test_returns_empty_when_unset(self):
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert browser_tool._get_chrome_args() == ""
+
+    def test_reads_from_config(self):
+        cfg = {"browser": {"chrome_args": "--no-sandbox"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert browser_tool._get_chrome_args() == "--no-sandbox"
+
+    def test_strips_whitespace(self):
+        cfg = {"browser": {"chrome_args": "  --no-sandbox  "}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert browser_tool._get_chrome_args() == "--no-sandbox"
+
+    def test_caches_result(self):
+        cfg = {"browser": {"chrome_args": "--no-sandbox"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg) as mock_read:
+            browser_tool._get_chrome_args()
+            browser_tool._get_chrome_args()
+            mock_read.assert_called_once()
+
+    def test_merges_env_var_before_config(self):
+        """AGENT_BROWSER_ARGS env var is prepended; config value is appended."""
+        cfg = {"browser": {"chrome_args": "--disable-gpu"}}
+        with patch.dict(os.environ, {"AGENT_BROWSER_ARGS": "--no-sandbox"}):
+            with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+                result = browser_tool._get_chrome_args()
+                assert "--no-sandbox" in result
+                assert "--disable-gpu" in result
+                # env var comes first, then config, comma-joined
+                assert result == "--no-sandbox,--disable-gpu"
+
+    def test_env_var_alone_when_config_empty(self):
+        with patch.dict(os.environ, {"AGENT_BROWSER_ARGS": "--no-sandbox"}):
+            with patch("hermes_cli.config.read_raw_config", return_value={}):
+                assert browser_tool._get_chrome_args() == "--no-sandbox"
+
+    def test_normalizes_spaces_to_commas(self):
+        """Shell-style space-separated flags are converted to commas."""
+        cfg = {"browser": {"chrome_args": "--no-sandbox --disable-gpu"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert browser_tool._get_chrome_args() == "--no-sandbox,--disable-gpu"
+
+    def test_does_not_normalize_when_commas_already_present(self):
+        """If user already used commas, don't touch spaces inside values."""
+        cfg = {"browser": {"chrome_args": "--foo,--bar=b a z"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            # commas present → spaces preserved
+            assert browser_tool._get_chrome_args() == "--foo,--bar=b a z"
+
+    def test_handles_config_read_failure(self):
+        with patch(
+            "hermes_cli.config.read_raw_config", side_effect=Exception("disk error")
+        ):
+            assert browser_tool._get_chrome_args() == ""
+
+
+class TestRunBrowserCommandEnvInjection:
+    """Tests that _run_browser_command injects AGENT_BROWSER_ARGS."""
+
+    def test_sets_agent_browser_args_when_chrome_args_configured(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(
+            browser_tool,
+            "_get_session_info",
+            lambda task_id: {"session_name": "sess_1", "cdp_url": None},
+        )
+        monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
+        monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda *a: None)
+        monkeypatch.setattr(browser_tool, "_get_chrome_args", lambda: "--no-sandbox")
+
+        captured_env = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            # Return a mock process that exits immediately
+            class MockProc:
+                returncode = 0
+                def wait(self, timeout=None):
+                    pass
+            return MockProc()
+
+        monkeypatch.setattr(browser_tool.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(browser_tool.os, "open", lambda *a, **k: 0)
+        monkeypatch.setattr(browser_tool.os, "close", lambda fd: None)
+
+        browser_tool._run_browser_command("task-1", "open", ["https://example.com"])
+
+        assert captured_env.get("AGENT_BROWSER_ARGS") == "--no-sandbox"
+
+    def test_preserves_existing_env_var_when_no_config(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(
+            browser_tool,
+            "_get_session_info",
+            lambda task_id: {"session_name": "sess_2", "cdp_url": None},
+        )
+        monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
+        monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda *a: None)
+        # Do NOT mock _get_chrome_args — let it read the real env var
+
+        captured_env = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            class MockProc:
+                returncode = 0
+                def wait(self, timeout=None):
+                    pass
+            return MockProc()
+
+        monkeypatch.setattr(browser_tool.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(browser_tool.os, "open", lambda *a, **k: 0)
+        monkeypatch.setattr(browser_tool.os, "close", lambda fd: None)
+
+        # Pre-set env var in os.environ (simulating user export)
+        monkeypatch.setenv("AGENT_BROWSER_ARGS", "--disable-gpu")
+        # Clear cache so _get_chrome_args picks up the env var
+        browser_tool._cached_chrome_args = None
+        browser_tool._chrome_args_resolved = False
+
+        browser_tool._run_browser_command("task-2", "snapshot", [])
+
+        assert captured_env.get("AGENT_BROWSER_ARGS") == "--disable-gpu"
+
+
+class TestCleanupClearsChromeArgsCache:
+    """Tests that cleanup_all_browsers resets the chrome_args cache."""
+
+    def test_cleanup_resets_chrome_args_cache(self, monkeypatch):
+        # Seed the cache
+        browser_tool._cached_chrome_args = "--no-sandbox"
+        browser_tool._chrome_args_resolved = True
+
+        monkeypatch.setattr(browser_tool, "_active_sessions", {})
+        monkeypatch.setattr(browser_tool, "_stop_cdp_supervisor", lambda t: None)
+
+        browser_tool.cleanup_all_browsers()
+
+        assert browser_tool._cached_chrome_args is None
+        assert browser_tool._chrome_args_resolved is False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -174,6 +174,9 @@ _EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})
 _cached_command_timeout: Optional[int] = None
 _command_timeout_resolved = False
 
+_cached_chrome_args: Optional[str] = None
+_chrome_args_resolved = False
+
 
 def _get_command_timeout() -> int:
     """Return the configured browser command timeout from config.yaml.
@@ -197,6 +200,48 @@ def _get_command_timeout() -> int:
     except Exception as e:
         logger.debug("Could not read command_timeout from config: %s", e)
     _cached_command_timeout = result
+    return result
+
+
+def _get_chrome_args() -> str:
+    """Return configured Chrome launch args from config.yaml.
+
+    Reads ``config["browser"]["chrome_args"]`` and falls back to an
+    empty string if unset or unreadable.  Result is cached after the
+    first call and cleared by ``cleanup_all_browsers()``.
+
+    When the ``AGENT_BROWSER_ARGS`` environment variable is already set,
+    the config value is appended (comma-separated) so both sources are
+    respected.
+    """
+    global _cached_chrome_args, _chrome_args_resolved
+    if _chrome_args_resolved:
+        return _cached_chrome_args  # type: ignore[return-value]
+
+    _chrome_args_resolved = True
+    result = ""
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg.get("browser", {}).get("chrome_args")
+        if val is not None:
+            result = str(val).strip()
+    except Exception as e:
+        logger.debug("Could not read chrome_args from config: %s", e)
+
+    env_args = os.environ.get("AGENT_BROWSER_ARGS", "").strip()
+    if env_args:
+        if result:
+            result = f"{env_args},{result}"
+        else:
+            result = env_args
+
+    # agent-browser splits AGENT_BROWSER_ARGS on comma or newline, not spaces.
+    # Normalize spaces to commas so shell-style multi-flag strings work.
+    if result and " " in result and "," not in result:
+        result = result.replace(" ", ",")
+
+    _cached_chrome_args = result
     return result
 
 
@@ -1290,6 +1335,14 @@ def _run_browser_command(
         if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
             idle_ms = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
             browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = idle_ms
+
+        # Pass through any configured custom Chrome launch arguments
+        # (e.g. --no-sandbox for container/VM environments).  Merges
+        # config.yaml browser.chrome_args with the AGENT_BROWSER_ARGS
+        # env var so both sources are respected.
+        chrome_args = _get_chrome_args()
+        if chrome_args:
+            browser_env["AGENT_BROWSER_ARGS"] = chrome_args
         
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file
@@ -2455,11 +2508,14 @@ def cleanup_all_browsers() -> None:
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
+    global _cached_chrome_args, _chrome_args_resolved
     _cached_agent_browser = None
     _agent_browser_resolved = False
     _discover_homebrew_node_dirs.cache_clear()
     _cached_command_timeout = None
     _command_timeout_resolved = False
+    _cached_chrome_args = None
+    _chrome_args_resolved = False
 
 
 # ============================================================================

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1240,6 +1240,11 @@ browser:
   inactivity_timeout: 120        # Seconds before auto-closing idle sessions
   command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
+  # Extra Chrome launch arguments for local browser mode.
+  # Common use case: "--no-sandbox" when running in Docker/VMs without proper
+  # sandbox permissions. Multiple flags are comma-separated.
+  # Also respects the AGENT_BROWSER_ARGS env var.
+  chrome_args: ""
   # Optional CDP override — when set, Hermes attaches directly to your own
   # Chrome (via /browser connect) rather than starting a headless browser.
   cdp_url: ""


### PR DESCRIPTION
## Problem
Hermes delegates local browser automation to the `agent-browser` CLI, which launches Chromium. On Linux containers/VMs without proper sandbox permissions, Chromium exits immediately because it cannot create its sandbox. The standard fix is `--no-sandbox`, but `agent-browser` only accepts custom flags via an undocumented environment variable (`AGENT_BROWSER_ARGS`). Hermes provided no `config.yaml` option, forcing users to discover and set the env var manually.

## Solution
Add a first-class `browser.chrome_args` config option. When set, Hermes passes the value to `agent-browser` via the `AGENT_BROWSER_ARGS` environment variable in the browser subprocess.

**`~/.hermes/config.yaml`**
```yaml
browser:
  # Single flag
  chrome_args: "--no-sandbox"

  # Multiple flags (comma-separated, or space-separated which is auto-normalized)
  chrome_args: "--no-sandbox,--disable-gpu"
```

**Implementation details:**
- `agent-browser` splits `AGENT_BROWSER_ARGS` on **comma or newline**, not spaces. To keep the UX shell-friendly, `_get_chrome_args()` auto-normalizes space-separated strings to commas (e.g. `--no-sandbox --disable-gpu` → `--no-sandbox,--disable-gpu`). If the user already used commas, normalization is skipped so intentional spaces inside values are preserved.
- Pre-existing `AGENT_BROWSER_ARGS` env vars are respected and merged with the config value (env var first, then config).
- Result is cached per-session and cleared by `cleanup_all_browsers()`, matching the existing pattern used by `command_timeout`.

## Files changed
| File | Change |
|------|--------|
| `tools/browser_tool.py` | Add `_get_chrome_args()` cached config reader; inject `AGENT_BROWSER_ARGS` into subprocess env; clear cache on cleanup |
| `cli.py` | Add `"chrome_args": ""` to default browser config |
| `website/docs/user-guide/configuration.md` | Document the new option |
| `tests/tools/test_browser_chrome_args.py` | New test file (12 tests) |

## Test results
```
tests/tools/test_browser_chrome_args.py      12 passed
tests/tools/test_browser_*.py (full suite)  217 passed, 17 skipped
```

No regressions.

## Checklist
- [x] Tests added and passing
- [x] Docs updated
- [x] Default config schema updated
- [x] No breaking changes
- [x] Backward-compatible with existing `AGENT_BROWSER_ARGS` env var usage