### PR TITLE
fix(agent): clear compressor state on session start to prevent cross-session task leakage (#14603)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -466,6 +466,18 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        """Clear cross-session summary state when a new session begins.
+
+        Without this, _previous_summary from a prior session leaks into the
+        next session's iterative summary update when the same AIAgent instance
+        is reused (common in gateway/cron), causing old task context to bleed
+        into the new session's compression summary (#14603).
+        """
+        super().on_session_start(session_id, **kwargs)
+        self._previous_summary = None
+        self._ineffective_compression_count = 0
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -288,6 +288,18 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        """Clear cross-session summary state when a new session begins.
+
+        Without this, _previous_summary from a prior session leaks into the
+        next session's iterative summary update when the same AIAgent instance
+        is reused (common in gateway/cron), causing old task context to bleed
+        into the new session's compression summary (#14603).
+        """
+        super().on_session_start(session_id, **kwargs)
+        self._previous_summary = None
+        self._ineffective_compression_count = 0
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()

--- a/tests/agent/test_compressor_session_isolation.py
+++ b/tests/agent/test_compressor_session_isolation.py
@@ -1,0 +1,44 @@
+"""Tests for ContextCompressor cross-session state isolation (#14603).
+
+_previous_summary leaks across sessions when the same cached AIAgent is
+reused in gateway/cron, causing old task context to bleed into new session
+compression summaries.
+"""
+import pytest
+from unittest.mock import patch
+from agent.context_compressor import ContextCompressor
+
+
+@pytest.fixture()
+def compressor():
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+
+
+class TestSessionIsolation:
+    """_previous_summary must not leak across sessions (#14603)."""
+
+    def test_on_session_start_clears_previous_summary(self, compressor):
+        compressor._previous_summary = "## Active Task\nDeploy the web server"
+        compressor._ineffective_compression_count = 3
+        compressor.on_session_start("new-session-123")
+        assert compressor._previous_summary is None
+        assert compressor._ineffective_compression_count == 0
+
+    def test_on_session_reset_still_works(self, compressor):
+        compressor._previous_summary = "old summary"
+        compressor._context_probed = True
+        compressor.on_session_reset()
+        assert compressor._previous_summary is None
+        assert compressor._context_probed is False
+
+    def test_summary_does_not_leak_between_sessions(self, compressor):
+        compressor._previous_summary = "## Active Task\nMigrate database schema"
+        compressor.on_session_start("session-2")
+        assert compressor._previous_summary is None


### PR DESCRIPTION
## What does this PR do?

`ContextCompressor._previous_summary` persists across session boundaries when the same cached `AIAgent` instance is reused in the gateway or cron. When a new session starts without an explicit `/reset`, `on_session_start()` is called but `on_session_reset()` is not. Since `on_session_start()` is a no-op on the base `ContextEngine`, `_previous_summary` from the old session leaks into the next session's iterative summary update, causing old task context (e.g. "## Active Task: Deploy the web server") to bleed into the new session's compression summary.

This PR overrides `on_session_start()` on `ContextCompressor` to clear `_previous_summary` and `_ineffective_compression_count`, ensuring a fresh compressor state when a new session begins while preserving the more thorough cleanup in `on_session_reset()` for explicit `/new` or `/reset`.

## Related Issue

Fixes #14603

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: Override `on_session_start()` to clear `_previous_summary` and `_ineffective_compression_count`.
- `tests/agent/test_compressor_session_isolation.py`: 3 targeted tests:
  1. `on_session_start` clears `_previous_summary`.
  2. `on_session_reset` still works as before.
  3. Summary state does not leak between sessions.

## How to Test

1. Run the targeted suite:
   ```bash
   pytest tests/agent/test_compressor_session_isolation.py -v
   ```
   Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
