### PR TITLE
fix(agent): guard against non-dict model_extra in tool call normalization

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1636,7 +1636,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             entry["function"]["arguments"] += tc_delta.function.arguments
                     extra = getattr(tc_delta, "extra_content", None)
                     if extra is None and hasattr(tc_delta, "model_extra"):
-                        extra = (tc_delta.model_extra or {}).get("extra_content")
+                        extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
                     if extra is not None:
                         if hasattr(extra, "model_dump"):
                             extra = extra.model_dump()

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -562,7 +562,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 tc_provider_data: dict[str, Any] = {}
                 extra = getattr(tc, "extra_content", None)
                 if extra is None and hasattr(tc, "model_extra"):
-                    extra = (tc.model_extra or {}).get("extra_content")
+                    extra = (tc.model_extra if isinstance(tc.model_extra, dict) else {}).get("extra_content")
                 if extra is not None:
                     if hasattr(extra, "model_dump"):
                         try:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -315,7 +315,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 tc_provider_data: Dict[str, Any] = {}
                 extra = getattr(tc, "extra_content", None)
                 if extra is None and hasattr(tc, "model_extra"):
-                    extra = (tc.model_extra or {}).get("extra_content")
+                    extra = (tc.model_extra if isinstance(tc.model_extra, dict) else {}).get("extra_content")
                 if extra is not None:
                     if hasattr(extra, "model_dump"):
                         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6154,7 +6154,7 @@ class AIAgent:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)
                         if extra is None and hasattr(tc_delta, "model_extra"):
-                            extra = (tc_delta.model_extra or {}).get("extra_content")
+                            extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
                         if extra is not None:
                             if hasattr(extra, "model_dump"):
                                 extra = extra.model_dump()

--- a/tests/agent/test_model_extra_type_guard.py
+++ b/tests/agent/test_model_extra_type_guard.py
@@ -1,0 +1,126 @@
+"""Tests for model_extra type guard in tool call normalization.
+
+Providers like NVIDIA NIM may return model_extra as a string instead
+of a dict, causing AttributeError on .get() calls.  The isinstance
+guard prevents this crash.
+"""
+import unittest
+from types import SimpleNamespace
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.transports.types import ToolCall
+
+
+class TestModelExtraTypeGuard(unittest.TestCase):
+    """Ensure the isinstance(dict) guard handles all model_extra types."""
+
+    def _extract(self, model_extra):
+        """Replicate the guarded extraction pattern used in production."""
+        return (model_extra if isinstance(model_extra, dict) else {}).get(
+            "extra_content"
+        )
+
+    def test_string_no_crash(self):
+        """String model_extra must not raise AttributeError."""
+        self.assertIsNone(self._extract("unexpected_string"))
+
+    def test_none_no_crash(self):
+        self.assertIsNone(self._extract(None))
+
+    def test_dict_extracts_extra_content(self):
+        self.assertEqual(
+            self._extract({"extra_content": {"key": "val"}}),
+            {"key": "val"},
+        )
+
+    def test_empty_dict(self):
+        self.assertIsNone(self._extract({}))
+
+    def test_integer_no_crash(self):
+        self.assertIsNone(self._extract(42))
+
+    def test_list_no_crash(self):
+        self.assertIsNone(self._extract(["a", "b"]))
+
+    def test_bool_no_crash(self):
+        """Boolean True is truthy but not a dict."""
+        self.assertIsNone(self._extract(True))
+
+
+class TestNormalizeResponseModelExtraGuard(unittest.TestCase):
+    """Integration: normalize_response must not crash on non-dict model_extra."""
+
+    def test_string_model_extra_normalize(self):
+        """Tool call with string model_extra should normalize without error."""
+        transport = ChatCompletionsTransport.__new__(ChatCompletionsTransport)
+
+        tc = SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="test_tool", arguments='{"x": 1}'),
+            extra_content=None,
+            model_extra="nvidia_nim_extra_string",
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=SimpleNamespace(
+                role="assistant",
+                content=None,
+                tool_calls=[tc],
+                refusal=None,
+            ),
+            finish_reason="tool_calls",
+        )
+        response = SimpleNamespace(
+            id="resp_1",
+            choices=[choice],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+            ),
+            model="test-model",
+        )
+
+        result = transport.normalize_response(response)
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].name, "test_tool")
+
+    def test_dict_model_extra_with_extra_content(self):
+        """Dict model_extra with extra_content should be preserved."""
+        transport = ChatCompletionsTransport.__new__(ChatCompletionsTransport)
+
+        tc = SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="test_tool", arguments='{}'),
+            extra_content=None,
+            model_extra={"extra_content": {"thought_signature": "abc123"}},
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=SimpleNamespace(
+                role="assistant",
+                content=None,
+                tool_calls=[tc],
+                refusal=None,
+            ),
+            finish_reason="tool_calls",
+        )
+        response = SimpleNamespace(
+            id="resp_1",
+            choices=[choice],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+            ),
+            model="test-model",
+        )
+
+        result = transport.normalize_response(response)
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(
+            result.tool_calls[0].provider_data.get("extra_content"),
+            {"thought_signature": "abc123"},
+        )


### PR DESCRIPTION
## What does this PR do?

Providers like NVIDIA NIM can return `model_extra` as a string rather than a dict. The previous `(model_extra or {}).get(...)` pattern crashes with `AttributeError` on truthy non-dict values.

This PR uses an `isinstance(tc.model_extra, dict)` check instead, applied in both the non-streaming `normalize_response` path and the streaming accumulation path.

## Related Issue

Addresses tool-call normalization crash with non-dict `model_extra` (supersedes #15157).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace `(model_extra or {}).get(...)` with `isinstance(tc.model_extra, dict)` check in the non-streaming `normalize_response` path and the streaming accumulation path.

## How to Test

1. Run the targeted tests:
   - 7 unit tests covering string, None, dict, empty dict, integer, list, and boolean `model_extra` types
   - 2 integration tests verifying `normalize_response` handles string and dict `model_extra` correctly
2. 9/9 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# 9/9 tests pass (7 unit + 2 integration)
```
