### PR TITLE
fix(delegation): inherit fallback chain in child agents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -263,6 +263,27 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
 
+    def test_child_inherits_parent_fallback_chain(self):
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [
+            {"provider": "kimi-coding", "model": "kimi-k2.6"},
+            {"provider": "minimax", "model": "MiniMax-M2.7"},
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Test fallback inheritance", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["fallback_model"], parent._fallback_chain)
+
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)
         sink = MagicMock()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -927,6 +927,18 @@ def _build_child_agent(
         if override_acp_args is not None
         else (getattr(parent_agent, "acp_args", []) or [])
     )
+    parent_fallback_chain = getattr(parent_agent, "_fallback_chain", None)
+    if isinstance(parent_fallback_chain, list) and parent_fallback_chain:
+        effective_fallback_model = list(parent_fallback_chain)
+    else:
+        parent_fallback_model = getattr(parent_agent, "_fallback_model", None)
+        effective_fallback_model = (
+            dict(parent_fallback_model)
+            if isinstance(parent_fallback_model, dict)
+            and parent_fallback_model.get("provider")
+            and parent_fallback_model.get("model")
+            else None
+        )
 
     if override_acp_command:
         # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
@@ -964,6 +976,7 @@ def _build_child_agent(
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
+        fallback_model=effective_fallback_model,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
         quiet_mode=True,


### PR DESCRIPTION
## Prompt to Recreate

> In NousResearch/hermes-agent, start from latest `origin/main`. Inspect PR #14839 and split only the delegation fallback inheritance concern into an atomic branch. Add a test that a delegated child agent receives the parent's fallback chain. Then update `tools/delegate_tool.py` so child `AIAgent` construction passes the effective fallback model without touching provider transport or runtime loop behavior.

---

## Bug Description

Delegated child agents did not inherit the parent's fallback chain, so subagent calls could lose configured provider fallback behavior.

## Root Cause

`_build_child_agent()` inherited runtime credentials and routing fields but omitted `fallback_model` when constructing the child `AIAgent`.

## Fix

- Detect a non-empty parent `_fallback_chain` and pass a copy as the child's `fallback_model`.
- Fall back to a valid parent `_fallback_model` dict when no chain exists.
- Add regression coverage in `tests/tools/test_delegate.py`.

## How to Verify

- `/home/agent/hermes-agent/venv/bin/python -m pytest tests/tools/test_delegate.py -q -o 'addopts=' --tb=short`
- `git diff --check origin/main..HEAD`

## Test Plan

- [x] RED: new fallback-chain inheritance test failed on `origin/main`.
- [x] GREEN: full delegate tool test file passes after the fix.
- [x] Whitespace check passes.

## Split From

Supersedes the delegation slice of non-atomic PR #14839. Excludes MiniMax transport normalization, runtime fallback status, and streaming accumulator changes.

## Risk Assessment

Low. Scoped to child agent construction and preserves existing credential/model inheritance behavior.