### PR TITLE
fix(auth): preserve corrupt auth.json and warn instead of silently resetting

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -743,7 +743,18 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
     try:
         raw = json.loads(auth_file.read_text())
-    except Exception:
+    except Exception as exc:
+        corrupt_path = auth_file.with_suffix(".json.corrupt")
+        try:
+            import shutil
+            shutil.copy2(auth_file, corrupt_path)
+        except Exception:
+            pass
+        logger.warning(
+            "auth: failed to parse %s (%s) — starting with empty store. "
+            "Corrupt file preserved at %s",
+            auth_file, exc, corrupt_path,
+        )
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     if isinstance(raw, dict) and (


### PR DESCRIPTION
Salvage of #15364 by @sprmn24, cherry-picked onto current main with authorship preserved.

## Summary
Corrupt `auth.json` now produces a warning and a `.corrupt` backup instead of silently returning an empty store.

## Changes
- `hermes_cli/auth.py`: on JSON parse failure in `_load_auth_store()`, copy the file to `auth.json.corrupt` and log a warning with the exception + backup path. Happy path untouched.

## Why not merge #15364 directly
The PR branch forked before commits 2beeedcdd and cf47e7fc0 (GATEWAY_HEALTH_TIMEOUT guard, OAuth session lock) landed on main. The diff against main made those changes look new but they're already present — salvaging only the novel auth.py commit (e3cc6a7f3).

## Validation
E2E with isolated HERMES_HOME:
- Corrupt JSON → warning logged, `auth.json.corrupt` created with original content, empty store returned.
- Valid JSON → store parsed normally, no spurious backup.

`tests/hermes_cli/test_auth_commands.py`: 44/44 passed.

Closes #15364.