### PR TITLE
fix(gateway): honor queue mode in runner PRIORITY interrupt path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3591,6 +3591,10 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
+            if self._busy_input_mode == "queue":
+                logger.debug("PRIORITY queue follow-up for session %s", _quick_key[:20])
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
             running_agent.interrupt(event.text)
             if _quick_key in self._pending_messages:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -70,6 +70,9 @@ def _make_runner():
     runner.session_store = None
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
     return runner, _AGENT_PENDING_SENTINEL
 
 
@@ -90,6 +93,30 @@ def _make_adapter(platform_val="telegram"):
 
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
+
+    @pytest.mark.asyncio
+    async def test_handle_message_queue_mode_queues_without_interrupt(self):
+        """Runner queue mode must not interrupt an active agent for text follow-ups."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="follow up in queue mode")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "queue"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert sk in adapter._pending_messages
+        assert adapter._pending_messages[sk] is event
+        assert sk not in runner._pending_messages
+        running_agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):


### PR DESCRIPTION
## Summary
`display.busy_input_mode: queue` now actually queues text follow-ups at every entry point. The runner-level PRIORITY block in `_handle_message` was still calling `running_agent.interrupt()` regardless of config, even though the adapter-level busy handler already honored queue mode (commit 9d147f7fd).

## Changes
- `gateway/run.py`: queue-mode branch before the PRIORITY interrupt — calls `_queue_or_replace_pending_event()` and returns None
- `tests/gateway/test_busy_session_ack.py`: regression test driving the full `_handle_message` path in queue mode

## Attribution
Salvage of #12070 by @knockyai — authorship preserved via cherry-pick. The original PR's config fan-out (propagating `display.busy_input_mode` into each platform's `extra`) was dropped as redundant: the runner already loads this value directly via `_load_busy_input_mode()`.

## Validation
`scripts/run_tests.sh tests/gateway/test_busy_session_ack.py tests/gateway/test_restart_drain.py tests/gateway/test_duplicate_reply_suppression.py` → 45 passed

Closes #12070.