### PR TITLE
fix: flatten tool messages for Codex auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -375,6 +375,16 @@ class _CodexCompletionsAdapter:
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
+                # The Codex Responses input schema rejects Chat Completions
+                # transcript-only roles such as ``tool`` (HTTP 400: supported
+                # values are assistant/system/developer/user).  Auxiliary
+                # flushes receive the full session transcript, so preserve tool
+                # output as user-visible context instead of forwarding an
+                # invalid role.
+                if role not in {"assistant", "developer", "user"}:
+                    name = msg.get("name") or msg.get("tool_call_id") or role
+                    content = f"[{role} result {name}: {content}]"
+                    role = "user"
                 input_msgs.append({
                     "role": role,
                     "content": _convert_content_for_responses(content),

--- a/tests/agent/test_auxiliary_client_codex.py
+++ b/tests/agent/test_auxiliary_client_codex.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from agent.auxiliary_client import _CodexCompletionsAdapter
+
+
+class _FakeStream:
+    def __init__(self):
+        self.kwargs = None
+
+    def __call__(self, **kwargs):
+        self.kwargs = kwargs
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_response(self):
+        return SimpleNamespace(output=[])
+
+
+def test_codex_adapter_flattens_tool_role_messages_for_responses_input():
+    stream = _FakeStream()
+    real_client = SimpleNamespace(responses=SimpleNamespace(stream=stream))
+    adapter = _CodexCompletionsAdapter(real_client, "gpt-5.2-codex")
+
+    adapter.create(
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "run a tool"},
+            {"role": "assistant", "content": None, "tool_calls": []},
+            {"role": "tool", "tool_call_id": "call_123", "content": "tool output"},
+        ],
+    )
+
+    assert stream.kwargs["instructions"] == "sys"
+    assert [m["role"] for m in stream.kwargs["input"]] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert stream.kwargs["input"][-1]["content"] == "[tool result call_123: tool output]"


### PR DESCRIPTION
## Summary
- Flatten unsupported chat-completions transcript roles before sending them to the Codex Responses input API
- Preserve `tool` output as user-visible context instead of forwarding an invalid `tool` role
- Add a focused regression test for Codex auxiliary input conversion

## Test Plan
- `python -m pytest tests/agent/test_auxiliary_client_codex.py -o 'addopts=' -q`

## Context
Codex auxiliary memory flushes can receive full Hermes transcripts containing chat-completions `tool` messages. The ChatGPT Codex Responses endpoint rejects those as input roles with:

`HTTP 400: Invalid value: 'tool'. Supported values are: 'assistant', 'system', 'developer', and 'user'.`
