### PR TITLE
fix(tools): pass target_model to resolve_runtime_provider in delegation (#15319)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -873,7 +873,24 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
 
-
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolves_full_credentials(self, mock_resolve):
+        """When delegation.provider is set, full credentials are resolved."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "google/gemini-3-flash-preview", "provider": "openrouter"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(creds["api_key"], "sk-or-test-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="google/gemini-3-flash-preview")
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -979,6 +996,39 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
+        """Nous provider resolves Nous Portal base_url and api_key."""
+        mock_resolve.return_value = {
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-agent-key-xyz",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "hermes-3-llama-3.1-8b", "provider": "nous"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "nous")
+        self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
+        self.assertEqual(creds["api_key"], "nous-agent-key-xyz")
+        mock_resolve.assert_called_once_with(requested="nous", target_model="hermes-3-llama-3.1-8b")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_target_model_forwarded_for_api_mode_resolution(self, mock_resolve):
+        """target_model kwarg lets resolve_runtime_provider pick the correct api_mode."""
+        mock_resolve.return_value = {
+            "provider": "opencode-zen",
+            "base_url": "https://opencode-zen.example/v1",
+            "api_key": "sk-test",
+            "api_mode": "anthropic_messages",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "claude-opus-4-6", "provider": "opencode-zen"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        mock_resolve.assert_called_once_with(
+            requested="opencode-zen", target_model="claude-opus-4-6"
+        )
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
@@ -990,6 +1040,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("openrouter", str(ctx.exception).lower())
         self.assertIn("Cannot resolve", str(ctx.exception))
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="some-model")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_but_no_api_key_raises(self, mock_resolve):
@@ -1005,6 +1056,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("no API key", str(ctx.exception))
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="some-model")
 
     def test_missing_config_keys_inherit_parent(self):
         """When config dict has no model/provider keys at all, inherits parent."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -627,7 +627,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
         self.assertEqual(creds["api_key"], "sk-or-test-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
-        mock_resolve.assert_called_once_with(requested="openrouter")
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="google/gemini-3-flash-preview")
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -688,7 +688,24 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["provider"], "nous")
         self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
         self.assertEqual(creds["api_key"], "nous-agent-key-xyz")
-        mock_resolve.assert_called_once_with(requested="nous")
+        mock_resolve.assert_called_once_with(requested="nous", target_model="hermes-3-llama-3.1-8b")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_target_model_forwarded_for_api_mode_resolution(self, mock_resolve):
+        """target_model kwarg lets resolve_runtime_provider pick the correct api_mode."""
+        mock_resolve.return_value = {
+            "provider": "opencode-zen",
+            "base_url": "https://opencode-zen.example/v1",
+            "api_key": "sk-test",
+            "api_mode": "anthropic_messages",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "claude-opus-4-6", "provider": "opencode-zen"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        mock_resolve.assert_called_once_with(
+            requested="opencode-zen", target_model="claude-opus-4-6"
+        )
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
@@ -700,6 +717,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("openrouter", str(ctx.exception).lower())
         self.assertIn("Cannot resolve", str(ctx.exception))
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="some-model")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_but_no_api_key_raises(self, mock_resolve):
@@ -715,6 +733,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("no API key", str(ctx.exception))
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="some-model")
 
     def test_missing_config_keys_inherit_parent(self):
         """When config dict has no model/provider keys at all, inherits parent."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2164,7 +2164,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider)
+        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
## What does this PR do?

When `delegation.model` differs from the parent model (e.g., delegating to `claude-opus-4-6` on an `opencode-zen` provider while the parent uses a `chat_completions` model), `resolve_runtime_provider` needs the target model to select the correct `api_mode`. Without `target_model`, the delegate inherits the parent's `api_mode` and gets 404 errors.

The fix is a 1-line change to forward `target_model` to `resolve_runtime_provider`, plus 5 test assertion updates and 1 new test case.

## Related Issue

Fixes #15319

Supersedes #15320.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Delegation call site now passes `target_model` to `resolve_runtime_provider` so api_mode is selected for the delegate, not the parent
- Updated 4 existing `TestDelegationCredentialResolution` assertions to verify `target_model` kwarg is forwarded
- Added `test_target_model_forwarded_for_api_mode_resolution` covering the `anthropic_messages` api_mode case

## How to Test

1. `pytest -k TestDelegationCredentialResolution` — 11/11 delegation credential tests pass
2. `pytest -k test_target_model_forwarded_for_api_mode_resolution` — covers the `anthropic_messages` api_mode case

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
11/11 delegation credential tests pass
```
