### PR TITLE
feat(models): add openai/gpt-5.5 + gpt-5.5-pro to OpenRouter and Nous Portal

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -42,7 +42,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("anthropic/claude-sonnet-4.5",     ""),
     ("anthropic/claude-haiku-4.5",      ""),
     ("openrouter/elephant-alpha",       "free"),
-    ("openai/gpt-5.4",                  ""),
+    ("openai/gpt-5.5",                  ""),
     ("openai/gpt-5.4-mini",             ""),
     ("xiaomi/mimo-v2.5-pro",             ""),
     ("xiaomi/mimo-v2.5",                 ""),
@@ -65,7 +65,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
     ("arcee-ai/trinity-large-preview:free", "free"),
     ("arcee-ai/trinity-large-thinking",  ""),
-    ("openai/gpt-5.4-pro",              ""),
+    ("openai/gpt-5.5-pro",              ""),
     ("openai/gpt-5.4-nano",             ""),
 ]
 
@@ -120,7 +120,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "anthropic/claude-sonnet-4.6",
         "anthropic/claude-sonnet-4.5",
         "anthropic/claude-haiku-4.5",
-        "openai/gpt-5.4",
+        "openai/gpt-5.5",
         "openai/gpt-5.4-mini",
         "openai/gpt-5.3-codex",
         "google/gemini-3-pro-preview",
@@ -139,7 +139,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "x-ai/grok-4.20-beta",
         "nvidia/nemotron-3-super-120b-a12b",
         "arcee-ai/trinity-large-thinking",
-        "openai/gpt-5.4-pro",
+        "openai/gpt-5.5-pro",
         "openai/gpt-5.4-nano",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and


### PR DESCRIPTION
## Summary
Adds `openai/gpt-5.5` and `openai/gpt-5.5-pro` to the OpenRouter fallback snapshot and the Nous Portal curated list, replacing the `gpt-5.4` / `gpt-5.4-pro` entries.

## Changes
- `hermes_cli/models.py`: `OPENROUTER_MODELS` — `gpt-5.4` → `gpt-5.5`, `gpt-5.4-pro` → `gpt-5.5-pro`
- `hermes_cli/models.py`: `_PROVIDER_MODELS["nous"]` — same two replacements

`-mini` / `-nano` variants, Vercel AI Gateway, and native OpenAI / Copilot / codex lists are untouched.