### PR TITLE
fix(nix): refresh tui + web npmDepsHash to unblock CI on every PR (#15244, #15272, #15314)

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -4,7 +4,7 @@ let
   src = ../ui-tui;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-RU4qSHgJPMyfRSEJDzkG4+MReDZDc6QbTD2wisa5QE0=";
+    hash = "sha256-/lL0IXurF4WlyFYVVwDI0Btcx0uChHdmKQ8ZW3NQf5E=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "ui-tui"; attr = "tui"; pname = "hermes-tui"; };

--- a/nix/web.nix
+++ b/nix/web.nix
@@ -4,7 +4,7 @@ let
   src = ../web;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-TS/vrCHbdvXkPcAPxImKzAd2pdDCrKlgYZkXBMQ+TEg=";
+    hash = "sha256-4Z8KQ69QhO83X6zff+5urWBv6MME686MhTTMdwSl65o=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "web"; attr = "web"; pname = "hermes-web"; };


### PR DESCRIPTION
## What does this PR do?

The \`Nix Lockfile Check\` on \`main\` has been failing across every open PR for several days because two pinned \`fetchNpmDeps\` hashes drifted out of sync with the actual \`package-lock.json\` contents in \`ui-tui/\` and \`web/\`.

The CI run prints the correct hash on each failure, so this is a one-character-precision drive-by — both new hashes are exactly what every recent \`Nix Lockfile Check\` run is reporting (e.g. run [24916813199](https://github.com/NousResearch/hermes-agent/actions/runs/24916813199/job/72970383179) from a few minutes ago):

| File | Old → New |
|---|---|
| \`nix/tui.nix\` | \`RU4qSHgJPMyfRSEJDzkG4+MReDZDc6QbTD2wisa5QE0=\` → \`/lL0IXurF4WlyFYVVwDI0Btcx0uChHdmKQ8ZW3NQf5E=\` |
| \`nix/web.nix\` | \`TS/vrCHbdvXkPcAPxImKzAd2pdDCrKlgYZkXBMQ+TEg=\` → \`4Z8KQ69QhO83X6zff+5urWBv6MME686MhTTMdwSl65o=\` |

The drift was caused by recent dependency-touching commits in:

- \`ui-tui/\`: PTY WebSocket bridge (\`f49afd31\`), package.json updates across the chat-unification series (\`c61547c0\`), \`fix(tui): warn on bare null sections in config.yaml\` (\`bfa60234\`)
- \`web/\`: docs embedding (\`0fdbfad2\`), sidebar layout (\`e5d2815b\`), dashboard extension points (\`f593c367\`)

None of those PRs ran the \`nix flake update\` follow-up, so the cached hashes never got refreshed.

## Related Issues

- Closes #15244 (\`nix ubuntu check failing on main again\`)
- Closes #15272 (\`nix CI broken on main — npmDepsHash out of date\`)
- Closes #15314 (\`hermes-tui npmDepsHash is out of date\`)

## Type of Change

- [x] 🐛 Bug fix (CI infrastructure)
- [ ] No tests required — pure config update; the existing \`Nix Lockfile Check\` workflow IS the regression guard for this kind of drift

## Test plan

- [x] Both new hashes are taken verbatim from \`Nix Lockfile Check\` failure output: the CI computes the correct hash from the actual \`package-lock.json\` and prints \"To correct the hash mismatch for npm-deps, use ...\"
- [x] No production code touched — only the two pinned hashes
- [ ] Once merged: every open PR's \`Nix Lockfile Check\` lane goes from FAILURE to SUCCESS on its next CI run

## Why a separate PR (vs piggybacking on another fix)

This fix unblocks ~30 open PRs at once, including all of mine. Keeping it isolated makes the merge low-risk (1 line per file), explicit in git history, and easy to cherry-pick onto release branches if needed.

## Out of scope

- Automating the hash refresh on every \`package-lock.json\` change (would need a CI job to compute and commit the hash). \`#13136\` proposed this with \`automatic lockfile fixing to keep main building with nix\` but was reverted in \`688c9f5b\`. Restoring that automation is a bigger conversation; this PR is a narrow unblock for today.