### PR TITLE
[codex] fix TUI nanostores dependency

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -12,6 +12,7 @@
         "@nanostores/react": "^1.1.0",
         "ink": "^6.8.0",
         "ink-text-input": "^6.0.0",
+        "nanostores": "^1.3.0",
         "react": "^19.2.4",
         "unicode-animations": "^1.0.3"
       },
@@ -4807,9 +4808,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
-      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
       "funding": [
         {
           "type": "github",
@@ -4817,7 +4818,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -20,6 +20,7 @@
     "@nanostores/react": "^1.1.0",
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
+    "nanostores": "^1.3.0",
     "react": "^19.2.4",
     "unicode-animations": "^1.0.3"
   },


### PR DESCRIPTION
## Summary

- declare nanostores as a direct TUI dependency because ui-tui imports it directly
- refresh the TUI package lock so nanostores is installed as a normal dependency instead of only appearing as a peer/transitive package

## Why

The TUI store files import from `nanostores` directly, but `ui-tui/package.json` only declared `@nanostores/react`. On installs where npm does not leave the peer/transitive `nanostores` package available, the TUI rebuild can fail with `TS2307: Cannot find module 'nanostores'`.

## Validation

- `npm run build` from `ui-tui` passed
- `npm run type-check` was attempted but hit an unrelated existing strictness error in `packages/hermes-ink/src/ink/dom.ts`
