### PR TITLE
fix(skills): google-workspace — shared HERMES_HOME helper + ship deps as optional extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,15 @@ termux = [
 ]
 dingtalk = ["dingtalk-stream>=0.20,<1", "alibabacloud-dingtalk>=2.0.0", "qrcode>=7.0,<8"]
 feishu = ["lark-oapi>=1.5.3,<2", "qrcode>=7.0,<8"]
+google = [
+  # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
+  # Sheets, Docs).  Declared here so packagers (Nix, Homebrew) ship them with
+  # the [all] extra and users don't hit runtime `pip install` paths that fail
+  # in environments without pip (e.g. Nix-managed Python).
+  "google-api-python-client>=2.100,<3",
+  "google-auth-oauthlib>=1.0,<2",
+  "google-auth-httplib2>=0.2,<1",
+]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 web = ["fastapi>=0.104.0,<1", "uvicorn[standard]>=0.24.0,<1"]
 rl = [
@@ -110,6 +119,7 @@ all = [
   "hermes-agent[voice]",
   "hermes-agent[dingtalk]",
   "hermes-agent[feishu]",
+  "hermes-agent[google]",
   "hermes-agent[mistral]",
   "hermes-agent[bedrock]",
   "hermes-agent[web]",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -112,6 +112,7 @@ AUTHOR_MAP = {
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",
     "jerome@clawwork.ai": "HiddenPuppy",
+    "jerome.benoit@sap.com": "jerome-benoit",
     "wysie@users.noreply.github.com": "Wysie",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",

--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
+++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
@@ -1,0 +1,42 @@
+"""Resolve HERMES_HOME for standalone skill scripts.
+
+Skill scripts may run outside the Hermes process (e.g. system Python,
+nix env, CI) where ``hermes_constants`` is not importable.  This module
+provides the same ``get_hermes_home()`` and ``display_hermes_home()``
+contracts as ``hermes_constants`` without requiring it on ``sys.path``.
+
+When ``hermes_constants`` IS available it is used directly so that any
+future enhancements (profile resolution, Docker detection, etc.) are
+picked up automatically.  The fallback path replicates the core logic
+from ``hermes_constants.py`` using only the stdlib.
+
+All scripts under ``google-workspace/scripts/`` should import from here
+instead of duplicating the ``HERMES_HOME = Path(os.getenv(...))`` pattern.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+try:
+    from hermes_constants import display_hermes_home as display_hermes_home
+    from hermes_constants import get_hermes_home as get_hermes_home
+except (ModuleNotFoundError, ImportError):
+
+    def get_hermes_home() -> Path:
+        """Return the Hermes home directory (default: ~/.hermes).
+
+        Mirrors ``hermes_constants.get_hermes_home()``."""
+        val = os.environ.get("HERMES_HOME", "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
+
+    def display_hermes_home() -> str:
+        """Return a user-friendly ``~/``-shortened display string.
+
+        Mirrors ``hermes_constants.display_hermes_home()``."""
+        home = get_hermes_home()
+        try:
+            return "~/" + str(home.relative_to(Path.home()))
+        except ValueError:
+            return str(home)

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -31,7 +31,14 @@ from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
 
-HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+# Ensure sibling modules (_hermes_home) are importable when run standalone.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _hermes_home import get_hermes_home
+
+HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
 

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -10,9 +10,12 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Ensure sibling modules (_hermes_home) are importable when run standalone.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
 
-def get_hermes_home() -> Path:
-    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+from _hermes_home import get_hermes_home
 
 
 def get_token_path() -> Path:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -21,6 +21,8 @@ Agent workflow:
   6. Run --check to verify. Done.
 """
 
+from __future__ import annotations  # allow PEP 604 `X | None` on Python 3.9+
+
 import argparse
 import json
 import os
@@ -110,7 +112,11 @@ def install_deps():
         return True
     except subprocess.CalledProcessError as e:
         print(f"ERROR: Failed to install dependencies: {e}")
-        print(f"Try manually: {sys.executable} -m pip install {' '.join(REQUIRED_PACKAGES)}")
+        print(
+            "On environments without pip (e.g. Nix), install the optional extra instead:"
+        )
+        print("  pip install 'hermes-agent[google]'")
+        print(f"Or manually: {sys.executable} -m pip install {' '.join(REQUIRED_PACKAGES)}")
         return False
 
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -28,13 +28,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    from hermes_constants import display_hermes_home, get_hermes_home
-except ModuleNotFoundError:
-    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
-    if HERMES_AGENT_ROOT.exists():
-        sys.path.insert(0, str(HERMES_AGENT_ROOT))
-    from hermes_constants import display_hermes_home, get_hermes_home
+# Ensure sibling modules (_hermes_home) are importable when run standalone.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _hermes_home import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -240,3 +240,69 @@ class TestExchangeAuthCode:
         assert setup_module.TOKEN_PATH.exists()
         # Pending auth is cleaned up
         assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+class TestHermesConstantsFallback:
+    """Tests for _hermes_home.py fallback when hermes_constants is unavailable."""
+
+    HELPER_PATH = (
+        Path(__file__).resolve().parents[2]
+        / "skills/productivity/google-workspace/scripts/_hermes_home.py"
+    )
+
+    def _load_helper(self, monkeypatch):
+        """Load _hermes_home.py with hermes_constants blocked."""
+        monkeypatch.setitem(sys.modules, "hermes_constants", None)
+        spec = importlib.util.spec_from_file_location("_hermes_home_test", self.HELPER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_fallback_uses_hermes_home_env_var(self, monkeypatch, tmp_path):
+        """When hermes_constants is missing, HERMES_HOME comes from env var."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom-hermes"))
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == tmp_path / "custom-hermes"
+
+    def test_fallback_defaults_to_dot_hermes(self, monkeypatch):
+        """When hermes_constants is missing and HERMES_HOME unset, default to ~/.hermes."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == Path.home() / ".hermes"
+
+    def test_fallback_ignores_empty_hermes_home(self, monkeypatch):
+        """Empty/whitespace HERMES_HOME is treated as unset."""
+        monkeypatch.setenv("HERMES_HOME", "  ")
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == Path.home() / ".hermes"
+
+    def test_fallback_display_hermes_home_shortens_path(self, monkeypatch):
+        """Fallback display_hermes_home() uses ~/ shorthand like the real one."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "~/.hermes"
+
+    def test_fallback_display_hermes_home_profile_path(self, monkeypatch):
+        """Fallback display_hermes_home() handles profile paths under ~/."""
+        monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes/profiles/coder"))
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "~/.hermes/profiles/coder"
+
+    def test_fallback_display_hermes_home_custom_path(self, monkeypatch):
+        """Fallback display_hermes_home() returns full path for non-home locations."""
+        monkeypatch.setenv("HERMES_HOME", "/opt/hermes-custom")
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "/opt/hermes-custom"
+
+    def test_delegates_to_hermes_constants_when_available(self):
+        """When hermes_constants IS importable, _hermes_home delegates to it."""
+        spec = importlib.util.spec_from_file_location(
+            "_hermes_home_happy", self.HELPER_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        import hermes_constants
+        assert module.get_hermes_home is hermes_constants.get_hermes_home
+        assert module.display_hermes_home is hermes_constants.display_hermes_home


### PR DESCRIPTION
Closes #13626. Supersedes #12729 (salvaged) and #11176.

## Summary
Google-workspace skill now works on Nix-managed Hermes and on systems whose default python is 3.9.

## Changes
- **skills/productivity/google-workspace/scripts/_hermes_home.py** (new, via @jerome-benoit's #12729): shared helper that resolves `HERMES_HOME` consistently across all three skill scripts — delegates to `hermes_constants` when importable, falls back to env var + `~/.hermes` default otherwise.
- **setup.py, google_api.py, gws_bridge.py** (via #12729): import from the new helper instead of duplicating or mis-falling-back.
- **pyproject.toml**: new `[google]` optional extra (`google-api-python-client`, `google-auth-oauthlib`, `google-auth-httplib2`), wired into `[all]`. Nix flake and Homebrew will now ship the deps; setup.py's runtime `pip install` path is no longer load-bearing on pip-less environments.
- **setup.py**: `from __future__ import annotations` so the PEP 604 `str | None` signature at line ~240 parses on Python 3.9 (macOS system `/usr/bin/python3`).
- **setup.py** `install_deps()` error message: points users at `pip install 'hermes-agent[google]'` instead of just the raw pip command.
- **scripts/release.py**: AUTHOR_MAP entry for `jerome.benoit@sap.com → jerome-benoit`.
- **tests/skills/test_google_oauth_setup.py**: 7 new tests for the helper's fallback path (env var, default, empty-string, display formatting, profile paths, delegation when `hermes_constants` is present).

## Validation
| | Before | After |
|---|---|---|
| `tests/skills/test_google_oauth_setup.py` + `test_google_workspace_api.py` | — | 21/21 pass |
| `tests/test_project_metadata.py` + `test_packaging_metadata.py` | — | 6/6 pass |
| System python3 (3.9, no `hermes_constants` on path) `setup.py --check` | `ModuleNotFoundError` / `SyntaxError` | exits 1 with `NOT_AUTHENTICATED: No token at …` as expected |
| `pip install 'hermes-agent[google]'` resolves to the 3 Google API packages | N/A (extra didn't exist) | Yes |

## Why not #11176
#11176 tried to solve the same problem with a bolted-in upward-walk path resolver plus a `uv pip` / `--user` fallback chain. The path resolver only fixed `setup.py` (leaving `gws_bridge.py`'s duplicated helper and `google_api.py`'s inconsistency in place), and `uv`/`--user` don't help Nix either — no pip machinery at all is available there. Shipping the deps as a proper optional extra is the correct fix and obsoletes both fallback chains.

Credit: path-resolution unification cherry-picked from @jerome-benoit's #12729; bug analysis and Nix pip/ensurepip finding from @jerome-benoit's #13626.