### PR TITLE
fix(agent): strip MEDIA directives from compressor summarizer input (#14665)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -840,10 +840,16 @@ class ContextCompressor(ContextEngine):
         (API keys, tokens, passwords) from leaking into the summary that
         gets sent to the auxiliary model and persisted across compactions.
         """
+        # Strip MEDIA directives before sending to the summarizer — if they
+        # leak into the summary, the downstream model may re-emit them as
+        # active directives on the next turn (#14665).
+        _MEDIA_RE = re.compile(r'MEDIA:\S+')
+
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
             content = redact_sensitive_text(msg.get("content") or "")
+            content = _MEDIA_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -597,10 +597,16 @@ class ContextCompressor(ContextEngine):
         (API keys, tokens, passwords) from leaking into the summary that
         gets sent to the auxiliary model and persisted across compactions.
         """
+        # Strip MEDIA directives before sending to the summarizer — if they
+        # leak into the summary, the downstream model may re-emit them as
+        # active directives on the next turn (#14665).
+        _MEDIA_RE = re.compile(r'MEDIA:\S+')
+
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
             content = redact_sensitive_text(msg.get("content") or "")
+            content = _MEDIA_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -1,0 +1,56 @@
+"""Tests for MEDIA directive stripping in context compaction (#14665).
+
+MEDIA directives in assistant messages must not leak into compaction
+summaries — if they do, the downstream model re-emits them as active
+directives on the next turn.
+"""
+import pytest
+from unittest.mock import patch
+from agent.context_compressor import ContextCompressor
+
+
+@pytest.fixture()
+def compressor():
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+
+
+class TestMediaDirectiveStripping:
+    """MEDIA directives must be stripped before summarization (#14665)."""
+
+    def test_media_directive_stripped_from_assistant(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "Here is the audio MEDIA:/tmp/voice.ogg done."},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "MEDIA:/tmp/voice.ogg" not in result
+        assert "[media attachment]" in result
+
+    def test_media_directive_stripped_from_tool_result(self, compressor):
+        turns = [
+            {"role": "tool", "tool_call_id": "t1", "content": "Generated MEDIA:/tmp/out.mp3 successfully"},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "MEDIA:/tmp/out.mp3" not in result
+        assert "[media attachment]" in result
+
+    def test_non_media_content_preserved(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "The file path is /tmp/test.txt and it works."},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "/tmp/test.txt" in result
+
+    def test_multiple_media_directives(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "MEDIA:/a.ogg and MEDIA:/b.mp3"},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "MEDIA:" not in result
+        assert result.count("[media attachment]") == 2


### PR DESCRIPTION
## What does this PR do?

`_serialize_for_summary()` passes full message content — including `MEDIA:/path/to/file.ogg` directives — to the summarizer LLM. If the summarizer echoes a MEDIA directive into the "## Critical Context" section, that summary gets re-injected into the next turn's message history via `SUMMARY_PREFIX`. The downstream model sees what it believes is a prior output directive and may re-emit it, triggering unwanted media delivery.

This PR strips MEDIA directives before they reach the summarizer, replacing them with a neutral `[media attachment]` placeholder.

## Related Issue

Fixes #14665

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py` — added `_MEDIA_RE = re.compile(r'MEDIA:\S+')` and stripped all MEDIA directives from content with `[media attachment]` placeholder before sending to the summarizer. Applied to all message roles (assistant, tool, user) uniformly.
- `tests/agent/test_compressor_media_stripping.py` — targeted tests (4)

### Validation table

| Content | Before (sent to summarizer) | After |
|---|---|---|
| `"Here is the audio MEDIA:/tmp/voice.ogg done."` | `MEDIA:/tmp/voice.ogg` visible | `[media attachment]` |
| `"The file path is /tmp/test.txt"` | Preserved | Preserved (no false positive) |

## How to Test

1. `pytest tests/agent/test_compressor_media_stripping.py -v` — 4 tests covering assistant content, tool results, preservation of non-MEDIA paths, and multiple directives
2. Tested on macOS (Python 3.14)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
