### PR TITLE
docs: add hermescheck to community ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ scripts/run_tests.sh
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🧭 [hermescheck](https://github.com/huangrichao2020/hermescheck) — Community health checks for Hermes Agent forks and deployments.
 
 ---
 


### PR DESCRIPTION
Adds a one-line entry for hermescheck (community Hermes Agent architecture health checker) to the Community section. It gives Hermes users and fork maintainers a dedicated scanner for runtime-contract drift, command-surface splits, gateway/skills/memory/cron health, and SARIF reports.

## Summary

HermesCheck community architecture health-check docs.

This PR adds a one-line README entry linking [hermescheck](https://github.com/huangrichao2020/hermescheck), a community-maintained Hermes Agent architecture and runtime health checker.

## What

Adds [hermescheck](https://github.com/huangrichao2020/hermescheck) to the community ecosystem section of the README. hermescheck is a small Python scanner I wrote by adapting my general agent architecture checker into a Hermes Agent-specific companion tool.

## Why

Hermes Agent is a multi-surface persistent runtime: CLI/TUI, gateway, skills, memory, session search, cron, tools, plugins, and execution environments all need to stay aligned. A Hermes-focused community checker can help contributors and fork maintainers catch architecture drift before it becomes a runtime surprise.

hermescheck is intended to stay aligned with Hermes Agent release by release, and to help Hermes Agent reach and support Chinese developer communities through a practical community health-check path.

## Disclosure

I am the author of hermescheck. Happy to maintain the entry, adjust the wording, or have it removed if maintainers prefer not to link external community tools.

## Validation

- `git diff --check`

Thanks for Hermes Agent — this tool exists because the runtime architecture is worth checking carefully.