### PR TITLE
fix(tools): show compression-continuation sessions in session search results (#13840)

### DIFF
--- a/tests/tools/test_session_search_compression.py
+++ b/tests/tools/test_session_search_compression.py
@@ -1,0 +1,51 @@
+"""Tests for session_search compression-continuation visibility (#13840).
+
+Compression-ended sessions have parent_session_id set (they are continuation
+children of compressed parents).  The blanket parent_session_id filter
+excluded them from search results, making compressed sessions invisible.
+"""
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestListRecentSessionsCompression:
+    """Compression-continuation sessions must be visible in recent sessions (#13840)."""
+
+    def _run_list_recent(self, sessions, current_session_id=None):
+        from tools.session_search_tool import _list_recent_sessions
+        db = MagicMock()
+        db.list_sessions_rich.return_value = sessions
+        db.get_session.return_value = None
+        return json.loads(_list_recent_sessions(db, limit=10, current_session_id=current_session_id))
+
+    def test_compression_continuation_visible(self):
+        """Sessions with parent_session_id AND end_reason=compression must be visible."""
+        sessions = [
+            {"id": "session-2", "parent_session_id": "session-1", "end_reason": "compression",
+             "title": "Continued after compression", "source": "cli", "started_at": "", "last_active": "",
+             "message_count": 5, "preview": "hello"},
+        ]
+        result = self._run_list_recent(sessions)
+        assert result["success"]
+        assert len(result["results"]) == 1
+        assert result["results"][0]["session_id"] == "session-2"
+
+    def test_delegation_child_still_hidden(self):
+        """Sessions with parent_session_id but no compression end_reason stay hidden."""
+        sessions = [
+            {"id": "delegate-1", "parent_session_id": "parent-1", "end_reason": None,
+             "title": "Delegated task", "source": "cli", "started_at": "", "last_active": "",
+             "message_count": 3, "preview": "sub-task"},
+        ]
+        result = self._run_list_recent(sessions)
+        assert len(result["results"]) == 0
+
+    def test_root_sessions_still_visible(self):
+        """Sessions without parent_session_id are always visible."""
+        sessions = [
+            {"id": "root-1", "parent_session_id": None, "title": "Root session",
+             "source": "cli", "started_at": "", "last_active": "", "message_count": 10, "preview": "hi"},
+        ]
+        result = self._run_list_recent(sessions)
+        assert len(result["results"]) == 1

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -123,8 +123,10 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             sid = s.get("id", "")
             if current_root and (sid == current_root or sid == current_session_id):
                 continue
-            # Skip child / delegation sessions
-            if s.get("parent_session_id"):
+            # Skip child/delegation sessions, but keep compression-continuation
+            # sessions — their parent ended via compression, not delegation,
+            # and they carry the active conversation forward (#13840).
+            if s.get("parent_session_id") and s.get("end_reason") != "compression":
                 continue
             results.append({
                 "session_id": sid,

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -288,8 +288,10 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             sid = s.get("id", "")
             if current_root and (sid == current_root or sid == current_session_id):
                 continue
-            # Skip child/delegation sessions (they have parent_session_id)
-            if s.get("parent_session_id"):
+            # Skip child/delegation sessions, but keep compression-continuation
+            # sessions — their parent ended via compression, not delegation,
+            # and they carry the active conversation forward (#13840).
+            if s.get("parent_session_id") and s.get("end_reason") != "compression":
                 continue
             results.append({
                 "session_id": sid,


### PR DESCRIPTION
## What does this PR do?

`_list_recent_sessions()` in `session_search_tool.py` blanket-skips all sessions with `parent_session_id` set (line 292: `if s.get("parent_session_id"): continue`). This correctly hides delegation child sessions, but also hides compression-continuation sessions — sessions created when context compression splits a long conversation into a parent (archived) and child (active continuation). Users who compress long conversations lose all access to the continuation via session search, creating a "memory black hole".

## Related Issue

Fixes #13840

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/session_search_tool.py`: Change the blanket `parent_session_id` filter to also check `end_reason`. Compression-continuation sessions (which have `end_reason == "compression"`) are now visible, while delegation children remain hidden.

## How to Test

1. Run the targeted test:
   ```bash
   python -m pytest tests/tools/test_session_search_compression.py -v
   ```
2. The 3 tests cover:
   - Compression-continuation sessions (parent + end_reason=compression) are visible
   - Delegation child sessions (parent, no compression reason) stay hidden
   - Root sessions without parent remain visible

Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest tests/tools/test_session_search_compression.py -v
# 3 passed
```
