### PR TITLE
fix: acquire lock in IterationBudget.used to prevent data race

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -254,7 +254,8 @@ class IterationBudget:
 
     @property
     def used(self) -> int:
-        return self._used
+        with self._lock:
+            return self._used
 
     @property
     def remaining(self) -> int:


### PR DESCRIPTION
## Summary

- `IterationBudget.used` reads `_used` without holding the lock, while `consume()`, `refund()`, and `remaining` all properly acquire `self._lock`
- A concurrent call to `used` during `consume()` or `refund()` can observe a partially-updated value
- This causes incorrect iteration budget metrics in the activity summary reported to the gateway

## Test plan

- [x] Verified `consume()`, `refund()`, and `remaining` all hold `self._lock` — `used` is the only accessor that doesn't
- [x] One-line fix: wrap the read in `with self._lock:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)