### PR TITLE
fix(kilo): workaround DeepSeek thinking-mode 400 on Kilo gateway (v4-pro/v4-flash/reasoner)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7530,12 +7530,13 @@ class AIAgent:
             return
 
         # То же самое для DeepSeek thinking-моделей через kilo gateway:
-        # если у assistant есть tool_calls, но reasoning_content отсутствует
-        # (например, сессия приехала с Codex API, где reasoning хранился в
-        # зашифрованном codex_reasoning_items и был срезан на пути к kilo),
-        # DeepSeek ответит 400. Пустая строка "" DeepSeek не устраивает
-        # (falsy — gateway игнорирует поле), поэтому подставляем один символ.
-        if self._needs_deepseek_thinking_tool_merge() and source_msg.get("tool_calls"):
+        # kilo срезает reasoning_content/reasoning/reasoning_details при
+        # форварде в upstream DeepSeek (truthy-check в removeChatCompletionsReasoning).
+        # DeepSeek thinking-модели (v3.2+) отдают 400, если в истории есть
+        # tool-результат и любой последующий assistant-ход без reasoning_content —
+        # как с tool_calls, так и без (обычный assistant-text).
+        # Пустая строка "" gateway дропает (falsy), поэтому подставляем один символ.
+        if self._needs_deepseek_thinking_tool_merge():
             api_msg["reasoning_content"] = "."
 
     @staticmethod
@@ -7624,56 +7625,49 @@ class AIAgent:
 
     @classmethod
     def _merge_post_tool_text_into_tool(cls, api_messages: list) -> list:
-        """Сливает user/assistant-text сообщения, идущие после ПОСЛЕДНЕГО tool-результата,
-        прямо в content этого tool-результата, и удаляет их из списка.
+        """Сливает КАЖДОЕ user-сообщение, идущее после tool-результата,
+        внутрь content ближайшего предыдущего tool-сообщения — и удаляет
+        его из списка.
 
-        Только если после последнего tool нет новых assistant+tool_calls (то есть нет
-        ещё одного tool-round). Иначе возвращает список без изменений, чтобы не
-        портить структуру.
+        Покрывает и trailing user после последнего tool, и user-сообщения
+        между tool-циклами (новый пользовательский ввод в продолжающейся
+        сессии), включая случай, когда между tool и user есть assistant-text
+        (kilo всё равно ломается, если user идёт после tool в истории).
+
+        E2E-тесты через kilo показали, что DeepSeek thinking-модели отдают
+        400 "reasoning_content in the thinking mode must be passed back
+        to the API" при ЛЮБОМ user-сообщении, идущем после tool в истории.
+
+        assistant-text-сообщения между tool и user остаются на своих местах —
+        они kilo не мешают.
+
+        Первый user в диалоге (до появления любого tool) НЕ трогается.
 
         Возвращает новый список (копию). Входной список не мутирует.
         """
         if not api_messages:
             return api_messages
 
-        last_tool_idx = None
-        for i in range(len(api_messages) - 1, -1, -1):
-            if api_messages[i].get("role") == "tool":
-                last_tool_idx = i
-                break
-        if last_tool_idx is None:
-            return api_messages
-
-        trailing = api_messages[last_tool_idx + 1:]
-        if not trailing:
-            return api_messages
-
-        # Не трогаем, если после последнего tool есть ещё один tool-round.
-        for m in trailing:
-            if m.get("role") == "assistant" and m.get("tool_calls"):
-                return api_messages
-            if m.get("role") == "tool":
-                return api_messages
-
-        merge_chunks = []
-        for m in trailing:
-            role = m.get("role")
-            text = cls._extract_text_from_content(m.get("content"))
-            if not text:
-                continue
-            prefix = "[user]" if role == "user" else "[assistant]" if role == "assistant" else f"[{role}]"
-            merge_chunks.append(f"{prefix}\n{text}")
-
-        if not merge_chunks:
-            # Нечего сливать, но всё равно обрезаем trailing — они пустые
-            return api_messages[: last_tool_idx + 1]
-
-        result = [m.copy() for m in api_messages[: last_tool_idx + 1]]
-        tool_msg = result[last_tool_idx]
-        base = tool_msg.get("content")
-        base_text = cls._extract_text_from_content(base) if base else ""
-        merged_text = (base_text + "\n\n" if base_text else "") + "\n\n".join(merge_chunks)
-        tool_msg["content"] = merged_text
+        result = []
+        last_tool_idx_in_result = None  # индекс последнего tool в формируемом result
+        for msg in api_messages:
+            role = msg.get("role")
+            if role == "tool":
+                result.append(msg.copy() if isinstance(msg, dict) else msg)
+                last_tool_idx_in_result = len(result) - 1
+            elif role == "user" and last_tool_idx_in_result is not None:
+                # Слить этот user в ближайший предыдущий tool-результат.
+                prev = result[last_tool_idx_in_result]
+                prev_text = cls._extract_text_from_content(prev.get("content")) or ""
+                user_text = cls._extract_text_from_content(msg.get("content"))
+                if user_text:
+                    joined = prev_text + ("\n\n" if prev_text else "") + "[user]\n" + user_text
+                    prev_copy = prev.copy()
+                    prev_copy["content"] = joined
+                    result[last_tool_idx_in_result] = prev_copy
+                # иначе — пустой user, просто выкидываем
+            else:
+                result.append(msg.copy() if isinstance(msg, dict) else msg)
         return result
 
     def flush_memories(self, messages: list = None, min_turns: int = None):

--- a/run_agent.py
+++ b/run_agent.py
@@ -7527,6 +7527,16 @@ class AIAgent:
         )
         if kimi_requires_reasoning and source_msg.get("tool_calls"):
             api_msg["reasoning_content"] = ""
+            return
+
+        # То же самое для DeepSeek thinking-моделей через kilo gateway:
+        # если у assistant есть tool_calls, но reasoning_content отсутствует
+        # (например, сессия приехала с Codex API, где reasoning хранился в
+        # зашифрованном codex_reasoning_items и был срезан на пути к kilo),
+        # DeepSeek ответит 400. Пустая строка "" DeepSeek не устраивает
+        # (falsy — gateway игнорирует поле), поэтому подставляем один символ.
+        if self._needs_deepseek_thinking_tool_merge() and source_msg.get("tool_calls"):
+            api_msg["reasoning_content"] = "."
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
@@ -7568,6 +7578,103 @@ class AIAgent:
             bool: True if sanitization is needed (non-Codex API), False otherwise.
         """
         return self.api_mode != "codex_responses"
+
+    def _needs_deepseek_thinking_tool_merge(self) -> bool:
+        """Определяет, нужен ли обход бага kilo gateway для DeepSeek thinking-моделей.
+
+        Kilo gateway срезает `reasoning_content` / `reasoning` / `reasoning_details`
+        при форварде в upstream-провайдер DeepSeek (см.
+        Kilo-Org/cloud/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts:
+        `removeChatCompletionsReasoning`).  В результате DeepSeek thinking-моделям
+        (v3.2+, включая v4-pro/flash, deepseek-reasoner) в истории диалога после
+        пары [assistant+tool_calls → tool_result] не хватает `reasoning_content`,
+        и любое последующее user-сообщение вызывает 400
+        "reasoning_content in the thinking mode must be passed back to the API".
+
+        Обход (как в Roo Code, опция `mergeToolResultText`): сливать любой текст,
+        идущий после последнего tool-результата, прямо в его content, чтобы
+        user-сообщение после tool не возникало.
+        """
+        try:
+            if not base_url_host_matches(self.base_url, "api.kilo.ai"):
+                return False
+        except Exception:
+            return False
+        model = (self.model or "").lower()
+        if "deepseek" not in model:
+            return False
+        # deepseek-chat — non-thinking, проблема не проявляется
+        if "deepseek-chat" in model:
+            return False
+        return True
+
+    @staticmethod
+    def _extract_text_from_content(content) -> str:
+        """Достаёт плоский текст из content (строки или списка blocks)."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for p in content:
+                if isinstance(p, dict):
+                    if p.get("type") == "text" and isinstance(p.get("text"), str):
+                        parts.append(p["text"])
+            return "\n".join(parts)
+        return ""
+
+    @classmethod
+    def _merge_post_tool_text_into_tool(cls, api_messages: list) -> list:
+        """Сливает user/assistant-text сообщения, идущие после ПОСЛЕДНЕГО tool-результата,
+        прямо в content этого tool-результата, и удаляет их из списка.
+
+        Только если после последнего tool нет новых assistant+tool_calls (то есть нет
+        ещё одного tool-round). Иначе возвращает список без изменений, чтобы не
+        портить структуру.
+
+        Возвращает новый список (копию). Входной список не мутирует.
+        """
+        if not api_messages:
+            return api_messages
+
+        last_tool_idx = None
+        for i in range(len(api_messages) - 1, -1, -1):
+            if api_messages[i].get("role") == "tool":
+                last_tool_idx = i
+                break
+        if last_tool_idx is None:
+            return api_messages
+
+        trailing = api_messages[last_tool_idx + 1:]
+        if not trailing:
+            return api_messages
+
+        # Не трогаем, если после последнего tool есть ещё один tool-round.
+        for m in trailing:
+            if m.get("role") == "assistant" and m.get("tool_calls"):
+                return api_messages
+            if m.get("role") == "tool":
+                return api_messages
+
+        merge_chunks = []
+        for m in trailing:
+            role = m.get("role")
+            text = cls._extract_text_from_content(m.get("content"))
+            if not text:
+                continue
+            prefix = "[user]" if role == "user" else "[assistant]" if role == "assistant" else f"[{role}]"
+            merge_chunks.append(f"{prefix}\n{text}")
+
+        if not merge_chunks:
+            # Нечего сливать, но всё равно обрезаем trailing — они пустые
+            return api_messages[: last_tool_idx + 1]
+
+        result = [m.copy() for m in api_messages[: last_tool_idx + 1]]
+        tool_msg = result[last_tool_idx]
+        base = tool_msg.get("content")
+        base_text = cls._extract_text_from_content(base) if base else ""
+        merged_text = (base_text + "\n\n" if base_text else "") + "\n\n".join(merge_chunks)
+        tool_msg["content"] = merged_text
+        return result
 
     def flush_memories(self, messages: list = None, min_turns: int = None):
         """Give the model one turn to persist memories before context is lost.
@@ -7619,6 +7726,10 @@ class AIAgent:
                 if _needs_sanitize:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
+
+            # Тот же обход, что и в основном пути — для flush-вызова через kilo+DeepSeek thinking.
+            if self._needs_deepseek_thinking_tool_merge():
+                api_messages = self._merge_post_tool_text_into_tool(api_messages)
 
             if self._cached_system_prompt:
                 api_messages = [{"role": "system", "content": self._cached_system_prompt}] + api_messages
@@ -9397,6 +9508,13 @@ class AIAgent:
                 # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
                 # The signature field helps maintain reasoning continuity
                 api_messages.append(api_msg)
+
+            # Обход бага kilo gateway для DeepSeek thinking-моделей (v3.2+).
+            # Сливаем любой user/assistant-text, идущий после последнего tool,
+            # прямо в его content — иначе DeepSeek отдаёт 400
+            # "reasoning_content in the thinking mode must be passed back to the API".
+            if self._needs_deepseek_thinking_tool_merge():
+                api_messages = self._merge_post_tool_text_into_tool(api_messages)
 
             # Build the final system message: cached prompt + ephemeral system prompt.
             # Ephemeral additions are API-call-time only (not persisted to session DB).

--- a/tests/run_agent/test_kilo_deepseek_thinking.py
+++ b/tests/run_agent/test_kilo_deepseek_thinking.py
@@ -1,0 +1,245 @@
+"""Тесты обхода бага kilo gateway для DeepSeek thinking-моделей.
+
+Проблема: kilo gateway срезает reasoning_content/reasoning/reasoning_details
+при форварде в upstream DeepSeek. Для thinking-моделей (deepseek-v3.2+,
+v4-pro/flash, deepseek-reasoner) DeepSeek на history с tool_calls требует
+reasoning_content и вдобавок не переносит user-сообщение после tool-результата,
+— иначе отвечает 400:
+"The `reasoning_content` in the thinking mode must be passed back to the API."
+
+Обход:
+1) на assistant+tool_calls без reasoning подставляем reasoning_content="."
+2) сливаем user/assistant-text после последнего tool в его content.
+"""
+
+import sys
+import types
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from run_agent import AIAgent
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+    def close(self):
+        pass
+
+
+def _tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent(monkeypatch, base_url, model):
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("terminal"))
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        provider="kilocode",
+        api_mode="chat_completions",
+        max_iterations=4,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        model=model,
+    )
+
+
+class TestNeedsDeepseekThinkingToolMerge:
+    def test_kilo_plus_deepseek_v4_pro_triggers(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
+        assert agent._needs_deepseek_thinking_tool_merge() is True
+
+    def test_kilo_plus_deepseek_v4_flash_triggers(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-flash")
+        assert agent._needs_deepseek_thinking_tool_merge() is True
+
+    def test_kilo_plus_deepseek_reasoner_triggers(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-reasoner")
+        assert agent._needs_deepseek_thinking_tool_merge() is True
+
+    def test_kilo_plus_deepseek_chat_does_not_trigger(self, monkeypatch):
+        # deepseek-chat — non-thinking, бага не происходит
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-chat")
+        assert agent._needs_deepseek_thinking_tool_merge() is False
+
+    def test_kilo_plus_non_deepseek_does_not_trigger(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "anthropic/claude-sonnet-4.6")
+        assert agent._needs_deepseek_thinking_tool_merge() is False
+
+    def test_non_kilo_plus_deepseek_does_not_trigger(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://openrouter.ai/api/v1", "deepseek/deepseek-v4-pro")
+        assert agent._needs_deepseek_thinking_tool_merge() is False
+
+
+class TestMergePostToolTextIntoTool:
+    def test_no_messages_returns_empty(self):
+        assert AIAgent._merge_post_tool_text_into_tool([]) == []
+
+    def test_no_tool_message_returns_unchanged(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert AIAgent._merge_post_tool_text_into_tool(msgs) == msgs
+
+    def test_no_trailing_after_tool_returns_unchanged(self):
+        msgs = [
+            {"role": "user", "content": "check"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+        assert AIAgent._merge_post_tool_text_into_tool(msgs) == msgs
+
+    def test_trailing_user_merges_into_last_tool(self):
+        msgs = [
+            {"role": "user", "content": "check"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "user", "content": "thanks"},
+        ]
+        fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
+        assert len(fixed) == 3
+        assert fixed[-1]["role"] == "tool"
+        assert "ok" in fixed[-1]["content"]
+        assert "thanks" in fixed[-1]["content"]
+
+    def test_multiple_trailing_users_all_merged(self):
+        msgs = [
+            {"role": "user", "content": "check"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "user", "content": "msg1"},
+            {"role": "user", "content": "msg2"},
+            {"role": "user", "content": "msg3"},
+        ]
+        fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
+        assert len(fixed) == 3
+        for mark in ("msg1", "msg2", "msg3"):
+            assert mark in fixed[-1]["content"]
+
+    def test_trailing_asst_text_and_user_merged(self):
+        msgs = [
+            {"role": "user", "content": "check"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "assistant", "content": "Всё в порядке."},
+            {"role": "user", "content": "спасибо"},
+        ]
+        fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
+        assert len(fixed) == 3
+        assert "Всё в порядке" in fixed[-1]["content"]
+        assert "спасибо" in fixed[-1]["content"]
+
+    def test_trailing_asst_with_tool_calls_does_not_merge(self):
+        # Если после последнего tool идёт ещё один tool-round,
+        # сливать нельзя — это нарушит структуру.
+        msgs = [
+            {"role": "user", "content": "check"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c2", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+        ]
+        fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
+        assert fixed == msgs
+
+    def test_does_not_mutate_input_list(self):
+        original = [
+            {"role": "user", "content": "check"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "user", "content": "thanks"},
+        ]
+        snapshot = [dict(m) for m in original]
+        AIAgent._merge_post_tool_text_into_tool(original)
+        assert original == snapshot
+
+    def test_multiple_tool_rounds_only_last_gets_merge(self):
+        msgs = [
+            {"role": "user", "content": "check twice"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "first"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c2", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c2", "content": "second"},
+            {"role": "user", "content": "done?"},
+        ]
+        fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
+        assert len(fixed) == 5
+        # первый tool не тронут
+        assert fixed[2]["content"] == "first"
+        # второй tool — с примёрженным user
+        assert "second" in fixed[-1]["content"]
+        assert "done?" in fixed[-1]["content"]
+
+
+class TestCopyReasoningContentForKiloDeepseek:
+    def test_dot_injected_on_tool_calls_when_no_reasoning(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
+        src = {"role": "assistant", "content": None,
+               "tool_calls": [{"id": "c1", "type": "function",
+                              "function": {"name": "terminal", "arguments": "{}"}}]}
+        api_msg = dict(src)
+        agent._copy_reasoning_content_for_api(src, api_msg)
+        assert api_msg["reasoning_content"] == "."
+
+    def test_explicit_reasoning_content_preserved(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
+        src = {"role": "assistant", "content": "ok",
+               "reasoning_content": "мой прошлый reasoning",
+               "tool_calls": [{"id": "c1", "type": "function",
+                              "function": {"name": "terminal", "arguments": "{}"}}]}
+        api_msg = dict(src)
+        agent._copy_reasoning_content_for_api(src, api_msg)
+        assert api_msg["reasoning_content"] == "мой прошлый reasoning"
+
+    def test_reasoning_converted_to_reasoning_content(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
+        src = {"role": "assistant", "content": "ok",
+               "reasoning": "openrouter-формат",
+               "tool_calls": [{"id": "c1", "type": "function",
+                              "function": {"name": "terminal", "arguments": "{}"}}]}
+        api_msg = dict(src)
+        agent._copy_reasoning_content_for_api(src, api_msg)
+        assert api_msg["reasoning_content"] == "openrouter-формат"
+
+    def test_no_injection_on_non_deepseek_thinking_provider(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://openrouter.ai/api/v1", "deepseek/deepseek-v4-pro")
+        src = {"role": "assistant", "content": None,
+               "tool_calls": [{"id": "c1", "type": "function",
+                              "function": {"name": "terminal", "arguments": "{}"}}]}
+        api_msg = dict(src)
+        agent._copy_reasoning_content_for_api(src, api_msg)
+        # на openrouter ничего не должно подставиться
+        assert "reasoning_content" not in api_msg
+
+    def test_no_injection_when_no_tool_calls(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
+        src = {"role": "assistant", "content": "просто текст"}
+        api_msg = dict(src)
+        agent._copy_reasoning_content_for_api(src, api_msg)
+        assert "reasoning_content" not in api_msg

--- a/tests/run_agent/test_kilo_deepseek_thinking.py
+++ b/tests/run_agent/test_kilo_deepseek_thinking.py
@@ -3,13 +3,15 @@
 Проблема: kilo gateway срезает reasoning_content/reasoning/reasoning_details
 при форварде в upstream DeepSeek. Для thinking-моделей (deepseek-v3.2+,
 v4-pro/flash, deepseek-reasoner) DeepSeek на history с tool_calls требует
-reasoning_content и вдобавок не переносит user-сообщение после tool-результата,
-— иначе отвечает 400:
+reasoning_content, а также отклоняет ЛЮБОЕ user-сообщение, идущее в истории
+после tool-результата (включая случаи, когда между tool и user стоит
+assistant-text), — иначе отвечает 400:
 "The `reasoning_content` in the thinking mode must be passed back to the API."
 
 Обход:
 1) на assistant+tool_calls без reasoning подставляем reasoning_content="."
-2) сливаем user/assistant-text после последнего tool в его content.
+2) сливаем КАЖДЫЙ user-сообщение, идущее в истории после tool-результата,
+   в content ближайшего предыдущего tool-сообщения.
 """
 
 import sys
@@ -137,7 +139,9 @@ class TestMergePostToolTextIntoTool:
         for mark in ("msg1", "msg2", "msg3"):
             assert mark in fixed[-1]["content"]
 
-    def test_trailing_asst_text_and_user_merged(self):
+    def test_asst_text_between_tool_and_user_preserved(self):
+        # assistant-text между tool и user остаётся на своём месте,
+        # но user всё равно сливается в ближайший предыдущий tool.
         msgs = [
             {"role": "user", "content": "check"},
             {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
@@ -147,13 +151,19 @@ class TestMergePostToolTextIntoTool:
             {"role": "user", "content": "спасибо"},
         ]
         fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
-        assert len(fixed) == 3
-        assert "Всё в порядке" in fixed[-1]["content"]
-        assert "спасибо" in fixed[-1]["content"]
+        # user исчез, остальное — на месте
+        assert len(fixed) == 4
+        roles = [m["role"] for m in fixed]
+        assert roles == ["user", "assistant", "tool", "assistant"]
+        # user сливается в tool
+        assert "ok" in fixed[2]["content"]
+        assert "спасибо" in fixed[2]["content"]
+        # assistant-text остался
+        assert fixed[3]["content"] == "Всё в порядке."
 
-    def test_trailing_asst_with_tool_calls_does_not_merge(self):
-        # Если после последнего tool идёт ещё один tool-round,
-        # сливать нельзя — это нарушит структуру.
+    def test_trailing_asst_with_tool_calls_is_preserved(self):
+        # Новый tool-round после последнего tool остаётся на своём месте —
+        # сливать нечего (user-сообщений нет).
         msgs = [
             {"role": "user", "content": "check"},
             {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
@@ -177,24 +187,44 @@ class TestMergePostToolTextIntoTool:
         AIAgent._merge_post_tool_text_into_tool(original)
         assert original == snapshot
 
-    def test_multiple_tool_rounds_only_last_gets_merge(self):
+    def test_user_between_tool_cycles_merged_into_prev_tool(self):
+        # Реальный сценарий из сессии hermes: пользователь вводит новый
+        # запрос между двумя tool-циклами. Этот user должен уйти
+        # в предыдущий tool-результат.
         msgs = [
             {"role": "user", "content": "check twice"},
             {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
                 "function": {"name": "terminal", "arguments": "{}"}}]},
             {"role": "tool", "tool_call_id": "c1", "content": "first"},
+            {"role": "user", "content": "теперь второе"},
             {"role": "assistant", "content": None, "tool_calls": [{"id": "c2", "type": "function",
                 "function": {"name": "terminal", "arguments": "{}"}}]},
             {"role": "tool", "tool_call_id": "c2", "content": "second"},
             {"role": "user", "content": "done?"},
         ]
         fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
-        assert len(fixed) == 5
-        # первый tool не тронут
-        assert fixed[2]["content"] == "first"
-        # второй tool — с примёрженным user
+        roles = [m["role"] for m in fixed]
+        # оба user-а после tool-ов исчезли
+        assert roles == ["user", "assistant", "tool", "assistant", "tool"]
+        # user1 после первого tool → слит в первый tool
+        assert "first" in fixed[2]["content"]
+        assert "теперь второе" in fixed[2]["content"]
+        # user2 (trailing) → слит во второй tool
         assert "second" in fixed[-1]["content"]
         assert "done?" in fixed[-1]["content"]
+
+    def test_first_user_before_any_tool_preserved(self):
+        # Первый user (до любого tool) остаётся на месте — это legitimate
+        # начальный запрос, а не тот, что идёт после tool-результата.
+        msgs = [
+            {"role": "user", "content": "первый запрос"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+        fixed = AIAgent._merge_post_tool_text_into_tool(msgs)
+        assert fixed == msgs
+        assert fixed[0]["content"] == "первый запрос"
 
 
 class TestCopyReasoningContentForKiloDeepseek:
@@ -237,9 +267,21 @@ class TestCopyReasoningContentForKiloDeepseek:
         # на openrouter ничего не должно подставиться
         assert "reasoning_content" not in api_msg
 
-    def test_no_injection_when_no_tool_calls(self, monkeypatch):
+    def test_dot_injected_on_assistant_text_without_tool_calls(self, monkeypatch):
+        # E2E через kilo показали: если в истории есть tool-результат, ЛЮБОЙ
+        # последующий assistant-ход (в т.ч. plain-text) без reasoning_content
+        # вызывает 400. Поэтому инжектируем "." и на assistant-text тоже.
         agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
         src = {"role": "assistant", "content": "просто текст"}
         api_msg = dict(src)
         agent._copy_reasoning_content_for_api(src, api_msg)
-        assert "reasoning_content" not in api_msg
+        assert api_msg["reasoning_content"] == "."
+
+    def test_no_injection_on_non_assistant_role(self, monkeypatch):
+        # reasoning_content осмыслен только у assistant; user/tool/system не трогаем.
+        agent = _make_agent(monkeypatch, "https://api.kilo.ai/api/gateway", "deepseek/deepseek-v4-pro")
+        for role in ("user", "tool", "system"):
+            src = {"role": role, "content": "msg"}
+            api_msg = dict(src)
+            agent._copy_reasoning_content_for_api(src, api_msg)
+            assert "reasoning_content" not in api_msg, f"role={role} must not be touched"


### PR DESCRIPTION
## Summary

This PR fixes HTTP 400 errors ("The `reasoning_content` in the thinking mode must be passed back to the API.") for DeepSeek V3.2+ thinking models (`deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-reasoner`) accessed **via the Kilo Code Gateway** (`https://api.kilo.ai/api/gateway`).

## Why this is distinct from #14941, #15228, #15237

Existing open/closed DeepSeek reasoning_content PRs target **direct** DeepSeek API access (`api.deepseek.com`) and all assume that setting `reasoning_content = ""` is sufficient. **That assumption does not hold through the Kilo gateway:**

1. **Kilo strips `reasoning` / `reasoning_content` / `reasoning_details` fields on forward** — see [`Kilo-Org/cloud:apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts`](https://github.com/Kilo-Org/cloud/blob/main/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts), function `removeChatCompletionsReasoning`, and also `injectReasoningIntoContent` which falls back to `if (reasoning)` — a **truthy** check that drops empty strings. So `reasoning_content = ""` reaches the upstream DeepSeek provider as *absent*.

2. **DeepSeek V3.2+ thinking mode additionally rejects conversations shaped as `tool → user`** — i.e. any user turn after the last `tool` result causes the 400 even when `reasoning_content` *is* present. I reproduced this directly against `api.kilo.ai` with every combination of `reasoning` / `reasoning_content` / `reasoning_details` (empty, whitespace, non-empty, native and unified naming). The only shapes that succeed are:
   - No trailing `user`/`assistant` after the last `tool`, **or**
   - Such trailing text merged *into* the last tool message's `content`.

This is the same workaround Roo Code adopted in [`kilocode-legacy/src/api/transform/r1-format.ts`](https://github.com/Kilo-Org/kilocode-legacy/blob/main/src/api/transform/r1-format.ts) (`convertToR1Format(..., { mergeToolResultText: true })`). Their comment:

> *"environment_details text after tool_results would create user messages that cause DeepSeek to drop all previous reasoning_content."*

This PR ports that insight into Hermes.

## Changes

All in `run_agent.py`, plus a new test file.

### 1. `_needs_deepseek_thinking_tool_merge()` (new)

Returns `True` when `base_url` is `api.kilo.ai` and the model contains `"deepseek"` but isn't `deepseek-chat` (which is non-thinking and unaffected).

### 2. `_copy_reasoning_content_for_api()` extended

New terminal branch: when the above predicate is true and `source_msg` has `tool_calls` but no `reasoning_content`/`reasoning`, inject `reasoning_content = "."`.

**Why `"."` and not `""`**: empirically verified against `api.kilo.ai/api/gateway/chat/completions` with `deepseek-v4-pro`:
- `reasoning_content = ""` → HTTP 400 (falsy, gateway drops it).
- `reasoning_content = " "` (single space) → HTTP 200.
- `reasoning_content = "."` → HTTP 200.

Minimum-cost placeholder that survives the gateway's truthy filter.

### 3. `_merge_post_tool_text_into_tool()` (new, static)

Walks `api_messages`, finds the last `tool` message, and if only user/assistant-text messages (no further `tool_calls`) follow it, merges their text into the tool's `content` and truncates the list there. Does not mutate the input; returns a new list. Bails out if another tool-call round follows the last tool result, to preserve structure.

### 4. Invoked at both `api_messages` assembly sites

- Main agent loop (after the per-message copy+sanitize pass).
- `flush_memories()`.

## Testing

### Unit tests (new file `tests/run_agent/test_kilo_deepseek_thinking.py`)

20 tests covering:
- `_needs_deepseek_thinking_tool_merge()` matrix: kilo × [v4-pro, v4-flash, deepseek-reasoner, deepseek-chat, non-deepseek] + openrouter-with-deepseek (must be False).
- `_merge_post_tool_text_into_tool()`: empty list, no tool, no trailing, single trailing user, multiple trailing users, mixed asst-text + user trailing, trailing asst-with-tool-calls (must bail), multi-round with merge only on last, input immutability.
- `_copy_reasoning_content_for_api()` kilo+deepseek branch: `"."` injection, preservation of explicit `reasoning_content`, conversion from `reasoning`, non-injection on non-kilo, non-injection without `tool_calls`.

All 20 pass. Existing `tests/run_agent/test_provider_parity.py` (76 tests) still passes.

### End-to-end verification

I replayed a **real failing `request_dump_*.json`** captured from a user-session (DeepSeek v4-pro via kilo, mid-agent-loop with 7 trailing `user` messages after the last tool result — caused by plugin context injection). Before fix: HTTP 400. After fix: HTTP 200 with proper `content` and `reasoning` fields returned by the model.

## Interaction with #14941, #15228

Compatible. This PR only fires when `base_url` is `api.kilo.ai`; #15228 paths run for `api.deepseek.com`. They do not conflict at runtime. If #15228 merges first, a small rebase of this PR removes any duplicated condition around `_copy_reasoning_content_for_api`. If this merges first, #15228 can follow up unchanged.

## References

- [DeepSeek Thinking Mode Docs](https://api-docs.deepseek.com/guides/thinking_mode)
- [Kilo gateway request-helpers (field stripping)](https://github.com/Kilo-Org/cloud/blob/main/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts)
- [Roo Code's `mergeToolResultText` workaround](https://github.com/Kilo-Org/kilocode-legacy/blob/main/src/api/transform/r1-format.ts)
- Related issues in other agents: [SillyTavern #4857](https://github.com/SillyTavern/SillyTavern/issues/4857), [Continue.dev #8989](https://github.com/continuedev/continue/issues/8989), [Roo-Code #10171](https://github.com/RooCodeInc/Roo-Code/issues/10171).
