### PR TITLE
fix: dedupe background process notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8442,6 +8442,18 @@ class GatewayRunner:
         Routing must come from the queued watch event itself, not from whatever
         foreground message happened to be active when the queue was drained.
         """
+        session_id = str(evt.get("session_id") or "")
+        try:
+            from tools.process_registry import process_registry as _pr_check
+            if session_id and _pr_check.is_completion_consumed(session_id):
+                logger.debug(
+                    "Skipping watch notification for already-consumed process %s",
+                    session_id,
+                )
+                return
+        except Exception:
+            pass
+
         source = self._build_process_event_source(evt)
         if not source:
             logger.warning(
@@ -8576,6 +8588,7 @@ class GatewayRunner:
                                 source.thread_id,
                             )
                             await adapter.handle_message(synth_event)
+                            _pr_check.mark_completion_consumed(session_id)
                         except Exception as e:
                             logger.error("Agent notify injection error: %s", e)
                     break

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -38,6 +38,9 @@ class _FakeRegistry:
     def is_completion_consumed(self, session_id):
         return session_id in self._completion_consumed
 
+    def mark_completion_consumed(self, session_id):
+        self._completion_consumed.add(session_id)
+
 
 def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:
     """Create a GatewayRunner with notifications set to 'all'."""
@@ -97,6 +100,56 @@ async def test_notify_on_complete_sets_internal_flag(monkeypatch, tmp_path):
     event = adapter.handle_message.await_args.args[0]
     assert isinstance(event, MessageEvent)
     assert event.internal is True, "Synthetic completion event must be marked internal"
+
+
+@pytest.mark.asyncio
+async def test_notify_on_complete_marks_completion_consumed_after_injection(monkeypatch, tmp_path):
+    """Injected completion notifications must suppress later duplicate watcher delivery."""
+    import tools.process_registry as pr_module
+
+    fake_registry = _FakeRegistry([
+        SimpleNamespace(
+            output_buffer="done\n", exited=True, exit_code=0, command="echo test"
+        ),
+    ])
+    monkeypatch.setattr(pr_module, "process_registry", fake_registry)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path)
+
+    await runner._run_process_watcher(_watcher_dict_with_notify())
+
+    assert fake_registry.is_completion_consumed("proc_test_internal")
+
+
+@pytest.mark.asyncio
+async def test_watch_notification_skips_already_consumed_process(monkeypatch, tmp_path):
+    """Watch-pattern events should not interrupt after completion was delivered."""
+    import tools.process_registry as pr_module
+
+    fake_registry = _FakeRegistry([])
+    fake_registry.mark_completion_consumed("proc_test_internal")
+    monkeypatch.setattr(pr_module, "process_registry", fake_registry)
+
+    runner = _build_runner(monkeypatch, tmp_path)
+    adapter = runner.adapters[Platform.DISCORD]
+
+    await runner._inject_watch_notification(
+        "[SYSTEM: Background process proc_test_internal matched watch pattern \"spec.md\".]",
+        {
+            "type": "watch_match",
+            "session_id": "proc_test_internal",
+            "session_key": "agent:main:discord:dm:123",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "",
+        },
+    )
+
+    assert adapter.handle_message.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -298,6 +298,14 @@ class TestCodeExecutionBlocked:
 class TestCompletionConsumed:
     """Test that wait/poll/log suppress redundant completion notifications."""
 
+    def test_mark_completion_consumed_suppresses_later_notifications(self, registry):
+        """Gateway delivery can mark a completion consumed without wait/poll/log."""
+        assert not registry.is_completion_consumed("proc_agent_notify")
+
+        registry.mark_completion_consumed("proc_agent_notify")
+
+        assert registry.is_completion_consumed("proc_agent_notify")
+
     def test_wait_marks_completion_consumed(self, registry):
         """wait() returning exited status marks session as consumed."""
         s = _make_session(sid="proc_wait", notify_on_complete=True, output="done")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -644,6 +644,10 @@ class ProcessRegistry:
         """Check if a completion notification was already consumed via wait/poll/log."""
         return session_id in self._completion_consumed
 
+    def mark_completion_consumed(self, session_id: str) -> None:
+        """Mark completion notification as delivered or otherwise consumed."""
+        self._completion_consumed.add(session_id)
+
     def get(self, session_id: str) -> Optional[ProcessSession]:
         """Get a session by ID (running or finished)."""
         with self._lock:


### PR DESCRIPTION
Closes #15276

## Summary

This PR prevents duplicate agent-facing background-process notifications when `notify_on_complete` and `watch_patterns` both apply to the same process.

The fix makes successful gateway delivery of a completion notification update the same consumed state already used by `wait`, `poll`, and `read_log`. Watch notifications now check that state before interrupting the agent, so a process that has already delivered its completion event cannot later send a duplicate watch notification for the same completed session.

## Problem

Background processes already track whether completion has been consumed, but that state was only updated through tool read paths such as `wait`, `poll`, and `read_log`.

When the gateway itself injected a synthetic `notify_on_complete` message into the agent thread, the registry still considered the completion unconsumed. If the same process also produced output matching `watch_patterns`, the watch path could inject another synthetic notification for that already-completed process.

## Changes

- Added `ProcessRegistry.mark_completion_consumed(session_id)` for explicit gateway-side completion delivery.
- Mark completion consumed after a successful gateway `notify_on_complete` injection.
- Skip `_inject_watch_notification` for process sessions whose completion has already been consumed.
- Added regression coverage for:
  - direct registry marking,
  - gateway completion injection marking the process consumed,
  - watch notifications being skipped after completion consumption.

## Files Changed

- `tools/process_registry.py`
  - Adds the explicit consumed-state marker used by gateway delivery.
- `gateway/run.py`
  - Marks completion consumed after successful synthetic completion injection.
  - Suppresses watch notifications for already-consumed process sessions.
- `tests/tools/test_notify_on_complete.py`
  - Covers direct consumed-state marking.
- `tests/gateway/test_internal_event_bypass_pairing.py`
  - Covers gateway completion injection and watch-notification suppression.

## Behavior Notes

- This does not change `wait`, `poll`, or `read_log` completion semantics.
- Watch patterns still work for active processes before completion is consumed.
- The new suppression only applies when a process session has already had its completion consumed or delivered.

## Test Plan

```bash
uv run --extra dev pytest tests/tools/test_notify_on_complete.py tests/gateway/test_internal_event_bypass_pairing.py tests/tools/test_watch_patterns.py
python3.11 -m py_compile gateway/run.py tools/process_registry.py
```
