### PR TITLE
fix(gateway/config): coerce quoted boolean values in config parsing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -135,7 +135,7 @@ class SessionResetPolicy:
             mode=mode if mode is not None else "both",
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
-            notify=notify if notify is not None else True,
+            notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
         )
 
@@ -178,7 +178,7 @@ class PlatformConfig:
             home_channel = HomeChannel.from_dict(data["home_channel"])
         
         return cls(
-            enabled=data.get("enabled", False),
+            enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
@@ -435,7 +435,7 @@ class GatewayConfig:
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),
             quick_commands=quick_commands,
             sessions_dir=sessions_dir,
-            always_log_local=data.get("always_log_local", True),
+            always_log_local=_coerce_bool(data.get("always_log_local"), True),
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -52,6 +52,10 @@ class TestPlatformConfigRoundtrip:
         assert restored.enabled is False
         assert restored.token is None
 
+    def test_from_dict_coerces_quoted_false_enabled(self):
+        restored = PlatformConfig.from_dict({"enabled": "false"})
+        assert restored.enabled is False
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -140,6 +144,10 @@ class TestSessionResetPolicy:
         assert restored.at_hour == 4
         assert restored.idle_minutes == 1440
 
+    def test_from_dict_coerces_quoted_false_notify(self):
+        restored = SessionResetPolicy.from_dict({"notify": "false"})
+        assert restored.notify is False
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):
@@ -181,6 +189,10 @@ class TestGatewayConfigRoundtrip:
 
         assert restored.unauthorized_dm_behavior == "ignore"
         assert restored.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
+
+    def test_from_dict_coerces_quoted_false_always_log_local(self):
+        restored = GatewayConfig.from_dict({"always_log_local": "false"})
+        assert restored.always_log_local is False
 
 
 class TestLoadGatewayConfig:
@@ -237,6 +249,55 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.thread_sessions_per_user is False
+
+    def test_bridges_quoted_false_platform_enabled_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  api_server:\n"
+            "    enabled: \"false\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.API_SERVER].enabled is False
+        assert Platform.API_SERVER not in config.get_connected_platforms()
+
+    def test_bridges_quoted_false_session_notify_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  notify: \"false\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.notify is False
+
+    def test_bridges_quoted_false_always_log_local_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "always_log_local: \"false\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.always_log_local is False
 
     def test_bridges_discord_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
Fixes an edge case where quoted boolean values (e.g. "false") in YAML/dict config were not being normalized correctly for three gateway config fields. Because bool("false") is True in Python, these fields could remain effectively enabled even when the user explicitly wrote "false" in their config.

## Bug

Class: invalid bool / config edge-case
Broken behavior: Quoted YAML strings like "false" were treated as truthy for some gateway bool fields.
User impact: A config value written as "false" could still behave as enabled/true.
Affected fields:

PlatformConfig.enabled
SessionResetPolicy.notify
GatewayConfig.always_log_local



## Root Cause
The _coerce_bool() helper already existed in gateway/config.py but was not being applied consistently across these three fields.
## Fix
Apply the existing _coerce_bool() helper to the three affected fields. No refactor — just consistent use of the helper that was already in place.
Changes in gateway/config.py:

line 138 — SessionResetPolicy.notify now normalizes quoted bool values via _coerce_bool()
line 181 — PlatformConfig.enabled now parses quoted bool values correctly
line 438 — GatewayConfig.always_log_local now parses quoted bool values correctly

## Repro
pythonPlatformConfig.from_dict({"enabled": "false"}).enabled          # before: truthy, now: False
SessionResetPolicy.from_dict({"notify": "false"}).notify        # before: truthy, now: False
GatewayConfig.from_dict({"always_log_local": "false"}).always_log_local  # before: truthy, now: False
## Tests
Added regression tests covering both the from_dict() path and the config.yaml bridge path in tests/gateway/test_config.py:

line 55 — PlatformConfig.from_dict({"enabled": "false"})
line 147 — SessionResetPolicy.from_dict({"notify": "false"})
line 193 — GatewayConfig.from_dict({"always_log_local": "false"})
line 253 — config.yaml → platforms.api_server.enabled: "false"
line 271 — config.yaml → session_reset.notify: "false"
line 287 — config.yaml → always_log_local: "false"

Result: 33 passed, 20 warnings in 3.37s