### PR TITLE
fix(transport): normalize MiniMax highspeed system messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -28,18 +28,86 @@ class ChatCompletionsTransport(ProviderTransport):
     def api_mode(self) -> str:
         return "chat_completions"
 
+    @staticmethod
+    def _has_internal_message_key(msg: Dict[str, Any]) -> bool:
+        """Return True if a message carries Hermes-only metadata."""
+        return any(isinstance(key, str) and key.startswith("_") for key in msg)
+
+    @staticmethod
+    def _strip_internal_message_keys(msg: Dict[str, Any]) -> None:
+        """Remove Hermes-only metadata before sending to provider APIs."""
+        for key in list(msg):
+            if isinstance(key, str) and key.startswith("_"):
+                msg.pop(key, None)
+
+    @staticmethod
+    def _requires_single_system_message(model: str) -> bool:
+        """MiniMax M2.7 highspeed rejects multiple system messages (400/2013)."""
+        model_lower = (model or "").lower()
+        return "m2.7-highspeed" in model_lower
+
+    @staticmethod
+    def _content_to_system_text(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text")
+                    if text is not None:
+                        parts.append(str(text))
+                elif item is not None:
+                    parts.append(str(item))
+            return "\n".join(part for part in parts if part)
+        return str(content)
+
+    def _coalesce_system_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        system_messages = [
+            msg for msg in messages
+            if isinstance(msg, dict) and msg.get("role") == "system"
+        ]
+        if len(system_messages) <= 1:
+            return messages
+
+        merged_content = "\n\n".join(
+            text for text in (
+                self._content_to_system_text(msg.get("content"))
+                for msg in system_messages
+            )
+            if text
+        )
+        merged_system = copy.deepcopy(system_messages[0])
+        merged_system["content"] = merged_content
+
+        coalesced: List[Dict[str, Any]] = []
+        inserted_system = False
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                if not inserted_system:
+                    coalesced.append(merged_system)
+                    inserted_system = True
+                continue
+            coalesced.append(copy.deepcopy(msg) if isinstance(msg, dict) else msg)
+        return coalesced
+
     def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> List[Dict[str, Any]]:
-        """Messages are already in OpenAI format — sanitize Codex leaks only.
+        """Messages are already in OpenAI format with provider-leak cleanup.
 
         Strips Codex Responses API fields (``codex_reasoning_items`` on the
-        message, ``call_id``/``response_item_id`` on tool_calls) that strict
+        message, ``call_id``/``response_item_id`` on tool_calls) and Hermes-only
+        underscore-prefixed metadata (for example ``_task_state``) that strict
         chat-completions providers reject with 400/422.
         """
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if "codex_reasoning_items" in msg:
+            if "codex_reasoning_items" in msg or self._has_internal_message_key(msg):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -58,6 +126,7 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in sanitized:
             if not isinstance(msg, dict):
                 continue
+            self._strip_internal_message_keys(msg)
             msg.pop("codex_reasoning_items", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
@@ -118,8 +187,11 @@ class ChatCompletionsTransport(ProviderTransport):
             # Extra
             extra_body_additions: dict | None — pre-built extra_body entries
         """
-        # Codex sanitization: drop reasoning_items / call_id / response_item_id
+        # Codex/internal metadata sanitization: drop reasoning_items,
+        # call_id / response_item_id, and Hermes-only underscore keys.
         sanitized = self.convert_messages(messages)
+        if self._requires_single_system_message(model):
+            sanitized = self._coalesce_system_messages(sanitized)
 
         # Qwen portal prep AFTER codex sanitization.  If sanitize already
         # deepcopied, reuse that copy via the in-place variant to avoid a

--- a/tests/agent/transports/test_chat_completions_transport.py
+++ b/tests/agent/transports/test_chat_completions_transport.py
@@ -1,0 +1,76 @@
+"""Regression tests for OpenAI-compatible chat-completions transport."""
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+def test_minimax_highspeed_coalesces_multiple_system_messages_and_strips_internal_keys():
+    transport = ChatCompletionsTransport()
+    messages = [
+        {"role": "system", "content": "base system"},
+        {
+            "role": "system",
+            "content": "[TASK_STATE_PRESERVE]\nOriginal user request: inspect logs",
+            "_task_state": {"original_request": "inspect logs"},
+        },
+        {"role": "user", "content": "Do the task"},
+    ]
+
+    kwargs = transport.build_kwargs(
+        model="MiniMax-M2.7-highspeed",
+        messages=messages,
+    )
+
+    assert [msg["role"] for msg in kwargs["messages"]] == ["system", "user"]
+    assert kwargs["messages"][0]["content"] == (
+        "base system\n\n"
+        "[TASK_STATE_PRESERVE]\nOriginal user request: inspect logs"
+    )
+    assert "_task_state" not in kwargs["messages"][0]
+    assert "_task_state" not in kwargs["messages"][1]
+    # Provider normalization must not mutate persisted conversation history.
+    assert [msg["role"] for msg in messages] == ["system", "system", "user"]
+    assert "_task_state" in messages[1]
+
+
+def test_non_highspeed_chat_keeps_multiple_system_messages_but_strips_internal_keys():
+    transport = ChatCompletionsTransport()
+    messages = [
+        {"role": "system", "content": "base system"},
+        {
+            "role": "system",
+            "content": "task state",
+            "_task_state": {"original_request": "inspect logs"},
+        },
+        {"role": "user", "content": "Do the task"},
+    ]
+
+    kwargs = transport.build_kwargs(
+        model="MiniMax-M2.7",
+        messages=messages,
+    )
+
+    assert [msg["role"] for msg in kwargs["messages"]] == ["system", "system", "user"]
+    assert all("_task_state" not in msg for msg in kwargs["messages"])
+    assert "_task_state" in messages[1]
+
+
+def test_highspeed_coalescing_keeps_qwen_inplace_prep_from_mutating_history():
+    transport = ChatCompletionsTransport()
+    messages = [
+        {"role": "system", "content": "base system"},
+        {"role": "system", "content": "task state"},
+        {"role": "user", "content": "Do the task"},
+    ]
+
+    def mutate_in_place(prepared):
+        prepared[-1]["content"] = "mutated by qwen prep"
+
+    kwargs = transport.build_kwargs(
+        model="MiniMax-M2.7-highspeed",
+        messages=messages,
+        is_qwen_portal=True,
+        qwen_prepare_inplace_fn=mutate_in_place,
+    )
+
+    assert kwargs["messages"][-1]["content"] == "mutated by qwen prep"
+    assert messages[-1]["content"] == "Do the task"


### PR DESCRIPTION
## Prompt to Recreate

> In NousResearch/hermes-agent, start from latest `origin/main`. Inspect PR #14839 and split only the MiniMax transport concern into an atomic branch. Add tests proving chat-completions requests strip Hermes underscore metadata for all providers, and coalesce multiple system messages only for `MiniMax-M2.7-highspeed` without mutating persisted conversation history. Implement the smallest transport-only fix in `agent/transports/chat_completions.py`.

---

## Bug Description

MiniMax M2.7 highspeed rejects requests with multiple system messages and internal Hermes metadata keys such as `_task_state` can leak into strict chat-completions providers.

## Root Cause

The chat-completions transport sanitized Codex-specific fields but did not remove Hermes-only underscore keys, and MiniMax highspeed received multiple system messages unchanged.

## Fix

- Strip underscore-prefixed internal message keys before provider requests.
- Coalesce multiple system messages only for models containing `m2.7-highspeed`.
- Preserve the caller's original message list by deep-copying when normalization is needed.

## How to Verify

- `/home/agent/hermes-agent/venv/bin/python -m pytest tests/agent/transports/test_chat_completions_transport.py -q -o 'addopts=' --tb=short`
- `git diff --check origin/main..HEAD`

## Test Plan

- [x] RED: new transport tests failed on `origin/main`.
- [x] GREEN: targeted transport tests pass after the fix.
- [x] Whitespace check passes.

## Split From

Supersedes the MiniMax transport slice of non-atomic PR #14839. Excludes delegation fallback, runtime fallback status, and streaming accumulator changes.

## Risk Assessment

Low. The behavior is scoped to chat-completions request normalization and coalesces system messages only for MiniMax highspeed.