### PR TITLE
fix(anthropic): cap max_tokens at 65536 for Qwen models via DashScope

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -88,6 +88,9 @@ _ANTHROPIC_OUTPUT_LIMITS = {
     "claude-3-haiku":      4_096,
     # Third-party Anthropic-compatible providers
     "minimax":            131_072,
+    # Qwen models via DashScope Anthropic-compatible endpoint
+    # DashScope enforces max_tokens ∈ [1, 65536]
+    "qwen3":               65_536,
 }
 
 # For any model not in the table, assume the highest current limit.


### PR DESCRIPTION
## What does this PR do?

Fixes premature context compression for Qwen models when using DashScope's Anthropic-compatible endpoint.

When a Qwen model (e.g. `qwen3.6-plus`) is configured with DashScope (`coding.dashscope.aliyuncs.com`), the first API call immediately triggers context compression even with very short messages (~4k tokens), eventually shrinking the context window from 1M to 64K.

**Root cause chain:**
1. `_ANTHROPIC_OUTPUT_LIMITS` has no entry for Qwen models → `_get_anthropic_max_output()` falls back to `128,000`
2. DashScope rejects `max_tokens > 65536` with a 400 error
3. The error classifier (`error_classifier.py`) matches `"max_tokens"` in the error message and misclassifies it as `context_overflow`
4. Hermes triggers context compression + step-down (1M → 128K → 64K) and persists the wrong value to `context_length_cache.yaml`

## Related Issue

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- **`agent/anthropic_adapter.py`**: Added `"qwen3": 65_536` to `_ANTHROPIC_OUTPUT_LIMITS` so all Qwen model requests respect DashScope's `max_tokens` cap, preventing the 400 error and the subsequent misclassification chain.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure a Qwen model with DashScope endpoint in `config.yaml`:
   ```yaml
   model:
     default: qwen3.6-plus
     provider: alibaba
     base_url: https://coding.dashscope.aliyuncs.com/apps/anthropic
   ```
2. Restart gateway and run `/new`
3. Send a short message like `你好`
4. **Before fix**: Shows `🗜️ Context too large (~4,365 tokens) — compressing (1/3)...`
5. **After fix**: Responds normally without triggering compression

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Orange Pi 5, Linux 5.10)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] N/A — No documentation update needed for this internal bug fix
- [x] N/A — No config keys changed
- [x] N/A — No architecture or workflow changes
- [x] N/A — No cross-platform impact (pattern-based fix applies everywhere)
- [x] N/A — No tool behavior changes

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
