### PR TITLE
fix(cli): stop idle prompt redraws

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10526,7 +10526,6 @@ class HermesCLI:
         app._on_resize = _resize_clear_ghosts
 
         def spinner_loop():
-            last_idle_refresh = 0.0
             while not self._should_exit:
                 if not self._app:
                     time.sleep(0.1)
@@ -10535,10 +10534,11 @@ class HermesCLI:
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
                 else:
-                    now = time.monotonic()
-                    if now - last_idle_refresh >= 1.0:
-                        last_idle_refresh = now
-                        self._invalidate(min_interval=1.0)
+                    # Do not repaint the idle prompt every second. In non-full-screen
+                    # prompt_toolkit mode, background redraws can fight tmux/Ghostty/cmux
+                    # viewport restoration after focus changes and visually move the
+                    # command input area. Keep idle stable; input/agent events still
+                    # invalidate explicitly when the UI actually changes.
                     time.sleep(0.2)
 
         spinner_thread = threading.Thread(target=spinner_loop, daemon=True)


### PR DESCRIPTION
## Summary
- Stop invalidating/redrawing the interactive CLI prompt once per second while it is idle.
- Keep the existing faster redraw loop while a command is actively running.
- Add an inline note explaining why idle repainting can destabilize terminal viewport restoration.

## Problem
`spinner_loop()` currently calls `_invalidate(min_interval=1.0)` every second even when the CLI is idle. In prompt_toolkit non-full-screen mode, these background repaints can conflict with tmux/Ghostty/cmux viewport restoration after switching away and back, making the command input area appear to jump or move.

This is related to previous CLI flicker/terminal redraw issues, but is scoped specifically to idle prompt redraws rather than spinner output during active work.

Relates to #464 and #5474.

## Fix
Remove the idle once-per-second invalidate path. The CLI still invalidates explicitly on input/agent events, and while `_command_running` is true it continues to invalidate at the existing 0.1s interval.

## Test Plan
- `./venv/bin/python -m py_compile cli.py`
- Manual: macOS + Ghostty/cmux/tmux with tmux mouse on; switch away from and back to an idle Hermes CLI window and verify the command input area stays stable.
