### PR TITLE
fix(cli): always write user config to ~/.hermes/config.yaml, never to repo cli-config.yaml (#14714)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1729,23 +1729,23 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
 
 def save_config_value(key_path: str, value: any) -> bool:
     """
-    Save a value to the active config file at the specified key path.
-    
-    Respects the same lookup order as load_cli_config():
-    1. ~/.hermes/config.yaml (user config - preferred, used if it exists)
-    2. ./cli-config.yaml (project config - fallback)
-    
+    Save a value to the user config file at the specified key path.
+
+    Always writes to ~/.hermes/config.yaml (creating it if needed).
+    The fallback to ./cli-config.yaml only applies to reads via
+    load_cli_config() — writes must never modify the repo config.
+
     Args:
         key_path: Dot-separated path like "agent.system_prompt"
         value: Value to save
-    
+
     Returns:
         True if successful, False otherwise
     """
-    # Use the same precedence as load_cli_config: user config first, then project config
+    # Always write to the user config — never to the repo's cli-config.yaml.
+    # The fallback to project config only applies to reads (load_cli_config).
     user_config_path = _hermes_home / 'config.yaml'
-    project_config_path = Path(__file__).parent / 'cli-config.yaml'
-    config_path = user_config_path if user_config_path.exists() else project_config_path
+    config_path = user_config_path
     
     try:
         # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -1,7 +1,9 @@
 """Tests for save_config_value() in cli.py — atomic write behavior."""
 
-import yaml
+from pathlib import Path
 from unittest.mock import MagicMock
+
+import yaml
 
 import pytest
 

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -96,3 +96,57 @@ class TestSaveConfigValueAtomic:
 
         assert result is False
         assert config_env.read_text() == original_content
+
+
+class TestSaveConfigValueWriteTarget:
+    """save_config_value() must always write to user config, never repo config."""
+
+    def test_writes_to_user_config_when_it_does_not_exist(self, tmp_path, monkeypatch):
+        """When ~/.hermes/config.yaml doesn't exist yet, create it there
+        instead of falling back to the repo's cli-config.yaml (#14714)."""
+        hermes_home = tmp_path / ".hermes"
+        # Do NOT create hermes_home or config.yaml — simulate first run
+        monkeypatch.setattr("cli._hermes_home", hermes_home)
+
+        from cli import save_config_value
+        result = save_config_value("model.default", "gpt-5")
+
+        assert result is True
+        user_config = hermes_home / "config.yaml"
+        assert user_config.exists(), "config.yaml must be created in ~/.hermes/"
+        saved = yaml.safe_load(user_config.read_text())
+        assert saved["model"]["default"] == "gpt-5"
+
+    def test_does_not_write_to_repo_config(self, tmp_path, monkeypatch):
+        """Repo cli-config.yaml must never be modified by save_config_value."""
+        hermes_home = tmp_path / ".hermes"
+        # No user config — triggers the old bug path
+        monkeypatch.setattr("cli._hermes_home", hermes_home)
+
+        repo_config = Path(__file__).resolve().parent.parent.parent / "cli-config.yaml"
+        if repo_config.exists():
+            original_content = repo_config.read_text()
+        else:
+            original_content = None
+
+        from cli import save_config_value
+        save_config_value("test_sentinel.value", "should-not-appear-in-repo")
+
+        if original_content is not None:
+            assert repo_config.read_text() == original_content, \
+                "repo cli-config.yaml was modified by save_config_value"
+        # If repo config didn't exist, it still shouldn't
+        # (but we only check if it was present to begin with)
+
+    def test_value_round_trips_through_fresh_user_config(self, tmp_path, monkeypatch):
+        """Value written to a new user config can be read back."""
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setattr("cli._hermes_home", hermes_home)
+
+        from cli import save_config_value
+        save_config_value("agent.system_prompt", "Be helpful")
+        save_config_value("display.skin", "moonsong")
+
+        config = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        assert config["agent"]["system_prompt"] == "Be helpful"
+        assert config["display"]["skin"] == "moonsong"


### PR DESCRIPTION
## What does this PR do?

`save_config_value()` uses `user_config_path if user_config_path.exists() else project_config_path` to choose where to write. On first run, when `~/.hermes/config.yaml` does not exist yet, this falls back to writing into the repo's `cli-config.yaml`. The comment at line 1751 says "Ensure parent directory exists (for ~/.hermes/config.yaml on first use)" but the `mkdir` runs after `config_path` is already chosen as the project fallback.

This PR makes `save_config_value()` always target `user_config_path` for writes. The fallback to project config should only apply to reads (which `load_cli_config()` already handles).

## Related Issue

Fixes #14714

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: Changed `save_config_value()` to always target `user_config_path` for writes. The existing `mkdir(parents=True, exist_ok=True)` handles creating `~/.hermes/` if needed, and the existing "Load existing config" block handles the case where the file does not yet exist.

## How to Test

Tests: `tests/cli/test_cli_save_config_value.py` — 3 new tests in `TestSaveConfigValueWriteTarget`:

1. Config is created in `~/.hermes/` when it does not exist
2. Repo `cli-config.yaml` is never modified
3. Values round-trip through a freshly created user config

Tested on macOS (Python 3.11).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/cli/test_cli_save_config_value.py::TestSaveConfigValueWriteTarget -q
3 passed
```
