### PR TITLE
fix(tui): declare nanostores dependency

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -12,6 +12,7 @@
         "@nanostores/react": "^1.1.0",
         "ink": "^6.8.0",
         "ink-text-input": "^6.0.0",
+        "nanostores": "^1.2.0",
         "react": "^19.2.4",
         "unicode-animations": "^1.0.3"
       },
@@ -4817,7 +4818,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -20,6 +20,7 @@
     "@nanostores/react": "^1.1.0",
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
+    "nanostores": "^1.2.0",
     "react": "^19.2.4",
     "unicode-animations": "^1.0.3"
   },


### PR DESCRIPTION
## Summary

- declare `nanostores` as a direct TUI dependency
- keep the existing locked `nanostores` version

## Why

The TUI imports from `nanostores` directly, but only `@nanostores/react` was declared in `ui-tui/package.json`. Some installs can therefore miss the direct package during rebuilds.

## Validation

- `npm run build` from `ui-tui` passed
