### PR TITLE
fix(agent): extract usageMetadata from Gemini streaming finish chunks

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -679,7 +679,21 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
         mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
-        chunks.append(_make_stream_chunk(model=model, finish_reason=mapped))
+        finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
+        # Attach usage from usageMetadata so the streaming loop in
+        # run_agent.py can record token counts (mirrors the non-streaming
+        # path in translate_gemini_response).
+        usage_meta = event.get("usageMetadata") or {}
+        if usage_meta:
+            finish_chunk.usage = SimpleNamespace(
+                prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
+                completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+                total_tokens=int(usage_meta.get("totalTokenCount") or 0),
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
+                ),
+            )
+        chunks.append(finish_chunk)
     return chunks
 
 

--- a/tests/agent/test_gemini_streaming_usage.py
+++ b/tests/agent/test_gemini_streaming_usage.py
@@ -1,0 +1,77 @@
+"""Tests for Gemini streaming usageMetadata extraction.
+
+The streaming path must extract token counts from usageMetadata on
+the finish chunk, matching the non-streaming translate_gemini_response
+behavior.
+"""
+import unittest
+
+from agent.gemini_native_adapter import translate_stream_event
+
+
+class TestGeminiStreamingUsageMetadata(unittest.TestCase):
+    """Verify usageMetadata is attached to streaming finish chunks."""
+
+    def _finish_event(self, usage_meta=None):
+        """Create a Gemini streaming event with finishReason and optional usageMetadata."""
+        event = {
+            "candidates": [{
+                "content": {"parts": [], "role": "model"},
+                "finishReason": "STOP",
+            }],
+        }
+        if usage_meta is not None:
+            event["usageMetadata"] = usage_meta
+        return event
+
+    def _get_usage(self, chunks):
+        """Extract usage from a list of chunks, if present."""
+        for c in chunks:
+            usage = getattr(c, "usage", None)
+            if usage is not None:
+                return usage
+        return None
+
+    def test_usage_attached_on_finish(self):
+        """Finish chunk should carry usage from usageMetadata."""
+        event = self._finish_event({
+            "promptTokenCount": 100,
+            "candidatesTokenCount": 50,
+            "totalTokenCount": 150,
+            "cachedContentTokenCount": 20,
+        })
+        chunks = translate_stream_event(event, model="gemini-2.5-pro", tool_call_indices={})
+        usage = self._get_usage(chunks)
+        self.assertIsNotNone(usage, "Finish chunk should have usage")
+        self.assertEqual(usage.prompt_tokens, 100)
+        self.assertEqual(usage.completion_tokens, 50)
+        self.assertEqual(usage.total_tokens, 150)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 20)
+
+    def test_no_usage_when_metadata_absent(self):
+        """When usageMetadata is missing, finish chunk should not have usage."""
+        chunks = translate_stream_event(
+            self._finish_event(), model="gemini-2.5-pro", tool_call_indices={}
+        )
+        self.assertIsNone(self._get_usage(chunks))
+
+    def test_partial_metadata_defaults_to_zero(self):
+        """Missing fields in usageMetadata should default to 0."""
+        event = self._finish_event({
+            "promptTokenCount": 200,
+            "totalTokenCount": 200,
+            # candidatesTokenCount and cachedContentTokenCount missing
+        })
+        chunks = translate_stream_event(event, model="gemini-2.5-pro", tool_call_indices={})
+        usage = self._get_usage(chunks)
+        self.assertIsNotNone(usage)
+        self.assertEqual(usage.prompt_tokens, 200)
+        self.assertEqual(usage.completion_tokens, 0)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 0)
+
+    def test_empty_metadata_no_usage(self):
+        """Empty usageMetadata dict should not create usage."""
+        chunks = translate_stream_event(
+            self._finish_event({}), model="gemini-2.5-pro", tool_call_indices={}
+        )
+        self.assertIsNone(self._get_usage(chunks))


### PR DESCRIPTION
## What does this PR do?

Gemini streaming sessions reported 0 tokens because `translate_stream_event` did not extract `usageMetadata` from the finish event. This PR mirrors the non-streaming `translate_gemini_response` path which already handles this correctly. The `usage` is attached as a `SimpleNamespace` on the finish chunk with `prompt_tokens`, `completion_tokens`, `total_tokens`, and `prompt_tokens_details.cached_tokens`.

## Related Issue

Addresses #15264 (this PR supersedes #15264 and drops the unrelated `.dockerignore` change from that PR).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `translate_stream_event` (Gemini streaming translator): extract `usageMetadata` from the finish event and attach as `usage` SimpleNamespace with `prompt_tokens`, `completion_tokens`, `total_tokens`, and `prompt_tokens_details.cached_tokens`
- New tests for the streaming usage path

## How to Test

1. `test_usage_attached_on_finish` — verifies all 4 token count fields
2. `test_no_usage_when_metadata_absent` — no usage object when `usageMetadata` missing
3. `test_partial_metadata_defaults_to_zero` — missing fields default to 0
4. `test_empty_metadata_no_usage` — empty dict does not create usage
5. 4/4 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
4 passed
```
