### PR TITLE
fix(delegation): pass target_model to resolve_runtime_provider in _resolve_delegation_credentials

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2164,7 +2164,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider)
+        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
## Problem

When `delegation.model` differs from `model.default` on `opencode-go` or `opencode-zen`, `delegate_task` fails with a 404. `_resolve_delegation_credentials` calls `resolve_runtime_provider(requested=configured_provider)` without a `target_model`, so `api_mode` is computed from `model_cfg.get("default")` — the **main** model — instead of the delegation model.

Example: `model.default=minimax-m2.7` (→ `anthropic_messages`) + `delegation.model=glm-5.1` (→ `chat_completions`). The subagent inherits `anthropic_messages`, `/v1` is stripped from the base URL, and the request hits `https://opencode.ai/zen/go/messages` instead of `https://opencode.ai/zen/go/v1/chat/completions` → **404**.

## Fix

`resolve_runtime_provider` already accepts `target_model` for this exact purpose (see its docstring: *"Callers performing an explicit mid-session model switch should pass the new model here"*). The delegation path just wasn't passing it.

```python
# Before
runtime = resolve_runtime_provider(requested=configured_provider)
# After
runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
```

## Testing

Verified locally with `opencode-go`, `model.default=minimax-m2.7`, `delegation.model=glm-5.1`:

- Before: `api_mode=anthropic_messages`, `base_url=https://opencode.ai/zen/go` → 404
- After: `api_mode=chat_completions`, `base_url=https://opencode.ai/zen/go/v1` → success

Closes #15319
Related: #13678