### PR TITLE
chore(release): map julia@alexland.us -> alexg0bot in AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "130918800+devorun@users.noreply.github.com": "devorun",
     "maks.mir@yahoo.com": "say8hi",
     "web3blind@users.noreply.github.com": "web3blind",
+    "julia@alexland.us": "alexg0bot",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",


### PR DESCRIPTION
Follow-up to #15382 so @alexg0bot's `julia@alexland.us` resolves to the correct GitHub handle in release notes.