### PR TITLE
fix(discord): route thread /sethome to stable homes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5974,6 +5974,33 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
+        reroute_note = None
+
+        # In Discord text-channel threads, the stable home destination should be the
+        # parent channel rather than the specific thread. Forum/media posts keep
+        # their own thread ID because deliveries without metadata.thread_id target
+        # chat_id directly, and those parents are not normal send destinations.
+        if platform_name == "discord" and getattr(source, "chat_type", None) == "thread":
+            raw = getattr(event, "raw_message", None)
+            channel = getattr(raw, "channel", None)
+            parent = getattr(channel, "parent", None)
+            parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
+            parent_type = getattr(parent, "type", None)
+            parent_type_value = getattr(parent_type, "value", parent_type)
+            parent_class_name = getattr(parent.__class__, "__name__", "")
+            is_forum_parent = parent_type_value in (15, 16) or parent_class_name in {"ForumChannel", "MediaChannel"}
+            if parent is not None and parent_id is not None and not is_forum_parent:
+                chat_id = str(parent_id)
+                parent_name = getattr(parent, "name", None)
+                guild = getattr(parent, "guild", None) or getattr(channel, "guild", None)
+                guild_name = getattr(guild, "name", None)
+                if parent_name and guild_name:
+                    chat_name = f"{guild_name} / #{parent_name}"
+                elif parent_name:
+                    chat_name = parent_name
+                else:
+                    chat_name = chat_id
+                reroute_note = "Using the parent channel for stable Discord home delivery; explicit thread deliveries still use thread metadata."
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
@@ -5992,10 +6019,13 @@ class GatewayRunner:
         except Exception as e:
             return f"Failed to save home channel: {e}"
         
-        return (
+        response = (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."
         )
+        if reroute_note:
+            response += f"\n{reroute_note}"
+        return response
     
     @staticmethod
     def _get_guild_id(event: MessageEvent) -> Optional[int]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5985,11 +5985,8 @@ class GatewayRunner:
             channel = getattr(raw, "channel", None)
             parent = getattr(channel, "parent", None)
             parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
-            parent_type = getattr(parent, "type", None)
-            parent_type_value = getattr(parent_type, "value", parent_type)
-            parent_class_name = getattr(parent.__class__, "__name__", "")
-            is_forum_parent = parent_type_value in (15, 16) or parent_class_name in {"ForumChannel", "MediaChannel"}
-            if parent is not None and parent_id is not None and not is_forum_parent:
+            is_post_parent = self._discord_parent_is_forum_or_media(parent)
+            if parent is not None and parent_id is not None and not is_post_parent:
                 chat_id = str(parent_id)
                 parent_name = getattr(parent, "name", None)
                 guild = getattr(parent, "guild", None) or getattr(channel, "guild", None)
@@ -6027,6 +6024,37 @@ class GatewayRunner:
             response += f"\n{reroute_note}"
         return response
     
+    @staticmethod
+    def _discord_parent_is_forum_or_media(parent: Any) -> bool:
+        """Return True for Discord forum/media parent channels.
+
+        Prefer discord.py's ChannelType enum when available. The lightweight
+        name/class fallbacks keep tests and older adapter objects working
+        without hard-coding Discord's numeric channel type values.
+        """
+        if parent is None:
+            return False
+        parent_type = getattr(parent, "type", None)
+        try:
+            import discord  # type: ignore
+
+            channel_type = getattr(discord, "ChannelType", None)
+            for expected in (
+                getattr(channel_type, "forum", None),
+                getattr(channel_type, "media", None),
+            ):
+                if expected is not None and parent_type == expected:
+                    return True
+        except Exception:
+            pass
+
+        parent_type_name = getattr(parent_type, "name", None)
+        if parent_type_name in {"forum", "media"}:
+            return True
+
+        parent_class_name = getattr(parent.__class__, "__name__", "")
+        return parent_class_name in {"ForumChannel", "MediaChannel"}
+
     @staticmethod
     def _get_guild_id(event: MessageEvent) -> Optional[int]:
         """Extract Discord guild_id from the raw message object."""

--- a/tests/gateway/test_set_home_command.py
+++ b/tests/gateway/test_set_home_command.py
@@ -1,0 +1,276 @@
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+class ForumChannel:
+    pass
+
+
+class MediaChannel:
+    pass
+
+
+class FakeType:
+    def __init__(self, value):
+        self.value = value
+
+
+@pytest.mark.asyncio
+async def test_sethome_uses_parent_channel_for_discord_thread(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = SimpleNamespace(id=987654321, name="agent-ops", guild=guild)
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1496043680090558464",
+            chat_name="hermes-apl",
+            chat_type="thread",
+            thread_id="1496043680090558464",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m1",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / #agent-ops" in result
+    assert "987654321" in result
+    assert "stable Discord home delivery" in result
+    assert (tmp_path / "config.yaml").exists()
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "987654321"
+    assert gateway_run.os.environ["DISCORD_HOME_CHANNEL"] == "987654321"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_forum_thread_as_home_target(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = ForumChannel()
+    parent.id = 222
+    parent.name = "ideas"
+    parent.guild = guild
+    parent.type = FakeType(15)
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="333",
+            chat_name="GSV / ideas / post-1",
+            chat_type="thread",
+            thread_id="333",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-forum",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / ideas / post-1" in result
+    assert "(ID: 333)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "333"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_media_thread_as_home_target(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = MediaChannel()
+    parent.id = 444
+    parent.name = "media"
+    parent.guild = guild
+    parent.type = FakeType(16)
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_name="GSV / media / post-1",
+            chat_type="thread",
+            thread_id="555",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-media",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / media / post-1" in result
+    assert "(ID: 555)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "555"
+
+
+@pytest.mark.asyncio
+async def test_sethome_uses_media_class_name_fallback_when_type_missing(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = MediaChannel()
+    parent.id = 666
+    parent.name = "media"
+    parent.guild = guild
+    parent.type = None
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="777",
+            chat_name="GSV / media / post-2",
+            chat_type="thread",
+            thread_id="777",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-media-fallback",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / media / post-2" in result
+    assert "(ID: 777)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "777"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_thread_when_parent_object_is_missing(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    channel = SimpleNamespace(parent=None, parent_id=987654321, guild=SimpleNamespace(name="GSV"))
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1496043680090558464",
+            chat_name="GSV / #agent-ops / hermes-apl",
+            chat_type="thread",
+            thread_id="1496043680090558464",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-missing-parent",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "(ID: 1496043680090558464)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "1496043680090558464"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_current_chat_for_non_thread_discord(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="444",
+            chat_name="GSV / #agent-ops",
+            chat_type="group",
+            user_id="u1",
+            user_name="tester",
+        ),
+        message_id="m3",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / #agent-ops" in result
+    assert "(ID: 444)" in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "444"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_current_chat_for_non_thread_sources(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_name="Primary DM",
+            chat_type="dm",
+            user_id="u1",
+            user_name="tester",
+        ),
+        message_id="m2",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "Primary DM" in result
+    assert "12345" in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["TELEGRAM_HOME_CHANNEL"] == "12345"
+    assert gateway_run.os.environ["TELEGRAM_HOME_CHANNEL"] == "12345"

--- a/tests/gateway/test_set_home_command.py
+++ b/tests/gateway/test_set_home_command.py
@@ -17,8 +17,8 @@ class MediaChannel:
 
 
 class FakeType:
-    def __init__(self, value):
-        self.value = value
+    def __init__(self, name):
+        self.name = name
 
 
 @pytest.mark.asyncio
@@ -73,7 +73,7 @@ async def test_sethome_keeps_forum_thread_as_home_target(monkeypatch, tmp_path):
     parent.id = 222
     parent.name = "ideas"
     parent.guild = guild
-    parent.type = FakeType(15)
+    parent.type = FakeType("forum")
     channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
     raw_message = SimpleNamespace(channel=channel)
 
@@ -114,7 +114,7 @@ async def test_sethome_keeps_media_thread_as_home_target(monkeypatch, tmp_path):
     parent.id = 444
     parent.name = "media"
     parent.guild = guild
-    parent.type = FakeType(16)
+    parent.type = FakeType("media")
     channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
     raw_message = SimpleNamespace(channel=channel)
 

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -157,9 +157,13 @@ Run `/usage` periodically to see your token consumption. Run `/insights` for a b
 
 Use `/sethome` in your preferred Telegram or Discord chat to designate it as the home channel. Cron job results and scheduled task outputs are delivered here. Without it, the agent has nowhere to send proactive messages.
 
+For Discord, the best personal pattern is a durable parent channel (for example `#agent-ops`) plus one thread per task. If you run `/sethome` from a normal thread, Hermes stores the parent channel so deliveries still land in the stable channel instead of a single task thread.
+
 ### Use /title to Organize Sessions
 
 Name your sessions with `/title auth-refactor` or `/title research-llm-quantization`. Named sessions are easy to find with `hermes sessions list` and resume with `hermes -r "auth-refactor"`. Unnamed sessions pile up and become impossible to distinguish.
+
+For Beads-driven work in Discord, include the issue ID in the title or opening message (`hermes-mge discord workflow`). That makes later pickup prompts like `pick up hermes-mge` much more reliable across threads and sessions.
 
 ### DM Pairing for Team Access
 

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -163,7 +163,7 @@ For Discord, the best personal pattern is a durable parent channel (for example 
 
 Name your sessions with `/title auth-refactor` or `/title research-llm-quantization`. Named sessions are easy to find with `hermes sessions list` and resume with `hermes -r "auth-refactor"`. Unnamed sessions pile up and become impossible to distinguish.
 
-For Beads-driven work in Discord, include the issue ID in the title or opening message (`hermes-mge discord workflow`). That makes later pickup prompts like `pick up hermes-mge` much more reliable across threads and sessions.
+For issue-driven work in Discord, include the issue or ticket ID in the title or opening message (`hermes-mge discord workflow`). That makes later pickup prompts like `pick up hermes-mge` much more reliable across threads and sessions.
 
 ### DM Pairing for Team Access
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -489,9 +489,9 @@ For a single operator using Hermes heavily in Discord, the smoothest pattern is:
 1. **Pick one durable parent channel** (for example `#agent-ops`) as the home base for deliveries.
 2. **Run `/sethome` there once**. If you happen to run `/sethome` from a normal thread under that channel, Hermes stores the parent channel ID so cron jobs and cross-platform deliveries still land in the stable parent channel. Forum/media post threads keep their own thread ID.
 3. **Use one thread per substantial task**. Start a new thread for each feature, bug, or research lane so transcript history stays isolated and easy to revisit.
-4. **Lead with the work item ID** when you want continuity, e.g. `pick up hermes-mge; continue ...`. This gives Hermes a strong retrieval handle for Beads issues and past session search.
-5. **Name the session with `/title`** if you expect to resume it from another surface later. A good default is the Beads ID plus a short slug, such as `/title hermes-mge discord workflow`.
-6. **Resume in place when possible**. If the original thread is still the right lane, keep talking there. If you need to move surfaces or recover after a reset, use `/resume <name>` or explicitly say `pick up <bead-id>`.
+4. **Lead with the work item ID** when you want continuity, e.g. `pick up hermes-mge; continue ...`. This gives Hermes a strong retrieval handle for past session search.
+5. **Name the session with `/title`** if you expect to resume it from another surface later. A good default is the work item ID plus a short slug, such as `/title hermes-mge discord workflow`.
+6. **Resume in place when possible**. If the original thread is still the right lane, keep talking there. If you need to move surfaces or recover after a reset, use `/resume <name>` or explicitly say `pick up <work-item-id>`.
 
 This gives you a stable inbox for proactive deliveries plus disposable task threads for execution.
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -17,7 +17,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
 | **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline — auto-threading is skipped so the channel stays a lightweight chat. |
-| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
+| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. For `/sethome`, a normal text-channel thread stores the parent channel as the stable home destination, while forum/media post threads keep their own thread ID. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
@@ -482,13 +482,30 @@ Hermes automatically registers installed skills as **native Discord Application 
 
 No extra configuration is needed — any skill installed via `hermes skills install` is automatically registered as a Discord slash command on the next gateway restart.
 
+## Recommended Personal Workflow
+
+For a single operator using Hermes heavily in Discord, the smoothest pattern is:
+
+1. **Pick one durable parent channel** (for example `#agent-ops`) as the home base for deliveries.
+2. **Run `/sethome` there once**. If you happen to run `/sethome` from a normal thread under that channel, Hermes stores the parent channel ID so cron jobs and cross-platform deliveries still land in the stable parent channel. Forum/media post threads keep their own thread ID.
+3. **Use one thread per substantial task**. Start a new thread for each feature, bug, or research lane so transcript history stays isolated and easy to revisit.
+4. **Lead with the work item ID** when you want continuity, e.g. `pick up hermes-mge; continue ...`. This gives Hermes a strong retrieval handle for Beads issues and past session search.
+5. **Name the session with `/title`** if you expect to resume it from another surface later. A good default is the Beads ID plus a short slug, such as `/title hermes-mge discord workflow`.
+6. **Resume in place when possible**. If the original thread is still the right lane, keep talking there. If you need to move surfaces or recover after a reset, use `/resume <name>` or explicitly say `pick up <bead-id>`.
+
+This gives you a stable inbox for proactive deliveries plus disposable task threads for execution.
+
 ## Home Channel
 
 You can designate a "home channel" where the bot sends proactive messages (such as cron job output, reminders, and notifications). There are two ways to set it:
 
 ### Using the Slash Command
 
-Type `/sethome` in any Discord channel where the bot is present. That channel becomes the home channel.
+Type `/sethome` in any Discord channel where the bot is present.
+
+- In a **regular channel**, that channel becomes the home channel.
+- In a **normal text-channel thread**, Hermes stores the **parent channel** as the home destination so scheduled deliveries do not get stranded in one ephemeral thread.
+- In a **forum or media post thread**, Hermes keeps the **thread itself** as the destination, because those parents are not directly messageable like normal text channels.
 
 ### Manual Configuration
 


### PR DESCRIPTION
## Prompt to Recreate

> Starting from `origin/main`, split the Discord-only `/sethome` routing changes out of non-atomic PR #14389. Preserve the behavior where `/sethome` invoked from a normal Discord text-channel thread stores the parent channel as the home destination, while forum/media post threads keep their thread ID. Keep the change limited to `gateway/run.py`, `tests/gateway/test_set_home_command.py`, and Discord docs.

---

## Bug Description

PR #14389 mixed a Discord gateway bugfix with an unrelated CASS tool feature. This replacement PR contains only the Discord `/sethome` routing fix.

When `/sethome` was invoked inside a normal Discord text-channel thread, Hermes stored that transient thread as the platform home channel. Cron jobs and cross-platform deliveries should use the stable parent channel instead. Forum/media post threads are different: the post thread itself is the send destination, so those must keep the thread ID.

## Root Cause

`GatewayRunner._handle_set_home_command()` used `event.source.chat_id` directly for all Discord threads. It did not distinguish normal text-channel threads from forum/media post threads.

## Fix

- Detect Discord thread sources in `_handle_set_home_command()`.
- For normal text-channel threads with a parent channel, store the parent channel ID/name.
- Preserve forum/media post thread IDs.
- Add a response note when Hermes reroutes to the parent channel.
- Add focused gateway regression tests.
- Update Discord docs for `/sethome` thread behavior.

## How to Verify

```bash
/home/agent/hermes-agent/venv/bin/python -m pytest tests/gateway/test_set_home_command.py -q -o 'addopts=' --tb=short
git diff --check origin/main..HEAD
```

Expected:

```text
7 passed
git diff --check: no output
```

## Test Plan

- [x] `tests/gateway/test_set_home_command.py`
- [x] `git diff --check origin/main..HEAD`

## Risk Assessment

Low. This is scoped to `/sethome` handling and Discord documentation. Non-Discord platforms keep the existing current-chat behavior.