### PR TITLE
fix(gateway): centralize Telegram forum chat detection for General topic routing (#13607)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -678,6 +678,11 @@ class TelegramAdapter(BasePlatformAdapter):
         return int(thread_id)
 
     @staticmethod
+    def _is_forum_chat(chat: Any) -> bool:
+        """Return True when Telegram marks a group/supergroup as a forum."""
+        return bool(getattr(chat, "is_forum", False))
+
+    @staticmethod
     def _is_thread_not_found_error(error: Exception) -> bool:
         return "thread not found" in str(error).lower()
 
@@ -4161,9 +4166,11 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_type = "dm"
             if chat.type == ChatType.GROUP:
                 chat_type = "group"
+                if self._is_forum_chat(chat):
+                    chat_type = "forum"
             elif chat.type == ChatType.SUPERGROUP:
                 chat_type = "group"
-                if chat.is_forum:
+                if self._is_forum_chat(chat):
                     chat_type = "forum"
             elif chat.type == ChatType.CHANNEL:
                 chat_type = "channel"
@@ -5657,7 +5664,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # can hit Telegram's 'Message thread not found' error (#3206).
         thread_id_raw = message.message_thread_id
         is_topic_message = bool(getattr(message, "is_topic_message", False))
-        is_forum_group = getattr(chat, "is_forum", False) is True
+        is_forum_group = self._is_forum_chat(chat)
         thread_id_str = None
         if thread_id_raw is not None:
             if chat_type == "group" and (is_topic_message or is_forum_group):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2989,8 +2989,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Resolve DM topic name and skill binding
         thread_id_raw = message.message_thread_id
         thread_id_str = str(thread_id_raw) if thread_id_raw is not None else None
-        if chat_type == "group" and thread_id_str is None and getattr(chat, "is_forum", False):
+        if chat_type in ("group", "supergroup") and thread_id_str is None and getattr(chat, "is_forum", False):
             thread_id_str = self._GENERAL_TOPIC_THREAD_ID
+            logger.debug(
+                "Forum %s message without thread_id — routing to General topic (thread=%s)",
+                chat_type, thread_id_str,
+            )
         chat_topic = None
         topic_skill = None
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -284,6 +284,14 @@ class TelegramAdapter(BasePlatformAdapter):
     def _is_thread_not_found_error(error: Exception) -> bool:
         return "thread not found" in str(error).lower()
 
+    @staticmethod
+    def _is_forum_group_chat(chat: Any) -> bool:
+        """Return True for Telegram forum chats that carry topic threads."""
+        return (
+            getattr(chat, "type", None) in (ChatType.GROUP, ChatType.SUPERGROUP)
+            and bool(getattr(chat, "is_forum", False))
+        )
+
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
         configured = self.config.extra.get("fallback_ips", []) if getattr(self.config, "extra", None) else []
@@ -2010,8 +2018,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_type = "group"
             elif chat.type == ChatType.SUPERGROUP:
                 chat_type = "group"
-                if chat.is_forum:
-                    chat_type = "forum"
+            if self._is_forum_group_chat(chat):
+                chat_type = "forum"
             elif chat.type == ChatType.CHANNEL:
                 chat_type = "channel"
             
@@ -2989,11 +2997,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Resolve DM topic name and skill binding
         thread_id_raw = message.message_thread_id
         thread_id_str = str(thread_id_raw) if thread_id_raw is not None else None
-        if chat_type in ("group", "supergroup") and thread_id_str is None and getattr(chat, "is_forum", False):
+        if self._is_forum_group_chat(chat) and thread_id_str is None:
             thread_id_str = self._GENERAL_TOPIC_THREAD_ID
             logger.debug(
-                "Forum %s message without thread_id — routing to General topic (thread=%s)",
-                chat_type, thread_id_str,
+                "Forum Telegram chat without thread_id — routing to General topic (thread=%s)",
+                thread_id_str,
             )
         chat_topic = None
         topic_skill = None

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -228,6 +228,41 @@ def test_forum_general_topic_without_message_thread_id_keeps_thread_context():
 
 
 @pytest.mark.asyncio
+async def test_get_chat_info_marks_forum_groups_and_supergroups():
+    """Forum chat detection should use raw Telegram chat type, not normalized labels."""
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = _make_adapter()
+    chats = iter([
+        SimpleNamespace(
+            type=telegram_mod.ChatType.GROUP,
+            is_forum=True,
+            title="Group forum",
+            full_name=None,
+            username=None,
+        ),
+        SimpleNamespace(
+            type=telegram_mod.ChatType.SUPERGROUP,
+            is_forum=True,
+            title="Supergroup forum",
+            full_name=None,
+            username=None,
+        ),
+    ])
+
+    async def mock_get_chat(_chat_id):
+        return next(chats)
+
+    adapter._bot = SimpleNamespace(get_chat=mock_get_chat)
+
+    group_info = await adapter.get_chat_info("-100111")
+    supergroup_info = await adapter.get_chat_info("-100222")
+
+    assert group_info["type"] == "forum"
+    assert supergroup_info["type"] == "forum"
+
+
+@pytest.mark.asyncio
 async def test_send_omits_general_topic_thread_id():
     """Telegram sends to forum General should omit message_thread_id=1."""
     adapter = _make_adapter()

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -132,6 +132,86 @@ def test_forum_general_topic_without_message_thread_id_keeps_thread_context():
     assert event.source.thread_id == "1"
 
 
+def test_forum_group_general_topic_fallback():
+    """Forum GROUP chat without thread_id should also fall back to General topic."""
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="hello from group forum General",
+        caption=None,
+        chat=SimpleNamespace(
+            id=-100999,
+            type=telegram_mod.ChatType.GROUP,
+            is_forum=True,
+            title="Group forum",
+        ),
+        from_user=SimpleNamespace(id=789, full_name="Bob"),
+        message_thread_id=None,
+        reply_to_message=None,
+        message_id=20,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.chat_id == "-100999"
+    assert event.source.chat_type == "group"
+    assert event.source.thread_id == "1"
+
+
+def test_forum_supergroup_with_thread_id_preserves_it():
+    """Forum supergroup messages WITH a thread_id should keep the original value."""
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="hello from a named topic",
+        caption=None,
+        chat=SimpleNamespace(
+            id=-100123,
+            type=telegram_mod.ChatType.SUPERGROUP,
+            is_forum=True,
+            title="Forum group",
+        ),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=42,
+        reply_to_message=None,
+        message_id=30,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.thread_id == "42"
+
+
+def test_non_forum_supergroup_without_thread_id_stays_none():
+    """Non-forum supergroup messages without thread_id should NOT get General topic."""
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="hello from a regular supergroup",
+        caption=None,
+        chat=SimpleNamespace(
+            id=-100555,
+            type=telegram_mod.ChatType.SUPERGROUP,
+            is_forum=False,
+            title="Regular supergroup",
+        ),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        reply_to_message=None,
+        message_id=40,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.thread_id is None
+
+
 @pytest.mark.asyncio
 async def test_send_omits_general_topic_thread_id():
     """Telegram sends to forum General should omit message_thread_id=1."""

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -213,6 +213,41 @@ def test_non_forum_supergroup_without_thread_id_stays_none():
 
 
 @pytest.mark.asyncio
+async def test_get_chat_info_marks_forum_groups_and_supergroups():
+    """Forum chat detection should use raw Telegram chat type, not normalized labels."""
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = _make_adapter()
+    chats = iter([
+        SimpleNamespace(
+            type=telegram_mod.ChatType.GROUP,
+            is_forum=True,
+            title="Group forum",
+            full_name=None,
+            username=None,
+        ),
+        SimpleNamespace(
+            type=telegram_mod.ChatType.SUPERGROUP,
+            is_forum=True,
+            title="Supergroup forum",
+            full_name=None,
+            username=None,
+        ),
+    ])
+
+    async def mock_get_chat(_chat_id):
+        return next(chats)
+
+    adapter._bot = SimpleNamespace(get_chat=mock_get_chat)
+
+    group_info = await adapter.get_chat_info("-100111")
+    supergroup_info = await adapter.get_chat_info("-100222")
+
+    assert group_info["type"] == "forum"
+    assert supergroup_info["type"] == "forum"
+
+
+@pytest.mark.asyncio
 async def test_send_omits_general_topic_thread_id():
     """Telegram sends to forum General should omit message_thread_id=1."""
     adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Telegram forum General topic messages can arrive from a supergroup with topic metadata shaped differently from regular topic messages. This PR centralizes forum chat detection so General-topic routing uses the same predicate consistently and avoids unexpected fallback behavior.

## Related Issue

Fixes #13607

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Centralize Telegram forum/supergroup detection in `gateway/platforms/telegram.py`.
- Use the helper in the General-topic fallback path.
- Add focused regression coverage for the General topic supergroup routing case.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_telegram_thread_fallback.py -q`
3. Expected result: 44 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_telegram_thread_fallback.py -q` — 44 passed
```
