### PR TITLE
fix(streaming): recover streamed text accumulator from None

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5608,7 +5608,7 @@ class AIAgent:
         """Accumulate visible assistant text emitted through stream callbacks."""
         if isinstance(text, str) and text:
             self._current_streamed_assistant_text = (
-                getattr(self, "_current_streamed_assistant_text", "") + text
+                (getattr(self, "_current_streamed_assistant_text", None) or "") + text
             )
 
     @staticmethod

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4074,6 +4074,13 @@ class TestStreamingApiCall:
         callback.assert_any_call("lo ")
         callback.assert_any_call("World")
 
+    def test_record_streamed_text_recovers_from_none_accumulator(self, agent):
+        agent._current_streamed_assistant_text = None
+
+        agent._record_streamed_assistant_text("delta")
+
+        assert agent._current_streamed_assistant_text == "delta"
+
     def test_tool_call_accumulation(self, agent):
         # Per OpenAI streaming spec, function names are delivered atomically
         # in the first chunk; only `arguments` is fragmented across chunks.


### PR DESCRIPTION
## Prompt to Recreate

> In NousResearch/hermes-agent, start from latest `origin/main`. Inspect PR #14839 and split only the streamed assistant-text accumulator None-safety concern into an atomic branch. Add a focused test that `_record_streamed_assistant_text()` recovers when `_current_streamed_assistant_text` is `None`. Then make the smallest `run_agent.py` accumulator guard.

---

## Bug Description

If `_current_streamed_assistant_text` is reset to `None`, appending a streamed delta raises `TypeError` instead of continuing to accumulate visible assistant text.

## Root Cause

`_record_streamed_assistant_text()` used `getattr(..., "") + text`, which still fails when the attribute exists but is `None`.

## Fix

Coerce the existing accumulator value with `(getattr(..., None) or "")` before appending the new string delta.

## How to Verify

- `/home/agent/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_record_streamed_text_recovers_from_none_accumulator tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_content_assembly -q -o 'addopts=' --tb=short`
- `git diff --check origin/main..HEAD`

## Test Plan

- [x] RED: new None-accumulator test failed on `origin/main`.
- [x] GREEN: targeted streaming tests pass after the fix.
- [x] Whitespace check passes.

## Split From

Supersedes the streaming accumulator slice of non-atomic PR #14839. Excludes MiniMax transport normalization, delegation fallback inheritance, and runtime fallback status changes.

## Risk Assessment

Low. One-line guard plus focused regression coverage.