### PR TITLE
fix(providers): register bedrock in HERMES_OVERLAYS so resolve_provider_full succeeds

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -167,6 +167,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="OLLAMA_BASE_URL",
     ),
+    "bedrock": HermesOverlay(
+        transport="bedrock_converse",
+        auth_type="aws_sdk",
+        extra_env_vars=("AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"),
+        base_url_env_var="BEDROCK_BASE_URL",
+    ),
 }
 
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -300,6 +300,37 @@ class TestResolveProvider:
             resolve_provider("auto")
 
 
+
+class TestBedrockResolution:
+    """Regression tests for AWS Bedrock provider resolution (#issue).
+
+    Bedrock is registered in PROVIDER_REGISTRY (auth.py) but was missing from
+    HERMES_OVERLAYS and models.dev uses the id 'amazon-bedrock', so
+    resolve_provider_full('bedrock') returned None and hermes doctor
+    falsely reported "model.provider 'bedrock' is not a recognised provider".
+    """
+
+    def test_bedrock_in_provider_registry(self):
+        assert "bedrock" in PROVIDER_REGISTRY
+
+    def test_resolve_provider_full_bedrock(self):
+        from hermes_cli.providers import resolve_provider_full
+        pdef = resolve_provider_full("bedrock", None, [])
+        assert pdef is not None, "resolve_provider_full('bedrock') must not return None"
+        assert pdef.id == "bedrock"
+        assert pdef.transport == "bedrock_converse"
+        assert pdef.auth_type == "aws_sdk"
+
+    def test_bedrock_aliases_resolve(self):
+        from hermes_cli.providers import resolve_provider_full
+        for alias in ("aws", "aws-bedrock", "amazon-bedrock", "amazon"):
+            pdef = resolve_provider_full(alias, None, [])
+            assert pdef is not None, f"alias {alias!r} should resolve to bedrock"
+            assert pdef.id == "bedrock"
+
+
+
+
 # =============================================================================
 # API Key Provider Status tests
 # =============================================================================


### PR DESCRIPTION
## What & Why

Fixes #15358.

`hermes doctor` emits a false-positive error on valid `provider: bedrock` configs:

> ✗ model.provider 'bedrock' is not a recognised provider (known: ..., bedrock, ...)

Root cause: `hermes_cli/auth.py::PROVIDER_REGISTRY` registers `bedrock`, but `hermes_cli/providers.py::HERMES_OVERLAYS` had no entry for it. models.dev publishes this provider under the id `amazon-bedrock`, not `bedrock`, so `get_provider('bedrock')` and therefore `resolve_provider_full('bedrock', ...)` both returned `None`. Doctor then flagged the provider as unknown, contradicting its own "known providers" list.

The rest of the agent (runtime resolution, bedrock_converse transport, AWS SDK auth) already works — only provider resolution in `providers.py` was missing.

## Change

`hermes_cli/providers.py`: add a minimal `HermesOverlay` entry for `bedrock`, mirroring the `PROVIDER_REGISTRY` metadata:

```python
"bedrock": HermesOverlay(
    transport="bedrock_converse",
    auth_type="aws_sdk",
    extra_env_vars=("AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"),
    base_url_env_var="BEDROCK_BASE_URL",
),
```

The existing `ALIASES` already map `aws`, `aws-bedrock`, `amazon-bedrock`, and `amazon` to `bedrock`, so this single entry also makes all aliases resolve correctly.

## Tests

Added `TestBedrockResolution` in `tests/hermes_cli/test_api_key_providers.py` with three regression tests:

- `bedrock` is present in `PROVIDER_REGISTRY`
- `resolve_provider_full('bedrock', None, [])` returns a `ProviderDef` with `transport='bedrock_converse'` and `auth_type='aws_sdk'`
- All four aliases (`aws`, `aws-bedrock`, `amazon-bedrock`, `amazon`) resolve to `bedrock`

### How to test

```bash
pytest tests/hermes_cli/test_api_key_providers.py::TestBedrockResolution -v
pytest tests/hermes_cli/test_doctor.py -v
pytest tests/agent/test_bedrock_integration.py -v
```

All pass locally (77 tests across doctor + bedrock integration + new regression tests).

Before the fix, `hermes doctor` on a `provider: bedrock` config prints:

> ✗ model.provider 'bedrock' is not a recognised provider

After the fix, it prints no such error and correctly moves on to API connectivity checks.

## Platforms tested

- macOS 14 (Apple Silicon), Python 3.11.14

## Scope

One logical change. No behavior change for other providers — the new overlay entry is only consulted when `provider == 'bedrock'` (or one of its existing aliases) is passed in.
