### PR TITLE
fix(agent): recognize emoji as natural response endings in stop-to-length heuristic (#14572)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2698,7 +2698,13 @@ class AIAgent:
             return False
         if stripped.endswith("```"):
             return True
-        return stripped[-1] in '.!?:)"\']}。！？：）】」』》'
+        last = stripped[-1]
+        if last in '.!?:)"\']}。！？：）】」』》':
+            return True
+        # Emoji and other symbols (Unicode categories So, Sk, Sm, Sc)
+        # are common sign-offs — treat them as intentional endings (#14572).
+        import unicodedata
+        return unicodedata.category(last).startswith('S')
 
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""

--- a/tests/run_agent/test_emoji_stop_detection.py
+++ b/tests/run_agent/test_emoji_stop_detection.py
@@ -1,0 +1,48 @@
+"""Tests for _has_natural_response_ending emoji/symbol handling (#14572).
+
+Ollama/GLM stop-to-length heuristic false-triggers on emoji sign-offs
+because the punctuation charset didn't include emoji characters.
+"""
+import pytest
+from run_agent import AIAgent
+
+
+class TestHasNaturalResponseEndingEmoji:
+    """Emoji sign-offs must be recognized as natural endings (#14572)."""
+
+    @pytest.mark.parametrize("text", [
+        "Thank you! 🌙",
+        "Done ✅",
+        "Here's the result 👍",
+        "All set! 🎉",
+        "Check it out →",   # Sm — math symbol
+        "Total: ¥",         # Sc — currency symbol
+        "Rating: ★",        # So — other symbol
+    ])
+    def test_emoji_and_symbol_endings_are_natural(self, text):
+        assert AIAgent._has_natural_response_ending(text) is True
+
+    @pytest.mark.parametrize("text", [
+        "Normal ending.",
+        "Normal ending!",
+        "Question?",
+        'She said "hello"',
+        "Code block ending```",
+        "日本語の文。",
+        "中文问号？",
+    ])
+    def test_punctuation_endings_still_work(self, text):
+        assert AIAgent._has_natural_response_ending(text) is True
+
+    @pytest.mark.parametrize("text", [
+        "No ending here",
+        "trailing word",
+        "abc",
+    ])
+    def test_non_natural_endings(self, text):
+        assert AIAgent._has_natural_response_ending(text) is False
+
+    def test_empty_and_whitespace(self):
+        assert AIAgent._has_natural_response_ending("") is False
+        assert AIAgent._has_natural_response_ending("   ") is False
+        assert AIAgent._has_natural_response_ending(None) is False


### PR DESCRIPTION
## What does this PR do?

`_has_natural_response_ending()` checks whether the last character of a response is in a hardcoded punctuation charset. Emoji characters (common sign-offs like `🌙`, `✅`, `👍`, `🎉`) are not in this charset, so responses ending with emoji are incorrectly classified as "truncated" by `_should_treat_stop_as_truncated()`. This causes silent retry loops for Ollama/GLM users whose responses naturally end with emoji.

The fix adds a Unicode category check — characters in categories starting with `S` (Symbol: So, Sk, Sm, Sc) are treated as natural endings.

## Related Issue

Fixes #14572

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: After the existing punctuation check, add a Unicode category check — characters in categories starting with `S` (Symbol: So, Sk, Sm, Sc) are treated as natural endings.

## How to Test

1. Run the targeted test:
   ```bash
   python -m pytest tests/run_agent/test_emoji_stop_detection.py -v
   ```
2. 18 parametrized cases cover emoji, CJK punctuation, code blocks, and non-endings.

Validation table:

| Input | Before | After |
|---|---|---|
| `"Thank you! 🌙"` | `False` → retried as truncated | `True` → accepted |
| `"Done ✅"` | `False` → retried | `True` → accepted |
| `"Normal ending."` | `True` | `True` (unchanged) |
| `"No ending here"` | `False` | `False` (unchanged) |

Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest tests/run_agent/test_emoji_stop_detection.py -v
# 18 parametrized cases pass
```
