### PR TITLE
fix(hindsight): preserve existing HINDSIGHT_LLM_API_KEY on blank re-setup input

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -592,6 +592,18 @@ class HindsightMemoryProvider(MemoryProvider):
             sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
             llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+            # A blank input means "keep whatever I already have configured"
+            # (re-running ``hermes memory setup`` without retyping the key).
+            # Reading the existing value out of ``.env`` BEFORE we overwrite
+            # it below preserves the key — the previous code unconditionally
+            # stamped ``env_writes[...] = ""``, which then overwrote the
+            # existing line during the write-back loop below and left the
+            # profile env with an empty ``HINDSIGHT_API_LLM_API_KEY``, so
+            # the daemon came up unauthenticated.  Pin both the preserve
+            # behaviour and the "always emit the variable" contract below.
+            if not llm_key:
+                existing = _load_simple_env(Path(hermes_home) / ".env")
+                llm_key = existing.get("HINDSIGHT_LLM_API_KEY", "")
             # Always write explicitly (including empty) so the provider sees ""
             # rather than a missing variable.  The daemon reads from .env at
             # startup and fails when HINDSIGHT_LLM_API_KEY is unset.


### PR DESCRIPTION
## What does this PR do?

Re-running \`hermes memory setup\` and pressing Enter at the \"LLM API key:\" prompt silently blanked out the previously-configured key. The prompt loop read the empty \`llm_key\`, stamped it into \`env_writes\` unconditionally, and then the write-back loop below overwrote the existing \`HINDSIGHT_LLM_API_KEY=<value>\` line in \`~/.hermes/.env\` with \`HINDSIGHT_LLM_API_KEY=\` (empty). The materialised profile env at \`~/.hindsight/profiles/hermes.env\` then wrote \`HINDSIGHT_API_LLM_API_KEY=\` — the Hindsight daemon came up unauthenticated.

The existing comment (\"always write explicitly including empty so the provider sees '' rather than a missing variable\") documents why the variable is always emitted, but it didn't distinguish \"user explicitly blanks the key\" from \"user pressed Enter to keep their existing key\".

## Fix

Before writing to \`env_writes\`, treat blank input as \"keep existing\": read the current value out of \`~/.hermes/.env\` and use that if present. Explicit blanking of a previously-set key still requires a deliberate action (deleting the value in \`.env\` directly, or typing a different key), which matches how every other setup prompt in Hermes behaves.

The \"always emit the variable\" contract is preserved — \`env_writes[...] = llm_key\` still runs unconditionally; only the SOURCE of \`llm_key\` changed for the blank-input case.

\`\`\`python
if not llm_key:
    existing = _load_simple_env(Path(hermes_home) / \".env\")
    llm_key = existing.get(\"HINDSIGHT_LLM_API_KEY\", \"\")
env_writes[\"HINDSIGHT_LLM_API_KEY\"] = llm_key
\`\`\`

## Test plan

- [x] This repairs \`tests/plugins/memory/test_hindsight_provider.py::TestPostSetup::test_local_embedded_setup_preserves_existing_key_when_input_left_blank\`, one of the long-standing baseline CI failures across every open PR (same cohort that #15246 cleared for \`test_custom_provider_model_switch\`)
- [x] **No new tests needed** — the existing regression test explicitly asserts the preserved-key behaviour and was already failing on clean \`origin/main\` waiting for this fix
- [x] **Verified regression guard**: temporarily removed the new preserve-existing block; the test correctly failed with \`'HINDSIGHT_API_LLM_API_KEY=existing-key' in 'HINDSIGHT_API_LLM_API_KEY=...'\`. Restored → all 3 TestPostSetup tests pass, full hindsight suite 75/75 green.
- [x] Pre-push discipline applied: no new bare \`except Exception\`, no \`int()\` on user data, no unused imports

## Not in scope

- Other baseline CI failures (\`test_no_single_field_categories\` is in LeonSGP43's #15222; \`test_matches_previous_manual_builtin_tool_set\` appears resolved). Once this PR + #15222 + #15246 land, the baseline \`test\` CI lane should be fully green across every open PR.

## Related

- #15246 cleared the first of the baseline failures (custom-provider model-switch \`fetch_api_models\` kwarg drift)
- #15222 (LeonSGP43) clears the second (prompt_caching category merge)
- This PR clears the third