### PR TITLE
fix(agent): clamp compression threshold below context_length to ensure compression can trigger (#14690)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -466,6 +466,23 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    def _recompute_thresholds_and_budgets(self) -> None:
+        """Rebuild derived token thresholds after a context/model change."""
+        self.threshold_tokens = max(
+            int(self.context_length * self.threshold_percent),
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        # Threshold must stay below context_length so compression can trigger
+        # before the provider rejects the request outright.
+        self.threshold_tokens = min(
+            self.threshold_tokens, int(self.context_length * 0.95)
+        )
+        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
+        self.tail_token_budget = target_tokens
+        self.max_summary_tokens = min(
+            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()
@@ -497,17 +514,7 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
-        # Recalculate token budgets for the new context length so the
-        # compressor stays calibrated after a model switch (e.g. 200K → 32K).
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
+        self._recompute_thresholds_and_budgets()
 
     def __init__(
         self,
@@ -550,18 +557,8 @@ class ContextCompressor(ContextEngine):
         # the percentage would suggest a lower value.  This prevents premature
         # compression on large-context models at 50% while keeping the % sane
         # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        self._recompute_thresholds_and_budgets()
         self.compression_count = 0
-
-        # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
 
         if not quiet_mode:
             logger.info(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -318,6 +318,12 @@ class ContextCompressor(ContextEngine):
             int(context_length * self.threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
         )
+        # Clamp: threshold must stay below context_length so compression can
+        # actually trigger before the API rejects the request.  The 95% cap
+        # gives 5% headroom — enough to catch the threshold in time.
+        self.threshold_tokens = min(
+            self.threshold_tokens, int(context_length * 0.95)
+        )
 
     def __init__(
         self,
@@ -357,6 +363,12 @@ class ContextCompressor(ContextEngine):
         self.threshold_tokens = max(
             int(self.context_length * threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
+        )
+        # Clamp: threshold must stay below context_length so compression can
+        # actually trigger before the API rejects the request.  The 95% cap
+        # gives 5% headroom — enough to catch the threshold in time.
+        self.threshold_tokens = min(
+            self.threshold_tokens, int(self.context_length * 0.95)
         )
         self.compression_count = 0
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -288,6 +288,23 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    def _recompute_thresholds_and_budgets(self) -> None:
+        """Rebuild derived token thresholds after a context/model change."""
+        self.threshold_tokens = max(
+            int(self.context_length * self.threshold_percent),
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        # Threshold must stay below context_length so compression can trigger
+        # before the provider rejects the request outright.
+        self.threshold_tokens = min(
+            self.threshold_tokens, int(self.context_length * 0.95)
+        )
+        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
+        self.tail_token_budget = target_tokens
+        self.max_summary_tokens = min(
+            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()
@@ -314,16 +331,7 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
-        # Clamp: threshold must stay below context_length so compression can
-        # actually trigger before the API rejects the request.  The 95% cap
-        # gives 5% headroom — enough to catch the threshold in time.
-        self.threshold_tokens = min(
-            self.threshold_tokens, int(context_length * 0.95)
-        )
+        self._recompute_thresholds_and_budgets()
 
     def __init__(
         self,
@@ -360,24 +368,8 @@ class ContextCompressor(ContextEngine):
         # the percentage would suggest a lower value.  This prevents premature
         # compression on large-context models at 50% while keeping the % sane
         # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
-        # Clamp: threshold must stay below context_length so compression can
-        # actually trigger before the API rejects the request.  The 95% cap
-        # gives 5% headroom — enough to catch the threshold in time.
-        self.threshold_tokens = min(
-            self.threshold_tokens, int(self.context_length * 0.95)
-        )
+        self._recompute_thresholds_and_budgets()
         self.compression_count = 0
-
-        # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
 
         if not quiet_mode:
             logger.info(

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
 
 
 @pytest.fixture()
@@ -1942,3 +1943,59 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+class TestThresholdClampAtMinimumContext:
+    """Regression test for #14690: when context_length == MINIMUM_CONTEXT_LENGTH,
+    the max() floor pushed threshold_tokens to 100% of the context window,
+    making auto-compression impossible (API errors before threshold is reached).
+    The fix clamps threshold_tokens to at most 95% of context_length."""
+
+    def test_init_threshold_below_context_length(self):
+        """__init__ must produce a threshold strictly below context_length."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=MINIMUM_CONTEXT_LENGTH,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        assert c.threshold_tokens < c.context_length
+        assert c.threshold_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.95)
+
+    def test_should_compress_at_threshold(self):
+        """should_compress returns True at the threshold and False just below."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=MINIMUM_CONTEXT_LENGTH,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        assert c.should_compress(c.threshold_tokens - 1) is False
+        assert c.should_compress(c.threshold_tokens) is True
+
+    def test_update_model_threshold_below_context_length(self):
+        """update_model() must also rebuild all derived budgets."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        c.update_model(
+            model="small/model",
+            context_length=MINIMUM_CONTEXT_LENGTH,
+        )
+        assert c.threshold_tokens < MINIMUM_CONTEXT_LENGTH
+        assert c.threshold_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.95)
+        assert c.tail_token_budget == int(c.threshold_tokens * c.summary_target_ratio)
+        assert c.max_summary_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.05)
+        assert c.should_compress(c.threshold_tokens - 1) is False
+        assert c.should_compress(c.threshold_tokens) is True
+
+    def test_large_context_unaffected_by_clamp(self):
+        """For large models the 95% cap does not change the threshold."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        # 50% of 200K = 100K, 95% of 200K = 190K => min(100K, 190K) = 100K
+        assert c.threshold_tokens == 100_000
+        assert c.tail_token_budget == int(100_000 * c.summary_target_ratio)
+        assert c.max_summary_tokens == 10_000

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -998,7 +998,7 @@ class TestThresholdClampAtMinimumContext:
         assert c.should_compress(c.threshold_tokens) is True
 
     def test_update_model_threshold_below_context_length(self):
-        """update_model() must also clamp the threshold."""
+        """update_model() must also rebuild all derived budgets."""
         with patch(
             "agent.context_compressor.get_model_context_length",
             return_value=200_000,
@@ -1010,6 +1010,8 @@ class TestThresholdClampAtMinimumContext:
         )
         assert c.threshold_tokens < MINIMUM_CONTEXT_LENGTH
         assert c.threshold_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.95)
+        assert c.tail_token_budget == int(c.threshold_tokens * c.summary_target_ratio)
+        assert c.max_summary_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.05)
         assert c.should_compress(c.threshold_tokens - 1) is False
         assert c.should_compress(c.threshold_tokens) is True
 
@@ -1022,3 +1024,5 @@ class TestThresholdClampAtMinimumContext:
             c = ContextCompressor(model="test", quiet_mode=True)
         # 50% of 200K = 100K, 95% of 200K = 190K => min(100K, 190K) = 100K
         assert c.threshold_tokens == 100_000
+        assert c.tail_token_budget == int(100_000 * c.summary_target_ratio)
+        assert c.max_summary_tokens == 10_000

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
 
 
 @pytest.fixture()
@@ -969,3 +970,55 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+class TestThresholdClampAtMinimumContext:
+    """Regression test for #14690: when context_length == MINIMUM_CONTEXT_LENGTH,
+    the max() floor pushed threshold_tokens to 100% of the context window,
+    making auto-compression impossible (API errors before threshold is reached).
+    The fix clamps threshold_tokens to at most 95% of context_length."""
+
+    def test_init_threshold_below_context_length(self):
+        """__init__ must produce a threshold strictly below context_length."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=MINIMUM_CONTEXT_LENGTH,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        assert c.threshold_tokens < c.context_length
+        assert c.threshold_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.95)
+
+    def test_should_compress_at_threshold(self):
+        """should_compress returns True at the threshold and False just below."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=MINIMUM_CONTEXT_LENGTH,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        assert c.should_compress(c.threshold_tokens - 1) is False
+        assert c.should_compress(c.threshold_tokens) is True
+
+    def test_update_model_threshold_below_context_length(self):
+        """update_model() must also clamp the threshold."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        c.update_model(
+            model="small/model",
+            context_length=MINIMUM_CONTEXT_LENGTH,
+        )
+        assert c.threshold_tokens < MINIMUM_CONTEXT_LENGTH
+        assert c.threshold_tokens == int(MINIMUM_CONTEXT_LENGTH * 0.95)
+        assert c.should_compress(c.threshold_tokens - 1) is False
+        assert c.should_compress(c.threshold_tokens) is True
+
+    def test_large_context_unaffected_by_clamp(self):
+        """For large models the 95% cap does not change the threshold."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        # 50% of 200K = 100K, 95% of 200K = 190K => min(100K, 190K) = 100K
+        assert c.threshold_tokens == 100_000


### PR DESCRIPTION
## What does this PR do?

When `context_length == MINIMUM_CONTEXT_LENGTH` (64000), the threshold calculation `max(int(context_length * 0.50), MINIMUM_CONTEXT_LENGTH)` produces `max(32000, 64000) = 64000`, setting the compression threshold to 100% of the context window. The API errors before tokens ever reach that value, so auto-compression never triggers for models at the minimum context length.

The fix clamps `threshold_tokens` to at most 95% of `context_length` after the existing floor, preserving the `MINIMUM_CONTEXT_LENGTH` floor for large-context models (where the clamp is a no-op) while ensuring compression can always trigger before the API limit.

## Related Issue

Fixes #14690

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: After the existing `max()` floor, clamp `threshold_tokens` to at most 95% of `context_length`. Applied in both `__init__` and `update_model()`. Additionally, `update_model()` now recomputes all derived budgets (`tail_token_budget`, `max_summary_tokens`) — previously it only updated `threshold_tokens`, leaving stale budget values after model switches.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/agent/test_context_compressor.py -v
   ```
2. 4 new tests in `TestThresholdClampAtMinimumContext`:
   - Threshold is below context_length at MINIMUM_CONTEXT_LENGTH
   - `should_compress()` triggers correctly at threshold boundary
   - `update_model()` produces a working threshold
   - Large-context models are unaffected by the clamp

Tested on macOS (Python 3.11).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest tests/agent/test_context_compressor.py -v
# 4 new tests in TestThresholdClampAtMinimumContext pass
```
