### PR TITLE
fix(cli): prevent trailing space in picker-command completions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -865,6 +865,12 @@ class SlashCommandCompleter(Completer):
         except Exception:
             return {}
 
+    # Commands that open pickers when run without arguments.
+    # These should NOT receive a trailing space in completions because
+    # the TUI's submit handler applies completions on Enter if input differs,
+    # which blocks picker execution.
+    _PICKER_COMMANDS = frozenset({"model", "skin", "personality"})
+
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
         """Return replacement text for a completion.
@@ -873,8 +879,16 @@ class SlashCommandCompleter(Completer):
         returning ``help`` would be a no-op and prompt_toolkit suppresses the
         menu. Appending a trailing space keeps the dropdown visible and makes
         backspacing retrigger it naturally.
+
+        However, commands that open pickers (model, skin, personality) should
+        NOT get a trailing space — the TUI would apply the completion on Enter
+        and block the picker from opening.
         """
-        return f"{cmd_name} " if cmd_name == word else cmd_name
+        if cmd_name != word:
+            return cmd_name
+        if cmd_name in SlashCommandCompleter._PICKER_COMMANDS:
+            return cmd_name
+        return f"{cmd_name} "
 
     @staticmethod
     def _extract_path_word(text: str) -> str | None:

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -522,6 +522,23 @@ class TestSlashCommandCompleter:
 
         assert [item.text for item in completions] == ["help"]
 
+    # -- picker commands must NOT get trailing space ---------------------
+
+    def test_picker_commands_no_trailing_space(self):
+        """Picker commands (/model, /skin, /personality) must not get trailing space."""
+        for cmd in ("model", "skin", "personality"):
+            result = SlashCommandCompleter._completion_text(cmd, cmd)
+            assert result == cmd, f"/{cmd} should not have trailing space"
+
+    def test_non_picker_exact_match_gets_trailing_space(self):
+        """Regular commands like /help should still get trailing space on exact match."""
+        assert SlashCommandCompleter._completion_text("help", "help") == "help "
+
+    def test_partial_match_never_has_trailing_space_for_picker(self):
+        """Partial matches should never have trailing space regardless of command type."""
+        assert SlashCommandCompleter._completion_text("model", "mo") == "model"
+        assert SlashCommandCompleter._completion_text("help", "he") == "help"
+
     # -- non-slash input returns nothing ---------------------------------
 
     def test_no_completions_for_non_slash_input(self):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -359,6 +359,23 @@ class TestSlashCommandCompleter:
 
         assert [item.text for item in completions] == ["help"]
 
+    # -- picker commands must NOT get trailing space ---------------------
+
+    def test_picker_commands_no_trailing_space(self):
+        """Picker commands (/model, /skin, /personality) must not get trailing space."""
+        for cmd in ("model", "skin", "personality"):
+            result = SlashCommandCompleter._completion_text(cmd, cmd)
+            assert result == cmd, f"/{cmd} should not have trailing space"
+
+    def test_non_picker_exact_match_gets_trailing_space(self):
+        """Regular commands like /help should still get trailing space on exact match."""
+        assert SlashCommandCompleter._completion_text("help", "help") == "help "
+
+    def test_partial_match_never_has_trailing_space_for_picker(self):
+        """Partial matches should never have trailing space regardless of command type."""
+        assert SlashCommandCompleter._completion_text("model", "mo") == "model"
+        assert SlashCommandCompleter._completion_text("help", "he") == "help"
+
     # -- non-slash input returns nothing ---------------------------------
 
     def test_no_completions_for_non_slash_input(self):


### PR DESCRIPTION
## What does this PR do?

Commands that open pickers (`/model`, `/skin`, `/personality`) were receiving a trailing space from the completion handler. The TUI's submit handler applies pending completions on Enter — adding a space makes the input differ from the original, blocking picker execution.

This PR adds a `_PICKER_COMMANDS` frozenset and updates `_completion_text` to skip the trailing space for these commands.

## Related Issue

Addresses #15339 (supersedes earlier attempt).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `_PICKER_COMMANDS` frozenset to the completion handler.
- Update `_completion_text` so commands in `_PICKER_COMMANDS` (`/model`, `/skin`, `/personality`) do not get a trailing space.

## How to Test

1. Run the completion suite:
   - `test_picker_commands_no_trailing_space` — verifies `/model`, `/skin`, `/personality` have no trailing space.
   - `test_non_picker_exact_match_gets_trailing_space` — verifies `/help` still gets trailing space.
   - `test_partial_match_never_has_trailing_space_for_picker` — verifies partial matches are unaffected.
   - All 15 completion-related tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
