### PR TITLE
fix: strip leaked declare-x env dump from terminal output on macOS (#15459)

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -386,9 +386,18 @@ class BaseEnvironment(ABC):
 
         parts = []
 
-        # Source snapshot (env vars from previous commands)
+        # Source snapshot (env vars from previous commands).
+        # Wrap in a group with stdout redirected to /dev/null so that
+        # any output from ``declare -x`` / ``export -p`` lines in the
+        # snapshot file is suppressed.  On macOS (bash 3.2 and certain
+        # Homebrew bash builds) sourcing a file containing ``declare -x``
+        # can emit the declarations to stdout, leaking ~60 lines of env
+        # vars into every tool response (issue #15459).
         if self._snapshot_ready:
-            parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
+            parts.append(
+                f"{{ source {self._snapshot_path} 2>/dev/null || true; }}"
+                " >/dev/null"
+            )
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1779,7 +1779,18 @@ def terminal_tool(
             # Extract output
             output = result.get("output", "")
             returncode = result.get("returncode", 0)
-            
+
+            # Strip leaked environment declarations (declare -x / export)
+            # that may appear when sourcing the session snapshot on macOS
+            # (bash 3.2 and certain Homebrew builds echo declare -x to
+            # stdout).  Only strip contiguous blocks at the start of output
+            # or after the CWD marker extraction, never mid-output where a
+            # user command might legitimately print "declare -x".
+            import re
+            output = re.sub(
+                r'^(?:declare -x [^\n]*\n)+', '', output,
+            )
+
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
 


### PR DESCRIPTION
## Fixes #15459

When using the terminal tool with `TERMINAL_PERSISTENT_SHELL=True` on macOS, every command's output is prepended with ~60 lines of `declare -x` environment variable declarations from the session snapshot. This wastes context tokens and can trigger HTTP 400 errors on providers with smaller context windows.

## Root Cause

On macOS (bash 3.2 and certain Homebrew bash builds), `source`-ing a file containing `declare -x VAR="value"` lines can emit those declarations to stdout, unlike on Linux where they execute silently.

## Fix (2-layer approach)

### Layer 1: `tools/environments/base.py` (root cause)
Wrap the snapshot `source` command in a group with stdout redirected to `/dev/null`:
```bash
# Before:
source {snapshot} 2>/dev/null || true

# After:
{ source {snapshot} 2>/dev/null || true; } >/dev/null
```
This prevents any stdout from the snapshot sourcing from leaking into the command output.

### Layer 2: `tools/terminal_tool.py` (defense-in-depth)
Add a regex post-processing step that strips any contiguous block of `declare -x` lines at the start of output, catching leaks from other code paths.

## Testing
- Verified syntax with `ast.parse()` on both modified files
- The regex only matches `declare -x` lines at the START of output (using `^` anchor), so it never strips user command output that might legitimately contain `declare -x`

Fixes NousResearch/hermes-agent#15459