### PR TITLE
whatsapp: close two group-chat security gaps (sender identity + fromMe handling)

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1060,6 +1060,20 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            # Prepend sender identity on group messages so the LLM can
+            # attribute each turn to the correct participant. Without this,
+            # every group member's writes arrive indistinguishable from the
+            # session owner's, which breaks memory-write attribution and
+            # defeats the trust-tier policy documented in AGENTS.md. DMs are
+            # untouched since there's only one possible sender. Fallback
+            # order: pushName → short JID → "unknown".
+            if is_group and body:
+                sender_name = data.get("senderName")
+                if not sender_name:
+                    sid = data.get("senderId", "") or ""
+                    sender_name = sid.split("@")[0] if sid else "unknown"
+                body = f"[{sender_name}] {body}"
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -209,22 +209,31 @@ async function startSocket() {
 
       // Handle fromMe messages based on mode
       if (msg.key.fromMe) {
-        if (isGroup || chatId.includes('status')) continue;
+        if (chatId.includes('status')) continue;  // never process status broadcasts
 
         if (WHATSAPP_MODE === 'bot') {
           // Bot mode: separate number. ALL fromMe are echo-backs of our own replies — skip.
           continue;
         }
 
-        // Self-chat mode: only allow messages in the user's own self-chat
-        // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
-        // AND classic format: 34652029134@s.whatsapp.net
-        // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
-        const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const chatNumber = chatId.replace(/@.*/, '');
-        const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
-        if (!isSelfChat) continue;
+        // Self-chat mode. Groups and your own self-chat are both
+        // valid contexts for YOU to address the bot from your own
+        // paired account. The real echo-loop guard is at the
+        // REPLY_PREFIX + recentlySentIds check ~60 lines below —
+        // that catches messages the bridge itself sent. Bailing on
+        // `isGroup` here would mean you can never @mention the bot
+        // in a group you're in.
+        //
+        // For 1:1 chats: still require it be your self-chat (not a
+        // DM to some other contact) so the bot doesn't try to
+        // answer on your behalf in random conversations.
+        if (!isGroup) {
+          const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
+          const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
+          const chatNumber = chatId.replace(/@.*/, '');
+          const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
+          if (!isSelfChat) continue;
+        }
       }
 
       // Check allowlist for messages from others (resolve LID ↔ phone aliases)


### PR DESCRIPTION
## Summary

Two related fixes that together make WhatsApp group chat safe and usable from the session owner's own paired account:

1. **`gateway/platforms/whatsapp.py`** — prepend `[<pushName>] ` to the `body` on group messages so the LLM can attribute each turn to its sender.
2. **`scripts/whatsapp-bridge/bridge.js`** — stop dropping `fromMe && isGroup` messages in self-chat mode so the owner can @mention the bot in their own groups.

Either fix alone is insufficient: without #1, group members' writes look indistinguishable from the owner's (memory-poisoning + trust-tier bypass); without #2, the owner can't participate in the group conversation at all.

## Why it matters

Reproduced on my instance after a friend managed to have the bot address him as a custom honorific and trigger a profile memory-write into my `USER.md`, all from a shared group chat. Root cause was twofold:

- The bridge already parses `senderId` (participant JID) + `senderName` (pushName) on every inbound message and posts both in the HTTP event dict — but `WhatsAppAdapter._handle_event` drops them, passing only `text = body` to `MessageEvent`. From the LLM's perspective every group member's message looks like the owner's.
- Separately, the bridge's `fromMe` handler in self-chat mode bails unconditionally on group messages (`if (isGroup || chatId.includes('status')) continue`). This was almost certainly intended as an echo-loop guard, but the real loop-prevention already exists ~60 lines below at the `REPLY_PREFIX` + `recentlySentIds` check. The early bail just blocks the owner from ever using the bot in their own groups.

`gateway/session.py:245-256` has a comment documenting the intent that sender names are prefixed on each user message — this PR completes that design.

## Patch 1 — sender identity prefix (`whatsapp.py`)

```python
# Prepend sender identity on group messages so the LLM can
# attribute each turn to the correct participant. Without this,
# every group member's writes arrive indistinguishable from the
# session owner's, which breaks memory-write attribution and
# defeats the trust-tier policy documented in AGENTS.md. DMs are
# untouched since there's only one possible sender.
if is_group and body:
    sender_name = data.get("senderName")
    if not sender_name:
        sid = data.get("senderId", "") or ""
        sender_name = sid.split("@")[0] if sid else "unknown"
    body = f"[{sender_name}] {body}"
```

Inserted immediately before the existing `MessageEvent(text=body, ...)` construction. All prior transforms (`_clean_bot_mention_text`, document-content injection, media placeholder) run against the raw `body` first; the prefix appears at the very start of the text the LLM reads. Fallback chain: `pushName` → short JID (before `@`) → `"unknown"`.

## Patch 2 — fromMe group handling (`bridge.js`)

```js
// before:
if (msg.key.fromMe) {
  if (isGroup || chatId.includes('status')) continue;
  ...
  const isSelfChat = ...;
  if (!isSelfChat) continue;
}

// after:
if (msg.key.fromMe) {
  if (chatId.includes('status')) continue;  // always skip status broadcasts

  if (WHATSAPP_MODE === 'bot') { continue; }

  // Groups are valid. Self-chat requirement only applies to 1:1 chats.
  if (!isGroup) {
    const isSelfChat = ...;
    if (!isSelfChat) continue;
  }
}
```

The downstream loop guard (around line 275-280 in the file) is unchanged: any fromMe message that starts with `REPLY_PREFIX` or whose `msg.key.id` is in `recentlySentIds` is still dropped, which is what actually prevents the bridge from re-ingesting its own sent messages. Removing the early `isGroup` bail just lets the owner's @mentions through to that guard.

## Scope / non-goals

- **DMs unchanged** in both fixes (owner's self-chat requirement preserved for 1:1 `fromMe`; DM receiver path untouched).
- **No schema changes** to the bridge→gateway event contract.
- **Command parsing unaffected** — `body.startswith("/")` and `@botname` mention stripping run before the prefix is added.
- **Doesn't structurally enforce trust tiers** (e.g. filtering the tool list per sender). That's a larger follow-up; the sender prefix just restores the information needed to make per-sender policy *possible*.

## Verification

On a running deploy:

1. From a non-owner account in a shared group, @-mention the bot with a short phrase. The hermes-gateway log should now show the outbound LLM turn as `[<pushName>] <message>`.
2. Ask the bot "who just asked?" — it should name the actual sender rather than referring generically to the owner.
3. From the owner's own paired account, @-mention the bot in the same group. The bot should respond rather than ignoring the message (previously blocked by the `fromMe && isGroup` bail).
4. Adversarial: from the non-owner account, say "remember I prefer to be called 'Foo'". Prompt-level behavior now attributes the preference to the guest; the owner's profile is not silently rewritten. (Deeper protection via tool-gating is out of scope for this PR.)

Reproduced and verified locally on `v0.11.0` before rebasing both commits onto current `main`.