### PR TITLE
fix: preserve exception tracebacks across 24 error logs (rollup of #12004..#12052)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -993,7 +993,7 @@ def discover_bedrock_models(
     try:
         client = _get_bedrock_control_client(region)
     except Exception as e:
-        logger.warning("Failed to create Bedrock client for model discovery: %s", e)
+        logger.warning("Failed to create Bedrock client for model discovery: %s", e, exc_info=True)
         return []
 
     models = []
@@ -1035,7 +1035,7 @@ def discover_bedrock_models(
             })
             seen_ids.add(model_id.lower())
     except Exception as e:
-        logger.warning("Failed to list Bedrock foundation models: %s", e)
+        logger.warning("Failed to list Bedrock foundation models: %s", e, exc_info=True)
 
     # 2. Discover inference profiles (cross-region, better capacity)
     try:

--- a/agent/google_code_assist.py
+++ b/agent/google_code_assist.py
@@ -252,7 +252,7 @@ def load_code_assist(
                     cloudaicompanion_project=project_id,
                 )
             last_err = exc
-            logger.warning("loadCodeAssist failed on %s: %s", endpoint, exc)
+            logger.warning("loadCodeAssist failed on %s: %s", endpoint, exc, exc_info=True)
             continue
     if last_err:
         raise last_err
@@ -327,7 +327,7 @@ def onboard_user(
             try:
                 poll_resp = _post_json(poll_url, {}, access_token, user_agent_model=user_agent_model)
             except CodeAssistError as exc:
-                logger.warning("Onboarding poll attempt %d failed: %s", attempt + 1, exc)
+                logger.warning("Onboarding poll attempt %d failed: %s", attempt + 1, exc, exc_info=True)
                 continue
             if poll_resp.get("done"):
                 return poll_resp

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -475,7 +475,7 @@ def load_credentials() -> Optional[GoogleCredentials]:
             raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
     except (json.JSONDecodeError, OSError, IOError) as exc:
-        logger.warning("Failed to read Google OAuth credentials at %s: %s", path, exc)
+        logger.warning("Failed to read Google OAuth credentials at %s: %s", path, exc, exc_info=True)
         return None
     if not isinstance(data, dict):
         return None
@@ -518,7 +518,7 @@ def clear_credentials() -> None:
         except FileNotFoundError:
             pass
         except OSError as exc:
-            logger.warning("Failed to remove Google OAuth credentials at %s: %s", path, exc)
+            logger.warning("Failed to remove Google OAuth credentials at %s: %s", path, exc, exc_info=True)
 
 
 # =============================================================================

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -583,7 +583,7 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
 
         return True, frontmatter, extract_skill_description(frontmatter)
     except Exception as e:
-        logger.warning("Failed to parse skill file %s: %s", skill_file, e)
+        logger.warning("Failed to parse skill file %s: %s", skill_file, e, exc_info=True)
         return True, {}, ""
 
 

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -53,4 +53,4 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
-        logger.warning("Failed to save trajectory: %s", e)
+        logger.warning("Failed to save trajectory: %s", e, exc_info=True)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -792,7 +792,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )[0]
                 payload = json.loads(payload_str) if payload_str else {}
         except Exception as exc:
-            logger.error("[bluebubbles] webhook parse error: %s", exc)
+            logger.error("[bluebubbles] webhook parse error: %s", exc, exc_info=True)
             return web.json_response({"error": "invalid payload"}, status=400)
 
         event_type = self._value(payload.get("type"), payload.get("event")) or ""

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -286,7 +286,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.logout()
             logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
         except Exception as e:
-            logger.error("[Email] IMAP connection failed: %s", e)
+            logger.error("[Email] IMAP connection failed: %s", e, exc_info=True)
             return False
 
         try:
@@ -297,7 +297,7 @@ class EmailAdapter(BasePlatformAdapter):
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
-            logger.error("[Email] SMTP connection failed: %s", e)
+            logger.error("[Email] SMTP connection failed: %s", e, exc_info=True)
             return False
 
         self._running = True
@@ -325,7 +325,7 @@ class EmailAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error("[Email] Poll error: %s", e)
+                logger.error("[Email] Poll error: %s", e, exc_info=True)
             await asyncio.sleep(self._poll_interval)
 
     async def _check_inbox(self) -> None:
@@ -399,7 +399,7 @@ class EmailAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
         except Exception as e:
-            logger.error("[Email] IMAP fetch error: %s", e)
+            logger.error("[Email] IMAP fetch error: %s", e, exc_info=True)
         return results
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
@@ -477,7 +477,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send failed to %s: %s", chat_id, e)
+            logger.error("[Email] Send failed to %s: %s", chat_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     def _send_email(
@@ -560,7 +560,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send document failed: %s", e)
+            logger.error("[Email] Send document failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     def _send_email_with_attachment(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1790,7 +1790,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 }
             return result
         except Exception as exc:
-            logger.warning("[Feishu] send_exec_approval failed: %s", exc)
+            logger.warning("[Feishu] send_exec_approval failed: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
     @staticmethod

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -134,7 +134,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             return True
 
         except Exception as e:
-            logger.error("[%s] Failed to connect: %s", self.name, e)
+            logger.error("[%s] Failed to connect: %s", self.name, e, exc_info=True)
             return False
 
     async def _ws_connect(self) -> bool:
@@ -224,7 +224,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 return
             except Exception as e:
-                logger.warning("[%s] WebSocket error: %s", self.name, e)
+                logger.warning("[%s] WebSocket error: %s", self.name, e, exc_info=True)
 
             if not self._running:
                 return
@@ -242,7 +242,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                     backoff_idx = 0  # Reset on successful reconnect
                     logger.info("[%s] Reconnected", self.name)
             except Exception as e:
-                logger.warning("[%s] Reconnection failed: %s", self.name, e)
+                logger.warning("[%s] Reconnection failed: %s", self.name, e, exc_info=True)
 
     async def _read_events(self) -> None:
         """Read events from WebSocket until disconnected."""

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -326,7 +326,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     )
                     return False
         except Exception as exc:
-            logger.error("Matrix: post-upload key verification failed: %s", exc)
+            logger.error("Matrix: post-upload key verification failed: %s", exc, exc_info=True)
             return False
         return True
 
@@ -342,6 +342,7 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.error(
                 "Matrix: cannot verify device keys on server: %s — refusing E2EE",
                 exc,
+                exc_info=True,
             )
             return False
 
@@ -356,7 +357,7 @@ class MatrixAdapter(BasePlatformAdapter):
             try:
                 await olm.share_keys()
             except Exception as exc:
-                logger.error("Matrix: failed to re-upload device keys: %s", exc)
+                logger.error("Matrix: failed to re-upload device keys: %s", exc, exc_info=True)
                 return False
             return await self._reverify_keys_after_upload(client, local_ed25519)
 
@@ -396,6 +397,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Try generating a new access token to get a fresh device.",
                     client.device_id,
                     exc,
+                    exc_info=True,
                 )
                 return False
             return await self._reverify_keys_after_upload(client, local_ed25519)
@@ -465,6 +467,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.error(
                     "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
                     exc,
+                    exc_info=True,
                 )
                 await api.session.close()
                 return False

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -121,7 +121,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     return {}
                 return await resp.json()
         except aiohttp.ClientError as exc:
-            logger.error("MM API GET %s network error: %s", path, exc)
+            logger.error("MM API GET %s network error: %s", path, exc, exc_info=True)
             return {}
 
     async def _api_post(
@@ -141,7 +141,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     return {}
                 return await resp.json()
         except aiohttp.ClientError as exc:
-            logger.error("MM API POST %s network error: %s", path, exc)
+            logger.error("MM API POST %s network error: %s", path, exc, exc_info=True)
             return {}
 
     async def _api_put(
@@ -160,7 +160,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     return {}
                 return await resp.json()
         except aiohttp.ClientError as exc:
-            logger.error("MM API PUT %s network error: %s", path, exc)
+            logger.error("MM API PUT %s network error: %s", path, exc, exc_info=True)
             return {}
 
     async def _upload_file(
@@ -435,7 +435,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 if attempt < 2:
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue
-                logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
+                logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc, exc_info=True)
                 return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
 
         if file_data is None:
@@ -522,9 +522,9 @@ class MattermostAdapter(BasePlatformAdapter):
                     logger.error("Mattermost WS auth failed (HTTP %d) — stopping reconnect", exc.status)
                     return
                 if "401" in err_str or "403" in err_str or "unauthorized" in err_str:
-                    logger.error("Mattermost WS permanent error: %s — stopping reconnect", exc)
+                    logger.error("Mattermost WS permanent error: %s — stopping reconnect", exc, exc_info=True)
                     return
-                logger.warning("Mattermost WS error: %s — reconnecting in %.0fs", exc, delay)
+                logger.warning("Mattermost WS error: %s — reconnecting in %.0fs", exc, delay, exc_info=True)
 
             if self._closing:
                 return
@@ -698,7 +698,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     else:
                         logger.warning("Mattermost: failed to download file %s: HTTP %s", fid, resp.status)
             except Exception as exc:
-                logger.warning("Mattermost: error downloading file %s: %s", fid, exc)
+                logger.warning("Mattermost: error downloading file %s: %s", fid, exc, exc_info=True)
 
         # Set message type based on downloaded media types.
         if media_types and msg_type == MessageType.TEXT:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -154,7 +154,7 @@ class SlackAdapter(BasePlatformAdapter):
                         team_label = entry.get("team_name", team_id) if isinstance(entry, dict) else team_id
                         logger.info("[Slack] Loaded saved token for workspace %s", team_label)
             except Exception as e:
-                logger.warning("[Slack] Failed to read %s: %s", tokens_file, e)
+                logger.warning("[Slack] Failed to read %s: %s", tokens_file, e, exc_info=True)
 
         lock_acquired = False
         try:
@@ -1434,7 +1434,7 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks=updated_blocks,
             )
         except Exception as e:
-            logger.warning("[Slack] Failed to update approval message: %s", e)
+            logger.warning("[Slack] Failed to update approval message: %s", e, exc_info=True)
 
         # Resolve the approval — this unblocks the agent thread
         try:
@@ -1445,7 +1445,7 @@ class SlackAdapter(BasePlatformAdapter):
                 count, session_key, choice, user_name,
             )
         except Exception as exc:
-            logger.error("Failed to resolve gateway approval from Slack button: %s", exc)
+            logger.error("Failed to resolve gateway approval from Slack button: %s", exc, exc_info=True)
 
         # (approval state already consumed by atomic pop above)
 
@@ -1557,7 +1557,7 @@ class SlackAdapter(BasePlatformAdapter):
             return content
 
         except Exception as e:
-            logger.warning("[Slack] Failed to fetch thread context: %s", e)
+            logger.warning("[Slack] Failed to fetch thread context: %s", e, exc_info=True)
             return ""
 
     async def _handle_slash_command(self, command: dict) -> None:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -391,7 +391,7 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             self._polling_network_error_count = 0
         except Exception as retry_err:
-            logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err)
+            logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err, exc_info=True)
             # start_polling failed — polling is dead and no further error
             # callbacks will fire, so schedule the next retry ourselves.
             if not self.has_fatal_error:
@@ -1238,7 +1238,7 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
+            logger.warning("[%s] send_update_prompt failed: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def send_exec_approval(
@@ -1302,7 +1302,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
+            logger.warning("[%s] send_exec_approval failed: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def send_model_picker(
@@ -1376,7 +1376,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] send_model_picker failed: %s", self.name, e)
+            logger.warning("[%s] send_model_picker failed: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     _MODEL_PAGE_SIZE = 8
@@ -1530,7 +1530,7 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 result_text = await callback(chat_id, model_id, provider_slug)
             except Exception as exc:
-                logger.error("Model picker switch failed: %s", exc)
+                logger.error("Model picker switch failed: %s", exc, exc_info=True)
                 result_text = f"Error switching model: {exc}"
 
             # Edit message to show confirmation, remove buttons
@@ -1670,7 +1670,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         count, session_key, choice, user_display,
                     )
                 except Exception as exc:
-                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc, exc_info=True)
             return
 
         # --- Update prompt callbacks ---
@@ -1703,7 +1703,7 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.info("Telegram update prompt answered '%s' by user %s",
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
-            logger.error("Failed to write update response from callback: %s", exc)
+            logger.error("Failed to write update response from callback: %s", exc, exc_info=True)
 
     def _missing_media_path_error(self, label: str, path: str) -> str:
         """Build an actionable file-not-found error for gateway MEDIA delivery.

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -290,7 +290,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 ", ".join(self._dynamic_routes.keys()) or "(none)",
             )
         except Exception as e:
-            logger.error("[webhook] Failed to reload dynamic routes: %s", e)
+            logger.error("[webhook] Failed to reload dynamic routes: %s", e, exc_info=True)
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
@@ -317,7 +317,7 @@ class WebhookAdapter(BasePlatformAdapter):
         try:
             raw_body = await request.read()
         except Exception as e:
-            logger.error("[webhook] Failed to read body: %s", e)
+            logger.error("[webhook] Failed to read body: %s", e, exc_info=True)
             return web.json_response({"error": "Bad request"}, status=400)
 
         # Validate HMAC signature FIRST (skip for INSECURE_NO_AUTH testing mode)
@@ -409,7 +409,7 @@ class WebhookAdapter(BasePlatformAdapter):
                             "[webhook] Skill '%s' not found", skill_name
                         )
             except Exception as e:
-                logger.warning("[webhook] Skill loading failed: %s", e)
+                logger.warning("[webhook] Skill loading failed: %s", e, exc_info=True)
 
         # Build a unique delivery ID
         delivery_id = request.headers.get(
@@ -726,7 +726,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error="gh CLI not installed"
             )
         except Exception as e:
-            logger.error("[webhook] github_comment delivery error: %s", e)
+            logger.error("[webhook] github_comment delivery error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def _deliver_cross_platform(

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1257,7 +1257,7 @@ class WeComAdapter(BasePlatformAdapter):
         except FileNotFoundError as exc:
             return SendResult(success=False, error=str(exc))
         except Exception as exc:
-            logger.error("[%s] Failed to prepare outbound media %s: %s", self.name, media_source, exc)
+            logger.error("[%s] Failed to prepare outbound media %s: %s", self.name, media_source, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
         if prepared["rejected"]:
@@ -1293,7 +1293,7 @@ class WeComAdapter(BasePlatformAdapter):
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending media to WeCom")
         except Exception as exc:
-            logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc)
+            logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
         caption_result = None
@@ -1357,7 +1357,7 @@ class WeComAdapter(BasePlatformAdapter):
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
-            logger.error("[%s] Send failed: %s", self.name, exc)
+            logger.error("[%s] Send failed: %s", self.name, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
         error = self._response_error(response)

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -371,7 +371,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 return False
             lock_acquired = True
         except Exception as e:
-            logger.warning("[%s] Could not acquire session lock (non-fatal): %s", self.name, e)
+            logger.warning("[%s] Could not acquire session lock (non-fatal): %s", self.name, e, exc_info=True)
 
         try:
             # Auto-install npm dependencies if node_modules doesn't exist

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -467,7 +467,7 @@ class GatewayStreamConsumer:
             if _best_effort_ok and not self._final_response_sent:
                 self._final_response_sent = True
         except Exception as e:
-            logger.error("Stream consumer error: %s", e)
+            logger.error("Stream consumer error: %s", e, exc_info=True)
 
     # Pattern to strip MEDIA:<path> tags (including optional surrounding quotes).
     # Matches the simple cleanup regex used by the non-streaming path in
@@ -519,7 +519,7 @@ class GatewayStreamConsumer:
                 self._edit_supported = False
                 return reply_to_id
         except Exception as e:
-            logger.error("Stream send chunk error: %s", e)
+            logger.error("Stream send chunk error: %s", e, exc_info=True)
             return reply_to_id
 
     def _visible_prefix(self) -> str:
@@ -731,7 +731,7 @@ class GatewayStreamConsumer:
             # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
             return result.success
         except Exception as e:
-            logger.error("Commentary send error: %s", e)
+            logger.error("Commentary send error: %s", e, exc_info=True)
             return False
 
     async def _send_or_edit(self, text: str, *, finalize: bool = False) -> bool:
@@ -869,5 +869,5 @@ class GatewayStreamConsumer:
                     self._edit_supported = False
                     return False
         except Exception as e:
-            logger.error("Stream send/edit error: %s", e)
+            logger.error("Stream send/edit error: %s", e, exc_info=True)
             return False

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -89,12 +89,12 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
         conn.close()
         return True
     except Exception as exc:
-        logger.warning("SQLite safe copy failed for %s: %s", src, exc)
+        logger.warning("SQLite safe copy failed for %s: %s", src, exc, exc_info=True)
         try:
             shutil.copy2(src, dst)
             return True
         except Exception as exc2:
-            logger.error("Raw copy also failed for %s: %s", src, exc2)
+            logger.error("Raw copy also failed for %s: %s", src, exc2, exc_info=True)
             return False
 
 
@@ -512,7 +512,7 @@ def create_quick_snapshot(
                 shutil.copy2(src, dst)
             manifest[rel] = dst.stat().st_size
         except (OSError, PermissionError) as exc:
-            logger.warning("Could not snapshot %s: %s", rel, exc)
+            logger.warning("Could not snapshot %s: %s", rel, exc, exc_info=True)
 
     if not manifest:
         shutil.rmtree(snap_dir, ignore_errors=True)
@@ -606,7 +606,7 @@ def restore_quick_snapshot(
                 shutil.copy2(src, dst)
             restored += 1
         except (OSError, PermissionError) as exc:
-            logger.error("Failed to restore %s: %s", rel, exc)
+            logger.error("Failed to restore %s: %s", rel, exc, exc_info=True)
 
     logger.info("Restored %d files from snapshot %s", restored, snapshot_id)
     return restored > 0
@@ -629,7 +629,7 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
             shutil.rmtree(d)
             deleted += 1
         except OSError as exc:
-            logger.warning("Failed to prune snapshot %s: %s", d.name, exc)
+            logger.warning("Failed to prune snapshot %s: %s", d.name, exc, exc_info=True)
 
     return deleted
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -395,7 +395,7 @@ def load_permanent_allowlist() -> set:
             load_permanent(patterns)
         return patterns
     except Exception as e:
-        logger.warning("Failed to load permanent allowlist: %s", e)
+        logger.warning("Failed to load permanent allowlist: %s", e, exc_info=True)
         return set()
 
 
@@ -407,7 +407,7 @@ def save_permanent_allowlist(patterns: set):
         config["command_allowlist"] = list(patterns)
         save_config(config)
     except Exception as e:
-        logger.warning("Could not save allowlist: %s", e)
+        logger.warning("Could not save allowlist: %s", e, exc_info=True)
 
 
 # =========================================================================
@@ -521,7 +521,7 @@ def _get_approval_config() -> dict:
         config = load_config()
         return config.get("approvals", {}) or {}
     except Exception as e:
-        logger.warning("Failed to load approval config: %s", e)
+        logger.warning("Failed to load approval config: %s", e, exc_info=True)
         return {}
 
 
@@ -865,7 +865,7 @@ def check_all_command_guards(command: str, env_type: str,
             try:
                 notify_cb(approval_data)
             except Exception as exc:
-                logger.warning("Gateway approval notify failed: %s", exc)
+                logger.warning("Gateway approval notify failed: %s", exc, exc_info=True)
                 with _lock:
                     queue = _gateway_queues.get(session_key, [])
                     if entry in queue:

--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -196,7 +196,7 @@ class BrowserUseProvider(CloudBrowserProvider):
                 )
                 return False
         except Exception as e:
-            logger.error("Exception closing Browser Use session %s: %s", session_id, e)
+            logger.error("Exception closing Browser Use session %s: %s", session_id, e, exc_info=True)
             return False
 
     def emergency_cleanup(self, session_id: str) -> None:

--- a/tools/browser_providers/browserbase.py
+++ b/tools/browser_providers/browserbase.py
@@ -192,7 +192,7 @@ class BrowserbaseProvider(CloudBrowserProvider):
                 )
                 return False
         except Exception as e:
-            logger.error("Exception closing Browserbase session %s: %s", session_id, e)
+            logger.error("Exception closing Browserbase session %s: %s", session_id, e, exc_info=True)
             return False
 
     def emergency_cleanup(self, session_id: str) -> None:

--- a/tools/browser_providers/firecrawl.py
+++ b/tools/browser_providers/firecrawl.py
@@ -91,7 +91,7 @@ class FirecrawlProvider(CloudBrowserProvider):
                 )
                 return False
         except Exception as e:
-            logger.error("Exception closing Firecrawl session %s: %s", session_id, e)
+            logger.error("Exception closing Firecrawl session %s: %s", session_id, e, exc_info=True)
             return False
 
     def emergency_cleanup(self, session_id: str) -> None:

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -166,7 +166,7 @@ def _load_config_files() -> List[Dict[str, str]]:
                             "container_path": container_path,
                         })
     except Exception as e:
-        logger.warning("Could not read terminal.credential_files from config: %s", e)
+        logger.warning("Could not read terminal.credential_files from config: %s", e, exc_info=True)
 
     _config_files = result
     return _config_files

--- a/tools/debug_helpers.py
+++ b/tools/debug_helpers.py
@@ -86,7 +86,7 @@ class DebugSession:
                 json.dump(payload, f, indent=2, ensure_ascii=False)
             logger.debug("%s debug log saved: %s", self.tool_name, filepath)
         except Exception as e:
-            logger.error("Error saving %s debug log: %s", self.tool_name, e)
+            logger.error("Error saving %s debug log: %s", self.tool_name, e, exc_info=True)
 
     def get_session_info(self) -> Dict[str, Any]:
         """Return a summary dict suitable for returning from get_debug_session_info()."""

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -229,7 +229,7 @@ def _handle_list_entities(args: dict, **kw) -> str:
         result = _run_async(_async_list_entities(domain=domain, area=area))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_list_entities error: %s", e)
+        logger.error("ha_list_entities error: %s", e, exc_info=True)
         return tool_error(f"Failed to list entities: {e}")
 
 
@@ -244,7 +244,7 @@ def _handle_get_state(args: dict, **kw) -> str:
         result = _run_async(_async_get_state(entity_id))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_get_state error: %s", e)
+        logger.error("ha_get_state error: %s", e, exc_info=True)
         return tool_error(f"Failed to get state for {entity_id}: {e}")
 
 
@@ -284,7 +284,7 @@ def _handle_call_service(args: dict, **kw) -> str:
         result = _run_async(_async_call_service(domain, service, entity_id, data))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_call_service error: %s", e)
+        logger.error("ha_call_service error: %s", e, exc_info=True)
         return tool_error(f"Failed to call {domain}.{service}: {e}")
 
 
@@ -333,7 +333,7 @@ def _handle_list_services(args: dict, **kw) -> str:
         result = _run_async(_async_list_services(domain=domain))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_list_services error: %s", e)
+        logger.error("ha_list_services error: %s", e, exc_info=True)
         return tool_error(f"Failed to list services: {e}")
 
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -151,7 +151,7 @@ def _read_json(path: Path) -> dict | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Failed to read %s: %s", path, exc)
+        logger.warning("Failed to read %s: %s", path, exc, exc_info=True)
         return None
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1106,7 +1106,7 @@ class MCPServerTask:
                     self.name, url, config.get("oauth"),
                 )
             except Exception as exc:
-                logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
+                logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc, exc_info=True)
                 raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1097,7 +1097,7 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
             if "404" in error_str or "not found" in error_str.lower():
                 logger.info("Environment for task %s already cleaned up", task_id)
             else:
-                logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", task_id, e, exc_info=True)
 
 
 def _cleanup_thread_worker():
@@ -1228,7 +1228,7 @@ def cleanup_vm(task_id: str):
         if "404" in error_str or "not found" in error_str.lower():
             logger.info("Environment for task %s already cleaned up", task_id)
         else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+            logger.warning("Error cleaning up environment for task %s: %s", task_id, e, exc_info=True)
 
 
 def _atexit_cleanup():

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -250,7 +250,7 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
                           result.returncode, result.stderr.strip())
             return False
     except (OSError, subprocess.TimeoutExpired) as exc:
-        logger.warning("cosign execution failed: %s", exc)
+        logger.warning("cosign execution failed: %s", exc, exc_info=True)
         return None
 
 
@@ -647,7 +647,7 @@ def check_command_security(command: str) -> dict:
         )
     except OSError as exc:
         # Covers FileNotFoundError, PermissionError, exec format error
-        logger.warning("tirith spawn failed: %s", exc)
+        logger.warning("tirith spawn failed: %s", exc, exc_info=True)
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith unavailable: {exc}"}
         return {"action": "block", "findings": [], "summary": f"tirith spawn failed (fail-closed): {exc}"}

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -159,7 +159,7 @@ def maybe_persist_tool_result(
                 )
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
-            logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
+            logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc, exc_info=True)
 
     logger.info(
         "Inline-truncating large tool result: %s (%d chars, no sandbox write)",

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -221,5 +221,5 @@ def is_safe_url(url: str) -> bool:
     except Exception as exc:
         # Fail closed on unexpected errors — don't let parsing edge cases
         # become SSRF bypass vectors
-        logger.warning("Blocked request — URL safety check error for %s: %s", url, exc)
+        logger.warning("Blocked request — URL safety check error for %s: %s", url, exc, exc_info=True)
         return False


### PR DESCRIPTION
## Summary

Rollup of 24 single-scope `exc_info=True` PRs filed 2026-04-18. Every edit:

```
-   logger.error(f"...: {e}")
+   logger.error(f"...: %s", e, exc_info=True)
```

No behavior change; no new imports. All 24 originals cherry-pick cleanly against current `main` (1077 commits ahead of their original submission), so none of the sites have drifted or been independently fixed.

## Why rollup

The 24 originals have sat without review since 2026-04-18. Reducing reviewer queue cost 24 → 1. If you prefer the split shape, say so and I'll close this and leave the originals as-is.

## Hot-loop risk (flagged)

3 of the touched sites sit inside recurring-failure loops where `exc_info=True` can produce log storms under sustained outage:

- `gateway/platforms/email.py:328` — IMAP `_poll_loop` (every ~15s)
- `gateway/platforms/mattermost.py:526,528` — WebSocket `_ws_loop` reconnect
- `gateway/platforms/homeassistant.py:227,245` — `_listen_loop` reconnect

Happy to drop `exc_info=True` on those 6 specific lines if log-storm risk outweighs traceback value.

## Originals (24) — will be closed with consolidation comment on land

#12004 #12005 #12007 #12018 #12021 #12024 #12033 #12034 #12035 #12036 #12037 #12038 #12039 #12040 #12041 #12042 #12043 #12044 #12047 #12048 #12049 #12050 #12051 #12052