### PR TITLE
fix(agent): increase skill description truncation limit from 60 to 120 chars (#13944)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -421,8 +421,8 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 120:
+        return desc[:117] + "..."
     return desc
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -521,8 +521,8 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 120:
+        return desc[:117] + "..."
     return desc
 
 

--- a/tests/agent/test_skill_description_truncation.py
+++ b/tests/agent/test_skill_description_truncation.py
@@ -1,0 +1,25 @@
+"""Tests for extract_skill_description truncation (#13944)."""
+import pytest
+from agent.skill_utils import extract_skill_description
+
+class TestExtractSkillDescriptionTruncation:
+    def test_short_description_unchanged(self):
+        assert extract_skill_description({"description": "Short"}) == "Short"
+
+    def test_70_char_description_preserved(self):
+        desc = "A" * 70
+        assert extract_skill_description({"description": desc}) == desc
+
+    def test_120_char_preserved(self):
+        desc = "A" * 120
+        assert extract_skill_description({"description": desc}) == desc
+
+    def test_121_char_truncated(self):
+        desc = "A" * 121
+        result = extract_skill_description({"description": desc})
+        assert result == "A" * 117 + "..."
+        assert len(result) == 120
+
+    def test_empty(self):
+        assert extract_skill_description({}) == ""
+        assert extract_skill_description({"description": ""}) == ""


### PR DESCRIPTION
## What does this PR do?

`extract_skill_description()` in `agent/skill_utils.py` hard-caps every skill description at 60 characters when building the system prompt skill index. Skills with routing keywords at positions 60-120 (e.g., "Generate comprehensive market research reports with competitive analysis and trend forecasting") get truncated to a vague prefix, degrading the model's ability to select the right skill.

This PR raises the truncation limit from 60 to 120 characters (`if len(desc) > 60` → `if len(desc) > 120`, `desc[:57]` → `desc[:117]`). 120 characters preserves meaningful routing keywords while keeping the system prompt index concise. Most skill descriptions fall within 80-120 chars and will now be fully preserved.

## Related Issue

Fixes #13944

Related: #13957.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/skill_utils.py`: Change the truncation limit from 60 to 120 characters.

## How to Test

1. Run the targeted suite:
   ```bash
   pytest tests/agent/test_skill_description_truncation.py -v
   ```
   5 tests covering short descriptions, boundary values (70, 120, 121 chars), and empty descriptions.

Tested on macOS (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
