### PR TITLE
feat(codex-bridge): 异步任务完成后主动通知目标会话

### DIFF
--- a/docs/brainstorms/2026-04-25-codex-bridge-completion-notification-requirements.md
+++ b/docs/brainstorms/2026-04-25-codex-bridge-completion-notification-requirements.md
@@ -1,0 +1,47 @@
+---
+title: Codex Bridge 异步完成通知 MVP 需求
+date: 2026-04-25
+status: accepted
+scope: lightweight
+---
+
+# Codex Bridge 异步完成通知 MVP 需求
+
+## 背景
+
+Hermes 通过 `skills/codex-bridge/references/cli.py start` 启动 Codex app-server stdio 任务后，会把任务状态写入本地 `codex_bridge.db`。当前实现不是常驻订阅或完成回调模式：Codex turn 完成后不会主动通知原 Feishu/平台会话，用户必须再次说“继续”后 Hermes 才会手动查询 `status` 或 `list`。
+
+这造成一个产品异味：异步任务已经启动，但完成后没有人主动查收。
+
+## 范围决策
+
+本次做窄范围 MVP：让 Codex Bridge 启动的异步任务在完成后能回到原会话或目标发送完成摘要。不要做多租户调度系统，不重写现有 Codex Bridge 低层协议，不引入 mailbox/outbox/inbox 作为主通信机制。
+
+## 目标
+
+- 启动任务时可选记录通知目标，例如 `local`、`feishu:<chat_id>` 或其他 `send_message` 支持的显式平台目标。
+- 默认不改变现有 API 行为；未传通知目标时仍能正常启动和查询。
+- 提供 watcher/one-shot poll 入口，发现已完成但未处理通知的任务。
+- 对有目标的任务读取 final summary，生成简洁完成摘要，并通过可注入 notifier 发送。
+- 对无目标的完成任务标记为 `no_target`，避免 watcher 重启后重复处理。
+- 通过持久化 `notification_status` / `notified_at` 防重复通知。
+
+## 非目标
+
+- 不实现常驻多租户调度器。
+- 不实现 pending approval / `requestUserInput` 的实时双向交互。
+- 不让测试向真实 Feishu、WeChat、Telegram 等外部平台发消息。
+- 不开放 `danger-full-access` 默认权限。
+- 不用 mailbox/outbox/inbox 作为通信机制。
+
+## 验收标准
+
+- `codex_bridge(action="start", notify_target=...)` 能把目标写入任务状态。
+- watcher/notify 入口只通知 terminal 状态任务一次；重启或重复运行不会重复发送。
+- terminal 任务没有 target 时会被标记为 `no_target`，不会调用 notifier。
+- CLI 暴露 `--notify-target` 和 one-shot `notify-completed` 入口，并支持 dry-run。
+- 测试通过 mock/inject notifier 覆盖通知行为。
+
+## 后续扩展说明
+
+pending approval 和 `requestUserInput` 后续可复用同一通知目标字段：当任务进入 `waiting_for_approval` 或 `waiting_for_user_input` 时，watcher 可以发送带 request id 的交互提示；平台侧回复再映射到 `codex_bridge respond`。本次先只处理 terminal completion，避免把交互式审批设计混入 MVP。

--- a/docs/plans/2026-04-25-codex-bridge-completion-notification-plan.md
+++ b/docs/plans/2026-04-25-codex-bridge-completion-notification-plan.md
@@ -1,0 +1,82 @@
+---
+title: Codex Bridge 异步完成通知 MVP 实现计划
+date: 2026-04-25
+status: active
+origin: docs/brainstorms/2026-04-25-codex-bridge-completion-notification-requirements.md
+---
+
+# Codex Bridge 异步完成通知 MVP 实现计划
+
+## 问题框架
+
+Codex Bridge 已能通过 app-server stdio 启动异步 Codex turn，并把状态写入 `codex_bridge.db`。缺口在完成后的主动送达：当前没有通知目标、通知状态，也没有 watcher 入口来把 terminal 任务的摘要回发给原会话。
+
+## 技术决策
+
+- 在 `codex_bridge_tasks` 上新增通知元数据：`notify_target`、`notification_status`、`notified_at`、`notification_error`。
+- `start` 接受可选 `notify_target`，不传时保持旧行为。
+- 新增 one-shot `notify_completed` action：扫描 terminal 且尚未处理通知的任务，按目标发送或标记 `no_target`。
+- 默认 notifier 复用现有 `send_message` 工具；测试和 CLI dry-run 通过注入或 dry-run 避免真实外发。
+- `local` 目标作为本地消费目标：记录为已通知并返回摘要，不调用外部平台。
+
+## 实现单元
+
+### U1: 持久化通知目标与状态
+
+修改文件：
+- `tools/codex_bridge_tool.py`
+- `tests/tools/test_codex_bridge_tool.py`
+
+做法：
+- 数据库初始化时对旧库执行兼容迁移。
+- `CodexBridgeTask.snapshot()`、`list_tasks()`、`get_task_snapshot()` 暴露通知字段。
+- `start_task()` 接受 `notify_target` 并保存。
+
+测试场景：
+- 启动任务时传入 `notify_target`，状态快照和持久化查询都能看到该值。
+
+### U2: 完成通知 one-shot watcher
+
+修改文件：
+- `tools/codex_bridge_tool.py`
+- `tests/tools/test_codex_bridge_tool.py`
+
+做法：
+- 增加扫描 terminal 任务的方法。
+- 对无 target 的任务标记 `no_target`，不调用 notifier。
+- 对有 target 的任务构造简洁摘要，调用 notifier 后标记 `sent` 和 `notified_at`。
+- 已 `sent` 或 `no_target` 的任务不再重复处理。
+- 支持 `dry_run`，只返回会处理的任务，不写通知状态，不发送。
+
+测试场景：
+- completed 任务只通知一次。
+- 无 target completed 任务不发送，并标记 `no_target`。
+- dry-run 不发送且不改变通知状态。
+
+### U3: 工具 schema 与 CLI 入口
+
+修改文件：
+- `tools/codex_bridge_tool.py`
+- `skills/codex-bridge/references/cli.py`
+- `skills/codex-bridge/references/validator.py`
+- `tests/skills/test_codex_bridge_skill.py`
+
+做法：
+- schema 加入 `notify_completed` action、`notify_target`、`dry_run`。
+- CLI `start`/`smoke-test` 增加 `--notify-target`。
+- CLI 增加 `notify-completed` one-shot 命令。
+- validator 校验 notify 输出的基本结构。
+
+测试场景：
+- CLI start 能把 `--notify-target` 传给工具。
+- CLI notify-completed dry-run 调用 bridge 且不依赖真实平台。
+
+## 验证
+
+- `python -m py_compile tools/codex_bridge_tool.py skills/codex-bridge/references/cli.py skills/codex-bridge/references/validator.py`
+- `scripts/run_tests.sh tests/tools/test_codex_bridge_tool.py tests/skills/test_codex_bridge_skill.py`
+
+## 风险
+
+- 默认 notifier 依赖 `send_message` 的运行环境；没有 gateway 或目标不可达时会记录 `notification_error` 并保留可重试状态。
+- 当前只处理 terminal completion，不处理实时 approval/input；后续应在同一 target 模型上扩展。

--- a/docs/solutions/developer-experience/codex-bridge-async-completion-notifications-2026-04-25.md
+++ b/docs/solutions/developer-experience/codex-bridge-async-completion-notifications-2026-04-25.md
@@ -1,0 +1,85 @@
+---
+title: Codex Bridge 异步任务需要持久化完成通知状态
+date: 2026-04-25
+category: docs/solutions/developer-experience/
+module: Codex Bridge
+problem_type: developer_experience
+component: assistant
+severity: medium
+applies_when:
+  - 异步 agent 任务由本地 bridge 启动，但完成结果需要回到原平台会话
+  - 任务状态已经持久化，但缺少完成后主动送达能力
+  - 测试不能向真实外部平台发送消息
+tags: [codex-bridge, async-notification, app-server, send-message, watcher]
+---
+
+# Codex Bridge 异步任务需要持久化完成通知状态
+
+## Context
+
+Codex Bridge 已经通过 app-server stdio 启动 Codex 任务，并把状态写入 `codex_bridge.db`。dogfood 暴露出的体验问题是：异步任务完成后没有主动通知原 Feishu/平台会话，用户必须再次触发 Hermes 查询 `status` 或 `list` 才能知道结果。
+
+这类问题不需要先做多租户调度系统。MVP 的关键是让任务在启动时可选记录通知目标，并让一个 one-shot watcher 可以可靠地处理 terminal 任务。
+
+## Guidance
+
+在已有任务表上补齐三个概念，而不是重写底层通信协议：
+
+- `notify_target`：启动时可选记录目标，例如 `local` 或 `feishu:<chat_id>`。
+- `notification_status`：记录通知生命周期，例如 `pending`、`sent`、`failed`、`no_target`。
+- `notified_at` / `notification_error`：让 watcher 重启后能防重复，并保留失败原因。
+
+watcher 应该只扫描 terminal 状态任务，并做幂等处理：
+
+- 有目标：构造简洁完成摘要，调用可注入 notifier，成功后标记 `sent`。
+- 无目标：标记 `no_target`，不发送，避免每次扫描重复捞到同一任务。
+- dry-run：返回预览，不发送，也不写通知状态。
+
+默认 notifier 可以复用现有 `send_message` 能力，但核心 manager 方法要允许注入 notifier。这样单元测试可以用 fake notifier 验证行为，避免真实平台副作用。
+
+## Why This Matters
+
+异步 bridge 的产品承诺不是“能启动后台任务”，而是“任务结束后用户能在原上下文看到结果”。如果只有状态表但没有通知状态，系统会卡在“完成但无人查收”的灰区；如果没有持久化防重复，watcher 或 daemon 重启又可能重复推送。
+
+把通知状态做成任务元数据，可以在不引入 mailbox/outbox/inbox 通信机制的情况下满足 MVP，并为后续实时 approval / `requestUserInput` 扩展留下同一套 target 语义。
+
+## When to Apply
+
+- 异步任务生命周期已经持久化，但完成后需要跨平台送达。
+- 现有平台发送能力已经存在，新增功能只需要选择目标和调用发送。
+- 需要保证测试环境不触发真实外部消息。
+- 需要 watcher/daemon 重启后不重复通知。
+
+## Examples
+
+启动时记录目标：
+
+```python
+codex_bridge(
+    action="start",
+    prompt="Investigate the failing tests",
+    notify_target="feishu:chat-1",
+)
+```
+
+one-shot watcher dry-run：
+
+```bash
+python skills/codex-bridge/references/cli.py notify-completed --dry-run
+```
+
+测试中注入 notifier：
+
+```python
+deliveries = []
+manager.notify_completed(
+    notifier=lambda target, message: deliveries.append((target, message)) or {"ok": True}
+)
+```
+
+## Related
+
+- `docs/brainstorms/2026-04-25-codex-bridge-completion-notification-requirements.md`
+- `docs/plans/2026-04-25-codex-bridge-completion-notification-plan.md`
+- `tools/codex_bridge_tool.py`
+- `skills/codex-bridge/references/cli.py`

--- a/skills/codex-bridge/SKILL.md
+++ b/skills/codex-bridge/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: codex-bridge
+description: Start and control local Codex tasks through Hermes Codex Bridge app-server integration.
+version: 1.0.0
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [codex, agent, bridge, app-server]
+    category: software-development
+---
+
+# Codex Bridge
+
+Use this skill when you need Hermes to start or steer a local Codex task through the Codex app-server protocol.
+
+## CLI
+
+Run the reference CLI from the repository root:
+
+```bash
+python skills/codex-bridge/references/cli.py start --prompt "Inspect this repository and summarize the test layout."
+python skills/codex-bridge/references/cli.py status <task_id>
+python skills/codex-bridge/references/cli.py list
+python skills/codex-bridge/references/cli.py steer <task_id> --instruction "Focus only on tests."
+python skills/codex-bridge/references/cli.py interrupt <task_id>
+python skills/codex-bridge/references/cli.py respond <task_id> --request-id <request_id> --decision decline
+python skills/codex-bridge/references/cli.py smoke-test --wait 10 --timeout 60
+```
+
+The CLI is a productized wrapper around `tools.codex_bridge_tool.codex_bridge`.
+It does not implement the app-server protocol itself and does not use mailbox,
+inbox, or outbox files.
+
+## Safety Defaults
+
+- Sandbox is limited to `read-only` or `workspace-write`.
+- `danger-full-access` is rejected.
+- Approval policy is limited to `untrusted` or `on-request`.
+- `approval_policy=never` is rejected.
+- `start` requires a non-empty prompt and an existing `cwd`.
+
+## Output
+
+Commands print JSON to stdout. Validation errors return:
+
+```json
+{"success": false, "error": "..."}
+```
+
+Successful `start` output is validated to ensure:
+
+- `success` is `true`
+- `protocol.mailbox` is `false`
+- `protocol.transport` includes `app-server`
+- task id, Codex thread id, and Codex turn id are present
+
+The smoke test starts an async Codex task, polls `status`, and succeeds only
+when the final task status is `completed` and `CODEX_ASYNC_OK` appears in
+`recent_events` or `final_summary`.

--- a/skills/codex-bridge/references/__init__.py
+++ b/skills/codex-bridge/references/__init__.py
@@ -1,0 +1,1 @@
+"""Codex Bridge skill reference utilities."""

--- a/skills/codex-bridge/references/cli.py
+++ b/skills/codex-bridge/references/cli.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Productized CLI for Hermes Codex Bridge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from .validator import (
+        SMOKE_SENTINEL,
+        TERMINAL_STATUSES,
+        ValidationError,
+        parse_json_object,
+        validate_approval_policy,
+        validate_bridge_output,
+        validate_interrupt_input,
+        validate_respond_input,
+        validate_sandbox,
+        validate_smoke_test_result,
+        validate_start_input,
+        validate_status_input,
+        validate_steer_input,
+    )
+except ImportError:
+    from validator import (  # type: ignore
+        SMOKE_SENTINEL,
+        TERMINAL_STATUSES,
+        ValidationError,
+        parse_json_object,
+        validate_approval_policy,
+        validate_bridge_output,
+        validate_interrupt_input,
+        validate_respond_input,
+        validate_sandbox,
+        validate_smoke_test_result,
+        validate_start_input,
+        validate_status_input,
+        validate_steer_input,
+    )
+
+from tools.codex_bridge_tool import DEFAULT_APPROVAL_POLICY, DEFAULT_SANDBOX, codex_bridge
+
+
+def emit(data: dict[str, Any]) -> None:
+    print(json.dumps(data, ensure_ascii=False, sort_keys=True))
+
+
+def call_bridge(action: str, **kwargs: Any) -> dict[str, Any]:
+    raw = codex_bridge(action=action, **kwargs)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"codex_bridge returned invalid JSON for {action}: {exc.msg}") from exc
+    validate_bridge_output(action, data)
+    return data
+
+
+def _prompt_from_args(args: argparse.Namespace) -> str:
+    prompt = args.prompt
+    if prompt is None and args.prompt_text:
+        prompt = " ".join(args.prompt_text)
+    return prompt or ""
+
+
+def cmd_start(args: argparse.Namespace) -> dict[str, Any]:
+    prompt = _prompt_from_args(args)
+    validate_start_input(prompt, args.cwd, args.sandbox, args.approval_policy)
+    return call_bridge(
+        "start",
+        prompt=prompt,
+        cwd=args.cwd,
+        model=args.model,
+        sandbox=args.sandbox,
+        approval_policy=args.approval_policy,
+        codex_home=args.codex_home,
+    )
+
+
+def cmd_status(args: argparse.Namespace) -> dict[str, Any]:
+    validate_status_input(args.task_id)
+    return call_bridge("status", task_id=args.task_id)
+
+
+def cmd_list(args: argparse.Namespace) -> dict[str, Any]:
+    return call_bridge("list", limit=args.limit)
+
+
+def cmd_steer(args: argparse.Namespace) -> dict[str, Any]:
+    validate_steer_input(args.task_id, args.instruction)
+    return call_bridge("steer", task_id=args.task_id, instruction=args.instruction)
+
+
+def cmd_interrupt(args: argparse.Namespace) -> dict[str, Any]:
+    validate_interrupt_input(args.task_id)
+    return call_bridge("interrupt", task_id=args.task_id)
+
+
+def cmd_respond(args: argparse.Namespace) -> dict[str, Any]:
+    answers = parse_json_object(args.answers, field_name="answers")
+    validate_respond_input(args.task_id, args.request_id, args.decision, answers)
+    return call_bridge(
+        "respond",
+        task_id=args.task_id,
+        instruction=args.request_id,
+        decision=args.decision,
+        answers=answers,
+    )
+
+
+def _smoke_prompt(wait_seconds: int) -> str:
+    return (
+        f"Wait {wait_seconds} seconds asynchronously, then reply exactly {SMOKE_SENTINEL}. "
+        "Do not modify files."
+    )
+
+
+def cmd_smoke_test(args: argparse.Namespace) -> dict[str, Any]:
+    validate_start_input(_smoke_prompt(args.wait), args.cwd, args.sandbox, args.approval_policy)
+    started = call_bridge(
+        "start",
+        prompt=_smoke_prompt(args.wait),
+        cwd=args.cwd,
+        model=args.model,
+        sandbox=args.sandbox,
+        approval_policy=args.approval_policy,
+        codex_home=args.codex_home,
+    )
+    task_id = started["task"]["hermes_task_id"]
+    deadline = time.monotonic() + args.timeout
+    last_status: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        time.sleep(args.poll_interval)
+        last_status = call_bridge("status", task_id=task_id)
+        task = last_status.get("task") or {}
+        if task.get("status") in TERMINAL_STATUSES:
+            validate_smoke_test_result(last_status)
+            return {
+                "success": True,
+                "task_id": task_id,
+                "status": task.get("status"),
+                "start": started,
+                "final_status": last_status,
+            }
+    return {
+        "success": False,
+        "error": f"smoke-test timed out after {args.timeout} seconds.",
+        "task_id": task_id,
+        "start": started,
+        "last_status": last_status,
+    }
+
+
+def add_common_start_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--cwd", default=str(Path.cwd()), help="Working directory for Codex.")
+    parser.add_argument("--model", default=None, help="Optional Codex model override.")
+    parser.add_argument("--sandbox", default=DEFAULT_SANDBOX, type=validate_sandbox)
+    parser.add_argument("--approval-policy", default=DEFAULT_APPROVAL_POLICY, type=validate_approval_policy)
+    parser.add_argument("--codex-home", default=None, help="Optional CODEX_HOME override.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hermes Codex Bridge skill CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start = subparsers.add_parser("start", help="Start a Codex task.")
+    start.add_argument("--prompt", help="Task prompt.")
+    start.add_argument("prompt_text", nargs="*", help="Task prompt as positional text.")
+    add_common_start_options(start)
+    start.set_defaults(func=cmd_start)
+
+    status = subparsers.add_parser("status", help="Show task status.")
+    status.add_argument("task_id")
+    status.set_defaults(func=cmd_status)
+
+    list_parser = subparsers.add_parser("list", help="List recent Codex Bridge tasks.")
+    list_parser.add_argument("--limit", type=int, default=10)
+    list_parser.set_defaults(func=cmd_list)
+
+    steer = subparsers.add_parser("steer", help="Steer an active Codex turn.")
+    steer.add_argument("task_id")
+    steer.add_argument("--instruction", required=True)
+    steer.set_defaults(func=cmd_steer)
+
+    interrupt = subparsers.add_parser("interrupt", help="Interrupt an active Codex turn.")
+    interrupt.add_argument("task_id")
+    interrupt.set_defaults(func=cmd_interrupt)
+
+    respond = subparsers.add_parser("respond", help="Respond to a pending Codex request.")
+    respond.add_argument("task_id")
+    respond.add_argument("--request-id", required=True)
+    respond.add_argument("--decision", default="decline")
+    respond.add_argument("--answers", default=None, help="JSON object for user-input answers.")
+    respond.set_defaults(func=cmd_respond)
+
+    smoke = subparsers.add_parser("smoke-test", help="Run an async Codex Bridge smoke test.")
+    smoke.add_argument("--wait", type=int, default=10)
+    smoke.add_argument("--timeout", type=int, default=60)
+    smoke.add_argument("--poll-interval", type=float, default=2.0)
+    add_common_start_options(smoke)
+    smoke.set_defaults(func=cmd_smoke_test)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+        result = args.func(args)
+        emit(result)
+        return 0 if result.get("success") is True else 1
+    except ValidationError as exc:
+        emit({"success": False, "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-bridge/references/cli.py
+++ b/skills/codex-bridge/references/cli.py
@@ -30,6 +30,8 @@ try:
         validate_start_input,
         validate_status_input,
         validate_steer_input,
+        validate_notify_completed_output,
+        validate_notify_target,
     )
 except ImportError:
     from validator import (  # type: ignore
@@ -46,6 +48,8 @@ except ImportError:
         validate_start_input,
         validate_status_input,
         validate_steer_input,
+        validate_notify_completed_output,
+        validate_notify_target,
     )
 
 from tools.codex_bridge_tool import DEFAULT_APPROVAL_POLICY, DEFAULT_SANDBOX, codex_bridge
@@ -75,6 +79,7 @@ def _prompt_from_args(args: argparse.Namespace) -> str:
 def cmd_start(args: argparse.Namespace) -> dict[str, Any]:
     prompt = _prompt_from_args(args)
     validate_start_input(prompt, args.cwd, args.sandbox, args.approval_policy)
+    notify_target = validate_notify_target(args.notify_target)
     return call_bridge(
         "start",
         prompt=prompt,
@@ -83,6 +88,7 @@ def cmd_start(args: argparse.Namespace) -> dict[str, Any]:
         sandbox=args.sandbox,
         approval_policy=args.approval_policy,
         codex_home=args.codex_home,
+        notify_target=notify_target,
     )
 
 
@@ -93,6 +99,12 @@ def cmd_status(args: argparse.Namespace) -> dict[str, Any]:
 
 def cmd_list(args: argparse.Namespace) -> dict[str, Any]:
     return call_bridge("list", limit=args.limit)
+
+
+def cmd_notify_completed(args: argparse.Namespace) -> dict[str, Any]:
+    data = call_bridge("notify_completed", limit=args.limit, dry_run=args.dry_run)
+    validate_notify_completed_output(data)
+    return data
 
 
 def cmd_steer(args: argparse.Namespace) -> dict[str, Any]:
@@ -126,6 +138,7 @@ def _smoke_prompt(wait_seconds: int) -> str:
 
 def cmd_smoke_test(args: argparse.Namespace) -> dict[str, Any]:
     validate_start_input(_smoke_prompt(args.wait), args.cwd, args.sandbox, args.approval_policy)
+    notify_target = validate_notify_target(args.notify_target)
     started = call_bridge(
         "start",
         prompt=_smoke_prompt(args.wait),
@@ -134,6 +147,7 @@ def cmd_smoke_test(args: argparse.Namespace) -> dict[str, Any]:
         sandbox=args.sandbox,
         approval_policy=args.approval_policy,
         codex_home=args.codex_home,
+        notify_target=notify_target,
     )
     task_id = started["task"]["hermes_task_id"]
     deadline = time.monotonic() + args.timeout
@@ -166,6 +180,11 @@ def add_common_start_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--sandbox", default=DEFAULT_SANDBOX, type=validate_sandbox)
     parser.add_argument("--approval-policy", default=DEFAULT_APPROVAL_POLICY, type=validate_approval_policy)
     parser.add_argument("--codex-home", default=None, help="Optional CODEX_HOME override.")
+    parser.add_argument(
+        "--notify-target",
+        default=None,
+        help="Optional completion notification target, e.g. local or feishu:<chat_id>.",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -185,6 +204,11 @@ def build_parser() -> argparse.ArgumentParser:
     list_parser = subparsers.add_parser("list", help="List recent Codex Bridge tasks.")
     list_parser.add_argument("--limit", type=int, default=10)
     list_parser.set_defaults(func=cmd_list)
+
+    notify = subparsers.add_parser("notify-completed", help="One-shot poll and notify completed tasks.")
+    notify.add_argument("--limit", type=int, default=10)
+    notify.add_argument("--dry-run", action="store_true", help="Preview notifications without sending or marking.")
+    notify.set_defaults(func=cmd_notify_completed)
 
     steer = subparsers.add_parser("steer", help="Steer an active Codex turn.")
     steer.add_argument("task_id")

--- a/skills/codex-bridge/references/validator.py
+++ b/skills/codex-bridge/references/validator.py
@@ -1,0 +1,152 @@
+"""Validation helpers for the Codex Bridge skill CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+ALLOWED_SANDBOXES = {"read-only", "workspace-write"}
+ALLOWED_APPROVAL_POLICIES = {"untrusted", "on-request"}
+ALLOWED_DECISIONS = {"accept", "acceptForSession", "decline", "cancel"}
+TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+SMOKE_SENTINEL = "CODEX_ASYNC_OK"
+
+
+class ValidationError(ValueError):
+    """Raised when a CLI input or bridge output fails validation."""
+
+
+def parse_json_object(value: str | None, *, field_name: str) -> dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"{field_name} must be valid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise ValidationError(f"{field_name} must be a JSON object.")
+    return parsed
+
+
+def validate_sandbox(sandbox: str) -> str:
+    if sandbox == "danger-full-access":
+        raise ValidationError("danger-full-access is not allowed for Codex Bridge.")
+    if sandbox not in ALLOWED_SANDBOXES:
+        allowed = ", ".join(sorted(ALLOWED_SANDBOXES))
+        raise ValidationError(f"sandbox must be one of: {allowed}.")
+    return sandbox
+
+
+def validate_approval_policy(approval_policy: str) -> str:
+    if approval_policy not in ALLOWED_APPROVAL_POLICIES:
+        allowed = ", ".join(sorted(ALLOWED_APPROVAL_POLICIES))
+        raise ValidationError(f"approval_policy must be one of: {allowed}.")
+    return approval_policy
+
+
+def validate_start_input(prompt: str, cwd: str, sandbox: str, approval_policy: str) -> None:
+    if not prompt or not prompt.strip():
+        raise ValidationError("start prompt must be non-empty.")
+    cwd_path = Path(cwd).expanduser()
+    if not cwd_path.exists() or not cwd_path.is_dir():
+        raise ValidationError(f"cwd must be an existing directory: {cwd}")
+    validate_sandbox(sandbox)
+    validate_approval_policy(approval_policy)
+
+
+def validate_task_id(action: str, task_id: str | None) -> None:
+    if not task_id or not str(task_id).strip():
+        raise ValidationError(f"{action} requires task_id.")
+
+
+def validate_steer_input(task_id: str | None, instruction: str | None) -> None:
+    validate_task_id("steer", task_id)
+    if not instruction or not instruction.strip():
+        raise ValidationError("steer requires instruction.")
+
+
+def validate_interrupt_input(task_id: str | None) -> None:
+    validate_task_id("interrupt", task_id)
+
+
+def validate_status_input(task_id: str | None) -> None:
+    validate_task_id("status", task_id)
+
+
+def validate_respond_input(
+    task_id: str | None,
+    request_id: str | None,
+    decision: str,
+    answers: Mapping[str, Any] | None,
+) -> None:
+    validate_task_id("respond", task_id)
+    if not request_id or not str(request_id).strip():
+        raise ValidationError("respond requires request_id.")
+    if decision not in ALLOWED_DECISIONS:
+        allowed = ", ".join(sorted(ALLOWED_DECISIONS))
+        raise ValidationError(f"decision must be one of: {allowed}.")
+    if answers is not None and not isinstance(answers, Mapping):
+        raise ValidationError("answers must be a JSON object.")
+
+
+def validate_start_output(data: Mapping[str, Any]) -> None:
+    if data.get("success") is not True:
+        raise ValidationError("start output must have success=true.")
+    protocol = data.get("protocol")
+    if not isinstance(protocol, Mapping):
+        raise ValidationError("start output must include protocol.")
+    if protocol.get("mailbox") is not False:
+        raise ValidationError("start output must have protocol.mailbox=false.")
+    transport = str(protocol.get("transport") or "")
+    if "app-server" not in transport:
+        raise ValidationError("start output protocol.transport must include app-server.")
+    task = data.get("task")
+    if not isinstance(task, Mapping):
+        raise ValidationError("start output must include task.")
+    required = {
+        "hermes_task_id": "task id",
+        "codex_thread_id": "thread id",
+        "codex_turn_id": "turn id",
+    }
+    for key, label in required.items():
+        if not task.get(key):
+            raise ValidationError(f"start output missing {label}.")
+
+
+def validate_bridge_output(action: str, data: Mapping[str, Any]) -> None:
+    if not isinstance(data, Mapping):
+        raise ValidationError("bridge output must be a JSON object.")
+    if data.get("success") is not True and data.get("error"):
+        raise ValidationError(str(data["error"]))
+    if action == "start":
+        validate_start_output(data)
+        return
+    if "success" in data and data.get("success") is not True:
+        raise ValidationError(str(data.get("error") or f"{action} failed."))
+
+
+def contains_text(value: Any, needle: str) -> bool:
+    if isinstance(value, str):
+        return needle in value
+    if isinstance(value, Mapping):
+        return any(contains_text(v, needle) for v in value.values())
+    if isinstance(value, list):
+        return any(contains_text(v, needle) for v in value)
+    return False
+
+
+def validate_smoke_test_result(status_data: Mapping[str, Any]) -> None:
+    task = status_data.get("task")
+    if not isinstance(task, Mapping):
+        raise ValidationError("smoke-test status output must include task.")
+    status = task.get("status")
+    if status != "completed":
+        raise ValidationError(f"smoke-test final status must be completed, got {status!r}.")
+    searchable = {
+        "recent_events": task.get("recent_events", []),
+        "final_summary": task.get("final_summary"),
+    }
+    if not contains_text(searchable, SMOKE_SENTINEL):
+        raise ValidationError(f"smoke-test output did not include {SMOKE_SENTINEL}.")

--- a/skills/codex-bridge/references/validator.py
+++ b/skills/codex-bridge/references/validator.py
@@ -11,6 +11,7 @@ ALLOWED_SANDBOXES = {"read-only", "workspace-write"}
 ALLOWED_APPROVAL_POLICIES = {"untrusted", "on-request"}
 ALLOWED_DECISIONS = {"accept", "acceptForSession", "decline", "cancel"}
 TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+NOTIFICATION_STATUSES = {"sent", "failed", "no_target", "dry_run", "pending"}
 SMOKE_SENTINEL = "CODEX_ASYNC_OK"
 
 
@@ -54,6 +55,15 @@ def validate_start_input(prompt: str, cwd: str, sandbox: str, approval_policy: s
         raise ValidationError(f"cwd must be an existing directory: {cwd}")
     validate_sandbox(sandbox)
     validate_approval_policy(approval_policy)
+
+
+def validate_notify_target(target: str | None) -> str | None:
+    if target is None:
+        return None
+    normalized = target.strip()
+    if not normalized:
+        raise ValidationError("notify_target must be non-empty when provided.")
+    return normalized
 
 
 def validate_task_id(action: str, task_id: str | None) -> None:
@@ -123,8 +133,28 @@ def validate_bridge_output(action: str, data: Mapping[str, Any]) -> None:
     if action == "start":
         validate_start_output(data)
         return
+    if action == "notify_completed":
+        validate_notify_completed_output(data)
+        return
     if "success" in data and data.get("success") is not True:
         raise ValidationError(str(data.get("error") or f"{action} failed."))
+
+
+def validate_notify_completed_output(data: Mapping[str, Any]) -> None:
+    if data.get("success") is not True:
+        raise ValidationError("notify_completed output must have success=true.")
+    notifications = data.get("notifications")
+    if not isinstance(notifications, list):
+        raise ValidationError("notify_completed output must include notifications list.")
+    for item in notifications:
+        if not isinstance(item, Mapping):
+            raise ValidationError("notify_completed notifications must be objects.")
+        if not item.get("task_id"):
+            raise ValidationError("notify_completed notification missing task_id.")
+        status = item.get("notification_status")
+        if status not in NOTIFICATION_STATUSES:
+            allowed = ", ".join(sorted(NOTIFICATION_STATUSES))
+            raise ValidationError(f"notification_status must be one of: {allowed}.")
 
 
 def contains_text(value: Any, needle: str) -> bool:

--- a/tests/skills/test_codex_bridge_skill.py
+++ b/tests/skills/test_codex_bridge_skill.py
@@ -1,0 +1,220 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SKILL_REFS = Path(__file__).resolve().parents[2] / "skills" / "codex-bridge" / "references"
+
+
+def load_reference_module(name):
+    module_path = SKILL_REFS / f"{name}.py"
+    sys.path.insert(0, str(SKILL_REFS))
+    try:
+        spec = importlib.util.spec_from_file_location(f"codex_bridge_skill_{name}", module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        try:
+            sys.path.remove(str(SKILL_REFS))
+        except ValueError:
+            pass
+
+
+def test_validator_rejects_unsafe_start_inputs(tmp_path):
+    validator = load_reference_module("validator")
+
+    for sandbox in ["danger-full-access", "network-only"]:
+        try:
+            validator.validate_start_input("hello", str(tmp_path), sandbox, "untrusted")
+        except validator.ValidationError as exc:
+            assert "sandbox" in str(exc) or "danger-full-access" in str(exc)
+        else:
+            raise AssertionError(f"expected {sandbox} to be rejected")
+
+    try:
+        validator.validate_start_input("hello", str(tmp_path), "read-only", "never")
+    except validator.ValidationError as exc:
+        assert "approval_policy" in str(exc)
+    else:
+        raise AssertionError("expected approval_policy=never to be rejected")
+
+    try:
+        validator.validate_start_input("", str(tmp_path), "read-only", "untrusted")
+    except validator.ValidationError as exc:
+        assert "prompt" in str(exc)
+    else:
+        raise AssertionError("expected empty prompt to be rejected")
+
+    try:
+        validator.validate_start_input("hello", str(tmp_path / "missing"), "read-only", "untrusted")
+    except validator.ValidationError as exc:
+        assert "cwd" in str(exc)
+    else:
+        raise AssertionError("expected missing cwd to be rejected")
+
+
+def test_validator_requires_safe_start_output_contract():
+    validator = load_reference_module("validator")
+
+    valid = {
+        "success": True,
+        "protocol": {"mailbox": False, "transport": "app-server stdio"},
+        "task": {
+            "hermes_task_id": "codex-1",
+            "codex_thread_id": "thread-1",
+            "codex_turn_id": "turn-1",
+        },
+    }
+    validator.validate_start_output(valid)
+
+    invalid = dict(valid)
+    invalid["protocol"] = {"mailbox": True, "transport": "app-server stdio"}
+    try:
+        validator.validate_start_output(invalid)
+    except validator.ValidationError as exc:
+        assert "mailbox" in str(exc)
+    else:
+        raise AssertionError("expected mailbox output to be rejected")
+
+    invalid = dict(valid)
+    invalid["protocol"] = {"mailbox": False, "transport": "mailbox"}
+    try:
+        validator.validate_start_output(invalid)
+    except validator.ValidationError as exc:
+        assert "app-server" in str(exc)
+    else:
+        raise AssertionError("expected non app-server transport to be rejected")
+
+
+def test_cli_start_validates_and_emits_bridge_json(tmp_path, monkeypatch, capsys):
+    cli = load_reference_module("cli")
+    calls = []
+
+    def fake_codex_bridge(**kwargs):
+        calls.append(kwargs)
+        return json.dumps(
+            {
+                "success": True,
+                "protocol": {"mailbox": False, "transport": "app-server stdio"},
+                "task": {
+                    "hermes_task_id": "codex-abc",
+                    "codex_thread_id": "thread-abc",
+                    "codex_turn_id": "turn-abc",
+                },
+            }
+        )
+
+    monkeypatch.setattr(cli, "codex_bridge", fake_codex_bridge)
+
+    exit_code = cli.main(["start", "--cwd", str(tmp_path), "--prompt", "Analyze tests"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["task"]["hermes_task_id"] == "codex-abc"
+    assert calls == [
+        {
+            "action": "start",
+            "prompt": "Analyze tests",
+            "cwd": str(tmp_path),
+            "model": None,
+            "sandbox": "read-only",
+            "approval_policy": "untrusted",
+            "codex_home": None,
+        }
+    ]
+
+
+def test_cli_respond_maps_request_id_to_bridge_instruction(monkeypatch, capsys):
+    cli = load_reference_module("cli")
+    calls = []
+
+    def fake_codex_bridge(**kwargs):
+        calls.append(kwargs)
+        return json.dumps({"success": True, "response": {"decision": kwargs["decision"]}})
+
+    monkeypatch.setattr(cli, "codex_bridge", fake_codex_bridge)
+
+    exit_code = cli.main(
+        [
+            "respond",
+            "codex-abc",
+            "--request-id",
+            "approval-1",
+            "--decision",
+            "decline",
+            "--answers",
+            '{"q1": {"answers": ["yes"]}}',
+        ]
+    )
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["response"] == {"decision": "decline"}
+    assert calls == [
+        {
+            "action": "respond",
+            "task_id": "codex-abc",
+            "instruction": "approval-1",
+            "decision": "decline",
+            "answers": {"q1": {"answers": ["yes"]}},
+        }
+    ]
+
+
+def test_cli_smoke_test_polls_until_completed_with_sentinel(tmp_path, monkeypatch, capsys):
+    cli = load_reference_module("cli")
+    calls = []
+
+    def fake_codex_bridge(**kwargs):
+        calls.append(kwargs)
+        action = kwargs["action"]
+        if action == "start":
+            return json.dumps(
+                {
+                    "success": True,
+                    "protocol": {"mailbox": False, "transport": "app-server stdio"},
+                    "task": {
+                        "hermes_task_id": "codex-smoke",
+                        "codex_thread_id": "thread-smoke",
+                        "codex_turn_id": "turn-smoke",
+                    },
+                }
+            )
+        return json.dumps(
+            {
+                "success": True,
+                "task": {
+                    "hermes_task_id": "codex-smoke",
+                    "status": "completed",
+                    "recent_events": [{"payload_summary": "assistant replied CODEX_ASYNC_OK"}],
+                    "final_summary": None,
+                },
+            }
+        )
+
+    monkeypatch.setattr(cli, "codex_bridge", fake_codex_bridge)
+    monkeypatch.setattr(cli.time, "sleep", lambda _seconds: None)
+
+    exit_code = cli.main(
+        [
+            "smoke-test",
+            "--cwd",
+            str(tmp_path),
+            "--wait",
+            "3",
+            "--timeout",
+            "10",
+            "--poll-interval",
+            "0.01",
+        ]
+    )
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["success"] is True
+    assert output["task_id"] == "codex-smoke"
+    assert [call["action"] for call in calls] == ["start", "status"]
+    assert "CODEX_ASYNC_OK" in calls[0]["prompt"]

--- a/tests/skills/test_codex_bridge_skill.py
+++ b/tests/skills/test_codex_bridge_skill.py
@@ -123,8 +123,38 @@ def test_cli_start_validates_and_emits_bridge_json(tmp_path, monkeypatch, capsys
             "sandbox": "read-only",
             "approval_policy": "untrusted",
             "codex_home": None,
+            "notify_target": None,
         }
     ]
+
+
+def test_cli_start_passes_notify_target(tmp_path, monkeypatch, capsys):
+    cli = load_reference_module("cli")
+    calls = []
+
+    def fake_codex_bridge(**kwargs):
+        calls.append(kwargs)
+        return json.dumps(
+            {
+                "success": True,
+                "protocol": {"mailbox": False, "transport": "app-server stdio"},
+                "task": {
+                    "hermes_task_id": "codex-abc",
+                    "codex_thread_id": "thread-abc",
+                    "codex_turn_id": "turn-abc",
+                    "notify_target": kwargs["notify_target"],
+                },
+            }
+        )
+
+    monkeypatch.setattr(cli, "codex_bridge", fake_codex_bridge)
+
+    exit_code = cli.main(["start", "--cwd", str(tmp_path), "--notify-target", "local", "--prompt", "Analyze tests"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["task"]["notify_target"] == "local"
+    assert calls[0]["notify_target"] == "local"
 
 
 def test_cli_respond_maps_request_id_to_bridge_instruction(monkeypatch, capsys):
@@ -218,3 +248,37 @@ def test_cli_smoke_test_polls_until_completed_with_sentinel(tmp_path, monkeypatc
     assert output["task_id"] == "codex-smoke"
     assert [call["action"] for call in calls] == ["start", "status"]
     assert "CODEX_ASYNC_OK" in calls[0]["prompt"]
+    assert calls[0]["notify_target"] is None
+
+
+def test_cli_notify_completed_dry_run_uses_bridge_without_real_notifier(monkeypatch, capsys):
+    cli = load_reference_module("cli")
+    calls = []
+
+    def fake_codex_bridge(**kwargs):
+        calls.append(kwargs)
+        return json.dumps(
+            {
+                "success": True,
+                "dry_run": True,
+                "processed": 1,
+                "notifications": [
+                    {
+                        "task_id": "codex-abc",
+                        "target": "local",
+                        "notification_status": "dry_run",
+                        "sent": False,
+                        "message": "preview",
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(cli, "codex_bridge", fake_codex_bridge)
+
+    exit_code = cli.main(["notify-completed", "--limit", "5", "--dry-run"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["notifications"][0]["notification_status"] == "dry_run"
+    assert calls == [{"action": "notify_completed", "limit": 5, "dry_run": True}]

--- a/tests/tools/test_codex_bridge_tool.py
+++ b/tests/tools/test_codex_bridge_tool.py
@@ -1,0 +1,150 @@
+import json
+
+import tools.codex_bridge_tool as bridge
+from tools.codex_bridge_tool import CodexBridgeManager, CodexBridgeStore
+
+
+class FakeCodexClient:
+    instances = []
+
+    def __init__(self, task_id, task, manager):
+        self.task_id = task_id
+        self.task = task
+        self.manager = manager
+        self.requests = []
+        self.responses = []
+        self.closed = False
+        FakeCodexClient.instances.append(self)
+
+    def start(self, *, codex_home=None):
+        self.codex_home = codex_home
+
+    def initialize(self):
+        return {"userAgent": "fake-codex", "codexHome": "/tmp/codex"}
+
+    def request(self, method, params=None, timeout=30):
+        self.requests.append((method, params, timeout))
+        if method == "thread/start":
+            return {"thread": {"id": "thread-1"}}
+        if method == "turn/start":
+            return {"turn": {"id": "turn-1", "status": "inProgress"}}
+        if method == "turn/steer":
+            return {"ok": True, "steered": params}
+        if method == "turn/interrupt":
+            return {"ok": True, "interrupted": params}
+        raise AssertionError(f"unexpected request: {method}")
+
+    def notify(self, method, params=None):
+        self.notifications = getattr(self, "notifications", [])
+        self.notifications.append((method, params))
+
+    def respond(self, request_id, result):
+        self.responses.append((request_id, result))
+
+    def close(self):
+        self.closed = True
+
+
+def make_manager(tmp_path, monkeypatch):
+    FakeCodexClient.instances.clear()
+    monkeypatch.setattr(bridge, "CodexJsonRpcClient", FakeCodexClient)
+    store = CodexBridgeStore(tmp_path / "codex_bridge.db")
+    return CodexBridgeManager(store=store)
+
+
+def test_start_task_uses_app_server_thread_turn_without_mailbox(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+
+    result = manager.start_task("Investigate the failing test", cwd=str(tmp_path))
+
+    assert result["success"] is True
+    assert result["protocol"] == {"transport": "app-server stdio", "mailbox": False}
+    task = result["task"]
+    assert task["status"] == "working"
+    assert task["codex_thread_id"] == "thread-1"
+    assert task["codex_turn_id"] == "turn-1"
+
+    client = FakeCodexClient.instances[0]
+    methods = [method for method, _params, _timeout in client.requests]
+    assert methods == ["thread/start", "turn/start"]
+    thread_params = client.requests[0][1]
+    assert thread_params["sandbox"] == "read-only"
+    assert thread_params["approvalPolicy"] == "untrusted"
+    assert "mailbox" not in json.dumps(client.requests).lower()
+    assert "outbox" not in json.dumps(client.requests).lower()
+    assert "inbox" not in json.dumps(client.requests).lower()
+
+
+def test_server_approval_request_can_be_reported_and_resolved(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+    started = manager.start_task("Run a safe command", cwd=str(tmp_path))
+    task_id = started["task"]["hermes_task_id"]
+    client = FakeCodexClient.instances[0]
+
+    manager.handle_server_request(
+        task_id,
+        client,
+        {
+            "id": "approval-1",
+            "method": "item/commandExecution/requestApproval",
+            "params": {"threadId": "thread-1", "turnId": "turn-1", "command": "pwd"},
+        },
+    )
+
+    status = manager.status(task_id)
+    assert status["task"]["status"] == "waiting_for_approval"
+    assert status["task"]["pending_requests"][0]["request_id"] == "approval-1"
+
+    response = manager.respond(task_id, "approval-1", decision="decline")
+    assert response["success"] is True
+    assert client.responses == [("approval-1", {"decision": "decline"})]
+    assert manager.status(task_id)["task"]["pending_requests"] == []
+
+
+def test_request_user_input_response_uses_answers_payload(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+    started = manager.start_task("Ask for missing context", cwd=str(tmp_path))
+    task_id = started["task"]["hermes_task_id"]
+    client = FakeCodexClient.instances[0]
+
+    manager.handle_server_request(
+        task_id,
+        client,
+        {
+            "id": "input-1",
+            "method": "item/tool/requestUserInput",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "questions": [{"id": "q1", "question": "Which file?", "options": None}],
+            },
+        },
+    )
+
+    answers = {"q1": {"answers": ["README.md"]}}
+    manager.respond(task_id, "input-1", decision="decline", answers=answers)
+
+    assert client.responses == [("input-1", {"answers": answers})]
+
+
+def test_steer_and_interrupt_call_codex_turn_methods(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+    started = manager.start_task("Long running task", cwd=str(tmp_path))
+    task_id = started["task"]["hermes_task_id"]
+    client = FakeCodexClient.instances[0]
+
+    steer = manager.steer(task_id, "Only analyze; do not edit.")
+    interrupt = manager.interrupt(task_id)
+
+    assert steer["success"] is True
+    assert interrupt["task"]["status"] == "cancelled"
+    assert client.requests[-2][0] == "turn/steer"
+    assert client.requests[-2][1]["expectedTurnId"] == "turn-1"
+    assert client.requests[-1][0] == "turn/interrupt"
+
+
+def test_tool_schema_refuses_danger_full_access():
+    props = bridge.CODEX_BRIDGE_SCHEMA["parameters"]["properties"]
+
+    assert "danger-full-access" not in props["sandbox"]["enum"]
+    assert "never" not in props["approval_policy"]["enum"]

--- a/tests/tools/test_codex_bridge_tool.py
+++ b/tests/tools/test_codex_bridge_tool.py
@@ -75,6 +75,19 @@ def test_start_task_uses_app_server_thread_turn_without_mailbox(tmp_path, monkey
     assert "inbox" not in json.dumps(client.requests).lower()
 
 
+def test_start_task_records_notify_target(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+
+    result = manager.start_task("Analyze tests", cwd=str(tmp_path), notify_target="feishu:chat-1")
+    task_id = result["task"]["hermes_task_id"]
+
+    assert result["task"]["notify_target"] == "feishu:chat-1"
+    assert result["task"]["notification_status"] == "pending"
+    persisted = manager.status(task_id)["task"]
+    assert persisted["notify_target"] == "feishu:chat-1"
+    assert persisted["notification_status"] == "pending"
+
+
 def test_server_approval_request_can_be_reported_and_resolved(tmp_path, monkeypatch):
     manager = make_manager(tmp_path, monkeypatch)
     started = manager.start_task("Run a safe command", cwd=str(tmp_path))
@@ -143,8 +156,76 @@ def test_steer_and_interrupt_call_codex_turn_methods(tmp_path, monkeypatch):
     assert client.requests[-1][0] == "turn/interrupt"
 
 
+def test_notify_completed_sends_once_for_targeted_completed_task(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+    started = manager.start_task("Summarize a bug", cwd=str(tmp_path), notify_target="feishu:chat-1")
+    task_id = started["task"]["hermes_task_id"]
+    deliveries = []
+
+    manager.record_event(
+        task_id,
+        "turn/completed",
+        {"turn": {"id": "turn-1", "status": "completed"}, "message": "Done fixing it."},
+    )
+
+    first = manager.notify_completed(notifier=lambda target, message: deliveries.append((target, message)) or {"ok": True})
+    second = manager.notify_completed(notifier=lambda target, message: deliveries.append((target, message)) or {"ok": True})
+
+    assert first["processed"] == 1
+    assert first["notifications"][0]["notification_status"] == "sent"
+    assert first["notifications"][0]["sent"] is True
+    assert second["processed"] == 0
+    assert len(deliveries) == 1
+    assert deliveries[0][0] == "feishu:chat-1"
+    assert task_id in deliveries[0][1]
+    assert manager.status(task_id)["task"]["notification_status"] == "sent"
+
+
+def test_notify_completed_marks_no_target_without_sending(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+    started = manager.start_task("No callback needed", cwd=str(tmp_path))
+    task_id = started["task"]["hermes_task_id"]
+
+    manager.record_event(
+        task_id,
+        "turn/completed",
+        {"turn": {"id": "turn-1", "status": "completed"}, "message": "Done."},
+    )
+
+    result = manager.notify_completed(notifier=lambda _target, _message: (_ for _ in ()).throw(AssertionError("sent")))
+
+    assert result["processed"] == 1
+    assert result["notifications"][0]["notification_status"] == "no_target"
+    assert result["notifications"][0]["sent"] is False
+    assert manager.status(task_id)["task"]["notification_status"] == "no_target"
+
+
+def test_notify_completed_dry_run_does_not_send_or_mark(tmp_path, monkeypatch):
+    manager = make_manager(tmp_path, monkeypatch)
+    started = manager.start_task("Preview callback", cwd=str(tmp_path), notify_target="local")
+    task_id = started["task"]["hermes_task_id"]
+
+    manager.record_event(
+        task_id,
+        "turn/completed",
+        {"turn": {"id": "turn-1", "status": "completed"}, "message": "Done."},
+    )
+
+    result = manager.notify_completed(
+        dry_run=True,
+        notifier=lambda _target, _message: (_ for _ in ()).throw(AssertionError("sent")),
+    )
+
+    assert result["processed"] == 1
+    assert result["notifications"][0]["notification_status"] == "dry_run"
+    assert result["notifications"][0]["sent"] is False
+    assert manager.status(task_id)["task"]["notification_status"] == "pending"
+
+
 def test_tool_schema_refuses_danger_full_access():
     props = bridge.CODEX_BRIDGE_SCHEMA["parameters"]["properties"]
 
     assert "danger-full-access" not in props["sandbox"]["enum"]
     assert "never" not in props["approval_policy"]["enum"]
+    assert "notify_completed" in props["action"]["enum"]
+    assert "notify_target" in props

--- a/tools/codex_bridge_tool.py
+++ b/tools/codex_bridge_tool.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+"""Codex app-server bridge tool.
+
+This module talks to Codex's native app-server protocol over stdio JSON-RPC.
+State is persisted for status/recovery, but communication never uses mailbox,
+inbox, or outbox files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import sqlite3
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_error
+
+
+CODEX_BRIDGE_DB = "codex_bridge.db"
+DEFAULT_APPROVAL_POLICY = "untrusted"
+DEFAULT_SANDBOX = "read-only"
+EVENT_TAIL_LIMIT = 20
+
+
+def check_codex_bridge_requirements() -> bool:
+    return shutil.which("codex") is not None
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _json_dumps(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True)
+
+
+def _text_input(text: str) -> List[Dict[str, Any]]:
+    return [{"type": "text", "text": text, "text_elements": []}]
+
+
+def _summarize_payload(payload: Any, max_chars: int = 1200) -> str:
+    if payload is None:
+        return ""
+    if isinstance(payload, str):
+        text = payload
+    else:
+        text = _json_dumps(payload)
+    text = " ".join(text.split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1] + "..."
+
+
+def _normalize_status(method: str, params: Dict[str, Any]) -> Optional[str]:
+    if method == "turn/started":
+        return "working"
+    if method == "turn/completed":
+        turn = params.get("turn") or {}
+        status = turn.get("status")
+        if status == "failed":
+            return "failed"
+        if status == "cancelled":
+            return "cancelled"
+        return "completed"
+    if method == "thread/status/changed":
+        status = params.get("status") or {}
+        if status.get("type") == "systemError":
+            return "failed"
+        if status.get("type") == "active":
+            return "working"
+    if method == "error":
+        return "failed" if not params.get("willRetry") else "working"
+    return None
+
+
+class CodexBridgeStore:
+    def __init__(self, db_path: Optional[Path] = None):
+        home = get_hermes_home()
+        self.db_path = db_path or (home / CODEX_BRIDGE_DB)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), timeout=30)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS codex_bridge_tasks (
+                    hermes_task_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    prompt_summary TEXT,
+                    codex_thread_id TEXT,
+                    codex_turn_id TEXT,
+                    cwd TEXT,
+                    model TEXT,
+                    sandbox TEXT,
+                    approval_policy TEXT,
+                    degraded_mode TEXT,
+                    last_progress_summary TEXT,
+                    final_summary TEXT,
+                    error_summary TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    completed_at REAL
+                );
+
+                CREATE TABLE IF NOT EXISTS codex_bridge_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    hermes_task_id TEXT NOT NULL,
+                    codex_thread_id TEXT,
+                    codex_turn_id TEXT,
+                    source_event_type TEXT NOT NULL,
+                    normalized_status TEXT,
+                    payload_summary TEXT,
+                    payload_json TEXT,
+                    created_at REAL NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS codex_bridge_pending_requests (
+                    request_id TEXT NOT NULL,
+                    hermes_task_id TEXT NOT NULL,
+                    method TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    resolved_at REAL,
+                    response_json TEXT,
+                    PRIMARY KEY (request_id, hermes_task_id)
+                );
+                """
+            )
+
+    def upsert_task(self, task: "CodexBridgeTask") -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO codex_bridge_tasks (
+                    hermes_task_id, status, prompt_summary, codex_thread_id,
+                    codex_turn_id, cwd, model, sandbox, approval_policy,
+                    degraded_mode, last_progress_summary, final_summary,
+                    error_summary, created_at, updated_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(hermes_task_id) DO UPDATE SET
+                    status=excluded.status,
+                    codex_thread_id=excluded.codex_thread_id,
+                    codex_turn_id=excluded.codex_turn_id,
+                    last_progress_summary=excluded.last_progress_summary,
+                    final_summary=excluded.final_summary,
+                    error_summary=excluded.error_summary,
+                    updated_at=excluded.updated_at,
+                    completed_at=excluded.completed_at
+                """,
+                (
+                    task.hermes_task_id,
+                    task.status,
+                    task.prompt_summary,
+                    task.codex_thread_id,
+                    task.codex_turn_id,
+                    task.cwd,
+                    task.model,
+                    task.sandbox,
+                    task.approval_policy,
+                    task.degraded_mode,
+                    task.last_progress_summary,
+                    task.final_summary,
+                    task.error_summary,
+                    task.created_at,
+                    task.updated_at,
+                    task.completed_at,
+                ),
+            )
+
+    def insert_event(
+        self,
+        task_id: str,
+        thread_id: Optional[str],
+        turn_id: Optional[str],
+        method: str,
+        normalized_status: Optional[str],
+        payload: Any,
+    ) -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO codex_bridge_events (
+                    hermes_task_id, codex_thread_id, codex_turn_id,
+                    source_event_type, normalized_status, payload_summary,
+                    payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task_id,
+                    thread_id,
+                    turn_id,
+                    method,
+                    normalized_status,
+                    _summarize_payload(payload),
+                    _json_dumps(payload),
+                    _now(),
+                ),
+            )
+
+    def upsert_pending_request(
+        self,
+        task_id: str,
+        request_id: str,
+        method: str,
+        payload: Any,
+        status: str = "pending",
+    ) -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO codex_bridge_pending_requests (
+                    request_id, hermes_task_id, method, payload_json,
+                    status, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(request_id, hermes_task_id) DO UPDATE SET
+                    payload_json=excluded.payload_json,
+                    status=excluded.status
+                """,
+                (request_id, task_id, method, _json_dumps(payload), status, _now()),
+            )
+
+    def resolve_pending_request(
+        self,
+        task_id: str,
+        request_id: str,
+        response: Any,
+        status: str = "resolved",
+    ) -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE codex_bridge_pending_requests
+                SET status=?, resolved_at=?, response_json=?
+                WHERE hermes_task_id=? AND request_id=?
+                """,
+                (status, _now(), _json_dumps(response), task_id, request_id),
+            )
+
+    def get_task_snapshot(self, task_id: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM codex_bridge_tasks WHERE hermes_task_id=?",
+                (task_id,),
+            ).fetchone()
+            if not row:
+                return None
+            events = conn.execute(
+                """
+                SELECT source_event_type, normalized_status, payload_summary, created_at
+                FROM codex_bridge_events
+                WHERE hermes_task_id=?
+                ORDER BY id DESC LIMIT ?
+                """,
+                (task_id, EVENT_TAIL_LIMIT),
+            ).fetchall()
+            pending = conn.execute(
+                """
+                SELECT request_id, method, payload_json, status, created_at
+                FROM codex_bridge_pending_requests
+                WHERE hermes_task_id=? AND status='pending'
+                ORDER BY created_at ASC
+                """,
+                (task_id,),
+            ).fetchall()
+        snap = dict(row)
+        snap["recent_events"] = [dict(r) for r in reversed(events)]
+        snap["pending_requests"] = [
+            {
+                "request_id": r["request_id"],
+                "method": r["method"],
+                "payload": json.loads(r["payload_json"]),
+                "status": r["status"],
+                "created_at": r["created_at"],
+            }
+            for r in pending
+        ]
+        return snap
+
+    def list_tasks(self, limit: int = 10) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT hermes_task_id, status, prompt_summary, codex_thread_id,
+                       codex_turn_id, last_progress_summary, final_summary,
+                       error_summary, created_at, updated_at, completed_at
+                FROM codex_bridge_tasks
+                ORDER BY updated_at DESC LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+
+@dataclass
+class CodexBridgeTask:
+    hermes_task_id: str
+    prompt_summary: str
+    cwd: str
+    model: Optional[str]
+    sandbox: str
+    approval_policy: str
+    status: str = "starting"
+    codex_thread_id: Optional[str] = None
+    codex_turn_id: Optional[str] = None
+    degraded_mode: str = "none"
+    last_progress_summary: Optional[str] = None
+    final_summary: Optional[str] = None
+    error_summary: Optional[str] = None
+    created_at: float = field(default_factory=_now)
+    updated_at: float = field(default_factory=_now)
+    completed_at: Optional[float] = None
+    pending_requests: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "hermes_task_id": self.hermes_task_id,
+            "status": self.status,
+            "codex_thread_id": self.codex_thread_id,
+            "codex_turn_id": self.codex_turn_id,
+            "prompt_summary": self.prompt_summary,
+            "cwd": self.cwd,
+            "model": self.model,
+            "sandbox": self.sandbox,
+            "approval_policy": self.approval_policy,
+            "degraded_mode": self.degraded_mode,
+            "last_progress_summary": self.last_progress_summary,
+            "final_summary": self.final_summary,
+            "error_summary": self.error_summary,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "completed_at": self.completed_at,
+            "pending_requests": list(self.pending_requests.values()),
+        }
+
+
+class CodexJsonRpcClient:
+    def __init__(self, task_id: str, task: CodexBridgeTask, manager: "CodexBridgeManager"):
+        self.task_id = task_id
+        self.task = task
+        self.manager = manager
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._next_id = 1
+        self._pending: Dict[int, queue.Queue] = {}
+        self._pending_lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._reader_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._closed = False
+
+    def start(self, *, codex_home: Optional[str] = None) -> None:
+        env = os.environ.copy()
+        if codex_home:
+            Path(codex_home).mkdir(parents=True, exist_ok=True)
+            env["CODEX_HOME"] = codex_home
+        self._process = subprocess.Popen(
+            ["codex", "app-server", "--listen", "stdio://"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=self.task.cwd,
+            env=env,
+        )
+        self._reader_thread = threading.Thread(target=self._read_stdout, daemon=True)
+        self._stderr_thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._reader_thread.start()
+        self._stderr_thread.start()
+
+    def initialize(self) -> Dict[str, Any]:
+        result = self.request(
+            "initialize",
+            {
+                "clientInfo": {"name": "hermes-codex-bridge", "version": "0.1.0"},
+                "capabilities": {"experimentalApi": True},
+            },
+            timeout=10,
+        )
+        self.notify("initialized")
+        return result
+
+    def request(self, method: str, params: Optional[Dict[str, Any]] = None, timeout: float = 30) -> Dict[str, Any]:
+        with self._pending_lock:
+            request_id = self._next_id
+            self._next_id += 1
+            response_q: queue.Queue = queue.Queue(maxsize=1)
+            self._pending[request_id] = response_q
+        self._send({"id": request_id, "method": method, "params": params})
+        try:
+            msg = response_q.get(timeout=timeout)
+        except queue.Empty:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise TimeoutError(f"Codex app-server request timed out: {method}")
+        if "error" in msg:
+            raise RuntimeError(msg["error"].get("message") or _json_dumps(msg["error"]))
+        return msg.get("result") or {}
+
+    def notify(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
+        msg: Dict[str, Any] = {"method": method}
+        if params is not None:
+            msg["params"] = params
+        self._send(msg)
+
+    def respond(self, request_id: str, result: Dict[str, Any]) -> None:
+        self._send({"id": request_id, "result": result})
+
+    def close(self) -> None:
+        self._closed = True
+        process = self._process
+        if process and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=3)
+            except Exception:
+                try:
+                    process.kill()
+                except Exception:
+                    pass
+
+    def _send(self, msg: Dict[str, Any]) -> None:
+        if not self._process or not self._process.stdin:
+            raise RuntimeError("Codex app-server process is not running.")
+        with self._write_lock:
+            self._process.stdin.write(json.dumps(msg) + "\n")
+            self._process.stdin.flush()
+
+    def _read_stdout(self) -> None:
+        assert self._process and self._process.stdout
+        for line in self._process.stdout:
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                self.manager.record_event(self.task_id, "protocol/raw", {"line": line.rstrip()})
+                continue
+            if "id" in msg and "method" not in msg:
+                with self._pending_lock:
+                    response_q = self._pending.pop(msg["id"], None)
+                if response_q:
+                    response_q.put(msg)
+                else:
+                    self.manager.record_event(self.task_id, "protocol/response", msg)
+                continue
+            if "id" in msg and "method" in msg:
+                self.manager.handle_server_request(self.task_id, self, msg)
+            else:
+                self.manager.record_event(self.task_id, msg.get("method", "unknown"), msg.get("params", {}))
+
+    def _read_stderr(self) -> None:
+        assert self._process and self._process.stderr
+        for line in self._process.stderr:
+            text = line.strip()
+            if text:
+                self.manager.record_event(self.task_id, "codex/stderr", {"message": text})
+
+
+class CodexBridgeManager:
+    def __init__(self, store: Optional[CodexBridgeStore] = None):
+        self.store = store or CodexBridgeStore()
+        self._tasks: Dict[str, CodexBridgeTask] = {}
+        self._clients: Dict[str, CodexJsonRpcClient] = {}
+        self._lock = threading.RLock()
+
+    def start_task(
+        self,
+        prompt: str,
+        *,
+        cwd: Optional[str] = None,
+        model: Optional[str] = None,
+        sandbox: str = DEFAULT_SANDBOX,
+        approval_policy: str = DEFAULT_APPROVAL_POLICY,
+        codex_home: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if not prompt or not prompt.strip():
+            raise ValueError("codex_bridge start requires a non-empty prompt.")
+        if sandbox == "danger-full-access":
+            raise ValueError("codex_bridge refuses danger-full-access as a default bridge sandbox.")
+        if approval_policy == "never":
+            raise ValueError("codex_bridge refuses approval_policy=never.")
+        task_id = f"codex-{uuid.uuid4().hex[:12]}"
+        cwd = str(Path(cwd or os.getcwd()).resolve())
+        task = CodexBridgeTask(
+            hermes_task_id=task_id,
+            prompt_summary=_summarize_payload(prompt, max_chars=300),
+            cwd=cwd,
+            model=model,
+            sandbox=sandbox,
+            approval_policy=approval_policy,
+        )
+        client = CodexJsonRpcClient(task_id, task, self)
+        with self._lock:
+            self._tasks[task_id] = task
+            self._clients[task_id] = client
+        self.store.upsert_task(task)
+
+        try:
+            client.start(codex_home=codex_home)
+            init = client.initialize()
+            self.record_event(task_id, "bridge/initialized", init)
+            thread_params: Dict[str, Any] = {
+                "cwd": cwd,
+                "sandbox": sandbox,
+                "approvalPolicy": approval_policy,
+                "approvalsReviewer": "user",
+                "ephemeral": True,
+                "sessionStartSource": "startup",
+                "developerInstructions": (
+                    "You are running under Hermes Codex Bridge. Do not treat your "
+                    "own output as approval. Ask for approval through Codex app-server "
+                    "requests when required."
+                ),
+            }
+            if model:
+                thread_params["model"] = model
+            thread_result = client.request("thread/start", thread_params, timeout=15)
+            thread = thread_result.get("thread") or {}
+            task.codex_thread_id = thread.get("id")
+            task.status = "starting"
+            task.updated_at = _now()
+            self.store.upsert_task(task)
+            if not task.codex_thread_id:
+                raise RuntimeError("Codex app-server did not return a thread id.")
+
+            turn_params: Dict[str, Any] = {
+                "threadId": task.codex_thread_id,
+                "input": _text_input(prompt),
+                "approvalPolicy": approval_policy,
+                "approvalsReviewer": "user",
+                "cwd": cwd,
+            }
+            if model:
+                turn_params["model"] = model
+            turn_result = client.request("turn/start", turn_params, timeout=15)
+            turn = turn_result.get("turn") or {}
+            task.codex_turn_id = turn.get("id")
+            task.status = "working"
+            task.updated_at = _now()
+            self.store.upsert_task(task)
+        except Exception:
+            client.close()
+            with self._lock:
+                self._clients.pop(task_id, None)
+            raise
+        return {
+            "success": True,
+            "message": "Codex task started through app-server stdio JSON-RPC.",
+            "task": task.snapshot(),
+            "protocol": {
+                "transport": "app-server stdio",
+                "mailbox": False,
+            },
+        }
+
+    def status(self, task_id: str) -> Dict[str, Any]:
+        with self._lock:
+            task = self._tasks.get(task_id)
+        if task:
+            snap = task.snapshot()
+            stored = self.store.get_task_snapshot(task_id)
+            if stored:
+                snap["recent_events"] = stored.get("recent_events", [])
+                snap["pending_requests"] = stored.get("pending_requests", snap["pending_requests"])
+            return {"success": True, "task": snap}
+        stored = self.store.get_task_snapshot(task_id)
+        if stored:
+            stored["active_connection"] = False
+            return {"success": True, "task": stored}
+        return {"success": False, "error": f"Unknown Codex bridge task: {task_id}"}
+
+    def list_tasks(self, limit: int = 10) -> Dict[str, Any]:
+        return {"success": True, "tasks": self.store.list_tasks(limit=limit)}
+
+    def steer(self, task_id: str, instruction: str) -> Dict[str, Any]:
+        task, client = self._active(task_id)
+        if not task.codex_thread_id or not task.codex_turn_id:
+            raise RuntimeError("Task has no active Codex turn to steer.")
+        result = client.request(
+            "turn/steer",
+            {
+                "threadId": task.codex_thread_id,
+                "expectedTurnId": task.codex_turn_id,
+                "input": _text_input(instruction),
+            },
+            timeout=15,
+        )
+        self.record_event(task_id, "bridge/steer", {"instruction": instruction, "result": result})
+        return {"success": True, "task": task.snapshot(), "result": result}
+
+    def interrupt(self, task_id: str) -> Dict[str, Any]:
+        task, client = self._active(task_id)
+        if not task.codex_thread_id or not task.codex_turn_id:
+            raise RuntimeError("Task has no active Codex turn to interrupt.")
+        result = client.request(
+            "turn/interrupt",
+            {"threadId": task.codex_thread_id, "turnId": task.codex_turn_id},
+            timeout=15,
+        )
+        task.status = "cancelled"
+        task.completed_at = _now()
+        task.updated_at = _now()
+        self.store.upsert_task(task)
+        self.record_event(task_id, "bridge/interrupt", result)
+        return {"success": True, "task": task.snapshot(), "result": result}
+
+    def respond(self, task_id: str, request_id: str, decision: str, answers: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        task, client = self._active(task_id)
+        pending = task.pending_requests.get(str(request_id))
+        if not pending:
+            raise RuntimeError(f"No pending Codex request {request_id!r} for task {task_id}.")
+        method = pending["method"]
+        if method == "item/tool/requestUserInput":
+            result = {"answers": answers or {}}
+        elif method == "item/commandExecution/requestApproval":
+            result = {"decision": decision}
+        elif method == "item/fileChange/requestApproval":
+            result = {"decision": decision}
+        elif method == "item/permissions/requestApproval":
+            result = {"decision": decision}
+        else:
+            result = {"decision": decision}
+        client.respond(str(request_id), result)
+        pending["status"] = "resolved"
+        pending["response"] = result
+        task.pending_requests.pop(str(request_id), None)
+        task.status = "working"
+        task.updated_at = _now()
+        self.store.resolve_pending_request(task_id, str(request_id), result)
+        self.store.upsert_task(task)
+        return {"success": True, "task": task.snapshot(), "response": result}
+
+    def handle_server_request(self, task_id: str, client: CodexJsonRpcClient, msg: Dict[str, Any]) -> None:
+        request_id = str(msg.get("id"))
+        method = msg.get("method", "unknown")
+        params = msg.get("params") or {}
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            if method == "item/tool/requestUserInput":
+                task.status = "waiting_for_user_input"
+            else:
+                task.status = "waiting_for_approval"
+            task.updated_at = _now()
+            task.pending_requests[request_id] = {
+                "request_id": request_id,
+                "method": method,
+                "payload": params,
+                "status": "pending",
+                "created_at": task.updated_at,
+            }
+            self.store.upsert_task(task)
+        self.store.upsert_pending_request(task_id, request_id, method, params)
+        self.record_event(task_id, method, params)
+
+    def record_event(self, task_id: str, method: str, params: Any) -> None:
+        terminal = False
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+            normalized = _normalize_status(method, params if isinstance(params, dict) else {})
+            if method == "turn/completed" and task.status == "cancelled" and normalized == "completed":
+                normalized = "cancelled"
+            if normalized:
+                task.status = normalized
+            if method == "turn/completed":
+                terminal = True
+                task.completed_at = _now()
+                turn = params.get("turn") if isinstance(params, dict) else {}
+                if isinstance(turn, dict) and turn.get("error"):
+                    task.error_summary = _summarize_payload(turn.get("error"), max_chars=500)
+                else:
+                    task.final_summary = _summarize_payload(params, max_chars=500)
+            elif method == "error":
+                task.error_summary = _summarize_payload(params, max_chars=500)
+            elif method not in {"codex/stderr"}:
+                task.last_progress_summary = f"{method}: {_summarize_payload(params, max_chars=300)}"
+            task.updated_at = _now()
+            thread_id = task.codex_thread_id
+            turn_id = task.codex_turn_id
+            self.store.upsert_task(task)
+        self.store.insert_event(task_id, thread_id, turn_id, method, normalized, params)
+        if terminal:
+            with self._lock:
+                client = self._clients.pop(task_id, None)
+            if client:
+                threading.Thread(target=client.close, daemon=True).start()
+
+    def _active(self, task_id: str) -> tuple[CodexBridgeTask, CodexJsonRpcClient]:
+        with self._lock:
+            task = self._tasks.get(task_id)
+            client = self._clients.get(task_id)
+        if not task or not client:
+            raise RuntimeError(f"Codex bridge task is not active in this process: {task_id}")
+        return task, client
+
+
+_MANAGER: Optional[CodexBridgeManager] = None
+_MANAGER_LOCK = threading.Lock()
+
+
+def _get_manager() -> CodexBridgeManager:
+    global _MANAGER
+    with _MANAGER_LOCK:
+        if _MANAGER is None:
+            _MANAGER = CodexBridgeManager()
+        return _MANAGER
+
+
+def codex_bridge(
+    action: str,
+    prompt: Optional[str] = None,
+    task_id: Optional[str] = None,
+    instruction: Optional[str] = None,
+    decision: str = "decline",
+    answers: Optional[Dict[str, Any]] = None,
+    cwd: Optional[str] = None,
+    model: Optional[str] = None,
+    sandbox: str = DEFAULT_SANDBOX,
+    approval_policy: str = DEFAULT_APPROVAL_POLICY,
+    codex_home: Optional[str] = None,
+    limit: int = 10,
+) -> str:
+    try:
+        action = (action or "").strip().lower()
+        if action == "start":
+            result = _get_manager().start_task(
+                prompt or "",
+                cwd=cwd,
+                model=model,
+                sandbox=sandbox or DEFAULT_SANDBOX,
+                approval_policy=approval_policy or DEFAULT_APPROVAL_POLICY,
+                codex_home=codex_home,
+            )
+        elif action == "status":
+            if not task_id:
+                raise ValueError("codex_bridge status requires task_id.")
+            result = _get_manager().status(task_id)
+        elif action == "list":
+            result = _get_manager().list_tasks(limit=limit)
+        elif action == "steer":
+            if not task_id or not instruction:
+                raise ValueError("codex_bridge steer requires task_id and instruction.")
+            result = _get_manager().steer(task_id, instruction)
+        elif action in {"interrupt", "cancel"}:
+            if not task_id:
+                raise ValueError("codex_bridge interrupt requires task_id.")
+            result = _get_manager().interrupt(task_id)
+        elif action == "respond":
+            if not task_id or not instruction:
+                raise ValueError("codex_bridge respond requires task_id and instruction=request_id.")
+            result = _get_manager().respond(task_id, instruction, decision=decision, answers=answers)
+        else:
+            raise ValueError("action must be one of start, status, list, steer, interrupt, respond.")
+        return _json_dumps(result)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+CODEX_BRIDGE_SCHEMA = {
+    "name": "codex_bridge",
+    "description": (
+        "Start and control local Codex tasks through Codex app-server JSON-RPC. "
+        "Uses stdio/WebSocket-capable app-server protocol semantics and never "
+        "uses mailbox, inbox, or outbox files as the communication path. "
+        "Actions: start, status, list, steer, interrupt, respond."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["start", "status", "list", "steer", "interrupt", "cancel", "respond"],
+                "description": "Bridge operation to perform.",
+            },
+            "prompt": {"type": "string", "description": "Task prompt for action=start."},
+            "task_id": {"type": "string", "description": "Hermes Codex task id for status/control actions."},
+            "instruction": {
+                "type": "string",
+                "description": "Steering text for steer, or pending request id for respond.",
+            },
+            "decision": {
+                "type": "string",
+                "enum": ["accept", "acceptForSession", "decline", "cancel"],
+                "description": "Approval decision for action=respond.",
+            },
+            "answers": {
+                "type": "object",
+                "description": "requestUserInput answers keyed by Codex question id, e.g. {'q1': {'answers': ['value']}}.",
+            },
+            "cwd": {"type": "string", "description": "Working directory for the Codex thread."},
+            "model": {"type": "string", "description": "Optional Codex model override."},
+            "sandbox": {
+                "type": "string",
+                "enum": ["read-only", "workspace-write"],
+                "description": "Codex sandbox mode. danger-full-access is intentionally not exposed.",
+            },
+            "approval_policy": {
+                "type": "string",
+                "enum": ["untrusted", "on-request"],
+                "description": "Codex approval policy. Default untrusted.",
+            },
+            "codex_home": {
+                "type": "string",
+                "description": "Optional CODEX_HOME override for testing or isolated runs.",
+            },
+            "limit": {"type": "integer", "description": "List limit for action=list."},
+        },
+        "required": ["action"],
+    },
+}
+
+
+registry.register(
+    name="codex_bridge",
+    toolset="codex_bridge",
+    schema=CODEX_BRIDGE_SCHEMA,
+    handler=lambda args, **kw: codex_bridge(
+        action=args.get("action", ""),
+        prompt=args.get("prompt"),
+        task_id=args.get("task_id"),
+        instruction=args.get("instruction"),
+        decision=args.get("decision", "decline"),
+        answers=args.get("answers"),
+        cwd=args.get("cwd"),
+        model=args.get("model"),
+        sandbox=args.get("sandbox", DEFAULT_SANDBOX),
+        approval_policy=args.get("approval_policy", DEFAULT_APPROVAL_POLICY),
+        codex_home=args.get("codex_home"),
+        limit=args.get("limit", 10),
+    ),
+    check_fn=check_codex_bridge_requirements,
+    emoji="C",
+)

--- a/tools/codex_bridge_tool.py
+++ b/tools/codex_bridge_tool.py
@@ -19,7 +19,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 from tools.registry import registry, tool_error
@@ -29,6 +29,7 @@ CODEX_BRIDGE_DB = "codex_bridge.db"
 DEFAULT_APPROVAL_POLICY = "untrusted"
 DEFAULT_SANDBOX = "read-only"
 EVENT_TAIL_LIMIT = 20
+TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
 
 
 def check_codex_bridge_requirements() -> bool:
@@ -113,6 +114,10 @@ class CodexBridgeStore:
                     last_progress_summary TEXT,
                     final_summary TEXT,
                     error_summary TEXT,
+                    notify_target TEXT,
+                    notification_status TEXT,
+                    notified_at REAL,
+                    notification_error TEXT,
                     created_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
                     completed_at REAL
@@ -143,6 +148,22 @@ class CodexBridgeStore:
                 );
                 """
             )
+            self._ensure_task_columns(conn)
+
+    def _ensure_task_columns(self, conn: sqlite3.Connection) -> None:
+        existing = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(codex_bridge_tasks)").fetchall()
+        }
+        migrations = {
+            "notify_target": "ALTER TABLE codex_bridge_tasks ADD COLUMN notify_target TEXT",
+            "notification_status": "ALTER TABLE codex_bridge_tasks ADD COLUMN notification_status TEXT",
+            "notified_at": "ALTER TABLE codex_bridge_tasks ADD COLUMN notified_at REAL",
+            "notification_error": "ALTER TABLE codex_bridge_tasks ADD COLUMN notification_error TEXT",
+        }
+        for column, statement in migrations.items():
+            if column not in existing:
+                conn.execute(statement)
 
     def upsert_task(self, task: "CodexBridgeTask") -> None:
         with self._lock, self._connect() as conn:
@@ -152,8 +173,9 @@ class CodexBridgeStore:
                     hermes_task_id, status, prompt_summary, codex_thread_id,
                     codex_turn_id, cwd, model, sandbox, approval_policy,
                     degraded_mode, last_progress_summary, final_summary,
-                    error_summary, created_at, updated_at, completed_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    error_summary, notify_target, notification_status, notified_at,
+                    notification_error, created_at, updated_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(hermes_task_id) DO UPDATE SET
                     status=excluded.status,
                     codex_thread_id=excluded.codex_thread_id,
@@ -161,6 +183,10 @@ class CodexBridgeStore:
                     last_progress_summary=excluded.last_progress_summary,
                     final_summary=excluded.final_summary,
                     error_summary=excluded.error_summary,
+                    notify_target=excluded.notify_target,
+                    notification_status=excluded.notification_status,
+                    notified_at=excluded.notified_at,
+                    notification_error=excluded.notification_error,
                     updated_at=excluded.updated_at,
                     completed_at=excluded.completed_at
                 """,
@@ -178,6 +204,10 @@ class CodexBridgeStore:
                     task.last_progress_summary,
                     task.final_summary,
                     task.error_summary,
+                    task.notify_target,
+                    task.notification_status,
+                    task.notified_at,
+                    task.notification_error,
                     task.created_at,
                     task.updated_at,
                     task.completed_at,
@@ -299,13 +329,53 @@ class CodexBridgeStore:
                 """
                 SELECT hermes_task_id, status, prompt_summary, codex_thread_id,
                        codex_turn_id, last_progress_summary, final_summary,
-                       error_summary, created_at, updated_at, completed_at
+                       error_summary, notify_target, notification_status,
+                       notified_at, notification_error, created_at, updated_at,
+                       completed_at
                 FROM codex_bridge_tasks
                 ORDER BY updated_at DESC LIMIT ?
                 """,
                 (limit,),
             ).fetchall()
         return [dict(r) for r in rows]
+
+    def list_completed_for_notification(self, limit: int = 10) -> List[Dict[str, Any]]:
+        placeholders = ",".join("?" for _ in TERMINAL_STATUSES)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT *
+                FROM codex_bridge_tasks
+                WHERE status IN ({placeholders})
+                  AND (
+                    notification_status IS NULL
+                    OR notification_status='pending'
+                    OR notification_status='failed'
+                  )
+                ORDER BY completed_at ASC, updated_at ASC
+                LIMIT ?
+                """,
+                (*sorted(TERMINAL_STATUSES), limit),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def update_notification_status(
+        self,
+        task_id: str,
+        status: str,
+        *,
+        notified_at: Optional[float] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE codex_bridge_tasks
+                SET notification_status=?, notified_at=?, notification_error=?, updated_at=?
+                WHERE hermes_task_id=?
+                """,
+                (status, notified_at, error, _now(), task_id),
+            )
 
 
 @dataclass
@@ -323,6 +393,10 @@ class CodexBridgeTask:
     last_progress_summary: Optional[str] = None
     final_summary: Optional[str] = None
     error_summary: Optional[str] = None
+    notify_target: Optional[str] = None
+    notification_status: Optional[str] = None
+    notified_at: Optional[float] = None
+    notification_error: Optional[str] = None
     created_at: float = field(default_factory=_now)
     updated_at: float = field(default_factory=_now)
     completed_at: Optional[float] = None
@@ -343,6 +417,10 @@ class CodexBridgeTask:
             "last_progress_summary": self.last_progress_summary,
             "final_summary": self.final_summary,
             "error_summary": self.error_summary,
+            "notify_target": self.notify_target,
+            "notification_status": self.notification_status,
+            "notified_at": self.notified_at,
+            "notification_error": self.notification_error,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "completed_at": self.completed_at,
@@ -489,6 +567,7 @@ class CodexBridgeManager:
         sandbox: str = DEFAULT_SANDBOX,
         approval_policy: str = DEFAULT_APPROVAL_POLICY,
         codex_home: Optional[str] = None,
+        notify_target: Optional[str] = None,
     ) -> Dict[str, Any]:
         if not prompt or not prompt.strip():
             raise ValueError("codex_bridge start requires a non-empty prompt.")
@@ -505,6 +584,8 @@ class CodexBridgeManager:
             model=model,
             sandbox=sandbox,
             approval_policy=approval_policy,
+            notify_target=notify_target.strip() if notify_target and notify_target.strip() else None,
+            notification_status="pending" if notify_target and notify_target.strip() else None,
         )
         client = CodexJsonRpcClient(task_id, task, self)
         with self._lock:
@@ -579,6 +660,8 @@ class CodexBridgeManager:
             if stored:
                 snap["recent_events"] = stored.get("recent_events", [])
                 snap["pending_requests"] = stored.get("pending_requests", snap["pending_requests"])
+                for key in ("notification_status", "notified_at", "notification_error"):
+                    snap[key] = stored.get(key)
             return {"success": True, "task": snap}
         stored = self.store.get_task_snapshot(task_id)
         if stored:
@@ -588,6 +671,70 @@ class CodexBridgeManager:
 
     def list_tasks(self, limit: int = 10) -> Dict[str, Any]:
         return {"success": True, "tasks": self.store.list_tasks(limit=limit)}
+
+    def notify_completed(
+        self,
+        *,
+        limit: int = 10,
+        dry_run: bool = False,
+        notifier: Optional[Callable[[str, str], Any]] = None,
+    ) -> Dict[str, Any]:
+        notifier = notifier or _default_completion_notifier
+        candidates = self.store.list_completed_for_notification(limit=limit)
+        results: List[Dict[str, Any]] = []
+        for task in candidates:
+            task_id = str(task["hermes_task_id"])
+            target = str(task.get("notify_target") or "").strip()
+            message = _completion_notification_message(task)
+            if not target:
+                result = {
+                    "task_id": task_id,
+                    "status": task.get("status"),
+                    "notification_status": "no_target",
+                    "sent": False,
+                    "message": message,
+                }
+                if not dry_run:
+                    self.store.update_notification_status(task_id, "no_target")
+                results.append(result)
+                continue
+
+            result = {
+                "task_id": task_id,
+                "status": task.get("status"),
+                "target": target,
+                "notification_status": "dry_run" if dry_run else "pending",
+                "sent": False,
+                "message": message,
+            }
+            if dry_run:
+                results.append(result)
+                continue
+
+            try:
+                delivery = notifier(target, message)
+            except Exception as exc:
+                error = str(exc)
+                self.store.update_notification_status(task_id, "failed", error=error)
+                result["notification_status"] = "failed"
+                result["error"] = error
+                results.append(result)
+                continue
+
+            notified_at = _now()
+            self.store.update_notification_status(task_id, "sent", notified_at=notified_at)
+            result["notification_status"] = "sent"
+            result["sent"] = True
+            result["notified_at"] = notified_at
+            result["delivery"] = delivery
+            results.append(result)
+
+        return {
+            "success": True,
+            "dry_run": dry_run,
+            "processed": len(results),
+            "notifications": results,
+        }
 
     def steer(self, task_id: str, instruction: str) -> Dict[str, Any]:
         task, client = self._active(task_id)
@@ -726,6 +873,35 @@ def _get_manager() -> CodexBridgeManager:
         return _MANAGER
 
 
+def _completion_notification_message(task: Dict[str, Any]) -> str:
+    task_id = task.get("hermes_task_id") or "unknown"
+    status = task.get("status") or "unknown"
+    prompt = task.get("prompt_summary") or "(no prompt summary)"
+    summary = task.get("final_summary") or task.get("error_summary") or task.get("last_progress_summary") or ""
+    lines = [
+        f"Codex Bridge task {task_id} finished with status: {status}.",
+        f"Prompt: {prompt}",
+    ]
+    if summary:
+        lines.append(f"Summary: {_summarize_payload(summary, max_chars=700)}")
+    return "\n".join(lines)
+
+
+def _default_completion_notifier(target: str, message: str) -> Dict[str, Any]:
+    if target == "local":
+        return {"success": True, "target": target, "local": True}
+    from tools.send_message_tool import send_message_tool
+
+    raw = send_message_tool({"action": "send", "target": target, "message": message})
+    try:
+        result = json.loads(raw)
+    except Exception:
+        result = {"raw": raw}
+    if isinstance(result, dict) and result.get("error"):
+        raise RuntimeError(str(result["error"]))
+    return result if isinstance(result, dict) else {"result": result}
+
+
 def codex_bridge(
     action: str,
     prompt: Optional[str] = None,
@@ -738,7 +914,9 @@ def codex_bridge(
     sandbox: str = DEFAULT_SANDBOX,
     approval_policy: str = DEFAULT_APPROVAL_POLICY,
     codex_home: Optional[str] = None,
+    notify_target: Optional[str] = None,
     limit: int = 10,
+    dry_run: bool = False,
 ) -> str:
     try:
         action = (action or "").strip().lower()
@@ -750,6 +928,7 @@ def codex_bridge(
                 sandbox=sandbox or DEFAULT_SANDBOX,
                 approval_policy=approval_policy or DEFAULT_APPROVAL_POLICY,
                 codex_home=codex_home,
+                notify_target=notify_target,
             )
         elif action == "status":
             if not task_id:
@@ -757,6 +936,8 @@ def codex_bridge(
             result = _get_manager().status(task_id)
         elif action == "list":
             result = _get_manager().list_tasks(limit=limit)
+        elif action == "notify_completed":
+            result = _get_manager().notify_completed(limit=limit, dry_run=dry_run)
         elif action == "steer":
             if not task_id or not instruction:
                 raise ValueError("codex_bridge steer requires task_id and instruction.")
@@ -770,7 +951,7 @@ def codex_bridge(
                 raise ValueError("codex_bridge respond requires task_id and instruction=request_id.")
             result = _get_manager().respond(task_id, instruction, decision=decision, answers=answers)
         else:
-            raise ValueError("action must be one of start, status, list, steer, interrupt, respond.")
+            raise ValueError("action must be one of start, status, list, notify_completed, steer, interrupt, respond.")
         return _json_dumps(result)
     except Exception as exc:
         return tool_error(str(exc))
@@ -782,14 +963,14 @@ CODEX_BRIDGE_SCHEMA = {
         "Start and control local Codex tasks through Codex app-server JSON-RPC. "
         "Uses stdio/WebSocket-capable app-server protocol semantics and never "
         "uses mailbox, inbox, or outbox files as the communication path. "
-        "Actions: start, status, list, steer, interrupt, respond."
+        "Actions: start, status, list, notify_completed, steer, interrupt, respond."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["start", "status", "list", "steer", "interrupt", "cancel", "respond"],
+                "enum": ["start", "status", "list", "notify_completed", "steer", "interrupt", "cancel", "respond"],
                 "description": "Bridge operation to perform.",
             },
             "prompt": {"type": "string", "description": "Task prompt for action=start."},
@@ -823,7 +1004,18 @@ CODEX_BRIDGE_SCHEMA = {
                 "type": "string",
                 "description": "Optional CODEX_HOME override for testing or isolated runs.",
             },
+            "notify_target": {
+                "type": "string",
+                "description": (
+                    "Optional completion notification target for action=start, such as "
+                    "'local', 'feishu:<chat_id>', or any send_message target."
+                ),
+            },
             "limit": {"type": "integer", "description": "List limit for action=list."},
+            "dry_run": {
+                "type": "boolean",
+                "description": "For action=notify_completed, preview notifications without sending or marking tasks.",
+            },
         },
         "required": ["action"],
     },
@@ -846,7 +1038,9 @@ registry.register(
         sandbox=args.get("sandbox", DEFAULT_SANDBOX),
         approval_policy=args.get("approval_policy", DEFAULT_APPROVAL_POLICY),
         codex_home=args.get("codex_home"),
+        notify_target=args.get("notify_target"),
         limit=args.get("limit", 10),
+        dry_run=bool(args.get("dry_run", False)),
     ),
     check_fn=check_codex_bridge_requirements,
     emoji="C",

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "codex_bridge",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -193,6 +193,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "codex_bridge": {
+        "description": "Run local Codex tasks through Codex app-server JSON-RPC without mailbox files",
+        "tools": ["codex_bridge"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -253,7 +259,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "codex_bridge",
         ],
         "includes": []
     },
@@ -281,7 +287,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "codex_bridge",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## 背景

本次 dogfood 暴露出 Codex Bridge 的一个产品异味：任务通过 app-server stdio 异步启动后，完成状态只写入本地状态库，用户必须再次唤醒 Hermes 手动查询，无法在完成时回到原会话通知。

## 改动

- 为 Codex Bridge 任务新增可选 `notify_target` 记录。
- 增加通知状态持久化字段和迁移，支持防重复通知。
- 新增 `notify_completed` one-shot watcher，可发现已完成但未通知任务，并通过可注入 notifier 发送摘要。
- CLI 新增 `start --notify-target` 与 `notify-completed --dry-run`。
- validator 增加通知目标与 watcher 输出校验。
- 补充测试覆盖记录 target、只通知一次、无 target 不发送、CLI dry-run/mock notifier。

## 验证

- `python -m py_compile tools/codex_bridge_tool.py skills/codex-bridge/references/cli.py skills/codex-bridge/references/validator.py`
- `/Users/wangrenzhu/work/hermes-agent/venv/bin/python -m pytest tests/tools/test_codex_bridge_tool.py tests/skills/test_codex_bridge_skill.py -q -n 4` -> `16 passed`

## 风险与后续

- 默认 notifier 复用现有 `send_message`，真实平台目标不可达时会记录失败，后续可由 watcher 重试。
- pending approval / requestUserInput 的实时交互只在文档中规划扩展路径，本 PR 聚焦完成通知 MVP。
- 本 PR 不使用 mailbox/outbox/inbox 作为通信机制。