### PR TITLE
install.sh: add progress, stall-detection, and retries to HTTPS clone

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -782,10 +782,42 @@ clone_repo() {
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
             log_info "SSH failed, trying HTTPS..."
-            if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+
+            # HTTPS clone with progress output + stall detection + retries.
+            # - --progress forces git to stream progress even when stdout is
+            #   redirected (happens with `curl | bash`), so users actually see
+            #   something instead of a frozen terminal.
+            # - GIT_HTTP_LOW_SPEED_LIMIT/TIME aborts the clone if throughput
+            #   drops below 1 KB/s for 30 seconds — prevents the install from
+            #   hanging indefinitely on flaky networks.
+            # - Up to 3 attempts with exponential backoff (5s, 15s).
+            local https_ok=false
+            local attempt
+            for attempt in 1 2 3; do
+                if [ "$attempt" -gt 1 ]; then
+                    local backoff=$(( (attempt - 1) * 10 + 5 ))
+                    log_warn "HTTPS clone attempt $((attempt - 1)) failed; retrying in ${backoff}s..."
+                    rm -rf "$INSTALL_DIR" 2>/dev/null
+                    sleep "$backoff"
+                fi
+                if GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=30 \
+                   GIT_TERMINAL_PROMPT=0 \
+                   git clone --progress --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                    https_ok=true
+                    break
+                fi
+            done
+
+            if [ "$https_ok" = true ]; then
                 log_success "Cloned via HTTPS"
             else
-                log_error "Failed to clone repository"
+                rm -rf "$INSTALL_DIR" 2>/dev/null
+                log_error "Failed to clone repository after 3 attempts"
+                log_info "This usually means a slow or blocked network connection to github.com."
+                log_info "You can clone manually and re-run the installer:"
+                log_info "  git clone $REPO_URL_HTTPS $INSTALL_DIR"
+                log_info "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+                log_info "Or set a proxy first:  export https_proxy=http://your-proxy:port"
                 exit 1
             fi
         fi


### PR DESCRIPTION
## Problem

When running the installer via `curl -fsSL .../install.sh | bash`, the HTTPS clone fallback can hang indefinitely with no visible output on slow or flaky networks. Real user report from a macOS user in a region with spotty GitHub connectivity: terminal appeared frozen at `→ Trying SSH clone...` with no way to tell whether anything was happening.

Root causes:
1. `git clone` suppresses progress output when stdout is piped (which is exactly what `curl | bash` does), so the user sees nothing.
2. No stall detection — if throughput drops to zero, clone hangs forever.
3. No retry on transient network failure.
4. No actionable guidance on failure.

## Fix

Minimal, low-risk changes to the HTTPS clone branch only (SSH path untouched since it already has `ConnectTimeout=5` + `BatchMode=yes`):

- `--progress` forces git to stream progress output even when stdout is redirected.
- `GIT_HTTP_LOW_SPEED_LIMIT=1000` + `GIT_HTTP_LOW_SPEED_TIME=30` aborts the clone if throughput drops below 1 KB/s for 30s.
- `GIT_TERMINAL_PROMPT=0` prevents git from hanging on credential prompts in non-interactive installs.
- Up to 3 attempts with 5s / 15s backoff; partial clones are cleaned up between attempts.
- On total failure, prints the manual clone command and a hint about `https_proxy`.

## Test

- `bash -n scripts/install.sh` passes.
- No changes to SSH path, Termux path, or any other stage of the installer.