### PR TITLE
fix(cli): pass None as system_message in manual /compress to prevent system prompt duplication

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6899,9 +6899,15 @@ class HermesCLI:
             else:
                 print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens)...")
 
+            # Pass None as system_message so _compress_context rebuilds
+            # the system prompt from scratch via _build_system_prompt(None).
+            # Passing _cached_system_prompt caused duplication because
+            # _build_system_prompt appends system_message to prompt_parts
+            # which already contain the agent identity — resulting in the
+            # identity block appearing twice (issue #15281).
             compressed, _ = self.agent._compress_context(
                 original_history,
-                self.agent._cached_system_prompt or "",
+                None,
                 approx_tokens=approx_tokens,
                 focus_topic=focus_topic or None,
             )


### PR DESCRIPTION
## Problem

Manual `/compress` caused system prompt to double in size (+102%) because `_manual_compress()` passed `self.agent._cached_system_prompt` as `system_message` to `_compress_context()`. `_build_system_prompt(system_message)` then appended it to `prompt_parts` which already contained the agent identity block — resulting in the identity appearing twice.

## Fix

Pass `None` instead of `_cached_system_prompt`. `_build_system_prompt(None)` rebuilds the system prompt correctly from scratch without appending a pre-built prompt on top of the identity layers.

Fixes #15281