### PR TITLE
fix: inject container-in-WSL hint instead of plain WSL hint

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -12,7 +12,7 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_hermes_home, get_skills_dir, is_container, is_wsl
 from typing import Optional
 
 from agent.skill_utils import (
@@ -606,6 +606,11 @@ WSL_ENVIRONMENT_HINT = (
     "the Windows username if needed."
 )
 
+CONTAINER_IN_WSL_ENVIRONMENT_HINT = (
+    "You are running inside a Podman/Docker container on WSL "
+    "(Windows Subsystem for Linux)."
+)
+
 
 # Non-local terminal backends that run commands (and therefore every file
 # tool: read_file, write_file, patch, search_files) inside a separate
@@ -747,7 +752,8 @@ def build_environment_hints() -> str:
       matters. A live probe inside the backend reports its OS, user, $HOME,
       and cwd. Falls back to a static summary if the probe fails.
 
-    The WSL environment hint is appended unchanged when running under WSL.
+    The WSL environment hint is appended when running under WSL.
+    Container-in-WSL is checked before plain WSL.
     """
     import platform
     import sys
@@ -816,7 +822,9 @@ def build_environment_hints() -> str:
                 f"`uname -a && whoami && pwd`."
             )
 
-    if is_wsl():
+    if is_container() and is_wsl():
+        hints.append(CONTAINER_IN_WSL_ENVIRONMENT_HINT)
+    elif is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
     return "\n\n".join(hints)
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -12,7 +12,7 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_hermes_home, get_skills_dir, is_container, is_wsl
 from typing import Optional
 
 from agent.skill_utils import (
@@ -441,15 +441,25 @@ WSL_ENVIRONMENT_HINT = (
     "the Windows username if needed."
 )
 
+CONTAINER_IN_WSL_ENVIRONMENT_HINT = (
+    "You are running inside a Podman/Docker container on WSL "
+    "(Windows Subsystem for Linux)."
+)
+
 
 def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
 
-    Detects WSL, and can be extended for Termux, Docker, etc.
+    Detects container-in-WSL, plain WSL, and can be extended for
+    Termux, Docker, etc.  Container-in-WSL is checked first because
+    ``is_wsl()`` returns True even inside a container on a WSL host,
+    but the container environment differs from bare-metal WSL.
     Returns an empty string when no special environment is detected.
     """
     hints: list[str] = []
-    if is_wsl():
+    if is_container() and is_wsl():
+        hints.append(CONTAINER_IN_WSL_ENVIRONMENT_HINT)
+    elif is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
     return "\n\n".join(hints)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -847,6 +847,7 @@ class TestEnvironmentHints:
     def test_build_environment_hints_on_wsl(self, monkeypatch):
         import agent.prompt_builder as _pb
         monkeypatch.setattr(_pb, "is_wsl", lambda: True)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
         _pb._clear_backend_probe_cache()
         result = _pb.build_environment_hints()
@@ -859,6 +860,7 @@ class TestEnvironmentHints:
         import agent.prompt_builder as _pb
         import sys, platform
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.setattr(sys, "platform", "linux")
         monkeypatch.setattr(platform, "system", lambda: "Linux")
         monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
@@ -879,6 +881,7 @@ class TestEnvironmentHints:
         import agent.prompt_builder as _pb
         import sys
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.setattr(sys, "platform", "win32")
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
         _pb._clear_backend_probe_cache()
@@ -896,6 +899,7 @@ class TestEnvironmentHints:
         import agent.prompt_builder as _pb
         import sys
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.setattr(sys, "platform", "darwin")
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
         _pb._clear_backend_probe_cache()
@@ -911,6 +915,7 @@ class TestEnvironmentHints:
         import agent.prompt_builder as _pb
         import sys
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.setattr(sys, "platform", "win32")
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         # Force the probe to fail so we exercise the static fallback path
@@ -930,6 +935,7 @@ class TestEnvironmentHints:
         """When the probe succeeds, its output must appear in the hint block."""
         import agent.prompt_builder as _pb
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.setenv("TERMINAL_ENV", "modal")
         fake_probe_output = "  OS: Linux 6.8.0\n  User: root\n  Home: /root\n  Working directory: /workspace"
         monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: fake_probe_output)
@@ -947,6 +953,32 @@ class TestEnvironmentHints:
                 f"{backend!r} must be in _REMOTE_TERMINAL_BACKENDS so its host "
                 f"info is suppressed in the system prompt"
             )
+
+    def test_build_environment_hints_container_in_wsl(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: True)
+        monkeypatch.setattr(_pb, "is_container", lambda: True)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Podman" in result or "Docker" in result
+        assert "container" in result.lower()
+        # Should NOT contain the plain-WSL /mnt/c guidance
+        assert "/mnt/c/" not in result
+
+    def test_build_environment_hints_container_not_wsl(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import sys, platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: True)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        # Container without WSL — the container-in-WSL hint must NOT appear,
+        # but host info is still emitted (local backend detected).
+        assert "Podman" not in result
+        assert "/mnt/c/" not in result
+        assert "CONTAINER_IN_WSL" not in result
 
 
 # =========================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -28,6 +28,7 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
+    CONTAINER_IN_WSL_ENVIRONMENT_HINT,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
@@ -835,9 +836,15 @@ class TestEnvironmentHints:
         assert "/mnt/c/" in WSL_ENVIRONMENT_HINT
         assert "WSL" in WSL_ENVIRONMENT_HINT
 
+    def test_container_in_wsl_hint_constant(self):
+        assert "Podman" in CONTAINER_IN_WSL_ENVIRONMENT_HINT
+        assert "container" in CONTAINER_IN_WSL_ENVIRONMENT_HINT.lower()
+        assert "WSL" in CONTAINER_IN_WSL_ENVIRONMENT_HINT
+
     def test_build_environment_hints_on_wsl(self, monkeypatch):
         import agent.prompt_builder as _pb
         monkeypatch.setattr(_pb, "is_wsl", lambda: True)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         result = _pb.build_environment_hints()
         assert "/mnt/" in result
         assert "WSL" in result
@@ -845,7 +852,26 @@ class TestEnvironmentHints:
     def test_build_environment_hints_not_wsl(self, monkeypatch):
         import agent.prompt_builder as _pb
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         result = _pb.build_environment_hints()
+        assert result == ""
+
+    def test_build_environment_hints_container_in_wsl(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: True)
+        monkeypatch.setattr(_pb, "is_container", lambda: True)
+        result = _pb.build_environment_hints()
+        assert "Podman" in result or "Docker" in result
+        assert "container" in result.lower()
+        # Should NOT contain the plain-WSL /mnt/c guidance
+        assert "/mnt/c/" not in result
+
+    def test_build_environment_hints_container_not_wsl(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "is_container", lambda: True)
+        result = _pb.build_environment_hints()
+        # Container without WSL — no hint currently defined for that
         assert result == ""
 
 


### PR DESCRIPTION
## Summary

Fixes incorrect system prompt when running hermes-agent inside a Podman/Docker container on a WSL host.

## Problem

`is_wsl()` returns `True` inside containers running on WSL because `/proc/version` still contains the `microsoft` marker. This causes the agent to inject `WSL_ENVIRONMENT_HINT` which tells it that
 `/mnt/c/` Windows paths are available  ^`^t but inside the container those paths don't exist unless explicitly bind-mounted.

## Solution

- Import `is_container()` from `hermes_constants` (already existed, just wasn't used here)
- Add a new `CONTAINER_IN_WSL_ENVIRONMENT_HINT` constant that correctly describes the environment
- Update `build_environment_hints()` to check `is_container() AND is_wsl()` first, falling back to plain `is_wsl()` only when not in a container

## Changes

- `agent/prompt_builder.py`  ^`^t import `is_container`, add `CONTAINER_IN_WSL_ENVIRONMENT_HINT`, update `build_environment_hints()` logic
- `tests/agent/test_prompt_builder.py` — add 2 new tests for container-in-WSL scenarios, update existing tests to also mock `is_container`

## Test plan

- [x] New test: `test_build_environment_hints_container_in_wsl` verifies container+WSL gets the right hint (no `/mnt/c/`)
- [x] New test: `test_build_environment_hints_container_not_wsl` verifies container without WSL does not get the container-in-WSL hint
- [x] Existing tests updated to mock `is_container` so they remain isolated

Fixes #24370

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 WSL2 Ubuntu 22.04/24.04

