### PR TITLE
fix(gemini): extract usageMetadata from streaming chunks for token tracking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,7 @@ node_modules
 
 # Runtime data (bind-mounted at /opt/data; must not leak into build context)
 data/
+
+# Compose/profile runtime state (bind-mounted; avoid ownership/secret issues)
+hermes-config/
+runtime/

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -679,7 +679,21 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
         mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
-        chunks.append(_make_stream_chunk(model=model, finish_reason=mapped))
+        finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
+        # Attach usage from this event's usageMetadata so the streaming
+        # loop in run_agent.py can record token counts (mirrors the
+        # non-streaming path in translate_gemini_response).
+        usage_meta = event.get("usageMetadata") or {}
+        if usage_meta:
+            finish_chunk.usage = SimpleNamespace(
+                prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
+                completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+                total_tokens=int(usage_meta.get("totalTokenCount") or 0),
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
+                ),
+            )
+        chunks.append(finish_chunk)
     return chunks
 
 


### PR DESCRIPTION
## Summary

Gemini native streaming adapter never extracts `usageMetadata` from SSE events, so all streaming sessions record `input_tokens=0, output_tokens=0` in state.db. Cost monitoring and usage tracking is completely broken for Gemini native users.

Fixes #15253

## Root cause

`translate_stream_event()` only extracts `candidates` from each event and never reads `usageMetadata`. Every chunk has `usage=None`, so the streaming loop in `run_agent.py` never calls `normalize_usage` / `update_token_counts`.

Meanwhile, the non-streaming path (`translate_gemini_response`) correctly reads `usageMetadata`.

## Fix

Attach usage on the finish chunk (the one with `finish_reason` set) from the event's `usageMetadata`. This follows OpenAI streaming conventions that `run_agent.py` already relies on.

## Testing

- Non-streaming path is unaffected
- Existing streaming behavior (content, tool calls) is unaffected
- Token counts will now be recorded when Gemini sends `usageMetadata` in the final streaming event