### PR TITLE
Let fromMe messages through in groups under self-chat mode

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -209,22 +209,30 @@ async function startSocket() {
 
       // Handle fromMe messages based on mode
       if (msg.key.fromMe) {
-        if (isGroup || chatId.includes('status')) continue;
+        if (chatId.includes('status')) continue;  // never process status broadcasts
 
         if (WHATSAPP_MODE === 'bot') {
           // Bot mode: separate number. ALL fromMe are echo-backs of our own replies — skip.
           continue;
         }
 
-        // Self-chat mode: only allow messages in the user's own self-chat
-        // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
-        // AND classic format: 34652029134@s.whatsapp.net
-        // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
-        const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const chatNumber = chatId.replace(/@.*/, '');
-        const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
-        if (!isSelfChat) continue;
+        // Self-chat mode. Groups and your own self-chat are both valid
+        // contexts for YOU to address the bot from your own paired account.
+        // The real echo-loop guard is at the REPLY_PREFIX + recentlySentIds
+        // check ~60 lines below — that catches messages the bridge itself
+        // sent. Bailing on `isGroup` here would mean you can never
+        // @mention the bot in a group you're in.
+        //
+        // For 1:1 chats: still require it be your self-chat (not a DM to
+        // some other contact) so the bot doesn't try to answer on your
+        // behalf in random conversations.
+        if (!isGroup) {
+          const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
+          const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
+          const chatNumber = chatId.replace(/@.*/, '');
+          const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
+          if (!isSelfChat) continue;
+        }
       }
 
       // Check allowlist for messages from others (resolve LID ↔ phone aliases)


### PR DESCRIPTION
## Summary

In `scripts/whatsapp-bridge/bridge.js`, the `fromMe` branch of the `messages.upsert` handler bails out on any group chat:

```js
if (msg.key.fromMe) {
  if (isGroup || chatId.includes('status')) continue;
  ...
}
```

That drops every message the paired user sends in any group, which breaks a legitimate self-chat-mode flow: a user with a single paired WhatsApp number wants to @mention their own bot from a group they're in alongside other humans (e.g. "@mybot check my calendar"). Under the current code the bridge never sees those messages.

## Use case

- Self-chat mode (`WHATSAPP_MODE !== 'bot'`): the agent is paired to the user's own number.
- The user is in a group with friends / family / coworkers.
- They want to trigger the agent from that group via @mention, just like any other group member would trigger a normal bot.

With this patch applied they can.

## Why the guard was redundant

The echo-loop concern that seemed to motivate dropping all group `fromMe` messages is already handled ~60 lines below:

```js
if (msg.key.fromMe && ((REPLY_PREFIX && body.startsWith(REPLY_PREFIX)) || recentlySentIds.has(msg.key.id))) {
  ...
}
```

That check — `REPLY_PREFIX` + `recentlySentIds` — is the real loop-breaker: it catches any message the bridge itself just sent, regardless of whether the chat is a group or a DM. The earlier blanket `isGroup` drop was a second, overly broad line of defense that also blocked legitimate user input.

## What changes

- Still skip `status@broadcast`-style chats unconditionally (always correct to drop).
- Bot mode (`WHATSAPP_MODE === 'bot'`) still unconditionally skips every `fromMe` — in that deployment the bridge runs on a separate number, so every `fromMe` really is a bridge echo.
- Self-chat mode: no longer bails on `isGroup`. Groups are now a valid context for the paired user to address the bot.
- Self-chat mode 1:1 chats still require the chat to be the user's own self-chat (same LID/phone match as before), so the bot doesn't try to respond on the user's behalf in DMs with arbitrary contacts.

## Diff shape

Before:

```js
if (msg.key.fromMe) {
  if (isGroup || chatId.includes('status')) continue;
  if (WHATSAPP_MODE === 'bot') continue;
  // self-chat check
  const isSelfChat = ...;
  if (!isSelfChat) continue;
}
```

After:

```js
if (msg.key.fromMe) {
  if (chatId.includes('status')) continue;
  if (WHATSAPP_MODE === 'bot') continue;
  if (!isGroup) {
    const isSelfChat = ...;
    if (!isSelfChat) continue;
  }
}
```

## Test plan

- [ ] Self-chat mode, 1:1 with a random contact (not the self-chat): still ignored (no `isSelfChat`).
- [ ] Self-chat mode, user's own self-chat: processed (unchanged).
- [ ] Self-chat mode, group containing the user: user's own messages now reach the allowlist + handler path; bridge's own outgoing replies are still filtered by the downstream `REPLY_PREFIX` / `recentlySentIds` guard (no echo loop).
- [ ] Bot mode, any chat: all `fromMe` still dropped (unchanged).
- [ ] `status@broadcast` messages: still dropped (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)