### PR TITLE
fix(agent): restrict dot-to-hyphen conversion to Claude models in Anthropic adapter (#14528)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1010,12 +1010,13 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     """Normalize a model name for the Anthropic API.
 
     - Strips 'anthropic/' prefix (OpenRouter format, case-insensitive)
-    - Converts dots to hyphens in version numbers (OpenRouter uses dots,
-      Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
-      preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
     - Preserves Bedrock model IDs (``anthropic.claude-opus-4-7``) and
       regional inference profiles (``us.anthropic.claude-*``) whose dots
       are namespace separators, not version separators.
+    - Converts dots to hyphens for Claude models only (OpenRouter uses dots,
+      Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6).  Non-Claude
+      models on third-party Anthropic-compatible endpoints keep their dots
+      intact (#14528), unless preserve_dots is True.
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
@@ -1026,9 +1027,11 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         # These must not be converted to hyphens.  See issue #12295.
         if _is_bedrock_model_id(model):
             return model
-        # OpenRouter uses dots for version separators (claude-opus-4.6),
-        # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.
-        model = model.replace(".", "-")
+        # Only convert dots for Claude models — non-Claude models
+        # (llama3.2-vision, qwen3.5-plus) on Anthropic-compatible
+        # endpoints must keep their dots (#14528).
+        if "claude" in model.lower():
+            model = model.replace(".", "-")
     return model
 
 

--- a/tests/agent/test_anthropic_normalize_dots.py
+++ b/tests/agent/test_anthropic_normalize_dots.py
@@ -1,0 +1,47 @@
+"""Tests for normalize_model_name dot-to-hyphen conversion (#14528).
+
+The blanket .replace(".", "-") corrupted non-Claude model names on
+third-party Anthropic-compatible endpoints.  The fix restricts
+conversion to digit-dot-digit version positions only.
+"""
+import pytest
+from agent.anthropic_adapter import normalize_model_name
+
+
+class TestNormalizeModelNameDots:
+    """Dot-to-hyphen conversion must only affect version numbers (#14528)."""
+
+    @pytest.mark.parametrize("input_name,expected", [
+        # Claude models: dots between digits should convert
+        ("claude-opus-4.6", "claude-opus-4-6"),
+        ("claude-sonnet-4.5", "claude-sonnet-4-5"),
+        ("claude-3.5-sonnet-20241022", "claude-3-5-sonnet-20241022"),
+        ("anthropic/claude-opus-4.6", "claude-opus-4-6"),
+        # Non-Claude models: dots NOT between digits must be preserved
+        ("llama3.2-vision", "llama3.2-vision"),
+        ("qwen3.5-plus", "qwen3.5-plus"),
+        ("gpt-4o", "gpt-4o"),
+        # No dots at all
+        ("claude-3-opus", "claude-3-opus"),
+        ("test-model", "test-model"),
+    ])
+    def test_dot_conversion(self, input_name, expected):
+        assert normalize_model_name(input_name) == expected
+
+    def test_preserve_dots_flag(self):
+        """preserve_dots=True should skip all conversion."""
+        assert normalize_model_name("claude-opus-4.6", preserve_dots=True) == "claude-opus-4.6"
+
+    @pytest.mark.parametrize("input_name", [
+        "llama3.2-vision",
+        "mixtral-8x7b.v0.1",
+        "model.name.with.dots",
+    ])
+    def test_non_version_dots_preserved(self, input_name):
+        """Dots that are NOT between two digits must be preserved (#14528)."""
+        result = normalize_model_name(input_name)
+        # Count non-digit-adjacent dots — they should all survive
+        import re
+        non_version_dots_input = len(re.findall(r'(?<!\d)\.|\.(?!\d)', input_name.removeprefix("anthropic/")))
+        non_version_dots_output = len(re.findall(r'(?<!\d)\.|\.(?!\d)', result))
+        assert non_version_dots_output == non_version_dots_input


### PR DESCRIPTION
## Summary

Fixes #14528.

`normalize_model_name()` does a blanket `.replace(".", "-")` on all model names when `preserve_dots` is False. This corrupts non-Claude models routed through third-party Anthropic-compatible endpoints: `llama3.2-vision` becomes `llama3-2-vision`, `qwen3.5-plus` becomes `qwen3-5-plus`, causing 404/model-not-found errors.

The existing `_anthropic_preserve_dots()` allowlist covers known providers (Alibaba, MiniMax, ZAI, Bedrock), but any unlisted third-party endpoint still gets blanket conversion.

## Changes

- `agent/anthropic_adapter.py`: Gate the `.replace(".", "-")` call with `if "claude" in model.lower()` so only Claude models (which legitimately need dot-to-hyphen conversion for the native Anthropic API) are affected. This works with the existing Bedrock `_is_bedrock_model_id()` guard that was added upstream in a recent commit.

## Validation

| Model | Before | After |
|---|---|---|
| `claude-opus-4.6` | `claude-opus-4-6` | `claude-opus-4-6` (unchanged) |
| `anthropic/claude-sonnet-4.5` | `claude-sonnet-4-5` | `claude-sonnet-4-5` (unchanged) |
| `llama3.2-vision` | `llama3-2-vision` (broken) | `llama3.2-vision` (preserved) |
| `qwen3.5-plus` | `qwen3-5-plus` (broken) | `qwen3.5-plus` (preserved) |

Targeted test: `tests/agent/test_anthropic_normalize_dots.py` — 13 cases. Existing suite `test_anthropic_adapter.py` (137 tests) passes with no regressions.

Tested on macOS (Python 3.14).