### PR TITLE
test(dingtalk): stub alibabacloud SDK symbols so AI-card tests run without the package

### DIFF
--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -788,11 +788,11 @@ def _install_dingtalk_sdk_mocks(monkeypatch):
         def __getattr__(self, name):
             return lambda *args, **kwargs: SimpleNamespace(**kwargs)
 
-    monkeypatch.setattr(_dt, "CARD_SDK_AVAILABLE", True, raising=False)
-    monkeypatch.setattr(_dt, "tea_util_models", _DataClassStub(), raising=False)
-    monkeypatch.setattr(_dt, "dingtalk_card_models", _DataClassStub(), raising=False)
-    monkeypatch.setattr(_dt, "dingtalk_robot_models", _DataClassStub(), raising=False)
-    monkeypatch.setattr(_dt, "open_api_models", _DataClassStub(), raising=False)
+    monkeypatch.setattr(_dt, "CARD_SDK_AVAILABLE", True)
+    monkeypatch.setattr(_dt, "tea_util_models", _DataClassStub())
+    monkeypatch.setattr(_dt, "dingtalk_card_models", _DataClassStub())
+    monkeypatch.setattr(_dt, "dingtalk_robot_models", _DataClassStub())
+    monkeypatch.setattr(_dt, "open_api_models", _DataClassStub())
 
 
 class TestCardLifecycle:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -748,10 +748,58 @@ class TestMessageContextIsolation:
 # ---------------------------------------------------------------------------
 
 
+def _install_dingtalk_sdk_mocks(monkeypatch):
+    """Replace the module-level ``alibabacloud_*`` SDK symbols with
+    test-friendly stand-ins.
+
+    The DingTalk adapter imports ``tea_util_models``, ``dingtalk_card_models``,
+    ``dingtalk_robot_models`` and ``open_api_models`` inside a
+    ``try/except ImportError`` — on machines without the Alibaba SDK
+    installed (CI, most dev envs) those symbols resolve to ``None``.
+    Tests that set ``adapter._card_sdk = MagicMock()`` force the AI Card
+    path to run, which then calls e.g. ``tea_util_models.RuntimeOptions()``
+    and crashes with ``AttributeError: 'NoneType' object has no attribute
+    'RuntimeOptions'`` (see the baseline failures of
+    ``TestCardLifecycle`` and ``TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured``
+    on pristine CI runners).
+
+    The real SDK request classes (``StreamingUpdateRequest``,
+    ``CreateCardRequest``, etc.) are plain data carriers — their
+    attributes are exactly the kwargs the caller passes.  Tests
+    introspect those attributes to verify behaviour
+    (``assert request.is_finalize is True``), so the stand-in for
+    ``dingtalk_card_models`` wires ``SimpleNamespace(**kwargs)`` as the
+    side-effect of each attribute access.  Plain ``MagicMock`` would
+    auto-generate child mocks on ``.out_track_id`` / ``.is_finalize``
+    that never equal the real values the test passed in.
+    """
+    import gateway.platforms.dingtalk as _dt
+
+    class _DataClassStub:
+        """Stand-in for an SDK module of dataclass-style request objects.
+
+        Any attribute access returns a factory that builds a
+        ``SimpleNamespace`` from the caller's kwargs — mirroring the
+        shape of the real ``alibabacloud_*.models.*Request`` classes so
+        tests can still introspect ``.out_track_id``, ``.is_finalize``,
+        etc. on the object passed into the mocked SDK call.
+        """
+
+        def __getattr__(self, name):
+            return lambda *args, **kwargs: SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(_dt, "CARD_SDK_AVAILABLE", True, raising=False)
+    monkeypatch.setattr(_dt, "tea_util_models", _DataClassStub(), raising=False)
+    monkeypatch.setattr(_dt, "dingtalk_card_models", _DataClassStub(), raising=False)
+    monkeypatch.setattr(_dt, "dingtalk_robot_models", _DataClassStub(), raising=False)
+    monkeypatch.setattr(_dt, "open_api_models", _DataClassStub(), raising=False)
+
+
 class TestCardLifecycle:
 
     @pytest.fixture
-    def adapter_with_card(self):
+    def adapter_with_card(self, monkeypatch):
+        _install_dingtalk_sdk_mocks(monkeypatch)
         from gateway.platforms.dingtalk import DingTalkAdapter
         a = DingTalkAdapter(PlatformConfig(
             enabled=True,
@@ -942,7 +990,8 @@ class TestDingTalkAdapterAICards:
         return msg
 
     @pytest.mark.asyncio
-    async def test_send_uses_ai_card_if_configured(self, config, mock_stream_client, mock_http_client, mock_message):
+    async def test_send_uses_ai_card_if_configured(self, config, mock_stream_client, mock_http_client, mock_message, monkeypatch):
+        _install_dingtalk_sdk_mocks(monkeypatch)
         from gateway.platforms.dingtalk import DingTalkAdapter
 
         adapter = DingTalkAdapter(config)


### PR DESCRIPTION
## Summary
- Fixes **7 baseline test failures** in `tests/gateway/test_dingtalk.py` that fail on every clean CI runner (any environment without the `alibabacloud_*` SDK installed) and surface as pre-existing noise on every open PR.
- Adds a shared `_install_dingtalk_sdk_mocks(monkeypatch)` helper that swaps the module-level `tea_util_models`, `dingtalk_card_models`, `dingtalk_robot_models`, and `open_api_models` symbols from `None` → lightweight stand-ins. Wires the helper into both AI-card test classes.
- **Test-only change — zero production code touched.**

## The bug
`gateway/platforms/dingtalk.py` imports the Alibaba SDK inside `try/except ImportError`:

```python
try:
    from alibabacloud_dingtalk.card_1_0 import client as dingtalk_card_client, models as dingtalk_card_models
    from alibabacloud_dingtalk.robot_1_0 import client as dingtalk_robot_client, models as dingtalk_robot_models
    from alibabacloud_tea_openapi import models as open_api_models
    from alibabacloud_tea_util import models as tea_util_models
    CARD_SDK_AVAILABLE = True
except ImportError:
    CARD_SDK_AVAILABLE = False
    dingtalk_card_models = None
    # ...
    tea_util_models = None
```

On CI / most dev machines the package isn't installed, so all four symbols resolve to `None`. Tests that manually set `adapter._card_sdk = MagicMock()` to exercise the AI-card path then reach `tea_util_models.RuntimeOptions()` at `dingtalk.py:914` and crash:

```
AttributeError: 'NoneType' object has no attribute 'RuntimeOptions'
```

The adapter catches the error, logs *"AI Card send failed, falling back to webhook"*, and falls through to the webhook path — where the `AsyncMock` HTTP client's `.status_code` isn't orderable against `int`, yielding a confusing secondary failure:

```
'<' not supported between instances of 'AsyncMock' and 'int'
```

So a test meant to assert an AI-card call ends up swallowed by webhook fallback.

## The fix
Two edits in `tests/gateway/test_dingtalk.py`:

1. **New helper** `_install_dingtalk_sdk_mocks(monkeypatch)` monkey-patches the four module symbols to safe stand-ins and flips `CARD_SDK_AVAILABLE = True` for any guard that reads it.

2. **`_DataClassStub`** is the critical piece. Tests introspect the request object passed into the mocked SDK call:
   ```python
   call = a._card_sdk.streaming_update_with_options_async.call_args
   assert call[0][0].is_finalize is True
   assert call[0][0].out_track_id == r1.message_id
   ```
   The real SDK request classes (`StreamingUpdateRequest`, `CreateCardRequest`, ...) are dataclass-shaped — their attributes are exactly the kwargs the caller passed. A plain `MagicMock` auto-synthesises child mocks on `.out_track_id` / `.is_finalize` / `.content`, so assertions spuriously fail against mock objects instead of the real values. `_DataClassStub.__getattr__` therefore returns a factory that builds a `SimpleNamespace(**kwargs)` on call, preserving the introspectable shape tests expect.

3. **Fixture + test wiring**: `TestCardLifecycle.adapter_with_card` takes `monkeypatch` and runs the helper at setup; `TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured` does the same. Both failing classes now share identical SDK stubbing.

## Test plan
- [x] **Before**: `./venv/bin/pytest tests/gateway/test_dingtalk.py -q` → **7 failed, 55 passed** on clean `origin/main` (2182de55).
- [x] **After**: **62 passed, 0 failed**.
- [x] **Regression guard**: reverted the two fixture edits + the helper; observed the same 7 failures by exact name. Re-applied → 0 failures. No accidental coverage loss.
- [x] **No production code touched** — `gateway/platforms/dingtalk.py` is untouched. `git diff --stat`:
  ```
  tests/gateway/test_dingtalk.py | 53 ++++++++++++++++++++++++++++++++++++++++++---
  1 file changed, 51 insertions(+), 2 deletions(-)
  ```
- [x] Adjacent suites (`test_matrix.py`, `test_approve_deny_commands.py`) still show their own pre-existing baselines — **not** regressed by this change, and out of scope here (Matrix needs the `mautrix` module; the approve-deny test is unrelated).

## Why this is worth landing
Every open PR right now carries this noise in its CI report — when I've been classifying "pre-existing baselines" in my own PR audit comments, these seven failures are the bulk of the DingTalk line. Clearing them up-front makes real regressions legible in future PR runs and stops blocking reviewers from trusting a green `test` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)