### PR TITLE
feat(deepseek): add thinking.type + reasoning_effort mapping for DeepSeek API

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -100,6 +100,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_github_models: bool
             is_nvidia_nim: bool
             is_kimi: bool
+            is_deepseek: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -238,6 +239,25 @@ class ChatCompletionsTransport(ProviderTransport):
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
             }
+
+        # DeepSeek extra_body.thinking + top-level reasoning_effort
+        is_deepseek = params.get("is_deepseek", False)
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
+            }
+            # DeepSeek effort: low/medium→high, high→high, xhigh/max→max
+            if _ds_thinking_enabled and reasoning_config:
+                _e = (reasoning_config.get("effort") or "").strip().lower()
+                if _e in ("xhigh", "max"):
+                    api_kwargs["reasoning_effort"] = "max"
+                elif _e in ("low", "medium", "high"):
+                    api_kwargs["reasoning_effort"] = _e
+            # If no effort configured, don't set it → DeepSeek defaults to high
 
         # Reasoning
         if params.get("supports_reasoning", False):

--- a/run_agent.py
+++ b/run_agent.py
@@ -7210,6 +7210,7 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = base_url_host_matches(self.base_url, "api.deepseek.com")
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7278,6 +7279,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,
@@ -7527,6 +7529,11 @@ class AIAgent:
         )
         if kimi_requires_reasoning and source_msg.get("tool_calls"):
             api_msg["reasoning_content"] = ""
+
+        # DeepSeek: strip reasoning_content on all assistant messages so the API
+        # doesn't return 400 when the model was invoked with thinking enabled.
+        if base_url_host_matches(self.base_url, "api.deepseek.com"):
+            api_msg.pop("reasoning_content", None)
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:


### PR DESCRIPTION
## Summary

DeepSeek's thinking mode requires both `extra_body.thinking.type: "enabled"` and a top-level `reasoning_effort` parameter to control thinking depth. The `ChatCompletionsTransport` previously only handled Kimi's thinking mode — DeepSeek was left unmapped, so any `reasoning_effort` config was silently dropped and no `thinking.type` was sent.

## Changes

1. **`agent/transports/chat_completions.py`** — Added `is_deepseek: bool` to the `Params` dataclass and a new DeepSeek-specific block that:
   - Sets `extra_body.thinking.type: "enabled"/"disabled"` (mirrors the existing Kimi logic)
   - Maps Hermes effort levels to DeepSeek's API: `xhigh`/`max` → `"max"`, `low`/`medium`/`high` → pass through, empty → omit (DeepSeek defaults to `high`)

2. **`run_agent.py`** — Detects DeepSeek base URL (`api.deepseek.com`) via `base_url_host_matches()` and passes `is_deepseek` to the transport params. Also strips `reasoning_content` from assistant messages on the DeepSeek path to prevent 400 errors (`The reasoning_content in the thinking mode must be passed back to the API`).

## Effort Mapping

| Config value | DeepSeek API |
|---|---|
| `low` | `low` |
| `medium` | `medium` |
| `high` | `high` |
| `xhigh`, `max` | `max` |
| (empty/unset) | omitted → defaults to `high` |

## Testing

- `parse_reasoning_effort("xhigh")` returns `{"enabled": true, "effort": "xhigh"}` ✓
- xhigh maps to `api_kwargs["reasoning_effort"] = "max"` ✓
- extra_body includes `thinking.type: "enabled"` ✓
- No `Unknown reasoning_effort` warnings in gateway logs after restart ✓
