### PR TITLE
fix(honcho): HOME-aware global config fallback path resolution

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
 HOST = "hermes"
 
 
@@ -53,6 +52,11 @@ def resolve_active_host() -> str:
     return HOST
 
 
+def resolve_global_config_path() -> Path:
+    """Return the shared Honcho config path for the current HOME."""
+    return Path.home() / ".honcho" / "config.json"
+
+
 def resolve_config_path() -> Path:
     """Return the active Honcho config path.
 
@@ -72,7 +76,7 @@ def resolve_config_path() -> Path:
     if default_path != local_path and default_path.exists():
         return default_path
 
-    return GLOBAL_CONFIG_PATH
+    return resolve_global_config_path()
 
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -14,7 +14,7 @@ from plugins.memory.honcho.client import (
     reset_honcho_client,
     resolve_active_host,
     resolve_config_path,
-    GLOBAL_CONFIG_PATH,
+    resolve_global_config_path,
     HOST,
 )
 
@@ -360,7 +360,7 @@ class TestResolveConfigPath:
         with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
              patch.object(Path, "home", return_value=fake_home):
             result = resolve_config_path()
-        assert result == GLOBAL_CONFIG_PATH
+        assert result == fake_home / ".honcho" / "config.json"
 
     def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
         fake_home = tmp_path / "fakehome"
@@ -370,7 +370,18 @@ class TestResolveConfigPath:
              patch.object(Path, "home", return_value=fake_home):
             os.environ.pop("HERMES_HOME", None)
             result = resolve_config_path()
-        assert result == GLOBAL_CONFIG_PATH
+        assert result == fake_home / ".honcho" / "config.json"
+
+    def test_global_fallback_uses_home_at_call_time(self, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=fake_home):
+            assert resolve_global_config_path() == fake_home / ".honcho" / "config.json"
+            assert resolve_config_path() == fake_home / ".honcho" / "config.json"
 
     def test_from_global_config_uses_local_path(self, tmp_path):
         hermes_home = tmp_path / "hermes"


### PR DESCRIPTION
Adopts #13320 by @HiddenPuppy with original authorship preserved.

Fixes #13283.

`GLOBAL_CONFIG_PATH` was resolved once at import time as `Path.home() / ".honcho" / "config.json"`. If `HOME` changes mid-process (profile switching, test fixtures using `patch.object(Path, "home", ...)`), the fallback read the cached import-time value instead of the current HOME.

Replaces the module-level constant with `resolve_global_config_path()` that computes the path at call time.

- plugins/memory/honcho/client.py: +5 -2
- tests/honcho_plugin/test_client.py: +15 -3

228/228 honcho_plugin tests pass locally.
