### PR TITLE
fix(hindsight): preserve existing key on blank local_embedded setup

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -478,7 +478,9 @@ class HindsightMemoryProvider(MemoryProvider):
         existing = {}
         if config_path.exists():
             try:
-                existing = json.loads(config_path.read_text())
+                parsed = json.loads(config_path.read_text())
+                if isinstance(parsed, dict):
+                    existing = parsed
             except Exception:
                 pass
         existing.update(values)
@@ -589,13 +591,12 @@ class HindsightMemoryProvider(MemoryProvider):
             val = input(f"  LLM model [{default_model}]: ").strip()
             provider_config["llm_model"] = val or default_model
 
-            sys.stdout.write("  LLM API key: ")
-            sys.stdout.flush()
-            llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             effective_config = dict(provider_config)
             config_path = Path(hermes_home) / "hindsight" / "config.json"
             try:
-                effective_config = json.loads(config_path.read_text(encoding="utf-8"))
+                saved_config = json.loads(config_path.read_text(encoding="utf-8"))
+                if isinstance(saved_config, dict):
+                    effective_config.update(saved_config)
             except Exception:
                 pass
             effective_config.update(provider_config)
@@ -605,6 +606,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     "HINDSIGHT_API_LLM_API_KEY",
                     "",
                 )
+            prompt = "  LLM API key (blank to keep existing): " if existing_llm_key else "  LLM API key: "
+            sys.stdout.write(prompt)
+            sys.stdout.flush()
+            llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             # Always write explicitly (including empty) so the provider sees ""
             # rather than a missing variable.  The daemon reads from .env at
             # startup and fails when HINDSIGHT_LLM_API_KEY is unset.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -592,10 +592,23 @@ class HindsightMemoryProvider(MemoryProvider):
             sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
             llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+            effective_config = dict(provider_config)
+            config_path = Path(hermes_home) / "hindsight" / "config.json"
+            try:
+                effective_config = json.loads(config_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+            effective_config.update(provider_config)
+            existing_llm_key = _load_simple_env(Path(hermes_home) / ".env").get("HINDSIGHT_LLM_API_KEY", "")
+            if not existing_llm_key:
+                existing_llm_key = _load_simple_env(_embedded_profile_env_path(effective_config)).get(
+                    "HINDSIGHT_API_LLM_API_KEY",
+                    "",
+                )
             # Always write explicitly (including empty) so the provider sees ""
             # rather than a missing variable.  The daemon reads from .env at
             # startup and fails when HINDSIGHT_LLM_API_KEY is unset.
-            env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
+            env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key or existing_llm_key
 
         # Step 4: Save everything
         provider_config["bank_id"] = "hermes"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -329,6 +329,7 @@ class TestPostSetup:
 
         profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
         assert profile_env.exists()
+        assert (hermes_home / ".env").read_text() == "HINDSIGHT_LLM_API_KEY=existing-key\nHINDSIGHT_TIMEOUT=120\n"
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
 
     def test_local_embedded_setup_preserves_existing_key_from_nondefault_profile_env_when_input_left_blank(self, tmp_path, monkeypatch):
@@ -357,6 +358,37 @@ class TestPostSetup:
         hermes_env = user_home / ".hindsight" / "profiles" / "hermes.env"
         assert profile_env.exists()
         assert not hermes_env.exists()
+        assert (hermes_home / ".env").read_text() == "HINDSIGHT_LLM_API_KEY=existing-key\nHINDSIGHT_TIMEOUT=120\n"
+        assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
+
+    def test_local_embedded_setup_ignores_nondict_saved_config_when_input_left_blank(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        selections = iter([1, 0])  # local_embedded, openai
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        config_path = hermes_home / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text("[]")
+
+        env_path = hermes_home / ".env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text("HINDSIGHT_LLM_API_KEY=existing-key\n")
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        assert profile_env.exists()
+        assert (hermes_home / ".env").read_text() == "HINDSIGHT_LLM_API_KEY=existing-key\nHINDSIGHT_TIMEOUT=120\n"
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -331,6 +331,34 @@ class TestPostSetup:
         assert profile_env.exists()
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
 
+    def test_local_embedded_setup_preserves_existing_key_from_nondefault_profile_env_when_input_left_blank(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        selections = iter([1, 0])  # local_embedded, openai
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.save_config({"profile": "coder"}, str(hermes_home))
+
+        profile_env = user_home / ".hindsight" / "profiles" / "coder.env"
+        profile_env.parent.mkdir(parents=True, exist_ok=True)
+        profile_env.write_text("HINDSIGHT_API_LLM_API_KEY=existing-key\n")
+
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        hermes_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        assert profile_env.exists()
+        assert not hermes_env.exists()
+        assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
+
 
 # ---------------------------------------------------------------------------
 # Tool handler tests


### PR DESCRIPTION
## Summary

This fixes a local_embedded setup bug in the Hindsight provider.

Re-running the setup wizard with a blank LLM API key input was wiping an existing key from the generated embedded profile env. This PR preserves the existing key instead of overwriting it with an empty value.

This is intended as a bugfix, not a new behavior change: the expected preserve-on-blank behavior was already covered by the existing post-setup test contract.

I split this out from the auto-prefetch tag redesign work so the fix can be reviewed independently.

The default preserve-on-blank expectation was already encoded in the existing post-setup test contract. This PR aligns the implementation with that contract, adds coverage for the non-default saved-profile fallback path, and hardens setup against malformed non-dict saved config.

## Root Cause

In `plugins/memory/hindsight/__init__.py`, `HindsightMemoryProvider.post_setup()` wrote an empty `HINDSIGHT_LLM_API_KEY` into the setup env writes, then rewrote `hermes_home/.env`, and only after that materialized the embedded profile env.

That order destroyed the fallback source before the later profile-env materialization step could reuse it.

## What Changed

- Preserve the existing `HINDSIGHT_LLM_API_KEY` when the local_embedded setup prompt is left blank.
- Prefer the existing key from `hermes_home/.env`.
- If that is absent, fall back to the existing embedded profile env resolved from the saved profile config.
- Ignore malformed non-dict `hindsight/config.json` content during setup recovery instead of crashing.
- Make the local_embedded wizard prompt explicitly say that blank input keeps the existing key.
- Keep the previous behavior for first-time setup when no key exists anywhere: write an explicit empty value rather than leaving the variable unset.

## How To Test

Run:

    uv run scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py::TestPostSetup::test_local_embedded_setup_preserves_existing_key_when_input_left_blank tests/plugins/memory/test_hindsight_provider.py::TestPostSetup::test_local_embedded_setup_preserves_existing_key_from_nondefault_profile_env_when_input_left_blank tests/plugins/memory/test_hindsight_provider.py::TestPostSetup::test_local_embedded_setup_ignores_nondict_saved_config_when_input_left_blank

    uv run scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py

For a direct setup-path check, exercise `HindsightMemoryProvider.post_setup()` in local_embedded mode with a blank key input and an existing `coder.env`, and verify both the generated profile env and `hermes_home/.env` still contain the existing key.

## Validation

Results:

- targeted tests: 3 passed
- focused hindsight provider tests: 77 passed
- direct setup-path check: preserved `existing-key` in `coder.env` on Linux

## Platforms Tested

- Linux

## Related

- Split out while validating #14620