### PR TITLE
fix(cronjob): treat bare 'custom' provider as unspecified in override

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -128,6 +128,15 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
         return (None, None)
     model_name = (model_obj.get("model") or "").strip() or None
     provider_name = (model_obj.get("provider") or "").strip() or None
+    # Bare "custom" is an incomplete spec — the canonical form is
+    # "custom:<name>" matching a custom_providers entry. LLMs frequently
+    # supply the bare type because the schema does not advertise the
+    # ":<name>" suffix, which used to bypass the pinning path below and
+    # leave the job stored with an unresolvable "custom" provider. Treat
+    # the bare value as "no provider supplied" so the current main
+    # provider gets pinned instead.
+    if provider_name == "custom":
+        provider_name = None
     if model_name and not provider_name:
         # Pin to the current main provider so the job is stable
         try:


### PR DESCRIPTION
## Summary

`_resolve_model_override` in `tools/cronjob_tools.py` treats any non-empty `provider` string the LLM emits as user-specified and skips the pin-to-current-provider fallback. When the LLM writes the bare type name `'custom'` (instead of the canonical `'custom:<name>'` that refers to a `custom_providers` entry), the value passes through unchanged and serialises into `jobs.json`:

\`\`\`json
{ "provider": "custom", "model": "..." }
\`\`\`

At run time the scheduler cannot resolve any provider from the bare string `'custom'` alone — no `custom_providers` entry matches that key — and the cron job fails silently.

## Fix

In `_resolve_model_override`, normalise bare `'custom'` to `None` so the existing `model_name && not provider_name` branch pins to the current main provider. Behaviour for `'custom:<name>'` and all other providers is unchanged.

\`\`\`python
if provider_name == \"custom\":
    provider_name = None
\`\`\`

## Relationship to #15477

Defence-in-depth complement to #15477, which updates the schema description so the LLM is less likely to emit bare `'custom'` to begin with. This resolver change handles the case where an LLM still does — either a model that ignores the clarified schema, or a pre-fix jobs.json being reloaded.

The two PRs are independent and can land in either order.

## Test plan

- [ ] `_resolve_model_override({\"provider\": \"custom\", \"model\": \"foo\"})` returns `(<current-main-provider>, \"foo\")` rather than `(\"custom\", \"foo\")`
- [ ] `_resolve_model_override({\"provider\": \"custom:byteplus\", \"model\": \"foo\"})` returns `(\"custom:byteplus\", \"foo\")` (unchanged)
- [ ] `_resolve_model_override({\"provider\": \"openrouter\", \"model\": \"foo\"})` returns `(\"openrouter\", \"foo\")` (unchanged)
- [ ] `_resolve_model_override({\"model\": \"foo\"})` still pins from config (unchanged)