### PR TITLE
fix: eliminate duplicate checkpoint entries and JSON-unsafe coercion

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -951,13 +951,9 @@ class BatchRunner:
                     root_logger.setLevel(original_level)
         
         # Aggregate all batch statistics and update checkpoint
-        all_completed_prompts = list(completed_prompts_set)
         total_reasoning_stats = {"total_assistant_turns": 0, "turns_with_reasoning": 0, "turns_without_reasoning": 0}
-        
+
         for batch_result in results:
-            # Add newly completed prompts
-            all_completed_prompts.extend(batch_result.get("completed_prompts", []))
-            
             # Aggregate tool stats
             for tool_name, stats in batch_result.get("tool_stats", {}).items():
                 if tool_name not in total_tool_stats:
@@ -977,7 +973,7 @@ class BatchRunner:
         
         # Save final checkpoint (best-effort; incremental writes already happened)
         try:
-            checkpoint_data["completed_prompts"] = all_completed_prompts
+            checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
             print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")

--- a/model_tools.py
+++ b/model_tools.py
@@ -464,9 +464,9 @@ def _coerce_number(value: str, integer_only: bool = False):
         f = float(value)
     except (ValueError, OverflowError):
         return value
-    # Guard against inf/nan before int() conversion
+    # Guard against inf/nan — not JSON-serializable, keep original string
     if f != f or f == float("inf") or f == float("-inf"):
-        return f
+        return value
     # If it looks like an integer (no fractional part), return int
     if f == int(f):
         return int(f)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,6 +60,7 @@ AUTHOR_MAP = {
     "keifergu@tencent.com": "keifergu",
     "kshitijk4poor@users.noreply.github.com": "kshitijk4poor",
     "abner.the.foreman@agentmail.to": "Abnertheforeman",
+    "thomasgeorgevii09@gmail.com": "tochukwuada",
     "harryykyle1@gmail.com": "hharry11",
     "kshitijk4poor@gmail.com": "kshitijk4poor",
     "keira.voss94@gmail.com": "keiravoss94",

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -186,3 +186,67 @@ class TestBatchWorkerResumeBehavior:
         assert result["discarded_no_reasoning"] == 1
         assert result["completed_prompts"] == [0]
         assert not batch_file.exists() or batch_file.read_text() == ""
+
+
+class TestFinalCheckpointNoDuplicates:
+    """Regression: the final checkpoint must not contain duplicate prompt
+    indices.
+
+    Before PR #15161, `run()` populated `completed_prompts_set` incrementally
+    as each batch completed, then at the end built `all_completed_prompts =
+    list(completed_prompts_set)` AND extended it again with every batch's
+    `completed_prompts` — double-counting every index.
+    """
+
+    def _simulate_final_aggregation_fixed(self, batch_results):
+        """Mirror the fixed code path in batch_runner.run()."""
+        completed_prompts_set = set()
+        for result in batch_results:
+            completed_prompts_set.update(result.get("completed_prompts", []))
+        # This is what the fixed code now writes to the checkpoint:
+        return sorted(completed_prompts_set)
+
+    def test_no_duplicates_in_final_list(self):
+        batch_results = [
+            {"completed_prompts": [0, 1, 2]},
+            {"completed_prompts": [3, 4]},
+            {"completed_prompts": [5]},
+        ]
+        final = self._simulate_final_aggregation_fixed(batch_results)
+        assert final == [0, 1, 2, 3, 4, 5]
+        assert len(final) == len(set(final))  # no duplicates
+
+    def test_persisted_checkpoint_has_unique_prompts(self, runner):
+        """Write what run()'s fixed aggregation produces to disk; the file
+        must load back with no duplicate indices."""
+        batch_results = [
+            {"completed_prompts": [0, 1]},
+            {"completed_prompts": [2, 3]},
+        ]
+        final = self._simulate_final_aggregation_fixed(batch_results)
+        runner._save_checkpoint({
+            "run_name": runner.run_name,
+            "completed_prompts": final,
+            "batch_stats": {},
+        })
+        loaded = json.loads(runner.checkpoint_file.read_text())
+        cp = loaded["completed_prompts"]
+        assert cp == sorted(set(cp))
+        assert len(cp) == 4
+
+    def test_old_buggy_pattern_would_have_duplicates(self):
+        """Document the bug this PR fixes: the old code shape produced
+        duplicates.  Kept as a sanity anchor so a future refactor that
+        re-introduces the pattern is immediately visible."""
+        completed_prompts_set = set()
+        results = []
+        for batch in ({"completed_prompts": [0, 1, 2]},
+                      {"completed_prompts": [3, 4]}):
+            completed_prompts_set.update(batch["completed_prompts"])
+            results.append(batch)
+        # Buggy aggregation (pre-fix):
+        buggy = list(completed_prompts_set)
+        for br in results:
+            buggy.extend(br.get("completed_prompts", []))
+        # Every index appears twice
+        assert len(buggy) == 2 * len(set(buggy))

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -231,3 +231,46 @@ class TestBackwardCompat:
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
+
+
+# =========================================================================
+# _coerce_number — inf / nan must fall through to the original string
+# (regression: fix: eliminate duplicate checkpoint entries and JSON-unsafe coercion)
+# =========================================================================
+
+class TestCoerceNumberInfNan:
+    """_coerce_number must honor its documented contract ("Returns original
+    string on failure") for inf/nan inputs, because float('inf') and
+    float('nan') are not JSON-compliant under strict serialization."""
+
+    def test_inf_returns_original_string(self):
+        from model_tools import _coerce_number
+        assert _coerce_number("inf") == "inf"
+
+    def test_negative_inf_returns_original_string(self):
+        from model_tools import _coerce_number
+        assert _coerce_number("-inf") == "-inf"
+
+    def test_nan_returns_original_string(self):
+        from model_tools import _coerce_number
+        assert _coerce_number("nan") == "nan"
+
+    def test_infinity_spelling_returns_original_string(self):
+        from model_tools import _coerce_number
+        # Python's float() parses "Infinity" too — still not JSON-safe.
+        assert _coerce_number("Infinity") == "Infinity"
+
+    def test_coerced_result_is_strict_json_safe(self):
+        """Whatever _coerce_number returns for inf/nan must round-trip
+        through strict (allow_nan=False) json.dumps without raising."""
+        from model_tools import _coerce_number
+        for s in ("inf", "-inf", "nan", "Infinity"):
+            result = _coerce_number(s)
+            json.dumps({"x": result}, allow_nan=False)  # must not raise
+
+    def test_normal_numbers_still_coerce(self):
+        """Guard against over-correction — real numbers still coerce."""
+        from model_tools import _coerce_number
+        assert _coerce_number("42") == 42
+        assert _coerce_number("3.14") == 3.14
+        assert _coerce_number("1e3") == 1000


### PR DESCRIPTION
Salvages #15161 by @tochukwuada onto current main, adds regression tests, and maps the contributor in AUTHOR_MAP.

## Summary
Two unrelated bug fixes:

- **batch_runner.py** — the final-aggregation loop in `run()` was double-counting completed prompt indices in the on-disk checkpoint. `completed_prompts_set` is already populated incrementally during result collection, but the subsequent block built `all_completed_prompts = list(completed_prompts_set)` and then re-extended it with every batch's `completed_prompts`. Fixed by writing `sorted(completed_prompts_set)` directly.
- **model_tools.py** — `_coerce_number("inf"|"-inf"|"nan"|"Infinity")` returned `float('inf')` / `float('nan')`, which is not JSON-compliant under strict serialization (`json.dumps(..., allow_nan=False)`). Also violated the function's own docstring ("Returns original string on failure"). Fixed by returning the original string.

## Changes
- `batch_runner.py`: drop redundant extend loop; write sorted set directly (contributor)
- `model_tools.py`: return original string on inf/nan (contributor)
- `tests/test_model_tools.py`: `TestCoerceNumberInfNan` — 6 regression tests incl. strict-JSON round-trip
- `tests/test_batch_runner_checkpoint.py`: `TestFinalCheckpointNoDuplicates` — 3 regression tests incl. anchor documenting the pre-fix bug pattern
- `scripts/release.py`: AUTHOR_MAP entry for @tochukwuada

## Validation
`scripts/run_tests.sh tests/test_model_tools.py tests/test_batch_runner_checkpoint.py` → 38 passed (10 new).

Closes #15161.