### PR TITLE
fix: add DeepSeek reasoning_content echo for tool-call messages (fixes #15353)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7217,6 +7217,12 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
+            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
+                # DeepSeek thinking mode requires reasoning_content on every
+                # assistant tool-call message. Without it, replaying the
+                # persisted message causes HTTP 400. Include empty string
+                # as a defensive compatibility fallback (refs #15250).
+                msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
@@ -7292,6 +7298,22 @@ class AIAgent:
 
         return msg
 
+    def _needs_deepseek_tool_reasoning(self) -> bool:
+        """Return True when the current provider is DeepSeek thinking mode.
+
+        Used to decide whether to store reasoning_content on tool-call
+        assistant messages. DeepSeek V4 thinking mode requires this field
+        on every assistant tool-call turn; omitting it causes HTTP 400
+        when the message is replayed in a subsequent API request (#15250).
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "deepseek"
+            or "deepseek" in model
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Copy provider-facing reasoning fields onto an API replay message."""
         if source_msg.get("role") != "assistant":
@@ -7307,13 +7329,17 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        kimi_requires_reasoning = (
-            self.provider in {"kimi-coding", "kimi-coding-cn"}
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        needs_tool_reasoning_echo = (
+            provider in {"kimi-coding", "kimi-coding-cn", "deepseek"}
+            or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
         )
-        if kimi_requires_reasoning and source_msg.get("tool_calls"):
+        if needs_tool_reasoning_echo and source_msg.get("tool_calls"):
             api_msg["reasoning_content"] = ""
 
     @staticmethod
@@ -8501,6 +8527,7 @@ class AIAgent:
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
+                self._copy_reasoning_content_for_api(msg, api_msg)
                 for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                     api_msg.pop(internal_field, None)
                 if _needs_sanitize:


### PR DESCRIPTION
## Summary

DeepSeek V4 thinking mode requires `reasoning_content` on every assistant message that includes `tool_calls`. When missing, replay causes HTTP 400.

Closes #15353
Related: #14938 #14933 #15213

## Changes

### 1. Merge DeepSeek into `needs_tool_reasoning_echo` check

In `_copy_reasoning_content_for_api()`, replaced the Kimi-only detection with a combined check covering:
- `provider == "deepseek"`
- `"deepseek" in model` (case-insensitive)
- `api.deepseek.com` base URL (custom provider)

This handles already-poisoned persisted sessions by injecting empty `reasoning_content` on replay.

### 2. Store `reasoning_content` on new tool-call messages

Added `_needs_deepseek_tool_reasoning()` helper method, wired into `_build_assistant_message()`. When a DeepSeek tool-call message is created without reasoning text (common for streaming tool-only turns), stores `reasoning_content=""` instead of omitting the field. Prevents future session poisoning at the source.

### 3. Fix `_handle_max_iterations` path

Added missing call to `_copy_reasoning_content_for_api()` in the max-iterations flush path. Previously only the main loop and `flush_memories()` had this call.

## Test Plan

- [x] Verified in state.db: new tool-call messages store `reasoning_content`
- [x] Previously poisoned messages handled by replay fix
- [x] Tested on Rocky Linux 9.7 with deepseek-v4-pro via custom provider

## Diff

1 file changed: `run_agent.py` (+30, -3)