### PR TITLE
fix(gateway): count only substantive messages for hard message cap, not tool plumbing rows (#15195)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8336,7 +8336,16 @@ class GatewayRunner:
                 )
                 _warn_token_threshold = int(_hyg_context_length * 0.95)
 
-                _msg_count = len(history)
+                # Count only substantive messages (user turns + assistant responses
+                # with content).  Tool-call/tool-result rows are internal plumbing
+                # -- a single user exchange with 10 tool calls produces 21 raw rows
+                # but represents only 1 turn.  (#15195)
+                _msg_count = sum(
+                    1 for m in history
+                    if m.get("role") in ("user", "assistant")
+                    and (m.get("content") or m.get("role") == "user")
+                )
+                _raw_row_count = len(history)
 
                 # Prefer actual API-reported tokens from the last turn
                 # (stored in session entry) over the rough char-based estimate.
@@ -8372,9 +8381,11 @@ class GatewayRunner:
 
                 if _needs_compress:
                     logger.info(
-                        "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
+                        "Session hygiene: %s substantive messages (%s raw rows), "
+                        "~%s tokens (%s) — auto-compressing "
                         "(threshold: %s%% of %s = %s tokens)",
-                        _msg_count, f"{_approx_tokens:,}", _token_source,
+                        _msg_count, _raw_row_count,
+                        f"{_approx_tokens:,}", _token_source,
                         int(_hyg_threshold_pct * 100),
                         f"{_hyg_context_length:,}",
                         f"{_compress_token_threshold:,}",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4369,7 +4369,16 @@ class GatewayRunner:
                 )
                 _warn_token_threshold = int(_hyg_context_length * 0.95)
 
-                _msg_count = len(history)
+                # Count only substantive messages (user turns + assistant responses
+                # with content).  Tool-call/tool-result rows are internal plumbing
+                # -- a single user exchange with 10 tool calls produces 21 raw rows
+                # but represents only 1 turn.  (#15195)
+                _msg_count = sum(
+                    1 for m in history
+                    if m.get("role") in ("user", "assistant")
+                    and (m.get("content") or m.get("role") == "user")
+                )
+                _raw_row_count = len(history)
 
                 # Prefer actual API-reported tokens from the last turn
                 # (stored in session entry) over the rough char-based estimate.
@@ -4403,9 +4412,11 @@ class GatewayRunner:
 
                 if _needs_compress:
                     logger.info(
-                        "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
+                        "Session hygiene: %s substantive messages (%s raw rows), "
+                        "~%s tokens (%s) — auto-compressing "
                         "(threshold: %s%% of %s = %s tokens)",
-                        _msg_count, f"{_approx_tokens:,}", _token_source,
+                        _msg_count, _raw_row_count,
+                        f"{_approx_tokens:,}", _token_source,
                         int(_hyg_threshold_pct * 100),
                         f"{_hyg_context_length:,}",
                         f"{_compress_token_threshold:,}",

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -298,6 +298,118 @@ class TestTokenEstimation:
         assert tokens > threshold
 
 
+def _make_tool_heavy_history(
+    n_user: int, n_assistant: int, n_tool: int, content_size: int = 10
+) -> list:
+    """Build a history mixing user/assistant/tool messages.
+
+    Tool messages include both ``tool`` role entries (tool results) and
+    assistant messages that carry only ``tool_calls`` (no ``content``).
+    """
+    content = "x" * content_size
+    history = []
+    for i in range(n_user):
+        history.append({"role": "user", "content": content, "timestamp": f"u{i}"})
+    for i in range(n_assistant):
+        history.append({"role": "assistant", "content": content, "timestamp": f"a{i}"})
+    # Half tool-result rows, half tool-call-only assistant rows
+    for i in range(n_tool // 2):
+        history.append({"role": "tool", "content": content, "timestamp": f"t{i}"})
+    for i in range(n_tool - n_tool // 2):
+        # Assistant message with tool_calls but no content -- internal plumbing
+        history.append({
+            "role": "assistant",
+            "tool_calls": [{"id": f"tc{i}", "function": {"name": "f", "arguments": "{}"}}],
+            "timestamp": f"tc{i}",
+        })
+    return history
+
+
+class TestHardMessageCapExcludesToolRows:
+    """The hard message cap should count only substantive messages (user +
+    assistant-with-content), not tool plumbing rows.  (#15195)
+
+    A session with 20 real exchanges that use tools heavily can produce 400+
+    raw rows, but the hard cap was designed for actual conversation growth.
+    """
+
+    _HARD_MSG_LIMIT = 400
+
+    def test_tool_heavy_session_does_not_trigger_cap(self):
+        """30 user + 30 assistant + 340 tool rows = 400 raw rows.
+        Only 60 are substantive -- well under the 400 hard cap."""
+        history = _make_tool_heavy_history(
+            n_user=30, n_assistant=30, n_tool=340, content_size=10,
+        )
+        assert len(history) == 400, "Precondition: 400 total raw rows"
+
+        _msg_count = sum(
+            1 for m in history
+            if m.get("role") in ("user", "assistant")
+            and (m.get("content") or m.get("role") == "user")
+        )
+        assert _msg_count == 60, f"Expected 60 substantive messages, got {_msg_count}"
+        assert _msg_count < self._HARD_MSG_LIMIT, (
+            "Tool-heavy session with 60 real messages must NOT trigger the 400-message cap"
+        )
+
+    def test_substantive_heavy_session_triggers_cap(self):
+        """200 user + 200 assistant messages (no tools) = 400 substantive.
+        This SHOULD trigger the hard cap."""
+        history = _make_tool_heavy_history(
+            n_user=200, n_assistant=200, n_tool=0, content_size=10,
+        )
+        assert len(history) == 400, "Precondition: 400 total rows"
+
+        _msg_count = sum(
+            1 for m in history
+            if m.get("role") in ("user", "assistant")
+            and (m.get("content") or m.get("role") == "user")
+        )
+        assert _msg_count == 400
+        assert _msg_count >= self._HARD_MSG_LIMIT, (
+            "400 substantive messages SHOULD trigger the hard cap"
+        )
+
+    def test_tool_call_only_assistant_not_counted(self):
+        """An assistant message with tool_calls but no content is plumbing."""
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "tool_calls": [{"id": "1", "function": {"name": "f", "arguments": "{}"}}]},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": "Here is the answer"},
+        ]
+        _msg_count = sum(
+            1 for m in history
+            if m.get("role") in ("user", "assistant")
+            and (m.get("content") or m.get("role") == "user")
+        )
+        # user + assistant-with-content = 2, not 4
+        assert _msg_count == 2
+
+    def test_user_without_content_still_counted(self):
+        """A user message with empty string content is still a real turn."""
+        history = [
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": "I can help with that"},
+        ]
+        _msg_count = sum(
+            1 for m in history
+            if m.get("role") in ("user", "assistant")
+            and (m.get("content") or m.get("role") == "user")
+        )
+        # User messages always count (even empty content), assistant with content counts
+        assert _msg_count == 2
+
+    def test_raw_row_count_preserved(self):
+        """The raw row count should still track total history length for logging."""
+        history = _make_tool_heavy_history(
+            n_user=10, n_assistant=10, n_tool=80, content_size=10,
+        )
+        _raw_row_count = len(history)
+        assert _raw_row_count == 100
+
+
 @pytest.mark.asyncio
 async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, tmp_path):
     fake_dotenv = types.ModuleType("dotenv")


### PR DESCRIPTION
## What does this PR do?

The gateway hygiene hard message cap uses `len(history)` to count messages, which includes tool-call wrappers and tool-result rows. A single user exchange with 10 tool calls produces 21+ raw rows. With `_HARD_MSG_LIMIT = 400`, a session with just 20 real user exchanges that use tools heavily can produce 400+ raw rows, triggering premature compaction and losing conversation context.

This PR changes the cap to count only substantive messages (user turns + assistant messages with actual content), while still logging the raw row count for debugging.

## Related Issue

Fixes #15195

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — replaced `_msg_count = len(history)` with a filtered count that only includes user messages and assistant messages with actual content. Tool-call-only assistant messages (no `content`) and `tool` role messages are excluded. Added `_raw_row_count` for logging. Updated the log message to show both substantive message count and raw row count for debugging clarity.
- `tests/gateway/test_session_hygiene.py` — 5 new tests in `TestHardMessageCapExcludesToolRows`

## How to Test

1. `pytest tests/gateway/test_session_hygiene.py::TestHardMessageCapExcludesToolRows -v` — 5 new tests:
   - Tool-heavy session (30 user + 30 assistant + 340 tool = 400 raw) does NOT trigger cap
   - Substantive-heavy session (200 user + 200 assistant = 400 substantive) DOES trigger
   - Tool-call-only assistant messages are not counted
   - Empty-content user messages still count
   - Raw row count preserved for logging
2. Tested on macOS (Python 3.11)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
