### PR TITLE
fix(dashboard): remove unimplemented 'block' busy_input_mode option

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -287,7 +287,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.busy_input_mode": {
         "type": "select",
         "description": "Input behavior while agent is running",
-        "options": ["queue", "interrupt", "block"],
+        "options": ["interrupt", "queue"],
     },
     "memory.provider": {
         "type": "select",


### PR DESCRIPTION
## Summary
The dashboard select for `display.busy_input_mode` offered `block`, but no implementation existed — the gateway and CLI both silently collapse anything other than `queue` to `interrupt`. Users picking `block` got interrupts anyway.

Drop `block` from the schema. Supported modes are `interrupt` (default) and `queue`.

Context: #15344 proposed implementing `block`/`ignore` as silent-drop modes. Silent-drop is bad UX for a messaging bot (users spam when they think the bot is broken), and the `queue` mode already covers the 'don't interrupt me' use case. Closing that PR in favor of removing the dashboard lie.

## Changes
- `hermes_cli/web_server.py`: schema options `[queue, interrupt, block]` → `[interrupt, queue]`

## Validation
py_compile passes. No other consumer references `block`.