### PR TITLE
fix(agent): use max_completion_tokens for gpt-4o/o-series on custom endpoints (#13901)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -980,6 +980,12 @@ class AIAgent:
                 pass
         return AIAgent._model_requires_responses_api(model)
 
+    # Models that require max_completion_tokens instead of max_tokens.
+    # These are OpenAI models that reject the legacy max_tokens parameter.
+    _MAX_COMPLETION_TOKENS_PREFIXES = (
+        "gpt-4o", "gpt-4.1", "gpt-5", "o1", "o3", "o4",
+    )
+
     def _max_tokens_param(self, value: int) -> dict:
         """Return the correct max tokens kwarg for the current provider.
 
@@ -988,8 +994,17 @@ class AIAgent:
         'max_completion_tokens' for gpt-5.x models served via the
         OpenAI-compatible endpoint. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
+
+        Custom OpenAI-compatible endpoints serving these model families
+        also need max_completion_tokens — checking the URL alone misses
+        them (#13901).
         """
         if self._is_direct_openai_url() or self._is_azure_openai_url() or self._is_github_copilot_url():
+            return {"max_completion_tokens": value}
+        # Check model name for known families that require max_completion_tokens,
+        # even on custom endpoints (#13901).
+        model_lower = (self.model or "").lower()
+        if any(model_lower.startswith(p) for p in self._MAX_COMPLETION_TOKENS_PREFIXES):
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2560,14 +2560,29 @@ class AIAgent:
                 pass
         return AIAgent._model_requires_responses_api(model)
 
+    # Models that require max_completion_tokens instead of max_tokens.
+    # These are OpenAI models that reject the legacy max_tokens parameter.
+    _MAX_COMPLETION_TOKENS_PREFIXES = (
+        "gpt-4o", "gpt-4.1", "gpt-5", "o1", "o3", "o4",
+    )
+
     def _max_tokens_param(self, value: int) -> dict:
         """Return the correct max tokens kwarg for the current provider.
-        
+
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
         'max_completion_tokens'. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
+
+        Custom OpenAI-compatible endpoints serving these model families
+        also need max_completion_tokens — checking the URL alone misses
+        them (#13901).
         """
         if self._is_direct_openai_url():
+            return {"max_completion_tokens": value}
+        # Check model name for known families that require max_completion_tokens,
+        # even on custom endpoints (#13901).
+        model_lower = (self.model or "").lower()
+        if any(model_lower.startswith(p) for p in self._MAX_COMPLETION_TOKENS_PREFIXES):
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/tests/run_agent/test_max_tokens_model_aware.py
+++ b/tests/run_agent/test_max_tokens_model_aware.py
@@ -1,0 +1,61 @@
+"""Tests for _max_tokens_param model-aware selection (#13901).
+
+Custom OpenAI-compatible endpoints serving gpt-4o/o-series/gpt-5+ models
+need max_completion_tokens, but the old code only checked the URL host.
+"""
+import pytest
+from unittest.mock import patch, PropertyMock
+
+
+class TestMaxTokensParamModelAware:
+    """_max_tokens_param must check model name, not just URL (#13901)."""
+
+    def _make_agent(self, model, base_url="https://my-proxy.internal/v1"):
+        from run_agent import AIAgent
+        agent = AIAgent.__new__(AIAgent)
+        agent.model = model
+        agent.base_url = base_url
+        agent._base_url_hostname = "my-proxy.internal"
+        agent._base_url_lower = base_url.lower()
+        return agent
+
+    @pytest.mark.parametrize("model", [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4.1",
+        "gpt-5",
+        "gpt-5.4",
+        "o1-preview",
+        "o3-mini",
+        "o4-mini",
+    ])
+    def test_new_openai_models_use_max_completion_tokens(self, model):
+        """Models that require max_completion_tokens should get it even on custom endpoints."""
+        agent = self._make_agent(model)
+        result = agent._max_tokens_param(4096)
+        assert "max_completion_tokens" in result, (
+            f"Model {model} on custom endpoint got max_tokens instead of max_completion_tokens"
+        )
+
+    @pytest.mark.parametrize("model", [
+        "gpt-3.5-turbo",
+        "gpt-4-turbo",
+        "llama-3.1-70b",
+        "claude-3-opus",
+        "mixtral-8x7b",
+        "qwen2.5-72b",
+    ])
+    def test_other_models_use_max_tokens(self, model):
+        """Non-OpenAI-new models should use max_tokens."""
+        agent = self._make_agent(model)
+        result = agent._max_tokens_param(4096)
+        assert "max_tokens" in result, (
+            f"Model {model} got max_completion_tokens instead of max_tokens"
+        )
+
+    def test_direct_openai_always_uses_max_completion_tokens(self):
+        """Direct api.openai.com should always use max_completion_tokens."""
+        agent = self._make_agent("gpt-3.5-turbo", base_url="https://api.openai.com/v1")
+        agent._base_url_hostname = "api.openai.com"
+        result = agent._max_tokens_param(4096)
+        assert "max_completion_tokens" in result


### PR DESCRIPTION
## What does this PR do?

`_max_tokens_param()` selects between `max_tokens` and `max_completion_tokens` purely by checking `hostname == "api.openai.com"`. Custom OpenAI-compatible endpoints (corporate proxies, Azure, self-hosted) serving gpt-4o, o-series, or gpt-5+ models get `max_tokens`, which these model families reject with HTTP 400.

The fix adds a `_MAX_COMPLETION_TOKENS_PREFIXES` tuple and checks the model name after the URL check. Models starting with `gpt-4o`, `gpt-4.1`, `gpt-5`, `o1`, `o3`, or `o4` get `max_completion_tokens` regardless of endpoint URL.

## Related Issue

Fixes #13901 (related: #13909)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: Add a `_MAX_COMPLETION_TOKENS_PREFIXES` tuple and check the model name after the URL check. Models starting with `gpt-4o`, `gpt-4.1`, `gpt-5`, `o1`, `o3`, or `o4` get `max_completion_tokens` regardless of endpoint URL.

## How to Test

1. Run targeted test:
   ```bash
   python -m pytest tests/run_agent/test_max_tokens_model_aware.py -v
   ```
2. 15 parametrized cases.

Validation table:

| Model | Endpoint | Before | After |
|---|---|---|---|
| `gpt-4o` | `my-proxy.internal` | `max_tokens` (400 error) | `max_completion_tokens` |
| `o3-mini` | `my-proxy.internal` | `max_tokens` (400 error) | `max_completion_tokens` |
| `gpt-3.5-turbo` | `my-proxy.internal` | `max_tokens` | `max_tokens` (unchanged) |
| `llama-3.1-70b` | `my-proxy.internal` | `max_tokens` | `max_tokens` (unchanged) |
| any model | `api.openai.com` | `max_completion_tokens` | `max_completion_tokens` (unchanged) |

Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest tests/run_agent/test_max_tokens_model_aware.py -v
# 15 parametrized cases pass
```
