### PR TITLE
feat: add conservative RTK terminal rewrite

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -910,6 +910,12 @@ DEFAULT_CONFIG = {
     # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}
     "personalities": {},
 
+    # RTK routing for terminal command rewriting
+    "rtk": {
+        "enabled": "auto",  # off | auto | force
+        "path": "rtk",
+    },
+
     # Pre-exec security scanning via tirith
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
@@ -3840,6 +3846,12 @@ def set_config_value(key: str, value: str):
         'TINKER_API_KEY',
     ]
     
+    if key.lower().startswith('rtk.'):
+        env_key = f"TERMINAL_RTK_{key.split('.')[-1].upper()}"
+        save_env_value(env_key, value)
+        print(f"✓ Set {key} in {get_env_path()}")
+        return
+
     if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -70,6 +70,7 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["rtk"]["enabled"] == "auto"
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -91,6 +91,12 @@ class TestCatchAllPatterns:
         env_content = _read_env(_isolated_hermes_home)
         assert "TERMINAL_SSH_PORT=2222" in env_content
 
+    def test_rtk_nested_key_routes_to_env(self, _isolated_hermes_home):
+        set_config_value("rtk.enabled", "force")
+        env_content = _read_env(_isolated_hermes_home)
+        assert "TERMINAL_RTK_ENABLED=force" in env_content
+        assert "rtk:" not in _read_config(_isolated_hermes_home)
+
 
 # ---------------------------------------------------------------------------
 # Non-secret keys → config.yaml

--- a/tests/tools/test_terminal_rtk_rewrite.py
+++ b/tests/tools/test_terminal_rtk_rewrite.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tools.terminal_tool import _apply_rtk_rewrite
+
+
+class _CompletedProcess:
+    def __init__(self, returncode: int, stdout: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_rtk_off_keeps_raw_command(monkeypatch):
+    called = False
+
+    def fake_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("subprocess.run should not be called when RTK is off")
+
+    monkeypatch.setattr("tools.terminal_tool.subprocess.run", fake_run)
+    monkeypatch.setattr("tools.terminal_tool.shutil.which", lambda name: "/usr/bin/rtk")
+
+    command, error, used_rtk = _apply_rtk_rewrite("git status", "off", "rtk")
+
+    assert command == "git status"
+    assert error is None
+    assert used_rtk is False
+    assert called is False
+
+
+def test_rtk_auto_rewrites_simple_command(monkeypatch):
+    monkeypatch.setattr("tools.terminal_tool.shutil.which", lambda name: "/usr/bin/rtk")
+    monkeypatch.setattr(
+        "tools.terminal_tool.subprocess.run",
+        lambda *args, **kwargs: _CompletedProcess(0, "git status --short"),
+    )
+
+    command, error, used_rtk = _apply_rtk_rewrite("git status", "auto", "rtk")
+
+    assert command == "git status --short"
+    assert error is None
+    assert used_rtk is True
+
+
+def test_rtk_auto_falls_back_for_complex_commands(monkeypatch):
+    called = False
+
+    def fake_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("subprocess.run should not be called for compound commands")
+
+    monkeypatch.setattr("tools.terminal_tool.subprocess.run", fake_run)
+    monkeypatch.setattr("tools.terminal_tool.shutil.which", lambda name: "/usr/bin/rtk")
+
+    command, error, used_rtk = _apply_rtk_rewrite("git status && git diff", "auto", "rtk")
+
+    assert command == "git status && git diff"
+    assert error is None
+    assert used_rtk is False
+    assert called is False
+
+
+def test_rtk_force_requires_binary(monkeypatch):
+    monkeypatch.setattr("tools.terminal_tool.shutil.which", lambda name: None)
+
+    command, error, used_rtk = _apply_rtk_rewrite("git status", "force", "")
+
+    assert command == "git status"
+    assert used_rtk is False
+    assert error == "RTK is enabled in force mode, but the `rtk` binary was not found."

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -501,6 +501,81 @@ def _rewrite_real_sudo_invocations(command: str) -> tuple[str, bool]:
     return "".join(out), found
 
 
+_RTK_CONTROL_TOKENS = (
+    "&&",
+    "||",
+    ";",
+    "|",
+    "&",
+    "<<",
+    ">>",
+    "<(",
+    ">(",
+    "`",
+    "$(",
+    "\n",
+)
+
+
+def _normalize_rtk_mode(raw_mode: Any) -> str:
+    """Normalize the RTK mode knob to off|auto|force."""
+    mode = str(raw_mode or "auto").strip().lower()
+    if mode not in {"off", "auto", "force"}:
+        return "auto"
+    return mode
+
+
+def _should_try_rtk_rewrite(command: str) -> bool:
+    """Return True when a command is simple enough for conservative RTK routing."""
+    stripped = command.strip()
+    if not stripped:
+        return False
+    if stripped == "rtk" or stripped.startswith("rtk "):
+        return False
+    return not any(token in command for token in _RTK_CONTROL_TOKENS)
+
+
+def _apply_rtk_rewrite(command: str, mode: str, rtk_path: str) -> tuple[str, str | None, bool]:
+    """Try to rewrite *command* through RTK and return the rewritten shell text.
+
+    Returns ``(command_to_execute, error_message, used_rtk)``.
+    """
+    mode = _normalize_rtk_mode(mode)
+    if mode == "off" or not _should_try_rtk_rewrite(command):
+        return command, None, False
+
+    rtk_bin = rtk_path or shutil.which("rtk")
+    if not rtk_bin:
+        if mode == "force":
+            return command, "RTK is enabled in force mode, but the `rtk` binary was not found.", False
+        return command, None, False
+
+    try:
+        result = subprocess.run(
+            [rtk_bin, "rewrite", command],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired) as exc:
+        if mode == "force":
+            return command, f"RTK rewrite failed: {exc}", False
+        logger.debug("RTK rewrite unavailable for %r: %s", _safe_command_preview(command), exc)
+        return command, None, False
+
+    rewritten = (result.stdout or "").strip()
+    if result.returncode == 0 and rewritten:
+        return rewritten, None, True
+
+    if mode == "force":
+        if result.returncode == 1 and not rewritten:
+            return command, "RTK could not rewrite this command in force mode.", False
+        return command, f"RTK rewrite failed with exit code {result.returncode}.", False
+
+    return command, None, False
+
+
 def _rewrite_compound_background(command: str) -> str:
     """Wrap `A && B &` (or `A || B &`) to `A && { B & }` at depth 0.
 
@@ -867,6 +942,8 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
+        "rtk_enabled": _normalize_rtk_mode(os.getenv("TERMINAL_RTK_ENABLED", "auto")),
+        "rtk_path": os.getenv("TERMINAL_RTK_PATH", "rtk"),
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
         "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"),
@@ -1644,8 +1721,25 @@ def terminal_tool(
                 "EOF."
             )
 
+        rtk_note = None
+        rewritten_command, rtk_error, used_rtk = _apply_rtk_rewrite(
+            command,
+            config.get("rtk_enabled", "auto"),
+            config.get("rtk_path", "rtk"),
+        )
+        if rtk_error:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": rtk_error,
+                "status": "blocked",
+            }, ensure_ascii=False)
+        if used_rtk:
+            command = rewritten_command
+            rtk_note = "RTK rewrote the command before execution."
+
         if background:
-            # Spawn a tracked background process via the process registry.
+
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
             from tools.approval import get_current_session_key
@@ -1683,6 +1777,8 @@ def terminal_tool(
                     result_data["approval"] = approval_note
                 if pty_disabled_reason:
                     result_data["pty_note"] = pty_disabled_reason
+                if rtk_note:
+                    result_data["rtk_note"] = rtk_note
 
                 # Populate routing metadata on the session so that
                 # watch-pattern and completion notifications can be
@@ -1839,6 +1935,8 @@ def terminal_tool(
                 result_dict["approval"] = approval_note
             if exit_note:
                 result_dict["exit_code_meaning"] = exit_note
+            if rtk_note:
+                result_dict["rtk_note"] = rtk_note
 
             return json.dumps(result_dict, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary

Adds a conservative RTK rewrite path for terminal commands, with `off` / `auto` / `force` modes and config/env wiring.

Done using GPT 5.4-mini on Hermes Agent

## What changed

- `tools/terminal_tool.py`
  - tries RTK rewrite only for simple commands
  - falls back safely in `auto`
  - blocks when `force` is enabled and RTK is unavailable
  - surfaces `rtk_note` / block errors in tool output
- `hermes_cli/config.py`
  - adds default `rtk.enabled = auto`
  - adds default `rtk.path = rtk`
  - routes `set_config_value("rtk.*")` to env vars
- tests for config routing and RTK rewrite behavior

## Verification

- `pytest tests/tools/test_terminal_rtk_rewrite.py tests/hermes_cli/test_config.py tests/hermes_cli/test_set_config_value.py -q`
