### PR TITLE
feat(session): inject Discord IDs into session context prompt

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2543,6 +2543,9 @@ class BasePlatformAdapter(ABC):
         user_id_alt: Optional[str] = None,
         chat_id_alt: Optional[str] = None,
         is_bot: bool = False,
+        guild_id: Optional[str] = None,
+        parent_chat_id: Optional[str] = None,
+        message_id: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -2560,6 +2563,9 @@ class BasePlatformAdapter(ABC):
             user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt,
             is_bot=is_bot,
+            guild_id=str(guild_id) if guild_id else None,
+            parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+            message_id=str(message_id) if message_id else None,
         )
     
     @abstractmethod

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3261,6 +3261,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)
                 if thread:
+                    parent_channel_id = str(message.channel.id)
                     is_thread = True
                     thread_id = str(thread.id)
                     auto_threaded_channel = thread
@@ -3320,6 +3321,9 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             chat_topic=chat_topic,
             is_bot=getattr(message.author, "bot", False),
+            guild_id=str(message.guild.id) if message.guild else None,
+            parent_chat_id=parent_channel_id,
+            message_id=str(message.id),
         )
 
         # Build media URLs -- download image attachments to local cache so the

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -289,14 +289,21 @@ def build_session_context_prompt(
             "that you can only read messages sent directly to you and respond."
         )
     elif context.source.platform == Platform.DISCORD:
-        lines.append("")
-        lines.append(
-            "**Platform notes:** You are running inside Discord. "
-            "You do NOT have access to Discord-specific APIs — you cannot search "
-            "channel history, pin messages, manage roles, or list server members. "
-            "Do not promise to perform these actions. If the user asks, explain "
-            "that you can only read messages sent directly to you and respond."
-        )
+        # Only emit the "no Discord APIs" disclaimer when the discord tool
+        # can't load.  The tool self-gates on DISCORD_BOT_TOKEN at registry
+        # check time, so matching that condition keeps the prompt honest:
+        # with a token the agent has fetch_messages/search_members/
+        # create_thread (and optionally discord_admin); without one it
+        # really is limited to reading/replying via the gateway.
+        if not (os.environ.get("DISCORD_BOT_TOKEN") or "").strip():
+            lines.append("")
+            lines.append(
+                "**Platform notes:** You are running inside Discord. "
+                "You do NOT have access to Discord-specific APIs — you cannot search "
+                "channel history, pin messages, manage roles, or list server members. "
+                "Do not promise to perform these actions. If the user asks, explain "
+                "that you can only read messages sent directly to you and respond."
+            )
     elif context.source.platform == Platform.BLUEBUBBLES:
         lines.append("")
         lines.append(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -87,6 +87,9 @@ class SessionSource:
     user_id_alt: Optional[str] = None  # Platform-specific stable alt ID (Signal UUID, Feishu union_id)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
     is_bot: bool = False  # True when the message author is a bot/webhook (Discord)
+    guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
+    parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
+    message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
     
     @property
     def description(self) -> str:
@@ -124,8 +127,14 @@ class SessionSource:
             d["user_id_alt"] = self.user_id_alt
         if self.chat_id_alt:
             d["chat_id_alt"] = self.chat_id_alt
+        if self.guild_id:
+            d["guild_id"] = self.guild_id
+        if self.parent_chat_id:
+            d["parent_chat_id"] = self.parent_chat_id
+        if self.message_id:
+            d["message_id"] = self.message_id
         return d
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionSource":
         return cls(
@@ -139,6 +148,9 @@ class SessionSource:
             chat_topic=data.get("chat_topic"),
             user_id_alt=data.get("user_id_alt"),
             chat_id_alt=data.get("chat_id_alt"),
+            guild_id=data.get("guild_id"),
+            parent_chat_id=data.get("parent_chat_id"),
+            message_id=data.get("message_id"),
         )
     
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -289,13 +289,26 @@ def build_session_context_prompt(
             "that you can only read messages sent directly to you and respond."
         )
     elif context.source.platform == Platform.DISCORD:
-        # Only emit the "no Discord APIs" disclaimer when the discord tool
-        # can't load.  The tool self-gates on DISCORD_BOT_TOKEN at registry
-        # check time, so matching that condition keeps the prompt honest:
+        # The discord tool self-gates on DISCORD_BOT_TOKEN at registry
+        # check time.  Match that condition so the prompt stays honest:
         # with a token the agent has fetch_messages/search_members/
-        # create_thread (and optionally discord_admin); without one it
-        # really is limited to reading/replying via the gateway.
-        if not (os.environ.get("DISCORD_BOT_TOKEN") or "").strip():
+        # create_thread (and optionally discord_admin) and should know
+        # the IDs it can call them with; without one it really is
+        # limited to reading/replying via the gateway.
+        if (os.environ.get("DISCORD_BOT_TOKEN") or "").strip():
+            src = context.source
+            id_lines = ["", "**Discord IDs (for the `discord` / `discord_admin` tools):**"]
+            if src.guild_id:
+                id_lines.append(f"  - Guild: `{src.guild_id}`")
+            if src.thread_id and src.parent_chat_id:
+                id_lines.append(f"  - Parent channel: `{src.parent_chat_id}`")
+                id_lines.append(f"  - Thread: `{src.thread_id}` (use as `channel_id` for fetch_messages etc.)")
+            else:
+                id_lines.append(f"  - Channel: `{src.chat_id}`")
+            if src.message_id:
+                id_lines.append(f"  - Triggering message: `{src.message_id}`")
+            lines.extend(id_lines)
+        else:
             lines.append("")
             lines.append(
                 "**Platform notes:** You are running inside Discord. "


### PR DESCRIPTION
## Summary
- Add `guild_id`, `parent_chat_id`, `message_id` fields to `SessionSource` dataclass
- Populate these fields from the Discord adapter when constructing session sources
- Gate the "no Discord APIs" disclaimer on `DISCORD_BOT_TOKEN` presence — when the token exists, the agent has the discord tools and the disclaimer is misleading
- When the token is present, inject a Discord IDs block into the session context prompt so the agent knows which guild/channel/thread/message IDs to pass to `discord` / `discord_admin` tool calls

Stacked on #15457 — merge that first, then retarget this to `main`.

## Test plan
- [x] Existing gateway session tests pass
- [x] Discord tool tests pass with split tools
- [x] Verify `build_session_context_prompt` includes IDs when `DISCORD_BOT_TOKEN` is set
- [x] Verify disclaimer is emitted when `DISCORD_BOT_TOKEN` is absent