### PR TITLE
feat(codex): add browser OAuth login via oauth-cli-kit

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6174,13 +6174,158 @@ def login_command(args) -> None:
     raise SystemExit(0)
 
 
+class _InMemoryOAuthTokenStorage:
+    """Private TokenStorage so oauth-cli-kit doesn't write its shared file.
+
+    oauth-cli-kit's ``login_oauth_interactive`` defaults to a
+    ``FileTokenStorage`` that writes the result to a shared location
+    (platform-specific, e.g. ``~/Library/Application Support/oauth-cli-kit/
+    auth/codex.json``).  We only want the flow helper, not the shared
+    credential store — Hermes persists the tokens into its own
+    ``providers.openai-codex`` the same way device-code login does.
+    Implementing the minimal ``TokenStorage`` protocol keeps the flow
+    in-memory for the duration of the login call.
+    """
+
+    def __init__(self) -> None:
+        self._token: Any = None
+
+    def load(self) -> Any:
+        return self._token
+
+    def save(self, token: Any) -> None:
+        self._token = token
+
+    def get_token_path(self) -> Path:
+        # Required by the protocol; returned path is never written to.
+        return Path(os.devnull)
+
+
+def _codex_browser_oauth_login() -> Dict[str, Any]:
+    """Run oauth-cli-kit's browser OAuth flow for openai-codex.
+
+    Returns a creds dict in the same shape as ``_codex_device_code_login``
+    so the rest of the login plumbing (``_save_codex_tokens`` +
+    ``_update_config_for_provider``) doesn't need to know which flow
+    produced the tokens.  Does NOT write to oauth-cli-kit's shared file:
+    we pass a private in-memory storage so the credential stays under
+    Hermes's ownership, matching the #12360 design (Hermes's refresh
+    token is independent of any cross-tool session).
+
+    Requires an interactive terminal: oauth-cli-kit falls back to
+    ``input()`` when its local-callback server can't bind, which would
+    block forever on a piped stdin.  We surface a clean AuthError up
+    front in that case.  KeyboardInterrupt / EOFError / RuntimeError
+    from inside the flow are also converted to AuthError so callers
+    get a consistent failure shape.
+    """
+    import sys as _sys
+
+    if not (_sys.stdin and _sys.stdin.isatty()):
+        raise AuthError(
+            "Browser-based Codex login requires an interactive terminal "
+            "(stdin is not a TTY). Use `--method device-code` or run "
+            "from an interactive shell.",
+            provider="openai-codex",
+            code="oauth_cli_kit_requires_tty",
+            relogin_required=True,
+        )
+
+    try:
+        from oauth_cli_kit import login_oauth_interactive
+    except ImportError as exc:
+        raise AuthError(
+            "Browser-based Codex login requires oauth-cli-kit. "
+            "Reinstall Hermes or `pip install oauth-cli-kit`.",
+            provider="openai-codex",
+            code="oauth_cli_kit_missing",
+            relogin_required=True,
+        ) from exc
+
+    # oauth-cli-kit emits Rich markup ("[cyan]...[/cyan]", "[dim]...[/dim]")
+    # through its print_fn, so we pass a Rich console. Plain print would
+    # leak the bracket tags into the terminal.
+    from rich.console import Console
+
+    console = Console()
+    try:
+        token = login_oauth_interactive(
+            print_fn=console.print,
+            prompt_fn=lambda s: input(s),
+            storage=_InMemoryOAuthTokenStorage(),
+        )
+    except (KeyboardInterrupt, EOFError) as exc:
+        raise AuthError(
+            "Browser-based Codex login was cancelled.",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_cancelled",
+            relogin_required=True,
+        ) from exc
+    except AuthError:
+        raise
+    except Exception as exc:
+        # oauth-cli-kit raises plain RuntimeError for state mismatch,
+        # missing code, server-start failure, etc.  Wrap into AuthError
+        # so the caller sees a consistent error type and code.
+        raise AuthError(
+            f"Browser-based Codex login failed: {exc}",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_failed",
+            relogin_required=True,
+        ) from exc
+
+    access = str(getattr(token, "access", "") or "").strip()
+    refresh = str(getattr(token, "refresh", "") or "").strip()
+    if not access:
+        raise AuthError(
+            "Browser-based Codex login did not return a usable access token.",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_failed",
+            relogin_required=True,
+        )
+
+    # Honour HERMES_CODEX_BASE_URL the same way `_codex_device_code_login`
+    # does — users with a proxy / custom Codex endpoint expect both
+    # login flows to write that endpoint into config.yaml, not silently
+    # fall back to ChatGPT's default.
+    base_url = (
+        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CODEX_BASE_URL
+    )
+    return {
+        "tokens": {
+            "access_token": access,
+            "refresh_token": refresh,
+        },
+        "base_url": base_url,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "auth_mode": "chatgpt",
+        "source": "browser",
+    }
+
+
 def _login_openai_codex(
     args,
     pconfig: ProviderConfig,
     *,
     force_new_login: bool = False,
 ) -> None:
-    """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
+    """OpenAI Codex login. Tokens stored in ~/.hermes/auth.json.
+
+    Two login methods are supported, selected via ``args.method``:
+      - ``device-code`` (default): OAuth device code flow.
+      - ``browser``: OAuth browser flow via oauth-cli-kit.  The
+        credential is stored in Hermes's own auth store the same way
+        device-code login does — oauth-cli-kit's shared file is not
+        written (see ``_codex_browser_oauth_login``).
+
+    ``force_new_login=True`` skips the "reuse existing?" prompt and the
+    Codex CLI import prompt, so `hermes model` can force a fresh
+    reauth when the user explicitly asked for one.
+    """
+    method = str(getattr(args, "method", "") or "device-code").strip().lower()
+    if method not in {"device-code", "browser"}:
+        raise SystemExit(f"Unsupported Codex login method: {method!r}")
 
     del args, pconfig  # kept for parity with other provider login helpers
 
@@ -6210,8 +6355,10 @@ def _login_openai_codex(
         except AuthError:
             pass
 
-    # Check for existing Codex CLI tokens we can import
-    if not force_new_login:
+    # Check for existing Codex CLI tokens we can import.  Only relevant
+    # when the user asked for device-code AND didn't explicitly force a
+    # fresh login (`hermes model` reauth skips this for a clean reset).
+    if method == "device-code" and not force_new_login:
         cli_tokens = _import_codex_cli_tokens()
         if cli_tokens:
             print("Found existing Codex CLI credentials at ~/.codex/auth.json")
@@ -6230,13 +6377,19 @@ def _login_openai_codex(
                 print(f"  Config updated: {config_path} (model.provider=openai-codex)")
                 return
 
-    # Run a fresh device code flow — Hermes gets its own OAuth session
+    # Run a fresh login — Hermes gets its own OAuth session regardless of method.
     print()
-    print("Signing in to OpenAI Codex...")
+    if method == "browser":
+        print("Signing in to OpenAI Codex (browser flow)...")
+    else:
+        print("Signing in to OpenAI Codex...")
     print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
     print()
 
-    creds = _codex_device_code_login()
+    if method == "browser":
+        creds = _codex_browser_oauth_login()
+    else:
+        creds = _codex_device_code_login()
 
     # Save tokens to Hermes auth store
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3818,13 +3818,158 @@ def login_command(args) -> None:
     raise SystemExit(0)
 
 
+class _InMemoryOAuthTokenStorage:
+    """Private TokenStorage so oauth-cli-kit doesn't write its shared file.
+
+    oauth-cli-kit's ``login_oauth_interactive`` defaults to a
+    ``FileTokenStorage`` that writes the result to a shared location
+    (platform-specific, e.g. ``~/Library/Application Support/oauth-cli-kit/
+    auth/codex.json``).  We only want the flow helper, not the shared
+    credential store — Hermes persists the tokens into its own
+    ``providers.openai-codex`` the same way device-code login does.
+    Implementing the minimal ``TokenStorage`` protocol keeps the flow
+    in-memory for the duration of the login call.
+    """
+
+    def __init__(self) -> None:
+        self._token: Any = None
+
+    def load(self) -> Any:
+        return self._token
+
+    def save(self, token: Any) -> None:
+        self._token = token
+
+    def get_token_path(self) -> Path:
+        # Required by the protocol; returned path is never written to.
+        return Path(os.devnull)
+
+
+def _codex_browser_oauth_login() -> Dict[str, Any]:
+    """Run oauth-cli-kit's browser OAuth flow for openai-codex.
+
+    Returns a creds dict in the same shape as ``_codex_device_code_login``
+    so the rest of the login plumbing (``_save_codex_tokens`` +
+    ``_update_config_for_provider``) doesn't need to know which flow
+    produced the tokens.  Does NOT write to oauth-cli-kit's shared file:
+    we pass a private in-memory storage so the credential stays under
+    Hermes's ownership, matching the #12360 design (Hermes's refresh
+    token is independent of any cross-tool session).
+
+    Requires an interactive terminal: oauth-cli-kit falls back to
+    ``input()`` when its local-callback server can't bind, which would
+    block forever on a piped stdin.  We surface a clean AuthError up
+    front in that case.  KeyboardInterrupt / EOFError / RuntimeError
+    from inside the flow are also converted to AuthError so callers
+    get a consistent failure shape.
+    """
+    import sys as _sys
+
+    if not (_sys.stdin and _sys.stdin.isatty()):
+        raise AuthError(
+            "Browser-based Codex login requires an interactive terminal "
+            "(stdin is not a TTY). Use `--method device-code` or run "
+            "from an interactive shell.",
+            provider="openai-codex",
+            code="oauth_cli_kit_requires_tty",
+            relogin_required=True,
+        )
+
+    try:
+        from oauth_cli_kit import login_oauth_interactive
+    except ImportError as exc:
+        raise AuthError(
+            "Browser-based Codex login requires oauth-cli-kit. "
+            "Reinstall Hermes or `pip install oauth-cli-kit`.",
+            provider="openai-codex",
+            code="oauth_cli_kit_missing",
+            relogin_required=True,
+        ) from exc
+
+    # oauth-cli-kit emits Rich markup ("[cyan]...[/cyan]", "[dim]...[/dim]")
+    # through its print_fn, so we pass a Rich console. Plain print would
+    # leak the bracket tags into the terminal.
+    from rich.console import Console
+
+    console = Console()
+    try:
+        token = login_oauth_interactive(
+            print_fn=console.print,
+            prompt_fn=lambda s: input(s),
+            storage=_InMemoryOAuthTokenStorage(),
+        )
+    except (KeyboardInterrupt, EOFError) as exc:
+        raise AuthError(
+            "Browser-based Codex login was cancelled.",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_cancelled",
+            relogin_required=True,
+        ) from exc
+    except AuthError:
+        raise
+    except Exception as exc:
+        # oauth-cli-kit raises plain RuntimeError for state mismatch,
+        # missing code, server-start failure, etc.  Wrap into AuthError
+        # so the caller sees a consistent error type and code.
+        raise AuthError(
+            f"Browser-based Codex login failed: {exc}",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_failed",
+            relogin_required=True,
+        ) from exc
+
+    access = str(getattr(token, "access", "") or "").strip()
+    refresh = str(getattr(token, "refresh", "") or "").strip()
+    if not access:
+        raise AuthError(
+            "Browser-based Codex login did not return a usable access token.",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_failed",
+            relogin_required=True,
+        )
+
+    # Honour HERMES_CODEX_BASE_URL the same way `_codex_device_code_login`
+    # does — users with a proxy / custom Codex endpoint expect both
+    # login flows to write that endpoint into config.yaml, not silently
+    # fall back to ChatGPT's default.
+    base_url = (
+        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CODEX_BASE_URL
+    )
+    return {
+        "tokens": {
+            "access_token": access,
+            "refresh_token": refresh,
+        },
+        "base_url": base_url,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "auth_mode": "chatgpt",
+        "source": "browser",
+    }
+
+
 def _login_openai_codex(
     args,
     pconfig: ProviderConfig,
     *,
     force_new_login: bool = False,
 ) -> None:
-    """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
+    """OpenAI Codex login. Tokens stored in ~/.hermes/auth.json.
+
+    Two login methods are supported, selected via ``args.method``:
+      - ``device-code`` (default): OAuth device code flow.
+      - ``browser``: OAuth browser flow via oauth-cli-kit.  The
+        credential is stored in Hermes's own auth store the same way
+        device-code login does — oauth-cli-kit's shared file is not
+        written (see ``_codex_browser_oauth_login``).
+
+    ``force_new_login=True`` skips the "reuse existing?" prompt and the
+    Codex CLI import prompt, so `hermes model` can force a fresh
+    reauth when the user explicitly asked for one.
+    """
+    method = str(getattr(args, "method", "") or "device-code").strip().lower()
+    if method not in {"device-code", "browser"}:
+        raise SystemExit(f"Unsupported Codex login method: {method!r}")
 
     del args, pconfig  # kept for parity with other provider login helpers
 
@@ -3854,8 +3999,10 @@ def _login_openai_codex(
         except AuthError:
             pass
 
-    # Check for existing Codex CLI tokens we can import
-    if not force_new_login:
+    # Check for existing Codex CLI tokens we can import.  Only relevant
+    # when the user asked for device-code AND didn't explicitly force a
+    # fresh login (`hermes model` reauth skips this for a clean reset).
+    if method == "device-code" and not force_new_login:
         cli_tokens = _import_codex_cli_tokens()
         if cli_tokens:
             print("Found existing Codex CLI credentials at ~/.codex/auth.json")
@@ -3874,13 +4021,19 @@ def _login_openai_codex(
                 print(f"  Config updated: {config_path} (model.provider=openai-codex)")
                 return
 
-    # Run a fresh device code flow — Hermes gets its own OAuth session
+    # Run a fresh login — Hermes gets its own OAuth session regardless of method.
     print()
-    print("Signing in to OpenAI Codex...")
+    if method == "browser":
+        print("Signing in to OpenAI Codex (browser flow)...")
+    else:
+        print("Signing in to OpenAI Codex...")
     print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
     print()
 
-    creds = _codex_device_code_login()
+    if method == "browser":
+        creds = _codex_browser_oauth_login()
+    else:
+        creds = _codex_device_code_login()
 
     # Save tokens to Hermes auth store
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -165,6 +165,15 @@ def auth_add_command(args) -> None:
     if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
         raise SystemExit(f"Unknown provider: {provider}")
 
+    # `--method` is openai-codex-only.  Reject it on other providers
+    # rather than silently ignoring the flag.  argparse default is None,
+    # so detection is a simple `is not None` check.
+    method_arg = getattr(args, "method", None)
+    if method_arg is not None and provider != "openai-codex":
+        raise SystemExit(
+            f"--method is only supported for `openai-codex`, not `{provider}`."
+        )
+
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()
     if requested_type in {AUTH_TYPE_API_KEY, "api-key"}:
         requested_type = AUTH_TYPE_API_KEY
@@ -311,10 +320,19 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
+        method = str(getattr(args, "method", "") or "device-code").strip().lower()
+        if method not in {"device-code", "browser"}:
+            raise SystemExit(f"Unsupported Codex login method: {method!r}")
+
         # Clear any existing suppression marker so a re-link after `hermes auth
         # remove openai-codex` works without the new tokens being skipped.
         auth_mod.unsuppress_credential_source(provider, "device_code")
-        creds = auth_mod._codex_device_code_login()
+
+        if method == "browser":
+            creds = auth_mod._codex_browser_oauth_login()
+        else:
+            creds = auth_mod._codex_device_code_login()
+
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -325,6 +343,10 @@ def auth_add_command(args) -> None:
             label=label,
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
+            # Both flows produce a Hermes-owned OAuth session with the
+            # same refresh/removal lifecycle — keep a single pool source
+            # so _remove_codex_device_code + its suppression key cover
+            # both paths.
             source=f"{SOURCE_MANUAL}:device_code",
             access_token=creds["tokens"]["access_token"],
             refresh_token=creds["tokens"].get("refresh_token"),

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -163,6 +163,15 @@ def auth_add_command(args) -> None:
     if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
         raise SystemExit(f"Unknown provider: {provider}")
 
+    # `--method` is openai-codex-only.  Reject it on other providers
+    # rather than silently ignoring the flag.  argparse default is None,
+    # so detection is a simple `is not None` check.
+    method_arg = getattr(args, "method", None)
+    if method_arg is not None and provider != "openai-codex":
+        raise SystemExit(
+            f"--method is only supported for `openai-codex`, not `{provider}`."
+        )
+
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()
     if requested_type in {AUTH_TYPE_API_KEY, "api-key"}:
         requested_type = AUTH_TYPE_API_KEY
@@ -268,10 +277,19 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
+        method = str(getattr(args, "method", "") or "device-code").strip().lower()
+        if method not in {"device-code", "browser"}:
+            raise SystemExit(f"Unsupported Codex login method: {method!r}")
+
         # Clear any existing suppression marker so a re-link after `hermes auth
         # remove openai-codex` works without the new tokens being skipped.
         auth_mod.unsuppress_credential_source(provider, "device_code")
-        creds = auth_mod._codex_device_code_login()
+
+        if method == "browser":
+            creds = auth_mod._codex_browser_oauth_login()
+        else:
+            creds = auth_mod._codex_device_code_login()
+
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -282,6 +300,10 @@ def auth_add_command(args) -> None:
             label=label,
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
+            # Both flows produce a Hermes-owned OAuth session with the
+            # same refresh/removal lifecycle — keep a single pool source
+            # so _remove_codex_device_code + its suppression key cover
+            # both paths.
             source=f"{SOURCE_MANUAL}:device_code",
             access_token=creds["tokens"]["access_token"],
             refresh_token=creds["tokens"].get("refresh_token"),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2901,6 +2901,35 @@ def _model_flow_openai_codex(config, current_model=""):
     )
     from hermes_cli.codex_models import get_codex_model_ids
 
+    def _prompt_codex_login_method() -> str | None:
+        """Ask the user to pick device-code vs browser login.
+
+        Returns the chosen method (``"device-code"`` or ``"browser"``)
+        or None if the user cancelled (Ctrl-C / EOF / "q" / "c").
+        Reprompts on invalid input rather than silently defaulting,
+        so a typo like "browser" / "3" / "b" doesn't get mapped to
+        device-code unintentionally.
+        """
+        print("Choose a login method:")
+        print("  1. Device code (default — open a URL, enter a code)")
+        print("  2. Browser (oauth-cli-kit — redirects back to a local callback)")
+        print("  q. Cancel")
+        while True:
+            try:
+                raw = input("  Choice [1]: ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                print("Login cancelled.")
+                return None
+            if raw in ("", "1"):
+                return "device-code"
+            if raw == "2":
+                return "browser"
+            if raw in ("q", "c", "quit", "cancel"):
+                print("Login cancelled.")
+                return None
+            print(f"  Invalid choice: {raw!r}. Enter 1, 2, or q.")
+
     status = get_codex_auth_status()
     if status.get("logged_in"):
         print("  OpenAI Codex credentials: ✓")
@@ -2915,10 +2944,13 @@ def _model_flow_openai_codex(config, current_model=""):
             choice = "1"
 
         if choice == "2":
+            method = _prompt_codex_login_method()
+            if method is None:
+                return
             print("Starting a fresh OpenAI Codex login...")
             print()
             try:
-                mock_args = argparse.Namespace()
+                mock_args = argparse.Namespace(method=method)
                 _login_openai_codex(
                     mock_args,
                     PROVIDER_REGISTRY["openai-codex"],
@@ -2937,10 +2969,13 @@ def _model_flow_openai_codex(config, current_model=""):
         elif choice == "3":
             return
     else:
-        print("Not logged into OpenAI Codex. Starting login...")
+        print("Not logged into OpenAI Codex.")
         print()
+        method = _prompt_codex_login_method()
+        if method is None:
+            return
         try:
-            mock_args = argparse.Namespace()
+            mock_args = argparse.Namespace(method=method)
             _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
         except SystemExit:
             print("Login cancelled or failed.")
@@ -11025,6 +11060,18 @@ def main():
         help="Disable TLS verification for OAuth login",
     )
     auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
+    auth_add.add_argument(
+        "--method",
+        choices=["device-code", "browser"],
+        default=None,
+        help=(
+            "OAuth login method.  Supported only for openai-codex; passing it "
+            "to another provider raises an error.  When omitted, openai-codex "
+            "defaults to 'device-code' (open a URL, enter a short code).  "
+            "'browser' runs an oauth-cli-kit browser flow.  Both produce "
+            "Hermes-owned tokens with the same refresh/removal lifecycle."
+        ),
+    )
     auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
     auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
     auth_remove = auth_subparsers.add_parser(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2348,6 +2348,35 @@ def _model_flow_openai_codex(config, current_model=""):
     )
     from hermes_cli.codex_models import get_codex_model_ids
 
+    def _prompt_codex_login_method() -> str | None:
+        """Ask the user to pick device-code vs browser login.
+
+        Returns the chosen method (``"device-code"`` or ``"browser"``)
+        or None if the user cancelled (Ctrl-C / EOF / "q" / "c").
+        Reprompts on invalid input rather than silently defaulting,
+        so a typo like "browser" / "3" / "b" doesn't get mapped to
+        device-code unintentionally.
+        """
+        print("Choose a login method:")
+        print("  1. Device code (default — open a URL, enter a code)")
+        print("  2. Browser (oauth-cli-kit — redirects back to a local callback)")
+        print("  q. Cancel")
+        while True:
+            try:
+                raw = input("  Choice [1]: ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                print("Login cancelled.")
+                return None
+            if raw in ("", "1"):
+                return "device-code"
+            if raw == "2":
+                return "browser"
+            if raw in ("q", "c", "quit", "cancel"):
+                print("Login cancelled.")
+                return None
+            print(f"  Invalid choice: {raw!r}. Enter 1, 2, or q.")
+
     status = get_codex_auth_status()
     if status.get("logged_in"):
         print("  OpenAI Codex credentials: ✓")
@@ -2362,10 +2391,13 @@ def _model_flow_openai_codex(config, current_model=""):
             choice = "1"
 
         if choice == "2":
+            method = _prompt_codex_login_method()
+            if method is None:
+                return
             print("Starting a fresh OpenAI Codex login...")
             print()
             try:
-                mock_args = argparse.Namespace()
+                mock_args = argparse.Namespace(method=method)
                 _login_openai_codex(
                     mock_args,
                     PROVIDER_REGISTRY["openai-codex"],
@@ -2384,10 +2416,13 @@ def _model_flow_openai_codex(config, current_model=""):
         elif choice == "3":
             return
     else:
-        print("Not logged into OpenAI Codex. Starting login...")
+        print("Not logged into OpenAI Codex.")
         print()
+        method = _prompt_codex_login_method()
+        if method is None:
+            return
         try:
-            mock_args = argparse.Namespace()
+            mock_args = argparse.Namespace(method=method)
             _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
         except SystemExit:
             print("Login cancelled or failed.")
@@ -7385,6 +7420,18 @@ For more help on a command:
         help="Disable TLS verification for OAuth login",
     )
     auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
+    auth_add.add_argument(
+        "--method",
+        choices=["device-code", "browser"],
+        default=None,
+        help=(
+            "OAuth login method.  Supported only for openai-codex; passing it "
+            "to another provider raises an error.  When omitted, openai-codex "
+            "defaults to 'device-code' (open a URL, enter a short code).  "
+            "'browser' runs an oauth-cli-kit browser flow.  Both produce "
+            "Hermes-owned tokens with the same refresh/removal lifecycle."
+        ),
+    )
     auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
     auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
     auth_remove = auth_subparsers.add_parser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,14 @@ dependencies = [
   "requests==2.33.0",  # CVE-2026-25645
   "jinja2==3.1.6",
   "pydantic==2.12.5",
+  # Browser OAuth flow helper for openai-codex (used only for the
+  # login redirect + callback loop; credentials are stored in Hermes's
+  # own auth store, not oauth-cli-kit's shared file). Exact pin:
+  # the package is new (first release 2026-02), has thin attribution
+  # ("nanobot contributors", no homepage/maintainer), and we audited
+  # this specific sdist (sha256 6612b3de...bfb8). Bump only after
+  # re-auditing the newer release.
+  "oauth-cli-kit==0.1.3",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit==3.0.52",
   # Cron scheduler (built-in feature — scheduled cron/interval jobs use croniter).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dependencies = [
   "requests>=2.33.0,<3",  # CVE-2026-25645
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
+  # Browser OAuth flow helper for openai-codex (used only for the
+  # login redirect + callback loop; credentials are stored in Hermes's
+  # own auth store, not oauth-cli-kit's shared file).  Exact pin:
+  # the package is new (first release 2026-02), has thin attribution
+  # ("nanobot contributors", no homepage/maintainer), and we audited
+  # this specific sdist (sha256 6612b3de...bfb8).  Bump only after
+  # re-auditing the newer release.
+  "oauth-cli-kit==0.1.3",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -1,7 +1,9 @@
 """Tests for Codex auth — tokens stored in Hermes auth store (~/.hermes/auth.json)."""
 
 import json
+import sys
 import time
+import types
 import base64
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +15,7 @@ from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
+    _codex_browser_oauth_login,
     _read_codex_tokens,
     _save_codex_tokens,
     _import_codex_cli_tokens,
@@ -351,3 +354,208 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
 
     assert called["device_login"] == 1
     assert called["tokens"]["access_token"] == "fresh-at"
+
+
+# ── Browser OAuth (oauth-cli-kit) login flow ───────────────────────────
+
+
+@pytest.fixture
+def _fake_tty(monkeypatch):
+    """Pretend stdin is a TTY so the browser-login TTY guard passes.
+
+    Pytest runs with a non-TTY stdin, which would otherwise short-circuit
+    every `_codex_browser_oauth_login` call with a TTY-required AuthError.
+    """
+    import sys as _sys
+
+    monkeypatch.setattr(_sys.stdin, "isatty", lambda: True, raising=False)
+
+
+def test_browser_oauth_login_returns_device_code_shaped_creds(_fake_tty, monkeypatch):
+    """_codex_browser_oauth_login returns the same shape as
+    _codex_device_code_login so the caller doesn't need to know which
+    flow produced the tokens.
+    """
+    monkeypatch.delenv("HERMES_CODEX_BASE_URL", raising=False)
+    fake_token = types.SimpleNamespace(
+        access="browser-at",
+        refresh="browser-rt",
+        expires=int(time.time() * 1000) + 3600_000,
+        account_id="acct_browser",
+    )
+
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    captured = {}
+
+    def _fake_login(*, print_fn, prompt_fn, storage=None, **kwargs):
+        captured["storage"] = storage
+        return fake_token
+
+    fake_oauth.login_oauth_interactive = _fake_login
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    creds = _codex_browser_oauth_login()
+
+    assert creds["tokens"]["access_token"] == "browser-at"
+    assert creds["tokens"]["refresh_token"] == "browser-rt"
+    assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
+    assert creds["auth_mode"] == "chatgpt"
+    assert "last_refresh" in creds
+
+    # We must have passed oauth-cli-kit a private storage — without it,
+    # the library would default to FileTokenStorage and silently write
+    # the shared codex.json on disk.
+    storage = captured["storage"]
+    assert storage is not None
+    assert hasattr(storage, "load") and hasattr(storage, "save")
+
+
+def test_browser_oauth_login_does_not_write_shared_file(_fake_tty, tmp_path, monkeypatch):
+    """Browser login must not create oauth-cli-kit's shared file.
+
+    We stub login_oauth_interactive to simulate a successful login
+    *and* assert that any default shared-file locations stay empty.
+    """
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    # macOS fallback location (oauth-cli-kit resolves per-platform via
+    # its own path helper — we don't exercise the real resolver here,
+    # we just prove that running the login doesn't touch either of the
+    # two plausible default locations).
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: types.SimpleNamespace(
+        access="browser-at",
+        refresh="browser-rt",
+        expires=0,
+        account_id=None,
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    _codex_browser_oauth_login()
+
+    xdg_path = tmp_path / "xdg" / "oauth-cli-kit" / "auth" / "codex.json"
+    mac_path = fake_home / "Library" / "Application Support" / "oauth-cli-kit" / "auth" / "codex.json"
+    assert not xdg_path.exists(), f"shared file appeared at {xdg_path}"
+    assert not mac_path.exists(), f"shared file appeared at {mac_path}"
+
+
+def test_browser_oauth_login_raises_when_package_missing(_fake_tty, monkeypatch):
+    """Missing oauth-cli-kit must surface a clean AuthError, not an ImportError."""
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", None)
+
+    with pytest.raises(AuthError) as exc:
+        _codex_browser_oauth_login()
+    assert exc.value.code == "oauth_cli_kit_missing"
+
+
+def test_browser_oauth_login_raises_on_empty_access_token(_fake_tty, monkeypatch):
+    """An oauth-cli-kit login that returns no access token is an error,
+    not a silent success.
+    """
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: types.SimpleNamespace(
+        access="",
+        refresh="",
+        expires=0,
+        account_id=None,
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    with pytest.raises(AuthError) as exc:
+        _codex_browser_oauth_login()
+    assert exc.value.code == "oauth_cli_kit_login_failed"
+
+
+def test_browser_oauth_login_requires_tty(monkeypatch):
+    """Non-TTY stdin must short-circuit before invoking oauth-cli-kit.
+    Otherwise the library's input() fallback would block forever on a
+    piped/closed stdin.  We explicitly do NOT use the _fake_tty fixture
+    here — pytest's stdin.isatty() returns False, simulating a piped run.
+    """
+    # Trip-wire: oauth-cli-kit must NOT be loaded.  If the TTY guard
+    # ever regresses, this will surface a different (later) failure.
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("login_oauth_interactive must not run on non-TTY stdin")
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    with pytest.raises(AuthError) as exc:
+        _codex_browser_oauth_login()
+    assert exc.value.code == "oauth_cli_kit_requires_tty"
+
+
+def test_browser_oauth_login_converts_keyboard_interrupt_to_auth_error(_fake_tty, monkeypatch):
+    """A Ctrl-C inside oauth-cli-kit's flow must come back as a clean
+    AuthError(code='oauth_cli_kit_login_cancelled'), not a bare
+    KeyboardInterrupt that would crash the surrounding command.
+    """
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: (_ for _ in ()).throw(
+        KeyboardInterrupt()
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    with pytest.raises(AuthError) as exc:
+        _codex_browser_oauth_login()
+    assert exc.value.code == "oauth_cli_kit_login_cancelled"
+
+
+def test_browser_oauth_login_honours_hermes_codex_base_url_override(_fake_tty, monkeypatch):
+    """When HERMES_CODEX_BASE_URL is set (custom/proxy Codex endpoint),
+    browser login must persist that override into the returned creds —
+    same as the device-code flow.  Otherwise users on a custom endpoint
+    silently get config rewritten to the default ChatGPT endpoint.
+    """
+    monkeypatch.setenv("HERMES_CODEX_BASE_URL", "https://codex.proxy.example/v1")
+
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: types.SimpleNamespace(
+        access="browser-at",
+        refresh="browser-rt",
+        expires=int(time.time() * 1000) + 3600_000,
+        account_id=None,
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    creds = _codex_browser_oauth_login()
+    assert creds["base_url"] == "https://codex.proxy.example/v1"
+
+
+def test_browser_oauth_login_strips_trailing_slash_in_override(_fake_tty, monkeypatch):
+    """Trailing slash on HERMES_CODEX_BASE_URL is stripped, matching
+    the device-code flow's normalisation.
+    """
+    monkeypatch.setenv("HERMES_CODEX_BASE_URL", "https://codex.proxy.example/v1/")
+
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: types.SimpleNamespace(
+        access="browser-at",
+        refresh="browser-rt",
+        expires=0,
+        account_id=None,
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    creds = _codex_browser_oauth_login()
+    assert creds["base_url"] == "https://codex.proxy.example/v1"
+
+
+def test_browser_oauth_login_wraps_runtime_errors_as_auth_error(_fake_tty, monkeypatch):
+    """oauth-cli-kit raises plain RuntimeError for state mismatch /
+    server failure / bad code.  Wrap into AuthError so callers see a
+    consistent error type.
+    """
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: (_ for _ in ()).throw(
+        RuntimeError("State validation failed.")
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    with pytest.raises(AuthError) as exc:
+        _codex_browser_oauth_login()
+    assert exc.value.code == "oauth_cli_kit_login_failed"
+    assert "State validation failed" in str(exc.value)

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -310,6 +310,55 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_codex_browser_persists_same_source_as_device_code(tmp_path, monkeypatch):
+    """`hermes auth add openai-codex --method browser` produces a pool
+    entry identical in shape to the device-code flow — Hermes-owned
+    tokens under source=manual:device_code so the existing refresh /
+    removal / suppression paths all still apply.
+
+    _codex_device_code_login is patched to throw to prove the browser
+    branch is what actually ran.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("browser@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: (_ for _ in ()).throw(AssertionError("device-code must not run")),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_browser_oauth_login",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "browser-refresh",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-04-24T10:00:00Z",
+            "auth_mode": "chatgpt",
+            "source": "browser",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        method = "browser"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    entry = next(item for item in entries if item["source"] == "manual:device_code")
+    assert entry["label"] == "browser@example.com"
+    assert entry["refresh_token"] == "browser-refresh"
+    assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources
@@ -1686,3 +1735,46 @@ def test_auth_remove_codex_manual_device_code_suppresses_canonical(tmp_path, mon
 
     auth_remove_command(SimpleNamespace(provider="openai-codex", target="1"))
     assert is_source_suppressed("openai-codex", "device_code")
+
+
+def test_auth_add_method_rejected_on_non_codex_provider(tmp_path, monkeypatch):
+    """--method is global on `hermes auth add` argparse but only
+    openai-codex consumes it.  Passing it to e.g. `nous` must fail
+    loudly rather than silently ignoring the flag.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "nous"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        method = "browser"
+
+    with pytest.raises(SystemExit) as exc:
+        auth_add_command(_Args())
+    msg = str(exc.value)
+    assert "--method" in msg and "openai-codex" in msg
+
+
+def test_auth_add_method_default_none_does_not_trip_validation(tmp_path, monkeypatch):
+    """Without --method (argparse default=None), other providers must
+    still work normally.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "sk-or-x"
+        label = None
+        method = None  # argparse default
+
+    # Should not raise — method=None is the "didn't pass --method" case.
+    auth_add_command(_Args())

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -264,6 +264,55 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_codex_browser_persists_same_source_as_device_code(tmp_path, monkeypatch):
+    """`hermes auth add openai-codex --method browser` produces a pool
+    entry identical in shape to the device-code flow — Hermes-owned
+    tokens under source=manual:device_code so the existing refresh /
+    removal / suppression paths all still apply.
+
+    _codex_device_code_login is patched to throw to prove the browser
+    branch is what actually ran.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("browser@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: (_ for _ in ()).throw(AssertionError("device-code must not run")),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_browser_oauth_login",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "browser-refresh",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-04-24T10:00:00Z",
+            "auth_mode": "chatgpt",
+            "source": "browser",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        method = "browser"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    entry = next(item for item in entries if item["source"] == "manual:device_code")
+    assert entry["label"] == "browser@example.com"
+    assert entry["refresh_token"] == "browser-refresh"
+    assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources
@@ -1594,3 +1643,46 @@ def test_auth_remove_codex_manual_device_code_suppresses_canonical(tmp_path, mon
 
     auth_remove_command(SimpleNamespace(provider="openai-codex", target="1"))
     assert is_source_suppressed("openai-codex", "device_code")
+
+
+def test_auth_add_method_rejected_on_non_codex_provider(tmp_path, monkeypatch):
+    """--method is global on `hermes auth add` argparse but only
+    openai-codex consumes it.  Passing it to e.g. `nous` must fail
+    loudly rather than silently ignoring the flag.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "nous"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        method = "browser"
+
+    with pytest.raises(SystemExit) as exc:
+        auth_add_command(_Args())
+    msg = str(exc.value)
+    assert "--method" in msg and "openai-codex" in msg
+
+
+def test_auth_add_method_default_none_does_not_trip_validation(tmp_path, monkeypatch):
+    """Without --method (argparse default=None), other providers must
+    still work normally.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "sk-or-x"
+        label = None
+        method = None  # argparse default
+
+    # Should not raise — method=None is the "didn't pass --method" case.
+    auth_add_command(_Args())

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -155,7 +155,8 @@ def test_model_command_prompts_to_reuse_or_reauthenticate_codex_session(monkeypa
     from hermes_cli.main import _model_flow_openai_codex
 
     captured = {"login_calls": 0}
-    choices = iter(["2"])
+    # First prompt: "2" = reauthenticate.  Second prompt: "1" = device code.
+    choices = iter(["2", "1"])
 
     monkeypatch.setattr("builtins.input", lambda prompt="": next(choices))
     monkeypatch.setattr(
@@ -167,9 +168,10 @@ def test_model_command_prompts_to_reuse_or_reauthenticate_codex_session(monkeypa
         lambda *args, **kwargs: {"api_key": "fresh-codex-token"},
     )
 
-    def _fake_login(*args, force_new_login=False, **kwargs):
+    def _fake_login(args, provider, *, force_new_login=False, **kwargs):
         captured["login_calls"] += 1
         captured["force_new_login"] = force_new_login
+        captured["method"] = getattr(args, "method", None)
 
     monkeypatch.setattr("hermes_cli.auth._login_openai_codex", _fake_login)
     monkeypatch.setattr(
@@ -187,6 +189,47 @@ def test_model_command_prompts_to_reuse_or_reauthenticate_codex_session(monkeypa
     assert "Use existing credentials" in out
     assert "Reauthenticate (new OAuth login)" in out
     assert captured["login_calls"] == 1
+    assert captured["force_new_login"] is True
+    assert captured["method"] == "device-code"
+
+
+def test_model_command_reauth_routes_browser_method_through(monkeypatch):
+    """Reauth menu → "2" picks browser method, which must be threaded
+    through to _login_openai_codex via args.method.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+    # First prompt: "2" = reauthenticate.  Second prompt: "2" = browser.
+    choices = iter(["2", "2"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(choices))
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": True, "source": "hermes-auth-store"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "fresh-codex-token"},
+    )
+
+    def _fake_login(args, provider, *, force_new_login=False, **kwargs):
+        captured["method"] = getattr(args, "method", None)
+        captured["force_new_login"] = force_new_login
+
+    monkeypatch.setattr("hermes_cli.auth._login_openai_codex", _fake_login)
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.4"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_ids, current_model="": None,
+    )
+
+    _model_flow_openai_codex({}, current_model="gpt-5.4")
+
+    assert captured["method"] == "browser"
     assert captured["force_new_login"] is True
 
 
@@ -226,6 +269,104 @@ def test_model_command_uses_existing_codex_session_without_relogin(monkeypatch):
     _model_flow_openai_codex({}, current_model="gpt-5.4")
 
     assert captured["access_token"] == "existing-codex-token"
+
+
+def test_model_command_offers_browser_login_choice_for_codex(monkeypatch):
+    """When the user isn't logged in, `hermes model` prompts for the
+    login method.  Answering "2" routes to the browser flow by passing
+    args.method="browser" to _login_openai_codex.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "2")
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda args, provider: captured.setdefault("method", getattr(args, "method", None)),
+    )
+    # Downstream plumbing — not under test here, just don't crash.
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "codex-access-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *args, **kwargs: None,
+    )
+
+    _model_flow_openai_codex({}, current_model="")
+
+    assert captured["method"] == "browser"
+
+
+def test_method_prompt_reprompts_on_invalid_input(monkeypatch, capsys):
+    """Typo or out-of-range input shouldn't silently default to
+    device-code — reprompt until the user picks a valid option.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+    # First "browser" / "3" / "b" are all invalid → reprompt.  Final "2"
+    # picks browser.
+    choices = iter(["browser", "3", "b", "2"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(choices))
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda args, provider: captured.setdefault("method", getattr(args, "method", None)),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "codex-access-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *args, **kwargs: None,
+    )
+
+    _model_flow_openai_codex({}, current_model="")
+
+    out = capsys.readouterr().out
+    # Three invalid attempts, each followed by an "Invalid choice" line.
+    assert out.count("Invalid choice") == 3
+    assert captured["method"] == "browser"
+
+
+def test_method_prompt_q_cancels_login(monkeypatch):
+    """Typing 'q' (or 'c'/'cancel'/'quit') at the method prompt must
+    cancel the login cleanly without invoking _login_openai_codex.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "q")
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("login must not run when cancelled")),
+    )
+
+    # Should return cleanly, not raise.
+    _model_flow_openai_codex({}, current_model="")
 
 
 # ── Tests for _normalize_model_for_provider ──────────────────────────

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -113,7 +113,8 @@ def test_model_command_prompts_to_reuse_or_reauthenticate_codex_session(monkeypa
     from hermes_cli.main import _model_flow_openai_codex
 
     captured = {"login_calls": 0}
-    choices = iter(["2"])
+    # First prompt: "2" = reauthenticate.  Second prompt: "1" = device code.
+    choices = iter(["2", "1"])
 
     monkeypatch.setattr("builtins.input", lambda prompt="": next(choices))
     monkeypatch.setattr(
@@ -125,9 +126,10 @@ def test_model_command_prompts_to_reuse_or_reauthenticate_codex_session(monkeypa
         lambda *args, **kwargs: {"api_key": "fresh-codex-token"},
     )
 
-    def _fake_login(*args, force_new_login=False, **kwargs):
+    def _fake_login(args, provider, *, force_new_login=False, **kwargs):
         captured["login_calls"] += 1
         captured["force_new_login"] = force_new_login
+        captured["method"] = getattr(args, "method", None)
 
     monkeypatch.setattr("hermes_cli.auth._login_openai_codex", _fake_login)
     monkeypatch.setattr(
@@ -145,6 +147,47 @@ def test_model_command_prompts_to_reuse_or_reauthenticate_codex_session(monkeypa
     assert "Use existing credentials" in out
     assert "Reauthenticate (new OAuth login)" in out
     assert captured["login_calls"] == 1
+    assert captured["force_new_login"] is True
+    assert captured["method"] == "device-code"
+
+
+def test_model_command_reauth_routes_browser_method_through(monkeypatch):
+    """Reauth menu → "2" picks browser method, which must be threaded
+    through to _login_openai_codex via args.method.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+    # First prompt: "2" = reauthenticate.  Second prompt: "2" = browser.
+    choices = iter(["2", "2"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(choices))
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": True, "source": "hermes-auth-store"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "fresh-codex-token"},
+    )
+
+    def _fake_login(args, provider, *, force_new_login=False, **kwargs):
+        captured["method"] = getattr(args, "method", None)
+        captured["force_new_login"] = force_new_login
+
+    monkeypatch.setattr("hermes_cli.auth._login_openai_codex", _fake_login)
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.4"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_ids, current_model="": None,
+    )
+
+    _model_flow_openai_codex({}, current_model="gpt-5.4")
+
+    assert captured["method"] == "browser"
     assert captured["force_new_login"] is True
 
 
@@ -184,6 +227,104 @@ def test_model_command_uses_existing_codex_session_without_relogin(monkeypatch):
     _model_flow_openai_codex({}, current_model="gpt-5.4")
 
     assert captured["access_token"] == "existing-codex-token"
+
+
+def test_model_command_offers_browser_login_choice_for_codex(monkeypatch):
+    """When the user isn't logged in, `hermes model` prompts for the
+    login method.  Answering "2" routes to the browser flow by passing
+    args.method="browser" to _login_openai_codex.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "2")
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda args, provider: captured.setdefault("method", getattr(args, "method", None)),
+    )
+    # Downstream plumbing — not under test here, just don't crash.
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "codex-access-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *args, **kwargs: None,
+    )
+
+    _model_flow_openai_codex({}, current_model="")
+
+    assert captured["method"] == "browser"
+
+
+def test_method_prompt_reprompts_on_invalid_input(monkeypatch, capsys):
+    """Typo or out-of-range input shouldn't silently default to
+    device-code — reprompt until the user picks a valid option.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+    # First "browser" / "3" / "b" are all invalid → reprompt.  Final "2"
+    # picks browser.
+    choices = iter(["browser", "3", "b", "2"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(choices))
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda args, provider: captured.setdefault("method", getattr(args, "method", None)),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "codex-access-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *args, **kwargs: None,
+    )
+
+    _model_flow_openai_codex({}, current_model="")
+
+    out = capsys.readouterr().out
+    # Three invalid attempts, each followed by an "Invalid choice" line.
+    assert out.count("Invalid choice") == 3
+    assert captured["method"] == "browser"
+
+
+def test_method_prompt_q_cancels_login(monkeypatch):
+    """Typing 'q' (or 'c'/'cancel'/'quit') at the method prompt must
+    cancel the login cleanly without invoking _login_openai_codex.
+    """
+    from hermes_cli.main import _model_flow_openai_codex
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "q")
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("login must not run when cancelled")),
+    )
+
+    # Should return cleanly, not raise.
+    _model_flow_openai_codex({}, current_model="")
 
 
 # ── Tests for _normalize_model_for_provider ──────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -1605,6 +1605,7 @@ dependencies = [
     { name = "fire" },
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
+    { name = "oauth-cli-kit" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "psutil" },
@@ -1854,6 +1855,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.26.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
+    { name = "oauth-cli-kit", specifier = "==0.1.3" },
     { name = "openai", specifier = "==2.24.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
@@ -2742,6 +2744,19 @@ wheels = [
 ]
 
 [[package]]
+name = "oauth-cli-kit"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/84/c6b1030669266378e2f286a4e3e8c020e7f2d537b711a2ad30a789e97097/oauth_cli_kit-0.1.3.tar.gz", hash = "sha256:6612b3dea1a97c4de4a7d3b828767d42f0a78eae93be56b90c55d3ab668ebfb8", size = 8551, upload-time = "2026-02-13T10:21:19.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/55/a4abfc5f9be60ffd7fedf0e808ffd0a1d35f3ecd6f7b2fc782b7948a8329/oauth_cli_kit-0.1.3-py3-none-any.whl", hash = "sha256:09aabde83fbb823b38de3b8c220f6c256df2d771bf31dccdb2680a5fbe383836", size = 11504, upload-time = "2026-02-13T10:21:18.282Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3015,6 +3030,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/50/fb9b28a679e01682006b5259abff96de3d16e114e9447a7793fec31715de/parallel_web-0.4.2.tar.gz", hash = "sha256:599b5a8f387dc35c7dc8c81e372eadf6958a40acacea58bf170dfc663c003da7", size = 140026, upload-time = "2026-03-09T22:24:35.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/3e/2218fa29637781b8e7ac35a928108ff2614ddd40879389d3af2caa725af5/parallel_web-0.4.2-py3-none-any.whl", hash = "sha256:aa3a4a9aecc08972c5ce9303271d4917903373dff4dd277d9a3e30f9cff53346", size = 144012, upload-time = "2026-03-09T22:24:33.979Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-17T16:49:45.944715922Z"
+exclude-newer = "2026-04-17T17:00:50.300654Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1881,6 +1881,7 @@ dependencies = [
     { name = "firecrawl-py" },
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
+    { name = "oauth-cli-kit" },
     { name = "openai" },
     { name = "parallel-web" },
     { name = "prompt-toolkit" },
@@ -2102,6 +2103,7 @@ requires-dist = [
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.3.0,<3" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.0.0,<2" },
     { name = "numpy", marker = "extra == 'voice'", specifier = ">=1.24.0,<3" },
+    { name = "oauth-cli-kit", specifier = "==0.1.3" },
     { name = "openai", specifier = ">=2.21.0,<3" },
     { name = "parallel-web", specifier = ">=0.4.2,<1" },
     { name = "prompt-toolkit", specifier = ">=3.0.52,<4" },
@@ -3275,6 +3277,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/ad/1100d7229bb248394939a12a8074d485b655e8ed44207d328fdd7fcebc7b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e58765ad74dcebd3ef0208a5078fba32dc8ec3578fe84a604432950cd043d79", size = 15800434, upload-time = "2026-03-09T07:58:44.837Z" },
     { url = "https://files.pythonhosted.org/packages/0c/fd/16d710c085d28ba4feaf29ac60c936c9d662e390344f94a6beaa2ac9899b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e236dbda4e1d319d681afcbb136c0c4a8e0f1a5c58ceec2adebb547357fe857", size = 16729409, upload-time = "2026-03-09T07:58:47.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/a7/b35835e278c18b85206834b3aa3abe68e77a98769c59233d1f6300284781/numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5", size = 12504685, upload-time = "2026-03-09T07:58:50.525Z" },
+]
+
+[[package]]
+name = "oauth-cli-kit"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/84/c6b1030669266378e2f286a4e3e8c020e7f2d537b711a2ad30a789e97097/oauth_cli_kit-0.1.3.tar.gz", hash = "sha256:6612b3dea1a97c4de4a7d3b828767d42f0a78eae93be56b90c55d3ab668ebfb8", size = 8551, upload-time = "2026-02-13T10:21:19.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/55/a4abfc5f9be60ffd7fedf0e808ffd0a1d35f3ecd6f7b2fc782b7948a8329/oauth_cli_kit-0.1.3-py3-none-any.whl", hash = "sha256:09aabde83fbb823b38de3b8c220f6c256df2d771bf31dccdb2680a5fbe383836", size = 11504, upload-time = "2026-02-13T10:21:18.282Z" },
 ]
 
 [[package]]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -138,9 +138,16 @@ Register a **Desktop app** OAuth client at
 with the Generative Language API enabled.
 
 :::info Codex Note
-The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
+The OpenAI Codex provider authenticates via OAuth. Two login methods are supported:
 
-If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add codex-oauth` (or `hermes model` → OpenAI Codex) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+- **Device code (default)** — `hermes auth add openai-codex`. Open a URL in any browser, enter a short code.
+- **Browser** — `hermes auth add openai-codex --method browser`. Runs an oauth-cli-kit browser redirect + local callback. Use this when you can't type a device code (e.g. the device-code page is blocked) or just prefer the redirect UX. Requires an interactive terminal.
+
+Both methods produce a Hermes-owned session: credentials are stored in `~/.hermes/auth.json` under `providers.openai-codex` and refreshed by Hermes. `hermes auth remove openai-codex` clears the credential from local Hermes state — it does not revoke the underlying OAuth grant server-side; revoke that separately at [chat.openai.com → Settings → Connected apps](https://chat.openai.com/) if needed.
+
+At runtime, neither method reads or writes `~/.codex/auth.json` (the Codex CLI's file). Separately, the interactive device-code login can prompt for a one-time, user-gated import of existing Codex CLI credentials when present. No Codex CLI installation is required.
+
+If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add openai-codex` (or `hermes model` → OpenAI Codex) to start a fresh login; the quarantine clears on the next successful exchange.
 :::
 
 :::warning

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -129,7 +129,14 @@ Register a **Desktop app** OAuth client at
 with the Generative Language API enabled.
 
 :::info Codex Note
-The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
+The OpenAI Codex provider authenticates via OAuth. Two login methods are supported:
+
+- **Device code (default)** — `hermes auth add openai-codex`. Open a URL in any browser, enter a short code.
+- **Browser** — `hermes auth add openai-codex --method browser`. Runs an oauth-cli-kit browser redirect + local callback. Use this when you can't type a device code (e.g. the device-code page is blocked) or just prefer the redirect UX. Requires an interactive terminal.
+
+Both methods produce a Hermes-owned session: credentials are stored in `~/.hermes/auth.json` under `providers.openai-codex` and refreshed by Hermes. `hermes auth remove openai-codex` clears the credential from local Hermes state — it does not revoke the underlying OAuth grant server-side; revoke that separately at [chat.openai.com → Settings → Connected apps](https://chat.openai.com/) if needed.
+
+At runtime, neither method reads or writes `~/.codex/auth.json` (the Codex CLI's file). Separately, the interactive device-code login can prompt for a one-time, user-gated import of existing Codex CLI credentials when present. No Codex CLI installation is required.
 :::
 
 :::warning


### PR DESCRIPTION
## Summary
- `hermes auth add openai-codex --method browser` runs an oauth-cli-kit browser redirect flow. The resulting tokens land in Hermes's own auth store under `providers.openai-codex`, sharing the existing refresh / removal / suppression lifecycle with device-code.
- `hermes model` prompts for the login method when the user isn't already signed in.
- oauth-cli-kit is used only as a flow helper. A private in-memory `TokenStorage` is passed in so the library never writes its shared `codex.json` on disk. #12360 invariant preserved — no read/write of `~/.codex/auth.json`, no cross-tool refresh-token contention.

## Out of scope (deliberately)
- No shared-credential reuse, NanoBOT interop, or `--purge-shared`. Those require a separate lifecycle (suppression, stale pruning, attribution rules, priority, platform paths) and should land as a follow-up PR if wanted.

## Files changed
- `hermes_cli/auth.py` — `_InMemoryOAuthTokenStorage`, `_codex_browser_oauth_login`, `--method` dispatch in `_login_openai_codex`.
- `hermes_cli/auth_commands.py` — Codex branch picks browser vs device-code based on `args.method`; pool entry still stored under `manual:device_code` so existing removal / suppression paths cover both.
- `hermes_cli/main.py` — `--method {device-code,browser}` on `auth add`; interactive prompt in `_model_flow_openai_codex`.
- `pyproject.toml`, `uv.lock` — pinned `oauth-cli-kit==0.1.3`.
- `website/docs/integrations/providers.md` — Codex note mentions both login methods.
- Tests — 6 new cases covering the browser flow end-to-end plus the no-shared-file invariant.