### PR TITLE
feat(tools): add CASS session intelligence tools

### DIFF
--- a/tests/tools/test_cass_tool.py
+++ b/tests/tools/test_cass_tool.py
@@ -115,6 +115,43 @@ def test_cass_search_uses_separator_for_hyphen_leading_query():
     assert runner.calls[0][0][-2:] == ["--", "-h"]
 
 
+def test_cass_search_rejects_invalid_integer_filters_before_subprocess():
+    from tools.cass_tool import cass_search
+
+    with patch("tools.cass_tool.subprocess.run") as run:
+        bad_offset = json.loads(cass_search("query", offset="not-a-number"))
+        bad_days = json.loads(cass_search("query", days="not-a-number"))
+
+    run.assert_not_called()
+    assert bad_offset["success"] is False
+    assert "offset" in bad_offset["error"]
+    assert bad_days["success"] is False
+    assert "days" in bad_days["error"]
+
+
+def test_cass_search_supports_repeated_workspace_and_agent_filters():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        json.loads(
+            cass_search(
+                "query",
+                workspace=["/repo/a", "/repo/b"],
+                agent=["claude_code", "codex"],
+            )
+        )
+
+    cmd = runner.calls[0][0]
+    assert cmd.count("--workspace") == 2
+    assert cmd.count("--agent") == 2
+    assert "/repo/a" in cmd and "/repo/b" in cmd
+    assert "claude_code" in cmd and "codex" in cmd
+
+
 def test_missing_cass_returns_clear_error():
     from tools.cass_tool import cass_status
 
@@ -175,3 +212,32 @@ def test_cass_context_and_analytics_parse_json_results():
         "--workspace",
         "/repo",
     ]
+
+
+def test_cass_analytics_rejects_invalid_days_before_subprocess():
+    from tools.cass_tool import cass_analytics
+
+    with patch("tools.cass_tool.subprocess.run") as run:
+        result = json.loads(cass_analytics(kind="tokens", days="not-a-number"))
+
+    run.assert_not_called()
+    assert result["success"] is False
+    assert "days" in result["error"]
+
+
+def test_cass_schemas_allow_repeated_filter_arrays():
+    from tools import cass_tool
+
+    search_props = cass_tool._CASS_SEARCH_SCHEMA["parameters"]["properties"]
+    timeline_props = cass_tool._CASS_TIMELINE_SCHEMA["parameters"]["properties"]
+    analytics_props = cass_tool._CASS_ANALYTICS_SCHEMA["parameters"]["properties"]
+
+    for schema in (
+        search_props["workspace"],
+        search_props["agent"],
+        timeline_props["agent"],
+        analytics_props["workspace"],
+        analytics_props["agent"],
+    ):
+        assert schema["type"] == "array"
+        assert schema["items"] == {"type": "string"}

--- a/tests/tools/test_cass_tool.py
+++ b/tests/tools/test_cass_tool.py
@@ -1,0 +1,177 @@
+"""Tests for tools/cass_tool.py — CASS CLI wrappers for session intelligence."""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+
+class _RunRecorder:
+    def __init__(self, returncode=0, stdout=None, stderr=""):
+        self.calls = []
+        self.returncode = returncode
+        self.stdout = stdout if stdout is not None else json.dumps({"ok": True})
+        self.stderr = stderr
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, self.returncode, self.stdout, self.stderr)
+
+
+def test_check_cass_requirements_uses_path_lookup():
+    from tools.cass_tool import check_cass_requirements
+
+    with patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"):
+        assert check_cass_requirements() is True
+
+    with patch("tools.cass_tool.shutil.which", return_value=None):
+        assert check_cass_requirements() is False
+
+
+def test_cass_search_builds_robot_json_command_with_filters():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": [{"title": "match"}]}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        result = json.loads(
+            cass_search(
+                "Sylveste Clavain",
+                limit=3,
+                mode="lexical",
+                workspace="/home/mk/projects/Sylveste",
+                agent="claude_code",
+                since="2026-04-01",
+                until="2026-04-23",
+            )
+        )
+
+    cmd, kwargs = runner.calls[0]
+    assert cmd == [
+        "cass",
+        "search",
+        "--json",
+        "--limit",
+        "3",
+        "--mode",
+        "lexical",
+        "--workspace",
+        "/home/mk/projects/Sylveste",
+        "--agent",
+        "claude_code",
+        "--since",
+        "2026-04-01",
+        "--until",
+        "2026-04-23",
+        "--max-content-length",
+        "2000",
+        "--",
+        "Sylveste Clavain",
+    ]
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
+    assert result["success"] is True
+    assert result["command"] == "search"
+    assert result["data"]["hits"][0]["title"] == "match"
+
+
+def test_cass_search_rejects_empty_query_before_running_subprocess():
+    from tools.cass_tool import cass_search
+
+    with patch("tools.cass_tool.subprocess.run") as run:
+        result = json.loads(cass_search("   "))
+
+    run.assert_not_called()
+    assert result["success"] is False
+    assert "query" in result["error"].lower()
+
+
+def test_cass_search_clamps_limit_to_bounded_positive_range():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        json.loads(cass_search("not unbounded", limit=0))
+        json.loads(cass_search("not huge", limit=5000))
+
+    assert runner.calls[0][0][runner.calls[0][0].index("--limit") + 1] == "1"
+    assert runner.calls[1][0][runner.calls[1][0].index("--limit") + 1] == "25"
+
+
+def test_cass_search_uses_separator_for_hyphen_leading_query():
+    from tools.cass_tool import cass_search
+
+    runner = _RunRecorder(stdout=json.dumps({"hits": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        json.loads(cass_search("-h", limit=1))
+
+    assert runner.calls[0][0][-2:] == ["--", "-h"]
+
+
+def test_missing_cass_returns_clear_error():
+    from tools.cass_tool import cass_status
+
+    with patch("tools.cass_tool.shutil.which", return_value=None):
+        result = json.loads(cass_status())
+
+    assert result["success"] is False
+    assert "cass" in result["error"].lower()
+    assert "install" in result["hint"].lower()
+
+
+def test_semantic_unavailable_error_suggests_lexical_fallback():
+    from tools.cass_tool import cass_search
+
+    payload = {
+        "error": {
+            "code": 15,
+            "kind": "semantic-unavailable",
+            "message": "Semantic search not available: vector index missing",
+            "hint": "Run cass index --semantic --embedder hash, or use --mode lexical",
+            "retryable": False,
+        }
+    }
+    runner = _RunRecorder(returncode=15, stdout=json.dumps(payload))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        result = json.loads(cass_search("intercore", mode="hybrid"))
+
+    assert result["success"] is False
+    assert result["code"] == 15
+    assert result["kind"] == "semantic-unavailable"
+    assert "--mode lexical" in result["hint"]
+
+
+def test_cass_context_and_analytics_parse_json_results():
+    from tools.cass_tool import cass_analytics, cass_context
+
+    runner = _RunRecorder(stdout=json.dumps({"items": []}))
+    with (
+        patch("tools.cass_tool.shutil.which", return_value="/usr/local/bin/cass"),
+        patch("tools.cass_tool.subprocess.run", runner),
+    ):
+        context_result = json.loads(cass_context("/tmp/session.jsonl", limit=2))
+        analytics_result = json.loads(cass_analytics(kind="tokens", days=7, workspace="/repo"))
+
+    assert context_result["success"] is True
+    assert analytics_result["success"] is True
+    assert runner.calls[0][0] == ["cass", "context", "--json", "--limit", "2", "--", "/tmp/session.jsonl"]
+    assert runner.calls[1][0] == [
+        "cass",
+        "analytics",
+        "tokens",
+        "--json",
+        "--days",
+        "7",
+        "--workspace",
+        "/repo",
+    ]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -294,6 +294,7 @@ class TestBuiltinDiscovery:
             "tools.browser_cdp_tool",
             "tools.browser_dialog_tool",
             "tools.browser_tool",
+            "tools.cass_tool",
             "tools.clarify_tool",
             "tools.code_execution_tool",
             "tools.cronjob_tools",

--- a/tools/cass_tool.py
+++ b/tools/cass_tool.py
@@ -138,6 +138,17 @@ def _bounded_int(value: int | str | None, *, default: int, minimum: int, maximum
     return min(max(number, minimum), maximum)
 
 
+def _nonnegative_int_arg(value: Any, *, name: str, command: str) -> tuple[int | None, str | None]:
+    try:
+        return max(0, int(value)), None
+    except (TypeError, ValueError):
+        return None, tool_error(f"{name} must be an integer", success=False, command=command)
+
+
+def _string_array_filter_schema(description: str) -> dict[str, Any]:
+    return {"type": "array", "items": {"type": "string"}, "description": description}
+
+
 def cass_status() -> str:
     """Return CASS index health and database status."""
     return _run_cass(["status", "--json"], command="status", timeout=30)
@@ -187,8 +198,11 @@ def cass_search(
         "--mode",
         mode,
     ]
-    if offset:
-        args.extend(["--offset", str(max(0, int(offset)))])
+    if offset not in (None, "", 0):
+        offset_value, error = _nonnegative_int_arg(offset, name="offset", command="search")
+        if error:
+            return error
+        args.extend(["--offset", str(offset_value)])
     _append_repeated(args, "--workspace", workspace)
     _append_repeated(args, "--agent", agent)
     if since:
@@ -196,7 +210,10 @@ def cass_search(
     if until:
         args.extend(["--until", until])
     if days is not None:
-        args.extend(["--days", str(max(0, int(days)))])
+        days_value, error = _nonnegative_int_arg(days, name="days", command="search")
+        if error:
+            return error
+        args.extend(["--days", str(days_value)])
     if fields:
         args.extend(["--fields", fields])
     if max_content_length is not None:
@@ -286,7 +303,10 @@ def cass_analytics(
     args = ["analytics", kind, "--json"]
     if kind != "status":
         if days is not None:
-            args.extend(["--days", str(max(0, int(days)))])
+            days_value, error = _nonnegative_int_arg(days, name="days", command="analytics")
+            if error:
+                return error
+            args.extend(["--days", str(days_value)])
         if since:
             args.extend(["--since", since])
         if until:
@@ -324,8 +344,8 @@ _CASS_SEARCH_SCHEMA = {
             "query": {"type": "string", "description": "Search query."},
             "limit": {"type": "integer", "description": "Maximum number of hits to return (bounded 1-25).", "default": 5, "minimum": 1, "maximum": 25},
             "mode": {"type": "string", "enum": sorted(_ALLOWED_SEARCH_MODES), "default": "lexical"},
-            "workspace": {"type": "string", "description": "Workspace path filter."},
-            "agent": {"type": "string", "description": "Agent slug filter, e.g. claude_code."},
+            "workspace": _string_array_filter_schema("Workspace path filters."),
+            "agent": _string_array_filter_schema("Agent slug filters, e.g. claude_code."),
             "since": {"type": "string", "description": "Start date/time filter."},
             "until": {"type": "string", "description": "End date/time filter."},
             "days": {"type": "integer", "description": "Filter to last N days."},
@@ -360,7 +380,7 @@ _CASS_TIMELINE_SCHEMA = {
             "since": {"type": "string"},
             "until": {"type": "string"},
             "today": {"type": "boolean", "default": False},
-            "agent": {"type": "string"},
+            "agent": _string_array_filter_schema("Agent slug filters."),
             "group_by": {"type": "string", "enum": ["hour", "day", "none"], "default": "day"},
             "source": {"type": "string"},
         },
@@ -391,8 +411,8 @@ _CASS_ANALYTICS_SCHEMA = {
         "properties": {
             "kind": {"type": "string", "enum": sorted(_ALLOWED_ANALYTICS_KINDS), "default": "tokens"},
             "days": {"type": "integer", "default": 7},
-            "workspace": {"type": "string"},
-            "agent": {"type": "string"},
+            "workspace": _string_array_filter_schema("Workspace path filters."),
+            "agent": _string_array_filter_schema("Agent slug filters."),
             "source": {"type": "string"},
             "group_by": {"type": "string", "enum": ["hour", "day", "week", "month"]},
             "since": {"type": "string"},

--- a/tools/cass_tool.py
+++ b/tools/cass_tool.py
@@ -1,0 +1,505 @@
+"""CASS CLI tools for cross-agent session intelligence.
+
+CASS (Coding Agent Session Search) indexes coding-agent histories across
+providers such as Claude Code, Codex, and Gemini.  Hermes uses these wrappers as
+an explicit continuity backend instead of shelling out through the generic
+terminal tool for every recall query.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections.abc import Iterable
+from typing import Any
+
+from tools.registry import registry, tool_error, tool_result
+
+_CASS_INSTALL_HINT = (
+    "Install cass and ensure it is on PATH. Expected binary name: cass. "
+    "See https://github.com/Dicklesworthstone/coding_agent_session_search"
+)
+_ALLOWED_SEARCH_MODES = {"lexical", "semantic", "hybrid"}
+_ALLOWED_EXPORT_FORMATS = {"markdown", "text", "json", "html"}
+_ALLOWED_ANALYTICS_KINDS = {"status", "tokens", "tools", "models"}
+_ALLOWED_GROUP_BY = {"hour", "day", "week", "month", "none"}
+_SEARCH_DEFAULT_LIMIT = 5
+_SEARCH_MAX_LIMIT = 25
+_DEFAULT_SEARCH_CONTENT_LENGTH = 2000
+
+
+def check_cass_requirements() -> bool:
+    """Return True when the CASS CLI is available on PATH."""
+    return shutil.which("cass") is not None
+
+
+def _parse_json_maybe(text: str) -> Any | None:
+    text = (text or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _normalize_cli_error(
+    *,
+    command: str,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+) -> str:
+    parsed = _parse_json_maybe(stdout) or _parse_json_maybe(stderr)
+    if isinstance(parsed, dict) and isinstance(parsed.get("error"), dict):
+        error = parsed["error"]
+        kind = error.get("kind")
+        message = error.get("message") or stderr or stdout or f"cass {command} failed"
+        hint = error.get("hint") or ""
+        if kind == "semantic-unavailable" and "--mode lexical" not in hint:
+            hint = (hint + " Use --mode lexical as a fallback.").strip()
+        return tool_result(
+            success=False,
+            command=command,
+            error=message,
+            code=error.get("code", returncode),
+            kind=kind,
+            hint=hint,
+            retryable=error.get("retryable"),
+        )
+
+    message = (stderr or stdout or f"cass {command} exited with status {returncode}").strip()
+    return tool_error(message, success=False, command=command, code=returncode)
+
+
+def _run_cass(args: list[str], *, command: str, timeout: int = 120) -> str:
+    if not check_cass_requirements():
+        return tool_error(
+            "cass CLI not found on PATH",
+            success=False,
+            command=command,
+            hint=_CASS_INSTALL_HINT,
+        )
+
+    argv = ["cass", *args]
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        return tool_error(
+            f"cass {command} timed out after {timeout}s",
+            success=False,
+            command=command,
+            code="timeout",
+        )
+    except OSError as exc:
+        return tool_error(str(exc), success=False, command=command)
+
+    if result.returncode != 0:
+        return _normalize_cli_error(
+            command=command,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    parsed = _parse_json_maybe(result.stdout)
+    return tool_result({
+        "success": True,
+        "command": command,
+        "data": parsed if parsed is not None else result.stdout,
+    })
+
+
+def _as_list(value: str | Iterable[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _append_repeated(args: list[str], flag: str, values: str | Iterable[str] | None) -> None:
+    for value in _as_list(values):
+        args.extend([flag, value])
+
+
+def _bounded_int(value: int | str | None, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        number = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        number = default
+    return min(max(number, minimum), maximum)
+
+
+def cass_status() -> str:
+    """Return CASS index health and database status."""
+    return _run_cass(["status", "--json"], command="status", timeout=30)
+
+
+def cass_search(
+    query: str,
+    limit: int = 5,
+    mode: str = "lexical",
+    workspace: str | list[str] | None = None,
+    agent: str | list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    days: int | None = None,
+    offset: int = 0,
+    fields: str | None = None,
+    max_content_length: int | None = None,
+    source: str | None = None,
+) -> str:
+    """Search indexed coding-agent sessions with CASS."""
+    if not (query or "").strip():
+        return tool_error("query is required", success=False, command="search")
+    if mode not in _ALLOWED_SEARCH_MODES:
+        return tool_error(
+            f"mode must be one of: {', '.join(sorted(_ALLOWED_SEARCH_MODES))}",
+            success=False,
+            command="search",
+        )
+
+    bounded_limit = _bounded_int(
+        limit,
+        default=_SEARCH_DEFAULT_LIMIT,
+        minimum=1,
+        maximum=_SEARCH_MAX_LIMIT,
+    )
+    bounded_content_length = _bounded_int(
+        max_content_length,
+        default=_DEFAULT_SEARCH_CONTENT_LENGTH,
+        minimum=200,
+        maximum=10_000,
+    )
+    args = [
+        "search",
+        "--json",
+        "--limit",
+        str(bounded_limit),
+        "--mode",
+        mode,
+    ]
+    if offset:
+        args.extend(["--offset", str(max(0, int(offset)))])
+    _append_repeated(args, "--workspace", workspace)
+    _append_repeated(args, "--agent", agent)
+    if since:
+        args.extend(["--since", since])
+    if until:
+        args.extend(["--until", until])
+    if days is not None:
+        args.extend(["--days", str(max(0, int(days)))])
+    if fields:
+        args.extend(["--fields", fields])
+    if max_content_length is not None:
+        args.extend(["--max-content-length", str(bounded_content_length)])
+    else:
+        args.extend(["--max-content-length", str(_DEFAULT_SEARCH_CONTENT_LENGTH)])
+    if source:
+        args.extend(["--source", source])
+    args.extend(["--", query])
+
+    return _run_cass(args, command="search")
+
+
+def cass_context(path: str, limit: int = 5) -> str:
+    """Find sessions related to a CASS source/session path."""
+    if not (path or "").strip():
+        return tool_error("path is required", success=False, command="context")
+    args = ["context", "--json", "--limit", str(_bounded_int(limit, default=5, minimum=1, maximum=25)), "--", path]
+    return _run_cass(args, command="context")
+
+
+def cass_timeline(
+    since: str | None = None,
+    until: str | None = None,
+    today: bool = False,
+    agent: str | list[str] | None = None,
+    group_by: str = "day",
+    source: str | None = None,
+) -> str:
+    """Return activity timeline data from indexed CASS sessions."""
+    if group_by not in {"hour", "day", "none"}:
+        return tool_error("group_by must be one of: hour, day, none", success=False, command="timeline")
+    args = ["timeline", "--json", "--group-by", group_by]
+    if today:
+        args.append("--today")
+    if since:
+        args.extend(["--since", since])
+    if until:
+        args.extend(["--until", until])
+    _append_repeated(args, "--agent", agent)
+    if source:
+        args.extend(["--source", source])
+    return _run_cass(args, command="timeline")
+
+
+def cass_export(
+    session_path: str,
+    format: str = "markdown",
+    output_path: str | None = None,
+    include_tools: bool = False,
+) -> str:
+    """Export a CASS session transcript."""
+    if not (session_path or "").strip():
+        return tool_error("session_path is required", success=False, command="export")
+    if format not in _ALLOWED_EXPORT_FORMATS:
+        return tool_error(
+            f"format must be one of: {', '.join(sorted(_ALLOWED_EXPORT_FORMATS))}",
+            success=False,
+            command="export",
+        )
+    args = ["export", "--format", format]
+    if output_path:
+        args.extend(["--output", output_path])
+    if include_tools:
+        args.append("--include-tools")
+    args.extend(["--", session_path])
+    return _run_cass(args, command="export")
+
+
+def cass_analytics(
+    kind: str = "tokens",
+    days: int | None = 7,
+    workspace: str | list[str] | None = None,
+    agent: str | list[str] | None = None,
+    source: str | None = None,
+    group_by: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> str:
+    """Return token/tool/model analytics from CASS rollups."""
+    if kind not in _ALLOWED_ANALYTICS_KINDS:
+        return tool_error(
+            f"kind must be one of: {', '.join(sorted(_ALLOWED_ANALYTICS_KINDS))}",
+            success=False,
+            command="analytics",
+        )
+    args = ["analytics", kind, "--json"]
+    if kind != "status":
+        if days is not None:
+            args.extend(["--days", str(max(0, int(days)))])
+        if since:
+            args.extend(["--since", since])
+        if until:
+            args.extend(["--until", until])
+        _append_repeated(args, "--workspace", workspace)
+        _append_repeated(args, "--agent", agent)
+        if source:
+            args.extend(["--source", source])
+        if group_by:
+            if group_by not in _ALLOWED_GROUP_BY - {"none"}:
+                return tool_error(
+                    "group_by must be one of: hour, day, week, month",
+                    success=False,
+                    command="analytics",
+                )
+            args.extend(["--group-by", group_by])
+    return _run_cass(args, command="analytics")
+
+
+_CASS_STATUS_SCHEMA = {
+    "name": "cass_status",
+    "description": "Check CASS index health and database status for coding-agent session history.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+_CASS_SEARCH_SCHEMA = {
+    "name": "cass_search",
+    "description": (
+        "Search coding-agent session history indexed by CASS across Claude Code, Codex, Gemini, and other agents. "
+        "Use lexical mode for reliable keyword recall; semantic/hybrid require a CASS vector index."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Maximum number of hits to return (bounded 1-25).", "default": 5, "minimum": 1, "maximum": 25},
+            "mode": {"type": "string", "enum": sorted(_ALLOWED_SEARCH_MODES), "default": "lexical"},
+            "workspace": {"type": "string", "description": "Workspace path filter."},
+            "agent": {"type": "string", "description": "Agent slug filter, e.g. claude_code."},
+            "since": {"type": "string", "description": "Start date/time filter."},
+            "until": {"type": "string", "description": "End date/time filter."},
+            "days": {"type": "integer", "description": "Filter to last N days."},
+            "offset": {"type": "integer", "default": 0},
+            "fields": {"type": "string", "description": "Optional CASS fields selector."},
+            "max_content_length": {"type": "integer", "description": "Content/snippet truncation length (bounded 200-10000).", "default": 2000, "minimum": 200, "maximum": 10000},
+            "source": {"type": "string", "description": "CASS source filter."},
+        },
+        "required": ["query"],
+    },
+}
+
+_CASS_CONTEXT_SCHEMA = {
+    "name": "cass_context",
+    "description": "Find CASS sessions related to a source/session file path.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "CASS source/session path."},
+            "limit": {"type": "integer", "default": 5},
+        },
+        "required": ["path"],
+    },
+}
+
+_CASS_TIMELINE_SCHEMA = {
+    "name": "cass_timeline",
+    "description": "Show activity timeline for indexed CASS sessions.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "since": {"type": "string"},
+            "until": {"type": "string"},
+            "today": {"type": "boolean", "default": False},
+            "agent": {"type": "string"},
+            "group_by": {"type": "string", "enum": ["hour", "day", "none"], "default": "day"},
+            "source": {"type": "string"},
+        },
+        "required": [],
+    },
+}
+
+_CASS_EXPORT_SCHEMA = {
+    "name": "cass_export",
+    "description": "Export a CASS session transcript as markdown, text, JSON, or HTML.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_path": {"type": "string", "description": "Path to a CASS source/session file."},
+            "format": {"type": "string", "enum": sorted(_ALLOWED_EXPORT_FORMATS), "default": "markdown"},
+            "output_path": {"type": "string", "description": "Optional output file path. If omitted, returns stdout content."},
+            "include_tools": {"type": "boolean", "default": False},
+        },
+        "required": ["session_path"],
+    },
+}
+
+_CASS_ANALYTICS_SCHEMA = {
+    "name": "cass_analytics",
+    "description": "Query CASS token, tool, model, or analytics status rollups.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string", "enum": sorted(_ALLOWED_ANALYTICS_KINDS), "default": "tokens"},
+            "days": {"type": "integer", "default": 7},
+            "workspace": {"type": "string"},
+            "agent": {"type": "string"},
+            "source": {"type": "string"},
+            "group_by": {"type": "string", "enum": ["hour", "day", "week", "month"]},
+            "since": {"type": "string"},
+            "until": {"type": "string"},
+        },
+        "required": [],
+    },
+}
+
+registry.register(
+    name="cass_status",
+    toolset="cass",
+    schema=_CASS_STATUS_SCHEMA,
+    handler=lambda args, **kw: cass_status(),
+    check_fn=check_cass_requirements,
+    description="Check CASS health and indexing status",
+    emoji="🗂️",
+)
+
+registry.register(
+    name="cass_search",
+    toolset="cass",
+    schema=_CASS_SEARCH_SCHEMA,
+    handler=lambda args, **kw: cass_search(
+        query=args.get("query", ""),
+        limit=args.get("limit", 5),
+        mode=args.get("mode", "lexical"),
+        workspace=args.get("workspace"),
+        agent=args.get("agent"),
+        since=args.get("since"),
+        until=args.get("until"),
+        days=args.get("days"),
+        offset=args.get("offset", 0),
+        fields=args.get("fields"),
+        max_content_length=args.get("max_content_length"),
+        source=args.get("source"),
+    ),
+    check_fn=check_cass_requirements,
+    description="Search CASS coding-agent session history",
+    emoji="🔎",
+    max_result_size_chars=60_000,
+)
+
+registry.register(
+    name="cass_context",
+    toolset="cass",
+    schema=_CASS_CONTEXT_SCHEMA,
+    handler=lambda args, **kw: cass_context(
+        path=args.get("path", ""),
+        limit=args.get("limit", 5),
+    ),
+    check_fn=check_cass_requirements,
+    description="Find related CASS sessions for a path",
+    emoji="🧭",
+    max_result_size_chars=40_000,
+)
+
+registry.register(
+    name="cass_timeline",
+    toolset="cass",
+    schema=_CASS_TIMELINE_SCHEMA,
+    handler=lambda args, **kw: cass_timeline(
+        since=args.get("since"),
+        until=args.get("until"),
+        today=args.get("today", False),
+        agent=args.get("agent"),
+        group_by=args.get("group_by", "day"),
+        source=args.get("source"),
+    ),
+    check_fn=check_cass_requirements,
+    description="Show CASS activity timeline",
+    emoji="🕰️",
+    max_result_size_chars=40_000,
+)
+
+registry.register(
+    name="cass_export",
+    toolset="cass",
+    schema=_CASS_EXPORT_SCHEMA,
+    handler=lambda args, **kw: cass_export(
+        session_path=args.get("session_path", ""),
+        format=args.get("format", "markdown"),
+        output_path=args.get("output_path"),
+        include_tools=args.get("include_tools", False),
+    ),
+    check_fn=check_cass_requirements,
+    description="Export CASS session transcripts",
+    emoji="📤",
+    max_result_size_chars=80_000,
+)
+
+registry.register(
+    name="cass_analytics",
+    toolset="cass",
+    schema=_CASS_ANALYTICS_SCHEMA,
+    handler=lambda args, **kw: cass_analytics(
+        kind=args.get("kind", "tokens"),
+        days=args.get("days", 7),
+        workspace=args.get("workspace"),
+        agent=args.get("agent"),
+        source=args.get("source"),
+        group_by=args.get("group_by"),
+        since=args.get("since"),
+        until=args.get("until"),
+    ),
+    check_fn=check_cass_requirements,
+    description="Query CASS analytics rollups",
+    emoji="📊",
+    max_result_size_chars=80_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -50,6 +50,8 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
+    # Cross-agent coding session intelligence (CASS)
+    "cass_status", "cass_search", "cass_context", "cass_timeline", "cass_export", "cass_analytics",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -76,6 +78,12 @@ TOOLSETS = {
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
+        "includes": []
+    },
+
+    "cass": {
+        "description": "CASS coding-agent session history search, context, export, and analytics",
+        "tools": ["cass_status", "cass_search", "cass_context", "cass_timeline", "cass_export", "cass_analytics"],
         "includes": []
     },
     


### PR DESCRIPTION
## Prompt to Recreate

> Starting from `origin/main`, split the CASS-only session intelligence tooling out of non-atomic PR #14389. Add a `tools/cass_tool.py` wrapper around the external `cass` CLI, register the tools, expose a `cass` toolset, and add focused tests. Do not include Discord gateway or documentation changes.

---

## Feature Description

PR #14389 mixed a Discord gateway bugfix with an unrelated CASS session intelligence feature. This replacement PR contains only the CASS tool integration.

CASS indexes coding-agent session histories across providers. Hermes should expose CASS through explicit tools rather than requiring generic terminal calls for every session-history query.

## Implementation

- Add `tools/cass_tool.py` with wrappers for:
  - `cass_status`
  - `cass_search`
  - `cass_context`
  - `cass_timeline`
  - `cass_export`
  - `cass_analytics`
- Return structured tool results/errors from CASS CLI JSON output.
- Provide clear install guidance when `cass` is not on `PATH`.
- Clamp high-risk numeric parameters like result limits and content length.
- Register the new module with builtin tool discovery.
- Add a dedicated `cass` toolset in `toolsets.py`.
- Add focused subprocess-mocked tests.

## How to Verify

```bash
/home/agent/hermes-agent/venv/bin/python -m pytest tests/tools/test_cass_tool.py tests/tools/test_registry.py -q -o 'addopts=' --tb=short
git diff --check origin/main..HEAD
```

Expected:

```text
39 passed
git diff --check: no output
```

## Test Plan

- [x] `tests/tools/test_cass_tool.py`
- [x] `tests/tools/test_registry.py`
- [x] `git diff --check origin/main..HEAD`

## Risk Assessment

Medium-low. This adds a new optional tool surface backed by an external CLI. The implementation degrades cleanly when `cass` is unavailable and the tests mock subprocess execution.