### PR TITLE
fix(pty): default TERM for resize probes

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -108,9 +108,14 @@ class PtyBridge:
                     "(or pip install -e '.[pty]')."
                 )
             raise PtyUnavailableError("Pseudo-terminals are unavailable.")
-        # Let caller-supplied env fully override inheritance; if they pass
-        # None we inherit the server's env (same semantics as subprocess).
-        spawn_env = os.environ.copy() if env is None else env
+        # PTY-hosted programs expect TERM to describe the terminal type.
+        # CI often runs without TERM in the parent process, which makes
+        # simple terminal probes like `tput cols` fail before winsize reads.
+        # Preserve explicit caller overrides, but backfill a sensible default
+        # when TERM is missing or blank.
+        spawn_env = (os.environ.copy() if env is None else env.copy())
+        if not spawn_env.get("TERM"):
+            spawn_env["TERM"] = "xterm-256color"
         proc = ptyprocess.PtyProcess.spawn(  # type: ignore[union-attr]
             list(argv),
             cwd=cwd,

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -95,9 +95,10 @@ class TestPtyBridgeIO:
 
 @skip_on_windows
 class TestPtyBridgeResize:
-    def test_resize_updates_child_winsize(self):
+    def test_resize_updates_child_winsize(self, monkeypatch):
         # tput reads COLUMNS/LINES from the TTY ioctl (TIOCGWINSZ).
         # Spawn a shell, resize, then ask tput for the dimensions.
+        monkeypatch.delenv("TERM", raising=False)
         bridge = PtyBridge.spawn(
             ["/bin/sh", "-c", "sleep 0.1; tput cols; tput lines"],
             cols=80,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1808,6 +1808,7 @@ class TestPtyWebSocket:
     def test_resize_escape_is_forwarded(self, monkeypatch):
         # Resize escape gets intercepted and applied via TIOCSWINSZ,
         # then ``tput cols/lines`` reports the new dimensions back.
+        monkeypatch.delenv("TERM", raising=False)
         monkeypatch.setattr(
             self.ws_module,
             "_resolve_chat_argv",


### PR DESCRIPTION
## Summary
- default PTY child `TERM` to `xterm-256color` when the parent env is missing or blank
- keep explicit caller-provided `TERM` values untouched
- make the PTY resize regression tests clear `TERM` first so the CI failure is reproduced deterministically

## Testing
- `python3 -m pytest -o addopts= tests/hermes_cli/test_pty_bridge.py::TestPtyBridgeResize::test_resize_updates_child_winsize -q`
- `python3 -m pytest -o addopts= tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_resize_escape_is_forwarded -q`
- `python3 -m pytest -o addopts= tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server.py -q`
  - expected unrelated baseline failure remains: `tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig::test_no_single_field_categories`
