### PR TITLE
fix(cronjob): advertise 'custom:<name>' provider format in tool schema

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -460,7 +460,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "properties": {
                     "provider": {
                         "type": "string",
-                        "description": "Provider name (e.g. 'openrouter', 'anthropic'). Omit to use and pin the current provider."
+                        "description": "Provider name (e.g. 'openrouter', 'anthropic', or 'custom:<name>' for a provider defined in custom_providers config — always include the ':<name>' suffix, never pass the bare 'custom'). Omit to use and pin the current provider."
                     },
                     "model": {
                         "type": "string",


### PR DESCRIPTION
## Summary

The `provider` field inside the `model` override of the `cronjob` tool schema only advertises examples like `'openrouter'` and `'anthropic'`, with no mention of the canonical `'custom:<name>'` form that `custom_providers` entries require.

When the user has custom providers configured (e.g. `byteplus`, `nvidia`, a local OpenAI-compatible endpoint), the LLM commonly writes the bare type name `'custom'` as `model.provider` in its tool call — because the schema description never shows the `:<name>` suffix. That value flows through `_resolve_model_override` as a non-empty `provider_name`, skips the pin-to-current-provider fallback, and serializes into `jobs.json` as:

```json
{ "provider": "custom", "model": "..." }
```

At run time the scheduler cannot resolve any provider from the bare string `'custom'` alone (no `custom_providers` entry matches that key), and the cron job fails silently.

## Fix

Clarify the schema description so the canonical form is discoverable and the failure mode is called out explicitly:

> Provider name (e.g. 'openrouter', 'anthropic', or 'custom:\<name\>' for a provider defined in custom_providers config — always include the ':\<name\>' suffix, never pass the bare 'custom'). Omit to use and pin the current provider.

One-line root-cause fix at the tool-definition boundary. Does not change resolver behaviour — existing jobs and non-custom paths are unaffected.

## Test plan

- [ ] Invoke `cronjob create` in a session where `custom_providers` has entries — LLM emits `provider: 'custom:<name>'` or omits `provider`, not bare `'custom'`
- [ ] Existing cron jobs with `provider: null` or already-resolvable providers continue to work unchanged