### PR TITLE
test(cli): align custom provider probe assertion with api_mode kwarg

### DIFF
--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -52,7 +52,9 @@ class TestCustomProviderModelSwitch:
             _model_flow_named_custom({}, provider_info)
 
         # fetch_api_models MUST be called even though model was saved
-        mock_fetch.assert_called_once_with("sk-test", "https://vllm.example.com/v1", timeout=8.0)
+        mock_fetch.assert_called_once_with(
+            "sk-test", "https://vllm.example.com/v1", timeout=8.0, api_mode=None
+        )
 
     def test_can_switch_to_different_model(self, config_home):
         """User selects a different model than the saved one."""


### PR DESCRIPTION
## Summary
- update one stale test assertion to match current `fetch_api_models` call signature
- keep scope to test-only change in `tests/hermes_cli/test_custom_provider_model_switch.py`

## Root cause
`_model_flow_named_custom()` now calls:
`fetch_api_models(api_key, base_url, timeout=8.0, api_mode=api_mode or None)`

The test `test_saved_model_still_probes_endpoint` still expected a call without `api_mode`, which causes a false failure.

## Validation
- `uv run pytest -q -n 0 tests/hermes_cli/test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_saved_model_still_probes_endpoint -vv`
- `uv run pytest -q -n 0 tests/hermes_cli/test_custom_provider_model_switch.py`
- `uv run pytest -q -n 0 tests/hermes_cli/test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_saved_model_still_probes_endpoint tests/hermes_cli/test_plugin_scanner_recursion.py::TestKindField::test_unknown_kind_falls_back_to_standalone tests/hermes_cli/test_provider_config_validation.py::TestNormalizeCustomProviderEntry::test_unknown_keys_logged tests/hermes_cli/test_provider_config_validation.py::TestNormalizeCustomProviderEntry::test_camel_case_warning_logged -vv`

Fixes #15243
