### PR TITLE
fix(gateway): pass session messages to shutdown_memory_provider (#15165)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1787,7 +1787,21 @@ class GatewayRunner:
             return
         try:
             if hasattr(agent, "shutdown_memory_provider"):
-                agent.shutdown_memory_provider()
+                # Pass the agent's own conversation transcript so memory
+                # providers' ``on_session_end`` hooks see the real messages
+                # instead of the empty default (#15165). ``_session_messages``
+                # is set on ``AIAgent`` (run_agent.py:1518) and refreshed at
+                # the end of every ``run_conversation`` turn via
+                # ``_persist_session``; on an agent built through
+                # ``object.__new__`` (test stubs) the attribute may be
+                # absent, so ``getattr`` with a ``None`` default keeps the
+                # call signature-compatible with the pre-fix behaviour
+                # (``shutdown_memory_provider(messages=None)``).
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
         except Exception:
             pass
         # Close tool resources (terminal sandboxes, browser daemons,

--- a/tests/gateway/test_shutdown_memory_provider_messages.py
+++ b/tests/gateway/test_shutdown_memory_provider_messages.py
@@ -1,0 +1,148 @@
+"""Regression tests for #15165 — gateway session shutdown must pass the
+agent's conversation transcript to ``shutdown_memory_provider`` so memory
+providers' ``on_session_end`` hooks see the real messages instead of an
+empty list.
+
+Before the fix, ``_cleanup_agent_resources`` called
+``agent.shutdown_memory_provider()`` with no arguments, which in turn
+invoked ``on_session_end([])`` on every memory provider. Providers with
+an empty-guard (Holographic, Hindsight, etc.) exited early and never
+persisted the session's facts, so the next gateway start-up surfaced no
+memories from the prior conversation.
+
+The fix reads ``agent._session_messages`` (set on ``AIAgent.__init__``
+and refreshed every turn via ``_persist_session``) and forwards it to
+``shutdown_memory_provider``. Test stubs built via ``object.__new__``
+or plain ``MagicMock()`` still exercise the legacy no-arg path, so the
+change is backward-compatible with existing suites.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_dotenv(monkeypatch):
+    """gateway.run imports dotenv at module load; stub so tests run bare."""
+    fake = types.ModuleType("dotenv")
+    fake.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    return runner
+
+
+# A lightweight stand-in for AIAgent so ``isinstance(..., list)`` correctly
+# discriminates between "attribute set to a list" and "attribute absent /
+# MagicMock auto-synthesised". Using MagicMock directly for the agent
+# would also work for the populated case, but attribute access on a
+# MagicMock always yields a child MagicMock — we want a real Python
+# object we can shape per-test.
+class _FakeAgent:
+    def __init__(self, session_messages=None, has_shutdown=True):
+        if session_messages is not None:
+            self._session_messages = session_messages
+        if has_shutdown:
+            self.shutdown_memory_provider = MagicMock()
+        self.close = MagicMock()
+
+
+class TestCleanupAgentResourcesPassesMessages:
+    """_cleanup_agent_resources forwards the agent's session messages."""
+
+    def test_populated_messages_forwarded(self):
+        """Real-world path: an agent that ran a turn has a populated
+        ``_session_messages`` list and the cleanup call forwards it."""
+        runner = _make_runner()
+        transcript = [
+            {"role": "user", "content": "remember my dog is named Biscuit"},
+            {"role": "assistant", "content": "Got it — Biscuit."},
+        ]
+        agent = _FakeAgent(session_messages=transcript)
+
+        runner._cleanup_agent_resources(agent)
+
+        # The fix must call shutdown_memory_provider with the exact list
+        # identity — providers iterate it to extract facts.
+        agent.shutdown_memory_provider.assert_called_once_with(transcript)
+
+    def test_empty_list_still_forwarded(self):
+        """An agent that initialised but ran no turns has an empty list
+        on ``_session_messages``. Forwarding it (rather than falling
+        through to the no-arg path) makes the absence of content
+        explicit to providers and matches the pre-fix observable
+        behaviour (``on_session_end([])``)."""
+        runner = _make_runner()
+        agent = _FakeAgent(session_messages=[])
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with([])
+
+    def test_missing_attribute_falls_back_to_no_arg(self):
+        """Test stubs built via ``object.__new__(AIAgent)`` skip
+        ``__init__`` and therefore have no ``_session_messages``
+        attribute. The fix must not explode — it falls back to the
+        legacy no-arg call so existing suites keep passing."""
+        runner = _make_runner()
+        agent = _FakeAgent(session_messages=None)  # attribute not set
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with()
+
+    def test_non_list_attribute_falls_back_to_no_arg(self):
+        """A MagicMock-based agent auto-synthesises ``_session_messages``
+        as a nested MagicMock. ``isinstance(mock, list)`` is False, so
+        we fall back to the no-arg path rather than passing a garbage
+        value to providers that expect ``List[Dict]``."""
+        runner = _make_runner()
+        agent = MagicMock()
+        # No explicit _session_messages assignment — MagicMock will
+        # synthesise one on access.
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with()
+
+    def test_provider_exception_is_swallowed(self):
+        """Provider teardown must be best-effort — a raising
+        ``shutdown_memory_provider`` must not prevent ``close()`` from
+        running (tool resource leak is worse than a missed memory
+        flush)."""
+        runner = _make_runner()
+        agent = _FakeAgent(session_messages=[{"role": "user", "content": "x"}])
+        agent.shutdown_memory_provider.side_effect = RuntimeError("boom")
+
+        # Must not raise.
+        runner._cleanup_agent_resources(agent)
+
+        # close() still invoked after the swallowed exception.
+        agent.close.assert_called_once()
+
+    def test_none_agent_is_noop(self):
+        """Defensive: None agent short-circuits (idle sweeps may
+        observe a None entry in the cache during eviction races)."""
+        runner = _make_runner()
+        # Must not raise.
+        runner._cleanup_agent_resources(None)
+
+    def test_agent_without_shutdown_method_is_tolerated(self):
+        """An agent without ``shutdown_memory_provider`` (old test
+        stub, partial mock) must still have ``close()`` called."""
+        runner = _make_runner()
+        agent = _FakeAgent(has_shutdown=False)
+        # No _session_messages either, to exercise the hasattr guard.
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.close.assert_called_once()


### PR DESCRIPTION
## Summary
- **Fixes #15165 Part A** — `_cleanup_agent_resources` previously invoked `agent.shutdown_memory_provider()` with no arguments, so every memory provider's `on_session_end` hook received an empty list. Providers with an early-return guard on empty input (Holographic, Hindsight, etc.) never extracted facts from the conversation.
- Forward `agent._session_messages` — the transcript `AIAgent` maintains and refreshes every turn via `_persist_session` — so providers see the actual conversation instead of `[]`.
- Falls back to the legacy no-arg call whenever `_session_messages` is absent or not a `list` (test stubs built via `object.__new__` or `MagicMock`) to keep every existing suite green.

## The bug
Per #15165:

> ...any provider that tries to extract facts from the session's conversation gets an empty list. Providers like Holographic (`on_session_end([])`) have an early return guard... Every gateway restart wipes the session's conversational memory...

Users saw "抱歉，找不到相關的對話記錄" (roughly: _"sorry, cannot find the corresponding conversation record"_) on the first turn after any gateway restart / idle expiry / session reset because no facts had ever been persisted.

## The fix
`AIAgent.shutdown_memory_provider` already accepts `messages: list = None` (run_agent.py:4126), so this is a pure caller-side change in `gateway/run.py`:

```python
session_messages = getattr(agent, "_session_messages", None)
if isinstance(session_messages, list):
    agent.shutdown_memory_provider(session_messages)
else:
    agent.shutdown_memory_provider()
```

- `_session_messages` is set on `AIAgent.__init__` (run_agent.py:1518) and refreshed at the end of every `run_conversation` turn (`_persist_session`, line 3264). By the time `_cleanup_agent_resources` fires, it holds the real transcript.
- `isinstance(..., list)` discrimination is deliberate — it protects against `MagicMock` agents (whose attribute access auto-synthesises a child mock, not `None`) falling through and passing a bogus object to the provider's `List[Dict]` hook.
- The `try/except Exception: pass` wrap is inherited; providers that raise never prevent `close()` from running.
- **Paths using `skip_memory=True` temporary agents** (pre-reset memory flush, session hygiene auto-compress, `/compress`) are no-ops inside `shutdown_memory_provider` because `self._memory_manager` is `None` — so this change has no behaviour effect on them.

## Scope
**Part A only.** Part B of #15165 (adding `on_session_end` to the Hindsight plugin) is a separate concern that benefits from this fix landing first — without Part A, a Hindsight `on_session_end` hook would still receive `[]`.

## Test plan
- [x] New regression suite: `tests/gateway/test_shutdown_memory_provider_messages.py` — 7 cases:
  - Populated `_session_messages` list is forwarded byte-for-byte
  - Empty list is still explicitly forwarded (matches pre-fix observable behaviour)
  - Agent without `_session_messages` falls back to no-arg call (stub compatibility)
  - `MagicMock` agent (non-list attribute) falls back to no-arg call
  - Provider exception is swallowed — `close()` still runs afterward
  - `None` agent is a no-op (idle-sweep race tolerance)
  - Agent without `shutdown_memory_provider` method still gets `close()`
- [x] Regression guard verified: reverted the fix → `test_populated_messages_forwarded` fails with `Expected: mock([...]) / Actual: mock()`; restored the fix → all 7 pass.
- [x] Full `tests/gateway/` suite: `3703 passed, 9 pre-existing failures` (dingtalk, matrix with missing `mautrix`, one approve-deny test — all fail identically on `main`, unrelated to this change).
- [x] Related suites pass clean (100/100): `test_agent_cache.py`, `test_compress_command.py`, `test_background_command.py`, `test_flush_memory_stale_guard.py`, `test_session_boundary_hooks.py`, `test_compress_plugin_engine.py`, `test_clean_shutdown_marker.py`.

## Related
- Fixes #15165 (Part A)
- #7759 (closed) — `/new` / `/reset` memory commit, different code path
- #14981 — `on_session_finalize` not fired on idle timeout (orthogonal)
- #15073 — Hindsight sync races interpreter shutdown (orthogonal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)