### PR TITLE
fix(run_agent): strip temperature from flush_memories Codex fallback path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -367,18 +367,26 @@ class _CodexCompletionsAdapter:
         # Separate system/instructions from conversation messages.
         # Convert chat.completions multimodal content blocks to Responses
         # API format (input_text / input_image instead of text / image_url).
+        # The Codex Responses endpoint only accepts user/assistant roles in
+        # input — skip tool/function messages and map system/developer to
+        # instructions.
+        _RESPONSES_INPUT_ROLES = {"user", "assistant"}
         instructions = "You are a helpful assistant."
         input_msgs: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
-            if role == "system":
+            if role in ("system", "developer"):
                 instructions = content if isinstance(content, str) else str(content)
-            else:
+            elif role in ("tool", "function"):
+                # Codex Responses endpoint does not support tool/function roles
+                continue
+            elif role in _RESPONSES_INPUT_ROLES:
                 input_msgs.append({
                     "role": role,
                     "content": _convert_content_for_responses(content),
                 })
+            # Unknown roles: skip rather than send an unsupported value
 
         resp_kwargs: Dict[str, Any] = {
             "model": model,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5084,7 +5084,6 @@ class AIAgent:
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
-
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
         max_stream_retries = 1
         has_tool_calls = False
@@ -7938,10 +7937,8 @@ class AIAgent:
                     codex_kwargs["tools"] = _ct_flush.convert_tools([memory_tool_def])
                 elif not codex_kwargs.get("tools"):
                     codex_kwargs["tools"] = [memory_tool_def]
-                if _flush_temperature is not None:
-                    codex_kwargs["temperature"] = _flush_temperature
-                else:
-                    codex_kwargs.pop("temperature", None)
+                # Codex Responses endpoint does not accept temperature — strip it
+                codex_kwargs.pop("temperature", None)
                 if "max_output_tokens" in codex_kwargs:
                     codex_kwargs["max_output_tokens"] = 5120
                 response = self._run_codex_stream(codex_kwargs)


### PR DESCRIPTION
## Problem

Two related bugs in the `flush_memories` Codex path cause `"Auxiliary memory flush failed"` with HTTP 400 errors.

### Bug 1 — temperature in fallback path

When `flush_memories` is in `codex_responses` mode and the auxiliary client fails for any reason, the fallback path explicitly sets `codex_kwargs["temperature"] = _flush_temperature` (0.3) before calling `_run_codex_stream`. The Codex Responses endpoint does not accept `temperature` and returns:

```
HTTP 400: Unsupported parameter: temperature
```

The error propagated to the outer `except Exception as e:` and surfaced as `"Auxiliary memory flush failed"` — misleadingly implicating temperature rather than the actual aux failure.

The bug was latent before `8a2506af` (which widened `except RuntimeError` → `except Exception as e:`). After that commit the inner failure started triggering the fallback path more frequently, exposing this.

### Bug 2 — unsupported message roles in adapter

`_CodexCompletionsAdapter.create()` passes all non-system message roles through to the Responses API unchanged. The Codex endpoint only accepts `user` and `assistant` in the `input` array. Sessions that include memory tool results (prior flush calls) contain `role: 'tool'` messages, causing:

```
HTTP 400: Invalid value: 'tool'. Supported values are: 'assistant', 'system', 'developer', and 'user'.
```

## Root Cause

**Bug 1** — `run_agent.py`, `flush_memories` Codex fallback:
```python
if _flush_temperature is not None:
    codex_kwargs["temperature"] = _flush_temperature  # ← sends to Codex endpoint
```

**Bug 2** — `agent/auxiliary_client.py`, `_CodexCompletionsAdapter.create()`:
```python
for msg in messages:
    role = msg.get("role", "user")
    # ...
    else:
        input_msgs.append({"role": role, ...})  # ← passes role='tool' through
```

Note: `_CodexCompletionsAdapter` already correctly omits temperature from `resp_kwargs`. The fallback path failed to do the same.

## Fix

**Bug 1**: Strip temperature unconditionally from `codex_kwargs` before `_run_codex_stream`.

**Bug 2**: In `_CodexCompletionsAdapter`, skip `role='tool'` and `role='function'` messages; map `role='developer'` to instructions; silently skip unknown roles.

## Tests

Existing `test_codex_mode_no_aux_uses_responses_api` in `tests/run_agent/test_flush_memories_codex.py` covers the fallback path.