### PR TITLE
fix(cli): make setup and gateway guidance profile-aware

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1176,13 +1176,13 @@ def _systemd_service_is_start_limited(system: bool = False) -> bool:
 def _print_systemd_start_limit_wait(system: bool = False) -> None:
     svc = get_service_name()
     scope_label = _service_scope_label(system).capitalize()
-    scope_flag = " --system" if system else ""
     systemctl_prefix = "systemctl " if system else "systemctl --user "
     journal_prefix = "journalctl " if system else "journalctl --user "
     print(f"⏳ {scope_label} service is temporarily rate-limited by systemd.")
     print("  systemd is refusing another immediate start after repeated exits.")
     print(
-        f"  Wait for the start-limit window to expire, then run: {'sudo ' if system else ''}hermes gateway restart{scope_flag}"
+        "  Wait for the start-limit window to expire, then run: "
+        f"{_gateway_service_command('restart', system=system)}"
     )
     print(f"  Or clear the failed state manually: {systemctl_prefix}reset-failed {svc}")
     print(f"  Check logs: {journal_prefix}-u {svc} -l --since '5 min ago'")
@@ -1393,13 +1393,16 @@ def _print_gateway_process_mismatch(snapshot: GatewayRuntimeSnapshot) -> None:
         )
         print(f"  PID(s): {_format_gateway_pids(snapshot.gateway_pids, limit=None)}")
         print("  Auto-start at login and auto-restart on crash are NOT available.")
-        print("  Stop it with: hermes gateway stop")
+        print(f"  Stop it with: {_gateway_cli_command('stop')}")
     else:
         print(
             "⚠ Gateway process is running for this profile, but the service is not active"
         )
         print(f"  PID(s): {_format_gateway_pids(snapshot.gateway_pids, limit=None)}")
-        print("  This is usually a manual foreground/tmux/nohup run, so `hermes gateway`")
+        print(
+            "  This is usually a manual foreground/tmux/nohup run, so "
+            f"`{_gateway_cli_command()}`"
+        )
         print("  can refuse to start another copy until this process stops.")
 
 
@@ -2377,7 +2380,8 @@ def install_linux_gateway_from_setup(force: bool = False, enable_on_startup: boo
             # direct caller — we do NOT print a self-elevation recipe.
             print_warning(
                 "  System service install requires root. Re-run setup from a "
-                "root shell, or install a user service instead: hermes gateway install"
+                "root shell, or install a user service instead: "
+                f"{_gateway_cli_command('install')}"
             )
             return scope, False
 
@@ -3119,8 +3123,8 @@ def _print_system_scope_remediation(action: str) -> None:
         print_info(f"         sudo systemctl {action} {svc}")
     print_info("    2. Switch to a per-user service (recommended for personal use):")
     print_info("         sudo hermes gateway uninstall --system")
-    print_info("         hermes gateway install")
-    print_info("         hermes gateway start")
+    print_info(f"         {_gateway_cli_command('install')}")
+    print_info(f"         {_gateway_cli_command('start')}")
 
 
 def _get_restart_drain_timeout() -> float:
@@ -3239,9 +3243,8 @@ def systemd_uninstall(system: bool = False):
 def _require_service_installed(action: str, system: bool = False) -> None:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
-        scope_flag = " --system" if system else ""
         print("✗ Gateway service is not installed")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print(f"  Run: {_gateway_service_command('install', system=system)}")
         sys.exit(1)
 
 
@@ -3285,7 +3288,8 @@ def systemd_stop(system: bool = False):
         label = _service_scope_label(system)
         print(
             f"Gateway {label} service is still stopping after 90s; "
-            "check `hermes gateway status` or logs for final shutdown state."
+            f"check `{_gateway_service_command('status', system=system)}` or logs "
+            "for final shutdown state."
         )
         return
     print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
@@ -3358,7 +3362,8 @@ def systemd_restart(system: bool = False):
             label = _service_scope_label(system)
             print(
                 f"Gateway {label} service is still restarting after 90s; "
-                "check `hermes gateway status` or logs for final state."
+                f"check `{_gateway_service_command('status', system=system)}` or logs "
+                "for final state."
             )
             return
         _wait_for_systemd_service_restart(system=system, previous_pid=pid)
@@ -3388,7 +3393,8 @@ def systemd_restart(system: bool = False):
         label = _service_scope_label(system)
         print(
             f"Gateway {label} service is still restarting after 90s; "
-            "check `hermes gateway status` or logs for final state."
+            f"check `{_gateway_service_command('status', system=system)}` or logs "
+            "for final state."
         )
         return
     _wait_for_systemd_service_restart(system=system, previous_pid=pid)
@@ -3864,11 +3870,11 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
         print("✓ Started gateway as a background process instead")
         print("  It will NOT auto-start at login or auto-restart on crash.")
         print(f"  Logs: {_dhh()}/logs/gateway.log")
-        print("  Stop it with: hermes gateway stop")
+        print(f"  Stop it with: {_gateway_cli_command('stop')}")
         return True
     print_error("Failed to start the gateway as a background process.")
     print(
-        f"  Try manually: nohup hermes gateway run --replace "
+        f"  Try manually: nohup {_gateway_cli_command('run --replace')} "
         f"> {_dhh()}/logs/gateway.log 2>&1 &"
     )
     if exit_on_failure:
@@ -4454,10 +4460,12 @@ def launchd_status(deep: bool = False):
             print("  launchd cannot manage the gateway on this macOS version.")
             if fallback_pid:
                 print(f"✓ Detached fallback process is running (PID {fallback_pid})")
-                print("  Cron jobs will fire. Stop with: hermes gateway stop")
+                print(
+                    f"  Cron jobs will fire. Stop with: {_gateway_cli_command('stop')}"
+                )
             else:
                 print("✗ No fallback process is running")
-                print("  Run: hermes gateway start")
+                print(f"  Run: {_gateway_cli_command('start')}")
             print("  ⚠ Auto-start at login and auto-restart on crash are NOT available.")
         else:
             print("✓ Gateway service is registered with launchd")
@@ -4641,7 +4649,7 @@ def _guard_supervised_gateway_conflict(force: bool = False) -> None:
         "  instead:"
     )
     print()
-    print("    hermes gateway restart")
+    print(f"    {_gateway_cli_command('restart')}")
     print()
     print(
         "  Pass --force to start a foreground gateway anyway (not recommended\n"
@@ -4676,9 +4684,9 @@ def _guard_existing_gateway_process_conflict(replace: bool = False) -> None:
     print_error(
         f"Another gateway instance is already running (PID {pid})."
     )
-    print("  Use 'hermes gateway restart' to replace it,")
-    print("  or 'hermes gateway stop' first.")
-    print("  Or use 'hermes gateway run --replace' to auto-replace.")
+    print(f"  Use '{_gateway_cli_command('restart')}' to replace it,")
+    print(f"  or '{_gateway_cli_command('stop')}' first.")
+    print(f"  Or use '{_gateway_cli_command('run --replace')}' to auto-replace.")
     sys.exit(1)
 
 
@@ -6783,7 +6791,7 @@ def _gateway_command_inner(args):
             print_error(
                 "Refusing to stop the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway stop` from a shell outside the running gateway."
+                f"Use `{_gateway_cli_command('stop')}` from a shell outside the running gateway."
             )
             sys.exit(1)
 
@@ -6876,7 +6884,7 @@ def _gateway_command_inner(args):
             print_error(
                 "Refusing to restart the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway restart` from a shell outside the running gateway."
+                f"Use `{_gateway_cli_command('restart')}` from a shell outside the running gateway."
             )
             sys.exit(1)
 
@@ -7081,7 +7089,7 @@ def _gateway_command_inner(args):
                     print(
                         "To install as a Windows Scheduled Task (auto-start on login):"
                     )
-                    print("  hermes gateway install")
+                    print(f"  {_gateway_cli_command('install')}")
                 else:
                     print("To install as a service:")
                     print(f"  {_gateway_cli_command('install')}")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -61,6 +61,21 @@ from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
 
+def _gateway_cli_command(subcommand: str | None = None) -> str:
+    """Return the current profile-aware gateway command."""
+    from hermes_cli.profiles import get_profile_command
+
+    base = f"{get_profile_command()} gateway"
+    return base if not subcommand else f"{base} {subcommand}"
+
+
+def _gateway_service_command(subcommand: str, *, system: bool = False) -> str:
+    """Return the gateway command shown in service-manager guidance."""
+    if system:
+        return f"sudo hermes gateway {subcommand} --system"
+    return _gateway_cli_command(subcommand)
+
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -1125,7 +1140,7 @@ def _wait_for_systemd_service_restart(
 
     print(
         f"⚠ {scope_label} service did not become active within {int(timeout)}s.\n"
-        f"  Check status: {'sudo ' if system else ''}hermes gateway status\n"
+        f"  Check status: {_gateway_service_command('status', system=system)}\n"
         f"  Check logs:   journalctl {'--user ' if not system else ''}-u {svc} -l --since '2 min ago'"
     )
     return False
@@ -1991,7 +2006,7 @@ def _raise_user_systemd_unavailable(
         "\n"
         "  Alternative: run the gateway in the foreground (stays up until\n"
         "  you exit / close the terminal):\n"
-        "    hermes gateway run"
+        f"    {_gateway_cli_command('run')}"
     )
     raise UserSystemdUnavailableError(msg)
 
@@ -2130,7 +2145,7 @@ def print_legacy_unit_warning() -> None:
     print_info("  These run alongside the current hermes-gateway service and")
     print_info("  cause SIGTERM flap loops — both try to use the same bot token.")
     print_info("  Remove them with:")
-    print_info("    hermes gateway migrate-legacy")
+    print_info(f"    {_gateway_cli_command('migrate-legacy')}")
 
 
 def remove_legacy_hermes_units(
@@ -2173,7 +2188,7 @@ def remove_legacy_hermes_units(
         return 0, [p for _, p, _ in legacy]
 
     if interactive and not prompt_yes_no("Remove these legacy units?", True):
-        print("Skipped. Run again with: hermes gateway migrate-legacy")
+        print(f"Skipped. Run again with: {_gateway_cli_command('migrate-legacy')}")
         return 0, [p for _, p, _ in legacy]
 
     removed = 0
@@ -2249,7 +2264,7 @@ def print_systemd_scope_conflict_warning() -> None:
         "  Default gateway commands target the user service unless you pass --system."
     )
     print_info("  Keep one of these:")
-    print_info("    hermes gateway uninstall")
+    print_info(f"    {_gateway_cli_command('uninstall')}")
     print_info("    sudo hermes gateway uninstall --system")
 
 
@@ -3146,7 +3161,6 @@ def systemd_install(
             print()
 
     unit_path = get_systemd_unit_path(system=system)
-    scope_flag = " --system" if system else ""
 
     # Existing system units already pin HERMES_HOME; adopt it before any
     # regenerate. This pre-sync is NOT redundant with the systemd_unit_is_current
@@ -3187,15 +3201,9 @@ def systemd_install(
     print(f"✓ {_service_scope_label(system).capitalize()} service {enable_label}!")
     print()
     print("Next steps:")
-    print(
-        f"  {'sudo ' if system else ''}hermes gateway start{scope_flag}              # Start the service"
-    )
-    print(
-        f"  {'sudo ' if system else ''}hermes gateway status{scope_flag}             # Check status"
-    )
-    print(
-        f"  {'journalctl' if system else 'journalctl --user'} -u {get_service_name()} -f  # View logs"
-    )
+    print(f"  {_gateway_service_command('start', system=system)}              # Start the service")
+    print(f"  {_gateway_service_command('status', system=system)}             # Check status")
+    print(f"  {'journalctl' if system else 'journalctl --user'} -u {get_service_name()} -f  # View logs")
     print()
 
     if system:
@@ -3389,11 +3397,10 @@ def systemd_restart(system: bool = False):
 def systemd_status(deep: bool = False, system: bool = False, full: bool = False):
     system = _select_systemd_scope(system)
     unit_path = get_systemd_unit_path(system=system)
-    scope_flag = " --system" if system else ""
 
     if not unit_path.exists():
         print("✗ Gateway service is not installed")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print(f"  Run: {_gateway_service_command('install', system=system)}")
         return
 
     if has_conflicting_systemd_units():
@@ -3406,9 +3413,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
     if not systemd_unit_is_current(system=system):
         print("⚠ Installed gateway service definition is outdated")
-        print(
-            f"  Run: {'sudo ' if system else ''}hermes gateway restart{scope_flag}  # auto-refreshes the unit"
-        )
+        print(f"  Run: {_gateway_service_command('restart', system=system)}  # auto-refreshes the unit")
         print()
 
     status_cmd = ["status", get_service_name(), "--no-pager"]
@@ -3440,7 +3445,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print(
             f"✗ {_service_scope_label(system).capitalize()} gateway service is stopped"
         )
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway start{scope_flag}")
+        print(f"  Run: {_gateway_service_command('start', system=system)}")
 
     configured_user = _read_systemd_user_from_unit(unit_path) if system else None
     if configured_user:
@@ -3463,7 +3468,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
     elif _systemd_unit_is_start_limited(unit_props):
         print("  ⏳ Restart pending: systemd is temporarily rate-limiting starts")
         print(
-            f"  Run after the start-limit window expires: {'sudo ' if system else ''}hermes gateway restart{scope_flag}"
+            "  Run after the start-limit window expires: "
+            f"{_gateway_service_command('restart', system=system)}"
         )
         print(
             f"  Or clear it manually: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()}"
@@ -3473,7 +3479,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
     ):
         print("  ⚠ Planned restart is stuck in systemd failed state (exit 75)")
         print(
-            f"  Run: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()} && {'sudo ' if system else ''}hermes gateway start{scope_flag}"
+            f"  Run: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()} && "
+            f"{_gateway_service_command('start', system=system)}"
         )
     elif active_state == "failed" and result_code:
         print(f"  ⚠ Systemd unit result: {result_code}")
@@ -4153,7 +4160,7 @@ def launchd_install(force: bool = False):
     _clear_launchd_unsupported_marker()
     print()
     print("Next steps:")
-    print("  hermes gateway status             # Check status")
+    print(f"  {_gateway_cli_command('status')}             # Check status")
     from hermes_constants import display_hermes_home as _dhh
 
     print(f"  tail -f {_dhh()}/logs/gateway.log  # View logs")
@@ -4434,7 +4441,7 @@ def launchd_status(deep: bool = False):
         print("✓ Service definition matches the current Hermes install")
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
-        print("  Run: hermes gateway start")
+        print(f"  Run: {_gateway_cli_command('start')}")
 
     if service_listed:
         if launchd_pid is not None:
@@ -4460,10 +4467,9 @@ def launchd_status(deep: bool = False):
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
-        print("  Run: hermes gateway start")
+        print(f"  Run: {_gateway_cli_command('start')}")
         if fallback_pid:
             print(f"  Note: a detached gateway process is running (PID {fallback_pid})")
-
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
         if log_file.exists():
@@ -5408,9 +5414,7 @@ def _setup_standard_platform(platform: dict):
                 elif is_email:
                     print_success("  Unknown email senders will be ignored.")
                 else:
-                    print_info(
-                        "  Skipped — configure later with 'hermes gateway setup'"
-                    )
+                    print_info(f"  Skipped — configure later with '{_gateway_cli_command('setup')}'")
             continue
 
         value = prompt(f"  {var['prompt']}", password=var.get("password", False))
@@ -5552,7 +5556,7 @@ def _setup_weixin():
 
     if not check_weixin_requirements():
         print_error("  Missing dependencies: Weixin needs aiohttp and cryptography.")
-        print_info("  Install them, then rerun `hermes gateway setup`.")
+        print_info(f"  Install them, then rerun `{_gateway_cli_command('setup')}`.")
         return
 
     print()
@@ -6170,7 +6174,7 @@ def gateway_setup():
                         gateway_windows.restart()
                     else:
                         stop_profile_gateway()
-                        print_info("Start manually: hermes gateway")
+                        print_info(f"Start manually: {_gateway_cli_command()}")
                 except UserSystemdUnavailableError as e:
                     print_error("  Restart failed — user systemd not reachable:")
                     for line in str(e).splitlines():
@@ -6254,20 +6258,20 @@ def gateway_setup():
                                 print_error(f"  Start failed: {e}")
                     except subprocess.CalledProcessError as e:
                         print_error(f"  Install failed: {e}")
-                        print_info("  You can try manually: hermes gateway install")
+                        print_info(f"  You can try manually: {_gateway_cli_command('install')}")
                 else:
                     print_info("  Skipped start and auto-start setup.")
-                    print_info("  You can install later: hermes gateway install")
+                    print_info(f"  You can install later: {_gateway_cli_command('install')}")
                     if supports_systemd_services():
                         print_info(
                             "  Or as a boot-time service: sudo hermes gateway install --system"
                         )
-                    print_info("  Or run in foreground:  hermes gateway run")
+                    print_info(f"  Or run in foreground:  {_gateway_cli_command('run')}")
             elif is_wsl():
                 print_info("  WSL detected but systemd is not running.")
-                print_info("  Run in foreground: hermes gateway run")
+                print_info(f"  Run in foreground: {_gateway_cli_command('run')}")
                 print_info(
-                    "  For persistence:   tmux new -s hermes 'hermes gateway run'"
+                    f"  For persistence:   tmux new -s hermes '{_gateway_cli_command('run')}'"
                 )
                 print_info(
                     "  To enable systemd: add systemd=true to /etc/wsl.conf, then 'wsl --shutdown'"
@@ -6276,16 +6280,16 @@ def gateway_setup():
                 from hermes_constants import display_hermes_home as _dhh
 
                 print_info("  Termux does not use systemd/launchd services.")
-                print_info("  Run in foreground: hermes gateway run")
+                print_info(f"  Run in foreground: {_gateway_cli_command('run')}")
                 print_info(
-                    f"  Or start it manually in the background (best effort): nohup hermes gateway run >{_dhh()}/logs/gateway.log 2>&1 &"
+                    f"  Or start it manually in the background (best effort): nohup {_gateway_cli_command('run')} >{_dhh()}/logs/gateway.log 2>&1 &"
                 )
             else:
                 print_info("  Service install not supported on this platform.")
-                print_info("  Run in foreground: hermes gateway run")
+                print_info(f"  Run in foreground: {_gateway_cli_command('run')}")
     else:
         print()
-        print_info("No platforms configured. Run 'hermes gateway setup' when ready.")
+        print_info(f"No platforms configured. Run '{_gateway_cli_command('setup')}' when ready.")
 
     print()
 
@@ -6561,7 +6565,7 @@ def _gateway_command_inner(args):
         run_as_user = getattr(args, "run_as_user", None)
         if is_termux():
             print("Gateway service installation is not supported on Termux.")
-            print("Run manually: hermes gateway")
+            print(f"Run manually: {_gateway_cli_command()}")
             sys.exit(1)
         if supports_systemd_services():
             if is_wsl():
@@ -6569,10 +6573,10 @@ def _gateway_command_inner(args):
                     "WSL detected — systemd services may not survive WSL restarts."
                 )
                 print_info(
-                    "  Consider running in foreground instead: hermes gateway run"
+                    f"  Consider running in foreground instead: {_gateway_cli_command('run')}"
                 )
                 print_info(
-                    "  Or use tmux/screen for persistence: tmux new -s hermes 'hermes gateway run'"
+                    f"  Or use tmux/screen for persistence: tmux new -s hermes '{_gateway_cli_command('run')}'"
                 )
                 print()
             # Honor CLI flags (--start-now / --no-start-now, --start-on-login /
@@ -6622,13 +6626,13 @@ def _gateway_command_inner(args):
             print("or run the gateway in foreground mode:")
             print()
             print(
-                "  hermes gateway run                              # direct foreground"
+                f"  {_gateway_cli_command('run')}                              # direct foreground"
             )
             print(
-                "  tmux new -s hermes 'hermes gateway run'         # persistent via tmux"
+                f"  tmux new -s hermes '{_gateway_cli_command('run')}'         # persistent via tmux"
             )
             print(
-                "  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background"
+                f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # background"
             )
             sys.exit(1)
         elif is_container():
@@ -6657,11 +6661,11 @@ def _gateway_command_inner(args):
             )
             print("  docker restart <container>                # manual restart")
             print()
-            print("To run the gateway: hermes gateway run")
+            print(f"To run the gateway: {_gateway_cli_command('run')}")
             sys.exit(0)
         else:
             print("Service installation not supported on this platform.")
-            print("Run manually: hermes gateway run")
+            print(f"Run manually: {_gateway_cli_command('run')}")
             sys.exit(1)
 
     elif subcmd == "uninstall":
@@ -6673,7 +6677,7 @@ def _gateway_command_inner(args):
             print(
                 "Gateway service uninstall is not supported on Termux because there is no managed service to remove."
             )
-            print("Stop manual runs with: hermes gateway stop")
+            print(f"Stop manual runs with: {_gateway_cli_command('stop')}")
             sys.exit(1)
         if supports_systemd_services():
             systemd_uninstall(system=system)
@@ -6726,7 +6730,7 @@ def _gateway_command_inner(args):
             print(
                 "Gateway service start is not supported on Termux because there is no system service manager."
             )
-            print("Run manually: hermes gateway")
+            print(f"Run manually: {_gateway_cli_command()}")
             sys.exit(1)
         if supports_systemd_services():
             systemd_start(system=system)
@@ -6741,13 +6745,13 @@ def _gateway_command_inner(args):
             print("Run the gateway in foreground mode instead:")
             print()
             print(
-                "  hermes gateway run                              # direct foreground"
+                f"  {_gateway_cli_command('run')}                              # direct foreground"
             )
             print(
-                "  tmux new -s hermes 'hermes gateway run'         # persistent via tmux"
+                f"  tmux new -s hermes '{_gateway_cli_command('run')}'         # persistent via tmux"
             )
             print(
-                "  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background"
+                f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # background"
             )
             print()
             print(
@@ -6766,7 +6770,7 @@ def _gateway_command_inner(args):
             print("  docker start <container>     # start a stopped container")
             print("  docker restart <container>   # restart a running container")
             print()
-            print("Or run the gateway directly: hermes gateway run")
+            print(f"Or run the gateway directly: {_gateway_cli_command('run')}")
             sys.exit(0)
         else:
             print("Not supported on this platform.")
@@ -7001,7 +7005,7 @@ def _gateway_command_inner(args):
                     print(f"  Run:  sudo loginctl enable-linger {_username}")
                     print()
                     print("  Then restart the gateway:")
-                    print("    hermes gateway restart")
+                    print(f"    {_gateway_cli_command('restart')}")
                     return
 
             if service_configured:
@@ -7010,7 +7014,7 @@ def _gateway_command_inner(args):
                 print(
                     "  The service definition exists, but the service manager did not recover it."
                 )
-                print("  Fix the service, then retry: hermes gateway start")
+                print(f"  Fix the service, then retry: {_gateway_cli_command('start')}")
                 sys.exit(1)
 
             # Manual restart: stop only this profile's gateway
@@ -7080,7 +7084,7 @@ def _gateway_command_inner(args):
                     print("  hermes gateway install")
                 else:
                     print("To install as a service:")
-                    print("  hermes gateway install")
+                    print(f"  {_gateway_cli_command('install')}")
                     print("  sudo hermes gateway install --system")
             else:
                 print("✗ Gateway is not running")
@@ -7092,24 +7096,24 @@ def _gateway_command_inner(args):
                         print(f"  {line}")
                 print()
                 print("To start:")
-                print("  hermes gateway run      # Run in foreground")
+                print(f"  {_gateway_cli_command('run')}      # Run in foreground")
                 if is_termux():
                     print(
-                        "  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # Best-effort background start"
+                        f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # Best-effort background start"
                     )
                 elif is_wsl():
                     print(
-                        "  tmux new -s hermes 'hermes gateway run'         # persistent via tmux"
+                        f"  tmux new -s hermes '{_gateway_cli_command('run')}'         # persistent via tmux"
                     )
                     print(
-                        "  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background"
+                        f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # background"
                     )
                 elif is_windows():
                     print(
-                        "  hermes gateway install  # Install as Windows Scheduled Task (auto-start on login)"
+                        f"  {_gateway_cli_command('install')}  # Install as Windows Scheduled Task (auto-start on login)"
                     )
                 else:
-                    print("  hermes gateway install  # Install as user service")
+                    print(f"  {_gateway_cli_command('install')}  # Install as user service")
                     print(
                         "  sudo hermes gateway install --system  # Install as boot-time system service"
                     )

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -38,6 +38,21 @@ from hermes_cli.setup import (
 from hermes_cli.colors import Colors, color
 
 
+def _gateway_cli_command(subcommand: str | None = None) -> str:
+    """Return the current profile-aware gateway command."""
+    from hermes_cli.profiles import get_profile_command
+
+    base = f"{get_profile_command()} gateway"
+    return base if not subcommand else f"{base} {subcommand}"
+
+
+def _gateway_service_command(subcommand: str, *, system: bool = False) -> str:
+    """Return the gateway command shown in service-manager guidance."""
+    if system:
+        return f"sudo hermes gateway {subcommand} --system"
+    return _gateway_cli_command(subcommand)
+
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -468,7 +483,7 @@ def _wait_for_systemd_service_restart(
 
     print(
         f"⚠ {scope_label} service did not become active within {int(timeout)}s.\n"
-        f"  Check status: {'sudo ' if system else ''}hermes gateway status\n"
+        f"  Check status: {_gateway_service_command('status', system=system)}\n"
         f"  Check logs:   journalctl {'--user ' if not system else ''}-u {svc} -l --since '2 min ago'"
     )
     return False
@@ -967,7 +982,7 @@ def _raise_user_systemd_unavailable(username: str, *, reason: str, fix_hint: str
         "\n"
         "  Alternative: run the gateway in the foreground (stays up until\n"
         "  you exit / close the terminal):\n"
-        "    hermes gateway run"
+        f"    {_gateway_cli_command('run')}"
     )
     raise UserSystemdUnavailableError(msg)
 
@@ -1106,7 +1121,7 @@ def print_legacy_unit_warning() -> None:
     print_info("  These run alongside the current hermes-gateway service and")
     print_info("  cause SIGTERM flap loops — both try to use the same bot token.")
     print_info("  Remove them with:")
-    print_info("    hermes gateway migrate-legacy")
+    print_info(f"    {_gateway_cli_command('migrate-legacy')}")
 
 
 def remove_legacy_hermes_units(
@@ -1149,7 +1164,7 @@ def remove_legacy_hermes_units(
         return 0, [p for _, p, _ in legacy]
 
     if interactive and not prompt_yes_no("Remove these legacy units?", True):
-        print("Skipped. Run again with: hermes gateway migrate-legacy")
+        print(f"Skipped. Run again with: {_gateway_cli_command('migrate-legacy')}")
         return 0, [p for _, p, _ in legacy]
 
     removed = 0
@@ -1217,7 +1232,7 @@ def print_systemd_scope_conflict_warning() -> None:
     print_info("  This is confusing and can make start/stop/status behavior ambiguous.")
     print_info("  Default gateway commands target the user service unless you pass --system.")
     print_info("  Keep one of these:")
-    print_info("    hermes gateway uninstall")
+    print_info(f"    {_gateway_cli_command('uninstall')}")
     print_info("    sudo hermes gateway uninstall --system")
 
 
@@ -1758,7 +1773,6 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
             print()
 
     unit_path = get_systemd_unit_path(system=system)
-    scope_flag = " --system" if system else ""
 
     if unit_path.exists() and not force:
         if not systemd_unit_is_current(system=system):
@@ -1782,8 +1796,8 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
     print(f"✓ {_service_scope_label(system).capitalize()} service installed and enabled!")
     print()
     print("Next steps:")
-    print(f"  {'sudo ' if system else ''}hermes gateway start{scope_flag}              # Start the service")
-    print(f"  {'sudo ' if system else ''}hermes gateway status{scope_flag}             # Check status")
+    print(f"  {_gateway_service_command('start', system=system)}              # Start the service")
+    print(f"  {_gateway_service_command('status', system=system)}             # Check status")
     print(f"  {'journalctl' if system else 'journalctl --user'} -u {get_service_name()} -f  # View logs")
     print()
 
@@ -1903,11 +1917,10 @@ def systemd_restart(system: bool = False):
 def systemd_status(deep: bool = False, system: bool = False, full: bool = False):
     system = _select_systemd_scope(system)
     unit_path = get_systemd_unit_path(system=system)
-    scope_flag = " --system" if system else ""
 
     if not unit_path.exists():
         print("✗ Gateway service is not installed")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print(f"  Run: {_gateway_service_command('install', system=system)}")
         return
 
     if has_conflicting_systemd_units():
@@ -1920,7 +1933,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
     if not systemd_unit_is_current(system=system):
         print("⚠ Installed gateway service definition is outdated")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway restart{scope_flag}  # auto-refreshes the unit")
+        print(f"  Run: {_gateway_service_command('restart', system=system)}  # auto-refreshes the unit")
         print()
 
     status_cmd = ["status", get_service_name(), "--no-pager"]
@@ -1948,7 +1961,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print(f"✓ {_service_scope_label(system).capitalize()} gateway service is running")
     else:
         print(f"✗ {_service_scope_label(system).capitalize()} gateway service is stopped")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway start{scope_flag}")
+        print(f"  Run: {_gateway_service_command('start', system=system)}")
 
     configured_user = _read_systemd_user_from_unit(unit_path) if system else None
     if configured_user:
@@ -1970,7 +1983,10 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print("  ⏳ Restart pending: systemd is waiting to relaunch the gateway")
     elif active_state == "failed" and exec_main_status == str(GATEWAY_SERVICE_RESTART_EXIT_CODE):
         print("  ⚠ Planned restart is stuck in systemd failed state (exit 75)")
-        print(f"  Run: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()} && {'sudo ' if system else ''}hermes gateway start{scope_flag}")
+        print(
+            f"  Run: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()} && "
+            f"{_gateway_service_command('start', system=system)}"
+        )
     elif active_state == "failed" and result_code:
         print(f"  ⚠ Systemd unit result: {result_code}")
 
@@ -2151,7 +2167,7 @@ def launchd_install(force: bool = False):
     print("✓ Service installed and loaded!")
     print()
     print("Next steps:")
-    print("  hermes gateway status             # Check status")
+    print(f"  {_gateway_cli_command('status')}             # Check status")
     from hermes_constants import display_hermes_home as _dhh
     print(f"  tail -f {_dhh()}/logs/gateway.log  # View logs")
 
@@ -2303,7 +2319,7 @@ def launchd_status(deep: bool = False):
         print("✓ Service definition matches the current Hermes install")
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
-        print("  Run: hermes gateway start")
+        print(f"  Run: {_gateway_cli_command('start')}")
 
     if loaded:
         print("✓ Gateway service is loaded")
@@ -2311,7 +2327,7 @@ def launchd_status(deep: bool = False):
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
-        print("  Run: hermes gateway start")
+        print(f"  Run: {_gateway_cli_command('start')}")
     
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
@@ -2886,7 +2902,7 @@ def _setup_standard_platform(platform: dict):
                     print_success("  DM pairing mode — users will receive a code to request access.")
                     print_info("  Approve with: hermes pairing approve <platform> <code>")
                 else:
-                    print_info("  Skipped — configure later with 'hermes gateway setup'")
+                    print_info(f"  Skipped — configure later with '{_gateway_cli_command('setup')}'")
             continue
 
         value = prompt(f"  {var['prompt']}", password=var.get("password", False))
@@ -3094,7 +3110,7 @@ def _setup_wecom():
             save_env_value("WECOM_DM_POLICY", "disabled")
             print_warning("  Direct messages disabled.")
         else:
-            print_info("  Skipped — configure later with 'hermes gateway setup'")
+            print_info(f"  Skipped — configure later with '{_gateway_cli_command('setup')}'")
 
     # ── Home channel (optional) ──
     print()
@@ -3186,7 +3202,7 @@ def _setup_weixin():
 
     if not check_weixin_requirements():
         print_error("  Missing dependencies: Weixin needs aiohttp and cryptography.")
-        print_info("  Install them, then rerun `hermes gateway setup`.")
+        print_info(f"  Install them, then rerun `{_gateway_cli_command('setup')}`.")
         return
 
     print()
@@ -3786,7 +3802,7 @@ def gateway_setup():
                         launchd_restart()
                     else:
                         stop_profile_gateway()
-                        print_info("Start manually: hermes gateway")
+                        print_info(f"Start manually: {_gateway_cli_command()}")
                 except UserSystemdUnavailableError as e:
                     print_error("  Restart failed — user systemd not reachable:")
                     for line in str(e).splitlines():
@@ -3835,29 +3851,31 @@ def gateway_setup():
                                 print_error(f"  Start failed: {e}")
                     except subprocess.CalledProcessError as e:
                         print_error(f"  Install failed: {e}")
-                        print_info("  You can try manually: hermes gateway install")
+                        print_info(f"  You can try manually: {_gateway_cli_command('install')}")
                 else:
-                    print_info("  You can install later: hermes gateway install")
+                    print_info(f"  You can install later: {_gateway_cli_command('install')}")
                     if supports_systemd_services():
                         print_info("  Or as a boot-time service: sudo hermes gateway install --system")
-                    print_info("  Or run in foreground:  hermes gateway run")
+                    print_info(f"  Or run in foreground:  {_gateway_cli_command('run')}")
             elif is_wsl():
                 print_info("  WSL detected but systemd is not running.")
-                print_info("  Run in foreground: hermes gateway run")
-                print_info("  For persistence:   tmux new -s hermes 'hermes gateway run'")
+                print_info(f"  Run in foreground: {_gateway_cli_command('run')}")
+                print_info(f"  For persistence:   tmux new -s hermes '{_gateway_cli_command('run')}'")
                 print_info("  To enable systemd: add systemd=true to /etc/wsl.conf, then 'wsl --shutdown'")
             else:
                 if is_termux():
                     from hermes_constants import display_hermes_home as _dhh
                     print_info("  Termux does not use systemd/launchd services.")
-                    print_info("  Run in foreground: hermes gateway run")
-                    print_info(f"  Or start it manually in the background (best effort): nohup hermes gateway run >{_dhh()}/logs/gateway.log 2>&1 &")
+                    print_info(f"  Run in foreground: {_gateway_cli_command('run')}")
+                    print_info(
+                        f"  Or start it manually in the background (best effort): nohup {_gateway_cli_command('run')} >{_dhh()}/logs/gateway.log 2>&1 &"
+                    )
                 else:
                     print_info("  Service install not supported on this platform.")
-                    print_info("  Run in foreground: hermes gateway run")
+                    print_info(f"  Run in foreground: {_gateway_cli_command('run')}")
     else:
         print()
-        print_info("No platforms configured. Run 'hermes gateway setup' when ready.")
+        print_info(f"No platforms configured. Run '{_gateway_cli_command('setup')}' when ready.")
 
     print()
 
@@ -3904,13 +3922,13 @@ def _gateway_command_inner(args):
         run_as_user = getattr(args, 'run_as_user', None)
         if is_termux():
             print("Gateway service installation is not supported on Termux.")
-            print("Run manually: hermes gateway")
+            print(f"Run manually: {_gateway_cli_command()}")
             sys.exit(1)
         if supports_systemd_services():
             if is_wsl():
                 print_warning("WSL detected — systemd services may not survive WSL restarts.")
-                print_info("  Consider running in foreground instead: hermes gateway run")
-                print_info("  Or use tmux/screen for persistence: tmux new -s hermes 'hermes gateway run'")
+                print_info(f"  Consider running in foreground instead: {_gateway_cli_command('run')}")
+                print_info(f"  Or use tmux/screen for persistence: tmux new -s hermes '{_gateway_cli_command('run')}'")
                 print()
             systemd_install(force=force, system=system, run_as_user=run_as_user)
         elif is_macos():
@@ -3920,9 +3938,9 @@ def _gateway_command_inner(args):
             print("Either enable systemd (add systemd=true to /etc/wsl.conf and restart WSL)")
             print("or run the gateway in foreground mode:")
             print()
-            print("  hermes gateway run                              # direct foreground")
-            print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
-            print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
+            print(f"  {_gateway_cli_command('run')}                              # direct foreground")
+            print(f"  tmux new -s hermes '{_gateway_cli_command('run')}'         # persistent via tmux")
+            print(f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # background")
             sys.exit(1)
         elif is_container():
             print("Service installation is not needed inside a Docker container.")
@@ -3931,11 +3949,11 @@ def _gateway_command_inner(args):
             print("  docker run --restart unless-stopped ...   # auto-restart on crash/reboot")
             print("  docker restart <container>                # manual restart")
             print()
-            print("To run the gateway: hermes gateway run")
+            print(f"To run the gateway: {_gateway_cli_command('run')}")
             sys.exit(0)
         else:
             print("Service installation not supported on this platform.")
-            print("Run manually: hermes gateway run")
+            print(f"Run manually: {_gateway_cli_command('run')}")
             sys.exit(1)
     
     elif subcmd == "uninstall":
@@ -3945,7 +3963,7 @@ def _gateway_command_inner(args):
         system = getattr(args, 'system', False)
         if is_termux():
             print("Gateway service uninstall is not supported on Termux because there is no managed service to remove.")
-            print("Stop manual runs with: hermes gateway stop")
+            print(f"Stop manual runs with: {_gateway_cli_command('stop')}")
             sys.exit(1)
         if supports_systemd_services():
             systemd_uninstall(system=system)
@@ -3975,7 +3993,7 @@ def _gateway_command_inner(args):
 
         if is_termux():
             print("Gateway service start is not supported on Termux because there is no system service manager.")
-            print("Run manually: hermes gateway")
+            print(f"Run manually: {_gateway_cli_command()}")
             sys.exit(1)
         if supports_systemd_services():
             systemd_start(system=system)
@@ -3985,9 +4003,9 @@ def _gateway_command_inner(args):
             print("WSL detected but systemd is not available.")
             print("Run the gateway in foreground mode instead:")
             print()
-            print("  hermes gateway run                              # direct foreground")
-            print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
-            print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
+            print(f"  {_gateway_cli_command('run')}                              # direct foreground")
+            print(f"  tmux new -s hermes '{_gateway_cli_command('run')}'         # persistent via tmux")
+            print(f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # background")
             print()
             print("To enable systemd: add systemd=true to /etc/wsl.conf and run 'wsl --shutdown' from PowerShell.")
             sys.exit(1)
@@ -3998,7 +4016,7 @@ def _gateway_command_inner(args):
             print("  docker start <container>     # start a stopped container")
             print("  docker restart <container>   # restart a running container")
             print()
-            print("Or run the gateway directly: hermes gateway run")
+            print(f"Or run the gateway directly: {_gateway_cli_command('run')}")
             sys.exit(0)
         else:
             print("Not supported on this platform.")
@@ -4121,14 +4139,14 @@ def _gateway_command_inner(args):
                     print(f"  Run:  sudo loginctl enable-linger {_username}")
                     print()
                     print("  Then restart the gateway:")
-                    print("    hermes gateway restart")
+                    print(f"    {_gateway_cli_command('restart')}")
                     return
 
             if service_configured:
                 print()
                 print("✗ Gateway service restart failed.")
                 print("  The service definition exists, but the service manager did not recover it.")
-                print("  Fix the service, then retry: hermes gateway start")
+                print(f"  Fix the service, then retry: {_gateway_cli_command('start')}")
                 sys.exit(1)
 
             # Manual restart: stop only this profile's gateway
@@ -4176,7 +4194,7 @@ def _gateway_command_inner(args):
                     print("  Use tmux or screen for persistence across terminal closes.")
                 else:
                     print("To install as a service:")
-                    print("  hermes gateway install")
+                    print(f"  {_gateway_cli_command('install')}")
                     print("  sudo hermes gateway install --system")
             else:
                 print("✗ Gateway is not running")
@@ -4188,14 +4206,14 @@ def _gateway_command_inner(args):
                         print(f"  {line}")
                 print()
                 print("To start:")
-                print("  hermes gateway run      # Run in foreground")
+                print(f"  {_gateway_cli_command('run')}      # Run in foreground")
                 if is_termux():
-                    print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # Best-effort background start")
+                    print(f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # Best-effort background start")
                 elif is_wsl():
-                    print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
-                    print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
+                    print(f"  tmux new -s hermes '{_gateway_cli_command('run')}'         # persistent via tmux")
+                    print(f"  nohup {_gateway_cli_command('run')} > ~/.hermes/logs/gateway.log 2>&1 &  # background")
                 else:
-                    print("  hermes gateway install  # Install as user service")
+                    print(f"  {_gateway_cli_command('install')}  # Install as user service")
                     print("  sudo hermes gateway install --system  # Install as boot-time system service")
 
     elif subcmd == "migrate-legacy":

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -261,6 +261,33 @@ _HERMES_SUBCOMMANDS = frozenset({
 # Path helpers
 # ---------------------------------------------------------------------------
 
+
+def get_profile_command(profile_name: Optional[str] = None) -> str:
+    """Return the recommended command used to invoke Hermes for a profile.
+
+    * Default/custom active profile: ``hermes``
+    * Named profile with an alias wrapper: ``<profile>``
+    * Named profile without a wrapper: ``hermes -p <profile>``
+    """
+    if profile_name is None:
+        profile_name = get_active_profile_name()
+
+    if profile_name in (None, "default", "custom"):
+        return "hermes"
+
+    if not _PROFILE_ID_RE.match(profile_name):
+        return "hermes"
+
+    wrapper_path = _get_wrapper_dir() / profile_name
+    try:
+        if wrapper_path.is_file() and f"hermes -p {profile_name}" in wrapper_path.read_text():
+            return profile_name
+    except Exception:
+        return "hermes -p " + profile_name
+
+    return "hermes -p " + profile_name
+
+
 def _get_profiles_root() -> Path:
     """Return the directory where named profiles are stored.
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -278,12 +278,12 @@ def get_profile_command(profile_name: Optional[str] = None) -> str:
     if not _PROFILE_ID_RE.match(profile_name):
         return "hermes"
 
-    wrapper_path = _get_wrapper_dir() / profile_name
     try:
-        if wrapper_path.is_file() and f"hermes -p {profile_name}" in wrapper_path.read_text():
-            return profile_name
+        alias = find_alias_for_profile(profile_name)
+        if alias:
+            return alias
     except Exception:
-        return "hermes -p " + profile_name
+        pass
 
     return "hermes -p " + profile_name
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -117,6 +117,33 @@ _HERMES_SUBCOMMANDS = frozenset({
 # Path helpers
 # ---------------------------------------------------------------------------
 
+
+def get_profile_command(profile_name: Optional[str] = None) -> str:
+    """Return the recommended command used to invoke Hermes for a profile.
+
+    * Default/custom active profile: ``hermes``
+    * Named profile with an alias wrapper: ``<profile>``
+    * Named profile without a wrapper: ``hermes -p <profile>``
+    """
+    if profile_name is None:
+        profile_name = get_active_profile_name()
+
+    if profile_name in (None, "default", "custom"):
+        return "hermes"
+
+    if not _PROFILE_ID_RE.match(profile_name):
+        return "hermes"
+
+    wrapper_path = _get_wrapper_dir() / profile_name
+    try:
+        if wrapper_path.is_file() and f"hermes -p {profile_name}" in wrapper_path.read_text():
+            return profile_name
+    except Exception:
+        return "hermes -p " + profile_name
+
+    return "hermes -p " + profile_name
+
+
 def _get_profiles_root() -> Path:
     """Return the directory where named profiles are stored.
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -202,9 +202,9 @@ def print_noninteractive_setup_guidance(reason: str | None = None) -> None:
     print_info("The interactive wizard cannot be used here.")
     print()
     print_info("Configure Hermes using environment variables or config commands:")
-    print_info("  hermes config set model.provider custom")
-    print_info("  hermes config set model.base_url http://localhost:8080/v1")
-    print_info("  hermes config set model.default your-model-name")
+    print_info(f"  {_profile_command('config set model.provider custom')}")
+    print_info(f"  {_profile_command('config set model.base_url http://localhost:8080/v1')}")
+    print_info(f"  {_profile_command('config set model.default your-model-name')}")
     print()
     print_info("Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.")
     print_info(f"Run '{_profile_command('setup')}' in an interactive terminal to use the full wizard.")
@@ -425,7 +425,9 @@ def _print_setup_summary(config: dict, hermes_home):
     if _vision_backends:
         tool_status.append(("Vision (image analysis)", True, None))
     else:
-        tool_status.append(("Vision (image analysis)", False, "run 'hermes setup' to configure"))
+        tool_status.append(
+            ("Vision (image analysis)", False, f"run '{_profile_command('setup')}' to configure")
+        )
 
 
     # Web tools (Exa, Parallel, Firecrawl, or Tavily)
@@ -547,7 +549,13 @@ def _print_setup_summary(config: dict, hermes_home):
         if neutts_ok:
             tool_status.append(("Text-to-Speech (NeuTTS local)", True, None))
         else:
-            tool_status.append(("Text-to-Speech (NeuTTS — not installed)", False, "run 'hermes setup tts'"))
+            tool_status.append(
+                (
+                    "Text-to-Speech (NeuTTS — not installed)",
+                    False,
+                    f"run '{_profile_command('setup tts')}'",
+                )
+            )
     elif tts_provider == "kittentts":
         try:
             kittentts_ok = importlib.util.find_spec("kittentts") is not None
@@ -556,7 +564,13 @@ def _print_setup_summary(config: dict, hermes_home):
         if kittentts_ok:
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
-            tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
+            tool_status.append(
+                (
+                    "Text-to-Speech (KittenTTS — not installed)",
+                    False,
+                    f"run '{_profile_command('setup tts')}'",
+                )
+            )
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
@@ -566,7 +580,9 @@ def _print_setup_summary(config: dict, hermes_home):
         if subscription_features.modal.direct_override:
             tool_status.append(("Modal Execution (direct Modal)", True, None))
         else:
-            tool_status.append(("Modal Execution", False, "run 'hermes setup terminal'"))
+            tool_status.append(
+                ("Modal Execution", False, f"run '{_profile_command('setup terminal')}'")
+            )
     elif managed_nous_tools_enabled() and subscription_features.nous_auth_present:
         tool_status.append(("Modal Execution (optional via Nous subscription)", True, None))
 
@@ -618,7 +634,7 @@ def _print_setup_summary(config: dict, hermes_home):
     disabled_tools = [(name, var) for name, avail, var in tool_status if not avail]
     if disabled_tools:
         print_warning(
-            "Some tools are disabled. Run 'hermes setup tools' to configure them,"
+            f"Some tools are disabled. Run '{_profile_command('setup tools')}' to configure them,"
         )
         from hermes_constants import display_hermes_home as _dhh
         print_warning(f"or edit {_dhh()}/.env directly to add the missing API keys.")
@@ -1098,7 +1114,7 @@ def _setup_tts_provider(config: dict):
                     from hermes_constants import display_hermes_home as _dhh
                     print_warning(
                         "No xAI API key provided for TTS. Configure XAI_API_KEY "
-                        f"via hermes setup model or {_dhh()}/.env to use xAI TTS. "
+                        f"via {_profile_command('setup model')} or {_dhh()}/.env to use xAI TTS. "
                         "Falling back to Edge TTS."
                     )
                     selected = "edge"
@@ -1488,7 +1504,7 @@ def _apply_default_agent_settings(config: dict):
     print_info("  Tool progress: all")
     print_info("  Compression threshold: 0.50")
     print_info("  Session reset: never (use /reset or compression)")
-    print_info("  Run `hermes setup agent` later to customize.")
+    print_info(f"  Run `{_profile_command('setup agent')}` later to customize.")
 
 
 def setup_agent_settings(config: dict):
@@ -1953,8 +1969,8 @@ def _setup_webhooks():
     print_info("   Route configuration guide:")
     print_info("   https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/#configuring-routes")
     print()
-    print_info("   Open config in your editor:  hermes config edit")
-    print_info("   Open config in your editor:  hermes config edit")
+    print_info(f"   Open config in your editor:  {_profile_command('config edit')}")
+    print_info(f"   Open config in your editor:  {_profile_command('config edit')}")
 
 
 def setup_gateway(config: dict):
@@ -2035,7 +2051,7 @@ def setup_gateway(config: dict):
             print_info("   Set one later with /set-home in your chat, or:")
             for plat in missing_home:
                 print_info(
-                    f"     hermes config set {plat.upper()}_HOME_CHANNEL <channel_id>"
+                    f"     {_profile_command(f'config set {plat.upper()}_HOME_CHANNEL <channel_id>')}"
                 )
 
         # Offer to install the gateway as a system service
@@ -2176,7 +2192,9 @@ def setup_gateway(config: dict):
             else:
                 print_info(f"  You can install later: {_profile_command('gateway install')}")
                 if supports_systemd and os.geteuid() == 0:  # windows-footgun: ok — guarded by supports_systemd (Linux only)
-                    print_info("  Or as a boot-time service: hermes gateway install --system")
+                    print_info(
+                        "  Or as a boot-time service: sudo hermes gateway install --system"
+                    )
                 print_info(f"  Or run in foreground:  {_profile_command('gateway')}")
         else:
             from hermes_constants import is_container
@@ -2862,7 +2880,9 @@ def run_setup_wizard(args):
         print_info("Running the full wizard — each prompt shows your current value.")
         print_info("Press Enter to keep it, or type a new value to change it.")
         print_info("")
-        print_info("Tip: jump straight to a section with 'hermes setup model|terminal|")
+        print_info(
+            f"Tip: jump straight to a section with '{_profile_command('setup')} model|terminal|"
+        )
         print_info("     gateway|tools|agent', or fill only missing items with --quick.")
         # Fall through to the "Full Setup — run all sections" block below.
         # --reconfigure is now the default on existing installs; the flag
@@ -2906,7 +2926,9 @@ def run_setup_wizard(args):
     print_info(f"Data folder:  {hermes_home}")
     print_info(f"Install dir:  {PROJECT_ROOT}")
     print()
-    print_info("You can edit these files directly or use 'hermes config edit'")
+    print_info(
+        f"You can edit these files directly or use '{_profile_command('config edit')}'"
+    )
 
     if migration_ran:
         print()
@@ -3163,7 +3185,7 @@ def _run_blank_slate_setup(config: dict, hermes_home, is_existing: bool):
         print_info("  Seed skills:         hermes skills opt-in --sync")
         print_info("  Add MCP servers:     hermes mcp add")
         print_info("  Enable plugins:      hermes plugins")
-        print_info("  Tune agent settings: hermes setup agent")
+        print_info(f"  Tune agent settings: {_profile_command('setup agent')}")
         print()
         _print_setup_summary(config, hermes_home)
         return
@@ -3249,7 +3271,7 @@ def _blank_slate_walkthrough(config: dict, hermes_home):
     print_info("  Enable more tools:   hermes tools")
     print_info("  Seed skills:         hermes skills opt-in --sync")
     print_info("  Add MCP servers:     hermes mcp add")
-    print_info("  Tune agent settings: hermes setup agent")
+    print_info(f"  Tune agent settings: {_profile_command('setup agent')}")
     print()
 
     _print_setup_summary(config, hermes_home)
@@ -3286,7 +3308,9 @@ def _run_quick_setup(config: dict, hermes_home):
     if not has_anything_missing:
         print_success("Everything is configured! Nothing to do.")
         print()
-        print_info("Run 'hermes setup' and choose 'Full Setup' to reconfigure,")
+        print_info(
+            f"Run '{_profile_command('setup')}' and choose 'Full Setup' to reconfigure,"
+        )
         print_info("or pick a specific section from the menu.")
         return
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -158,6 +158,20 @@ def print_header(title: str):
     print(color(f"◆ {title}", Colors.CYAN, Colors.BOLD))
 
 
+def _profile_command(command: str | None = None) -> str:
+    """Return the current profile-aware command prefix.
+
+    Examples:
+      - default profile:     ``hermes setup``
+      - named profile + alias: ``janedoe setup``
+      - named profile no alias: ``hermes -p janedoe setup``
+    """
+    from hermes_cli.profiles import get_profile_command
+
+    base = get_profile_command()
+    return base if not command else f"{base} {command}"
+
+
 from hermes_cli.cli_output import (  # noqa: E402
     print_error,
     print_info,
@@ -193,7 +207,7 @@ def print_noninteractive_setup_guidance(reason: str | None = None) -> None:
     print_info("  hermes config set model.default your-model-name")
     print()
     print_info("Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.")
-    print_info("Run 'hermes setup' in an interactive terminal to use the full wizard.")
+    print_info(f"Run '{_profile_command('setup')}' in an interactive terminal to use the full wizard.")
     print()
 
 
@@ -388,7 +402,7 @@ def _prompt_api_key(var: dict):
         save_env_value(var["name"], value)
         print_success("  ✓ Saved")
     else:
-        print_warning("  Skipped (configure later with 'hermes setup')")
+        print_warning(f"  Skipped (configure later with '{_profile_command('setup')}')")
 
 
 def _print_setup_summary(config: dict, hermes_home):
@@ -644,17 +658,17 @@ def _print_setup_summary(config: dict, hermes_home):
     print()
     print(color("📝 To edit your configuration:", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('hermes setup', Colors.GREEN)}          Re-run the full wizard")
-    print(f"   {color('hermes setup model', Colors.GREEN)}    Change model/provider")
-    print(f"   {color('hermes setup terminal', Colors.GREEN)} Change terminal backend")
-    print(f"   {color('hermes setup gateway', Colors.GREEN)}  Configure messaging")
-    print(f"   {color('hermes setup tools', Colors.GREEN)}    Configure tool providers")
+    print(f"   {color(_profile_command('setup'), Colors.GREEN)}          Re-run the full wizard")
+    print(f"   {color(_profile_command('setup model'), Colors.GREEN)}    Change model/provider")
+    print(f"   {color(_profile_command('setup terminal'), Colors.GREEN)} Change terminal backend")
+    print(f"   {color(_profile_command('setup gateway'), Colors.GREEN)}  Configure messaging")
+    print(f"   {color(_profile_command('setup tools'), Colors.GREEN)}    Configure tool providers")
     print()
-    print(f"   {color('hermes config', Colors.GREEN)}         View current settings")
+    print(f"   {color(_profile_command('config'), Colors.GREEN)}         View current settings")
     print(
-        f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor"
+        f"   {color(_profile_command('config edit'), Colors.GREEN)}    Open config in your editor"
     )
-    print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
+    print(f"   {color(_profile_command('config set <key> <value>'), Colors.GREEN)}")
     print("                          Set a specific value")
     print()
     print("   Or edit the files directly:")
@@ -666,9 +680,9 @@ def _print_setup_summary(config: dict, hermes_home):
     print()
     print(color("🚀 Ready to go!", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('hermes', Colors.GREEN)}              Start chatting")
-    print(f"   {color('hermes gateway', Colors.GREEN)}      Start messaging gateway")
-    print(f"   {color('hermes doctor', Colors.GREEN)}       Check for issues")
+    print(f"   {color(_profile_command(), Colors.GREEN)}              Start chatting")
+    print(f"   {color(_profile_command('gateway'), Colors.GREEN)}      Start messaging gateway")
+    print(f"   {color(_profile_command('doctor'), Colors.GREEN)}       Check for issues")
     print()
 
 
@@ -1966,7 +1980,9 @@ def setup_gateway(config: dict):
     selected = prompt_checklist("Select platforms to configure:", items, pre_selected)
 
     if not selected:
-        print_info("No platforms selected. Run 'hermes setup gateway' later to configure.")
+        print_info(
+            f"No platforms selected. Run '{_profile_command('setup gateway')}' later to configure."
+        )
         return
 
     for idx in selected:
@@ -2156,24 +2172,24 @@ def setup_gateway(config: dict):
                             print_error(f"  Start failed: {e}")
                 except Exception as e:
                     print_error(f"  Install failed: {e}")
-                    print_info("  You can try manually: hermes gateway install")
+                    print_info(f"  You can try manually: {_profile_command('gateway install')}")
             else:
-                print_info("  You can install later: hermes gateway install")
+                print_info(f"  You can install later: {_profile_command('gateway install')}")
                 if supports_systemd and os.geteuid() == 0:  # windows-footgun: ok — guarded by supports_systemd (Linux only)
                     print_info("  Or as a boot-time service: hermes gateway install --system")
-                print_info("  Or run in foreground:  hermes gateway")
+                print_info(f"  Or run in foreground:  {_profile_command('gateway')}")
         else:
             from hermes_constants import is_container
             if is_container():
                 print_info("Start the gateway to bring your bots online:")
-                print_info("   hermes gateway run          # Run as container main process")
+                print_info(f"   {_profile_command('gateway run')}          # Run as container main process")
                 print_info("")
                 print_info("For automatic restarts, use a Docker restart policy:")
                 print_info("   docker run --restart unless-stopped ...")
                 print_info("   docker restart <container>  # Manual restart")
             else:
                 print_info("Start the gateway to bring your bots online:")
-                print_info("   hermes gateway              # Run in foreground")
+                print_info(f"   {_profile_command('gateway')}              # Run in foreground")
 
         print_info("━" * 50)
 
@@ -2982,7 +2998,7 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
         "Connect a messaging platform? (Telegram, Discord, etc.)",
         [
             "Set up messaging now (recommended)",
-            "Skip — set up later with 'hermes setup gateway'",
+            f"Skip — set up later with '{_profile_command('setup gateway')}'",
         ],
         0,
     )
@@ -2994,9 +3010,9 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
     print()
     print_success("Setup complete! You're ready to go.")
     print()
-    print_info("  Configure all settings:    hermes setup")
+    print_info(f"  Configure all settings:    {_profile_command('setup')}")
     if gateway_choice != 0:
-        print_info("  Connect Telegram/Discord:  hermes setup gateway")
+        print_info(f"  Connect Telegram/Discord:  {_profile_command('setup gateway')}")
     print()
 
     _print_setup_summary(config, hermes_home)
@@ -3333,7 +3349,7 @@ def _run_quick_setup(config: dict, hermes_home):
         print()
         print_header("Messaging Platforms")
         print_info("Connect Hermes to messaging apps to chat from anywhere.")
-        print_info("You can configure these later with 'hermes setup gateway'.")
+        print_info(f"You can configure these later with '{_profile_command('setup gateway')}'.")
 
         # Group by platform (preserving order)
         platform_order = []

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -152,6 +152,20 @@ def print_header(title: str):
     print(color(f"◆ {title}", Colors.CYAN, Colors.BOLD))
 
 
+def _profile_command(command: str | None = None) -> str:
+    """Return the current profile-aware command prefix.
+
+    Examples:
+      - default profile:     ``hermes setup``
+      - named profile + alias: ``janedoe setup``
+      - named profile no alias: ``hermes -p janedoe setup``
+    """
+    from hermes_cli.profiles import get_profile_command
+
+    base = get_profile_command()
+    return base if not command else f"{base} {command}"
+
+
 from hermes_cli.cli_output import (  # noqa: E402
     print_error,
     print_info,
@@ -186,7 +200,7 @@ def print_noninteractive_setup_guidance(reason: str | None = None) -> None:
     print_info("  hermes config set model.default your-model-name")
     print()
     print_info("Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.")
-    print_info("Run 'hermes setup' in an interactive terminal to use the full wizard.")
+    print_info(f"Run '{_profile_command('setup')}' in an interactive terminal to use the full wizard.")
     print()
 
 
@@ -339,7 +353,7 @@ def _prompt_api_key(var: dict):
         save_env_value(var["name"], value)
         print_success("  ✓ Saved")
     else:
-        print_warning("  Skipped (configure later with 'hermes setup')")
+        print_warning(f"  Skipped (configure later with '{_profile_command('setup')}')")
 
 
 def _print_setup_summary(config: dict, hermes_home):
@@ -584,17 +598,17 @@ def _print_setup_summary(config: dict, hermes_home):
     print()
     print(color("📝 To edit your configuration:", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('hermes setup', Colors.GREEN)}          Re-run the full wizard")
-    print(f"   {color('hermes setup model', Colors.GREEN)}    Change model/provider")
-    print(f"   {color('hermes setup terminal', Colors.GREEN)} Change terminal backend")
-    print(f"   {color('hermes setup gateway', Colors.GREEN)}  Configure messaging")
-    print(f"   {color('hermes setup tools', Colors.GREEN)}    Configure tool providers")
+    print(f"   {color(_profile_command('setup'), Colors.GREEN)}          Re-run the full wizard")
+    print(f"   {color(_profile_command('setup model'), Colors.GREEN)}    Change model/provider")
+    print(f"   {color(_profile_command('setup terminal'), Colors.GREEN)} Change terminal backend")
+    print(f"   {color(_profile_command('setup gateway'), Colors.GREEN)}  Configure messaging")
+    print(f"   {color(_profile_command('setup tools'), Colors.GREEN)}    Configure tool providers")
     print()
-    print(f"   {color('hermes config', Colors.GREEN)}         View current settings")
+    print(f"   {color(_profile_command('config'), Colors.GREEN)}         View current settings")
     print(
-        f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor"
+        f"   {color(_profile_command('config edit'), Colors.GREEN)}    Open config in your editor"
     )
-    print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
+    print(f"   {color(_profile_command('config set <key> <value>'), Colors.GREEN)}")
     print("                          Set a specific value")
     print()
     print("   Or edit the files directly:")
@@ -606,9 +620,9 @@ def _print_setup_summary(config: dict, hermes_home):
     print()
     print(color("🚀 Ready to go!", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('hermes', Colors.GREEN)}              Start chatting")
-    print(f"   {color('hermes gateway', Colors.GREEN)}      Start messaging gateway")
-    print(f"   {color('hermes doctor', Colors.GREEN)}       Check for issues")
+    print(f"   {color(_profile_command(), Colors.GREEN)}              Start chatting")
+    print(f"   {color(_profile_command('gateway'), Colors.GREEN)}      Start messaging gateway")
+    print(f"   {color(_profile_command('doctor'), Colors.GREEN)}       Check for issues")
     print()
 
 
@@ -2261,7 +2275,9 @@ def setup_gateway(config: dict):
     selected = prompt_checklist("Select platforms to configure:", items, pre_selected)
 
     if not selected:
-        print_info("No platforms selected. Run 'hermes setup gateway' later to configure.")
+        print_info(
+            f"No platforms selected. Run '{_profile_command('setup gateway')}' later to configure."
+        )
         return
 
     for idx in selected:
@@ -2415,24 +2431,24 @@ def setup_gateway(config: dict):
                             print_error(f"  Start failed: {e}")
                 except Exception as e:
                     print_error(f"  Install failed: {e}")
-                    print_info("  You can try manually: hermes gateway install")
+                    print_info(f"  You can try manually: {_profile_command('gateway install')}")
             else:
-                print_info("  You can install later: hermes gateway install")
+                print_info(f"  You can install later: {_profile_command('gateway install')}")
                 if supports_systemd:
                     print_info("  Or as a boot-time service: sudo hermes gateway install --system")
-                print_info("  Or run in foreground:  hermes gateway")
+                print_info(f"  Or run in foreground:  {_profile_command('gateway')}")
         else:
             from hermes_constants import is_container
             if is_container():
                 print_info("Start the gateway to bring your bots online:")
-                print_info("   hermes gateway run          # Run as container main process")
+                print_info(f"   {_profile_command('gateway run')}          # Run as container main process")
                 print_info("")
                 print_info("For automatic restarts, use a Docker restart policy:")
                 print_info("   docker run --restart unless-stopped ...")
                 print_info("   docker restart <container>  # Manual restart")
             else:
                 print_info("Start the gateway to bring your bots online:")
-                print_info("   hermes gateway              # Run in foreground")
+                print_info(f"   {_profile_command('gateway')}              # Run in foreground")
 
         print_info("━" * 50)
 
@@ -3140,7 +3156,7 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
         "Connect a messaging platform? (Telegram, Discord, etc.)",
         [
             "Set up messaging now (recommended)",
-            "Skip — set up later with 'hermes setup gateway'",
+            f"Skip — set up later with '{_profile_command('setup gateway')}'",
         ],
         0,
     )
@@ -3152,9 +3168,9 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
     print()
     print_success("Setup complete! You're ready to go.")
     print()
-    print_info("  Configure all settings:    hermes setup")
+    print_info(f"  Configure all settings:    {_profile_command('setup')}")
     if gateway_choice != 0:
-        print_info("  Connect Telegram/Discord:  hermes setup gateway")
+        print_info(f"  Connect Telegram/Discord:  {_profile_command('setup gateway')}")
     print()
 
     _print_setup_summary(config, hermes_home)
@@ -3256,7 +3272,7 @@ def _run_quick_setup(config: dict, hermes_home):
         print()
         print_header("Messaging Platforms")
         print_info("Connect Hermes to messaging apps to chat from anywhere.")
-        print_info("You can configure these later with 'hermes setup gateway'.")
+        print_info(f"You can configure these later with '{_profile_command('setup gateway')}'.")
 
         # Group by platform (preserving order)
         platform_order = []

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -3,7 +3,9 @@
 import argparse
 import signal
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from unittest.mock import call, patch
 
 import pytest
 
@@ -662,6 +664,40 @@ def test_systemd_install_can_skip_enable_on_startup(monkeypatch, tmp_path, capsy
     assert helper_calls == [True]
     assert "User service installed!" in out
     assert "installed and enabled" not in out
+
+
+def test_systemd_install_user_scope_uses_profile_alias_in_next_steps(monkeypatch, tmp_path, capsys):
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+
+    wrapper_dir = tmp_path / ".local" / "bin"
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+
+    unit_path = tmp_path / "systemd" / "user" / "hermes-gateway-johndoe.service"
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(
+        gateway,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: (
+            '[Service]\nEnvironment="HERMES_HOME=/home/alice/.hermes"\n'
+        ),
+    )
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: None)
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "run",
+        lambda cmd, check=False, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway.systemd_install(force=False)
+
+    out = capsys.readouterr().out
+    assert "johndoe gateway start" in out
+    assert "johndoe gateway status" in out
 
 
 def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -672,7 +672,9 @@ def test_systemd_install_user_scope_uses_profile_alias_in_next_steps(monkeypatch
 
     wrapper_dir = tmp_path / ".local" / "bin"
     wrapper_dir.mkdir(parents=True, exist_ok=True)
-    (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+    (wrapper_dir / "janes-agent").write_text(
+        "#!/bin/sh\nexec hermes -p johndoe \"$@\"\n"
+    )
 
     unit_path = tmp_path / "systemd" / "user" / "hermes-gateway-johndoe.service"
 
@@ -696,13 +698,22 @@ def test_systemd_install_user_scope_uses_profile_alias_in_next_steps(monkeypatch
     gateway.systemd_install(force=False)
 
     out = capsys.readouterr().out
-    assert "johndoe gateway start" in out
-    assert "johndoe gateway status" in out
+    assert "janes-agent gateway start" in out
+    assert "janes-agent gateway status" in out
 
 
 def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatch, tmp_path, capsys):
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    wrapper_dir = tmp_path / ".local" / "bin"
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    (wrapper_dir / "janes-agent").write_text(
+        "#!/bin/sh\nexec hermes -p johndoe \"$@\"\n"
+    )
     unit_path = tmp_path / "etc" / "systemd" / "system" / "hermes-gateway.service"
 
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
     monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
     monkeypatch.setattr(
         gateway,
@@ -733,6 +744,9 @@ def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatc
     assert helper_calls == []
     assert "Configured to run as: alice" not in out  # generated test unit has no User= line
     assert "System service installed and enabled" in out
+    assert "sudo hermes gateway start --system" in out
+    assert "sudo hermes gateway status --system" in out
+    assert "janes-agent gateway" not in out
 
 
 def test_conflicting_systemd_units_warning(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.gateway."""
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, call
 
@@ -164,6 +165,33 @@ def test_systemd_install_checks_linger_status(monkeypatch, tmp_path, capsys):
     ]
     assert helper_calls == [True]
     assert "User service installed and enabled" in out
+
+
+def test_systemd_install_user_scope_uses_profile_alias_in_next_steps(monkeypatch, tmp_path, capsys):
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+
+    wrapper_dir = tmp_path / ".local" / "bin"
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+
+    unit_path = tmp_path / "systemd" / "user" / "hermes-gateway-johndoe.service"
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: None)
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "run",
+        lambda cmd, check=False, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway.systemd_install(force=False)
+
+    out = capsys.readouterr().out
+    assert "johndoe gateway start" in out
+    assert "johndoe gateway status" in out
 
 
 def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -21,6 +21,7 @@ import yaml
 from hermes_cli import profiles
 from hermes_cli.profiles import (
     normalize_profile_name,
+    get_profile_command,
     validate_profile_name,
     get_profile_dir,
     create_profile,
@@ -769,6 +770,33 @@ class TestGetActiveProfileName:
         # not "custom".  The user is on the default profile of their
         # custom deployment.
         assert get_active_profile_name() == "default"
+
+
+class TestProfileCommandFormatter:
+    """Tests for profile-aware command formatting."""
+
+    def test_default_profile_command_is_hermes(self, profile_env):
+        assert get_profile_command() == "hermes"
+
+    def test_named_profile_with_alias_uses_wrapper_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        wrapper_dir = tmp_path / ".local" / "bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+
+        assert get_profile_command() == "johndoe"
+
+    def test_named_profile_without_alias_uses_flag_command(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        assert get_profile_command() == "hermes -p johndoe"
 
 
 # ===================================================================

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -566,8 +566,9 @@ class TestDeleteProfile:
     def test_removes_directory(self, profile_env):
         profile_dir = create_profile("coder", no_alias=True)
         assert profile_dir.is_dir()
-        # Mock gateway import to avoid real systemd/launchd interaction
-        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+        # Keep deletion isolated from any live profile-bound backend.
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]):
             delete_profile("coder", yes=True)
         assert not profile_dir.is_dir()
 
@@ -584,6 +585,7 @@ class TestDeleteProfile:
         set_active_profile("coder")
 
         with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]), \
              patch("hermes_cli.profiles.time.sleep"), \
              patch("hermes_cli.profiles.shutil.rmtree", side_effect=PermissionError("locked")):
             with pytest.raises(RuntimeError, match="Could not remove profile directory"):
@@ -778,23 +780,39 @@ class TestProfileCommandFormatter:
     def test_default_profile_command_is_hermes(self, profile_env):
         assert get_profile_command() == "hermes"
 
-    def test_named_profile_with_alias_uses_wrapper_name(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    @staticmethod
+    def _activate_profile(profile_env, monkeypatch, name="johndoe"):
+        profile_dir = profile_env / ".hermes" / "profiles" / name
         profile_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        return profile_dir
 
-        wrapper_dir = tmp_path / ".local" / "bin"
-        wrapper_dir.mkdir(parents=True, exist_ok=True)
-        (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+    def test_profile_named_alias_uses_wrapper_name(self, profile_env, monkeypatch):
+        self._activate_profile(profile_env, monkeypatch)
+        monkeypatch.setattr("sys.platform", "darwin")
+        create_wrapper_script("johndoe")
 
         assert get_profile_command() == "johndoe"
 
-    def test_named_profile_without_alias_uses_flag_command(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
-        profile_dir.mkdir(parents=True, exist_ok=True)
-        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    def test_custom_unix_alias_uses_custom_wrapper_name(self, profile_env, monkeypatch):
+        self._activate_profile(profile_env, monkeypatch)
+        monkeypatch.setattr("sys.platform", "darwin")
+        create_wrapper_script("janes-agent", target="johndoe")
+
+        assert get_profile_command() == "janes-agent"
+
+    def test_custom_windows_alias_uses_bat_wrapper_name(self, profile_env, monkeypatch):
+        self._activate_profile(profile_env, monkeypatch)
+        monkeypatch.setattr("sys.platform", "win32")
+        wrapper = create_wrapper_script("janes-agent", target="johndoe")
+
+        assert wrapper is not None
+        assert wrapper.suffix == ".bat"
+        assert get_profile_command() == "janes-agent"
+
+    def test_named_profile_without_alias_uses_flag_command(self, profile_env, monkeypatch):
+        self._activate_profile(profile_env, monkeypatch)
+        monkeypatch.setattr("sys.platform", "darwin")
 
         assert get_profile_command() == "hermes -p johndoe"
 
@@ -1875,7 +1893,8 @@ class TestEdgeCases:
         set_active_profile("coder")
         assert get_active_profile() == "coder"
 
-        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]):
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -15,6 +15,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from hermes_cli.profiles import (
+    get_profile_command,
     validate_profile_name,
     get_profile_dir,
     create_profile,
@@ -304,6 +305,33 @@ class TestGetActiveProfileName:
         # not "custom".  The user is on the default profile of their
         # custom deployment.
         assert get_active_profile_name() == "default"
+
+
+class TestProfileCommandFormatter:
+    """Tests for profile-aware command formatting."""
+
+    def test_default_profile_command_is_hermes(self, profile_env):
+        assert get_profile_command() == "hermes"
+
+    def test_named_profile_with_alias_uses_wrapper_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        wrapper_dir = tmp_path / ".local" / "bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+
+        assert get_profile_command() == "johndoe"
+
+    def test_named_profile_without_alias_uses_flag_command(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        assert get_profile_command() == "hermes -p johndoe"
 
 
 # ===================================================================

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -1,6 +1,7 @@
 """Tests for setup.py configuration flows."""
 import sys
 import types
+from pathlib import Path
 
 
 from hermes_cli.config import load_config, save_config
@@ -540,3 +541,25 @@ def test_prompt_yes_no_keyboard_interrupt_still_exits(monkeypatch):
     with pytest.raises(SystemExit):
         setup_mod.prompt_yes_no("Install it now?", True)
 
+
+def test_print_setup_summary_uses_profile_command_for_profile_with_alias(
+    tmp_path, monkeypatch, capsys
+):
+    """Setup summary prints commands using a profile's wrapper alias when available."""
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+    wrapper_dir = tmp_path / ".local" / "bin"
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+
+    from hermes_cli.setup import _print_setup_summary
+
+    _print_setup_summary(load_config(), profile_dir)
+
+    out = capsys.readouterr().out
+    assert "johndoe setup gateway" in out
+    assert "johndoe gateway" in out
+    assert "johndoe doctor" in out

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -551,15 +551,80 @@ def test_print_setup_summary_uses_profile_command_for_profile_with_alias(
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(profile_dir))
 
-    wrapper_dir = tmp_path / ".local" / "bin"
-    wrapper_dir.mkdir(parents=True, exist_ok=True)
-    (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+    from hermes_cli.profiles import create_wrapper_script
+
+    create_wrapper_script("janes-agent", target="johndoe")
 
     from hermes_cli.setup import _print_setup_summary
 
     _print_setup_summary(load_config(), profile_dir)
 
     out = capsys.readouterr().out
-    assert "johndoe setup gateway" in out
-    assert "johndoe gateway" in out
-    assert "johndoe doctor" in out
+    assert "janes-agent setup gateway" in out
+    assert "janes-agent setup tools" in out
+    assert "janes-agent config edit" in out
+    assert "janes-agent gateway" in out
+    assert "janes-agent doctor" in out
+
+
+def test_quick_setup_reconfigure_guidance_uses_custom_profile_alias(
+    tmp_path, monkeypatch, capsys
+):
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+    from hermes_cli.profiles import create_wrapper_script
+
+    create_wrapper_script("janes-agent", target="johndoe")
+    monkeypatch.setattr("hermes_cli.config.get_missing_env_vars", lambda **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.config.get_missing_config_fields", lambda: [])
+    monkeypatch.setattr("hermes_cli.config.check_config_version", lambda: (1, 1))
+
+    setup_mod._run_quick_setup({}, profile_dir)
+
+    assert "Run 'janes-agent setup' and choose 'Full Setup'" in capsys.readouterr().out
+
+
+def test_full_setup_section_guidance_uses_custom_profile_alias(
+    tmp_path, monkeypatch, capsys
+):
+    import pytest
+
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+    from hermes_cli.profiles import create_wrapper_script
+
+    create_wrapper_script("janes-agent", target="johndoe")
+    monkeypatch.setattr(setup_mod, "ensure_hermes_home", lambda: None)
+    monkeypatch.setattr(setup_mod, "load_config", lambda: {})
+    monkeypatch.setattr(setup_mod, "get_hermes_home", lambda: profile_dir)
+    monkeypatch.setattr(setup_mod, "get_config_path", lambda: tmp_path / "missing.yaml")
+    monkeypatch.setattr(setup_mod, "get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(setup_mod, "is_interactive_stdin", lambda: True)
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: "openrouter")
+    monkeypatch.setattr(
+        setup_mod,
+        "setup_model_provider",
+        lambda _config: (_ for _ in ()).throw(RuntimeError("stop after guidance")),
+    )
+
+    args = types.SimpleNamespace(
+        reset=False,
+        reconfigure=False,
+        quick=False,
+        non_interactive=False,
+        portal=False,
+        section=None,
+    )
+    with pytest.raises(RuntimeError, match="stop after guidance"):
+        setup_mod.run_setup_wizard(args)
+
+    out = capsys.readouterr().out
+    assert "'janes-agent setup model|terminal|" in out
+    assert "use 'janes-agent config edit'" in out

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -2,6 +2,7 @@
 import json
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
@@ -527,3 +528,26 @@ def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys
 
     captured = capsys.readouterr()
     assert "Run 'hermes chat' manually" in captured.out
+
+
+def test_print_setup_summary_uses_profile_command_for_profile_with_alias(
+    tmp_path, monkeypatch, capsys
+):
+    """Setup summary prints commands using a profile's wrapper alias when available."""
+    profile_dir = tmp_path / ".hermes" / "profiles" / "johndoe"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+    wrapper_dir = tmp_path / ".local" / "bin"
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    (wrapper_dir / "johndoe").write_text("#!/bin/sh\nexec hermes -p johndoe \"$@\"\n")
+
+    from hermes_cli.setup import _print_setup_summary
+
+    _print_setup_summary(load_config(), profile_dir)
+
+    out = capsys.readouterr().out
+    assert "johndoe setup gateway" in out
+    assert "johndoe gateway" in out
+    assert "johndoe doctor" in out


### PR DESCRIPTION
## What does this PR do?

Make setup and gateway guidance profile-aware so users now receive instructions that reference the correct profile-specific Hermes home path instead of hardcoded `~/.hermes`. This fixes inconsistencies introduced by profile-based isolation and keeps guidance/messages consistent with active profile state.

## Related Issue

Fixes # <!-- replace if applicable -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: update gateway guidance text and path rendering to use profile-aware helpers.
- `hermes_cli/profiles.py`: centralize profile home path formatting in user-facing path output.
- `hermes_cli/setup.py`: apply profile-aware `~/.hermes` output equivalents for setup instructions.
- `tests/hermes_cli/test_gateway.py`: add coverage for profile-aware guidance behavior.
- `tests/hermes_cli/test_profiles.py`: add profile path formatting unit coverage.
- `tests/hermes_cli/test_setup.py`: add regression tests for profile-aware setup output.

## How to Test

1. Run tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_setup.py
```

2. Start Hermes in a non-default profile and verify gateway/setup user-facing path instructions use the profile path.
3. Verify default-profile behavior remains unchanged for non-profile `HERMES_HOME`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://wwwconventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

### Before
Run gateway setup of that profile:
<img width="276" height="43" alt="image" src="https://github.com/user-attachments/assets/1f8374b3-d66b-46ef-8f61-6cc536573c0b" />

When finish, it show guide to next step but use general command instead of comamnd of that profile:
<img width="1766" height="358" alt="2026-04-25_09-47" src="https://github.com/user-attachments/assets/9033e4da-22cb-40fa-a17f-78fcad6e1010" />

### After
Now when finish, it show correct profile command.
<img width="1884" height="326" alt="image" src="https://github.com/user-attachments/assets/616875fd-b228-4568-8475-616bea49ee89" />
