### PR TITLE
fix: omit empty api_mode when probing custom provider models

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2917,10 +2917,10 @@ def _model_flow_named_custom(config, provider_info):
     print()
 
     print("Fetching available models...")
-    models = fetch_api_models(
-        api_key, base_url, timeout=8.0,
-        api_mode=api_mode or None,
-    )
+    fetch_kwargs = {"timeout": 8.0}
+    if api_mode:
+        fetch_kwargs["api_mode"] = api_mode
+    models = fetch_api_models(api_key, base_url, **fetch_kwargs)
 
     if models:
         default_idx = 0

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -136,11 +136,16 @@ class TestCustomProviderModelSwitch:
             "api_mode": "anthropic_messages",
         }
 
-        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3"]), \
+        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3"]) as mock_fetch, \
              patch.dict("sys.modules", {"simple_term_menu": None}), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
+
+        assert mock_fetch.call_count == 1
+        args, kwargs = mock_fetch.call_args
+        assert args[1] == "https://proxy.example.com/anthropic"
+        assert kwargs == {"timeout": 8.0, "api_mode": "anthropic_messages"}
 
         config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
         model = config.get("model")


### PR DESCRIPTION
## Why
`_model_flow_named_custom()` always passed `api_mode=None` into `fetch_api_models()` when a custom provider had no explicit transport override. That changed the mock call shape in the custom-provider model switch flow and broke the regression test that ensures saved models still probe the endpoint before showing the picker.

## Files changed
- `hermes_cli/main.py` — only include `api_mode` in the probe call when the provider explicitly sets one
- `tests/hermes_cli/test_custom_provider_model_switch.py` — keep coverage for the no-`api_mode` path and assert the explicit `api_mode` path still forwards the transport override

## Verification run
- `./scripts/run_tests.sh tests/hermes_cli/test_custom_provider_model_switch.py -q`
- result: `6 passed`

## Risk level
Low. Small CLI-only change in custom-provider model discovery call construction. No dependency changes, no secrets handling changes, no broader runtime behavior change outside omitting a redundant `None` kwarg.
