### PR TITLE
feat(discord): add video attachment caching\n\nHermes Agent downloads…

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -451,6 +451,27 @@ def cleanup_image_cache(max_age_hours: int = 24) -> int:
     return removed
 
 
+def cleanup_video_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached videos older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    import time
+
+    cache_dir = get_video_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
 # ---------------------------------------------------------------------------
 # Audio cache utilities
 #
@@ -575,6 +596,65 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)
+
+
+async def cache_video_from_url(url: str, ext: str = ".mp4", retries: int = 2) -> str:
+    """
+    Download a video from a URL and save it to the local cache.
+
+    Retries on transient failures (timeouts, 429, 5xx) with exponential
+    backoff so a single slow CDN response doesn't lose the media.
+
+    Args:
+        url: The HTTP/HTTPS URL to download from.
+        ext: File extension including the dot (e.g. ".mp4", ".webm").
+        retries: Number of retry attempts on transient failures.
+
+    Returns:
+        Absolute path to the cached video file as a string.
+
+    Raises:
+        ValueError: If the URL targets a private/internal network (SSRF protection).
+    """
+    from tools.url_safety import is_safe_url
+    if not is_safe_url(url):
+        raise ValueError(f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}")
+
+    import httpx
+    _log = logging.getLogger(__name__)
+
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
+        for attempt in range(retries + 1):
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                        "Accept": "video/*,*/*;q=0.8",
+                    },
+                )
+                response.raise_for_status()
+                return cache_video_from_bytes(response.content, ext)
+            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
+                    raise
+                if attempt < retries:
+                    wait = 1.5 * (attempt + 1)
+                    _log.debug(
+                        "Media cache retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -54,7 +54,9 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_url,
     cache_audio_from_bytes,
+    cache_video_from_bytes,
     cache_document_from_bytes,
+    SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
 )
 from tools.url_safety import is_safe_url
@@ -2937,6 +2939,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
         return await cache_audio_from_url(att.url, ext=ext)
 
+    async def _cache_discord_video(self, att, ext: str) -> str:
+        """Cache a Discord video attachment to local disk.
+
+        Primary path: ``att.read()`` + ``cache_video_from_bytes``
+        (authenticated, no SSRF gate).
+
+        Fallback: ``cache_video_from_url`` (plain httpx, SSRF-gated).
+        """
+        raw_bytes = await self._read_attachment_bytes(att)
+        if raw_bytes is not None:
+            try:
+                return cache_video_from_bytes(raw_bytes, ext=ext)
+            except Exception as e:
+                logger.debug(
+                    "[Discord] cache_video_from_bytes rejected att.read() data; falling back to URL: %s",
+                    e,
+                )
+        return await cache_video_from_url(att.url, ext=ext)
+
     async def _cache_discord_document(self, att, ext: str) -> bytes:
         """Download a Discord document attachment and return the raw bytes.
 
@@ -3151,6 +3172,25 @@ class DiscordAdapter(BasePlatformAdapter):
                     print(f"[Discord] Cached user audio: {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
+                    media_urls.append(att.url)
+                    media_types.append(content_type)
+            elif content_type.startswith("video/") or (
+                att.filename and os.path.splitext(att.filename)[1].lower() in SUPPORTED_VIDEO_TYPES
+            ):
+                try:
+                    # Prefer content_type for ext; fall back to filename
+                    if content_type.startswith("video/"):
+                        ext = "." + content_type.split("/")[-1].split(";")[0]
+                    else:
+                        ext = os.path.splitext(att.filename)[1].lower()
+                    if ext not in SUPPORTED_VIDEO_TYPES:
+                        ext = ".mp4"
+                    cached_path = await self._cache_discord_video(att, ext)
+                    media_urls.append(cached_path)
+                    media_types.append(SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4"))
+                    print(f"[Discord] Cached user video: {cached_path}", flush=True)
+                except Exception as e:
+                    print(f"[Discord] Failed to cache video attachment: {e}", flush=True)
                     media_urls.append(att.url)
                     media_types.append(content_type)
             else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10787,7 +10787,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     image/audio/document cache once per hour.
     """
     from cron.scheduler import tick as cron_tick
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import cleanup_image_cache, cleanup_video_cache, cleanup_document_cache
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
@@ -10816,6 +10816,12 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
                     logger.info("Image cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Image cache cleanup error: %s", e)
+            try:
+                removed = cleanup_video_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Video cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Video cache cleanup error: %s", e)
             try:
                 removed = cleanup_document_cache(max_age_hours=24)
                 if removed:


### PR DESCRIPTION
Hermes Agent downloads and caches Discord image/audio attachments, but video attachments are passed through as raw URLs only. This adds `_cache_discord_video()` to the Discord adapter, mirroring the exact pattern of `_cache_discord_image/audio` — authenticated `att.read()` primary, URL fallback with SSRF gate, same error handling/logging.

Videos now cache to `~/.hermes/cache/videos/` and are delivered via `media_urls` identically to images. No breaking changes; pure extension.

### Changes
- `gateway/platforms/discord.py`: add `_cache_discord_video()` and video branch in attachment loop
- `gateway/platforms/base.py`: add `cache_video_from_url()`, `cleanup_video_cache()`, `SUPPORTED_VIDEO_TYPES`
- `gateway/run.py`: add hourly video cache cleanup to cron ticker

### Testing
- Attach an MP4/WebM/MOV to a Discord channel the bot can read
- Verify log shows cached video path
- Confirm file exists in the video cache directory
- Verify `media_urls` in the message event includes the cached path
