### PR TITLE
feat(pricing): add provider routing for nous and xai

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -400,6 +400,10 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "nous" or base_url_host_matches(base_url or "", "nousresearch"):
+        return BillingRoute(provider="nous", model=(model.split("/")[-1] if model else model), base_url=base_url or "", billing_mode="official_models_api")
+    if provider_name == "xai":
+        return BillingRoute(provider="xai", model=(model.split("/")[-1] if model else model), base_url=base_url or "", billing_mode="official_models_api")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")


### PR DESCRIPTION
## WhatAdds provider resolution for `nous` and `xai` providers in `resolve_billing_route()` so cost estimation attempts model metadata lookups at the endpoint instead of falling through to `"unknown"`.## WhyWithout these routes, any session using Nous or xAI providers returns `cost_status: unknown` — meaning the dashboard, CLI usage summary, and session ledger show \$0.00 for real token consumption. With this change, `get_pricing_entry()` can attempt the endpoint's `/models` API to discover pricing, and falls back to the OpenRouter metadata API as a last resort.## Testing```pythonfrom agent.usage_pricing import resolve_billing_routeassert resolve_billing_route("qwen3.6-plus", provider="nous").provider == "nous"assert resolve_billing_route("grok-4-1-fast-reasoning", provider="xai").provider == "xai"```## Files changed- `agent/usage_pricing.py` — 4 lines added