### PR TITLE
TUI: rebind runtime state during compression session splits

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -789,6 +789,7 @@ class AIAgent:
         interim_assistant_callback: callable = None,
         tool_gen_callback: callable = None,
         status_callback: callable = None,
+        session_split_callback: callable = None,
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
         service_tier: str = None,
@@ -994,6 +995,7 @@ class AIAgent:
         self.stream_delta_callback = stream_delta_callback
         self.interim_assistant_callback = interim_assistant_callback
         self.status_callback = status_callback
+        self.session_split_callback = session_split_callback
         self.tool_gen_callback = tool_gen_callback
 
         
@@ -7807,6 +7809,8 @@ class AIAgent:
         new_system_prompt = self._build_system_prompt(system_message)
         self._cached_system_prompt = new_system_prompt
 
+        split_old_session_id = None
+        split_new_session_id = None
         if self._session_db:
             try:
                 # Propagate title to the new session with auto-numbering
@@ -7816,6 +7820,8 @@ class AIAgent:
                 self._session_db.end_session(self.session_id, "compression")
                 old_session_id = self.session_id
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                split_old_session_id = old_session_id
+                split_new_session_id = self.session_id
                 # Update session_log_file to point to the new session's JSON file
                 self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
                 self._session_db.create_session(
@@ -7836,6 +7842,23 @@ class AIAgent:
                 self._last_flushed_db_idx = 0
             except Exception as e:
                 logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+
+        if (
+            split_old_session_id
+            and split_new_session_id
+            and split_new_session_id != split_old_session_id
+        ):
+            callback = getattr(self, "session_split_callback", None)
+            if callback:
+                try:
+                    callback(split_old_session_id, split_new_session_id, "compression")
+                except TypeError:
+                    try:
+                        callback(split_old_session_id, split_new_session_id)
+                    except Exception:
+                        logger.debug("session_split_callback error", exc_info=True)
+                except Exception:
+                    logger.debug("session_split_callback error", exc_info=True)
 
         # Warn on repeated compressions (quality degrades with each pass)
         _cc = self.context_compressor.compression_count

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -133,6 +133,48 @@ class TestFlushAfterCompression:
                 "(this test verifies the bug condition exists)"
             )
 
+    def test_compress_context_notifies_session_split_immediately(self):
+        """Compression must notify callers as soon as session_id rotates."""
+        from hermes_state import SessionDB
+
+        class _Compressor:
+            compression_count = 1
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+
+            def compress(self, messages, current_tokens=None, focus_topic=None):
+                return [{"role": "user", "content": "summary"}]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+            agent = self._make_agent(db)
+            agent.context_compressor = _Compressor()
+            agent.flush_memories = lambda *args, **kwargs: None
+            agent.commit_memory_session = lambda *args, **kwargs: None
+            agent._invalidate_system_prompt = lambda: None
+            agent._build_system_prompt = lambda _system_message=None: "system"
+
+            calls: list[tuple[str, str, str]] = []
+            agent.session_split_callback = (
+                lambda old, new, reason: calls.append((old, new, reason))
+            )
+
+            compressed, system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system",
+                approx_tokens=100,
+            )
+
+            assert compressed == [{"role": "user", "content": "summary"}]
+            assert system_prompt == "system"
+            assert len(calls) == 1
+            old_session_id, new_session_id, reason = calls[0]
+            assert old_session_id == "original-session"
+            assert new_session_id == agent.session_id
+            assert reason == "compression"
+            assert db.get_session(new_session_id)["parent_session_id"] == old_session_id
+
 
 # ---------------------------------------------------------------------------
 # Part 2: Gateway-side — history_offset after session split

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -89,6 +89,7 @@ def _session(agent=None, **extra):
         "session_key": "session-key",
         "history": [],
         "history_lock": threading.Lock(),
+        "runtime_lock": threading.RLock(),
         "history_version": 0,
         "running": False,
         "attached_images": [],
@@ -1068,6 +1069,352 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
         assert "warning" not in payload
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_rebinds_runtime_state_after_session_split(monkeypatch):
+    import tools.approval as _approval
+
+    class _Agent:
+        model = "x"
+
+        def __init__(self):
+            self.session_id = "old-session"
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            self.session_id = "new-session"
+            return {
+                "final_response": "reply",
+                "messages": [{"role": "assistant", "content": "reply"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    created_workers: list[tuple[str, str]] = []
+    closed_workers: list[str] = []
+    worker_runs: list[tuple[str, str]] = []
+
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.session_key = key
+            self.model = model
+            created_workers.append((key, model))
+
+        def close(self):
+            closed_workers.append(self.session_key)
+
+        def run(self, command):
+            worker_runs.append((self.session_key, command))
+            return "slash ok"
+
+    registered: list[str] = []
+    unregistered: list[str] = []
+    complete_running_values: list[bool] = []
+    emits: list[tuple] = []
+    agent = _Agent()
+    old_worker = _FakeWorker("old-session", "x")
+    server._sessions["sid"] = _session(
+        agent=agent, session_key="old-session", slash_worker=old_worker
+    )
+
+    def _capture_emit(*args):
+        if args and args[0] == "message.complete":
+            complete_running_values.append(server._sessions["sid"]["running"])
+        emits.append(args)
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+        monkeypatch.setattr(server, "render_message", lambda _text, _cols: "")
+        monkeypatch.setattr(server, "_emit", _capture_emit)
+        monkeypatch.setattr(
+            _approval, "register_gateway_notify", lambda key, cb: registered.append(key)
+        )
+        monkeypatch.setattr(
+            _approval, "unregister_gateway_notify", lambda key: unregistered.append(key)
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+
+        assert server._sessions["sid"]["session_key"] == "new-session"
+        assert agent.session_id == "new-session"
+        assert ("new-session", "x") in created_workers
+        assert "old-session" in closed_workers
+        assert "old-session" in unregistered
+        assert "new-session" in registered
+        assert complete_running_values == [False]
+        assert any(call[0] == "session.info" for call in emits)
+
+        slash_resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "slash.exec",
+                "params": {"session_id": "sid", "command": "status"},
+            }
+        )
+        assert slash_resp["result"]["output"] == "slash ok"
+        assert worker_runs[-1] == ("new-session", "status")
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_rebinds_runtime_state_during_mid_run_session_split(
+    monkeypatch,
+):
+    import tools.approval as _approval
+    from gateway.session_context import get_session_env
+    from tools.approval import get_current_session_key
+
+    observed: dict[str, object] = {}
+
+    class _Agent:
+        model = "x"
+
+        def __init__(self):
+            self.session_id = "old-session"
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            self.session_id = "new-session"
+            callback = getattr(self, "session_split_callback", None)
+            observed["callback_installed"] = callback is not None
+            if callback is not None:
+                callback("old-session", "new-session", "compression")
+
+            worker = server._sessions["sid"]["slash_worker"]
+            observed["worker_session_key"] = worker.session_key
+            observed["approval_session_key"] = get_current_session_key(default="")
+            observed["context_session_key"] = get_session_env(
+                "HERMES_SESSION_KEY", ""
+            )
+            return {
+                "final_response": "reply",
+                "messages": [{"role": "assistant", "content": "reply"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    created_workers: list[str] = []
+    closed_workers: list[str] = []
+
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.session_key = key
+            created_workers.append(key)
+
+        def close(self):
+            closed_workers.append(self.session_key)
+
+    registered: list[str] = []
+    unregistered: list[str] = []
+    emits: list[tuple] = []
+    agent = _Agent()
+    server._sessions["sid"] = _session(
+        agent=agent,
+        session_key="old-session",
+        slash_worker=_FakeWorker("old-session", "x"),
+    )
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+        monkeypatch.setattr(server, "render_message", lambda _text, _cols: "")
+        monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
+        monkeypatch.setattr(
+            _approval, "register_gateway_notify", lambda key, cb: registered.append(key)
+        )
+        monkeypatch.setattr(
+            _approval, "unregister_gateway_notify", lambda key: unregistered.append(key)
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            }
+        )
+
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert observed["callback_installed"] is True
+        assert observed["worker_session_key"] == "new-session"
+        assert observed["approval_session_key"] == "new-session"
+        assert observed["context_session_key"] == "new-session"
+        assert server._sessions["sid"]["session_key"] == "new-session"
+        assert "old-session" in closed_workers
+        assert "new-session" in created_workers
+        assert "old-session" in unregistered
+        assert "new-session" in registered
+        assert any(call[0] == "session.info" for call in emits)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_does_not_rebind_when_session_id_is_unchanged(monkeypatch):
+    import tools.approval as _approval
+
+    class _Agent:
+        model = "x"
+        session_id = "same-session"
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "reply",
+                "messages": [{"role": "assistant", "content": "reply"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _ExistingWorker:
+        session_key = "same-session"
+
+        def close(self):
+            raise AssertionError("worker should not be closed without a split")
+
+    registered: list[str] = []
+    unregistered: list[str] = []
+    server._sessions["sid"] = _session(
+        agent=_Agent(), session_key="same-session", slash_worker=_ExistingWorker()
+    )
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(
+            server,
+            "_SlashWorker",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("worker should not restart without a split")
+            ),
+        )
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+        monkeypatch.setattr(server, "render_message", lambda _text, _cols: "")
+        monkeypatch.setattr(server, "_emit", lambda *args: None)
+        monkeypatch.setattr(
+            _approval, "register_gateway_notify", lambda key, cb: registered.append(key)
+        )
+        monkeypatch.setattr(
+            _approval, "unregister_gateway_notify", lambda key: unregistered.append(key)
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            }
+        )
+
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert server._sessions["sid"]["session_key"] == "same-session"
+        assert registered == []
+        assert unregistered == []
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_compress_rebinds_runtime_state_after_session_split(monkeypatch):
+    import tools.approval as _approval
+
+    agent = types.SimpleNamespace(model="x", session_id="old-session")
+    created_workers: list[str] = []
+    closed_workers: list[str] = []
+
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.session_key = key
+            created_workers.append(key)
+
+        def close(self):
+            closed_workers.append(self.session_key)
+
+    registered: list[str] = []
+    unregistered: list[str] = []
+
+    def _fake_compress(session, focus_topic=None):
+        session["agent"].session_id = "new-session"
+        session["history"] = [{"role": "assistant", "content": "summary"}]
+        return 3, {"total": 7}
+
+    server._sessions["sid"] = _session(
+        agent=agent,
+        session_key="old-session",
+        slash_worker=_FakeWorker("old-session", "x"),
+        history=[{"role": "user", "content": "a"}] * 4,
+    )
+
+    try:
+        monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+        monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+        monkeypatch.setattr(server, "_emit", lambda *args: None)
+        monkeypatch.setattr(
+            _approval, "register_gateway_notify", lambda key, cb: registered.append(key)
+        )
+        monkeypatch.setattr(
+            _approval, "unregister_gateway_notify", lambda key: unregistered.append(key)
+        )
+
+        resp = server.handle_request(
+            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
+        )
+
+        assert resp["result"]["status"] == "compressed"
+        assert server._sessions["sid"]["session_key"] == "new-session"
+        assert "old-session" in closed_workers
+        assert "new-session" in created_workers
+        assert "old-session" in unregistered
+        assert "new-session" in registered
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_build_session_info_exposes_runtime_session_state(monkeypatch):
+    agent = types.SimpleNamespace(model="x", session_id="agent-session")
+    worker = types.SimpleNamespace(session_key="worker-session")
+    session = _session(
+        agent=agent,
+        session_key="backend-session",
+        slash_worker=worker,
+        running=True,
+    )
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "x"})
+
+    info = server._build_session_info(session)
+
+    assert info["runtime"]["session_key"] == "backend-session"
+    assert info["runtime"]["agent_session_id"] == "agent-session"
+    assert info["runtime"]["slash_worker_session_key"] == "worker-session"
+    assert info["runtime"]["running"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -172,6 +172,8 @@ class _SlashWorker:
     def __init__(self, session_key: str, model: str):
         self._lock = threading.Lock()
         self._seq = 0
+        self.session_key = session_key
+        self.model = model
         self.stderr_tail: list[str] = []
         self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
 
@@ -671,6 +673,74 @@ def _restart_slash_worker(session: dict):
         )
     except Exception:
         session["slash_worker"] = None
+
+
+def _runtime_lock(session: dict):
+    lock = session.get("runtime_lock")
+    if lock is None:
+        lock = threading.RLock()
+        session["runtime_lock"] = lock
+    return lock
+
+
+def _runtime_session_info(session: dict) -> dict:
+    agent = session.get("agent")
+    worker = session.get("slash_worker")
+    return {
+        "session_key": session.get("session_key", ""),
+        "agent_session_id": getattr(agent, "session_id", "") or "",
+        "slash_worker_session_key": getattr(worker, "session_key", "") or "",
+        "running": bool(session.get("running")),
+    }
+
+
+def _build_session_info(session: dict) -> dict:
+    info = _session_info(session.get("agent"))
+    info["runtime"] = _runtime_session_info(session)
+    return info
+
+
+def _register_approval_notify(sid: str, session_key: str) -> None:
+    from tools.approval import register_gateway_notify
+
+    register_gateway_notify(
+        session_key, lambda data: _emit("approval.request", sid, data)
+    )
+
+
+def _sync_session_after_agent_run(
+    sid: str, session: dict, agent, *, reason: str
+) -> bool:
+    """Rebind TUI-owned runtime state after compression rotates agent.session_id."""
+    if not session:
+        return False
+    new_key = getattr(agent, "session_id", None)
+    if not new_key:
+        return False
+
+    with _runtime_lock(session):
+        old_key = session.get("session_key")
+        if new_key == old_key:
+            return False
+        session["session_key"] = new_key
+
+    logger.info("TUI session split detected: %s -> %s (%s)", old_key, new_key, reason)
+
+    if old_key:
+        try:
+            from tools.approval import unregister_gateway_notify
+
+            unregister_gateway_notify(old_key)
+        except Exception:
+            logger.warning("failed to unregister old TUI approval route %s", old_key)
+
+    try:
+        _register_approval_notify(sid, new_key)
+    except Exception:
+        logger.warning("failed to register new TUI approval route %s", new_key)
+
+    _restart_slash_worker(session)
+    return True
 
 
 def _persist_model_switch(result) -> None:
@@ -1332,6 +1402,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "session_key": key,
         "history": history,
         "history_lock": threading.Lock(),
+        "runtime_lock": threading.RLock(),
         "history_version": 0,
         "running": False,
         "attached_images": [],
@@ -1710,6 +1781,12 @@ def _(rid, params: dict) -> dict:
     return err or _ok(rid, _get_usage(session["agent"]))
 
 
+@method("session.runtime")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    return err or _ok(rid, _runtime_session_info(session))
+
+
 @method("session.history")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
@@ -1765,6 +1842,12 @@ def _(rid, params: dict) -> dict:
                 session, str(params.get("focus_topic", "") or "").strip()
             )
             messages = list(session.get("history", []))
+        _sync_session_after_agent_run(
+            params.get("session_id", ""),
+            session,
+            session["agent"],
+            reason="session.compress",
+        )
         info = _session_info(session["agent"])
         _emit("session.info", params.get("session_id", ""), info)
         return _ok(
@@ -2184,6 +2267,17 @@ def _(rid, params: dict) -> dict:
     def run():
         approval_token = None
         session_tokens = []
+        running_cleared = False
+        previous_session_split_callback = None
+
+        def _clear_running():
+            nonlocal running_cleared
+            if running_cleared:
+                return
+            with session["history_lock"]:
+                session["running"] = False
+                running_cleared = True
+
         try:
             from tools.approval import (
                 reset_current_session_key,
@@ -2192,6 +2286,51 @@ def _(rid, params: dict) -> dict:
 
             approval_token = set_current_session_key(session["session_key"])
             session_tokens = _set_session_context(session["session_key"])
+
+            previous_session_split_callback = getattr(
+                agent, "session_split_callback", None
+            )
+
+            def _refresh_runtime_context(new_key: str) -> None:
+                nonlocal approval_token, session_tokens
+                if approval_token is not None:
+                    try:
+                        reset_current_session_key(approval_token)
+                    except Exception:
+                        pass
+                    approval_token = None
+                approval_token = set_current_session_key(new_key)
+                _clear_session_context(session_tokens)
+                session_tokens = _set_session_context(new_key)
+
+            def _on_session_split(old_key: str, new_key: str, reason: str = "") -> None:
+                if new_key:
+                    _refresh_runtime_context(new_key)
+                session_rebound = _sync_session_after_agent_run(
+                    sid,
+                    session,
+                    agent,
+                    reason=f"prompt.submit.{reason or 'session_split'}",
+                )
+                if session_rebound:
+                    _emit("session.info", sid, _build_session_info(session))
+                if previous_session_split_callback:
+                    try:
+                        previous_session_split_callback(old_key, new_key, reason)
+                    except TypeError:
+                        try:
+                            previous_session_split_callback(old_key, new_key)
+                        except Exception:
+                            logger.debug(
+                                "previous session_split_callback error",
+                                exc_info=True,
+                            )
+                    except Exception:
+                        logger.debug(
+                            "previous session_split_callback error", exc_info=True
+                        )
+
+            agent.session_split_callback = _on_session_split
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text
@@ -2212,6 +2351,7 @@ def _(rid, params: dict) -> dict:
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
+                    _clear_running()
                     _emit(
                         "error",
                         sid,
@@ -2278,6 +2418,9 @@ def _(rid, params: dict) -> dict:
                 raw = str(result)
                 status = "complete"
 
+            session_rebound = _sync_session_after_agent_run(
+                sid, session, agent, reason="prompt.submit"
+            )
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
@@ -2286,6 +2429,9 @@ def _(rid, params: dict) -> dict:
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
+            if session_rebound:
+                _emit("session.info", sid, _build_session_info(session))
+            _clear_running()
             _emit("message.complete", sid, payload)
 
             # CLI parity: when voice-mode TTS is on, speak the agent reply
@@ -2326,16 +2472,26 @@ def _(rid, params: dict) -> dict:
             print(
                 f"[gateway-turn] {type(e).__name__}: {e}", file=sys.stderr, flush=True
             )
+            _clear_running()
             _emit("error", sid, {"message": str(e)})
         finally:
+            if previous_session_split_callback is None:
+                try:
+                    delattr(agent, "session_split_callback")
+                except Exception:
+                    pass
+            else:
+                try:
+                    agent.session_split_callback = previous_session_split_callback
+                except Exception:
+                    pass
             try:
                 if approval_token is not None:
                     reset_current_session_key(approval_token)
             except Exception:
                 pass
             _clear_session_context(session_tokens)
-            with session["history_lock"]:
-                session["running"] = False
+            _clear_running()
 
     threading.Thread(target=run, daemon=True).start()
     return _ok(rid, {"status": "streaming"})
@@ -3785,6 +3941,9 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "compress" and agent:
             with session["history_lock"]:
                 _compress_session_history(session, arg)
+            _sync_session_after_agent_run(
+                sid, session, agent, reason="slash.compress"
+            )
             _emit("session.info", sid, _session_info(agent))
         elif name == "fast" and agent:
             mode = arg.lower()


### PR DESCRIPTION
## Summary
- Add an `AIAgent.session_split_callback` fired immediately after compression rotates `agent.session_id`.
- Rebind TUI runtime state during the active prompt turn: backend session key, approval/session contextvars, approval notify route, slash worker, and refreshed `session.info`.
- Keep the post-run/manual compression rebind path and expose runtime session state for diagnostics.

## Tests
- `uv run --extra dev pytest tests/test_tui_gateway_server.py tests/run_agent/test_compression_persistence.py` -> 67 passed, 14 warnings
- `git diff --check`
- `python3 /home/jerome/.codex/repos/codex-skills/plandoc-review/scripts/plandoc_review_lint.py .plandoc/plans/todo/hermes-tui-compression-session-stability.md`