### PR TITLE
fix(tui): rebuild when ink bundle is missing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -839,6 +839,8 @@ def _find_bundled_tui(tui_dir: Path) -> Optional[Path]:
 
 
 def _tui_build_needed(tui_dir: Path) -> bool:
+    if _hermes_ink_bundle_stale(tui_dir):
+        return True
     entry = tui_dir / "dist" / "entry.js"
     if not entry.exists():
         return True

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -19,6 +19,18 @@ def _touch_ink(root: Path) -> None:
     ink.write_text("{}")
 
 
+def _touch_tui_entry(root: Path) -> None:
+    entry = root / "dist" / "entry.js"
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    entry.write_text("console.log('tui')")
+
+
+def _touch_ink_bundle(root: Path) -> None:
+    bundle = root / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_text("export {}")
+
+
 def test_need_install_when_ink_missing(tmp_path: Path, main_mod) -> None:
     (tmp_path / "package-lock.json").write_text("{}")
     assert main_mod._tui_need_npm_install(tmp_path) is True
@@ -51,3 +63,19 @@ def test_need_install_when_marker_missing(tmp_path: Path, main_mod) -> None:
 def test_no_install_without_lockfile_when_ink_present(tmp_path: Path, main_mod) -> None:
     _touch_ink(tmp_path)
     assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_build_needed_when_local_ink_bundle_missing(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    _touch_ink(tmp_path)
+
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+    assert main_mod._tui_build_needed(tmp_path) is True
+
+
+def test_build_not_needed_when_entry_and_ink_bundle_present(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    _touch_ink(tmp_path)
+    _touch_ink_bundle(tmp_path)
+
+    assert main_mod._tui_build_needed(tmp_path) is False


### PR DESCRIPTION
## What does this PR do?

Repairs a TUI first-launch/update failure where `hermes --tui` could crash after a partial npm install/build.

The TUI imports the local workspace package `@hermes/ink`, whose `index.js` re-exports `packages/hermes-ink/dist/ink-bundle.js`. If a network failure interrupts setup after `node_modules/@hermes/ink/package.json` exists but before the bundle is built, the production launch path can think dependencies are installed and the main TUI bundle is current, then crash with:

`Cannot find module '.../ui-tui/node_modules/@hermes/ink/dist/ink-bundle.js'`

The normal production build script already rebuilds `@hermes/ink`; the missing piece was detecting that the local Ink bundle was absent/stale before deciding whether the TUI build is needed.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: makes `_tui_build_needed()` return true when `packages/hermes-ink/dist/ink-bundle.js` is missing or stale.
- `tests/hermes_cli/test_tui_npm_install.py`: adds regression coverage for the partial-install state where `@hermes/ink` appears installed but its bundle is missing.

## How to Test

1. Delete `ui-tui/packages/hermes-ink/dist/ink-bundle.js` while keeping `ui-tui/dist/entry.js` and `ui-tui/node_modules/@hermes/ink/package.json`.
2. Run `hermes --tui`.
3. Confirm Hermes rebuilds the TUI instead of launching into the missing-module crash.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m py_compile hermes_cli/main.py` → passed
- `./scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -n 4` → `7 passed`
- `./scripts/run_tests.sh tests/ -n 4` → attempted; the current baseline showed broad unrelated failures, then stalled near 98% after cleanup-thread logging errors (`ValueError: I/O operation on closed file`) and was stopped instead of leaving pytest wedged.
