### PR TITLE
fix(docker): exclude compose/profile runtime state from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,7 @@ node_modules
 
 # Runtime data (bind-mounted at /opt/data; must not leak into build context)
 data/
+
+# Compose/profile runtime state (bind-mounted; avoid ownership/secret issues)
+hermes-config/
+runtime/


### PR DESCRIPTION
## Summary

Add `hermes-config/` and `runtime/` to `.dockerignore` to prevent local compose/profile runtime state from leaking into Docker build context.

Fixes #15221

## Why

Compose/profile setups keep runtime state (config, auth, session data) outside the image via bind mounts. Including these directories in the build context causes:
- Slower builds
- Potential secret/local data exposure
- Rebuild failures when Docker can't read container-runtime-owned files

## Changes

- Added `hermes-config/` and `runtime/` to `.dockerignore`

## Testing

- Existing source files required for image builds are unaffected
- Safe for users who don't use those directories (no-op)