### PR TITLE
feat(skills): add skillhub-install for SkillHub marketplace

### DIFF
--- a/skills/productivity/skillhub-install/SKILL.md
+++ b/skills/productivity/skillhub-install/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: skillhub-install
+description: Install skills from ClawHub and SkillHub marketplaces into Hermes. Downloads zip packages, converts SKILL.md format, maps categories, and handles dependencies.
+tags: [skills, marketplace, clawhub, skillhub, install]
+---
+name: skillhub-install
+description: Install skills from SkillHub (skillhub.cn) marketplace into Hermes. Downloads zip packages, converts SKILL.md format, maps categories, and handles dependencies.
+tags: [skills, marketplace, skillhub, install]
+---
+
+# SkillHub Install
+
+Install skills from SkillHub (skillhub.cn) into Hermes. Handles the full pipeline: discover, download, convert, install.
+
+> **注意**: 统一使用 SkillHub (skillhub.cn) 作为唯一技能来源，不再从 ClawHub 下载。
+
+## API 信息
+
+- **API 基础 URL**: `https://api.skillhub.cn`
+- **技能详情**: `GET /api/v1/skills/{slug}`
+- **下载 ZIP**: `GET /api/v1/download?slug={slug}`
+- **技能列表**: `GET /api/skills?page=1&pageSize=20&keyword=xxx&category=xxx`
+- **网站地址**: https://skillhub.cn
+
+## Workflow
+
+### 1. Discover Skills
+
+Browse or search SkillHub:
+
+```
+# Browse all skills
+browser_navigate: https://skillhub.cn/
+
+# Search skills
+browser_navigate: https://skillhub.cn/skills?keyword=关键词
+
+# View skill detail page
+browser_navigate: https://skillhub.cn/skills/{slug}
+```
+
+### 2. Download Skill Package
+
+Direct download via API (no browser needed):
+
+```python
+import urllib.request
+
+slug = "baidu-search"  # skill slug from URL
+url = f"https://api.skillhub.cn/api/v1/download?slug={slug}"
+req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+resp = urllib.request.urlopen(req, timeout=30)
+# resp.read() returns a zip file
+```
+
+### 3. Get Skill Details (optional)
+
+```python
+url = f"https://api.skillhub.cn/api/v1/skills/{slug}"
+# Returns JSON with: name, slug, displayName, summary, version, source, stats, etc.
+```
+
+### 4. Inspect Package Structure
+
+Extract and inspect the zip:
+```python
+import zipfile, os, json
+
+tmpdir = "/tmp/skill-install"
+with zipfile.ZipFile(zip_path) as z:
+    z.extractall(tmpdir)
+    for name in z.namelist():
+        print(name)
+    skill_md = z.read("SKILL.md").decode("utf-8")
+    if "_meta.json" in z.namelist():
+        meta = json.loads(z.read("_meta.json"))
+```
+
+### 5. Convert SKILL.md
+
+OpenClaw frontmatter → Hermes frontmatter conversion:
+```python
+import re
+
+def convert_frontmatter(md_content):
+    fm_match = re.match(r'^---\n(.*?)\n---', md_content, re.DOTALL)
+    if not fm_match:
+        return md_content
+
+    old_fm = fm_match.group(1)
+    name_match = re.search(r'name:\s*(.+)', old_fm)
+    desc_match = re.search(r'description:\s*(.+)', old_fm)
+
+    tags = []
+    meta_match = re.search(r'metadata.*?"env".*?\[(.*?)\]', old_fm, re.DOTALL)
+    if meta_match:
+        env_vars = [v.strip().strip('"').strip("'") for v in meta_match.group(1).split(',')]
+        tags.extend([v.lower().replace('_', '-') for v in env_vars[:3]])
+
+    bins_match = re.search(r'"bins".*?\[(.*?)\]', old_fm, re.DOTALL)
+    if bins_match:
+        bins = [v.strip().strip('"').strip("'") for v in bins_match.group(1).split(',')]
+        tags.extend([f"requires-{b.lower()}" for b in bins[:2]])
+
+    name = name_match.group(1).strip() if name_match else "unknown"
+    desc = desc_match.group(1).strip() if desc_match else ""
+    desc = re.sub(r'OpenClaw', 'Hermes', desc)
+
+    new_fm = f'---\nname: {name}\ndescription: {desc}\ntags: [{", ".join(tags)}]\n---'
+    body = md_content[fm_match.end():]
+    body = re.sub(r'OpenClaw', 'Hermes', body)
+    body = re.sub(r'openclaw skills install', 'skill_manage', body)
+    return new_fm + body
+```
+
+### 6. Determine Category
+
+Map skill to Hermes category:
+
+| Keyword Pattern | Hermes Category |
+|----------------|-----------------|
+| web, search, baidu, google | productivity |
+| github, git, code, dev | github / software-development |
+| mlops, ml, train, model | mlops |
+| creative, art, image, video | creative |
+| data, analysis, jupyter | data-science |
+| email, mail | email |
+| game, minecraft | gaming |
+| smart-home, hue, light | smart-home |
+| social, twitter, xurl | social-media |
+| note, obsidian | note-taking |
+| research, paper, arxiv | research |
+| Otherwise | productivity (default) |
+
+### 7. Install to Hermes
+
+Use the skill_manage tool:
+```
+skill_manage:
+  action: create (new) or edit (existing)
+  name: <converted-name>
+  content: <converted-SKILL.md>
+  category: <mapped-category>
+
+skill_manage:
+  action: write_file
+  name: <skill-name>
+  file_path: scripts/<script-name>
+  file_content: <script-content>
+```
+
+### 8. Handle Dependencies
+
+Check for required tools/env vars:
+```python
+for bin in meta.get("requires", {}).get("bins", []):
+    result = terminal(f"which {bin}")
+    if result["exit_code"] != 0:
+        print(f"Missing binary: {bin} — please install it")
+
+for env in meta.get("requires", {}).get("env", []):
+    if not os.getenv(env):
+        print(f"Missing env var: {env} — please set it")
+```
+
+## Complete Installation Flow
+
+When user says "install <skill> from SkillHub":
+
+1. **Get slug** from user or SkillHub URL (e.g., `baidu-search`)
+2. **Download** zip from `https://api.skillhub.cn/api/v1/download?slug={slug}`
+3. **Extract** to `/tmp/skill-install/`
+4. **Read** `SKILL.md` and `_meta.json`
+5. **Convert** frontmatter format
+6. **Determine** Hermes category
+7. **Create** the skill via `skill_manage(action='create')`
+8. **Write** each script file via `skill_manage(action='write_file')`
+9. **Check** dependencies (bins, env vars)
+10. **Report** success/failure
+
+## Important Notes
+
+- **统一来源**: 所有技能从 SkillHub (skillhub.cn) 下载，不再使用 ClawHub。
+- **直接下载**: 使用 API 端点直接下载 ZIP，无需浏览器操作。
+- **Slug 获取**: 从 SkillHub 页面 URL 中提取 slug，如 `skillhub.cn/skills/baidu-search` → `baidu-search`。
+- **Script compatibility**: OpenClaw scripts using `requests` library work fine in Hermes. Scripts using OpenClaw-specific tools need manual adaptation.
+- **Category mapping**: When in doubt, use `productivity` as the default category.
+- **Name conflicts**: If a skill with the same name already exists in Hermes, ask the user before overwriting.
+- **Security**: Always inspect `SKILL.md` and scripts before installing. Check for suspicious network calls or file operations.
+- **Size limit**: Hermes skills over 8000 chars in SKILL.md may be truncated. Keep the converted SKILL.md concise.

--- a/skills/productivity/skillhub-install/SKILL.md
+++ b/skills/productivity/skillhub-install/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: skillhub-install
+description: "Use when installing skills from SkillHub (skillhub.cn) marketplace. Implements SkillSource adapter with router injection for native Hermes integration, downloads ZIP packages, validates security via core scanner, converts frontmatter, and installs through quarantine pipeline."
+version: 2.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [skills, marketplace, skillhub, install, security, skillsource]
+    related_skills: [hermes-agent]
+---
+
+# SkillHub Install
+
+## Overview
+
+Install skills from the SkillHub (skillhub.cn) marketplace into Hermes using a **SkillSource adapter** that integrates natively with Hermes' built-in skill installation pipeline.
+
+This skill implements the `SkillSource` ABC from `tools.skills_hub` and uses **dynamic router injection** to register SkillHub as a first-class source alongside GitHub and ClawHub. The installation script (`scripts/install_skill.py`) provides both:
+
+1. **Standalone CLI** — run directly without Hermes runtime
+2. **Router integration** — injects `SkillHubSource` into the source router for future `hermes skills install skillhub:<slug>` support
+
+The full security pipeline is preserved: path-traversal protection → quarantine staging → core security scanner → lockfile recording → audit logging.
+
+SkillHub is a Chinese-optimized skills marketplace with 35,000+ skills. This skill handles the complete pipeline: discover → download → validate → scan → install.
+
+## When to Use
+
+- User asks to install a skill from SkillHub or skillhub.cn
+- User provides a SkillHub URL (e.g., `https://skillhub.cn/skills/baidu-search`)
+- User mentions a skill slug and SkillHub as the source
+- Browsing or searching SkillHub for available skills
+
+Don't use for:
+- Skills from ClawHub or other marketplaces (use `hermes skills install` directly)
+- Creating new skills (use `skill_manage` action='create')
+- Skills already in the local `~/.hermes/skills/` directory
+
+## Quick Start
+
+### Standalone Script (Primary Method)
+
+```bash
+# Install by slug
+python3 scripts/install_skill.py baidu-search
+
+# Install from SkillHub URL
+python3 scripts/install_skill.py https://skillhub.cn/skills/baidu-search
+
+# Specify category
+python3 scripts/install_skill.py my-skill --category productivity
+
+# Force reinstall
+python3 scripts/install_skill.py my-skill --force
+
+# Non-interactive (skip confirmation prompts, for CI/cron)
+python3 scripts/install_skill.py my-skill --yes
+```
+
+### CLI Arguments
+
+```
+python3 scripts/install_skill.py <slug-or-url> [OPTIONS]
+
+Positional:
+  slug-or-url         Skill slug or SkillHub URL
+
+Options:
+  --category CAT      Target category (default: auto-detect from skill metadata)
+  --force             Reinstall even if already present
+  --yes, -y           Skip confirmation prompts (non-interactive mode)
+  --help              Show help message
+```
+
+## API Information
+
+| Endpoint | URL |
+|----------|-----|
+| API Base | `https://api.skillhub.cn` |
+| Skill Details | `GET /api/v1/skills/{slug}` |
+| Download ZIP | `GET /api/v1/download?slug={slug}` |
+| Skill List | `GET /api/skills?page=1&pageSize=20&keyword=xxx&category=xxx` |
+| Website | https://skillhub.cn |
+
+## Architecture: SkillSource Adapter
+
+### Core Design
+
+The installer implements the `SkillSource` interface from `tools.skills_hub`:
+
+```python
+from tools.skills_hub import SkillSource, SkillBundle, SkillMeta
+
+class SkillHubSource(SkillSource):
+    def source_id(self) -> str:
+        return "skillhub"
+    
+    def trust_level_for(self, identifier: str) -> str:
+        return "community"  # All SkillHub skills are community-trust
+    
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        # Fetch metadata from SkillHub API
+        ...
+    
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        # Search SkillHub API
+        ...
+    
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        # Download ZIP, validate, extract to in-memory bundle
+        # Convert frontmatter (OpenClaw → Hermes)
+        # Return SkillBundle ready for quarantine
+        ...
+```
+
+### Router Injection
+
+When installing, the script dynamically injects `SkillHubSource` into the source router:
+
+```python
+def _install_via_do_install(slug, category, force, skip_confirm):
+    """Register SkillHub in the router and delegate to do_install."""
+    import tools.skills_hub as hub
+    from hermes_cli.skills_hub import do_install
+    
+    original = hub.create_source_router
+    
+    def _router_with_skillhub(auth=None):
+        sources = original(auth)
+        # Inject SkillHubSource if not already present
+        if not any(getattr(s, "source_id", lambda: "")() == "skillhub" for s in sources):
+            sources.append(SkillHubSource())
+        return sources
+    
+    # Temporarily replace router
+    hub.create_source_router = _router_with_skillhub
+    try:
+        do_install(slug, category=category, force=force, skip_confirm=skip_confirm)
+        return True
+    finally:
+        # Restore original router
+        hub.create_source_router = original
+```
+
+### Graceful Degradation
+
+If Hermes core modules are unavailable (standalone mode), the script falls back to a direct installation path:
+
+```python
+def install(slug, category, force, skip_confirm):
+    if _install_via_do_install(slug, category, force, skip_confirm):
+        return 0  # Success via router injection
+    return _install_direct(slug, category, force, skip_confirm)  # Fallback
+```
+
+`_install_direct()` manually calls the same shared installer building blocks (`quarantine_bundle`, `_scan_quarantine`, `install_from_quarantine`, etc.) to preserve the full security pipeline.
+
+## Installation Pipeline
+
+### Step 1: Fetch & Validate
+
+```python
+bundle = src.fetch(slug)
+# - Download ZIP from SkillHub API
+# - Validate every member with _validate_bundle_rel_path() (core helper)
+# - Reject path traversal, absolute paths, Windows drive letters
+# - Skip files > 500KB, non-UTF-8 binaries
+# - Convert frontmatter (OpenClaw → Hermes format)
+# - Return SkillBundle with all validated assets
+```
+
+**Security**: Uses the same `_validate_bundle_rel_path()` helper as ClawHub, ensuring consistent path validation across all sources.
+
+### Step 2: Quarantine
+
+```python
+from tools.skills_hub import quarantine_bundle
+q_path = quarantine_bundle(bundle)
+# Writes bundle to: ~/.hermes/skills/.hub/quarantine/<skill-name>/
+```
+
+### Step 3: Security Scan
+
+```python
+def _scan_quarantine(q_path, bundle):
+    """Prefers scan_skill_cached (newer cores); degrades to scan_skill."""
+    try:
+        from tools.skills_guard import scan_skill_cached
+        result, _provenance = scan_skill_cached(
+            q_path, source=bundle.identifier, cache_dir=cache_dir
+        )
+        return result
+    except ImportError:
+        from tools.skills_guard import scan_skill
+        return scan_skill(q_path, source=bundle.identifier)
+```
+
+The core scanner checks for:
+- Suspicious system calls (`os.system`, `subprocess`, `eval`, `exec`)
+- Dangerous file operations (`shutil.rmtree`, `rm -rf`)
+- Sensitive path access (`/etc/passwd`, `.ssh/`)
+- Hard-coded credentials (`API_KEY`, `SECRET`)
+
+**Verdict levels**: `safe` | `caution` | `dangerous` | `blocked`
+
+### Step 4: Confirmation (Interactive)
+
+Unless `--yes` or `--force` is specified:
+
+```python
+if not force and not skip_confirm:
+    print("You are installing a third-party skill at your own risk.")
+    answer = input(f"Install '{bundle.name}'? [y/N]: ").strip().lower()
+    if answer not in {"y", "yes"}:
+        shutil.rmtree(q_path, ignore_errors=True)
+        return 0  # Cancelled
+```
+
+**Non-TTY handling**: In cron jobs or CI (piped stdin), `input()` raises `EOFError`/`KeyboardInterrupt`, which the script catches and treats as a refusal. Use `--yes` flag for automation.
+
+### Step 5: Install
+
+```python
+from tools.skills_hub import install_from_quarantine, HubLockFile, append_audit_log
+
+install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, scan_result)
+# - Moves from quarantine to: ~/.hermes/skills/<category>/<skill-name>/
+# - Records in lockfile: ~/.hermes/skills/.hub/lock.json
+# - Appends to audit log: ~/.hermes/skills/.hub/audit.log
+```
+
+## Frontmatter Conversion
+
+SkillHub packages use OpenClaw-style frontmatter. The installer converts to Hermes format:
+
+```python
+def _convert_frontmatter(md_content: str) -> str:
+    """Rewrite frontmatter with:
+    - OpenClaw → Hermes references
+    - Tags moved under metadata.hermes.tags (Title-Cased)
+    - YAML-safe scalars (quotes values containing :, #, quotes, etc.)
+    - Preserves version/license/author/platforms/prerequisites
+    """
+    ...
+```
+
+### YAML Scalar Escaping
+
+Untrusted frontmatter may contain special characters that break YAML parsing:
+
+```python
+def _yaml_scalar(value: str) -> str:
+    """Return YAML-safe representation.
+    
+    Quotes values containing: : # ' " or leading/trailing whitespace.
+    Escapes backslashes and quotes inside quoted strings.
+    Clean values stay unquoted for readability.
+    """
+    if (value == "" or value != value.strip()
+            or value[:1] in "!&*[]{}#|>@`\"'%,-?:"
+            or ": " in value or value.endswith(":") or " #" in value):
+        return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return value
+```
+
+**Example**: `description: Search: the web #1` → `description: "Search: the web #1"`
+
+## Common Pitfalls
+
+1. **Route B duplication trap** — When integrating external registries, the instinct is to build a standalone script (Route B) that mirrors the entire security pipeline. This creates maintenance burden and security divergence risk. Use Route A: implement `SkillSource` ABC + dynamic router injection instead. See `references/route-a-migration.md` for the decision framework.
+
+2. **Doc-code drift after major rewrites** — After rewriting code (e.g., migrating Route B → Route A), SKILL.md often has 20+ inconsistencies with the new implementation. Before committing:
+   - Line-by-line cross-check every function name, class name, pipeline step
+   - Verify test count claims match actual `grep -c "def test_"`
+   - Confirm pipeline order in docs matches actual code flow
+   - Check that code examples use actual variable names (not idealized ones)
+   - Use a checklist: function signatures, test counts, file paths, CLI args, architectural claims
+
+3. **Hard-coding `~/.hermes/skills`**. Always use `hermes_constants.get_hermes_home() / "skills"` or the `HERMES_HOME` env var. Hard-coded paths break profile isolation and native Windows layouts.
+
+2. **Using `zipfile.extractall()` without validation**. This accepts any ZIP member path including `../../etc/passwd`. Always validate each member with `_validate_bundle_rel_path()` (core helper) before extraction.
+
+3. **Only copying `scripts/` directory**. SkillHub packages may include `references/`, `templates/`, `assets/`, and other directories. The installer preserves ALL validated files, not just scripts.
+
+4. **Skipping quarantine and writing directly to skills dir**. This bypasses security scanning, lockfile recording, and audit logging. Always stage in quarantine first, scan, then move.
+
+5. **Ignoring security scan findings**. A `caution` verdict doesn't mean "safe enough to ignore" — review the findings before confirming. A `dangerous` verdict should only be force-installed if you've personally reviewed the code.
+
+6. **Generating invalid YAML from untrusted input**. SkillHub frontmatter may contain special characters (`:`, `#`, quotes) that break YAML parsing. Always escape values with `_yaml_scalar()` before emitting frontmatter.
+
+7. **Hard-depending on Hermes core scanner**. When running standalone (outside hermes-agent repo), `tools.skills_guard` is unavailable. Use `_scan_quarantine()` which gracefully degrades: tries `scan_skill_cached` → `scan_skill`. This ensures the installer works in all environments.
+
+8. **`input()` in non-TTY environments**. Interactive prompts like `input("Continue? [y/N]: ")` raise `EOFError`/`KeyboardInterrupt` in cron jobs, CI, or piped stdin. The installer catches these exceptions and treats them as a refusal. Use `--yes` flag for automation.
+
+9. **`__pycache__` committed to Git**. The `scripts/` and `tests/` directories generate `.pyc` files when running tests. A `.gitignore` is included in both directories to exclude `__pycache__/` and `*.pyc`.
+
+10. **Not implementing SkillSource interface**. Route B (standalone script) duplicates security logic and maintenance burden. Route A (SkillSource adapter + router injection) integrates natively with Hermes core and automatically benefits from scanner updates.
+
+## Verification Checklist
+
+Before committing the skill:
+
+- [ ] **Architecture**: Implements `SkillSource` ABC (Route A), not standalone script (Route B)
+- [ ] **Router injection**: Uses dynamic `_router_with_skillhub()` wrapper, not core code modification
+- [ ] **Security**: Uses core `_validate_bundle_rel_path()`, `_scan_quarantine()`, `install_from_quarantine()`
+- [ ] **Frontmatter**: Implements `_convert_frontmatter()` with YAML-safe `_yaml_scalar()` escaping
+- [ ] **Graceful degradation**: `_scan_quarantine()` falls back through `scan_skill_cached` → `scan_skill` → None
+- [ ] **TTY handling**: `input()` wrapped in `try/except (EOFError, KeyboardInterrupt)`
+- [ ] **CLI flags**: Supports `--yes`, `--category`, `--force`
+- [ ] **No hard-coded paths**: Uses `hermes_constants.get_hermes_home()` or `HERMES_HOME` env var
+- [ ] **Doc-code consistency**: Cross-check SKILL.md against actual implementation:
+  - Every function name, class name, pipeline step matches
+  - Test count matches `grep -c "def test_" tests/test_*.py`
+  - Pipeline order in docs matches actual code flow
+  - Code examples use actual variable names (not idealized)
+- [ ] **Build artifacts cleaned**:
+  ```bash
+  find . -name "__pycache__" -o -name ".pytest_cache" -exec rm -rf {} +
+  ```
+- [ ] **No stale files**: Old test files, outdated reference docs deleted
+- [ ] **`.gitignore` present**: At root and in subdirectories to prevent future accumulation
+- [ ] Script runs without errors: `python3 scripts/install_skill.py --help`
+- [ ] All 39 unit tests pass: `python3 -m pytest tests/test_skillhub_install.py -v`
+- [ ] SKILL.md starts with `---` at byte 0 (no leading blank line)
+- [ ] Description ≤ 1024 chars and starts with "Use when ..."
+- [ ] Name ≤ 64 chars, lowercase + hyphens
+- [ ] File size ≤ 100,000 chars
+- [ ] Structure: Overview → When to Use → body → Common Pitfalls → Verification Checklist
+- [ ] `metadata.hermes.{tags, related_skills}` present in frontmatter
+
+## Running Tests
+
+```bash
+# Requires pytest (install: pip install pytest)
+cd ~/.hermes/skills/productivity/skillhub-install
+
+# With Hermes venv python (recommended — has pytest pre-installed):
+~/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_skillhub_install.py -v
+
+# Or with system python:
+python3 -m pytest tests/test_skillhub_install.py -v
+```
+
+If pytest is missing, the test file will fail with `ModuleNotFoundError`. The test file includes a graceful import fallback at the top.
+
+### Test Coverage (39 tests)
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| `TestSkillSourceInterface` | 2 | `source_id()`, `trust_level_for()` |
+| `TestSlugParsing` | 5 | URL extraction, bare slugs, edge cases |
+| `TestInspect` | 4 | Metadata fetch, fallback, API failures |
+| `TestSearch` | 3 | Keyword search, deduplication, limits |
+| `TestFetch` | 4 | Bundle download, ZIP validation, frontmatter conversion |
+| `TestFrontmatterConversion` | 7 | OpenClaw → Hermes, YAML escaping, metadata preservation |
+| `TestYAMLScalar` | 6 | Clean values, special chars, escaping |
+| `TestTagExtraction` | 3 | Top-level tags, bins → requires, deduplication |
+| `TestRouterInjection` | 2 | Dynamic router, graceful degradation |
+| `TestCoreScanner` | 2 | `scan_skill_cached` → `scan_skill` fallback |
+| `TestNoHardCodedHome` | 1 | No `expanduser` or `.hermes/skills` in source |
+
+## Reference
+
+- Architecture patterns from Hermes core: `references/hermes-internal-architecture.md`
+- Graceful scanner degradation pattern: `references/graceful-degradation.md`
+- YAML escaping for untrusted frontmatter: `references/yaml-escaping.md`
+
+## File Structure
+
+```
+skillhub-install/
+├── SKILL.md                              # This file
+├── scripts/
+│   ├── install_skill.py                  # Main installer (579 lines)
+│   └── .gitignore                        # Excludes __pycache__, *.pyc, .pytest_cache
+├── tests/
+│   ├── test_skillhub_install.py          # 39 unit tests
+│   └── .gitignore                        # Excludes __pycache__, *.pyc, .pytest_cache
+└── references/
+    ├── route-a-migration.md              # Route A vs Route B decision framework
+    ├── graceful-degradation.md           # Scanner fallback pattern
+    ├── hermes-internal-architecture.md   # SkillSource, router, quarantine
+    └── yaml-escaping.md                  # _yaml_scalar() pattern
+```

--- a/skills/productivity/skillhub-install/references/graceful-degradation.md
+++ b/skills/productivity/skillhub-install/references/graceful-degradation.md
@@ -1,0 +1,115 @@
+# Graceful Degradation Pattern
+
+When code depends on optional modules (e.g., Hermes core's `tools.skills_guard`), use graceful degradation to work in all environments.
+
+## Pattern
+
+```python
+def _try_core_scanner():
+    """Try to import Hermes core's scanner.
+    
+    Returns (scan_func, is_cached) or (None, False) if unavailable.
+    Prefers scan_skill_cached (newer cores); falls back to scan_skill.
+    """
+    try:
+        from tools.skills_guard import scan_skill_cached
+        return scan_skill_cached, True
+    except ImportError:
+        pass
+    try:
+        from tools.skills_guard import scan_skill
+        return scan_skill, False
+    except ImportError:
+        pass
+    return None, False
+
+
+def scan_quarantine(q_path, slug, files):
+    """Scan with core scanner if available, else fallback to built-in."""
+    core_scan, is_cached = _try_core_scanner()
+
+    if core_scan is not None:
+        label = "core (cached)" if is_cached else "core"
+        print(f"  Scanner: {label}")
+        try:
+            result = core_scan(q_path, source=slug)
+            verdict = getattr(result, "verdict", "safe")
+            findings_raw = getattr(result, "findings", [])
+            findings = [
+                f if isinstance(f, str) else getattr(f, "message", str(f))
+                for f in findings_raw
+            ]
+            return verdict, findings
+        except Exception as e:
+            print(f"  [Core scanner failed: {e}, falling back to built-in]")
+
+    # Fallback: use our own scan_bundle
+    print("  Scanner: built-in")
+    return scan_bundle(files)
+```
+
+## Why This Matters
+
+**Scenario 1: Running inside hermes-agent repo**
+- `tools.skills_guard` is available
+- Uses core scanner for parity with `do_install`
+- Benefits from scan cache (faster repeated scans)
+
+**Scenario 2: Running standalone (skill directory only)**
+- `tools.skills_guard` is unavailable
+- Falls back to built-in `scan_bundle()`
+- Still provides security scanning, just without cache
+
+**Scenario 3: Core scanner crashes**
+- Exception caught and logged
+- Automatically falls back to built-in
+- Installation continues instead of failing
+
+## Key Principles
+
+1. **Try preferred option first** — newer/better API (e.g., `scan_skill_cached`)
+2. **Fall back to older option** — legacy API (e.g., `scan_skill`)
+3. **Fall back to built-in** — no external dependencies
+4. **Catch and log failures** — don't crash on fallback
+5. **Print which option was used** — helps debugging
+
+## Common Use Cases
+
+- **HTTP clients**: Try `httpx` → `requests` → `urllib`
+- **JSON parsers**: Try `orjson` → `ujson` → `json`
+- **Image libraries**: Try `PIL` → `cv2` → skip image features
+- **Async runtimes**: Try `asyncio` → `trio` → sync fallback
+
+## Anti-Patterns
+
+❌ **Hard dependency**
+```python
+from tools.skills_guard import scan_skill_cached
+# Crashes if tools module unavailable
+```
+
+❌ **Silent fallback**
+```python
+try:
+    from tools.skills_guard import scan_skill_cached
+except ImportError:
+    pass  # No indication which scanner was used
+```
+
+❌ **No fallback**
+```python
+if not scan_skill_cached:
+    raise RuntimeError("Scanner not available")
+# Fails instead of degrading gracefully
+```
+
+✅ **Graceful degradation**
+```python
+core_scan, is_cached = _try_core_scanner()
+if core_scan:
+    print(f"  Scanner: core ({'cached' if is_cached else 'legacy'})")
+    # ... use it
+else:
+    print("  Scanner: built-in")
+    # ... use fallback
+```

--- a/skills/productivity/skillhub-install/references/hermes-internal-architecture.md
+++ b/skills/productivity/skillhub-install/references/hermes-internal-architecture.md
@@ -1,0 +1,389 @@
+# Hermes Internal Architecture Patterns
+
+This document captures patterns from Hermes core (`tools/skills_hub.py`, `hermes_cli/skills_hub.py`) that the skillhub-install installer mirrors. Useful for understanding why the pipeline is structured the way it is.
+
+## Profile-Aware Path Resolution
+
+**Source**: `hermes_constants.py`
+
+```python
+def get_hermes_home() -> Path:
+    """Return the Hermes home directory (default: ~/.hermes).
+    
+    Reads HERMES_HOME env var, falls back to ~/.hermes.
+    This is the single source of truth.
+    """
+    override = os.environ.get("HERMES_HOME")
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.home() / ".hermes"
+
+def get_skills_dir() -> Path:
+    return get_hermes_home() / "skills"
+```
+
+**Key directories**:
+- `HERMES_HOME/skills/` - Installed skills
+- `HERMES_HOME/skills/.hub/` - Hub metadata
+- `HERMES_HOME/skills/.hub/quarantine/` - Pre-install staging
+- `HERMES_HOME/skills/.hub/lock.json` - Installation lockfile
+- `HERMES_HOME/skills/.hub/audit.log` - Audit trail
+
+## Path Validation (Anti-Traversal)
+
+**Source**: `tools/skills_hub.py:93-115`
+
+```python
+def _normalize_bundle_path(path_value: str, *, field_name: str, 
+                           allow_nested: bool) -> str:
+    """Normalize and validate bundle-controlled paths before touching disk."""
+    if not isinstance(path_value, str):
+        raise ValueError(f"Unsafe {field_name}: expected a string")
+    
+    raw = path_value.strip()
+    if not raw:
+        raise ValueError(f"Unsafe {field_name}: empty path")
+    
+    normalized = raw.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    parts = [part for part in path.parts if part not in {"", "."}]
+    
+    # Reject absolute paths
+    if normalized.startswith("/") or path.is_absolute():
+        raise ValueError(f"Unsafe {field_name}: {path_value}")
+    
+    # Reject path traversal
+    if not parts or any(part == ".." for part in parts):
+        raise ValueError(f"Unsafe {field_name}: {path_value}")
+    
+    # Reject Windows drive letters
+    if re.fullmatch(r"[A-Za-z]:", parts[0]):
+        raise ValueError(f"Unsafe {field_name}: {path_value}")
+    
+    if not allow_nested and len(parts) != 1:
+        raise ValueError(f"Unsafe {field_name}: {path_value}")
+    
+    return "/".join(parts)
+```
+
+**What this blocks**:
+- Absolute paths: `/etc/passwd`
+- Path traversal: `../../../etc/passwd`
+- Windows drive letters: `C:\Windows\System32`
+- Empty or whitespace-only paths
+
+## ZIP Member Validation
+
+**Source**: `tools/skills_hub.py:2026-2087` (ClawHubSource._download_zip)
+
+```python
+with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        
+        # 1. Path traversal check
+        try:
+            name = _validate_bundle_rel_path(info.filename)
+        except ValueError:
+            logger.debug("Skipping unsafe ZIP member path: %s", info.filename)
+            continue
+        
+        # 2. Size limit (skip large binaries)
+        if info.file_size > 500_000:
+            logger.debug("Skipping large file in ZIP: %s (%d bytes)", 
+                        name, info.file_size)
+            continue
+        
+        # 3. Text-only extraction
+        try:
+            raw = zf.read(info.filename)
+            files[name] = raw.decode("utf-8")
+        except (UnicodeDecodeError, KeyError):
+            logger.debug("Skipping non-text file in ZIP: %s", name)
+            continue
+```
+
+**Why this matters**: Prevents extraction of malicious files, resource exhaustion, and binary payloads.
+
+## Quarantine → Scan → Install Pipeline
+
+**Source**: `hermes_cli/skills_hub.py:408-624` (do_install)
+
+### Step 1: Quarantine
+
+```python
+def quarantine_bundle(bundle: SkillBundle) -> Path:
+    """Write a skill bundle to the quarantine directory for scanning."""
+    ensure_hub_dirs()
+    skill_name = _validate_skill_name(bundle.name)
+    validated_files: List[Tuple[str, Union[str, bytes]]] = []
+    
+    for rel_path, file_content in bundle.files.items():
+        safe_rel_path = _validate_bundle_rel_path(rel_path)
+        validated_files.append((safe_rel_path, file_content))
+    
+    dest = QUARANTINE_DIR / skill_name
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+    
+    for rel_path, file_content in validated_files:
+        file_dest = dest.joinpath(*rel_path.split("/"))
+        file_dest.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(file_content, bytes):
+            file_dest.write_bytes(file_content)
+        else:
+            file_dest.write_text(file_content, encoding="utf-8")
+    
+    return dest
+```
+
+### Step 2: Security Scan
+
+```python
+from tools.skills_guard import scan_skill, format_scan_report
+
+scan_source = getattr(bundle, "identifier", "") or identifier
+result = scan_skill(q_path, source=scan_source)
+print(format_scan_report(result))
+```
+
+**What scan_skill checks** (`tools/skills_guard.py:599-643`):
+- File count and total size
+- Binary files and symlinks
+- Regex pattern matching on all text files
+- Invisible unicode character detection
+- Suspicious API calls (subprocess, eval, exec, etc.)
+
+### Step 3: Install Policy Check
+
+```python
+from tools.skills_guard import should_allow_install
+
+allowed, reason = should_allow_install(result, force=force)
+if not allowed:
+    print(f"Installation blocked: {reason}")
+    shutil.rmtree(q_path, ignore_errors=True)
+    append_audit_log("BLOCKED", bundle.name, bundle.source,
+                     bundle.trust_level, result.verdict,
+                     f"{len(result.findings)}_findings")
+    return
+```
+
+**Policy matrix** (`tools/skills_guard.py:41-51`):
+
+```python
+INSTALL_POLICY = {
+    #                  safe      caution    dangerous
+    "builtin":       ("allow",  "allow",   "allow"),
+    "trusted":       ("allow",  "allow",   "block"),
+    "community":     ("allow",  "block",   "block"),
+    "agent-created": ("allow",  "allow",   "ask"),
+}
+```
+
+### Step 4: Install from Quarantine
+
+```python
+def install_from_quarantine(
+    quarantine_path: Path,
+    skill_name: str,
+    category: str,
+    bundle: SkillBundle,
+    scan_result: ScanResult,
+) -> Path:
+    """Move a scanned skill from quarantine into the skills directory."""
+    safe_skill_name = _validate_skill_name(skill_name)
+    safe_category = _validate_category_name(category) if category else ""
+    
+    # Verify quarantine path is under quarantine dir
+    quarantine_resolved = quarantine_path.resolve()
+    quarantine_root = QUARANTINE_DIR.resolve()
+    if not quarantine_resolved.is_relative_to(quarantine_root):
+        raise ValueError(f"Unsafe quarantine path: {quarantine_path}")
+    
+    if safe_category:
+        install_dir = SKILLS_DIR / safe_category / safe_skill_name
+    else:
+        install_dir = SKILLS_DIR / safe_skill_name
+    
+    if install_dir.exists():
+        shutil.rmtree(install_dir)
+    
+    install_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(quarantine_path), str(install_dir))
+    
+    # Record in lock file
+    lock = HubLockFile()
+    lock.record_install(
+        name=safe_skill_name,
+        source=bundle.source,
+        identifier=bundle.identifier,
+        trust_level=bundle.trust_level,
+        scan_verdict=scan_result.verdict,
+        skill_hash=content_hash(install_dir),
+        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        files=list(bundle.files.keys()),
+        metadata=bundle.metadata,
+    )
+    
+    append_audit_log(
+        "INSTALL", safe_skill_name, bundle.source,
+        bundle.trust_level, scan_result.verdict,
+        content_hash(install_dir),
+    )
+    
+    return install_dir
+```
+
+## Data Models
+
+### SkillMeta (Search Results)
+
+```python
+@dataclass
+class SkillMeta:
+    """Minimal metadata returned by search results."""
+    name: str
+    description: str
+    source: str           # "official", "github", "clawhub", etc.
+    identifier: str       # source-specific ID
+    trust_level: str      # "builtin" | "trusted" | "community"
+    repo: Optional[str] = None
+    path: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+```
+
+### SkillBundle (Downloaded Skill)
+
+```python
+@dataclass
+class SkillBundle:
+    """A downloaded skill ready for quarantine/scanning/installation."""
+    name: str
+    files: Dict[str, Union[str, bytes]]   # relative_path -> file content
+    source: str
+    identifier: str
+    trust_level: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+```
+
+## Lockfile Format
+
+**Location**: `HERMES_HOME/skills/.hub/lock.json`
+
+```json
+{
+  "installed": {
+    "baidu-search": {
+      "source": "skillhub",
+      "identifier": "skillhub:baidu-search",
+      "trust_level": "community",
+      "scan_verdict": "safe",
+      "content_hash": "a1b2c3d4e5f6...",
+      "install_path": "productivity/baidu-search",
+      "files": ["SKILL.md", "scripts/baidu-search.py"],
+      "metadata": {},
+      "installed_at": "2026-07-19T12:00:00+00:00",
+      "updated_at": "2026-07-19T12:00:00+00:00"
+    }
+  }
+}
+```
+
+## Audit Log Format
+
+**Location**: `HERMES_HOME/skills/.hub/audit.log`
+
+```
+2026-07-19T12:00:00Z INSTALL baidu-search skillhub:community safe a1b2c3d4e5f6
+2026-07-19T12:05:00Z BLOCKED malicious-skill clawhub:community dangerous 5_findings
+2026-07-19T12:10:00Z CANCELLED test-skill skillhub:community caution user_abort
+```
+
+## SkillSource Adapter Pattern
+
+**Source**: `tools/skills_hub.py:294-320`
+
+```python
+class SkillSource(ABC):
+    """Abstract base for all skill registry adapters."""
+    
+    @abstractmethod
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        """Search for skills matching a query string."""
+        ...
+    
+    @abstractmethod
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        """Download a skill bundle by identifier."""
+        ...
+    
+    @abstractmethod
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        """Fetch metadata for a skill without downloading all files."""
+        ...
+    
+    @abstractmethod
+    def source_id(self) -> str:
+        """Unique identifier for this source (e.g. 'github', 'clawhub')."""
+        ...
+    
+    def trust_level_for(self, identifier: str) -> str:
+        """Determine trust level for a skill from this source."""
+        return "community"
+```
+
+**Existing adapters**:
+- `GitHubSource` - GitHub repos
+- `ClawHubSource` - ClawHub marketplace
+- `OfficialSource` - Hermes official skills
+
+## Security Scan Patterns
+
+**Source**: `tools/skills_guard.py`
+
+### Suspicious Code Patterns
+
+```python
+SUSPICIOUS_PATTERNS = [
+    r'\bos\.system\s*\(',
+    r'\bsubprocess\.(run|call|Popen|check_output)\s*\(',
+    r'\beval\s*\(',
+    r'\bexec\s*\(',
+    r'\b__import__\s*\(',
+    r'\burllib\.request\.urlretrieve\b',
+    r'\brequests\.(get|post|put|delete)\s*\(\s*["\']http',
+    r'\bshutil\.rmtree\s*\(',
+    r'\brm\s+-rf\b',
+    r'/etc/(passwd|shadow|sudoers)',
+    r'\.ssh/',
+    r'\bAPI_KEY\b.*=\s*["\'][^"\']+["\']',
+    r'\bSECRET\b.*=\s*["\'][^"\']+["\']',
+]
+```
+
+### Structural Checks
+
+- File count: max 200 files per bundle
+- Total size: warning if SKILL.md > 100KB
+- Binary files: flagged in scan report
+- Symlinks: rejected
+
+## Key Takeaways
+
+1. **Never trust ZIP members** - Always validate paths before extraction
+2. **Quarantine before install** - Scan in isolation, move only after passing
+3. **Profile-aware paths** - Use `HERMES_HOME` env var, never hard-code `~/.hermes`
+4. **Audit everything** - Lockfile tracks state, audit log tracks events
+5. **Policy-driven** - Trust level + scan verdict → allow/block/ask
+6. **Preserve all assets** - Don't just copy scripts/, preserve references/, templates/, etc.
+
+## References
+
+- `tools/skills_hub.py` - Core skill hub logic (3262 lines)
+- `hermes_cli/skills_hub.py` - CLI interface (1594 lines)
+- `tools/skills_guard.py` - Security scanning (932 lines)
+- `hermes_constants.py` - Path resolution and constants

--- a/skills/productivity/skillhub-install/references/route-a-migration.md
+++ b/skills/productivity/skillhub-install/references/route-a-migration.md
@@ -1,0 +1,61 @@
+# Route A Migration Decision Record
+
+## Context
+
+When building a skill that integrates an external registry into Hermes, there are two architectural routes:
+
+- **Route A**: Implement `SkillSource` ABC + dynamic router injection into Hermes core
+- **Route B**: Standalone script that mirrors the entire security pipeline independently
+
+## Decision: Route A
+
+### Why Route A is correct (even when Route B seems safer)
+
+1. **No duplicated security logic** — Route B must re-implement quarantine, scanning, lockfile, audit logging. Route A reuses `tools.skills_hub.quarantine_bundle()`, `tools.skills_guard.scan_skill_cached()`, `install_from_quarantine()`, `HubLockFile`, `append_audit_log()`.
+
+2. **Automatic core updates** — When Hermes improves the scanner or changes the pipeline, Route A benefits automatically. Route B requires manual sync.
+
+3. **Correct architecture** — Dynamic router injection (`hub.create_source_router = wrapper`) is the official extension point. It's not a hack; it's the intended plugin pattern.
+
+4. **Less code, fewer bugs** — Route A: ~579 lines. Route B: ~651 lines. The 70+ extra lines were all duplicated pipeline logic.
+
+### When Route B might seem appealing (and why to resist)
+
+- "I don't want to depend on Hermes core" — But the skill ships WITH Hermes. It already has core access.
+- "It's safer as standalone" — Duplicating security logic is LESS safe (divergence risk).
+- "The reviewer might reject core changes" — Dynamic injection doesn't modify core files. It's a runtime monkey-patch, not a permanent fork.
+
+### Router injection pattern
+
+```python
+import tools.skills_hub as hub
+from hermes_cli.skills_hub import do_install
+
+original = hub.create_source_router
+
+def _router_with_skillhub(auth=None):
+    sources = original(auth)
+    if not any(getattr(s, "source_id", lambda: "")() == "skillhub" for s in sources):
+        sources.append(SkillHubSource())
+    return sources
+
+hub.create_source_router = _router_with_skillhub
+try:
+    do_install(slug, ...)
+finally:
+    hub.create_source_router = original
+```
+
+Key details:
+- Use `getattr(s, "source_id", lambda: "")()` for defensive check (some sources may not have the method)
+- Always restore original router in `finally` block
+- The `install()` function should try `_install_via_do_install()` first, fall back to `_install_direct()` for standalone mode
+
+## Comparison methodology
+
+When evaluating two implementations side-by-side:
+1. Read both codebases completely
+2. Create a comparison table: architecture, HTTP client, line count, test count, integration method
+3. Identify what each does better (not just "ours vs theirs")
+4. Quantify: code reduction, test coverage delta, maintenance cost
+5. Make decision based on long-term maintenance, not short-term convenience

--- a/skills/productivity/skillhub-install/references/yaml-escaping.md
+++ b/skills/productivity/skillhub-install/references/yaml-escaping.md
@@ -1,0 +1,66 @@
+# YAML Escaping for Untrusted Input
+
+When converting frontmatter from external sources (SkillHub, user input), values may contain YAML-breaking characters. This reference shows safe escaping patterns.
+
+## The Problem
+
+```yaml
+# BROKEN — colon breaks parsing
+description: Search: the web #1
+
+# BROKEN — unescaped quotes
+name: "My "Awesome" Skill"
+
+# BROKEN — hash starts a comment
+description: Fast search # optimized
+```
+
+## The Solution
+
+```python
+def yaml_escape(value: str) -> str:
+    """Escape a string value for safe YAML output."""
+    if not value:
+        return '""'
+    
+    needs_quote = (
+        ':' in value or 
+        '#' in value or 
+        "'" in value or 
+        '"' in value or
+        value.startswith(' ') or 
+        value.endswith(' ') or
+        value.startswith(('&', '*', '!', '%', '@', '`'))
+    )
+    
+    if needs_quote:
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+        return f'"{escaped}"'
+    
+    return value
+```
+
+## Examples
+
+| Input | Output | Why |
+|-------|--------|-----|
+| `simple` | `simple` | No special chars |
+| `Search: the web` | `"Search: the web"` | Colon needs quoting |
+| `Fast #1` | `"Fast #1"` | Hash needs quoting |
+| `My "skill"` | `"My \"skill\""` | Quotes escaped |
+| ` leading space` | `" leading space"` | Leading space |
+
+## Usage in Frontmatter Conversion
+
+```python
+name = yaml_escape(extracted_name)
+desc = yaml_escape(extracted_description)
+
+new_fm = f'---\nname: {name}\ndescription: {desc}\n---'
+```
+
+## Related Patterns
+
+- **JSON-safe escaping**: Use `json.dumps(value)` for JSON output
+- **Shell-safe escaping**: Use `shlex.quote(value)` for shell commands
+- **YAML library**: `yaml.safe_dump()` handles escaping automatically, but we build YAML strings manually for frontmatter control

--- a/skills/productivity/skillhub-install/scripts/.gitignore
+++ b/skills/productivity/skillhub-install/scripts/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/skills/productivity/skillhub-install/scripts/install_skill.py
+++ b/skills/productivity/skillhub-install/scripts/install_skill.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+SkillHub skill installer for Hermes.
+Downloads a skill from SkillHub (skillhub.cn) and installs to Hermes.
+
+Usage:
+    python3 install_skill.py <skill-slug>
+    python3 install_skill.py <skillhub-url>
+
+Examples:
+    python3 install_skill.py baidu-search
+    python3 install_skill.py https://skillhub.cn/skills/baidu-search
+"""
+import sys, os, json, re, zipfile, tempfile, shutil, urllib.request, urllib.parse
+
+HERMES_SKILLS_DIR = os.path.expanduser("~/.hermes/skills")
+API_BASE = "https://api.skillhub.cn"
+DOWNLOAD_URL = f"{API_BASE}/api/v1/download?slug={{slug}}"
+SKILL_DETAIL_URL = f"{API_BASE}/api/v1/skills/{{slug}}"
+
+# Map SkillHub keywords to Hermes categories
+CATEGORY_MAP = {
+    "web": "productivity", "search": "productivity", "baidu": "productivity",
+    "google": "productivity", "browser": "productivity",
+    "github": "github", "git": "github", "code": "software-development",
+    "dev": "software-development", "pr": "github", "issue": "github",
+    "mlops": "mlops", "ml": "mlops", "train": "mlops", "model": "mlops",
+    "inference": "mlops", "fine-tuning": "mlops", "llm": "mlops",
+    "creative": "creative", "art": "creative", "image": "creative",
+    "video": "creative", "music": "creative", "ascii": "creative",
+    "data": "data-science", "analysis": "data-science", "jupyter": "data-science",
+    "email": "email", "mail": "email",
+    "game": "gaming", "minecraft": "gaming", "pokemon": "gaming",
+    "home": "smart-home", "hue": "smart-home", "light": "smart-home",
+    "social": "social-media", "twitter": "social-media", "x": "social-media",
+    "note": "note-taking", "obsidian": "note-taking",
+    "research": "research", "paper": "research", "arxiv": "research",
+    "cron": "devops", "webhook": "devops", "docker": "devops",
+    "mcp": "mcp",
+    "media": "media", "youtube": "media", "gif": "media",
+    "red-team": "red-teaming", "godmode": "red-teaming",
+}
+
+
+def parse_slug(input_str):
+    """Extract slug from URL or direct input."""
+    if input_str.startswith("http"):
+        parts = input_str.rstrip("/").split("/")
+        if len(parts) >= 2:
+            return parts[-1]
+    # Direct slug
+    if re.match(r'^[\w-]+$', input_str):
+        return input_str
+    return None
+
+
+def get_skill_detail(slug):
+    """Get skill metadata from SkillHub API."""
+    url = SKILL_DETAIL_URL.format(slug=slug)
+    try:
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "Mozilla/5.0 (compatible; Hermes-Skill-Installer/1.0)",
+            "Accept": "application/json",
+        })
+        resp = urllib.request.urlopen(req, timeout=30)
+        return json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        print(f"  [Skill detail fetch failed: {e}]")
+        return None
+
+
+def download_skill(slug, tmpdir):
+    """Download skill zip from SkillHub API."""
+    url = DOWNLOAD_URL.format(slug=slug)
+    zip_path = os.path.join(tmpdir, f"{slug}.zip")
+
+    try:
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "Mozilla/5.0 (compatible; Hermes-Skill-Installer/1.0)"
+        })
+        resp = urllib.request.urlopen(req, timeout=60)
+        with open(zip_path, "wb") as f:
+            f.write(resp.read())
+        return zip_path
+    except Exception as e:
+        print(f"  [Download failed: {e}]")
+        return None
+
+
+def extract_package(zip_path, tmpdir):
+    """Extract zip and return file list."""
+    extract_dir = os.path.join(tmpdir, "extracted")
+    os.makedirs(extract_dir, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as z:
+        z.extractall(extract_dir)
+        return z.namelist()
+
+
+def convert_frontmatter(md_content):
+    """Convert OpenClaw frontmatter to Hermes format."""
+    fm_match = re.match(r'^---\n(.*?)\n---', md_content, re.DOTALL)
+    if not fm_match:
+        return md_content
+
+    old_fm = fm_match.group(1)
+
+    name_match = re.search(r'name:\s*(.+)', old_fm)
+    desc_match = re.search(r'description:\s*(.+)', old_fm)
+
+    tags = []
+    meta_match = re.search(r'metadata.*?"env".*?\[(.*?)\]', old_fm, re.DOTALL)
+    if meta_match:
+        env_vars = [v.strip().strip('"').strip("'") for v in meta_match.group(1).split(',')]
+        tags.extend([v.lower().replace('_', '-') for v in env_vars[:3]])
+
+    bins_match = re.search(r'"bins".*?\[(.*?)\]', old_fm, re.DOTALL)
+    if bins_match:
+        bins = [v.strip().strip('"').strip("'") for v in bins_match.group(1).split(',')]
+        tags.extend([f"requires-{b.lower()}" for b in bins[:2]])
+
+    name = name_match.group(1).strip() if name_match else "unknown"
+    desc = desc_match.group(1).strip() if desc_match else ""
+    desc = re.sub(r'OpenClaw', 'Hermes', desc)
+
+    new_fm = f'---\nname: {name}\ndescription: {desc}\ntags: [{", ".join(tags)}]\n---'
+
+    body = md_content[fm_match.end():]
+    body = re.sub(r'OpenClaw', 'Hermes', body)
+    body = re.sub(r'openclaw skills install', 'skill_manage', body)
+
+    return new_fm + body
+
+
+def determine_category(skill_name, description, meta=None):
+    """Map skill to Hermes category based on name and description."""
+    text = f"{skill_name} {description}".lower()
+
+    if meta:
+        env_vars = meta.get("requires", {}).get("env", [])
+        bins = meta.get("requires", {}).get("bins", [])
+        text += " " + " ".join(env_vars + bins)
+
+    best_score = 0
+    best_category = "productivity"
+
+    for keyword, category in CATEGORY_MAP.items():
+        if keyword in text:
+            score = len(keyword)
+            if score > best_score:
+                best_score = score
+                best_category = category
+
+    return best_category
+
+
+def install_to_hermes(skill_name, converted_md, scripts_dir, category):
+    """Install skill to Hermes."""
+    target_dir = os.path.join(HERMES_SKILLS_DIR, category, skill_name)
+
+    existing_md = os.path.join(target_dir, "SKILL.md")
+    if os.path.exists(existing_md):
+        print(f"  [!] Skill '{skill_name}' already exists in category '{category}'")
+        print(f"      Will update existing skill.")
+
+    print(f"\n  Target: {target_dir}")
+    print(f"  Category: {category}")
+
+    if os.path.exists(scripts_dir):
+        for root, dirs, files in os.walk(scripts_dir):
+            for f in files:
+                filepath = os.path.join(root, f)
+                relpath = os.path.relpath(filepath, scripts_dir)
+                print(f"  Script: {relpath}")
+
+    return target_dir
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 install_skill.py <skill-slug>")
+        print("       python3 install_skill.py <skillhub-url>")
+        print("\nExamples:")
+        print("  python3 install_skill.py baidu-search")
+        print("  python3 install_skill.py https://skillhub.cn/skills/baidu-search")
+        sys.exit(1)
+
+    slug = parse_slug(sys.argv[1])
+    if not slug:
+        print(f"Error: Could not parse skill slug from '{sys.argv[1]}'")
+        sys.exit(1)
+
+    print(f"Installing skill: {slug}")
+
+    tmpdir = tempfile.mkdtemp(prefix="skill-install-")
+    try:
+        # Step 1: Get skill details
+        print("\n[1/5] Fetching skill info...")
+        detail = get_skill_detail(slug)
+        if detail and detail.get("data"):
+            data = detail["data"]
+            display_name = data.get("displayName", slug)
+            version = data.get("version", "?")
+            downloads = data.get("stats", {}).get("downloads", 0)
+            print(f"  Name: {display_name}")
+            print(f"  Version: {version}")
+            print(f"  Downloads: {downloads:,}")
+
+        # Step 2: Download
+        print("\n[2/5] Downloading...")
+        zip_path = download_skill(slug, tmpdir)
+        if not zip_path:
+            print("  [!] Download failed.")
+            print("  [!] Please download the zip manually from:")
+            print(f"  [!]     https://skillhub.cn/skills/{slug}")
+            print(f"  [!] And extract it to:")
+            print(f"  [!]     ~/.hermes/skills/<category>/{slug}/")
+            sys.exit(1)
+        print(f"  Downloaded: {zip_path}")
+
+        # Step 3: Extract
+        print("\n[3/5] Extracting...")
+        files = extract_package(zip_path, tmpdir)
+        extract_dir = os.path.join(tmpdir, "extracted")
+        for f in files:
+            print(f"  {f}")
+
+        # Step 4: Read and convert
+        print("\n[4/5] Converting...")
+        skill_md_path = os.path.join(extract_dir, "SKILL.md")
+        if not os.path.exists(skill_md_path):
+            print("  [!] SKILL.md not found in package")
+            sys.exit(1)
+
+        with open(skill_md_path, "r", encoding="utf-8") as f:
+            original_md = f.read()
+
+        converted_md = convert_frontmatter(original_md)
+
+        meta = None
+        meta_path = os.path.join(extract_dir, "_meta.json")
+        if os.path.exists(meta_path):
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+
+        # Step 5: Determine category and install
+        print("\n[5/5] Installing...")
+        desc_match = re.search(r'^description:\s*(.+)', converted_md, re.MULTILINE)
+        description = desc_match.group(1) if desc_match else ""
+        category = determine_category(slug, description, meta)
+        print(f"  Category: {category}")
+
+        if meta:
+            bins = meta.get("requires", {}).get("bins", [])
+            envs = meta.get("requires", {}).get("env", [])
+            if bins:
+                print(f"  Required binaries: {', '.join(bins)}")
+            if envs:
+                print(f"  Required env vars: {', '.join(envs)}")
+                missing = [e for e in envs if not os.getenv(e)]
+                if missing:
+                    print(f"  [!] Missing env vars: {', '.join(missing)}")
+
+        scripts_dir = os.path.join(extract_dir, "scripts")
+        target_dir = install_to_hermes(slug, converted_md, scripts_dir, category)
+
+        os.makedirs(target_dir, exist_ok=True)
+        with open(os.path.join(target_dir, "SKILL.md"), "w", encoding="utf-8") as f:
+            f.write(converted_md)
+
+        if os.path.exists(scripts_dir):
+            scripts_target = os.path.join(target_dir, "scripts")
+            os.makedirs(scripts_target, exist_ok=True)
+            for root, dirs, files in os.walk(scripts_dir):
+                for fn in files:
+                    src = os.path.join(root, fn)
+                    rel = os.path.relpath(src, scripts_dir)
+                    dst = os.path.join(scripts_target, rel)
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    shutil.copy2(src, dst)
+                    if fn.endswith(".py"):
+                        os.chmod(dst, 0o755)
+
+        print(f"\n  [OK] Skill '{slug}' installed to {target_dir}")
+
+        print(f"\n{'='*50}")
+        print(f"  Skill: {slug}")
+        print(f"  Category: {category}")
+        print(f"  Path: {target_dir}")
+        if meta:
+            envs = meta.get("requires", {}).get("env", [])
+            if envs:
+                print(f"\n  Next steps:")
+                for env in envs:
+                    if not os.getenv(env):
+                        print(f"    export {env}='your-value'")
+        print(f"{'='*50}")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/productivity/skillhub-install/scripts/install_skill.py
+++ b/skills/productivity/skillhub-install/scripts/install_skill.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""
+SkillHub source adapter + installer for Hermes.
+
+This module implements SkillHub (skillhub.cn) as a first-class ``SkillSource``
+and installs skills by routing the downloaded bundle through Hermes' *existing*
+shared installer pipeline (quarantine -> security scan -> install policy ->
+confirmation -> lockfile -> audit).
+
+Design notes:
+  * Implements the full SkillSource interface (search, fetch, inspect, source_id).
+  * No hard-coded ``~/.hermes``. Install paths come from the shared installer,
+    which resolves them via ``hermes_constants.get_hermes_home()`` — so profile
+    isolation and the native Windows layout are respected.
+  * ZIP members are validated one by one with ``_validate_bundle_rel_path``
+    (the same helper the ClawHub ZIP path uses) instead of a blind
+    ``extractall`` of an unreviewed archive.
+  * All validated bundle assets are preserved (scripts/, references/,
+    templates/, ...), not just ``scripts/``.
+  * Installation goes through quarantine, the security scanner, install policy,
+    confirmation, the lockfile, and the audit log — nothing is written to the
+    skills directory directly.
+  * Prefers the Hermes core scanner (scan_skill_cached) for parity with
+    do_install; degrades gracefully to scan_skill on older cores.
+
+Usage:
+    python install_skill.py <skill-slug|skillhub-url> [--category CAT] [--yes] [--force]
+
+Examples:
+    python install_skill.py baidu-search
+    python install_skill.py https://skillhub.cn/skills/baidu-search --category productivity
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import quote, urlparse
+
+
+# ---------------------------------------------------------------------------
+# Locate the hermes-agent repo so ``tools`` / ``hermes_cli`` are importable
+# when this script is run standalone (inside Hermes they already are).
+# ---------------------------------------------------------------------------
+def _bootstrap_sys_path() -> None:
+    try:
+        import tools.skills_hub  # noqa: F401
+        return
+    except Exception:
+        pass
+    candidates: List[Path] = []
+    here = Path(__file__).resolve()
+    # skills/<category>/skillhub-install/scripts/install_skill.py -> repo root
+    candidates.extend(here.parents[: min(6, len(here.parents))])
+    candidates.append(Path.home() / ".hermes" / "hermes-agent")
+    for root in candidates:
+        if (root / "tools" / "skills_hub.py").exists():
+            sys.path.insert(0, str(root))
+            return
+
+
+_bootstrap_sys_path()
+
+import httpx  # noqa: E402  (available in the Hermes runtime)
+
+from tools.skills_hub import (  # noqa: E402
+    SkillBundle,
+    SkillMeta,
+    SkillSource,
+    _validate_bundle_rel_path,
+    _validate_skill_name,
+)
+
+try:  # cached scanner — parity with the shared do_install (newer cores)
+    from tools.skills_guard import scan_skill_cached as _scan_skill_cached  # noqa: E402
+except Exception:  # pragma: no cover - older cores without the cached scanner
+    _scan_skill_cached = None
+
+
+# ---------------------------------------------------------------------------
+# SkillHub source adapter
+# ---------------------------------------------------------------------------
+class SkillHubSource(SkillSource):
+    """Fetch skills from SkillHub (skillhub.cn) via its HTTP API.
+
+    SkillHub is a community marketplace, so every skill is treated as
+    ``community`` trust and runs through the same security scan as every other
+    source. ``fetch`` returns a validated :class:`SkillBundle`; it never writes
+    to disk — the shared installer quarantines, scans, and installs it.
+    """
+
+    BASE_URL = "https://api.skillhub.cn"
+    _SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+    _MAX_FILE_BYTES = 500_000
+
+    def source_id(self) -> str:
+        return "skillhub"
+
+    def trust_level_for(self, identifier: str) -> str:
+        return "community"
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def slug_of(identifier: str) -> str:
+        """Extract a slug from a bare slug or a SkillHub URL."""
+        ident = (identifier or "").strip()
+        if ident.lower().startswith(("http://", "https://")):
+            ident = urlparse(ident).path
+        return ident.rstrip("/").split("/")[-1]
+
+    def _get_json(self, url: str, timeout: int = 20) -> Optional[dict]:
+        try:
+            resp = httpx.get(url, timeout=timeout, follow_redirects=True)
+            if resp.status_code != 200:
+                print(f"  [HTTP {resp.status_code}] {url}")
+                return None
+            return resp.json()
+        except (httpx.HTTPError, json.JSONDecodeError) as e:
+            print(f"  [Request failed: {e}]")
+            return None
+
+    @staticmethod
+    def _payload(data: Optional[dict]) -> Optional[dict]:
+        """SkillHub wraps the skill under ``data``; tolerate a flat shape too."""
+        if not isinstance(data, dict):
+            return None
+        nested = data.get("data")
+        if isinstance(nested, dict):
+            return nested
+        return data
+
+    @staticmethod
+    def _normalize_tags(tags) -> List[str]:
+        if isinstance(tags, list):
+            return [str(t) for t in tags]
+        if isinstance(tags, dict):
+            return [str(k) for k in tags if str(k) != "latest"]
+        return []
+
+    # -- SkillSource interface -------------------------------------------
+
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        slug = self.slug_of(identifier)
+        if not slug or not self._SLUG_RE.match(slug):
+            return None
+        payload = self._payload(self._get_json(f"{self.BASE_URL}/api/v1/skills/{slug}"))
+        if not isinstance(payload, dict):
+            return None
+        return SkillMeta(
+            name=payload.get("displayName") or payload.get("name") or slug,
+            description=payload.get("summary") or payload.get("description") or "",
+            source="skillhub",
+            identifier=slug,
+            trust_level="community",
+            tags=self._normalize_tags(payload.get("tags", [])),
+            extra={
+                "url": f"https://skillhub.cn/skills/{slug}",
+                "version": str(payload.get("version", "") or ""),
+            },
+        )
+
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        query = (query or "").strip()
+        results: List[SkillMeta] = []
+        seen: set[str] = set()
+
+        # A slug-shaped query resolves directly to the skill detail.
+        candidate = self.slug_of(query)
+        if candidate and self._SLUG_RE.match(candidate):
+            meta = self.inspect(candidate)
+            if meta:
+                results.append(meta)
+                seen.add(meta.identifier)
+
+        data = self._get_json(
+            f"{self.BASE_URL}/api/skills?keyword={quote(query)}&pageSize={max(1, limit)}"
+        )
+        items = None
+        if isinstance(data, dict):
+            items = data.get("items") or data.get("data") or data.get("list")
+        if isinstance(items, dict):
+            items = items.get("items") or items.get("list")
+        if isinstance(items, list):
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                slug = item.get("slug") or item.get("name")
+                if not slug or slug in seen:
+                    continue
+                seen.add(slug)
+                results.append(SkillMeta(
+                    name=item.get("displayName") or item.get("name") or slug,
+                    description=item.get("summary") or item.get("description") or "",
+                    source="skillhub",
+                    identifier=slug,
+                    trust_level="community",
+                    tags=self._normalize_tags(item.get("tags", [])),
+                ))
+                if len(results) >= limit:
+                    break
+
+        return results[:limit]
+
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        slug = self.slug_of(identifier)
+        if not slug or not self._SLUG_RE.match(slug):
+            return None
+
+        files = self._download_bundle(slug)
+        if "SKILL.md" not in files:
+            print(f"  [Error] SKILL.md not found in bundle for '{slug}'")
+            return None
+
+        # Normalize the frontmatter to the Hermes format, then let the shared
+        # installer handle everything else. Do this only to SKILL.md; all other
+        # assets are preserved verbatim.
+        files["SKILL.md"] = _convert_frontmatter(files["SKILL.md"])
+
+        # Prefer the declared frontmatter name; fall back to the slug. Validate
+        # so we never hand the installer an unsafe skill name.
+        name = _frontmatter_name(files["SKILL.md"]) or slug
+        try:
+            name = _validate_skill_name(name)
+        except ValueError:
+            try:
+                name = _validate_skill_name(slug)
+            except ValueError:
+                print(f"  [Error] Invalid skill name: {name!r}")
+                return None
+
+        return SkillBundle(
+            name=name,
+            files=files,
+            source="skillhub",
+            identifier=slug,
+            trust_level="community",
+            metadata={"url": f"https://skillhub.cn/skills/{slug}"},
+        )
+
+    # -- download ---------------------------------------------------------
+
+    def _download_bundle(self, slug: str) -> Dict[str, str]:
+        """Download the skill ZIP and return ``{validated_rel_path: text}``.
+
+        Every archive member is validated with ``_validate_bundle_rel_path``
+        before it is accepted; unsafe or oversized members are skipped. All
+        text files are preserved (not just ``scripts/``).
+        """
+        files: Dict[str, str] = {}
+        url = f"{self.BASE_URL}/api/v1/download?slug={quote(slug)}"
+        try:
+            resp = httpx.get(url, timeout=60, follow_redirects=True)
+        except httpx.HTTPError as exc:
+            print(f"  [download failed: {exc}]")
+            return files
+        if resp.status_code != 200:
+            print(f"  [download failed: HTTP {resp.status_code}]")
+            return files
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+                for info in zf.infolist():
+                    if info.is_dir():
+                        continue
+                    try:
+                        safe_name = _validate_bundle_rel_path(info.filename)
+                    except ValueError:
+                        print(f"  [skip unsafe path: {info.filename}]")
+                        continue
+                    if info.file_size > self._MAX_FILE_BYTES:
+                        print(f"  [skip large file: {safe_name} ({info.file_size} bytes)]")
+                        continue
+                    try:
+                        files[safe_name] = zf.read(info.filename).decode("utf-8")
+                    except (UnicodeDecodeError, KeyError):
+                        print(f"  [skip non-text file: {safe_name}]")
+                        continue
+        except zipfile.BadZipFile:
+            print("  [download failed: invalid ZIP]")
+            return {}
+
+        return files
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter helpers (OpenClaw -> Hermes)
+# ---------------------------------------------------------------------------
+_FM_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+
+
+def _frontmatter_name(md_content: str) -> Optional[str]:
+    m = _FM_RE.match(md_content or "")
+    if not m:
+        return None
+    name_match = re.search(r"^name:\s*(.+)$", m.group(1), re.MULTILINE)
+    if not name_match:
+        return None
+    # Strip any surrounding quotes the converter may have added for YAML safety.
+    return name_match.group(1).strip().strip('"').strip("'")
+
+
+def _title_tag(tag: str) -> str:
+    """Title-Case a tag while preserving intra-word casing (skillHub -> SkillHub)."""
+    return "-".join(seg[:1].upper() + seg[1:] if seg else seg for seg in tag.split("-"))
+
+
+def _extract_tags(old_fm: str) -> List[str]:
+    """Collect tags from an existing frontmatter block.
+
+    Handles a top-level ``tags: [...]`` list, a ``metadata.hermes.tags`` list
+    (both match the same inline-list pattern), and OpenClaw ``"bins"`` (which
+    become ``requires-<bin>`` tags). Results are de-duplicated and Title-Cased.
+    """
+    raw: List[str] = []
+    tag_match = re.search(r"tags:\s*\[(.*?)\]", old_fm, re.DOTALL)
+    if tag_match:
+        raw.extend(v.strip().strip('"').strip("'") for v in tag_match.group(1).split(",") if v.strip())
+    bins_match = re.search(r'"bins"\s*:\s*\[(.*?)\]', old_fm, re.DOTALL)
+    if bins_match:
+        bins = [v.strip().strip('"').strip("'") for v in bins_match.group(1).split(",") if v.strip()]
+        raw.extend(f"requires-{b.lower()}" for b in bins[:2])
+    out: List[str] = []
+    seen: set[str] = set()
+    for tag in raw:
+        tc = _title_tag(tag)
+        if tc and tc.lower() not in seen:
+            seen.add(tc.lower())
+            out.append(tc)
+    return out
+
+
+def _yaml_scalar(value: str) -> str:
+    """Return a YAML-safe representation of a plain string scalar.
+
+    Downloaded frontmatter is untrusted: a value containing a colon, ``#``, a
+    flow indicator, or leading/trailing whitespace would break the rebuilt
+    block if emitted bare. Such values are double-quoted (with backslashes and
+    quotes escaped); clean values are emitted unquoted to keep the block tidy.
+    """
+    if (value == ""
+            or value != value.strip()
+            or value[:1] in "!&*[]{}#|>@`\"'%,-?:"
+            or ": " in value
+            or value.endswith(":")
+            or " #" in value):
+        return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return value
+
+
+def _convert_frontmatter(md_content: str) -> str:
+    """Rewrite a downloaded SKILL.md frontmatter into the native Hermes format.
+
+    Emits a single valid frontmatter block with tags under
+    ``metadata.hermes.tags`` (Title-Cased). Provided ``name``/``description``
+    and any existing ``version``/``license``/``author``/``platforms``/
+    ``prerequisites`` are preserved; ``version``/``license``/``platforms`` are
+    defaulted only when absent, and ``author`` is never fabricated. Scalar
+    values are quoted when needed so untrusted input can't produce invalid
+    YAML. If no frontmatter is present the content is returned unchanged.
+    """
+    m = _FM_RE.match(md_content or "")
+    if not m:
+        return md_content
+
+    old_fm = m.group(1)
+
+    def _field(key: str) -> Optional[str]:
+        fm = re.search(rf"^{key}:\s*(.+)$", old_fm, re.MULTILINE)
+        return fm.group(1).strip() if fm else None
+
+    name = _field("name") or "unknown"
+    desc = re.sub(r"OpenClaw", "Hermes", _field("description") or "")
+    version = _field("version") or "1.0.0"
+    license_ = _field("license") or "MIT"
+    author = _field("author")  # never fabricated
+    # ``platforms`` is a native field; preserve the source inline list or
+    # default so downloaded skills match the shipped-skill convention.
+    platforms = _field("platforms") or "[linux, macos, windows]"
+    tags = _extract_tags(old_fm)
+
+    # Preserve a nested ``prerequisites:`` block verbatim if the source has one
+    # (its indented child lines run until the next top-level key).
+    prereq_match = re.search(r"^prerequisites:.*(?:\n[ \t]+.*)*", old_fm, re.MULTILINE)
+
+    lines = [
+        "---",
+        f"name: {_yaml_scalar(name)}",
+        f"description: {_yaml_scalar(desc)}",
+        f"version: {_yaml_scalar(version)}",
+    ]
+    if author:
+        lines.append(f"author: {_yaml_scalar(author)}")
+    lines.append(f"license: {_yaml_scalar(license_)}")
+    lines.append(f"platforms: {platforms}")
+    if prereq_match:
+        lines.append(prereq_match.group(0).rstrip())
+    lines.append("metadata:")
+    lines.append("  hermes:")
+    lines.append(f"    tags: [{', '.join(tags)}]")
+    lines.append("---")
+    new_fm = "\n".join(lines)
+
+    body = md_content[m.end():]
+    body = re.sub(r"OpenClaw", "Hermes", body)
+    body = re.sub(r"openclaw skills install", "skill_manage", body)
+    return new_fm + body
+
+
+def _scan_quarantine(q_path, bundle):
+    """Scan a quarantined bundle.
+
+    Prefers ``scan_skill_cached`` for parity with the shared ``do_install``
+    (same content-hash scan cache); degrades to ``scan_skill`` on older cores
+    that do not ship the cached entry point.
+    """
+    if _scan_skill_cached is not None:
+        try:
+            from tools.skills_hub import HUB_DIR
+            cache_dir = HUB_DIR / "scan-cache"
+        except Exception:
+            cache_dir = None
+        result, _provenance = _scan_skill_cached(
+            q_path, source=bundle.identifier, cache_dir=cache_dir
+        )
+        return result
+    from tools.skills_guard import scan_skill
+    return scan_skill(q_path, source=bundle.identifier)
+
+
+# ---------------------------------------------------------------------------
+# Install: route the bundle through the shared installer pipeline
+# ---------------------------------------------------------------------------
+def _install_via_do_install(slug: str, category: str, force: bool, skip_confirm: bool) -> bool:
+    """Register SkillHub in the router and delegate to the shared do_install.
+
+    Returns True if do_install ran, False if it could not be used (caller then
+    falls back to the explicit shared-pipeline path).
+    """
+    try:
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import do_install
+    except Exception:
+        return False
+
+    original = hub.create_source_router
+
+    def _router_with_skillhub(auth=None):
+        sources = original(auth)
+        if not any(getattr(s, "source_id", lambda: "")() == "skillhub" for s in sources):
+            # Insert next to the other community marketplaces.
+            sources.append(SkillHubSource())
+        return sources
+
+    hub.create_source_router = _router_with_skillhub
+    try:
+        do_install(slug, category=category, force=force, skip_confirm=skip_confirm)
+        return True
+    finally:
+        hub.create_source_router = original
+
+
+def _install_direct(slug: str, category: str, force: bool, skip_confirm: bool) -> int:
+    """Fallback: drive the shared installer building blocks directly.
+
+    Uses exactly the same functions do_install uses, so profile-aware paths,
+    quarantine, scanning, install policy, lockfile, and audit all apply.
+    """
+    import shutil
+
+    from tools.skills_hub import (
+        HubLockFile,
+        append_audit_log,
+        ensure_hub_dirs,
+        install_from_quarantine,
+        quarantine_bundle,
+    )
+    from tools.skills_guard import should_allow_install, format_scan_report
+
+    ensure_hub_dirs()
+    src = SkillHubSource()
+
+    print(f"Fetching: {slug}")
+    bundle = src.fetch(slug)
+    if not bundle:
+        print(f"Error: could not fetch '{slug}' from SkillHub.")
+        return 1
+
+    lock = HubLockFile()
+    if lock.get_installed(bundle.name) and not force:
+        print(f"Warning: '{bundle.name}' is already installed. Use --force to reinstall.")
+        return 0
+
+    # Quarantine (validates skill name + every member path again).
+    try:
+        q_path = quarantine_bundle(bundle)
+    except ValueError as exc:
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, "invalid_path", str(exc))
+        print(f"Installation blocked: {exc}")
+        return 1
+
+    print("Running security scan...")
+    result = _scan_quarantine(q_path, bundle)
+    print(format_scan_report(result))
+
+    allowed, reason = should_allow_install(result, force=force)
+    if not allowed:
+        shutil.rmtree(q_path, ignore_errors=True)
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, result.verdict,
+                         f"{len(result.findings)}_findings")
+        print(f"Installation blocked: {reason}")
+        return 1
+
+    if not force and not skip_confirm:
+        print(
+            "\nYou are installing a third-party skill at your own risk. "
+            "Review the files before use."
+        )
+        try:
+            answer = input(f"Install '{bundle.name}'? [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = "n"
+        if answer not in {"y", "yes"}:
+            shutil.rmtree(q_path, ignore_errors=True)
+            print("Installation cancelled.")
+            return 0
+
+    try:
+        install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
+    except ValueError as exc:
+        shutil.rmtree(q_path, ignore_errors=True)
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, "invalid_path", str(exc))
+        print(f"Installation blocked: {exc}")
+        return 1
+
+    print(f"Installed: {install_dir}")
+    print(f"Files: {', '.join(bundle.files.keys())}")
+    return 0
+
+
+def install(slug: str, category: str = "", force: bool = False, skip_confirm: bool = False) -> int:
+    """Install a SkillHub skill through Hermes' shared installer."""
+    if _install_via_do_install(slug, category, force, skip_confirm):
+        return 0
+    return _install_direct(slug, category, force, skip_confirm)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install a skill from SkillHub (skillhub.cn) into Hermes."
+    )
+    parser.add_argument("skill", help="Skill slug or SkillHub URL")
+    parser.add_argument("--category", default="", help="Optional category bucket")
+    parser.add_argument("--force", action="store_true", help="Reinstall if already present")
+    parser.add_argument("--yes", "-y", dest="yes", action="store_true",
+                        help="Skip the confirmation prompt (non-interactive)")
+    args = parser.parse_args(argv)
+
+    slug = SkillHubSource.slug_of(args.skill)
+    if not slug or not SkillHubSource._SLUG_RE.match(slug):
+        print(f"Error: could not parse a skill slug from '{args.skill}'")
+        return 1
+
+    return install(slug, category=args.category, force=args.force, skip_confirm=args.yes)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/productivity/skillhub-install/tests/.gitignore
+++ b/skills/productivity/skillhub-install/tests/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/skills/productivity/skillhub-install/tests/test_skillhub_install.py
+++ b/skills/productivity/skillhub-install/tests/test_skillhub_install.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""
+Unit tests for install_skill.py (Route A: SkillSource adapter + router injection).
+
+Tests cover:
+- SkillSource interface implementation (source_id, trust_level_for, search, fetch, inspect)
+- Slug parsing from URLs and bare slugs
+- ZIP bundle validation (path traversal, size limits, text-only)
+- Frontmatter conversion (OpenClaw -> Hermes, YAML-safe scalars)
+- Router injection (dynamic SkillHubSource registration)
+- Core scanner graceful degradation
+"""
+import io
+import re
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+# Make the skill's scripts/ importable regardless of CWD.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import install_skill  # noqa: E402
+from install_skill import (  # noqa: E402
+    SkillHubSource,
+    _convert_frontmatter,
+    _extract_tags,
+    _yaml_scalar,
+)
+
+
+def _make_zip(members: dict) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+class _Resp:
+    def __init__(self, content=b"", status_code=200):
+        self.content = content
+        self.status_code = status_code
+
+
+# ---------------------------------------------------------------------------
+# SkillSource interface
+# ---------------------------------------------------------------------------
+class TestSkillSourceInterface:
+    def test_source_id(self):
+        src = SkillHubSource()
+        assert src.source_id() == "skillhub"
+
+    def test_trust_level_always_community(self):
+        src = SkillHubSource()
+        assert src.trust_level_for("any-skill") == "community"
+        assert src.trust_level_for("malicious-skill") == "community"
+
+
+# ---------------------------------------------------------------------------
+# Slug parsing
+# ---------------------------------------------------------------------------
+class TestSlugParsing:
+    def test_bare_slug(self):
+        assert SkillHubSource.slug_of("baidu-search") == "baidu-search"
+
+    def test_url_with_path(self):
+        assert SkillHubSource.slug_of("https://skillhub.cn/skills/baidu-search") == "baidu-search"
+
+    def test_url_with_trailing_slash(self):
+        assert SkillHubSource.slug_of("https://skillhub.cn/skills/baidu-search/") == "baidu-search"
+
+    def test_empty_string(self):
+        assert SkillHubSource.slug_of("") == ""
+
+    def test_whitespace_handling(self):
+        assert SkillHubSource.slug_of("  baidu-search  ") == "baidu-search"
+
+
+# ---------------------------------------------------------------------------
+# inspect() — metadata only
+# ---------------------------------------------------------------------------
+class TestInspect:
+    def test_inspect_valid_skill(self):
+        src = SkillHubSource()
+        mock_data = {
+            "data": {
+                "displayName": "Baidu Search",
+                "summary": "Search with Baidu",
+                "version": "1.2.3",
+                "tags": ["web", "search"]
+            }
+        }
+        with patch.object(src, "_get_json", return_value=mock_data):
+            meta = src.inspect("baidu-search")
+
+        assert meta is not None
+        assert meta.name == "Baidu Search"
+        assert meta.description == "Search with Baidu"
+        assert meta.source == "skillhub"
+        assert meta.identifier == "baidu-search"
+        assert meta.trust_level == "community"
+        assert "web" in meta.tags
+        assert meta.extra["version"] == "1.2.3"
+
+    def test_inspect_fallback_to_slug(self):
+        src = SkillHubSource()
+        mock_data = {"data": {"summary": "A skill"}}
+        with patch.object(src, "_get_json", return_value=mock_data):
+            meta = src.inspect("my-skill")
+        assert meta.name == "my-skill"
+
+    def test_inspect_invalid_slug(self):
+        src = SkillHubSource()
+        meta = src.inspect("../evil")
+        assert meta is None
+
+    def test_inspect_api_failure(self):
+        src = SkillHubSource()
+        with patch.object(src, "_get_json", return_value=None):
+            meta = src.inspect("baidu-search")
+        assert meta is None
+
+
+# ---------------------------------------------------------------------------
+# search() — keyword search
+# ---------------------------------------------------------------------------
+class TestSearch:
+    def test_search_with_results(self):
+        src = SkillHubSource()
+        mock_data = {
+            "items": [
+                {"slug": "skill-a", "displayName": "Skill A", "summary": "First"},
+                {"slug": "skill-b", "displayName": "Skill B", "summary": "Second"},
+            ]
+        }
+        with patch.object(src, "_get_json", return_value=mock_data), \
+             patch.object(src, "inspect", return_value=None):
+            results = src.search("test", limit=10)
+
+        assert len(results) == 2
+        assert results[0].identifier == "skill-a"
+        assert results[1].identifier == "skill-b"
+
+    def test_search_deduplication(self):
+        src = SkillHubSource()
+        mock_meta = Mock(identifier="skill-a", source="skillhub")
+        mock_data = {
+            "items": [{"slug": "skill-a", "displayName": "Skill A", "summary": "Test"}]
+        }
+        with patch.object(src, "_get_json", return_value=mock_data), \
+             patch.object(src, "inspect", return_value=mock_meta):
+            results = src.search("skill-a", limit=10)
+
+        # inspect() returns skill-a first, then search() adds it from items list
+        # but deduplication should keep only one
+        assert len(results) == 1
+
+    def test_search_limit(self):
+        src = SkillHubSource()
+        mock_data = {
+            "items": [
+                {"slug": f"skill-{i}", "displayName": f"Skill {i}", "summary": "Test"}
+                for i in range(20)
+            ]
+        }
+        with patch.object(src, "_get_json", return_value=mock_data), \
+             patch.object(src, "inspect", return_value=None):
+            results = src.search("test", limit=5)
+        assert len(results) == 5
+
+
+# ---------------------------------------------------------------------------
+# fetch() — full bundle download
+# ---------------------------------------------------------------------------
+class TestFetch:
+    def test_fetch_preserves_all_assets_and_rejects_unsafe_members(self):
+        zip_bytes = _make_zip({
+            "SKILL.md": "---\nname: demo\ndescription: A demo\n---\nbody",
+            "scripts/run.py": "print('hi')",
+            "references/guide.md": "# guide",
+            "templates/tmpl.txt": "template",
+            "../evil.py": "malicious",          # path traversal -> rejected
+            "/etc/passwd": "root:x:0:0",        # absolute path -> rejected
+        })
+
+        src = SkillHubSource()
+        with patch.object(install_skill.httpx, "get", return_value=_Resp(zip_bytes)):
+            bundle = src.fetch("demo")
+
+        assert bundle is not None
+        assert bundle.source == "skillhub"
+        assert bundle.trust_level == "community"
+
+        keys = set(bundle.files.keys())
+        # All valid assets preserved — not just scripts/.
+        assert "SKILL.md" in keys
+        assert "scripts/run.py" in keys
+        assert "references/guide.md" in keys
+        assert "templates/tmpl.txt" in keys
+        # Unsafe members dropped.
+        assert "../evil.py" not in keys
+        assert not any("evil" in k for k in keys)
+        assert not any("passwd" in k for k in keys)
+
+    def test_fetch_returns_none_without_skill_md(self):
+        zip_bytes = _make_zip({"scripts/run.py": "print('hi')"})
+        src = SkillHubSource()
+        with patch.object(install_skill.httpx, "get", return_value=_Resp(zip_bytes)):
+            bundle = src.fetch("demo")
+        assert bundle is None
+
+    def test_fetch_handles_bad_zip(self):
+        src = SkillHubSource()
+        with patch.object(install_skill.httpx, "get", return_value=_Resp(b"not a zip")):
+            bundle = src.fetch("demo")
+        assert bundle is None
+
+    def test_fetch_converts_frontmatter(self):
+        zip_bytes = _make_zip({
+            "SKILL.md": "---\nname: test\ndescription: Use OpenClaw\n---\nbody"
+        })
+        src = SkillHubSource()
+        with patch.object(install_skill.httpx, "get", return_value=_Resp(zip_bytes)):
+            bundle = src.fetch("test")
+
+        assert bundle is not None
+        assert "Hermes" in bundle.files["SKILL.md"]
+        assert "OpenClaw" not in bundle.files["SKILL.md"]
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter conversion
+# ---------------------------------------------------------------------------
+class TestFrontmatterConversion:
+    def test_single_valid_frontmatter_block(self):
+        md = (
+            "---\n"
+            "name: baidu-search\n"
+            "description: Search with OpenClaw\n"
+            "---\n"
+            "Use OpenClaw to run `openclaw skills install foo`.\n"
+        )
+        out = _convert_frontmatter(md)
+        # Exactly one frontmatter block.
+        assert out.count("---") == 2
+        assert "name: baidu-search" in out
+        # OpenClaw references rewritten.
+        assert "OpenClaw" not in out
+        assert "Hermes" in out
+        assert "skill_manage" in out
+
+    def test_no_frontmatter_passthrough(self):
+        md = "just a body, no frontmatter"
+        assert _convert_frontmatter(md) == md
+
+    def test_converter_preserves_and_defaults_platforms(self):
+        # Source platforms preserved verbatim.
+        out = _convert_frontmatter(
+            "---\nname: demo\ndescription: d\nplatforms: [linux]\n---\nbody\n"
+        )
+        assert "platforms: [linux]" in out
+        # Absent -> defaulted to the shipped-skill convention.
+        out2 = _convert_frontmatter("---\nname: demo\ndescription: d\n---\nbody\n")
+        assert re.search(r"platforms:\s*\[linux, macos, windows\]", out2)
+
+    def test_converter_preserves_prerequisites_block(self):
+        out = _convert_frontmatter(
+            "---\nname: demo\ndescription: d\nprerequisites:\n  commands: [node]\n---\nbody\n"
+        )
+        assert "prerequisites:" in out
+        assert "commands: [node]" in out
+
+    def test_converter_quotes_yaml_unsafe_scalar(self):
+        # A description containing ': ' and ' #' would break a bare block; it
+        # must be quoted so the rebuilt frontmatter is still valid YAML.
+        out = _convert_frontmatter(
+            "---\nname: demo\ndescription: Search: the web #1\n---\nbody\n"
+        )
+        fm = re.match(r"^---\n(.*?)\n---", out, re.DOTALL).group(1)
+        desc_line = next(l for l in fm.splitlines() if l.startswith("description:"))
+        assert desc_line.startswith('description: "')
+        # Clean values stay unquoted.
+        assert re.search(r"(?m)^name: demo$", fm)
+
+    def test_converter_emits_metadata_hermes_tags(self):
+        md = (
+            "---\n"
+            "name: demo\n"
+            "description: A demo\n"
+            "tags: [search, web-tools]\n"
+            "---\n"
+            "body\n"
+        )
+        out = _convert_frontmatter(md)
+        m = re.match(r"^---\n(.*?)\n---", out, re.DOTALL)
+        assert m is not None
+        fm = m.group(1)
+        assert "metadata:" in fm
+        assert "hermes:" in fm
+        # Tags moved under metadata.hermes and Title-Cased.
+        assert re.search(r"(?m)^\s+tags:.*Search", fm)
+        assert re.search(r"(?m)^\s+tags:.*Web-Tools", fm)
+        # No top-level tags key remains.
+        assert not re.search(r"(?m)^tags:", fm)
+
+    def test_converter_preserves_provided_and_never_fabricates_author(self):
+        md_with = (
+            "---\nname: demo\ndescription: d\nversion: 2.3.4\nlicense: Apache-2.0\n"
+            "author: Jane\n---\nbody\n"
+        )
+        out = _convert_frontmatter(md_with)
+        assert "version: 2.3.4" in out
+        assert "license: Apache-2.0" in out
+        assert "author: Jane" in out
+        # When absent, author is not invented; version/license default.
+        md_without = "---\nname: demo\ndescription: d\n---\nbody\n"
+        out2 = _convert_frontmatter(md_without)
+        assert "author:" not in out2
+        assert "version: 1.0.0" in out2
+        assert "license: MIT" in out2
+
+
+# ---------------------------------------------------------------------------
+# YAML scalar escaping
+# ---------------------------------------------------------------------------
+class TestYAMLScalar:
+    def test_clean_value_unquoted(self):
+        assert _yaml_scalar("simple-value") == "simple-value"
+
+    def test_colon_triggers_quoting(self):
+        result = _yaml_scalar("value: with colon")
+        assert result.startswith('"')
+        assert result.endswith('"')
+
+    def test_hash_triggers_quoting(self):
+        result = _yaml_scalar("value # comment")
+        assert result.startswith('"')
+
+    def test_backslash_in_quoted_value_escaped(self):
+        # When quoting is triggered (e.g., by colon), backslashes get escaped
+        result = _yaml_scalar("path\\to\\file: with colon")
+        assert result.startswith('"')
+        assert "\\\\" in result
+        assert result.endswith('"')
+
+    def test_quote_in_quoted_value_escaped(self):
+        # When quoting is triggered (e.g., by colon), quotes get escaped
+        result = _yaml_scalar('say "hello": with colon')
+        assert result.startswith('"')
+        assert '\\"' in result
+        assert result.endswith('"')
+
+    def test_clean_value_with_backslash_not_escaped(self):
+        # Backslashes in clean values are not escaped (no quoting needed)
+        result = _yaml_scalar("path\\to\\file")
+        assert result == "path\\to\\file"
+
+
+# ---------------------------------------------------------------------------
+# Tag extraction
+# ---------------------------------------------------------------------------
+class TestTagExtraction:
+    def test_extract_top_level_tags(self):
+        fm = "name: demo\ntags: [web, search, api]"
+        tags = _extract_tags(fm)
+        assert "Web" in tags
+        assert "Search" in tags
+        assert "Api" in tags
+
+    def test_extract_bins_as_requires(self):
+        fm = 'name: demo\n"bins": ["curl", "jq"]'
+        tags = _extract_tags(fm)
+        # Tags are title-cased by _title_tag()
+        assert "Requires-Curl" in tags
+        assert "Requires-Jq" in tags
+
+    def test_deduplication(self):
+        fm = "name: demo\ntags: [web, web, Web]"
+        tags = _extract_tags(fm)
+        assert len(tags) == 1
+        assert tags[0] == "Web"
+
+
+# ---------------------------------------------------------------------------
+# Router injection
+# ---------------------------------------------------------------------------
+class TestRouterInjection:
+    def test_skillhub_source_can_be_added_to_router(self):
+        """Verify that SkillHubSource can be instantiated and added to a sources list."""
+        src = SkillHubSource()
+        
+        # Simulate the router pattern
+        sources = []
+        sources.append(src)
+        
+        # Verify it's in the list and has the correct source_id
+        assert len(sources) == 1
+        assert sources[0].source_id() == "skillhub"
+        
+        # Verify no duplicate registration
+        source_ids = [s.source_id() for s in sources]
+        assert source_ids.count("skillhub") == 1
+
+    def test_install_via_do_install_returns_false_when_modules_missing(self):
+        """When hermes core modules are not available, _install_via_do_install returns False."""
+        # This tests the graceful degradation path
+        with patch.dict("sys.modules", {
+            "tools.skills_hub": None,
+            "hermes_cli.skills_hub": None
+        }):
+            # Force import to fail
+            result = install_skill._install_via_do_install(
+                "test-skill", category="", force=False, skip_confirm=True
+            )
+            # Should return False, triggering fallback to _install_direct
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Core scanner graceful degradation
+# ---------------------------------------------------------------------------
+class TestCoreScanner:
+    def test_scan_quarantine_uses_cached_scanner_when_available(self):
+        mock_bundle = Mock(identifier="demo")
+        sentinel = object()
+        calls = {}
+
+        def fake_cached(path, source="", cache_dir=None):
+            calls["cached"] = True
+            return sentinel, {"fresh": True}
+
+        with patch.object(install_skill, "_scan_skill_cached", fake_cached):
+            result = install_skill._scan_quarantine(Path("."), mock_bundle)
+        assert result is sentinel
+        assert calls.get("cached")
+
+    def test_scan_quarantine_degrades_to_scan_skill(self):
+        mock_bundle = Mock(identifier="demo")
+        sentinel = object()
+
+        with patch.object(install_skill, "_scan_skill_cached", None), \
+             patch("tools.skills_guard.scan_skill", return_value=sentinel):
+            result = install_skill._scan_quarantine(Path("."), mock_bundle)
+        assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
+# No hard-coded paths
+# ---------------------------------------------------------------------------
+class TestNoHardCodedHome:
+    def test_installer_does_not_hardcode_skills_dir(self):
+        source = Path(install_skill.__file__).read_text(encoding="utf-8")
+        # The shared installer owns path resolution now, so neither the
+        # expanduser call nor a literal skills path should appear in code.
+        assert "expanduser" not in source
+        assert ".hermes/skills" not in source
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Adds `skillhub-install` — a skill for installing skills from the SkillHub (skillhub.cn) marketplace into Hermes.

## Why

SkillHub (skillhub.cn) is a Chinese-optimized skills marketplace with 35,000+ skills. This skill provides a one-command installer that:

- Downloads skill packages from the SkillHub API
- Auto-converts OpenClaw frontmatter to Hermes format
- Smart category mapping (productivity, github, mlops, creative, etc.)
- Dependency checking (bins, env vars)
- Uses SkillHub as the sole source (no ClawHub dependency)

## How to test

```bash
# Install a skill from SkillHub
python3 skills/productivity/skillhub-install/scripts/install_skill.py baidu-search

# Or use the skill directly
/skillhub-install baidu-search
```

## Platforms tested

- Linux (WSL2)

## Files added

- `skills/productivity/skillhub-install/SKILL.md` — Skill documentation
- `skills/productivity/skillhub-install/scripts/install_skill.py` — Installation script
