### PR TITLE
fix(nix): refresh hermes-web npm lockfile hash

### DIFF
--- a/nix/web.nix
+++ b/nix/web.nix
@@ -4,7 +4,7 @@ let
   src = ../web;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-TS/vrCHbdvXkPcAPxImKzAd2pdDCrKlgYZkXBMQ+TEg=";
+    hash = "sha256-4Z8KQ69QhO83X6zff+5urWBv6MME686MhTTMdwSl65o=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "web"; attr = "web"; pname = "hermes-web"; };


### PR DESCRIPTION
## Summary\n- refresh the stale  npm deps hash for \n- unblock the shared Nix failure tracked in #15272\n\n## Verification\n- extracted the updated hash from the repository's  workflow report for probe PR #15293\n- final verification is pending on this PR's CI