### PR TITLE
fix(gateway): fix underscore-stripping regex to preserve snake_case identifiers

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -157,8 +157,8 @@ class TextBatchAggregator:
 # Pre-compiled regexes for performance
 _RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 _RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
-_RE_BOLD_UNDER = re.compile(r"__(.+?)__", re.DOTALL)
-_RE_ITALIC_UNDER = re.compile(r"_(.+?)_", re.DOTALL)
+_RE_BOLD_UNDER = re.compile(r"(?<![a-zA-Z0-9])__(?=[^_\s])(.+?)(?<=[^_])__(?![a-zA-Z0-9])", re.DOTALL)
+_RE_ITALIC_UNDER = re.compile(r"(?<![a-zA-Z0-9])_(?=[^_\s])(.+?)(?<=[^_])_(?![a-zA-Z0-9])", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")
 _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)

--- a/tests/gateway/test_helpers_markdown_underscore.py
+++ b/tests/gateway/test_helpers_markdown_underscore.py
@@ -1,0 +1,60 @@
+"""Tests for underscore markdown stripping in gateway helpers.
+
+The blanket _(.+?)_ and __(.+?)__ patterns incorrectly consumed
+snake_case identifiers like send_as_bot and user_id.  The fix adds
+lookbehind/lookahead boundaries so underscores adjacent to
+alphanumeric characters are not treated as markdown formatting.
+
+Mirrors fixes already tested in hermes_cli/test_cli_markdown_rendering.py.
+"""
+import unittest
+
+from gateway.platforms.helpers import strip_markdown
+
+
+class TestGatewayUnderscoreRegex(unittest.TestCase):
+    """Verify markdown stripping preserves snake_case identifiers."""
+
+    def test_snake_case_preserved(self):
+        text = "Set send_as_bot to true and check user_id"
+        result = strip_markdown(text)
+        self.assertIn("send_as_bot", result)
+        self.assertIn("user_id", result)
+
+    def test_bold_underscore_stripped(self):
+        result = strip_markdown("Here is __bold text__ for you")
+        self.assertIn("bold text", result)
+        self.assertNotIn("__bold", result)
+
+    def test_italic_underscore_stripped(self):
+        result = strip_markdown("Here is _italic_ text")
+        self.assertIn("italic", result)
+        self.assertNotIn("_italic_", result)
+
+    def test_double_underscore_in_identifier_preserved(self):
+        """Double underscores embedded in alphanumeric context should survive."""
+        # e.g. x__y where underscores are between alphanumeric chars
+        result = strip_markdown("Check my_var__name for details")
+        self.assertIn("my_var__name", result)
+
+    def test_config_keys_preserved(self):
+        result = strip_markdown("Set max_tokens to 4096 and api_base_url to localhost")
+        self.assertIn("max_tokens", result)
+        self.assertIn("api_base_url", result)
+
+    def test_asterisk_bold_unaffected(self):
+        result = strip_markdown("This is **bold** text")
+        self.assertIn("bold", result)
+        self.assertNotIn("**", result)
+
+    def test_mixed_formatting_and_identifiers(self):
+        result = strip_markdown("Use **bold** and set send_as_bot to _true_")
+        self.assertIn("send_as_bot", result)
+        self.assertNotIn("**", result)
+
+    def test_multiple_snake_case_in_one_line(self):
+        text = "Configure thread_id, session_key, and platform_name"
+        result = strip_markdown(text)
+        self.assertIn("thread_id", result)
+        self.assertIn("session_key", result)
+        self.assertIn("platform_name", result)


### PR DESCRIPTION
## What does this PR do?

The blanket `_(.+?)_` and `__(.+?)__` patterns in `gateway/platforms/helpers.py` incorrectly consumed snake_case identifiers like `send_as_bot` and `user_id`. This adds lookbehind/lookahead boundaries (`(?<![a-zA-Z0-9])` / `(?![a-zA-Z0-9])`) so underscores adjacent to alphanumeric characters are not treated as markdown formatting.

The same fix was already applied and tested in the CLI renderer (`cli.py`); this addresses the gateway copy.

## Related Issue

Supersedes #15076.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/helpers.py` — added non-alphanumeric boundary assertions to `_RE_BOLD_UNDER` and `_RE_ITALIC_UNDER` so they only match real Markdown delimiters
- New tests covering snake_case preservation, bold/italic stripping behaviour, mixed cases

## How to Test

1. `pytest -k test_snake_case_preserved` — `send_as_bot`, `user_id` survive stripping
2. `pytest -k test_bold_underscore_stripped` — actual `__bold__` formatting is stripped
3. `pytest -k test_italic_underscore_stripped` — actual `_italic_` formatting is stripped
4. `pytest -k test_double_underscore_in_identifier_preserved` — `my_var__name` survives
5. `pytest -k test_config_keys_preserved` — `max_tokens`, `api_base_url` survive
6. `pytest -k test_asterisk_bold_unaffected` — `**bold**` still works
7. `pytest -k test_mixed_formatting_and_identifiers` — both formatting and identifiers handled correctly
8. `pytest -k test_multiple_snake_case_in_one_line` — multiple identifiers in one line

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
8/8 tests pass
```
