### PR TITLE
test(model-switch): assert fetch_api_models kwargs match current signature (#15243)

### DIFF
--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -51,8 +51,14 @@ class TestCustomProviderModelSwitch:
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
-        # fetch_api_models MUST be called even though model was saved
-        mock_fetch.assert_called_once_with("sk-test", "https://vllm.example.com/v1", timeout=8.0)
+        # fetch_api_models MUST be called even though model was saved.
+        # ``api_mode`` was added to the production signature by 647900e8
+        # ("fix(cli): support model validation for anthropic_messages and
+        # cloudflare-protected endpoints") — the test fixture has no
+        # ``api_mode`` entry so ``api_mode or None`` resolves to ``None``.
+        mock_fetch.assert_called_once_with(
+            "sk-test", "https://vllm.example.com/v1", timeout=8.0, api_mode=None,
+        )
 
     def test_can_switch_to_different_model(self, config_home):
         """User selects a different model than the saved one."""


### PR DESCRIPTION
## What does this PR do?

Fixes \`#15243\`.

\`_model_flow_named_custom\` was extended in \`647900e8\` (\"fix(cli): support model validation for anthropic_messages and cloudflare-protected endpoints\") to pass \`api_mode\` through to \`fetch_api_models\` so Anthropic-messages and Cloudflare-protected endpoints validate correctly. The test that pins \"we must still probe the endpoint when a model is already saved\" was never updated for that new kwarg and has been failing on every PR's \`test\` CI lane since — it's one of the four standing baseline failures I've been calling out in CI notes on every open PR (#15158, #15162, #15173, #15185 at minimum, plus any PR a reporter opens in this window).

## Fix

One line, plus a comment pointing future readers at the history so no one strips the kwarg again.

**Before:**
\`\`\`python
mock_fetch.assert_called_once_with(\"sk-test\", \"https://vllm.example.com/v1\", timeout=8.0)
\`\`\`

**After:**
\`\`\`python
# fetch_api_models MUST be called even though model was saved.
# ``api_mode`` was added to the production signature by 647900e8
# (\"fix(cli): support model validation for anthropic_messages and
# cloudflare-protected endpoints\") — the test fixture has no
# ``api_mode`` entry so ``api_mode or None`` resolves to ``None``.
mock_fetch.assert_called_once_with(
    \"sk-test\", \"https://vllm.example.com/v1\", timeout=8.0, api_mode=None,
)
\`\`\`

The production call at \`hermes_cli/main.py:2920-2923\` is:

\`\`\`python
models = fetch_api_models(
    api_key, base_url, timeout=8.0,
    api_mode=api_mode or None,
)
\`\`\`

where \`api_mode\` comes from \`provider_info.get(\"api_mode\", \"\")\`. The test fixture has no \`api_mode\` entry so \`api_mode or None\` resolves to \`None\` — the expected assertion kwarg.

## Related Issue

Fixes #15243

## Type of Change

- [x] 🔧 Test fix (no production behavior change)

## Test plan

- [x] All 6 tests in \`TestCustomProviderModelSwitch\` pass locally
- [x] This failure has appeared on every open PR's \`test\` CI lane since 647900e8 landed — the fix clears it from the baseline failure set
- [x] No production code touched