### PR TITLE
fix(agent): check credential pool exhaustion before restoring primary runtime (#15298)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1160,6 +1160,31 @@ def restore_primary_runtime(agent) -> bool:
     if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
         return False  # primary still in rate-limit cooldown, stay on fallback
 
+    # Also defer if the credential pool for the primary provider reports
+    # all credentials still exhausted — avoids burning retries while the
+    # provider's own cooldown hasn't elapsed. Custom providers use named
+    # pool keys (``custom:<name>``), so compare against the canonical pool
+    # key rather than the generic runtime provider ``custom``.
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is not None:
+        primary_provider = str((agent._primary_runtime or {}).get("provider", "")).strip().lower()
+        primary_pool_provider = primary_provider
+        if primary_provider == "custom":
+            try:
+                from agent.credential_pool import get_custom_provider_pool_key
+
+                primary_pool_provider = (
+                    get_custom_provider_pool_key(
+                        str((agent._primary_runtime or {}).get("base_url") or "")
+                    )
+                    or primary_pool_provider
+                ).strip().lower()
+            except Exception:
+                primary_pool_provider = primary_provider
+        pool_provider = str(getattr(pool, "provider", "") or "").strip().lower()
+        if primary_pool_provider and pool_provider == primary_pool_provider and not pool.has_available():
+            return False
+
     rt = agent._primary_runtime
     try:
         # ── Core runtime state ──

--- a/run_agent.py
+++ b/run_agent.py
@@ -6917,6 +6917,16 @@ class AIAgent:
         if getattr(self, "_rate_limited_until", 0) > time.monotonic():
             return False  # primary still in rate-limit cooldown, stay on fallback
 
+        # Also defer if the credential pool for the primary provider reports
+        # all credentials still exhausted — avoids burning retries while the
+        # provider's own cooldown hasn't elapsed.
+        if hasattr(self, '_credential_pool') and self._credential_pool is not None:
+            primary_provider = (self._primary_runtime or {}).get("provider", "")
+            if (primary_provider
+                    and self._credential_pool.provider == primary_provider
+                    and not self._credential_pool.has_available()):
+                return False
+
         rt = self._primary_runtime
         try:
             # ── Core runtime state ──

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -731,3 +731,122 @@ class TestRateLimitCooldown:
 
         # second call should not have extended the cooldown
         assert second_cooldown == first_cooldown
+
+
+# =============================================================================
+# Credential pool exhaustion gate (#15298)
+# =============================================================================
+
+class TestCredentialPoolExhaustionGate:
+    """_restore_primary_runtime() should defer when the credential pool
+    for the primary provider reports all credentials exhausted."""
+
+    def _activate_fallback(self, agent):
+        """Helper: activate fallback and clear the rate-limit timer."""
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                    return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+        assert agent._fallback_activated is True
+        agent._rate_limited_until = 0
+
+    def test_restore_blocked_when_pool_exhausted(self):
+        """If the pool exists, matches the primary provider, and has no
+        available credentials, restoration must be skipped."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+
+        pool = MagicMock()
+        pool.provider = "custom"
+        pool.has_available.return_value = False
+        agent._credential_pool = pool
+
+        result = agent._restore_primary_runtime()
+        assert result is False
+        assert agent._fallback_activated is True  # still on fallback
+
+    def test_restore_blocked_for_named_custom_pool_exhaustion(self):
+        """Custom providers compare against custom:<name>, not generic custom."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+            base_url="https://named-custom.example/v1",
+        )
+        self._activate_fallback(agent)
+
+        pool = MagicMock()
+        pool.provider = "custom:named-custom"
+        pool.has_available.return_value = False
+        agent._credential_pool = pool
+
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:named-custom",
+        ):
+            result = agent._restore_primary_runtime()
+
+        assert result is False
+        assert agent._fallback_activated is True  # still on fallback
+
+    def test_restore_proceeds_when_pool_has_available(self):
+        """Once the pool reports available credentials, restoration proceeds."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+
+        pool = MagicMock()
+        pool.provider = "custom"
+        pool.has_available.return_value = True
+        agent._credential_pool = pool
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
+
+    def test_restore_proceeds_when_pool_provider_differs(self):
+        """If the credential pool is for a different provider than the primary,
+        the exhaustion check should not block restoration."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+
+        # Pool for a different provider — should not block
+        pool = MagicMock()
+        pool.provider = "other-provider"
+        pool.has_available.return_value = False
+        agent._credential_pool = pool
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
+
+    def test_restore_proceeds_when_no_pool(self):
+        """Without a credential pool, restoration is unaffected."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+        agent._credential_pool = None
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -528,3 +528,98 @@ class TestRateLimitCooldown:
 
         # second call should not have extended the cooldown
         assert second_cooldown == first_cooldown
+
+
+# =============================================================================
+# Credential pool exhaustion gate (#15298)
+# =============================================================================
+
+class TestCredentialPoolExhaustionGate:
+    """_restore_primary_runtime() should defer when the credential pool
+    for the primary provider reports all credentials exhausted."""
+
+    def _activate_fallback(self, agent):
+        """Helper: activate fallback and clear the rate-limit timer."""
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                    return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+        assert agent._fallback_activated is True
+        agent._rate_limited_until = 0
+
+    def test_restore_blocked_when_pool_exhausted(self):
+        """If the pool exists, matches the primary provider, and has no
+        available credentials, restoration must be skipped."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+
+        pool = MagicMock()
+        pool.provider = "custom"
+        pool.has_available.return_value = False
+        agent._credential_pool = pool
+
+        result = agent._restore_primary_runtime()
+        assert result is False
+        assert agent._fallback_activated is True  # still on fallback
+
+    def test_restore_proceeds_when_pool_has_available(self):
+        """Once the pool reports available credentials, restoration proceeds."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+
+        pool = MagicMock()
+        pool.provider = "custom"
+        pool.has_available.return_value = True
+        agent._credential_pool = pool
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
+
+    def test_restore_proceeds_when_pool_provider_differs(self):
+        """If the credential pool is for a different provider than the primary,
+        the exhaustion check should not block restoration."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+
+        # Pool for a different provider — should not block
+        pool = MagicMock()
+        pool.provider = "other-provider"
+        pool.has_available.return_value = False
+        agent._credential_pool = pool
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
+
+    def test_restore_proceeds_when_no_pool(self):
+        """Without a credential pool, restoration is unaffected."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter",
+                            "model": "anthropic/claude-sonnet-4"},
+            provider="custom",
+        )
+        self._activate_fallback(agent)
+        agent._credential_pool = None
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False


### PR DESCRIPTION
## What does this PR do?

`_restore_primary_runtime()` checks a 60-second rate-limit timer (`_rate_limited_until`) but does not consult the credential pool's exhaustion state. After the 60-second timer expires, it attempts to restore the primary provider every turn even if the credential pool still marks that provider as exhausted. This burns retries and generates noise during extended outages.

## Related Issue

Fixes #15298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py` — after the `_rate_limited_until` check in `_restore_primary_runtime()`, added a guard that consults `self._credential_pool.has_available()`. If the pool exists for the primary provider and reports all credentials exhausted, restoration is skipped. This integrates with the existing `CredentialPool` architecture (which already tracks per-credential exhaustion with cooldowns) rather than adding another independent timer.
- `tests/run_agent/test_primary_runtime_restore.py` — 4 new tests in `TestCredentialPoolExhaustionGate`

## How to Test

1. `pytest tests/run_agent/test_primary_runtime_restore.py::TestCredentialPoolExhaustionGate -v` — 4 new tests cover:
   - Pool exhausted, same provider: restoration blocked
   - Pool has credentials: restoration proceeds
   - Pool for different provider: not blocked
   - No pool at all: not blocked
2. Tested on macOS (Python 3.11)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
