### PR TITLE
fix(agent): add pure tool guardrail primitives

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -80,6 +80,13 @@ def detect_tool_failure(tool_name: str, result: Optional[str]) -> bool:
         data = None
 
     if isinstance(data, dict):
+        # Memory-specific: "full" detection (existing display semantics).
+        # Check before generic success:false so this branch stays reachable if
+        # callers later add richer classification around memory capacity errors.
+        if tool_name == "memory":
+            error = data.get("error", "")
+            if data.get("success") is False and isinstance(error, str) and "exceed the limit" in error:
+                return True
         # JSON success: false
         if data.get("success") is False:
             return True
@@ -94,10 +101,6 @@ def detect_tool_failure(tool_name: str, result: Optional[str]) -> bool:
         if tool_name == "terminal":
             exit_code = data.get("exit_code")
             if exit_code is not None and exit_code != 0:
-                return True
-        # Memory-specific: "full" detection (existing display semantics)
-        if tool_name == "memory":
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True
         # If we parsed JSON and none of the above failure conditions matched,
         # treat as success (even if error field is empty).

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -1,0 +1,203 @@
+"""
+Pure guardrail primitives for tool calls.
+
+This module provides utility functions for:
+- Canonicalizing tool call arguments (sorted compact JSON)
+- Detecting tool failures based on various heuristics
+- Tracking repeated identical failed tool calls
+- Validating memory tool arguments (rejecting display artifacts)
+
+No runtime behavior changes; this is a pure library.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+
+def canonicalize_tool_args(args: Dict[str, Any]) -> str:
+    """
+    Canonicalize tool call arguments with sorted compact JSON.
+
+    Args:
+        args: Dictionary of tool arguments.
+
+    Returns:
+        Compact JSON string with keys sorted alphabetically.
+
+    Raises:
+        TypeError: If args is not a dict.
+    """
+    if not isinstance(args, dict):
+        raise TypeError(f"args must be a dict, got {type(args).__name__}")
+    # Ensure ASCII is disabled to preserve Unicode characters.
+    return json.dumps(args, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def compute_args_hash(canonical_args: str) -> str:
+    """
+    Compute a deterministic hash of canonical args string.
+
+    Uses SHA-256 and returns hex digest.
+
+    Args:
+        canonical_args: The canonical JSON string from canonicalize_tool_args.
+
+    Returns:
+        64-character hex string.
+    """
+    return hashlib.sha256(canonical_args.encode("utf-8")).hexdigest()
+
+
+def detect_tool_failure(tool_name: str, result: Optional[str]) -> bool:
+    """
+    Detect whether a tool result indicates failure.
+
+    Consistent with existing display semantics where practical.
+    Rules:
+    - JSON 'success: false' -> failure
+    - JSON non-empty 'error' -> failure
+    - Terminal nonzero exit_code -> failure
+    - Python exception-shaped strings (Traceback, Error:) -> failure
+    - Obvious error strings compatible with display heuristics -> failure
+    - Empty successful content / empty reads are NOT failures
+
+    Args:
+        tool_name: Name of the tool (e.g., "terminal", "memory").
+        result: Tool result string (may be JSON or plain text).
+
+    Returns:
+        True if failure detected, False otherwise.
+    """
+    if result is None:
+        return False
+
+    # Try to parse as JSON
+    try:
+        data = json.loads(result)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        data = None
+
+    if isinstance(data, dict):
+        # JSON success: false
+        if data.get("success") is False:
+            return True
+        # JSON non-empty error
+        error = data.get("error")
+        if error is not None and error != "":
+            return True
+        # JSON failed: true
+        if data.get("failed") is True:
+            return True
+        # Terminal exit_code
+        if tool_name == "terminal":
+            exit_code = data.get("exit_code")
+            if exit_code is not None and exit_code != 0:
+                return True
+        # Memory-specific: "full" detection (existing display semantics)
+        if tool_name == "memory":
+            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+                return True
+        # If we parsed JSON and none of the above failure conditions matched,
+        # treat as success (even if error field is empty).
+        return False
+
+    # Non-JSON detection
+    # Python exception-shaped strings
+    lower = result[:500].lower()
+    if "traceback" in lower or lower.startswith("error:"):
+        return True
+    # Obvious error strings (existing display semantics).
+    # Keep this intentionally conservative: plain text containing "failed" can
+    # be a false positive (for example, "failed successfully"), but quoted
+    # structured fields like "failed" are treated as errors.
+    if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
+        return True
+
+    # Empty successful content / empty reads are NOT failures
+    # (already covered by returning False)
+    return False
+
+
+@dataclass
+class RepeatedFailureTracker:
+    """
+    Track consecutive identical failed tool calls by (tool_name, canonical_args_hash).
+
+    Only one streak is active at a time: the current key and its count.
+    A materially different (tool_name, args_hash) resets the previous streak
+    and starts a new streak at 1. A success resets the current matching streak.
+
+    Attributes:
+        threshold: Number of identical failures before blocking (default 3).
+    """
+    threshold: int = 3
+    _current_key: Optional[Tuple[str, str]] = None
+    _current_count: int = 0
+
+    def failure_count(self, tool_name: str, args_hash: str) -> int:
+        """Return current failure count for the given tool and args hash,
+        but only if it's the current key; otherwise 0."""
+        if self._current_key == (tool_name, args_hash):
+            return self._current_count
+        return 0
+
+    def record_failure(self, tool_name: str, args_hash: str) -> None:
+        """Increment failure count for the given tool and args hash.
+        If key matches current key, increment; otherwise set new key and count=1."""
+        key = (tool_name, args_hash)
+        if self._current_key == key:
+            self._current_count += 1
+        else:
+            self._current_key = key
+            self._current_count = 1
+
+    def reset_on_success(self, tool_name: str, args_hash: str) -> None:
+        """Reset failure count for the given tool and args hash on success,
+        but only if it's the current key."""
+        key = (tool_name, args_hash)
+        if self._current_key == key:
+            self._current_count = 0
+
+    def should_block(self, tool_name: str, args_hash: str) -> bool:
+        """Return True if failure count for this key meets threshold."""
+        return self.failure_count(tool_name, args_hash) >= self.threshold
+
+
+def memory_argument_policy(args: Dict[str, Any]) -> bool:
+    """
+    Pure memory argument policy rejecting display artifacts.
+
+    Rejects old_text / content that contain display artifacts:
+    - [truncated]
+    - [...]
+    - [cont]
+    - [more]
+
+    Handles non-string args cleanly without TypeError (returns False).
+
+    Args:
+        args: Dictionary of memory tool arguments (may contain 'content', 'old_text').
+
+    Returns:
+        True if arguments are acceptable (no display artifacts), False otherwise.
+    """
+    # List of artifact patterns (case-sensitive as they appear in output)
+    artifacts = ["[truncated]", "[...]", "[cont]", "[more]"]
+
+    for key in ("content", "old_text"):
+        if key not in args:
+            # Missing key is acceptable (optional parameter)
+            continue
+        value = args[key]
+        if isinstance(value, str):
+            for artifact in artifacts:
+                if artifact in value:
+                    return False
+        else:
+            # Non-string argument (e.g., int, list, None) is considered invalid
+            # (memory tool expects string). Return False without raising TypeError.
+            return False
+    # All checks passed
+    return True

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -190,7 +190,7 @@ class TestRepeatedFailureTracker:
         # Return to hash123 (old hash) should start at 1, not cumulative
         tracker.record_failure("foo", "hash123")
         assert tracker.failure_count("foo", "hash123") == 1
-        # Ensure hash456 streak is still current (should be 1)
+        # hash456 is no longer current after returning to hash123.
         assert tracker.failure_count("foo", "hash456") == 0  # not current key
 
     def test_block_decision(self):

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -1,0 +1,239 @@
+"""Tests for agent.tool_guardrails — pure guardrail primitives for tool calls."""
+
+import json
+import pytest
+from agent.tool_guardrails import (
+    canonicalize_tool_args,
+    compute_args_hash,
+    detect_tool_failure,
+    RepeatedFailureTracker,
+    memory_argument_policy,
+)
+
+
+class TestCanonicalizeToolArgs:
+    """Canonicalize tool call args with sorted compact JSON."""
+
+    def test_empty_dict(self):
+        assert canonicalize_tool_args({}) == "{}"
+
+    def test_sorted_keys(self):
+        args = {"z": 1, "a": 2, "b": 3}
+        canonical = canonicalize_tool_args(args)
+        # Expect keys sorted alphabetically, compact (no spaces)
+        assert canonical == '{"a":2,"b":3,"z":1}'
+
+    def test_nested_structure(self):
+        args = {"b": {"y": 2, "x": 1}, "a": [3, 2, 1]}
+        canonical = canonicalize_tool_args(args)
+        # Nested dicts and lists should also be canonicalized (sorted keys inside)
+        assert canonical == '{"a":[3,2,1],"b":{"x":1,"y":2}}'
+
+    def test_non_dict_input_raises(self):
+        with pytest.raises(TypeError):
+            canonicalize_tool_args("not a dict")
+        with pytest.raises(TypeError):
+            canonicalize_tool_args(None)
+
+
+class TestComputeArgsHash:
+    """Hash of canonical args string."""
+
+    def test_hash_of_empty(self):
+        h = compute_args_hash("{}")
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA256 hex
+
+    def test_hash_consistency(self):
+        canonical = '{"a":1}'
+        h1 = compute_args_hash(canonical)
+        h2 = compute_args_hash(canonical)
+        assert h1 == h2
+
+    def test_hash_of_different_strings(self):
+        h1 = compute_args_hash('{"a":1}')
+        h2 = compute_args_hash('{"a":2}')
+        assert h1 != h2
+
+
+class TestDetectToolFailure:
+    """Detect failure for various tool result patterns."""
+
+    # JSON success: false
+    def test_json_success_false(self):
+        result = json.dumps({"success": False})
+        assert detect_tool_failure("any_tool", result) is True
+
+    def test_json_success_false_with_error(self):
+        result = json.dumps({"success": False, "error": "something went wrong"})
+        assert detect_tool_failure("any_tool", result) is True
+
+    # JSON non-empty error
+    def test_json_error_nonempty(self):
+        result = json.dumps({"error": "something"})
+        assert detect_tool_failure("any_tool", result) is True
+
+    def test_json_error_empty(self):
+        result = json.dumps({"error": ""})
+        assert detect_tool_failure("any_tool", result) is False
+
+    # Terminal nonzero exit code
+    def test_terminal_exit_code_nonzero(self):
+        result = json.dumps({"exit_code": 1})
+        assert detect_tool_failure("terminal", result) is True
+
+    def test_terminal_exit_code_zero(self):
+        result = json.dumps({"exit_code": 0})
+        assert detect_tool_failure("terminal", result) is False
+
+    # Python exception-shaped strings (e.g., "Traceback ...")
+    def test_exception_traceback(self):
+        result = "Traceback (most recent call last):\n  File ..."
+        assert detect_tool_failure("any_tool", result) is True
+
+    # Obvious error strings (e.g., "Error:", "failed")
+    def test_error_prefix(self):
+        result = "Error: something"
+        assert detect_tool_failure("any_tool", result) is True
+
+    def test_failed_substring(self):
+        # "failed" substring without quotes is not considered an error
+        result = "The operation failed successfully"
+        assert detect_tool_failure("any_tool", result) is False
+
+    def test_failed_json_key(self):
+        # JSON key "failed" should be detected as failure
+        result = '{"failed": true}'
+        assert detect_tool_failure("any_tool", result) is True
+
+    # Successful empty content / empty reads should NOT be failures
+    def test_empty_string_success(self):
+        assert detect_tool_failure("any_tool", "") is False
+
+    def test_empty_json_success(self):
+        result = json.dumps({"success": True})
+        assert detect_tool_failure("any_tool", result) is False
+
+    def test_empty_read_file_result(self):
+        # read_file returns empty string for empty file
+        result = ""
+        assert detect_tool_failure("read_file", result) is False
+
+    # Memory-specific: "full" detection
+    def test_memory_full(self):
+        result = json.dumps({"success": False, "error": "exceed the limit"})
+        assert detect_tool_failure("memory", result) is True
+
+    # Generic heuristic: should not flag successful results
+    def test_generic_success(self):
+        result = json.dumps({"data": "ok"})
+        assert detect_tool_failure("any_tool", result) is False
+
+
+class TestRepeatedFailureTracker:
+    """Track consecutive identical failed tool calls by (tool_name, canonical_args_hash)."""
+
+    def test_initial_state(self):
+        tracker = RepeatedFailureTracker()
+        assert tracker.failure_count("foo", "hash123") == 0
+
+    def test_increment_on_failure(self):
+        tracker = RepeatedFailureTracker()
+        tracker.record_failure("foo", "hash123")
+        assert tracker.failure_count("foo", "hash123") == 1
+
+    def test_multiple_failures_same_key(self):
+        tracker = RepeatedFailureTracker()
+        tracker.record_failure("foo", "hash123")
+        tracker.record_failure("foo", "hash123")
+        assert tracker.failure_count("foo", "hash123") == 2
+
+    def test_different_tool_name_resets_previous_streak(self):
+        tracker = RepeatedFailureTracker()
+        tracker.record_failure("foo", "hash123")
+        # Different tool name resets previous streak
+        tracker.record_failure("bar", "hash123")
+        # Previous streak for foo is reset (should be 0 because not current key)
+        assert tracker.failure_count("foo", "hash123") == 0
+        # New streak for bar starts at 1
+        assert tracker.failure_count("bar", "hash123") == 1
+
+    def test_different_args_hash_resets_previous_streak(self):
+        tracker = RepeatedFailureTracker()
+        tracker.record_failure("foo", "hash123")
+        tracker.record_failure("foo", "hash123")
+        # Different args hash resets previous streak
+        tracker.record_failure("foo", "hash456")
+        # Previous streak for hash123 is reset (should be 0 because not current key)
+        assert tracker.failure_count("foo", "hash123") == 0
+        # New streak for hash456 starts at 1
+        assert tracker.failure_count("foo", "hash456") == 1
+
+    def test_success_resets_current_streak(self):
+        tracker = RepeatedFailureTracker()
+        tracker.record_failure("foo", "hash123")
+        tracker.record_failure("foo", "hash123")
+        tracker.reset_on_success("foo", "hash123")
+        # Streak for current key is reset
+        assert tracker.failure_count("foo", "hash123") == 0
+        # Current key remains the same; subsequent failure increments from 0
+        tracker.record_failure("foo", "hash123")
+        assert tracker.failure_count("foo", "hash123") == 1
+
+    def test_returning_to_old_hash_starts_at_one(self):
+        tracker = RepeatedFailureTracker()
+        # First streak for hash123
+        tracker.record_failure("foo", "hash123")
+        tracker.record_failure("foo", "hash123")
+        # Different hash resets previous streak
+        tracker.record_failure("foo", "hash456")
+        # Return to hash123 (old hash) should start at 1, not cumulative
+        tracker.record_failure("foo", "hash123")
+        assert tracker.failure_count("foo", "hash123") == 1
+        # Ensure hash456 streak is still current (should be 1)
+        assert tracker.failure_count("foo", "hash456") == 0  # not current key
+
+    def test_block_decision(self):
+        tracker = RepeatedFailureTracker(threshold=3)
+        tracker.record_failure("foo", "hash123")
+        tracker.record_failure("foo", "hash123")
+        tracker.record_failure("foo", "hash123")
+        assert tracker.should_block("foo", "hash123") is True
+        # Different key should not be blocked
+        assert tracker.should_block("foo", "hash456") is False
+        # Different tool should not be blocked
+        assert tracker.should_block("bar", "hash123") is False
+
+class TestMemoryArgumentPolicy:
+    """Reject display artifacts in old_text / content."""
+
+    def test_reject_truncated(self):
+        assert memory_argument_policy({"content": "[truncated]"}) is False
+        assert memory_argument_policy({"old_text": "[truncated]"}) is False
+
+    def test_reject_ellipsis(self):
+        assert memory_argument_policy({"content": "[...]"}) is False
+        assert memory_argument_policy({"old_text": "[...]"}) is False
+
+    def test_reject_cont(self):
+        assert memory_argument_policy({"content": "[cont]"}) is False
+        assert memory_argument_policy({"old_text": "[cont]"}) is False
+
+    def test_reject_more(self):
+        assert memory_argument_policy({"content": "[more]"}) is False
+        assert memory_argument_policy({"old_text": "[more]"}) is False
+
+    def test_accept_normal_string(self):
+        assert memory_argument_policy({"content": "some content"}) is True
+        assert memory_argument_policy({"old_text": "some old text"}) is True
+
+    def test_non_string_args_cleanly(self):
+        # Non-string content should be rejected without raising TypeError.
+        assert memory_argument_policy({"content": 123}) is False
+        assert memory_argument_policy({"old_text": ["list"]}) is False
+        assert memory_argument_policy({"content": None}) is False
+        assert memory_argument_policy({"content": ""}) is True
+
+    def test_missing_key(self):
+        assert memory_argument_policy({}) is True
+        assert memory_argument_policy({"action": "add"}) is True


### PR DESCRIPTION
## Prompt to Recreate

Starting from `origin/main`, add pure guardrail primitives for detecting repeated identical failed tool calls and invalid memory-tool display artifacts. Do not wire them into `run_agent.py`, gateway, TUI, or session lifecycle code. Add focused unit tests in `tests/agent/test_tool_guardrails.py` and verify with:

```bash
/home/agent/hermes-agent/venv/bin/python -m pytest tests/agent/test_tool_guardrails.py -q -o 'addopts=' --tb=short
git diff --check origin/main..HEAD
```

---

## Bug Description

The previous loop-guardrail branch mixed detector logic, runtime tool execution changes, objective steering, gateway halt handling, and session reset behavior in one broad PR. That made review risky and obscured the pure policy behavior needed before any runtime integration.

## Root Cause

There was no isolated, tested primitive layer for:

- canonical tool-call argument identity
- repeated identical tool-failure streak detection
- tool-result failure classification
- memory display-artifact argument rejection

Without that layer, runtime fixes had to define policy and side effects at the same time.

## Fix

Adds `agent/tool_guardrails.py` with pure primitives only:

- `canonicalize_tool_args()` for sorted compact JSON arguments
- `compute_args_hash()` for deterministic SHA-256 argument identities
- `detect_tool_failure()` for JSON failure flags, non-empty errors, terminal nonzero exit codes, Python exception-shaped strings, and conservative display-compatible error strings
- `RepeatedFailureTracker` for consecutive identical `(tool_name, args_hash)` failure streaks
- `memory_argument_policy()` for rejecting `[truncated]`, `[...]`, `[cont]`, and `[more]` in memory `content` / `old_text`

Adds `tests/agent/test_tool_guardrails.py` with 37 focused unit tests.

No runtime behavior changes are included.

## How to Verify

```bash
/home/agent/hermes-agent/venv/bin/python -m pytest tests/agent/test_tool_guardrails.py -q -o 'addopts=' --tb=short
git diff --check origin/main..HEAD
```

Observed locally:

```text
37 passed in 0.22s
```

`git diff --check origin/main..HEAD` produced no output.

## Test Plan

- [x] Focused guardrail primitive tests pass
- [x] Whitespace diff check passes
- [x] Diff limited to pure primitive module and tests

## Risk Assessment

Low. This PR only adds unused pure primitives and tests. It does not touch `run_agent.py`, gateway, TUI, tool execution, session state, or streaming event behavior.

## Follow-up PRs

This supersedes #14202 with an atomic sequence:

1. This PR: pure guardrail primitives
2. Runtime tool-call contract integration
3. Objective steering and one-shot recovery
4. Controlled `turn_exit_reason="guardrail_halt"` response shape
5. Gateway/session reset-cascade hardening if still reproduced
