### PR TITLE
fix: DeepSeek/Kimi thinking mode requires reasoning_content on ALL assistant messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7785,7 +7785,17 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        # 4. reasoning_content was present but not a string (e.g. None after
+        # 4. DeepSeek / Kimi thinking mode: all assistant messages need
+        # reasoning_content. Inject "" to satisfy the provider's requirement
+        # when no explicit reasoning content is present.
+        if (
+            self._needs_kimi_tool_reasoning()
+            or self._needs_deepseek_tool_reasoning()
+        ):
+            api_msg["reasoning_content"] = ""
+            return
+
+        # 5. reasoning_content was present but not a string (e.g. None after
         # context compaction).  Don't pass null to the API.
         api_msg.pop("reasoning_content", None)
 

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -88,13 +88,13 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg.get("reasoning_content") == ""
 
-    def test_deepseek_assistant_no_tool_call_left_alone(self) -> None:
-        """Plain assistant turns without tool_calls don't get padded."""
+    def test_deepseek_assistant_no_tool_call_gets_padded(self) -> None:
+        """DeepSeek thinking mode pads ALL assistant turns, even without tool_calls."""
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
         source = {"role": "assistant", "content": "hello"}
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
-        assert "reasoning_content" not in api_msg
+        assert api_msg.get("reasoning_content") == ""
 
     def test_deepseek_explicit_reasoning_content_preserved(self) -> None:
         """When reasoning_content is already set, it's copied verbatim."""


### PR DESCRIPTION
## Problem

DeepSeek V4 thinking mode requires `reasoning_content` on **every** assistant message, not just tool-call turns. The existing fix (#15250) only covered the tool-call path.

When an assistant message is a plain text reply (no `tool_calls`) and `reasoning` is empty, `_copy_reasoning_content_for_api` skips padding entirely, causing DeepSeek to reject the next request with:

> The reasoning_content in the thinking mode must be passed back to the API.

## Fix

Remove the `source_msg.get("tool_calls") and` guard in `_copy_reasoning_content_for_api` so **all** DeepSeek/Kimi assistant messages get `reasoning_content=""` when needed.

## Changes

- `run_agent.py`: broaden condition from `tool_calls + provider` to just `provider`
- `test_deepseek_reasoning_content_echo.py`: update test to expect padding on plain assistant turns

## Verification

`pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -v` — 21/21 passed.

Fixes #15213