### PR TITLE
fix(agent): skip non-vision models in vision auto-detection fallback (#14744)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -70,6 +70,33 @@ if TYPE_CHECKING:
 _OPENAI_CLS_CACHE: Optional[type] = None
 
 
+def _is_vision_capability_error(exc: Exception) -> bool:
+    """Return True for provider errors that mean the model cannot accept images."""
+    status = getattr(exc, "status_code", None)
+    if status not in (None, 400, 415, 422):
+        return False
+    err_lower = str(exc).lower()
+    return any(
+        phrase in err_lower
+        for phrase in (
+            "does not support image",
+            "doesn't support image",
+            "images are not supported",
+            "image input is not supported",
+            "image input",
+            "image_in capability",
+            "unknown variant `image_url`",
+            "expected `text`",
+            "vision is not supported",
+            "vision not supported",
+            "multimodal input is not supported",
+            "multimodal is not supported",
+            "model is not multimodal",
+            "text-only model",
+        )
+    )
+
+
 def _load_openai_cls() -> type:
     """Import and cache ``openai.OpenAI``."""
     global _OPENAI_CLS_CACHE
@@ -515,6 +542,41 @@ _OR_HEADERS_BASE = {
 
 # Truthy values for boolean env-var parsing.
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _try_vision_fallback(
+    failed_provider: str,
+    *,
+    async_mode: bool = False,
+    reason: str = "vision capability error",
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Try the next strict vision backend after a main-provider vision failure."""
+    skip = _normalize_vision_provider(failed_provider)
+    tried = []
+    for label in _VISION_AUTO_PROVIDER_ORDER:
+        if label == skip:
+            continue
+        client, model = _resolve_strict_vision_backend(label)
+        if client is not None:
+            if async_mode:
+                client, model = _to_async_client(client, model or "", is_vision=True)
+            logger.info(
+                "Auxiliary vision: %s on %s — falling back to %s (%s)",
+                reason,
+                failed_provider,
+                label,
+                model or "default",
+            )
+            return client, model, label
+        tried.append(label)
+
+    logger.warning(
+        "Auxiliary vision: %s on %s and no fallback available (tried: %s)",
+        reason,
+        failed_provider,
+        ", ".join(tried),
+    )
+    return None, None, ""
 
 
 def _apply_user_default_headers(headers: dict | None) -> dict | None:
@@ -5181,6 +5243,81 @@ _VISION_AUTO_PROVIDER_ORDER = (
 )
 
 
+def _is_likely_vision_model(model: Optional[str]) -> bool:
+    """Heuristic fallback for model slugs that are visibly multimodal."""
+    slug = str(model or "").lower()
+    if not slug:
+        return False
+    vision_markers = (
+        "vision",
+        "multimodal",
+        "omni",
+        "llava",
+        "qwen-vl",
+        "qwen2-vl",
+        "qwen2.5-vl",
+        "glm-4v",
+        "glm-5v",
+        "pixtral",
+        "internvl",
+        "cogvlm",
+        "idefics",
+        "deepseek-vl",
+    )
+    exact_or_prefix_markers = (
+        "gpt-4o",
+        "claude-sonnet-4",
+        "gemini-3",
+        "mimo-v2",
+    )
+    return any(marker in slug for marker in vision_markers) or any(
+        marker in slug for marker in exact_or_prefix_markers
+    )
+
+
+def _get_named_custom_provider_entry(provider: str) -> Optional[dict]:
+    """Return config for a named custom provider, when present."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return None
+    candidates = []
+    if isinstance(cfg, dict):
+        for key in ("custom_providers", "providers"):
+            value = cfg.get(key)
+            if isinstance(value, dict):
+                candidates.extend(value.values())
+            elif isinstance(value, list):
+                candidates.extend(value)
+        auxiliary = cfg.get("auxiliary")
+        if isinstance(auxiliary, dict):
+            value = auxiliary.get("providers")
+            if isinstance(value, dict):
+                candidates.extend(value.values())
+            elif isinstance(value, list):
+                candidates.extend(value)
+    wanted = str(provider or "").strip().lower()
+    for entry in candidates:
+        if isinstance(entry, dict) and str(entry.get("name") or "").strip().lower() == wanted:
+            return entry
+    return None
+
+
+def _custom_vision_model_override(entry: Optional[dict], model: Optional[str]) -> Optional[str]:
+    if not isinstance(entry, dict):
+        return None
+    models = entry.get("models")
+    if isinstance(models, dict):
+        model_cfg = models.get(model) or models.get(str(model or ""))
+        if isinstance(model_cfg, dict):
+            override = model_cfg.get("vision_model") or model_cfg.get("vision")
+            if override:
+                return str(override)
+    override = entry.get("vision_model")
+    return str(override) if override else None
+
+
 def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     """Return True when ``provider``/``model`` is known to accept image input.
 
@@ -5195,6 +5332,11 @@ def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     behaviour of attempting the call, so providers we haven't catalogued yet
     don't silently regress to text-only.
     """
+    if provider == "copilot":
+        # GitHub Copilot exposes vision through the same configured model plus
+        # a request header. Its slugs may be opaque in config/tests, so the
+        # generic text-only slug heuristic must not skip it.
+        return True
     try:
         from agent.image_routing import _lookup_supports_vision
         from hermes_cli.config import load_config
@@ -5205,10 +5347,16 @@ def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     except Exception:  # pragma: no cover - defensive
         return True
     if supports is None:
-        # No capability data — keep current behaviour and let the call attempt
-        # happen rather than silently skipping. This avoids false-positive
-        # skips for new/custom providers.
-        return True
+        if _get_named_custom_provider_entry(provider) is not None:
+            # Named custom providers may expose private/experimental VLMs whose
+            # slugs are not in our static capability tables. Trust explicit
+            # provider configuration rather than silently rerouting.
+            return True
+        # Unknown capability for built-in providers: use a conservative slug
+        # heuristic so plainly text-only models (llama3, qwen3, deepseek-coder)
+        # fall through to strict vision aggregators instead of receiving image
+        # blocks they cannot parse.
+        return _is_likely_vision_model(model)
     return bool(supports)
 
 
@@ -5329,6 +5477,8 @@ def resolve_vision_provider_client(
         main_model = _read_main_model()
         if main_provider and main_provider not in {"auto", ""}:
             vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
+            custom_entry = _get_named_custom_provider_entry(main_provider)
+            vision_model = _custom_vision_model_override(custom_entry, vision_model) or vision_model
             if main_provider == "nous":
                 sync_client, default_model = _resolve_strict_vision_backend(
                     main_provider, vision_model
@@ -6640,6 +6790,26 @@ def call_llm(
                 kwargs = retry_kwargs
 
         err_str = str(first_err)
+        if task == "vision" and _is_vision_capability_error(first_err):
+            fb_client, fb_model, fb_label = _try_vision_fallback(
+                resolved_provider or "auto",
+                reason="vision capability error",
+            )
+            if fb_client is not None:
+                fb_kwargs = _build_call_kwargs(
+                    fb_label,
+                    fb_model,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=effective_timeout,
+                    extra_body=effective_extra_body,
+                    base_url=str(getattr(fb_client, "base_url", "") or ""),
+                )
+                return _validate_llm_response(
+                    fb_client.chat.completions.create(**fb_kwargs), task)
+
         # ZAI vision models (glm-4v-flash etc.) return error code 1210
         # ("API 调用参数有误") when max_tokens is passed on multimodal
         # calls.  The error message does NOT contain "max_tokens" so the
@@ -7191,6 +7361,27 @@ async def async_call_llm(
                 kwargs = retry_kwargs
 
         err_str = str(first_err)
+        if task == "vision" and _is_vision_capability_error(first_err):
+            fb_client, fb_model, fb_label = _try_vision_fallback(
+                resolved_provider or "auto",
+                async_mode=True,
+                reason="vision capability error",
+            )
+            if fb_client is not None:
+                fb_kwargs = _build_call_kwargs(
+                    fb_label,
+                    fb_model,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=effective_timeout,
+                    extra_body=effective_extra_body,
+                    base_url=str(getattr(fb_client, "base_url", "") or ""),
+                )
+                return _validate_llm_response(
+                    await fb_client.chat.completions.create(**fb_kwargs), task)
+
         # ZAI vision models (glm-4v-flash etc.) return error code 1210
         # ("API 调用参数有误") when max_tokens is passed on multimodal
         # calls.  The error message does NOT contain "max_tokens" so the

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -183,6 +183,37 @@ def _is_likely_vision_model(model: str) -> bool:
     lower = model.lower()
     return any(indicator in lower for indicator in _VISION_MODEL_INDICATORS)
 
+
+def _get_named_custom_provider_entry(provider: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return the named custom-provider entry for *provider*, if any."""
+    if not provider or provider == "custom":
+        return None
+    try:
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+        entry = _get_named_custom_provider(provider)
+    except Exception:
+        return None
+    return entry if isinstance(entry, dict) else None
+
+
+def _configured_vision_model(provider: Optional[str], model: Optional[str]) -> Optional[str]:
+    """Read per-model vision routing hints from named custom-provider config."""
+    entry = _get_named_custom_provider_entry(provider)
+    if not entry or not model:
+        return None
+    models_cfg = entry.get("models")
+    if not isinstance(models_cfg, dict):
+        return None
+    model_cfg = models_cfg.get(model)
+    if not isinstance(model_cfg, dict):
+        return None
+    explicit = model_cfg.get("vision_model") or model_cfg.get("multimodal_model")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    if model_cfg.get("supports_vision") is True or model_cfg.get("multimodal") is True:
+        return model
+    return None
+
 # OpenRouter app attribution headers
 _OR_HEADERS = {
     "HTTP-Referer": "https://hermes-agent.nousresearch.com",
@@ -1361,6 +1392,25 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _is_vision_capability_error(exc: Exception) -> bool:
+    """Detect errors from sending image input to a text-only model."""
+    status = getattr(exc, "status_code", None)
+    if status not in (None, 400, 415, 422):
+        return False
+    err_lower = str(exc).lower()
+    return any(phrase in err_lower for phrase in (
+        "does not support image",
+        "doesn't support image",
+        "images are not supported",
+        "image input is not supported",
+        "vision is not supported",
+        "vision not supported",
+        "multimodal input is not supported",
+        "model is not multimodal",
+        "text-only model",
+    ))
+
+
 def _is_auth_error(exc: Exception) -> bool:
     """Detect auth failures that should trigger provider-specific refresh."""
     status = getattr(exc, "status_code", None)
@@ -1475,6 +1525,41 @@ def _try_payment_fallback(
     logger.warning(
         "Auxiliary %s: %s on %s and no fallback available (tried: %s)",
         task or "call", reason, failed_provider, ", ".join(tried),
+    )
+    return None, None, ""
+
+
+def _try_vision_fallback(
+    failed_provider: str,
+    *,
+    async_mode: bool = False,
+    reason: str = "vision capability error",
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Try the next strict vision backend after a main-provider vision failure."""
+    skip = _normalize_vision_provider(failed_provider)
+    tried = []
+    for label in _VISION_AUTO_PROVIDER_ORDER:
+        if label == skip:
+            continue
+        client, model = _resolve_strict_vision_backend(label)
+        if client is not None:
+            if async_mode:
+                client, model = _to_async_client(client, model)
+            logger.info(
+                "Auxiliary vision: %s on %s — falling back to %s (%s)",
+                reason,
+                failed_provider,
+                label,
+                model or "default",
+            )
+            return client, model, label
+        tried.append(label)
+
+    logger.warning(
+        "Auxiliary vision: %s on %s and no fallback available (tried: %s)",
+        reason,
+        failed_provider,
+        ", ".join(tried),
     )
     return None, None, ""
 
@@ -2229,12 +2314,25 @@ def resolve_vision_provider_client(
                     )
                     return _finalize(main_provider, sync_client, default_model)
             else:
-                vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
+                vision_model = (
+                    _configured_vision_model(main_provider, main_model)
+                    or _PROVIDER_VISION_MODELS.get(main_provider)
+                    or main_model
+                )
                 # When no explicit vision override exists (fell through to
                 # main_model), check if the main model looks vision-capable.
+                # Trust direct/named custom providers: users may intentionally
+                # point Hermes at a self-hosted multimodal model whose name is
+                # unknown to our heuristic.
+                trusted_main_model = (
+                    main_provider == "custom"
+                    or _get_named_custom_provider_entry(main_provider) is not None
+                )
                 # If not, skip directly to aggregator fallbacks instead of
-                # sending an image payload to a text-only model (#14744).
-                if vision_model == main_model and not _is_likely_vision_model(main_model):
+                # sending an image payload to a clearly text-only model.
+                if (vision_model == main_model
+                        and not trusted_main_model
+                        and not _is_likely_vision_model(main_model)):
                     logger.info(
                         "Vision auto-detect: skipping main provider %s "
                         "(model %r is not vision-capable)",
@@ -2900,6 +2998,7 @@ def call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    allow_auto_fallback = resolved_provider in ("auto", "", None)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -3081,17 +3180,29 @@ def call_llm(
         # Codex/OAuth tokens that authenticate but whose endpoint is down,
         # and providers the user never configured that got picked up by
         # the auto-detection chain.
-        should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
+        vision_capability_error = task == "vision" and _is_vision_capability_error(first_err)
+        should_fallback = (
+            _is_payment_error(first_err)
+            or _is_connection_error(first_err)
+            or vision_capability_error
+        )
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
-        is_auto = resolved_provider in ("auto", "", None)
-        if should_fallback and is_auto:
-            reason = "payment error" if _is_payment_error(first_err) else "connection error"
+        if should_fallback and allow_auto_fallback:
+            if vision_capability_error:
+                reason = "vision capability error"
+                fb_client, fb_model, fb_label = _try_vision_fallback(
+                    resolved_provider,
+                    async_mode=False,
+                    reason=reason,
+                )
+            else:
+                reason = "payment error" if _is_payment_error(first_err) else "connection error"
+                fb_client, fb_model, fb_label = _try_payment_fallback(
+                    resolved_provider, task, reason=reason)
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
@@ -3180,6 +3291,7 @@ async def async_call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    allow_auto_fallback = resolved_provider in ("auto", "", None)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -3332,14 +3444,26 @@ async def async_call_llm(
                         await retry_client.chat.completions.create(**retry_kwargs), task)
 
         # ── Payment / connection fallback (mirrors sync call_llm) ─────
-        should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
-        is_auto = resolved_provider in ("auto", "", None)
-        if should_fallback and is_auto:
-            reason = "payment error" if _is_payment_error(first_err) else "connection error"
+        vision_capability_error = task == "vision" and _is_vision_capability_error(first_err)
+        should_fallback = (
+            _is_payment_error(first_err)
+            or _is_connection_error(first_err)
+            or vision_capability_error
+        )
+        if should_fallback and allow_auto_fallback:
+            if vision_capability_error:
+                reason = "vision capability error"
+                fb_client, fb_model, fb_label = _try_vision_fallback(
+                    resolved_provider,
+                    async_mode=False,
+                    reason=reason,
+                )
+            else:
+                reason = "payment error" if _is_payment_error(first_err) else "connection error"
+                fb_client, fb_model, fb_label = _try_payment_fallback(
+                    resolved_provider, task, reason=reason)
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -162,6 +162,27 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "zai": "glm-5v-turbo",
 }
 
+# Known substrings that indicate a model is vision/multimodal-capable.
+_VISION_MODEL_INDICATORS = (
+    "vision", "vl", "omni", "multimodal", "4o", "gpt-4o",
+    "gemini", "claude", "mimo", "pixtral", "llava", "cogvlm",
+    "fuyu", "idefics", "internvl", "qwen-vl", "qwen2-vl",
+    "glm-5v", "glm-4v",
+)
+
+
+def _is_likely_vision_model(model: str) -> bool:
+    """Heuristic check whether a model name looks vision-capable.
+
+    Returns True if the model name contains a known vision/multimodal
+    indicator substring.  Used by the vision auto-detection fallback to
+    avoid sending image payloads to models that cannot process them.
+    """
+    if not model:
+        return False
+    lower = model.lower()
+    return any(indicator in lower for indicator in _VISION_MODEL_INDICATORS)
+
 # OpenRouter app attribution headers
 _OR_HEADERS = {
     "HTTP-Referer": "https://hermes-agent.nousresearch.com",
@@ -2209,16 +2230,27 @@ def resolve_vision_provider_client(
                     return _finalize(main_provider, sync_client, default_model)
             else:
                 vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
-                rpc_client, rpc_model = resolve_provider_client(
-                    main_provider, vision_model,
-                    api_mode=resolved_api_mode)
-                if rpc_client is not None:
+                # When no explicit vision override exists (fell through to
+                # main_model), check if the main model looks vision-capable.
+                # If not, skip directly to aggregator fallbacks instead of
+                # sending an image payload to a text-only model (#14744).
+                if vision_model == main_model and not _is_likely_vision_model(main_model):
                     logger.info(
-                        "Vision auto-detect: using main provider %s (%s)",
-                        main_provider, rpc_model or vision_model,
+                        "Vision auto-detect: skipping main provider %s "
+                        "(model %r is not vision-capable)",
+                        main_provider, main_model,
                     )
-                    return _finalize(
-                        main_provider, rpc_client, rpc_model or vision_model)
+                else:
+                    rpc_client, rpc_model = resolve_provider_client(
+                        main_provider, vision_model,
+                        api_mode=resolved_api_mode)
+                    if rpc_client is not None:
+                        logger.info(
+                            "Vision auto-detect: using main provider %s (%s)",
+                            main_provider, rpc_model or vision_model,
+                        )
+                        return _finalize(
+                            main_provider, rpc_client, rpc_model or vision_model)
 
         # Fall back through aggregators (uses their dedicated vision model,
         # not the user's main model) when main provider has no client.

--- a/tests/agent/test_vision_non_vision_fallthrough.py
+++ b/tests/agent/test_vision_non_vision_fallthrough.py
@@ -1,0 +1,280 @@
+"""Verify vision auto-detection skips non-vision models to aggregator fallback.
+
+Regression test for #14744 -- when the user's main provider (e.g. ollama-cloud)
+is not in _PROVIDER_VISION_MODELS and the main model is not vision-capable,
+the auto-detection should skip directly to aggregator fallbacks instead of
+sending an image payload to a text-only model.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import _is_likely_vision_model, call_llm
+
+
+# -- _is_likely_vision_model heuristic --
+
+
+class TestIsLikelyVisionModel:
+    """Tests for the vision model name heuristic."""
+
+    @pytest.mark.parametrize("model", [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "claude-sonnet-4.6",
+        "gemini-3-flash-preview",
+        "mimo-v2-omni",
+        "mimo-v2.5",
+        "llava-v1.6",
+        "qwen-vl-plus",
+        "qwen2-vl-7b",
+        "glm-5v-turbo",
+        "glm-4v",
+        "pixtral-12b",
+        "internvl2-8b",
+        "cogvlm-17b",
+        "idefics2-8b",
+        "some-vision-model",
+        "my-multimodal-v3",
+        "deepseek-vl-7b",
+    ])
+    def test_vision_models_detected(self, model):
+        assert _is_likely_vision_model(model) is True
+
+    @pytest.mark.parametrize("model", [
+        "llama3",
+        "llama3:70b",
+        "mistral-7b",
+        "qwen3:14b",
+        "deepseek-coder-v2",
+        "codestral-latest",
+        "nemotron-3-nano:30b",
+        "phi-3-mini",
+        "mixtral-8x7b",
+        "",
+    ])
+    def test_non_vision_models_rejected(self, model):
+        assert _is_likely_vision_model(model) is False
+
+    def test_none_returns_false(self):
+        assert _is_likely_vision_model("") is False
+
+
+# -- Vision auto-detection with non-vision main model --
+
+
+class TestVisionNonVisionFallthrough:
+    """Vision auto-detect must skip non-vision main models (#14744)."""
+
+    def test_ollama_cloud_non_vision_skips_to_aggregator(self):
+        """ollama-cloud with llama3 must skip to aggregator, not try llama3."""
+        mock_aggregator_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="ollama-cloud",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="llama3",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(mock_aggregator_client, "google/gemini-3-flash-preview"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        # Should have fallen through to the aggregator
+        assert client is mock_aggregator_client
+        assert model == "google/gemini-3-flash-preview"
+        # resolve_provider_client must NOT have been called with ollama-cloud
+        for call in mock_resolve.call_args_list:
+            assert call.args[0] != "ollama-cloud" or call.args[1] != "llama3", (
+                "Should not have tried llama3 on ollama-cloud for vision"
+            )
+
+    def test_ollama_with_llava_uses_main_provider(self):
+        """ollama with llava (vision model) must use main provider directly."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="ollama",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="llava-v1.6",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "llava-v1.6"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "ollama"
+        assert client is mock_client
+        assert model == "llava-v1.6"
+
+    def test_provider_with_vision_override_still_works(self):
+        """xiaomi with explicit vision override must still use the override."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="xiaomi",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="mimo-v2-pro",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "mimo-v2.5"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "xiaomi"
+        assert client is mock_client
+        assert model == "mimo-v2.5"
+
+    def test_named_custom_provider_unknown_model_is_trusted(self):
+        """Named custom providers should not be skipped by the name heuristic."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="beans",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="my-company-vlm",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_named_custom_provider_entry",
+            return_value={"name": "beans", "base_url": "http://vlm.test/v1"},
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "my-company-vlm"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "beans"
+        assert client is mock_client
+        assert model == "my-company-vlm"
+
+    def test_named_custom_provider_can_declare_vision_model_override(self):
+        """Named custom providers can route vision to a dedicated model."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="beans",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="chat-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_named_custom_provider_entry",
+            return_value={
+                "name": "beans",
+                "base_url": "http://vlm.test/v1",
+                "models": {"chat-model": {"vision_model": "vision-model"}},
+            },
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "vision-model"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "beans"
+        assert client is mock_client
+        assert model == "vision-model"
+        assert mock_resolve.call_args.args[:2] == ("beans", "vision-model")
+
+    def test_non_vision_model_all_aggregators_fail(self):
+        """Non-vision main + no aggregators available must return None."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="ollama-cloud",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="qwen3:14b",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(None, None),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert client is None
+        assert model is None
+
+
+class VisionUnsupportedError(Exception):
+    def __init__(self, message, status_code=400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TestVisionCapabilityFallback:
+    def test_call_llm_retries_auto_vision_on_capability_error(self):
+        """A text-only main provider should fall through to strict vision backends."""
+        primary_client = MagicMock()
+        fallback_client = MagicMock()
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+        primary_client.chat.completions.create.side_effect = VisionUnsupportedError(
+            "This model does not support image input"
+        )
+        fallback_client.chat.completions.create.return_value = response
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("ollama-cloud", primary_client, "llama3"),
+        ), patch(
+            "agent.auxiliary_client._build_call_kwargs",
+            return_value={
+                "model": "llama3",
+                "messages": [{"role": "user", "content": "analyze"}],
+            },
+        ), patch(
+            "agent.auxiliary_client._try_vision_fallback",
+            return_value=(fallback_client, "google/gemini-3-flash-preview", "openrouter"),
+        ):
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "analyze"}],
+            )
+
+        assert result is response
+        assert primary_client.chat.completions.create.call_count == 1
+        assert fallback_client.chat.completions.create.call_count == 1

--- a/tests/agent/test_vision_non_vision_fallthrough.py
+++ b/tests/agent/test_vision_non_vision_fallthrough.py
@@ -1,0 +1,172 @@
+"""Verify vision auto-detection skips non-vision models to aggregator fallback.
+
+Regression test for #14744 -- when the user's main provider (e.g. ollama-cloud)
+is not in _PROVIDER_VISION_MODELS and the main model is not vision-capable,
+the auto-detection should skip directly to aggregator fallbacks instead of
+sending an image payload to a text-only model.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import _is_likely_vision_model
+
+
+# -- _is_likely_vision_model heuristic --
+
+
+class TestIsLikelyVisionModel:
+    """Tests for the vision model name heuristic."""
+
+    @pytest.mark.parametrize("model", [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "claude-sonnet-4.6",
+        "gemini-3-flash-preview",
+        "mimo-v2-omni",
+        "mimo-v2.5",
+        "llava-v1.6",
+        "qwen-vl-plus",
+        "qwen2-vl-7b",
+        "glm-5v-turbo",
+        "glm-4v",
+        "pixtral-12b",
+        "internvl2-8b",
+        "cogvlm-17b",
+        "idefics2-8b",
+        "some-vision-model",
+        "my-multimodal-v3",
+        "deepseek-vl-7b",
+    ])
+    def test_vision_models_detected(self, model):
+        assert _is_likely_vision_model(model) is True
+
+    @pytest.mark.parametrize("model", [
+        "llama3",
+        "llama3:70b",
+        "mistral-7b",
+        "qwen3:14b",
+        "deepseek-coder-v2",
+        "codestral-latest",
+        "nemotron-3-nano:30b",
+        "phi-3-mini",
+        "mixtral-8x7b",
+        "",
+    ])
+    def test_non_vision_models_rejected(self, model):
+        assert _is_likely_vision_model(model) is False
+
+    def test_none_returns_false(self):
+        assert _is_likely_vision_model("") is False
+
+
+# -- Vision auto-detection with non-vision main model --
+
+
+class TestVisionNonVisionFallthrough:
+    """Vision auto-detect must skip non-vision main models (#14744)."""
+
+    def test_ollama_cloud_non_vision_skips_to_aggregator(self):
+        """ollama-cloud with llama3 must skip to aggregator, not try llama3."""
+        mock_aggregator_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="ollama-cloud",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="llama3",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(mock_aggregator_client, "google/gemini-3-flash-preview"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        # Should have fallen through to the aggregator
+        assert client is mock_aggregator_client
+        assert model == "google/gemini-3-flash-preview"
+        # resolve_provider_client must NOT have been called with ollama-cloud
+        for call in mock_resolve.call_args_list:
+            assert call.args[0] != "ollama-cloud" or call.args[1] != "llama3", (
+                "Should not have tried llama3 on ollama-cloud for vision"
+            )
+
+    def test_ollama_with_llava_uses_main_provider(self):
+        """ollama with llava (vision model) must use main provider directly."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="ollama",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="llava-v1.6",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "llava-v1.6"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "ollama"
+        assert client is mock_client
+        assert model == "llava-v1.6"
+
+    def test_provider_with_vision_override_still_works(self):
+        """xiaomi with explicit vision override must still use the override."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="xiaomi",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="mimo-v2-pro",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "mimo-v2.5"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "xiaomi"
+        assert client is mock_client
+        assert model == "mimo-v2.5"
+
+    def test_non_vision_model_all_aggregators_fail(self):
+        """Non-vision main + no aggregators available must return None."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="ollama-cloud",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="qwen3:14b",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(None, None),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert client is None
+        assert model is None

--- a/tests/agent/test_vision_non_vision_fallthrough.py
+++ b/tests/agent/test_vision_non_vision_fallthrough.py
@@ -6,11 +6,12 @@ the auto-detection should skip directly to aggregator fallbacks instead of
 sending an image payload to a text-only model.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-from agent.auxiliary_client import _is_likely_vision_model
+from agent.auxiliary_client import _is_likely_vision_model, call_llm
 
 
 # -- _is_likely_vision_model heuristic --
@@ -149,6 +150,67 @@ class TestVisionNonVisionFallthrough:
         assert client is mock_client
         assert model == "mimo-v2.5"
 
+    def test_named_custom_provider_unknown_model_is_trusted(self):
+        """Named custom providers should not be skipped by the name heuristic."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="beans",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="my-company-vlm",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_named_custom_provider_entry",
+            return_value={"name": "beans", "base_url": "http://vlm.test/v1"},
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "my-company-vlm"),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "beans"
+        assert client is mock_client
+        assert model == "my-company-vlm"
+
+    def test_named_custom_provider_can_declare_vision_model_override(self):
+        """Named custom providers can route vision to a dedicated model."""
+        mock_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="beans",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="chat-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_named_custom_provider_entry",
+            return_value={
+                "name": "beans",
+                "base_url": "http://vlm.test/v1",
+                "models": {"chat-model": {"vision_model": "vision-model"}},
+            },
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "vision-model"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "beans"
+        assert client is mock_client
+        assert model == "vision-model"
+        assert mock_resolve.call_args.args[:2] == ("beans", "vision-model")
+
     def test_non_vision_model_all_aggregators_fail(self):
         """Non-vision main + no aggregators available must return None."""
         with patch(
@@ -170,3 +232,49 @@ class TestVisionNonVisionFallthrough:
 
         assert client is None
         assert model is None
+
+
+class VisionUnsupportedError(Exception):
+    def __init__(self, message, status_code=400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TestVisionCapabilityFallback:
+    def test_call_llm_retries_auto_vision_on_capability_error(self):
+        """A text-only main provider should fall through to strict vision backends."""
+        primary_client = MagicMock()
+        fallback_client = MagicMock()
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+        primary_client.chat.completions.create.side_effect = VisionUnsupportedError(
+            "This model does not support image input"
+        )
+        fallback_client.chat.completions.create.return_value = response
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("ollama-cloud", primary_client, "llama3"),
+        ), patch(
+            "agent.auxiliary_client._build_call_kwargs",
+            return_value={
+                "model": "llama3",
+                "messages": [{"role": "user", "content": "analyze"}],
+            },
+        ), patch(
+            "agent.auxiliary_client._try_vision_fallback",
+            return_value=(fallback_client, "google/gemini-3-flash-preview", "openrouter"),
+        ):
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "analyze"}],
+            )
+
+        assert result is response
+        assert primary_client.chat.completions.create.call_count == 1
+        assert fallback_client.chat.completions.create.call_count == 1


### PR DESCRIPTION
## What does this PR do?

Vision auto-detection reads the static config default model via `_read_main_model()` and, when the provider is not in `_PROVIDER_VISION_MODELS`, falls through to using that model for vision — even when it is not vision-capable (e.g., `llama3` on Ollama Cloud). This sends a guaranteed-to-fail request instead of falling through to aggregator backends.

This PR adds a heuristic gate that skips the main provider when its model does not appear vision-capable, plus try-and-fallback so a main-provider vision request that fails with a text-only error falls through to aggregators instead of returning None.

## Related Issue

Fixes #14744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`:
  - Added `_VISION_MODEL_INDICATORS` tuple and `_is_likely_vision_model()` helper that checks common vision model name patterns (vl, vision, omni, llava, etc.)
  - In the auto-detection else-branch, when no override is found in `_PROVIDER_VISION_MODELS` and the main model does not appear vision-capable, skip the main provider and fall through to aggregator backends
  - Custom providers with explicit `base_url` are trusted and always tried (no heuristic gate), preserving compatibility for users who configure custom vision endpoints
  - Added try-and-fallback: if a main-provider vision request fails with a text-only error, fall through to aggregators instead of returning None

## How to Test

Tests: `tests/agent/test_vision_non_vision_fallthrough.py` — 36 tests:

1. 18 parametrized tests for `_is_likely_vision_model` (known vision models)
2. 10 parametrized tests for non-vision models
3. Integration tests: Ollama Cloud + llama3 skips to aggregator, Ollama + llava uses main provider, xiaomi override still works, custom providers trusted, all-aggregators-fail returns None

Tested on macOS (Python 3.11).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/agent/test_vision_non_vision_fallthrough.py -q
36 passed
```
