### PR TITLE
fix(tui): prevent trailing space in picker-command completions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -972,6 +972,12 @@ class SlashCommandCompleter(Completer):
         except Exception:
             return {}
 
+    # Commands that open pickers when run without arguments.
+    # These should NOT receive a trailing space in completions because:
+    # - The TUI's submit handler applies completions on Enter if input differs
+    # - Adding space makes "/model" → "/model " which blocks picker execution
+    _PICKER_COMMANDS = frozenset({"model", "skin", "personality"})
+
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
         """Return replacement text for a completion.
@@ -980,8 +986,17 @@ class SlashCommandCompleter(Completer):
         returning ``help`` would be a no-op and prompt_toolkit suppresses the
         menu. Appending a trailing space keeps the dropdown visible and makes
         backspacing retrigger it naturally.
+
+        However, commands that open pickers (model, skin, personality) should
+        NOT get a trailing space — the TUI would apply the completion on Enter
+        and block the picker from opening.
         """
-        return f"{cmd_name} " if cmd_name == word else cmd_name
+        if cmd_name != word:
+            return cmd_name
+        # Don't add space for picker commands — allows Enter to execute them
+        if cmd_name in SlashCommandCompleter._PICKER_COMMANDS:
+            return cmd_name
+        return f"{cmd_name} "
 
     @staticmethod
     def _extract_path_word(text: str) -> str | None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -292,6 +292,7 @@ AUTHOR_MAP = {
     "xowiekk@gmail.com": "Xowiek",
     "1243352777@qq.com": "zons-zhaozhy",
     "e.silacandmr@gmail.com": "Es1la",
+    "simplenamebox@gmail.com": "simplenamebox-ops",
     # ── bulk addition: 75 emails resolved via API, PR salvage bodies, noreply
     #    crossref, and GH contributor list matching (April 2026 audit) ──
     "1115117931@qq.com": "aaronagent",


### PR DESCRIPTION
Commands that open pickers (/model, /skin, /personality) previously received a trailing space in their completions to keep the dropdown visible in the classic CLI. However, the TUI's submit handler applies the completion when Enter is pressed and the result differs from the input — so '/model' + space became '/model ' and the command was never executed.

Picker commands now omit the trailing space for exact matches, allowing Enter to submit and open the picker. Non-picker commands (/help, etc.) are unaffected.