### PR TITLE
fix(cli): accept placeholder URLs in custom provider config without validation (#14457)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3089,6 +3089,7 @@ def _normalize_custom_provider_entry(
             provider_key or "?", ", ".join(sorted(unknown)),
         )
 
+    import re
     from urllib.parse import urlparse
 
     base_url = ""
@@ -3096,6 +3097,11 @@ def _normalize_custom_provider_entry(
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()
+            # Accept URLs containing {placeholder} tokens — they will be
+            # expanded at runtime and cannot be validated yet (#14457).
+            if re.search(r'\{[^}]+\}', candidate):
+                base_url = candidate
+                break
             parsed = urlparse(candidate)
             if parsed.scheme and parsed.netloc:
                 base_url = candidate

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2064,6 +2064,7 @@ def _normalize_custom_provider_entry(
             provider_key or "?", ", ".join(sorted(unknown)),
         )
 
+    import re
     from urllib.parse import urlparse
 
     base_url = ""
@@ -2071,6 +2072,11 @@ def _normalize_custom_provider_entry(
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()
+            # Accept URLs containing {placeholder} tokens — they will be
+            # expanded at runtime and cannot be validated yet (#14457).
+            if re.search(r'\{[^}]+\}', candidate):
+                base_url = candidate
+                break
             parsed = urlparse(candidate)
             if parsed.scheme and parsed.netloc:
                 base_url = candidate

--- a/tests/hermes_cli/test_custom_provider_placeholder_url.py
+++ b/tests/hermes_cli/test_custom_provider_placeholder_url.py
@@ -1,0 +1,38 @@
+"""Tests for _normalize_custom_provider_entry placeholder URL handling (#14457).
+
+URLs containing {placeholder} tokens are validated before expansion,
+causing them to be rejected as invalid URLs and the provider silently dropped.
+"""
+import pytest
+
+
+class TestPlaceholderURLAccepted:
+    """Placeholder URLs must be accepted without validation (#14457)."""
+
+    def _normalize(self, entry, key="test-provider"):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        return _normalize_custom_provider_entry(entry, provider_key=key)
+
+    def test_placeholder_url_accepted(self):
+        """URLs with {placeholder} tokens should not be rejected."""
+        result = self._normalize({"base_url": "{base_url}/v1", "name": "test"})
+        assert result is not None
+        assert result["base_url"] == "{base_url}/v1"
+
+    def test_env_var_placeholder_accepted(self):
+        result = self._normalize({"base_url": "${API_ENDPOINT}/v1", "name": "test"})
+        assert result is not None
+
+    def test_region_placeholder_accepted(self):
+        result = self._normalize({"base_url": "https://{region}.api.example.com/v1", "name": "test"})
+        assert result is not None
+
+    def test_normal_url_still_works(self):
+        result = self._normalize({"base_url": "https://api.example.com/v1", "name": "test"})
+        assert result is not None
+        assert result["base_url"] == "https://api.example.com/v1"
+
+    def test_invalid_url_without_placeholder_still_rejected(self):
+        """Non-placeholder URLs without scheme/host should still be rejected."""
+        result = self._normalize({"base_url": "not-a-url", "name": "test"})
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

`_normalize_custom_provider_entry()` validates `base_url` with `urlparse()` before placeholder tokens like `{base_url}` or `${API_ENDPOINT}` are expanded. URLs that are pure placeholders without a scheme fail the `parsed.scheme and parsed.netloc` check and the entire provider entry is silently dropped with a warning.

## Related Issue

Fixes #14457. Related: #14524.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: Before the `urlparse` validation, check for `{placeholder}` tokens via `re.search(r'\{[^}]+\}', candidate)`. If present, accept the URL as-is for runtime expansion — it cannot be validated yet.

## How to Test

Behavior matrix:

| URL | Before | After |
|---|---|---|
| `{base_url}/v1` | Rejected (no scheme) | Accepted |
| `${API_ENDPOINT}/v1` | Rejected (no scheme) | Accepted |
| `https://{region}.api.example.com/v1` | Accepted (urlparse works) | Accepted (unchanged) |
| `https://api.example.com/v1` | Accepted | Accepted (unchanged) |
| `not-a-url` | Rejected | Rejected (unchanged) |

Targeted test: `tests/hermes_cli/test_custom_provider_placeholder_url.py` — 5 tests.

Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/hermes_cli/test_custom_provider_placeholder_url.py -q
5 passed
```
