### PR TITLE
fix(gateway): honor silent busy input modes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1842,9 +1842,10 @@ class HermesCLI:
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
-        # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
+        # busy_input_mode controls Enter while the agent is running.
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
-        self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
+        _bim = str(_bim).strip().lower()
+        self.busy_input_mode = _bim if _bim in {"interrupt", "queue", "block", "ignore"} else "interrupt"
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -9251,6 +9252,8 @@ class HermesCLI:
                         self._pending_input.put(payload)
                         preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
                         _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
+                    elif self.busy_input_mode in {"block", "ignore"}:
+                        pass
                     else:
                         self._interrupt_queue.put(payload)
                         # Debug: log to file when message enters interrupt queue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1441,7 +1441,9 @@ class GatewayRunner:
                     mode = str(cfg.get("display", {}).get("busy_input_mode", "") or "").strip().lower()
             except Exception:
                 pass
-        return "queue" if mode == "queue" else "interrupt"
+        if mode in {"interrupt", "queue", "block", "ignore"}:
+            return mode
+        return "interrupt"
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -1575,6 +1577,14 @@ class GatewayRunner:
             return True
 
         # Normal busy case (agent actively running a task)
+        if self._busy_input_mode in {"block", "ignore"}:
+            logger.debug(
+                "Ignoring busy input for session %s because busy_input_mode=%s",
+                session_key[:20],
+                self._busy_input_mode,
+            )
+            return True
+
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return False  # let default path handle it
@@ -3530,6 +3540,14 @@ class GatewayRunner:
                     f"⏳ Agent is running — `/{_cmd_def_inner.name}` can't run "
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
+
+            if self._busy_input_mode in {"block", "ignore"}:
+                logger.debug(
+                    "Ignoring busy input for session %s because busy_input_mode=%s",
+                    _quick_key[:20],
+                    self._busy_input_mode,
+                )
+                return None
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -287,7 +287,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.busy_input_mode": {
         "type": "select",
         "description": "Input behavior while agent is running",
-        "options": ["queue", "interrupt", "block"],
+        "options": ["interrupt", "queue", "block", "ignore"],
     },
     "memory.provider": {
         "type": "select",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -105,6 +105,14 @@ class TestBusyInputMode:
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
         assert cli.busy_input_mode == "queue"
 
+    def test_busy_input_mode_block_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "block"}})
+        assert cli.busy_input_mode == "block"
+
+    def test_busy_input_mode_ignore_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "ignore"}})
+        assert cli.busy_input_mode == "ignore"
+
     def test_unknown_busy_input_mode_falls_back_to_interrupt(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "bogus"}})
         assert cli.busy_input_mode == "interrupt"
@@ -147,6 +155,20 @@ class TestBusyInputMode:
             cli._interrupt_queue.put(text)
         assert cli._interrupt_queue.get_nowait() == "redirect"
         assert cli._pending_input.empty()
+
+    def test_block_mode_drops_busy_enter(self):
+        """In block mode, Enter while busy does not queue or interrupt."""
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "block"}})
+        cli._agent_running = True
+        text = "drop this"
+        if cli.busy_input_mode == "queue":
+            cli._pending_input.put(text)
+        elif cli.busy_input_mode in {"block", "ignore"}:
+            pass
+        else:
+            cli._interrupt_queue.put(text)
+        assert cli._pending_input.empty()
+        assert cli._interrupt_queue.empty()
 
 
 class TestSingleQueryState:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -160,6 +160,48 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_ignore_mode_suppresses_interrupt_queue_and_ack(self):
+        """When busy_input_mode is 'ignore', busy messages are silently dropped."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "ignore"
+        adapter = _make_adapter()
+
+        event = _make_event(text="please stop posting")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+        assert adapter._pending_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_block_mode_suppresses_interrupt_queue_and_ack(self):
+        """Dashboard's 'block' spelling maps to the same silent drop behavior."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "block"
+        adapter = _make_adapter()
+
+        event = _make_event(text="extra input")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+        assert adapter._pending_messages == {}
+
+    @pytest.mark.asyncio
     async def test_debounce_suppresses_rapid_acks(self):
         """Second message within 30s should NOT send another ack."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -90,6 +90,14 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     )
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_input_mode: ignore\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "ignore"
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "block")
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "block"
+
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "interrupt")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
 

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -247,6 +247,28 @@ async def test_recent_telegram_text_followup_is_queued_without_interrupt():
 
 
 @pytest.mark.asyncio
+async def test_ignore_busy_input_mode_drops_running_agent_followup():
+    runner = _make_runner()
+    runner._busy_input_mode = "ignore"
+    event = _make_event(text="follow-up")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+
+    import time as _time
+    runner._running_agents_ts[session_key] = _time.time()
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    fake_agent.interrupt.assert_not_called()
+    adapter = runner.adapters[Platform.TELEGRAM]
+    assert session_key not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
 async def test_recent_telegram_followups_append_in_pending_queue():
     runner = _make_runner()
     first = _make_event(text="part one")

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -225,11 +225,12 @@ The `display.busy_input_mode` config key controls what happens when you press En
 |------|----------|
 | `"interrupt"` (default) | Your message interrupts the current operation and is processed immediately |
 | `"queue"` | Your message is silently queued and sent as the next turn after the agent finishes |
+| `"block"` / `"ignore"` | Your message is silently ignored while the agent is busy |
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  busy_input_mode: "queue"   # or "interrupt" (default)
+  busy_input_mode: "queue"   # or "interrupt" (default), "block", "ignore"
 ```
 
 Queue mode is useful when you want to prepare follow-up messages without accidentally canceling in-flight work. Unknown values fall back to `"interrupt"`.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -212,12 +212,15 @@ Pairing codes expire after 1 hour, are rate-limited, and use cryptographic rando
 
 ## Interrupting the Agent
 
-Send any message while the agent is working to interrupt it. Key behaviors:
+By default, sending any message while the agent is working interrupts it. Set `display.busy_input_mode` in `~/.hermes/config.yaml` to change that behavior:
 
-- **In-progress terminal commands are killed immediately** (SIGTERM, then SIGKILL after 1s)
-- **Tool calls are cancelled** — only the currently-executing one runs, the rest are skipped
-- **Multiple messages are combined** — messages sent during interruption are joined into one prompt
-- **`/stop` command** — interrupts without queuing a follow-up message
+| Mode | Behavior |
+|------|----------|
+| `"interrupt"` (default) | New messages interrupt the current operation and are processed immediately |
+| `"queue"` | New messages are queued and sent as the next turn after the agent finishes |
+| `"block"` / `"ignore"` | New messages are silently ignored while the agent is busy |
+
+`/stop` still interrupts without queuing a follow-up message.
 
 ## Tool Progress Notifications
 


### PR DESCRIPTION
## What does this PR do?

Honors silent busy-input modes for CLI and gateway sessions.

`display.busy_input_mode` was only effectively supporting `interrupt` and `queue` in the gateway. Any other value, including the dashboard-exposed `block` option and user-configured `ignore`, fell back to `interrupt`, so busy Discord/Telegram sessions could still post "Interrupting current task..." acknowledgements and interrupt the active run.

This PR makes `block` and `ignore` explicit silent-drop modes for normal busy-session input. Dedicated mid-run controls such as `/stop`, `/status`, `/approve`, `/deny`, `/queue`, and `/steer` still work.

Related open PRs:

- https://github.com/NousResearch/hermes-agent/pull/12070 covers queue-mode gateway follow-ups.
- https://github.com/NousResearch/hermes-agent/pull/11782 adds CLI runtime controls for busy-input mode.
- https://github.com/NousResearch/hermes-agent/pull/10303 covers blocking input during compression.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: accepts `interrupt`, `queue`, `block`, and `ignore` from config/env and silently drops normal busy-session input in `block`/`ignore` mode.
- `cli.py`: honors `block` and `ignore` for busy Enter behavior instead of falling back to interrupt.
- `hermes_cli/web_server.py`: exposes all supported busy-input modes in the settings schema.
- `website/docs/user-guide/cli.md` and `website/docs/user-guide/messaging/index.md`: document the supported modes.
- Tests cover gateway config loading, adapter-level busy handling, direct running-agent busy handling, and CLI config normalization.

## How to Test

1. Set `display.busy_input_mode: ignore` or `display.busy_input_mode: block`.
2. Start a gateway session and send a normal follow-up message while the agent is still running.
3. Confirm the follow-up does not interrupt the active run, does not get queued, and does not send a busy acknowledgement.
4. Confirm explicit commands such as `/stop` and `/status` still work while the agent is running.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `./scripts/run_tests.sh tests/gateway/test_busy_session_ack.py tests/gateway/test_restart_drain.py tests/gateway/test_session_race_guard.py tests/cli/test_cli_init.py -n 4` → `70 passed`
- `./scripts/run_tests.sh tests/ -n 4` → `135 failed, 15357 passed, 40 skipped, 184 warnings in 304.57s`
