### PR TITLE
feat: add OpenAI backend for image_generate

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -278,6 +278,15 @@ TOOL_CATEGORIES = {
                 ],
                 "imagegen_backend": "fal",
             },
+            {
+                "name": "OpenAI Official",
+                "badge": "paid",
+                "tag": "Official OpenAI Images API (gpt-image-1)",
+                "env_vars": [
+                    {"key": "OPENAI_API_KEY", "prompt": "OpenAI API key", "url": "https://platform.openai.com/api-keys"},
+                ],
+                "imagegen_backend": "openai",
+            },
         ],
     },
     "browser": {
@@ -1014,11 +1023,27 @@ def _fal_model_catalog():
     return FAL_MODELS, DEFAULT_MODEL
 
 
+def _openai_model_catalog():
+    """Minimal official OpenAI image catalog."""
+    return {
+        "gpt-image-1": {
+            "speed": "~15s",
+            "strengths": "Official OpenAI image generation",
+            "price": "OpenAI API billing",
+        },
+    }, "gpt-image-1"
+
+
 IMAGEGEN_BACKENDS = {
     "fal": {
         "display": "FAL.ai",
         "config_key": "image_gen",
         "catalog_fn": _fal_model_catalog,
+    },
+    "openai": {
+        "display": "OpenAI Official",
+        "config_key": "image_gen",
+        "catalog_fn": _openai_model_catalog,
     },
 }
 
@@ -1091,6 +1116,7 @@ def _configure_imagegen_model(backend_name: str, config: dict) -> None:
     )
 
     chosen = ordered[idx]
+    cur_cfg["backend"] = backend_name
     cur_cfg["model"] = chosen
     _print_success(f"  Model set to: {chosen}")
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -533,15 +533,27 @@ class TestImagegenBackendRegistry:
         assert "fal-ai/flux-2/klein/9b" in catalog
         assert "fal-ai/flux-2-pro" in catalog
 
-    def test_image_gen_providers_tagged_with_fal_backend(self):
-        """Both Nous Subscription and FAL.ai providers must carry the
-        imagegen_backend tag so _configure_provider fires the picker."""
+    def test_image_gen_providers_tagged_with_expected_backends(self):
+        """Each image provider must advertise the backend that drives the picker."""
         from hermes_cli.tools_config import TOOL_CATEGORIES
         providers = TOOL_CATEGORIES["image_gen"]["providers"]
-        for p in providers:
-            assert p.get("imagegen_backend") == "fal", (
-                f"{p['name']} missing imagegen_backend tag"
-            )
+        by_name = {p["name"]: p for p in providers}
+
+        assert by_name["Nous Subscription"].get("imagegen_backend") == "fal"
+        assert by_name["FAL.ai"].get("imagegen_backend") == "fal"
+        assert by_name["OpenAI Official"].get("imagegen_backend") == "openai"
+
+    def test_openai_backend_registered(self):
+        from hermes_cli.tools_config import IMAGEGEN_BACKENDS
+
+        assert "openai" in IMAGEGEN_BACKENDS
+
+    def test_openai_catalog_loads(self):
+        from hermes_cli.tools_config import IMAGEGEN_BACKENDS
+
+        catalog, default = IMAGEGEN_BACKENDS["openai"]["catalog_fn"]()
+        assert default == "gpt-image-1"
+        assert "gpt-image-1" in catalog
 
 
 class TestImagegenModelPicker:
@@ -555,8 +567,19 @@ class TestImagegenModelPicker:
         with patch("hermes_cli.tools_config._prompt_choice", return_value=1):
             _configure_imagegen_model("fal", config)
         # ordered[0] == current (default klein), ordered[1] == first non-default
+        assert config["image_gen"]["backend"] == "fal"
         assert config["image_gen"]["model"] != "fal-ai/flux-2/klein/9b"
         assert config["image_gen"]["model"].startswith("fal-ai/")
+
+    def test_openai_picker_writes_backend_and_model_to_config(self):
+        from hermes_cli.tools_config import _configure_imagegen_model
+
+        config = {}
+        with patch("hermes_cli.tools_config._prompt_choice", return_value=0):
+            _configure_imagegen_model("openai", config)
+
+        assert config["image_gen"]["backend"] == "openai"
+        assert config["image_gen"]["model"] == "gpt-image-1"
 
     def test_picker_with_gpt_image_does_not_prompt_quality(self):
         """GPT-Image quality is pinned to medium in the tool's defaults —
@@ -600,4 +623,5 @@ class TestImagegenModelPicker:
         with patch("hermes_cli.tools_config._prompt_choice", return_value=0):
             _configure_imagegen_model("fal", config)
         assert isinstance(config["image_gen"], dict)
+        assert config["image_gen"]["backend"] == "fal"
         assert config["image_gen"]["model"] == "fal-ai/flux-2/klein/9b"

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -314,6 +314,117 @@ class TestAspectRatioNormalization:
 
 
 # ---------------------------------------------------------------------------
+# OpenAI backend support
+# ---------------------------------------------------------------------------
+
+class TestOpenAIBackendResolution:
+
+    def test_backend_defaults_to_fal(self, image_tool):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert image_tool._resolve_image_backend() == "fal"
+
+    def test_backend_reads_openai_from_config(self, image_tool):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"image_gen": {"backend": "openai"}}):
+            assert image_tool._resolve_image_backend() == "openai"
+
+    def test_openai_model_defaults_to_gpt_image_1(self, image_tool):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert image_tool._resolve_openai_image_model() == "gpt-image-1"
+
+    def test_openai_model_reads_config(self, image_tool):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"image_gen": {"model": "dall-e-3"}}):
+            assert image_tool._resolve_openai_image_model() == "dall-e-3"
+
+
+class TestOpenAIAspectRatioMapping:
+
+    def test_openai_landscape_maps_to_1536x1024(self, image_tool):
+        assert image_tool._aspect_ratio_to_openai_size("landscape", "gpt-image-1") == "1536x1024"
+
+    def test_openai_square_maps_to_1024x1024(self, image_tool):
+        assert image_tool._aspect_ratio_to_openai_size("square", "gpt-image-1") == "1024x1024"
+
+    def test_openai_portrait_maps_to_1024x1536(self, image_tool):
+        assert image_tool._aspect_ratio_to_openai_size("portrait", "gpt-image-1") == "1024x1536"
+
+    def test_dalle_3_forces_square(self, image_tool):
+        assert image_tool._aspect_ratio_to_openai_size("portrait", "dall-e-3") == "1024x1024"
+
+    def test_invalid_openai_aspect_defaults_to_landscape(self, image_tool):
+        assert image_tool._aspect_ratio_to_openai_size("wide", "gpt-image-1") == "1536x1024"
+
+
+class TestOpenAIRequirements:
+
+    def test_openai_requirements_true_when_api_key_present(self, image_tool, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setattr(image_tool, "_resolve_image_backend", lambda: "openai")
+        assert image_tool.check_image_generation_requirements() is True
+
+    def test_openai_requirements_false_when_api_key_missing(self, image_tool, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(image_tool, "_resolve_image_backend", lambda: "openai")
+        monkeypatch.setattr(image_tool, "_resolve_openai_api_key", lambda: "")
+        assert image_tool.check_image_generation_requirements() is False
+
+
+class TestOpenAISaveImage:
+
+    def test_save_openai_generated_image_from_b64(self, image_tool, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        payload = "aGVsbG8="  # base64('hello')
+
+        out = image_tool._save_openai_generated_image(b64_json=payload)
+
+        from pathlib import Path
+        p = Path(out)
+        assert p.exists()
+        assert p.read_bytes() == b"hello"
+        assert p.parent == tmp_path / "generated_images"
+
+
+class TestOpenAIGenerateFlow:
+
+    def test_generate_image_via_openai_uses_client_and_saves_file(self, image_tool, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_tool, "_resolve_openai_api_key", lambda: "sk-test")
+        monkeypatch.setattr(image_tool, "_resolve_openai_image_model", lambda: "gpt-image-1")
+        monkeypatch.setattr(image_tool, "_resolve_openai_base_url", lambda: "https://api.openai.com/v1")
+
+        calls = {}
+
+        class _RespItem:
+            b64_json = "aGVsbG8="
+            url = None
+
+        class _Resp:
+            data = [_RespItem()]
+
+        class _Images:
+            def generate(self, **kwargs):
+                calls["generate"] = kwargs
+                return _Resp()
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                calls["client_init"] = kwargs
+                self.images = _Images()
+
+        monkeypatch.setattr(image_tool, "OpenAI", _Client)
+
+        result = image_tool._generate_image_via_openai("blue circle", "portrait")
+
+        data = __import__("json").loads(result)
+        assert data["success"] is True
+        assert calls["client_init"]["api_key"] == "sk-test"
+        assert calls["generate"]["model"] == "gpt-image-1"
+        assert calls["generate"]["size"] == "1024x1536"
+        assert (tmp_path / "generated_images").exists()
+
+
+# ---------------------------------------------------------------------------
 # Schema + registry integrity
 # ---------------------------------------------------------------------------
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -26,11 +26,16 @@ import os
 import datetime
 import threading
 import uuid
+import base64
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urlencode
+from urllib.request import urlopen
 
 import fal_client
+from openai import OpenAI
 
+from hermes_constants import get_hermes_home
 from tools.debug_helpers import DebugSession
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
@@ -259,6 +264,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
 
 # Default model is the fastest reasonable option. Kept cheap and sub-1s.
 DEFAULT_MODEL = "fal-ai/flux-2/klein/9b"
+DEFAULT_OPENAI_MODEL = "gpt-image-1"
 
 DEFAULT_ASPECT_RATIO = "landscape"
 VALID_ASPECT_RATIOS = ("landscape", "square", "portrait")
@@ -488,6 +494,121 @@ def _resolve_fal_model() -> tuple:
     return model_id, FAL_MODELS[model_id]
 
 
+def _load_image_gen_config() -> Dict[str, Any]:
+    """Return image_gen config dict or an empty dict when absent/corrupt."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        img_cfg = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return img_cfg if isinstance(img_cfg, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_image_backend() -> str:
+    """Resolve active image backend. Defaults to FAL for backward-compat."""
+    backend = str(_load_image_gen_config().get("backend") or "").strip().lower()
+    if backend in {"fal", "openai"}:
+        return backend
+    return "fal"
+
+
+def _resolve_openai_image_model() -> str:
+    """Resolve active OpenAI image model from config or fallback default."""
+    raw = str(_load_image_gen_config().get("model") or "").strip()
+    if raw in {"gpt-image-1", "dall-e-3"}:
+        return raw
+    return DEFAULT_OPENAI_MODEL
+
+
+def _resolve_openai_base_url() -> str:
+    """Use configured OpenAI base URL when present, else official default."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        providers = cfg.get("providers") if isinstance(cfg, dict) else None
+        if isinstance(providers, dict):
+            openai_cfg = providers.get("openai")
+            if isinstance(openai_cfg, dict):
+                base = str(openai_cfg.get("base_url") or "").strip()
+                if base:
+                    return base
+    except Exception as exc:
+        logger.debug("Could not load OpenAI base URL from config: %s", exc)
+    return "https://api.openai.com/v1"
+
+
+def _resolve_openai_api_key() -> str:
+    """Resolve OpenAI API key from env / ~/.hermes/.env."""
+    value = os.getenv("OPENAI_API_KEY")
+    if value is None:
+        try:
+            from hermes_cli.config import get_env_value
+            value = get_env_value("OPENAI_API_KEY")
+        except Exception:
+            value = None
+    return str(value or "").strip()
+
+
+def _aspect_ratio_to_openai_size(aspect_ratio: str, model_id: str) -> str:
+    """Map Hermes aspect ratios to official OpenAI image sizes."""
+    aspect_lc = (aspect_ratio or DEFAULT_ASPECT_RATIO).lower().strip()
+    if aspect_lc not in VALID_ASPECT_RATIOS:
+        aspect_lc = DEFAULT_ASPECT_RATIO
+    if model_id == "dall-e-3":
+        return "1024x1024"
+    mapping = {
+        "landscape": "1536x1024",
+        "square": "1024x1024",
+        "portrait": "1024x1536",
+    }
+    return mapping[aspect_lc]
+
+
+def _save_openai_generated_image(*, b64_json: Optional[str] = None, url: Optional[str] = None, model_id: str = DEFAULT_OPENAI_MODEL) -> str:
+    """Persist OpenAI image output under ~/.hermes/generated_images and return the path."""
+    out_dir = get_hermes_home() / "generated_images"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"openai_image_{ts}.png"
+
+    if b64_json:
+        out_path.write_bytes(base64.b64decode(b64_json))
+        return str(out_path)
+    if url:
+        with urlopen(url, timeout=60) as resp:
+            out_path.write_bytes(resp.read())
+        return str(out_path)
+    raise ValueError("OpenAI image response did not include b64_json or url")
+
+
+def _generate_image_via_openai(prompt: str, aspect_ratio: str = DEFAULT_ASPECT_RATIO) -> str:
+    """Generate an image via OpenAI official Images API and save locally."""
+    api_key = _resolve_openai_api_key()
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY environment variable not set")
+
+    model_id = _resolve_openai_image_model()
+    size = _aspect_ratio_to_openai_size(aspect_ratio, model_id)
+    client = OpenAI(api_key=api_key, base_url=_resolve_openai_base_url())
+    response = client.images.generate(
+        model=model_id,
+        prompt=prompt,
+        size=size,
+        quality="auto",
+    )
+    if not getattr(response, "data", None):
+        raise ValueError("OpenAI Images API returned no images")
+    first = response.data[0]
+    local_path = _save_openai_generated_image(
+        b64_json=getattr(first, "b64_json", None),
+        url=getattr(first, "url", None),
+        model_id=model_id,
+    )
+    return json.dumps({"success": True, "image": local_path}, indent=2, ensure_ascii=False)
+
+
 def _build_fal_payload(
     model_id: str,
     prompt: str,
@@ -592,19 +713,21 @@ def image_generate_tool(
     output_format: Optional[str] = None,
     seed: Optional[int] = None,
 ) -> str:
-    """Generate an image from a text prompt using the configured FAL model.
+    """Generate an image from a text prompt using the configured backend.
 
     The agent-facing schema exposes only ``prompt`` and ``aspect_ratio``; the
     remaining kwargs are overrides for direct Python callers and are filtered
     per-model via the ``supports`` whitelist (unsupported overrides are
     silently dropped so legacy callers don't break when switching models).
 
-    Returns a JSON string with ``{"success": bool, "image": url | None,
+    Returns a JSON string with ``{"success": bool, "image": url|path|None,
     "error": str, "error_type": str}``.
     """
-    model_id, meta = _resolve_fal_model()
+    backend = _resolve_image_backend()
+    model_id = _resolve_openai_image_model() if backend == "openai" else _resolve_fal_model()[0]
 
     debug_call_data = {
+        "backend": backend,
         "model": model_id,
         "parameters": {
             "prompt": prompt,
@@ -626,6 +749,20 @@ def image_generate_tool(
     try:
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
+
+        if backend == "openai":
+            result_json = _generate_image_via_openai(prompt, aspect_ratio)
+            result = json.loads(result_json)
+            generation_time = (datetime.datetime.now() - start_time).total_seconds()
+            debug_call_data["success"] = bool(result.get("success"))
+            debug_call_data["images_generated"] = 1 if result.get("image") else 0
+            debug_call_data["generation_time"] = generation_time
+            _debug.log_call("image_generate_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        model_id, meta = _resolve_fal_model()
+        debug_call_data["model"] = model_id
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
             message = "FAL_KEY environment variable not set"
@@ -741,9 +878,17 @@ def check_fal_api_key() -> bool:
     return bool(fal_key_is_configured() or _resolve_managed_fal_gateway())
 
 
+def check_openai_image_api_key() -> bool:
+    """True if the OpenAI Images API key is available."""
+    return bool(_resolve_openai_api_key())
+
+
 def check_image_generation_requirements() -> bool:
-    """True if FAL credentials and fal_client SDK are both available."""
+    """True if the active image backend has the credentials and SDK it needs."""
     try:
+        backend = _resolve_image_backend()
+        if backend == "openai":
+            return check_openai_image_api_key()
         if not check_fal_api_key():
             return False
         fal_client  # noqa: F401 — SDK presence check


### PR DESCRIPTION
## Summary
This PR adds an official OpenAI backend for Hermes `image_generate` while preserving the existing FAL flow.

### What changed

#### Runtime
- Added backend resolution for image generation: `fal` or `openai`
- Added OpenAI image model resolution with default: `gpt-image-1`
- Added aspect ratio mapping for OpenAI image sizes:
  - `landscape` → `1536x1024`
  - `square` → `1024x1024`
  - `portrait` → `1024x1536`
- Added local file persistence for OpenAI image outputs under: `~/.hermes/generated_images/`

#### Config UI
- Added `OpenAI Official` to image generation providers
- Added `openai` backend registry for image generation
- Updated the image model picker to persist: `image_gen.backend` and `image_gen.model`

#### Tests
Added targeted coverage for:
- OpenAI backend resolution
- OpenAI model resolution
- aspect-ratio-to-size mapping
- backend-aware requirement checks
- base64 image save flow
- mocked OpenAI image generation flow

### Verification

#### Targeted tests
`103 passed` - image generation and tools config tests

#### Smoke test
Successfully generated a real image via CLI in isolated HERMES_HOME:
- Output: `/tmp/hermes-openai-image-smoke-4WfUAV/generated_images/openai_image_20260424_222643.png`

## Why this matters
This closes the gap between task-level image generation (already possible via fallback) and native Hermes `image_generate` (previously FAL-only). Users with OpenAI image access can now use the native image tool directly.