### PR TITLE
fix(agent): prevent GLM stop-to-length heuristic false positives (#14572)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -524,7 +524,16 @@ agent:
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
-  
+
+  # Ollama/GLM truncation heuristic.  When using Ollama-hosted GLM models,
+  # some finish_reason='stop' responses are actually truncated.  This heuristic
+  # detects such cases and requests continuations.  However, it can false-trigger
+  # on responses ending with emoji sign-offs or conversational text lacking
+  # terminal punctuation (see #14572).  The heuristic now has guard rails
+  # (500-char minimum, emoji recognition) but if you still hit false positives,
+  # set this to false to disable it entirely.
+  # glm_truncation_heuristic: true
+
   # Enable verbose logging
   verbose: false
   

--- a/run_agent.py
+++ b/run_agent.py
@@ -36,6 +36,7 @@ import sys
 import tempfile
 import time
 import threading
+import unicodedata
 from types import SimpleNamespace
 import urllib.request
 import uuid
@@ -2830,7 +2831,6 @@ class AIAgent:
 
         # Strip trailing variation selectors (U+FE0F) and zero-width joiners
         # (U+200D) that emoji sequences use, so we check the "real" base glyph.
-        import unicodedata
         i = len(stripped) - 1
         while i >= 0 and unicodedata.category(stripped[i]) in ("Mn", "Me", "Cf"):
             i -= 1
@@ -2843,22 +2843,20 @@ class AIAgent:
             return True
 
         # Emoji and other Unicode sign-off glyphs.
-        # We already imported unicodedata above.  We use it rather than a
-        # hard-coded codepoint list so we automatically cover new emoji as
-        # Python's Unicode database grows.
+        # We use unicodedata categories rather than a hard-coded codepoint
+        # list so we automatically cover new emoji as Python's Unicode
+        # database grows.
         cat = unicodedata.category(last_char)
-        # So (Other_Symbol) covers ✨ 💪 🚀 etc.
+        # So (Other_Symbol) covers ✨ 💪 🚀 ✅ ❌ ⚠ etc.
         # Sk (Modifier_Symbol) covers VS16 (❤️ variation selector, etc.)
-        if cat in ("So", "Sk"):
+        # Sm (Math_Symbol) covers → ← ∞ ≈ and similar sign-off glyphs.
+        if cat in ("So", "Sk", "Sm"):
             return True
         # Emoji_Presentation property: many emoji are General_Category=So
         # but some are in Lo/Lm/Other.  Check the wide "Extended_Pictographic"
         # property via the Emoji character range heuristic (U+1F000..U+1FAFF).
         cp = ord(last_char)
         if 0x1F000 <= cp <= 0x1FAFF:
-            return True
-        # A few common sign-off codepoints outside those ranges.
-        if last_char in "✓✔✗✘♠♣♥♦♪♫☀☁☂★☆":
             return True
 
         return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -1700,6 +1700,17 @@ class AIAgent:
             _agent_section = {}
         self._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+        # Ollama/GLM stop-to-length truncation heuristic.  Enabled by default
+        # but can be disabled via agent.glm_truncation_heuristic: false in
+        # config.yaml.  See #14572 for the false-positive bug that led to
+        # this being made configurable.
+        _glm_heuristic = _agent_section.get("glm_truncation_heuristic", True)
+        self._glm_truncation_heuristic_enabled = (
+            str(_glm_heuristic).lower() in ("true", "1", "yes")
+            if isinstance(_glm_heuristic, str)
+            else bool(_glm_heuristic)
+        )
+
         # App-level API retry count (wraps each model API call).  Default 3,
         # overridable via agent.api_max_retries in config.yaml.  See #11616.
         try:
@@ -2799,7 +2810,16 @@ class AIAgent:
 
     @staticmethod
     def _has_natural_response_ending(content: str) -> bool:
-        """Heuristic: does visible assistant text look intentionally finished?"""
+        """Heuristic: does visible assistant text look intentionally finished?
+
+        Recognises ASCII/CJK punctuation, emoji, and other common sign-off
+        glyphs as natural endings.  Returns True for characters that are
+        unlikely to appear mid-sentence in a truncated response.
+
+        Extended in #14572 to cover emoji sign-offs (e.g. 💛, ✨, 🙌)
+        which were previously false-positive triggers for the Ollama/GLM
+        stop-to-length heuristic.
+        """
         if not content:
             return False
         stripped = content.rstrip()
@@ -2807,7 +2827,41 @@ class AIAgent:
             return False
         if stripped.endswith("```"):
             return True
-        return stripped[-1] in '.!?:)"\']}。！？：）】」』》'
+
+        # Strip trailing variation selectors (U+FE0F) and zero-width joiners
+        # (U+200D) that emoji sequences use, so we check the "real" base glyph.
+        import unicodedata
+        i = len(stripped) - 1
+        while i >= 0 and unicodedata.category(stripped[i]) in ("Mn", "Me", "Cf"):
+            i -= 1
+        if i < 0:
+            return False
+        last_char = stripped[i]
+
+        # ASCII and CJK punctuation that signal a complete thought.
+        if last_char in '.!?:)"\']}。！？：）】」』》':
+            return True
+
+        # Emoji and other Unicode sign-off glyphs.
+        # We already imported unicodedata above.  We use it rather than a
+        # hard-coded codepoint list so we automatically cover new emoji as
+        # Python's Unicode database grows.
+        cat = unicodedata.category(last_char)
+        # So (Other_Symbol) covers ✨ 💪 🚀 etc.
+        # Sk (Modifier_Symbol) covers VS16 (❤️ variation selector, etc.)
+        if cat in ("So", "Sk"):
+            return True
+        # Emoji_Presentation property: many emoji are General_Category=So
+        # but some are in Lo/Lm/Other.  Check the wide "Extended_Pictographic"
+        # property via the Emoji character range heuristic (U+1F000..U+1FAFF).
+        cp = ord(last_char)
+        if 0x1F000 <= cp <= 0x1FAFF:
+            return True
+        # A few common sign-off codepoints outside those ranges.
+        if last_char in "✓✔✗✘♠♣♥♦♪♫☀☁☂★☆":
+            return True
+
+        return False
 
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""
@@ -2825,7 +2879,28 @@ class AIAgent:
         assistant_message,
         messages: Optional[list] = None,
     ) -> bool:
-        """Detect conservative stop->length misreports for Ollama-hosted GLM models."""
+        """Detect conservative stop->length misreports for Ollama-hosted GLM models.
+
+        The Ollama/GLM backend sometimes reports finish_reason='stop' on
+        responses that were actually truncated by the max_tokens limit.
+        This heuristic detects such cases by looking for responses that
+        appear to end mid-sentence (no natural ending punctuation or emoji).
+
+        Guard rails (to avoid false positives, cf. #14572):
+          - Config flag agent.glm_truncation_heuristic (default True) disables the
+            heuristic entirely when set to False.
+          - Short responses (<500 chars with whitespace) are almost certainly
+            complete — a truly truncated response would be long enough to hit
+            the token limit.
+          - Only applies after tool-use turns (Ollama/GLM is known to
+            misreport stop-after-tool continuations).
+          - Responses ending with emoji or other Unicode sign-off glyphs are
+            treated as naturally complete (see _has_natural_response_ending).
+        """
+        # Config opt-out: if the user has disabled the heuristic, never trigger.
+        if not getattr(self, "_glm_truncation_heuristic_enabled", True):
+            return False
+
         if finish_reason != "stop" or self.api_mode != "chat_completions":
             return False
         if not self._is_ollama_glm_backend():
@@ -2845,7 +2920,16 @@ class AIAgent:
         visible_text = self._strip_think_blocks(content).strip()
         if not visible_text:
             return False
+        # Very short responses with spaces are almost certainly complete —
+        # they couldn't have hit a meaningful token limit.
         if len(visible_text) < 20 or not re.search(r"\s", visible_text):
+            return False
+        # Short-to-medium responses (<500 chars) are very unlikely to be
+        # truncated.  Raising this gate from 20 to 500 eliminates the vast
+        # majority of false positives from conversational replies that simply
+        # lack terminal punctuation.  (See #14572 for the original bug where
+        # emoji sign-offs triggered continuation loops on every turn.)
+        if len(visible_text) < 500:
             return False
 
         return not self._has_natural_response_ending(visible_text)

--- a/tests/run_agent/test_glm_stop_heuristic.py
+++ b/tests/run_agent/test_glm_stop_heuristic.py
@@ -1,0 +1,367 @@
+"""Tests for Ollama/GLM stop-to-length truncation heuristic (bug #14572).
+
+The heuristic in _should_treat_stop_as_truncated() reclassifies certain
+Ollama/GLM finish_reason='stop' responses as truncated, then requests
+continuations.  This is necessary because Ollama/GLM sometimes reports
+genuinely truncated output as stop rather than length.
+
+However, the heuristic was too aggressive: any response not ending with
+a whitelisted punctuation character was treated as truncated.  Since
+the whitelist only covered ASCII and CJK punctuation, responses ending
+with emoji (like yellow_heart, sparkles, raised_hands), Markdown links,
+or just bare words were all false-positive triggers -- each one wasted
+up to 3 continuation API calls.
+
+These tests verify the fix:
+  1. _has_natural_response_ending() now recognizes emoji and other
+     common Unicode sign-off characters as natural endings.
+  2. _should_treat_stop_as_truncated() has a minimum-length gate
+     (short responses within max_tokens budget are NOT suspicious).
+  3. A config flag agent.glm_truncation_heuristic allows users to
+     disable the heuristic entirely if they hit edge cases.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id="c1"):
+    tc = MagicMock()
+    tc.function.name = name
+    tc.function.arguments = arguments
+    tc.id = call_id
+    tc.type = "function"
+    return tc
+
+
+def _mock_response(content="", finish_reason="stop", tool_calls=None):
+    msg = MagicMock()
+    msg.content = content
+    msg.tool_calls = tool_calls
+    msg.finish_reason = finish_reason
+    msg.function_call = None
+    msg.refusal = None
+    msg.role = "assistant"
+    msg.audio = None
+    msg.annotations = []
+    return msg
+
+
+def _make_agent(base_url="http://localhost:11434/v1", model="glm-5.1:cloud"):
+    """Create a minimal AIAgent wired for Ollama/GLM."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=MagicMock(),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            model=model,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._base_url_lower = base_url.lower()
+    agent.client = MagicMock()
+    return agent
+
+
+# ===========================================================================
+# _has_natural_response_ending
+# ===========================================================================
+
+class TestHasNaturalResponseEnding:
+    """Tests for AIAgent._has_natural_response_ending (static method)."""
+
+    @pytest.mark.parametrize("ending", [
+        ".", "!", "?", ":", ")", "\"", "'", "]", "}",
+        "\u3002", "\uff01", "\uff1f", "\uff1a", "\uff09", "\u3011", "\u300d", "\u300f", "\u300b",
+    ])
+    def test_ascii_and_cjk_punctuation(self, ending):
+        assert AIAgent._has_natural_response_ending(f"Hello world{ending}") is True
+
+    @pytest.mark.parametrize("emoji", [
+        "\U0001f49b",  # 💛
+        "\u2728",       # ✨
+        "\U0001f64c",  # 🙌
+        "\U0001f919",  # 🤙
+        "\U0001f525",  # 🔥
+        "\U0001f4aa",  # 💪
+        "\U0001f680",  # 🚀
+        "\U0001f60e",  # 😎
+        "\U0001f60a",  # 😊
+        "\U0001f44b",  # 👋
+        "\u2764\ufe0f", # ❤️
+        "\U0001f64f",  # 🙏
+        "\U0001f44d",  # 👍
+        "\U0001f4af",  # 💯
+        "\U0001f389",  # 🎉
+        "\U0001fae1",  # 🫡
+    ])
+    def test_emoji_sign_offs_are_natural_endings(self, emoji):
+        """Emoji at end of response should count as natural ending (#14572)."""
+        assert AIAgent._has_natural_response_ending(
+            f"Here's your answer. Let me know if you need more {emoji}"
+        ) is True
+
+    @pytest.mark.parametrize("text", [
+        "```python\nprint('hello')\n```",
+        "```",
+        "Here is the output:\n```\nDone\n```",
+    ])
+    def test_code_block_endings(self, text):
+        assert AIAgent._has_natural_response_ending(text) is True
+
+    @pytest.mark.parametrize("bare_word", [
+        "the best next",
+        "here are the results from the search",
+        "updating the config file now",
+    ])
+    def test_bare_words_without_punctuation_are_not_natural(self, bare_word):
+        assert AIAgent._has_natural_response_ending(bare_word) is False
+
+    def test_empty_string(self):
+        assert AIAgent._has_natural_response_ending("") is False
+
+    def test_whitespace_only(self):
+        assert AIAgent._has_natural_response_ending("   \n\t  ") is False
+
+    @pytest.mark.parametrize("dash_ending", [
+        "Here's the list:\n- Item 1\n- Item 2\n-",
+    ])
+    def test_trailing_dash_in_list(self, dash_ending):
+        """A trailing dash from a markdown list is not a natural ending."""
+        assert AIAgent._has_natural_response_ending(dash_ending) is False
+
+    @pytest.mark.parametrize("url_ending", [
+        "Check out https://example.com/docs",
+        "More info at http://test.com",
+    ])
+    def test_urls_without_punctuation(self, url_ending):
+        """URLs ending without punctuation look like truncation."""
+        assert AIAgent._has_natural_response_ending(url_ending) is False
+
+
+# ===========================================================================
+# _should_treat_stop_as_truncated
+# ===========================================================================
+
+class TestShouldTreatStopAsTruncated:
+    """Tests for AIAgent._should_treat_stop_as_truncated."""
+
+    def test_emoji_ending_does_not_trigger_heuristic(self):
+        """A response ending with emoji should NOT be treated as truncated."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "search result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="Here's what I found! Let me know if you need more details \U0001f49b",
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_bare_word_ending_still_triggers_heuristic(self):
+        """A genuinely suspicious bare-word ending SHOULD still trigger continuation.
+        Must be >=500 chars to pass the minimum-length gate."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "search result", "tool_call_id": "c1"},
+        ]
+        # Long response that clearly trails off mid-sentence
+        long_text = (
+            "Based on the search results, I found several relevant findings that "
+            "connect to your query. The first result indicates that the configuration "
+            "parameters need to be adjusted to match the new requirements. Specifically, "
+            "the timeout value should be increased from 30 to 120 seconds, and the "
+            "retry count should be set to 5 rather than 3. Additionally, the endpoint "
+            "URL needs to be updated to reflect the new server location, which is now "
+            "at https://api.v2.example.com instead of the previous one. The migration "
+            "guide suggests running the update script with the --force flag to ensure "
+            "all changes are applied correctly, and then verifying by checking the "
+            "configuration of the"
+        )
+        response = _mock_response(
+            content=long_text,
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is True
+
+    def test_period_ending_does_not_trigger(self):
+        """A response ending with period is clearly natural."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="Based on the search results, the best next step is to update the config.",
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_short_response_within_budget_does_not_trigger(self):
+        """A short response (well within max_tokens) ending with a bare word
+        is almost certainly complete -- it didn't hit any token limit.
+        This addresses the false-positive case where the heuristic fires
+        on short conversational replies that just happen to lack punctuation."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="Sure, I'll look into that for you",
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_config_flag_disables_heuristic(self):
+        """When glm_truncation_heuristic is set to False in config,
+        the heuristic should never trigger, regardless of content."""
+        agent = _make_agent()
+        agent._glm_truncation_heuristic_enabled = False
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        # Long suspicious text that would normally trigger
+        long_text = (
+            "Based on the search results, I found several relevant findings that "
+            "connect to your query. The first result indicates that the configuration "
+            "parameters need to be adjusted to match the new requirements. Specifically, "
+            "the timeout value should be increased from 30 to 120 seconds, and the "
+            "retry count should be set to 5 rather than 3. Additionally, the endpoint "
+            "URL needs to be updated to reflect the new server location, which is now "
+            "at https://api.v2.example.com instead of the previous one. The migration "
+            "guide suggests running the update script with the --force flag to ensure "
+            "all changes are applied correctly, and then verifying by checking the "
+            "configuration of the"
+        )
+        response = _mock_response(
+            content=long_text,
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_non_ollama_provider_never_triggers(self):
+        """Non-Ollama providers should never have this heuristic applied."""
+        agent = _make_agent(base_url="https://api.openai.com/v1", model="gpt-4o-mini")
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="Based on the search results, the best next step is to update the",
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_finish_reason_length_always_false(self):
+        """finish_reason='length' should not re-trigger; it's already length."""
+        agent = _make_agent()
+        messages = [{"role": "user", "content": "hello"}]
+        response = _mock_response(content="truncated text", finish_reason="length")
+        assert agent._should_treat_stop_as_truncated("length", response, messages) is False
+
+    def test_no_tool_messages_never_triggers(self):
+        """Without tool messages in context, the heuristic doesn't apply."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+        ]
+        response = _mock_response(
+            content="Here is the answer without punctuation",
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_tool_call_response_never_triggers(self):
+        """If the assistant message has tool calls, it's not a text response."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="",
+            finish_reason="stop",
+            tool_calls=[_mock_tool_call(name="another_search", call_id="c2")],
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_emoji_sign_off_with_100_chars_does_not_trigger(self):
+        """A substantive response (~100 chars) ending with emoji is complete."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="The configuration file is located at /etc/app/config.yaml. Let me know if you need more help \u2728",
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_think_tags_stripped_period_ending(self):
+        """Reasoning tags stripped, visible text ends with period."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        response = _mock_response(
+            content="<tool_call>Let me think about this problem carefully.</think>The answer is 42.",
+            finish_reason="stop",
+        )
+        # After stripping think blocks, visible text ends with "." -- natural
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
+
+    def test_think_tags_stripped_bare_word_still_triggers(self):
+        """Reasoning tags stripped, bare word still looks truncated (>500 chars after strip)."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "tool_calls": [_mock_tool_call()]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        long_thought = "I need to think very carefully about this problem and consider all the possible angles and implications of each approach before giving my final answer to this complex question that requires deep analysis"
+        long_visible = (
+            "Based on the search results, I found several relevant findings that "
+            "connect to your query. The first result indicates that the configuration "
+            "parameters need to be adjusted to match the new requirements. Specifically, "
+            "the timeout value should be increased from 30 to 120 seconds, and the "
+            "retry count should be set to 5 rather than 3. Additionally, the endpoint "
+            "URL needs to be updated to reflect the new server location, which is now "
+            "at https://api.v2.example.com instead of the previous one. The migration "
+            "guide suggests running the update script with the --force flag to ensure "
+            "all changes are applied correctly, and then verifying by checking the "
+            "configuration of the"
+        )
+        combined = "<think>" + long_thought + "</think>\n\n" + long_visible
+        response = _mock_response(
+            content=combined,
+            finish_reason="stop",
+        )
+        assert agent._should_treat_stop_as_truncated("stop", response, messages) is True

--- a/tests/run_agent/test_glm_stop_heuristic.py
+++ b/tests/run_agent/test_glm_stop_heuristic.py
@@ -114,6 +114,28 @@ class TestHasNaturalResponseEnding:
             f"Here's your answer. Let me know if you need more {emoji}"
         ) is True
 
+    @pytest.mark.parametrize("symbol", [
+        "\u2192",  # → (RIGHTWARDS ARROW, Sm)
+        "\u2190",  # ← (LEFTWARDS ARROW, Sm)
+        "\u2794",  # ➔ (RIGHTWARD ARROW, So — broad arrow variant)
+        "\u221e",  # ∞ (INFINITY, Sm)
+        "\u2248",  # ≈ (ALMOST EQUAL TO, Sm)
+        "\u2713",  # ✓ (CHECK MARK, So — was in old hardcoded list)
+        "\u2764",  # ❤ (HEAVY BLACK HEART, So — was in old hardcoded list)
+        "\u2605",  # ★ (BLACK STAR, So — was in old hardcoded list)
+    ])
+    def test_math_symbols_and_sign_off_glyphs_are_natural(self, symbol):
+        """Math symbols (Sm) and sign-off glyphs (So) are natural endings.
+
+        The Sm category covers arrows (→ ←) and math symbols (∞ ≈) that
+        commonly appear at the end of structured responses. The So category
+        covers check marks (✓), hearts (❤), and stars (★) that were previously
+        in a now-removed hardcoded string.
+        """
+        assert AIAgent._has_natural_response_ending(
+            f"Here's the result {symbol}"
+        ) is True
+
     @pytest.mark.parametrize("text", [
         "```python\nprint('hello')\n```",
         "```",
@@ -309,8 +331,12 @@ class TestShouldTreatStopAsTruncated:
         )
         assert agent._should_treat_stop_as_truncated("stop", response, messages) is False
 
-    def test_emoji_sign_off_with_100_chars_does_not_trigger(self):
-        """A substantive response (~100 chars) ending with emoji is complete."""
+    def test_short_response_with_emoji_does_not_trigger(self):
+        """A short response (<500 chars) ending with emoji is not truncated.
+
+        Tests the 500-char minimum-length gate: short conversational replies
+        that happen to end with emoji are complete, not truncated continuations.
+        """
         agent = _make_agent()
         messages = [
             {"role": "user", "content": "hello"},

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2752,8 +2752,28 @@ class TestRunConversation:
             finish_reason="tool_calls",
             tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
         )
+        # Content must be >=500 chars to pass the minimum-length gate
+        # introduced in #14572; shorter responses are assumed complete.
+        long_truncated = (
+            "Based on my thorough analysis of the search results and the documentation "
+            "you provided, I have identified several key findings that are worth discussing "
+            "in detail. First, the configuration parameters need to be updated to reflect "
+            "the new API endpoint structure that was introduced in version 3.2 of the "
+            "framework. This is particularly important because the old endpoint format "
+            "is being deprecated starting next quarter and will no longer receive security "
+            "patches. Second, the authentication mechanism should be migrated from the "
+            "legacy token-based system to the newer OAuth 2.0 flow that the platform team "
+            "has been rolling out across all services. The migration guide mentions that "
+            "you will need to update your client libraries to version 5.0 or later to "
+            "maintain compatibility, and there is a migration script available in the "
+            "repository that can handle most of the common refactoring patterns "
+            "automatically. Third, and perhaps most importantly for your use case, the "
+            "rate limiting behavior has changed significantly in the new version, so you "
+            "should review your current throttling strategy to make sure it aligns with "
+            "the updated quota system before deploying to production. The best next"
+        )
         misreported_stop = _mock_response(
-            content="Based on the search results, the best next",
+            content=long_truncated,
             finish_reason="stop",
         )
         continued = _mock_response(
@@ -2778,7 +2798,7 @@ class TestRunConversation:
         assert result["api_calls"] == 3
         assert (
             result["final_response"]
-            == "Based on the search results, the best next step is to update the config."
+            == long_truncated + " step is to update the config."
         )
 
         third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]


### PR DESCRIPTION
## Summary

Fixes #14572 — the Ollama/GLM stop-to-length heuristic was triggering 100% false positives on responses ending with emoji sign-offs (💛, ✨, 🙌), Markdown links, or conversational text lacking terminal punctuation. Each false positive wasted up to 3 continuation API calls per turn.

**Root cause:** `_has_natural_response_ending()` only recognized ASCII and CJK punctuation as natural endings. Any response ending with an emoji, symbol, or bare word was classified as truncated.

## Three-pronged fix

### 1. Expand `_has_natural_response_ending()` — emoji and symbol recognition
- Strip trailing Unicode combining marks (variation selectors U+FE0F, ZWJ U+200D) before checking last character
- Detect `unicodedata.category()` **So** (Other_Symbol), **Sk** (Modifier_Symbol), and **Sm** (Math_Symbol) as natural endings
- Check Extended Pictographic heuristic range U+1F000–U+1FAFF
- Removed dead hardcoded string `"✓✔✗✘♠♣♥♦♪♫☀☁☂★☆"` — every character was already caught by the So category check (the comment incorrectly claimed they were "outside those ranges")
- Added Sm category to cover arrows (→ ←) and math symbols (∞ ≈) that commonly end structured responses

### 2. 500-char minimum-length gate in `_should_treat_stop_as_truncated()`
- Responses under 500 visible chars are almost certainly complete — they couldn't have hit a meaningful token limit
- Retains original 20-char/no-whitespace short-junk detection
- Eliminates the vast majority of false positives from conversational replies

### 3. Config opt-out — `agent.glm_truncation_heuristic`
- New flag in `cli-config.yaml.example`, defaults to `true` (heuristic enabled)
- Set to `false` to disable the heuristic entirely
- Read with `getattr(self, "_glm_truncation_heuristic_enabled", True)` for backwards compatibility

## Refactoring pass (commit 2)
- Moved `import unicodedata` from inline in method body to module top-level
- Added Sm (Math_Symbol) to category check for arrows and math symbols
- Removed dead hardcoded string (all chars were So, already covered)
- Renamed misleading test `test_emoji_sign_off_with_100_chars` → `test_short_response_with_emoji_does_not_trigger` (it tests the 500-char gate, not emoji recognition)
- Added 8 parametrized tests for Sm/So characters including arrows and codepoints from the removed list

## Test plan

- [x] 65 tests total (57 original + 8 new Sm/So parametrized tests)
- [x] 2 existing integration tests pass with updated mock content
- [x] All categories covered: So, Sk, Sm, Extended Pictographic range, variation selectors
- [x] 500-char gate verified for both short (pass) and long (block) responses
- [x] Config opt-out verified