### PR TITLE
fix(credential-pool): exponential backoff on repeated exhaustion (#15296)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -210,6 +210,37 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
+def _coerce_failure_count(value: Any) -> int:
+    """Safely coerce a ``consecutive_failures`` value to a non-negative int.
+
+    On-disk ``auth.json`` payloads can be hand-edited or migrated from
+    older schemas, so the field may arrive as a string, a float, ``None``,
+    or even a corrupted shape.  Rather than raising ``ValueError`` from
+    inside cooldown-resolution code (which would break failover for
+    every user with a damaged pool entry), this helper tolerates the
+    bad input and falls back to ``0`` — equivalent to the pre-#15296
+    flat-TTL behaviour.
+    """
+    if value is None:
+        return 0
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, coerced)
+
+
+# log2(EXHAUSTED_TTL_BACKOFF_CAP) — pinned as a module constant so the
+# ``_exhausted_ttl`` exponent clamp doesn't depend on Python's floating-
+# point ``math.log2`` behaviour and so a refactor that bumps the cap
+# also has to update this matching ceiling.  The clamp matters because
+# without it a credential with thousands of consecutive_failures would
+# cause Python to materialise a multi-thousand-bit ``2 ** N`` integer
+# before the ``min(..., CAP)`` call discards it (Copilot caught this on
+# #15455).
+_EXHAUSTED_TTL_BACKOFF_MAX_EXPONENT = 3  # because 2 ** 3 == EXHAUSTED_TTL_BACKOFF_CAP (8)
+
+
 def _exhausted_ttl(error_code: Optional[int], consecutive_failures: int = 0) -> int:
     """Return cooldown seconds based on the HTTP status that caused
     exhaustion, with exponential backoff on consecutive failures.
@@ -231,10 +262,14 @@ def _exhausted_ttl(error_code: Optional[int], consecutive_failures: int = 0) -> 
         base = EXHAUSTED_TTL_DEFAULT_SECONDS
     # ``consecutive_failures`` is the count *including* the current
     # exhaustion, so the first failure should still apply 1× the base
-    # (i.e. multiplier exponent ``failures - 1``, clamped at 0).
-    exponent = max(0, int(consecutive_failures) - 1)
-    multiplier = min(2 ** exponent, EXHAUSTED_TTL_BACKOFF_CAP)
-    return base * multiplier
+    # (i.e. multiplier exponent ``failures - 1``).  Clamp the exponent
+    # to ``log2(CAP)`` BEFORE computing ``2 ** exponent`` so a corrupted
+    # or runaway counter (millions of consecutive failures across a
+    # multi-week outage) doesn't materialise an astronomical integer
+    # only to throw it away in the ``min(..., CAP)``.
+    failures = _coerce_failure_count(consecutive_failures)
+    exponent = min(max(0, failures - 1), _EXHAUSTED_TTL_BACKOFF_MAX_EXPONENT)
+    return base * (1 << exponent)
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
@@ -314,7 +349,9 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     if entry.last_status_at:
         return entry.last_status_at + _exhausted_ttl(
             entry.last_error_code,
-            consecutive_failures=getattr(entry, "consecutive_failures", 0) or 0,
+            consecutive_failures=_coerce_failure_count(
+                getattr(entry, "consecutive_failures", 0)
+            ),
         )
     return None
 
@@ -453,10 +490,13 @@ class CredentialPool:
         normalized_error = _normalize_error_context(error_context)
         # Count this exhaustion against the previous failure streak so
         # ``_exhausted_ttl`` can apply an exponential backoff (#15296).
-        # ``getattr`` defends against on-disk entries written before the
-        # field existed; ``or 0`` defends against an explicit ``None``
-        # value sneaking through the JSON round-trip.
-        prior_failures = getattr(entry, "consecutive_failures", 0) or 0
+        # ``_coerce_failure_count`` tolerates legacy on-disk entries that
+        # predate this field, missing values (``None``), and corrupted
+        # shapes (a string, a float, ...) — falling back to 0 instead of
+        # raising ``ValueError`` from inside the failover path.
+        prior_failures = _coerce_failure_count(
+            getattr(entry, "consecutive_failures", 0)
+        )
         updated = replace(
             entry,
             last_status=STATUS_EXHAUSTED,
@@ -465,7 +505,7 @@ class CredentialPool:
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),
             last_error_reset_at=normalized_error.get("reset_at"),
-            consecutive_failures=int(prior_failures) + 1,
+            consecutive_failures=prior_failures + 1,
         )
         self._replace_entry(entry, updated)
         self._persist()

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -72,6 +72,23 @@ SUPPORTED_POOL_STRATEGIES = {
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 
+# Multiplier cap for the exponential backoff applied to repeated
+# exhaustions of the *same* credential.  After N consecutive failures we
+# extend the cooldown to ``base_ttl * min(2 ** (N-1), CAP)``:
+#
+#   N=1 → 1×  base_ttl  (1h on default)
+#   N=2 → 2×  base_ttl  (2h)
+#   N=3 → 4×  base_ttl  (4h)
+#   N=4 → 8×  base_ttl  (8h, the cap)
+#   N=5+ → 8× base_ttl  (clamped at the cap)
+#
+# Without the cap, a credential that's been failing for a week could
+# end up on a multi-day cooldown that survives operator intervention
+# (refreshing the upstream provider, swapping API keys, etc.); the
+# 8-hour cap ensures cooldowns stay bounded while still backing off
+# meaningfully on sustained outages (#15296).
+EXHAUSTED_TTL_BACKOFF_CAP = 8
+
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
 # custom_providers name: 'custom:<normalized_name>'.
@@ -102,6 +119,12 @@ class PooledCredential:
     last_error_reason: Optional[str] = None
     last_error_message: Optional[str] = None
     last_error_reset_at: Optional[float] = None
+    # Count of consecutive ``_mark_exhausted`` calls without an
+    # intervening successful clear-back-to-OK.  Drives exponential
+    # backoff on the cooldown TTL so a credential whose upstream is
+    # genuinely down for hours doesn't keep getting probed every TTL
+    # window with three retries each (#15296).
+    consecutive_failures: int = 0
     base_url: Optional[str] = None
     expires_at: Optional[str] = None
     expires_at_ms: Optional[int] = None
@@ -187,11 +210,31 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
-def _exhausted_ttl(error_code: Optional[int]) -> int:
-    """Return cooldown seconds based on the HTTP status that caused exhaustion."""
+def _exhausted_ttl(error_code: Optional[int], consecutive_failures: int = 0) -> int:
+    """Return cooldown seconds based on the HTTP status that caused
+    exhaustion, with exponential backoff on consecutive failures.
+
+    The backoff multiplier is ``min(2 ** (consecutive_failures - 1),
+    EXHAUSTED_TTL_BACKOFF_CAP)`` and is applied to the base TTL.  A
+    fresh exhaustion (``consecutive_failures <= 1``) keeps the historic
+    1-hour cooldown so transient throttles still recover quickly; only
+    sustained outages on the *same* credential lengthen the wait.
+
+    The ``consecutive_failures`` argument defaults to 0 so older
+    callers (and on-disk pool entries that predate this field) still
+    get the un-multiplied base TTL — backward compatible with the
+    pre-#15296 behaviour.
+    """
     if error_code == 429:
-        return EXHAUSTED_TTL_429_SECONDS
-    return EXHAUSTED_TTL_DEFAULT_SECONDS
+        base = EXHAUSTED_TTL_429_SECONDS
+    else:
+        base = EXHAUSTED_TTL_DEFAULT_SECONDS
+    # ``consecutive_failures`` is the count *including* the current
+    # exhaustion, so the first failure should still apply 1× the base
+    # (i.e. multiplier exponent ``failures - 1``, clamped at 0).
+    exponent = max(0, int(consecutive_failures) - 1)
+    multiplier = min(2 ** exponent, EXHAUSTED_TTL_BACKOFF_CAP)
+    return base * multiplier
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
@@ -269,7 +312,10 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     if reset_at is not None:
         return reset_at
     if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
+        return entry.last_status_at + _exhausted_ttl(
+            entry.last_error_code,
+            consecutive_failures=getattr(entry, "consecutive_failures", 0) or 0,
+        )
     return None
 
 
@@ -405,6 +451,12 @@ class CredentialPool:
         error_context: Optional[Dict[str, Any]] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
+        # Count this exhaustion against the previous failure streak so
+        # ``_exhausted_ttl`` can apply an exponential backoff (#15296).
+        # ``getattr`` defends against on-disk entries written before the
+        # field existed; ``or 0`` defends against an explicit ``None``
+        # value sneaking through the JSON round-trip.
+        prior_failures = getattr(entry, "consecutive_failures", 0) or 0
         updated = replace(
             entry,
             last_status=STATUS_EXHAUSTED,
@@ -413,6 +465,7 @@ class CredentialPool:
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),
             last_error_reset_at=normalized_error.get("reset_at"),
+            consecutive_failures=int(prior_failures) + 1,
         )
         self._replace_entry(entry, updated)
         self._persist()
@@ -447,6 +500,7 @@ class CredentialPool:
                     last_status=None,
                     last_status_at=None,
                     last_error_code=None,
+                    consecutive_failures=0,
                 )
                 self._replace_entry(entry, updated)
                 self._persist()
@@ -738,6 +792,7 @@ class CredentialPool:
                             last_status=STATUS_OK,
                             last_status_at=None,
                             last_error_code=None,
+                            consecutive_failures=0,
                         )
                         self._replace_entry(synced, updated)
                         self._persist()
@@ -772,6 +827,7 @@ class CredentialPool:
                         last_error_reason=None,
                         last_error_message=None,
                         last_error_reset_at=None,
+                        consecutive_failures=0,
                     )
                     self._replace_entry(synced, updated)
                     self._persist()
@@ -788,6 +844,7 @@ class CredentialPool:
             last_error_reason=None,
             last_error_message=None,
             last_error_reset_at=None,
+            consecutive_failures=0,
         )
         self._replace_entry(entry, updated)
         self._persist()
@@ -1010,7 +1067,8 @@ class CredentialPool:
         count = 0
         new_entries = []
         for entry in self._entries:
-            if entry.last_status or entry.last_status_at or entry.last_error_code:
+            if (entry.last_status or entry.last_status_at
+                    or entry.last_error_code or entry.consecutive_failures):
                 new_entries.append(
                     replace(
                         entry,
@@ -1020,6 +1078,10 @@ class CredentialPool:
                         last_error_reason=None,
                         last_error_message=None,
                         last_error_reset_at=None,
+                        # Operator-driven reset: clear the backoff streak
+                        # too so the next exhaustion starts at base TTL
+                        # rather than 8× cap (#15296).
+                        consecutive_failures=0,
                     )
                 )
                 count += 1

--- a/tests/agent/test_credential_pool_backoff.py
+++ b/tests/agent/test_credential_pool_backoff.py
@@ -1,0 +1,363 @@
+"""Regression guard for #15296 — exponential backoff on credential exhaustion.
+
+The credential pool's ``_exhausted_ttl`` was a flat ``EXHAUSTED_TTL_*``
+constant regardless of how many consecutive times a credential had
+failed.  When a provider was overloaded for hours, the pool cycled
+through:
+
+    TTL expires → cleared to ``ok`` → tried again → fails with same
+    error (3 retries wasted) → marked exhausted with same flat TTL → wait
+    → repeat
+
+For cron jobs (each run = one turn), every execution burned its retry
+budget on the same dead credential until the upstream actually
+recovered.
+
+Fix — track ``consecutive_failures`` on each ``PooledCredential`` entry,
+increment in ``_mark_exhausted``, reset on a successful refresh OR an
+operator-initiated ``reset_statuses`` call, and use it as an exponent
+on the cooldown TTL.  The ``clear_expired`` path that auto-clears an
+entry back to ``STATUS_OK`` after the cooldown elapses **deliberately
+does NOT reset the counter** — that's the entire point: if the same
+credential exhausts again right after the cooldown expires, the
+upstream is still down and the next cooldown should be longer.
+
+These tests pin the contract at the production-code entry points
+(``_exhausted_ttl``, ``_mark_exhausted``, ``_exhausted_until``,
+``reset_statuses``) so attribute renames or formula tweaks surface
+loudly.
+"""
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+from agent.credential_pool import (
+    EXHAUSTED_TTL_429_SECONDS,
+    EXHAUSTED_TTL_BACKOFF_CAP,
+    EXHAUSTED_TTL_DEFAULT_SECONDS,
+    PooledCredential,
+    _exhausted_ttl,
+    _exhausted_until,
+)
+
+
+# ---------------------------------------------------------------------------
+# _exhausted_ttl — pure function, easy to pin
+# ---------------------------------------------------------------------------
+
+
+class TestExhaustedTtl:
+    """``_exhausted_ttl(error_code, consecutive_failures)`` formula."""
+
+    def test_default_ttl_when_no_failures_recorded(self):
+        """Backward-compat: callers that don't pass ``consecutive_failures``
+        (or pre-#15296 on-disk entries that lack the field) get the same
+        flat TTL the pool always returned."""
+        assert _exhausted_ttl(429) == EXHAUSTED_TTL_429_SECONDS
+        assert _exhausted_ttl(402) == EXHAUSTED_TTL_DEFAULT_SECONDS
+        assert _exhausted_ttl(None) == EXHAUSTED_TTL_DEFAULT_SECONDS
+
+    def test_first_failure_uses_base_ttl(self):
+        """``consecutive_failures=1`` means this is the first exhaustion;
+        the multiplier exponent is ``failures - 1 = 0``, so ``2 ** 0 = 1×``
+        — same as the no-failures default.  Prevents accidental 2× on
+        the very first failure."""
+        assert _exhausted_ttl(429, consecutive_failures=1) == EXHAUSTED_TTL_429_SECONDS
+
+    @pytest.mark.parametrize("failures,multiplier", [
+        (1, 1),
+        (2, 2),
+        (3, 4),
+        (4, 8),
+        (5, 8),    # capped
+        (6, 8),    # capped
+        (10, 8),   # capped
+        (100, 8),  # capped
+    ])
+    def test_backoff_progression_429(self, failures, multiplier):
+        """1h → 2h → 4h → 8h → cap at 8h.  The cap matters: without it
+        a long-running outage could push the cooldown into days, which
+        survives operator intervention (refresh upstream provider, swap
+        keys) and feels broken from the user side."""
+        expected = EXHAUSTED_TTL_429_SECONDS * multiplier
+        assert _exhausted_ttl(429, consecutive_failures=failures) == expected
+
+    @pytest.mark.parametrize("failures,multiplier", [
+        (1, 1), (2, 2), (3, 4), (4, 8), (5, 8), (10, 8),
+    ])
+    def test_backoff_progression_402(self, failures, multiplier):
+        """Same backoff applies to non-429 cooldowns (e.g. 402 billing)."""
+        expected = EXHAUSTED_TTL_DEFAULT_SECONDS * multiplier
+        assert _exhausted_ttl(402, consecutive_failures=failures) == expected
+
+    def test_zero_failures_treated_as_default(self):
+        """``consecutive_failures=0`` is the on-disk default for entries
+        that have never been marked exhausted — must produce 1× the base
+        TTL, not 0× (which would zero the cooldown and let a freshly
+        exhausted credential be reused immediately)."""
+        assert _exhausted_ttl(429, consecutive_failures=0) == EXHAUSTED_TTL_429_SECONDS
+
+    def test_negative_failures_treated_as_default(self):
+        """Defensive: a corrupted on-disk entry with a negative count
+        must NOT shrink the cooldown below base.  ``max(0, failures-1)``
+        clamps the exponent to 0 minimum."""
+        assert _exhausted_ttl(429, consecutive_failures=-5) == EXHAUSTED_TTL_429_SECONDS
+
+    def test_cap_constant_is_eight(self):
+        """Pin the documented cap value so a refactor that changes
+        ``EXHAUSTED_TTL_BACKOFF_CAP`` flags this test, prompting a
+        comment update."""
+        assert EXHAUSTED_TTL_BACKOFF_CAP == 8
+
+
+# ---------------------------------------------------------------------------
+# _exhausted_until — uses _exhausted_ttl with the entry's failure count
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(**overrides):
+    """Build a minimal ``PooledCredential`` for cooldown tests."""
+    base = dict(
+        provider="openrouter",
+        id="cred-1",
+        label="primary",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="sk-test",
+        last_status="exhausted",
+        last_status_at=1_000_000.0,
+        last_error_code=429,
+        consecutive_failures=1,
+    )
+    base.update(overrides)
+    return PooledCredential(**base)
+
+
+class TestExhaustedUntil:
+    """``_exhausted_until(entry)`` returns the absolute time when the
+    entry stops being in cooldown.  After backoff, that time should
+    extend further on each consecutive failure."""
+
+    def test_first_failure_yields_one_base_ttl_after_status_at(self):
+        entry = _make_entry(consecutive_failures=1)
+        until = _exhausted_until(entry)
+        assert until == entry.last_status_at + EXHAUSTED_TTL_429_SECONDS
+
+    def test_fourth_failure_yields_eight_base_ttls_after_status_at(self):
+        entry = _make_entry(consecutive_failures=4)
+        until = _exhausted_until(entry)
+        assert until == entry.last_status_at + 8 * EXHAUSTED_TTL_429_SECONDS
+
+    def test_capped_at_eight_after_many_failures(self):
+        entry = _make_entry(consecutive_failures=20)
+        until = _exhausted_until(entry)
+        assert until == entry.last_status_at + 8 * EXHAUSTED_TTL_429_SECONDS
+
+    def test_explicit_reset_at_overrides_backoff(self):
+        """When the provider sends a ``reset_at`` header (e.g. Anthropic
+        long-context-tier reset), that absolute timestamp wins — the
+        backoff multiplier is irrelevant because the upstream told us
+        exactly when to retry."""
+        entry = _make_entry(
+            consecutive_failures=10,  # would normally be 8× cooldown
+            last_error_reset_at=1_000_500.0,  # 500s away — much sooner
+        )
+        until = _exhausted_until(entry)
+        assert until == 1_000_500.0
+
+
+# ---------------------------------------------------------------------------
+# _mark_exhausted increments the counter
+# ---------------------------------------------------------------------------
+
+
+def _make_pool_with_one_entry(tmp_path, monkeypatch, *, consecutive_failures=0):
+    """Build a real pool on disk so ``_mark_exhausted`` exercises the
+    real persistence path, not a mock surrogate.  Mirrors the pattern
+    in ``test_credential_pool.py``'s helpers."""
+    import json
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    auth = home / "auth.json"
+    auth.write_text(json.dumps({
+        "version": 1,
+        "credential_pool": {
+            "openrouter": [
+                {
+                    "id": "cred-1",
+                    "label": "primary",
+                    "auth_type": "api_key",
+                    "priority": 0,
+                    "source": "manual",
+                    "access_token": "sk-test",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "consecutive_failures": consecutive_failures,
+                }
+            ]
+        },
+    }))
+
+    from agent.credential_pool import load_pool
+    return load_pool("openrouter")
+
+
+class TestMarkExhaustedIncrement:
+    """``_mark_exhausted`` must increment ``consecutive_failures`` from
+    the prior value, persist it, and let ``_exhausted_until`` see the
+    new count."""
+
+    def test_first_exhaustion_sets_counter_to_one(self, tmp_path, monkeypatch):
+        pool = _make_pool_with_one_entry(tmp_path, monkeypatch, consecutive_failures=0)
+        entry = pool._entries[0]
+        assert entry.consecutive_failures == 0
+
+        updated = pool._mark_exhausted(entry, status_code=429)
+        assert updated.consecutive_failures == 1
+
+    def test_consecutive_exhaustions_accumulate(self, tmp_path, monkeypatch):
+        """The whole point of the fix: if the same credential exhausts
+        again WITHOUT being successfully refreshed in between, the
+        counter keeps climbing.  Otherwise the cooldown can never
+        actually back off."""
+        pool = _make_pool_with_one_entry(tmp_path, monkeypatch, consecutive_failures=2)
+        entry = pool._entries[0]
+        assert entry.consecutive_failures == 2
+
+        updated = pool._mark_exhausted(entry, status_code=429)
+        assert updated.consecutive_failures == 3
+
+    def test_increment_persists_to_disk(self, tmp_path, monkeypatch):
+        """Reload from disk to confirm the counter survives a pool
+        rebuild — without persistence the backoff would reset on every
+        gateway restart."""
+        pool = _make_pool_with_one_entry(tmp_path, monkeypatch)
+        entry = pool._entries[0]
+        pool._mark_exhausted(entry, status_code=429)
+        pool._mark_exhausted(pool._entries[0], status_code=429)
+        pool._mark_exhausted(pool._entries[0], status_code=429)
+
+        from agent.credential_pool import load_pool
+        reloaded = load_pool("openrouter")
+        assert reloaded._entries[0].consecutive_failures == 3
+
+    def test_increment_handles_legacy_entry_missing_field(self, tmp_path, monkeypatch):
+        """Defensive: a pool entry persisted before this PR doesn't
+        carry the ``consecutive_failures`` field on disk.  When loaded,
+        the dataclass default kicks in (0); ``_mark_exhausted`` must
+        therefore correctly set it to 1, not crash with ``AttributeError``
+        or silently start at the (legacy-loaded) None."""
+        import json
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        home = tmp_path / "hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        # Note: deliberately omit consecutive_failures from the on-disk
+        # payload — the pre-#15296 schema.
+        (home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "legacy",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-test",
+                    }
+                ]
+            },
+        }))
+
+        from agent.credential_pool import load_pool
+        pool = load_pool("openrouter")
+        entry = pool._entries[0]
+        assert entry.consecutive_failures == 0  # dataclass default
+
+        updated = pool._mark_exhausted(entry, status_code=429)
+        assert updated.consecutive_failures == 1
+
+
+# ---------------------------------------------------------------------------
+# Reset semantics — when does the counter zero out?
+# ---------------------------------------------------------------------------
+
+
+class TestCounterResetSemantics:
+    """The streak persists across cooldown auto-clears (the bug fix's
+    whole point) but resets on real success markers and operator
+    intervention."""
+
+    def test_reset_statuses_clears_counter(self, tmp_path, monkeypatch):
+        """``reset_statuses()`` is the explicit operator command —
+        clear everything including the streak."""
+        pool = _make_pool_with_one_entry(tmp_path, monkeypatch, consecutive_failures=5)
+        assert pool._entries[0].consecutive_failures == 5
+
+        pool.reset_statuses()
+        assert pool._entries[0].consecutive_failures == 0
+
+    def test_clear_expired_does_not_reset_counter(self, tmp_path, monkeypatch):
+        """Critical for #15296: when the cooldown auto-elapses and the
+        entry becomes available again, the streak MUST persist.  If we
+        reset here, the next exhaustion would start at 1× again — the
+        backoff would never accumulate, defeating the entire fix.
+        """
+        import time
+        import json
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        home = tmp_path / "hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        # Entry exhausted long enough ago that the 1× cooldown has
+        # elapsed.  ``consecutive_failures=3`` means a 4× cooldown
+        # would still be in effect.  Use cf=1 here so we test the
+        # auto-clear path without the cooldown blocking.
+        long_ago = time.time() - 2 * EXHAUSTED_TTL_429_SECONDS
+        (home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-test",
+                        "last_status": "exhausted",
+                        "last_status_at": long_ago,
+                        "last_error_code": 429,
+                        "consecutive_failures": 1,
+                    }
+                ]
+            },
+        }))
+
+        from agent.credential_pool import load_pool
+        pool = load_pool("openrouter")
+        # Expired entries get cleared back to STATUS_OK during select.
+        available = pool._available_entries(clear_expired=True)
+        assert len(available) == 1
+        assert available[0].last_status == "ok"
+        # The streak must NOT have been zeroed — that's the bug fix.
+        assert available[0].consecutive_failures == 1, (
+            "clear_expired auto-reset wiped consecutive_failures; the "
+            "next exhaustion would restart at 1× cooldown instead of "
+            "extending the backoff (#15296)"
+        )
+
+    def test_consecutive_failures_field_round_trips_through_to_dict(self, tmp_path, monkeypatch):
+        """The new field must survive the on-disk JSON round-trip.
+        Without explicit serialization support, a value of 0 might be
+        dropped (the existing ``to_dict`` skips ``None``-but-not-zero
+        fields, so 0 should serialize fine — pinned here in case the
+        skip rules change)."""
+        pool = _make_pool_with_one_entry(tmp_path, monkeypatch, consecutive_failures=4)
+        as_dict = pool._entries[0].to_dict()
+        assert as_dict.get("consecutive_failures") == 4
+
+        # Round trip via from_dict.
+        rebuilt = PooledCredential.from_dict("openrouter", as_dict)
+        assert rebuilt.consecutive_failures == 4

--- a/tests/agent/test_credential_pool_backoff.py
+++ b/tests/agent/test_credential_pool_backoff.py
@@ -27,9 +27,6 @@ These tests pin the contract at the production-code entry points
 ``reset_statuses``) so attribute renames or formula tweaks surface
 loudly.
 """
-from dataclasses import replace
-from unittest.mock import patch
-
 import pytest
 
 from agent.credential_pool import (
@@ -109,6 +106,55 @@ class TestExhaustedTtl:
         ``EXHAUSTED_TTL_BACKOFF_CAP`` flags this test, prompting a
         comment update."""
         assert EXHAUSTED_TTL_BACKOFF_CAP == 8
+
+    @pytest.mark.parametrize("bad_value", [None, "5", "not-a-number", 3.7, [], {}])
+    def test_corrupted_failure_value_falls_back_to_zero(self, bad_value):
+        """A malformed ``consecutive_failures`` value (string, list,
+        ``None``, etc.) from a hand-edited or migrated ``auth.json``
+        must NOT crash cooldown resolution — Copilot caught this on
+        #15455.  Fall back to the un-multiplied base TTL instead of
+        propagating ``ValueError`` from inside the failover path.
+
+        ``"5"`` is included intentionally: even though Python's
+        ``int(\"5\")`` would succeed, we prefer the conservative path
+        of treating un-typed inputs as 0 so the contract is uniform.
+        """
+        result = _exhausted_ttl(429, consecutive_failures=bad_value)
+        # The "5" string DOES coerce cleanly via int() in our helper —
+        # that's the one defensive case we choose to honour rather than
+        # discard, since it's unambiguous numeric data.
+        if bad_value == "5":
+            assert result == EXHAUSTED_TTL_429_SECONDS * 8  # 5→exponent 3→cap
+        elif bad_value == 3.7:
+            assert result == EXHAUSTED_TTL_429_SECONDS * 4  # int(3.7)=3, exp=2
+        else:
+            assert result == EXHAUSTED_TTL_429_SECONDS  # 1× base
+
+    def test_runaway_failure_count_does_not_compute_huge_int(self):
+        """Regression guard for Copilot's #15455 perf comment: a
+        credential whose upstream is permanently dead could see the
+        counter climb to thousands.  Without an exponent clamp,
+        ``2 ** 10000`` would materialise a ~3000-digit integer just to
+        be discarded by the ``min(..., CAP)``.  We clamp the exponent
+        BEFORE the shift, so the actual integer math stays trivial.
+
+        This test asserts the result equals the cap (no surprise) AND
+        that it returns instantly — if the clamp regressed, the
+        big-int construction would still produce the right value but
+        burn measurable wall time on the way there.
+        """
+        import time as _time
+        start = _time.monotonic()
+        result = _exhausted_ttl(429, consecutive_failures=10_000)
+        elapsed = _time.monotonic() - start
+        assert result == EXHAUSTED_TTL_429_SECONDS * 8
+        # Tight bound: should be sub-millisecond on every machine.
+        # If the clamp regresses to ``2 ** 10000``, this jumps to
+        # tens or hundreds of milliseconds depending on arch.
+        assert elapsed < 0.05, (
+            f"_exhausted_ttl took {elapsed:.4f}s — exponent clamp likely "
+            f"regressed; ``2 ** 10000`` is being computed before the cap"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes \`#15296\`. The pool's \`_exhausted_ttl\` returned a flat \`EXHAUSTED_TTL_*\` constant regardless of how many consecutive times the same credential had failed. When a provider was overloaded for hours, the pool cycled through:

1. TTL expires → credential cleared back to \`ok\`
2. Provider tried again → fails with the same error (3 retries wasted)
3. Credential re-exhausted with the same flat TTL
4. Wait for TTL to expire again → repeat

For cron jobs (each run = one turn), every execution burned its retry budget on the same dead credential until the upstream actually recovered.

## Fix

- **New \`consecutive_failures: int = 0\` field on \`PooledCredential\`**
- **\`_mark_exhausted\` increments it from the prior value** (defensive \`getattr\` + \`or 0\` so legacy on-disk entries that predate the field default to 0 via the dataclass and get promoted to 1 on first failure)
- **\`_exhausted_ttl(error_code, consecutive_failures=0)\`** now applies \`base_ttl * min(2 ** (failures - 1), 8)\` — capped at 8× so a long-running outage doesn't push the cooldown into days. The default-arg keeps backward compat with any caller still using the old single-arg signature.
- **\`_exhausted_until\` passes \`entry.consecutive_failures\` through**
- **Resets to 0** happen on real success markers (refresh produces fresh tokens, anthropic claude_code sync from credentials file, nous adopts newer tokens from auth.json) and on operator-driven \`reset_statuses()\`
- **The cooldown auto-clear path** (\`_available_entries(clear_expired=True)\` flipping \`last_status\` back to \`STATUS_OK\` when the TTL elapses) **deliberately does NOT reset the counter** — that's the entire point of the fix. If the same credential exhausts again right after the cooldown expires, the upstream is still down and the next cooldown should be longer.

### Backoff progression

| consecutive_failures | multiplier | cooldown (default 1h base) |
|---:|---:|---|
| 0 (default) | 1× | 1h |
| 1 (first) | 1× | 1h |
| 2 | 2× | 2h |
| 3 | 4× | 4h |
| 4 | 8× | 8h |
| 5+ | 8× | 8h (cap) |

The 8h cap matters: without it, a credential that's been failing for a week could end up on a multi-day cooldown that survives operator intervention (refreshing the upstream provider, swapping API keys, etc.).

## Related Issue

Fixes #15296

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Test plan

- [x] **21 new tests in \`tests/agent/test_credential_pool_backoff.py\`** — all green on py3.11 venv
- [x] **All 44 pre-existing \`test_credential_pool.py\` tests still pass** — backward compat preserved (the default-argument keeps the single-arg signature working)
- [x] **Verified regression guards**: temporarily reverted the \`_mark_exhausted\` increment to a no-op; 4 tests in \`TestMarkExhaustedIncrement\` correctly failed with clear assertion messages pointing at the regressed invariant. Restored fix → all 30 backoff tests pass.

## Test coverage detail

**\`TestExhaustedTtl\`** (8 cases):
- Backward-compat default (no \`consecutive_failures\` arg → flat base TTL)
- \`consecutive_failures=1\` is 1× (not 2×) — prevents off-by-one on the very first failure
- 8-row parametrised matrix on 429 progression: 1× → 2× → 4× → 8× → cap
- Same matrix on 402 (non-429 cooldowns also back off)
- \`consecutive_failures=0\` defensive default
- Negative count clamped to base (corrupted on-disk entry safety)
- Cap constant pinned to 8 so a refactor flagging this test prompts a docstring update

**\`TestExhaustedUntil\`** (4 cases):
- First failure → 1× base TTL after \`last_status_at\`
- Fourth failure → 8× base TTL
- 20 failures → still 8× (cap holds)
- Explicit \`last_error_reset_at\` from upstream wins over backoff (provider-supplied resets are absolute truth)

**\`TestMarkExhaustedIncrement\`** (4 cases):
- 0 → 1 on first exhaustion
- 2 → 3 on consecutive (the streak persists)
- Round-trips through pool reload (persistence)
- Legacy on-disk entry without the field → loads as 0, increments to 1

**\`TestCounterResetSemantics\`** (3 cases):
- \`reset_statuses()\` zeroes the counter (operator path)
- **\`clear_expired\` does NOT zero the counter** — the bug-fix invariant; without this assertion a future refactor could silently break the backoff
- \`to_dict\`/\`from_dict\` round-trips the field

## Companion PRs

This is one of three related credential-pool resilience fixes filed by @mordekai-lab:
- **#15297** — error classifier disambiguates 429 \"overloaded\" from rate_limit (my open PR #15414)
- **#15298** — \`_restore_primary_runtime\` cooldown check (Tranquil-Flow's #15434)
- **#15296** — this PR

The three are independent and can land in any order.

## Not in scope

- Per-provider tuning of the cap or base TTL — currently uses the same 8× cap for every provider. A future enhancement could let providers configure their own backoff curve, but that's a bigger surface than this user-facing regression needs to unblock.