### PR TITLE
fix: parse DeepSeek-V4 DSML tool calls from response content (#15453)

### DIFF
--- a/environments/tool_call_parsers/__init__.py
+++ b/environments/tool_call_parsers/__init__.py
@@ -114,6 +114,7 @@ from environments.tool_call_parsers.llama_parser import LlamaToolCallParser  # n
 from environments.tool_call_parsers.qwen_parser import QwenToolCallParser  # noqa: E402, F401
 from environments.tool_call_parsers.deepseek_v3_parser import DeepSeekV3ToolCallParser  # noqa: E402, F401
 from environments.tool_call_parsers.deepseek_v3_1_parser import DeepSeekV31ToolCallParser  # noqa: E402, F401
+from environments.tool_call_parsers.deepseek_v4_parser import DeepSeekV4ToolCallParser  # noqa: E402, F401
 from environments.tool_call_parsers.kimi_k2_parser import KimiK2ToolCallParser  # noqa: E402, F401
 from environments.tool_call_parsers.glm45_parser import Glm45ToolCallParser  # noqa: E402, F401
 from environments.tool_call_parsers.glm47_parser import Glm47ToolCallParser  # noqa: E402, F401

--- a/environments/tool_call_parsers/deepseek_v4_parser.py
+++ b/environments/tool_call_parsers/deepseek_v4_parser.py
@@ -1,0 +1,127 @@
+"""
+DeepSeek V4 (DSML) tool call parser.
+
+DeepSeek-V4 uses DSML (DeepSeek Markup Language) format for tool calls.
+When the API provider doesn't parse these into structured tool_calls,
+they appear as raw text in the response content.
+
+DSML tool call format (inferred from observed output):
+    <｜DSML｜tool_calls_begin｜>
+    <｜DSML｜tool_call_begin｜>function_name
+    ```json
+    {"arg": "value"}
+    ```
+    <｜DSML｜tool_call_end｜>
+    <｜DSML｜tool_calls_end｜>
+
+The parser also handles the ASCII pipe variant observed in issue #15453:
+    < | DSML | tool_calls_begin >
+    < | DSML | tool_call_begin > function_name
+    ...
+    < | DSML | tool_call_end >
+    < | DSML | tool_calls_end >
+"""
+
+import re
+import uuid
+import logging
+from typing import List, Optional
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+from environments.tool_call_parsers import ParseResult, ToolCallParser, register_parser
+
+logger = logging.getLogger(__name__)
+
+# Unicode fullwidth pipe ＋ Unicode block element separator (▁ = U+2581)
+# Matches: <｜DSML｜tool_calls_begin｜> and <｜DSML｜tool_calls_end｜>
+_UNICODE_DSML_BEGIN = r"<｜DSML｜tool.calls.begin｜>"
+_UNICODE_DSML_CALL_BEGIN = r"<｜DSML｜tool.call.begin｜>"
+_UNICODE_DSML_CALL_END = r"<｜DSML｜tool.call.end｜>"
+
+# ASCII pipe variant with optional spaces (as seen in issue #15453 raw output)
+# Matches: < | DSML | tool_calls_begin > etc.
+_ASCII_DSML_BEGIN = r"<\s*\|\s*DSML\s*\|\s*tool.calls.begin\s*>"
+_ASCII_DSML_CALL_BEGIN = r"<\s*\|\s*DSML\s*\|\s*tool.call.begin\s*>"
+_ASCII_DSML_CALL_END = r"<\s*\|\s*DSML\s*\|\s*tool.call.end\s*>"
+
+# Combined pattern: either Unicode or ASCII variant
+_DSML_CALL_BEGIN = f"(?:{_UNICODE_DSML_CALL_BEGIN}|{_ASCII_DSML_CALL_BEGIN})"
+_DSML_CALL_END = f"(?:{_UNICODE_DSML_CALL_END}|{_ASCII_DSML_CALL_END})"
+
+# Full tool-call block pattern:
+#   <call_begin> function_name
+#   ```json
+#   {arguments}
+#   ```
+#   <call_end>
+# Also handles the case where arguments are raw JSON without code fence.
+TOOL_CALL_PATTERN = re.compile(
+    _DSML_CALL_BEGIN
+    + r"\s*(?P<function_name>[^\n<|]+?)\s*"
+    + r"(?:```json\s*(?P<json_args>.*?)\s*```|(?P<raw_args>\{[^}]*\}))"
+    + r"\s*"
+    + _DSML_CALL_END,
+    re.DOTALL,
+)
+
+
+@register_parser("deepseek_v4")
+@register_parser("deepseek_dsml")
+class DeepSeekV4ToolCallParser(ToolCallParser):
+    """
+    Parser for DeepSeek V4 DSML tool calls.
+
+    Handles both Unicode fullwidth and ASCII pipe variants of the DSML
+    tool call delimiters.  Extracts function name and JSON arguments
+    from each tool call block.
+    """
+
+    # Fast-path sentinel: skip regex if neither variant is present.
+    _SENTINELS = ("<｜DSML｜", "< | DSML |")
+
+    def parse(self, text: str) -> ParseResult:
+        if not any(s in text for s in self._SENTINELS):
+            return text, None
+
+        try:
+            matches = list(TOOL_CALL_PATTERN.finditer(text))
+            if not matches:
+                return text, None
+
+            tool_calls: List[ChatCompletionMessageToolCall] = []
+
+            for match in matches:
+                func_name = match.group("function_name").strip()
+                func_args = (
+                    match.group("json_args") or match.group("raw_args") or "{}"
+                ).strip()
+
+                if not func_name:
+                    continue
+
+                tool_calls.append(
+                    ChatCompletionMessageToolCall(
+                        id=f"call_{uuid.uuid4().hex[:8]}",
+                        type="function",
+                        function=Function(
+                            name=func_name,
+                            arguments=func_args,
+                        ),
+                    )
+                )
+
+            if not tool_calls:
+                return text, None
+
+            # Content is everything before the first DSML tag
+            first_match = matches[0]
+            content = text[: first_match.start()].strip()
+            return content if content else None, tool_calls
+
+        except Exception as e:
+            logger.error(f"Error parsing DeepSeek V4 DSML tool calls: {e}")
+            return text, None

--- a/run_agent.py
+++ b/run_agent.py
@@ -10528,6 +10528,28 @@ class AIAgent:
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
                 
+                # Fallback: extract tool calls from content text when the API
+                # provider didn't parse them into structured tool_calls.
+                # This handles DeepSeek-V4 DSML format (issue #15453) where
+                # tool calls appear as raw DSML tags in the response content.
+                if not assistant_message.tool_calls:
+                    _content_text = getattr(assistant_message, "content", None) or ""
+                    if _content_text and ("<｜DSML｜" in _content_text or "< | DSML |" in _content_text):
+                        try:
+                            from environments.tool_call_parsers import get_parser as _get_tc_parser
+                            _dsml_parser = _get_tc_parser("deepseek_v4")
+                            _parsed_content, _parsed_tc = _dsml_parser.parse(_content_text)
+                            if _parsed_tc:
+                                assistant_message.tool_calls = _parsed_tc
+                                if _parsed_content:
+                                    assistant_message.content = _parsed_content
+                                logger.info(
+                                    "Extracted %d DSML tool call(s) from content text",
+                                    len(_parsed_tc),
+                                )
+                        except Exception as _dsml_err:
+                            logger.debug("DSML content-based tool call extraction failed: %s", _dsml_err)
+
                 # Check for tool calls
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:


### PR DESCRIPTION
## Fixes #15453

When using DeepSeek-V4 as the backend model, tool calls are output in DSML (DeepSeek Markup Language) format as raw text in the response content field instead of being parsed into structured `tool_calls`. The agent never executes any tools and terminates immediately.

## Root Cause

No parser existed for DeepSeek-V4's DSML format. The main agent loop only checks `assistant_message.tool_calls` (which is empty), treats the raw DSML text as the final response, and terminates.

## Fix (3 files)

### New: `environments/tool_call_parsers/deepseek_v4_parser.py`
- `DeepSeekV4ToolCallParser` class registered as `"deepseek_v4"` and `"deepseek_dsml"`
- Regex handles both Unicode fullwidth delimiters (`<｜DSML｜...｜>`) and ASCII pipe variants (`< | DSML | ... >`)
- Extracts function name + JSON arguments from DSML tool call blocks
- Returns `(content, tool_calls)` tuple following the existing parser interface

### Modified: `environments/tool_call_parsers/__init__.py`
- Added import of `DeepSeekV4ToolCallParser` to register it

### Modified: `run_agent.py`
- Added content-based DSML fallback BEFORE the existing `tool_calls` check
- When `assistant_message.tool_calls` is empty AND content contains DSML markers, invokes the parser
- Wrapped in try/except to never break the existing flow

Fixes NousResearch/hermes-agent#15453