### PR TITLE
fix(agent): set codex_responses api_mode for copilot-acp provider (#14437)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -319,6 +319,8 @@ def init_agent(
         # AWS Bedrock — auto-detect from provider name or base URL
         # (bedrock-runtime.<region>.amazonaws.com).
         agent.api_mode = "bedrock_converse"
+    elif agent.provider == "copilot-acp":
+        agent.api_mode = "codex_responses"
     else:
         agent.api_mode = "chat_completions"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -924,6 +924,8 @@ class AIAgent:
             # AWS Bedrock — auto-detect from provider name or base URL
             # (bedrock-runtime.<region>.amazonaws.com).
             self.api_mode = "bedrock_converse"
+        elif self.provider == "copilot-acp":
+            self.api_mode = "codex_responses"
         else:
             self.api_mode = "chat_completions"
 

--- a/tests/run_agent/test_copilot_acp_api_mode.py
+++ b/tests/run_agent/test_copilot_acp_api_mode.py
@@ -1,0 +1,63 @@
+"""Tests for copilot-acp api_mode detection (#14437).
+
+Without the fix, copilot-acp falls through to the default chat_completions
+api_mode. The streaming path then attempts to iterate a SimpleNamespace
+object returned by CopilotACPClient, causing a TypeError crash.
+"""
+import re
+import pytest
+
+
+def _extract_api_mode_chain(source: str) -> list[tuple[str, str]]:
+    """Parse the api_mode if/elif/else chain from the init function.
+
+    Accepts both ``self.`` (legacy AIAgent.__init__) and ``agent.``
+    (current ``agent.agent_init.init_agent``) attribute styles so this
+    test survives the refactor that moved init logic into a helper.
+    """
+    results = []
+    for match in re.finditer(
+        r'(?:self|agent)\.provider\s*==\s*"([^"]+)".*?(?:self|agent)\.api_mode\s*=\s*"([^"]+)"',
+        source,
+        re.DOTALL,
+    ):
+        results.append((match.group(1), match.group(2)))
+    return results
+
+
+def _init_source() -> str:
+    """Return the source of whichever function owns api_mode detection.
+
+    Tries the refactored helper first, then falls back to ``AIAgent.__init__``.
+    """
+    import inspect
+    try:
+        from agent.agent_init import init_agent
+        return inspect.getsource(init_agent)
+    except Exception:
+        from run_agent import AIAgent
+        return inspect.getsource(AIAgent.__init__)
+
+
+class TestCopilotACPApiMode:
+    """copilot-acp provider must use codex_responses api_mode (#14437)."""
+
+    def test_copilot_acp_in_api_mode_chain(self):
+        """Verify that copilot-acp is explicitly handled before the else clause."""
+        source = _init_source()
+        chain = _extract_api_mode_chain(source)
+        providers = {provider for provider, _ in chain}
+        assert "copilot-acp" in providers, (
+            "copilot-acp is not in the api_mode detection chain — "
+            "will fall through to chat_completions and crash"
+        )
+
+    def test_copilot_acp_gets_codex_responses(self):
+        """Verify copilot-acp is mapped to codex_responses, not chat_completions."""
+        source = _init_source()
+        chain = _extract_api_mode_chain(source)
+        mode_map = dict(chain)
+        assert mode_map.get("copilot-acp") == "codex_responses", (
+            f"copilot-acp mapped to '{mode_map.get('copilot-acp', 'MISSING')}' "
+            f"instead of 'codex_responses'"
+        )

--- a/tests/run_agent/test_copilot_acp_api_mode.py
+++ b/tests/run_agent/test_copilot_acp_api_mode.py
@@ -1,0 +1,49 @@
+"""Tests for copilot-acp api_mode detection (#14437).
+
+Without the fix, copilot-acp falls through to the default chat_completions
+api_mode. The streaming path then attempts to iterate a SimpleNamespace
+object returned by CopilotACPClient, causing a TypeError crash.
+"""
+import re
+import pytest
+
+
+def _extract_api_mode_chain(source: str) -> list[tuple[str, str]]:
+    """Parse the api_mode if/elif/else chain from run_agent.py __init__."""
+    # Find provider == "X" patterns paired with api_mode assignments
+    results = []
+    for match in re.finditer(
+        r'self\.provider\s*==\s*"([^"]+)".*?self\.api_mode\s*=\s*"([^"]+)"',
+        source,
+        re.DOTALL,
+    ):
+        results.append((match.group(1), match.group(2)))
+    return results
+
+
+class TestCopilotACPApiMode:
+    """copilot-acp provider must use codex_responses api_mode (#14437)."""
+
+    def test_copilot_acp_in_api_mode_chain(self):
+        """Verify that copilot-acp is explicitly handled before the else clause."""
+        import inspect
+        from run_agent import AIAgent
+        source = inspect.getsource(AIAgent.__init__)
+        chain = _extract_api_mode_chain(source)
+        providers = {provider for provider, _ in chain}
+        assert "copilot-acp" in providers, (
+            "copilot-acp is not in the api_mode detection chain — "
+            "will fall through to chat_completions and crash"
+        )
+
+    def test_copilot_acp_gets_codex_responses(self):
+        """Verify copilot-acp is mapped to codex_responses, not chat_completions."""
+        import inspect
+        from run_agent import AIAgent
+        source = inspect.getsource(AIAgent.__init__)
+        chain = _extract_api_mode_chain(source)
+        mode_map = dict(chain)
+        assert mode_map.get("copilot-acp") == "codex_responses", (
+            f"copilot-acp mapped to '{mode_map.get('copilot-acp', 'MISSING')}' "
+            f"instead of 'codex_responses'"
+        )


### PR DESCRIPTION
## What does this PR do?

The `__init__` api_mode detection chain has no `elif self.provider == "copilot-acp"` case. The provider falls through to the `else` branch and gets `chat_completions` mode. When the streaming path fires, it calls `for chunk in stream:` on the result of `CopilotACPClient._ACPChatCompletions.create()`, which returns a `SimpleNamespace` (not iterable), causing `TypeError: 'types.SimpleNamespace' object is not iterable`.

## Related Issue

Fixes #14437

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: Add `elif self.provider == "copilot-acp": self.api_mode = "codex_responses"` before the final `else` clause in the api_mode detection chain.

## How to Test

1. Without fix: copilot-acp provider crashes with `TypeError` on every API call.
2. With fix: copilot-acp correctly uses the `codex_responses` path which calls `_interruptible_api_call` (non-streaming).
3. Targeted test: `tests/run_agent/test_copilot_acp_api_mode.py` — verifies copilot-acp is explicitly mapped to `codex_responses` in the `__init__` source.

Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
