### PR TITLE
fix(gateway): don't exit when messaging adapters disconnect if API server is still active

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1187,26 +1187,45 @@ class GatewayRunner:
                     adapter.platform.value,
                 )
 
-        if not self.adapters and not self._failed_platforms:
-            self._exit_reason = adapter.fatal_error_message or "All messaging adapters disconnected"
-            if adapter.fatal_error_retryable:
-                self._exit_with_failure = True
-                logger.error("No connected messaging platforms remain. Shutting down gateway for service restart.")
-            else:
-                logger.error("No connected messaging platforms remain. Shutting down gateway cleanly.")
-            await self.stop()
-        elif not self.adapters and self._failed_platforms:
-            # All platforms are down and queued for background reconnection.
-            # If the error is retryable, exit with failure so systemd Restart=on-failure
-            # can restart the process. Otherwise stay alive and keep retrying in background.
-            if adapter.fatal_error_retryable:
-                self._exit_reason = adapter.fatal_error_message or "All messaging platforms failed with retryable errors"
-                self._exit_with_failure = True
-                logger.error(
-                    "All messaging platforms failed with retryable errors. "
-                    "Shutting down gateway for service restart (systemd will retry)."
+        # Service adapters (API server, webhook) are not messaging platforms — their
+        # presence means the gateway is still actively serving clients and must not shut
+        # down just because all *messaging* platform adapters have disconnected.
+        _service_platforms = {Platform.LOCAL, Platform.API_SERVER, Platform.WEBHOOK}
+        _messaging_adapters = {p for p in self.adapters if p not in _service_platforms}
+        _service_still_active = bool(self.adapters.keys() & _service_platforms)
+
+        if not _messaging_adapters and not self._failed_platforms:
+            if _service_still_active:
+                logger.warning(
+                    "All messaging platform adapters disconnected, but API/service adapters remain active. "
+                    "Gateway will keep running to serve API requests."
                 )
+            else:
+                self._exit_reason = adapter.fatal_error_message or "All messaging adapters disconnected"
+                if adapter.fatal_error_retryable:
+                    self._exit_with_failure = True
+                    logger.error("No connected messaging platforms remain. Shutting down gateway for service restart.")
+                else:
+                    logger.error("No connected messaging platforms remain. Shutting down gateway cleanly.")
                 await self.stop()
+        elif not _messaging_adapters and self._failed_platforms:
+            # All messaging platforms are down and queued for background reconnection.
+            # If the error is retryable, exit with failure so systemd Restart=on-failure
+            # can restart the process — but only if no service adapter is still active.
+            if adapter.fatal_error_retryable:
+                if _service_still_active:
+                    logger.warning(
+                        "All messaging platforms failed with retryable errors, but API/service adapters remain "
+                        "active. Gateway will keep running; messaging platforms queued for reconnection."
+                    )
+                else:
+                    self._exit_reason = adapter.fatal_error_message or "All messaging platforms failed with retryable errors"
+                    self._exit_with_failure = True
+                    logger.error(
+                        "All messaging platforms failed with retryable errors. "
+                        "Shutting down gateway for service restart (systemd will retry)."
+                    )
+                    await self.stop()
             else:
                 logger.warning(
                     "No connected messaging platforms remain, but %d platform(s) queued for reconnection",


### PR DESCRIPTION
## Summary

When all messaging platform adapters (Telegram, Discord, etc.) disconnect, `_handle_adapter_disconnect` calls `stop()` unconditionally — even when an API server or webhook adapter is still connected and actively serving requests. This causes the gateway process to terminate mid-session whenever the only messaging platform fails, taking down the HTTP API with it.

This is particularly painful for **API-only deployments** where Telegram/Discord is configured but the primary use is the HTTP WebSocket API: a Telegram rate-limit or token error kills the entire gateway.

## Root cause

`_handle_adapter_disconnect` checks `not self.adapters` to decide whether to shut down, but `self.adapters` is a dict keyed by `Platform` that includes both messaging adapters **and** service adapters (`Platform.API_SERVER`, `Platform.WEBHOOK`, `Platform.LOCAL`). The check doesn't distinguish between them.

## Fix

Separate messaging adapters from service adapters using the same pattern already used in `_log_terminal_docker_warning` (line 742):

```python
_service_platforms = {Platform.LOCAL, Platform.API_SERVER, Platform.WEBHOOK}
_messaging_adapters = {p for p in self.adapters if p not in _service_platforms}
_service_still_active = bool(self.adapters.keys() & _service_platforms)
```

Shutdown is only triggered when **both** conditions hold:
- No messaging adapters remain (connected or queued for retry)  
- No service adapters are active

When a service adapter is still running, the gateway logs a warning and stays alive so that API clients continue to work while messaging platforms queue for reconnection in the background.

## Test plan

- [ ] Gateway with API server + Telegram: revoke Telegram token → gateway stays alive, API continues serving
- [ ] Gateway with API server + Telegram: Telegram disconnects with retryable error → gateway stays alive, queues reconnect, API unaffected  
- [ ] Gateway with Telegram only (no API server): Telegram fails → gateway exits as before (no regression)
- [ ] Gateway with API server only (no messaging): gateway runs and serves API requests normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)