### PR TITLE
fix(web_server): hold _oauth_sessions_lock during PKCE session state writes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1533,26 +1533,30 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
         with urllib.request.urlopen(req, timeout=20) as resp:
             result = json.loads(resp.read().decode())
     except Exception as e:
-        sess["status"] = "error"
-        sess["error_message"] = f"Token exchange failed: {e}"
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = f"Token exchange failed: {e}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     access_token = result.get("access_token", "")
     refresh_token = result.get("refresh_token", "")
     expires_in = int(result.get("expires_in") or 3600)
     if not access_token:
-        sess["status"] = "error"
-        sess["error_message"] = "No access token returned"
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = "No access token returned"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     expires_at_ms = int(time.time() * 1000) + (expires_in * 1000)
     try:
         _save_anthropic_oauth_creds(access_token, refresh_token, expires_at_ms)
     except Exception as e:
-        sess["status"] = "error"
-        sess["error_message"] = f"Save failed: {e}"
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = f"Save failed: {e}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
-    sess["status"] = "approved"
+    with _oauth_sessions_lock:
+        sess["status"] = "approved"
     _log.info("oauth/pkce: anthropic login completed (session=%s)", session_id)
     return {"ok": True, "status": "approved"}
 


### PR DESCRIPTION
Salvage of #15350 by @sprmn24 onto current main.

## Summary
`_submit_anthropic_pkce()` now writes `sess["status"]` and `sess["error_message"]` under `_oauth_sessions_lock`, matching the locking discipline already used by the sibling device-code workers (`_nous_device_login_worker`, `_codex_full_login_worker`). Anthropic PKCE was the only OAuth handler mutating session state unlocked.

## Why this matters
`_gc_oauth_sessions()` iterates `_oauth_sessions.items()` under the lock, and `/oauth/status` polling reads sess fields under the lock. With the writes unlocked, a concurrent GC or poll could observe a half-updated sess dict (e.g. new `status` with stale `error_message`, or vice versa).

## Changes
- `hermes_cli/web_server.py`: wrap all four sess write sites in `_submit_anthropic_pkce()` with `with _oauth_sessions_lock:` — token-exchange failure, missing-access-token, credential-save failure, and approved.

## Scope note
The original PR also bundled a `GATEWAY_HEALTH_TIMEOUT` env-parsing guard. That change already landed on main via @sprmn24's earlier PR (78d1e252f), so this salvage keeps only the locking fix.

Closes #15350. Credit: @sprmn24.