### PR TITLE
fix(agent): avoid false fallback status on client errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10989,14 +10989,26 @@ class AIAgent:
                     ) and not is_context_length_error
 
                     if is_client_error:
-                        # Try fallback before aborting — a different provider
-                        # may not have the same issue (rate limit, auth, etc.)
-                        self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                        if self._try_activate_fallback():
-                            retry_count = 0
-                            compression_attempts = 0
-                            primary_recovery_attempted = False
-                            continue
+                        # Try fallback before aborting only when a fallback is
+                        # actually pending.  Otherwise avoid misleading logs
+                        # like "trying fallback" followed immediately by abort.
+                        _pending_fallback = (
+                            getattr(self, "_fallback_index", 0)
+                            < len(getattr(self, "_fallback_chain", []) or [])
+                        )
+                        if _pending_fallback:
+                            self._emit_status(
+                                f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback..."
+                            )
+                            if self._try_activate_fallback():
+                                retry_count = 0
+                                compression_attempts = 0
+                                primary_recovery_attempted = False
+                                continue
+                        else:
+                            self._emit_status(
+                                f"⚠️ Non-retryable error (HTTP {status_code}) — no fallback configured."
+                            )
                         if api_kwargs is not None:
                             self._dump_api_request_debug(
                                 api_kwargs, reason="non_retryable_client_error", error=api_error,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1629,6 +1629,35 @@ class TestExecuteToolCalls:
         assert "API call failed" not in output
         assert "Rate limit reached" not in output
 
+    def test_non_retryable_client_error_without_fallback_does_not_claim_fallback(self, agent):
+        class _BadRequestError(Exception):
+            status_code = 400
+
+            def __str__(self):
+                return "HTTP 400: invalid params, invalid chat setting (2013)"
+
+        def _fake_api_call(api_kwargs):
+            raise _BadRequestError()
+
+        status_messages = []
+        agent._fallback_chain = []
+        agent._fallback_index = 0
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_emit_status", side_effect=status_messages.append),
+            patch.object(agent, "_try_activate_fallback", return_value=False) as mock_fallback,
+            patch.object(agent, "_dump_api_request_debug"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["failed"] is True
+        mock_fallback.assert_not_called()
+        assert not any("trying fallback" in msg.lower() for msg in status_messages)
+
 
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""


### PR DESCRIPTION
## Prompt to Recreate

> In NousResearch/hermes-agent, start from latest `origin/main`. Inspect PR #14839 and split only the misleading non-retryable fallback status concern into an atomic branch. Add a test that a 400 client error with an empty fallback chain does not emit `trying fallback` or call `_try_activate_fallback`. Then update the non-retryable client-error path in `run_agent.py` only.

---

## Bug Description

For non-retryable client errors with no fallback configured, Hermes emitted `trying fallback` and called fallback activation anyway before aborting.

## Root Cause

The non-retryable client-error branch unconditionally announced and attempted fallback, even when `_fallback_chain` was empty or already exhausted.

## Fix

- Check whether `_fallback_index` is still within `_fallback_chain` before announcing or attempting fallback.
- Emit `no fallback configured` when no fallback is pending.
- Preserve existing behavior when a fallback is available.

## How to Verify

- `/home/agent/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_non_retryable_client_error_without_fallback_does_not_claim_fallback -q -o 'addopts=' --tb=short`
- `git diff --check origin/main..HEAD`

## Test Plan

- [x] RED: new no-fallback status test failed on `origin/main`.
- [x] GREEN: targeted run-agent test passes after the fix.
- [x] Whitespace check passes.

## Split From

Supersedes the runtime status slice of non-atomic PR #14839. Excludes MiniMax transport normalization, delegation fallback inheritance, and streaming accumulator changes.

## Risk Assessment

Low. The change only avoids misleading fallback behavior when no fallback exists.