### PR TITLE
fix(cli): Ctrl+D = readline semantics (delete-char + EOF-only-when-empty)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9526,11 +9526,16 @@ class HermesCLI:
         @kb.add('c-d')
         def handle_ctrl_d(event):
             """Ctrl+D: delete char under cursor (standard readline behaviour).
-            Only exit when the input is empty — same as bash/zsh.
+            Only exit when the input is empty — same as bash/zsh. Pending
+            attached images count as input and block the EOF-exit so the
+            user doesn't lose them silently.
             """
             buf = event.app.current_buffer
             if buf.text:
                 buf.delete()
+            elif self._attached_images:
+                # Empty text but pending attachments — no-op, don't exit.
+                return
             else:
                 self._should_exit = True
                 event.app.exit()

--- a/cli.py
+++ b/cli.py
@@ -9525,9 +9525,15 @@ class HermesCLI:
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Ctrl+D: delete char under cursor (standard readline behaviour).
+            Only exit when the input is empty — same as bash/zsh.
+            """
+            buf = event.app.current_buffer
+            if buf.text:
+                buf.delete()
+            else:
+                self._should_exit = True
+                event.app.exit()
 
         _modal_prompt_active = Condition(
             lambda: bool(self._secret_state or self._sudo_state)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -68,6 +68,7 @@ AUTHOR_MAP = {
     "185121704+stablegenius49@users.noreply.github.com": "stablegenius49",
     "101283333+batuhankocyigit@users.noreply.github.com": "batuhankocyigit",
     "255305877+ismell0992-afk@users.noreply.github.com": "ismell0992-afk",
+    "cyprian@ironin.pl": "iRonin",
     "valdi.jorge@gmail.com": "jvcl",
     "q19dcp@gmail.com": "aj-nt",
     "francip@gmail.com": "francip",


### PR DESCRIPTION
## Summary
Ctrl+D now matches bash/zsh/readline: delete-char on non-empty input, EOF-exit only when input is truly empty. Pending attached images block the EOF-exit so a stray Ctrl+D doesn't silently discard attachments.

Salvages #4783 (@iRonin) on current main, plus a 6-line follow-up for the attached-images case.

## Changes
- cli.py `handle_ctrl_d`: `buf.text` → delete; no text + `_attached_images` → no-op; empty → exit (as before)
- scripts/release.py: AUTHOR_MAP entry for @iRonin

## Closes
Supersedes PRs #4783, #9252, #6476, #4278, #8297 — all addressing the same Ctrl+D behavior. This picks the minimal-diff approach (6 net lines in the handler) over the config-knob and full-keybinding-system variants.

## Validation
| | Before | After |
|---|---|---|
| Ctrl+D mid-word | exit CLI | delete char under cursor |
| Ctrl+D on empty input | exit CLI | exit CLI |
| Ctrl+D with only attached images | exit CLI (attachments lost) | no-op |

Three-case behavior smoke passes against the handler logic.
