### PR TITLE
fix(credential-pool): distinguish OpenRouter upstream 429s from account 429s

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -31,6 +31,8 @@ class FailoverReason(enum.Enum):
     # Billing / quota
     billing = "billing"                  # 402 or confirmed credit exhaustion — rotate immediately
     rate_limit = "rate_limit"            # 429 or quota-based throttling — backoff then rotate
+    # Upstream model rate-limited (aggregator 429) — fallback to different model, NOT credential rotation
+    upstream_rate_limit = "upstream_rate_limit"  # OpenRouter upstream provider 429 — fallback, don't rotate credential
 
     # Server-side
     overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
@@ -589,7 +591,23 @@ def _classify_by_status(
         )
 
     if status_code == 429:
-        # Already checked long_context_tier above; this is a normal rate limit
+        # Already checked long_context_tier above.
+        # Distinguish OpenRouter-aggregator upstream 429 (upstream model
+        # like DeepSeek rate-limited OpenRouter as a whole) from account-
+        # level 429 (user's key actually throttled).  The outer message
+        # "Provider returned error" is OpenRouter's unambiguous wrapper
+        # for an upstream error — the user's key is healthy, so rotating
+        # /marking it exhausted is wrong.  Fall back to a different model.
+        if _is_openrouter_upstream_error(body, provider):
+            upstream_provider = _extract_upstream_provider_name(body)
+            ctx = {"upstream_provider": upstream_provider} if upstream_provider else {}
+            return result_fn(
+                FailoverReason.upstream_rate_limit,
+                retryable=True,
+                should_rotate_credential=False,
+                should_fallback=True,
+                error_context=ctx,
+            )
         return result_fn(
             FailoverReason.rate_limit,
             retryable=True,
@@ -946,3 +964,49 @@ def _extract_message(error: Exception, body: dict) -> str:
             return msg.strip()[:500]
     # Fallback to str(error)
     return str(error)[:500]
+
+
+def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
+    """Detect OpenRouter's aggregator-wrapped upstream provider errors.
+
+    OpenRouter returns errors from upstream model providers (DeepSeek,
+    Anthropic, etc.) wrapped with the outer message "Provider returned
+    error" and the real error nested in metadata.raw.  This signal means
+    the user's OpenRouter key is healthy — the upstream provider is the
+    one that failed — so credential rotation is the wrong recovery.
+    """
+    if not isinstance(body, dict):
+        return False
+    provider_lower = (provider or "").strip().lower()
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return False
+    outer_msg = str(err.get("message") or "").strip().lower()
+    if outer_msg != "provider returned error":
+        return False
+    # Require either the explicit provider OR the metadata shape that
+    # only OpenRouter produces (metadata.raw or metadata.provider_name).
+    if provider_lower == "openrouter":
+        return True
+    metadata = err.get("metadata")
+    if isinstance(metadata, dict) and (
+        "raw" in metadata or "provider_name" in metadata
+    ):
+        return True
+    return False
+
+
+def _extract_upstream_provider_name(body: Any) -> Optional[str]:
+    """Pull the upstream provider name out of OpenRouter's error metadata."""
+    if not isinstance(body, dict):
+        return None
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return None
+    metadata = err.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    name = metadata.get("provider_name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -5588,6 +5588,25 @@ class AIAgent:
                 return True, False
             return False, True
 
+        if effective_reason == FailoverReason.upstream_rate_limit:
+            # Upstream provider (e.g. DeepSeek behind OpenRouter) is
+            # rate-limiting the aggregator's traffic — the user's credential
+            # is healthy.  Do NOT rotate or mark exhausted; let the caller's
+            # fallback path switch to a different model entirely.
+            upstream = (error_context or {}).get("upstream_provider") if error_context else None
+            if upstream:
+                logger.info(
+                    "Upstream provider %s rate-limited via aggregator — "
+                    "skipping credential rotation, deferring to fallback chain",
+                    upstream,
+                )
+            else:
+                logger.info(
+                    "Upstream aggregator 429 (provider unknown) — skipping "
+                    "credential rotation, deferring to fallback chain"
+                )
+            return False, has_retried_429
+
         if effective_reason == FailoverReason.auth:
             refreshed = pool.try_refresh_current()
             if refreshed is not None:
@@ -6722,7 +6741,7 @@ class AIAgent:
         auth resolution and client construction — no duplicated provider→key
         mappings.
         """
-        if reason in (FailoverReason.rate_limit, FailoverReason.billing):
+        if reason in (FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit):
             # Only start cooldown when leaving the primary provider.  If we're
             # already on a fallback and chain-switching, the primary wasn't the
             # source of the 429 so the cooldown should not be reset/extended.
@@ -11109,16 +11128,31 @@ class AIAgent:
                     is_rate_limited = classified.reason in (
                         FailoverReason.rate_limit,
                         FailoverReason.billing,
+                        FailoverReason.upstream_rate_limit,
                     )
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  See _pool_may_recover_from_rate_limit
                         # for the single-credential-pool exception.  Fixes #11314.
-                        pool_may_recover = _pool_may_recover_from_rate_limit(
-                            self._credential_pool
+                        # Exception: upstream-aggregator 429 — the pool can't
+                        # help when the *upstream* model is being throttled,
+                        # so always fall back regardless of pool state.
+                        is_upstream = classified.reason == FailoverReason.upstream_rate_limit
+                        pool_may_recover = (
+                            False if is_upstream
+                            else _pool_may_recover_from_rate_limit(self._credential_pool)
                         )
                         if not pool_may_recover:
-                            self._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                            if is_upstream:
+                                upstream_name = (classified.error_context or {}).get(
+                                    "upstream_provider", "aggregator"
+                                )
+                                self._emit_status(
+                                    f"⚠️ Upstream {upstream_name} rate-limited — "
+                                    "switching to fallback model..."
+                                )
+                            else:
+                                self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                             if self._try_activate_fallback(reason=classified.reason):
                                 retry_count = 0
                                 compression_attempts = 0

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -53,6 +53,7 @@ class TestFailoverReason:
     def test_enum_members_exist(self):
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
+            "upstream_rate_limit",
             "overloaded", "server_error", "timeout",
             "context_overflow", "payload_too_large",
             "model_not_found", "format_error",
@@ -1128,3 +1129,91 @@ class TestRateLimitErrorWithoutStatusCode:
         e.status_code = None
         result = classify_api_error(e, provider="copilot", model="gpt-4o")
         assert result.reason != FailoverReason.rate_limit
+
+
+class TestOpenRouterUpstreamRateLimit:
+    """Distinguish upstream-provider 429 from account-level 429 on OpenRouter.
+
+    When an upstream model (DeepSeek, Anthropic, etc.) rate-limits
+    OpenRouter's aggregate traffic, OpenRouter returns 429 with the outer
+    message "Provider returned error".  The user's key is healthy — we
+    must fall back to a different model, NOT mark the credential exhausted.
+    """
+
+    def test_openrouter_upstream_429_classified_as_upstream_rate_limit(self):
+        """OpenRouter 429 with 'Provider returned error' → upstream_rate_limit."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 429,
+                    "metadata": {
+                        "provider_name": "DeepSeek",
+                        "raw": '{"error":{"message":"Rate limit exceeded"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context.get("upstream_provider") == "DeepSeek"
+
+    def test_openrouter_account_429_still_rotates_credential(self):
+        """Plain 429 WITHOUT 'Provider returned error' wrapper → rate_limit (rotates)."""
+        e = MockAPIError(
+            "Rate limit exceeded",
+            status_code=429,
+            body={"error": {"message": "Rate limit exceeded: 200 requests per minute"}},
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_openrouter_upstream_429_without_provider_name(self):
+        """Upstream 429 without provider_name still classifies as upstream_rate_limit."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": '{"error":{"message":"slow down"}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+
+    def test_non_openrouter_429_not_misclassified(self):
+        """A 429 from a non-OpenRouter provider must NOT trigger the upstream check."""
+        e = MockAPIError(
+            "Too many requests",
+            status_code=429,
+            body={"error": {"message": "Too many requests"}},
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_openrouter_upstream_429_inferred_from_metadata_shape(self):
+        """Upstream 429 with empty provider arg still detected via metadata shape."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Anthropic"},
+                }
+            },
+        )
+        # provider="" — base_url routing may not always populate provider
+        result = classify_api_error(e, provider="")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.error_context.get("upstream_provider") == "Anthropic"


### PR DESCRIPTION
## What does this PR do?

When using OpenRouter as the LLM provider, a single HTTP 429 would mark
the user's `OPENROUTER_API_KEY` as `exhausted` in the credential pool
for ~24 minutes — silently disabling auxiliary features (context
compression, summarization, vision) and surfacing this misleading
warning on the next session start:

```
⚠ No auxiliary LLM provider configured — context compression will drop
  middle turns without a summary. Run `hermes setup` or set
  OPENROUTER_API_KEY.
```

The root cause: OpenRouter returns 429 in two very different scenarios,
and the classifier was treating them identically:

1. **Account-level 429** — the user's key is throttled. Credential
   rotation is correct.
2. **Upstream-provider 429** — an upstream model (DeepSeek, Anthropic,
   etc.) rate-limits OpenRouter's aggregate traffic. The user's key is
   healthy. Credential rotation is **wrong** — it burns the key for
   ~24min for no benefit. The right recovery is to fall back to a
   different model.

The two shapes are distinguishable with high confidence:

```
# Upstream 429 (wrapped)                # Account 429 (direct)
{                                        {
  "error": {                               "error": {
    "message": "Provider returned            "message": "Rate limit exceeded:
                error",                                    200 requests per minute"
    "code": 429,                           }
    "metadata": {                        }
      "provider_name": "DeepSeek",
      "raw": "<upstream JSON>"
    }
  }
}
```

Real-world logs confirming the bug (from my install, running
`deepseek/deepseek-v4-flash` via OpenRouter):

```
2026-04-24 22:40:55 INFO  credential_pool: marking OPENROUTER_API_KEY exhausted (status=429), rotating
2026-04-24 22:40:55 INFO  credential_pool: no available entries (all exhausted or empty)
2026-04-24 22:41:01 ERROR HTTP 429: Provider returned error | provider=openrouter model=deepseek/deepseek-v4-flash
2026-04-24 22:44:32 WARN  resolve_provider_client: openrouter requested but OpenRouter credential pool has no usable entries (credentials may be exhausted)
```

The key's cooldown — not any actual rate-limit on the key — was what
blocked the auxiliary client for 24 minutes.

## Related Issue

No existing issue — filing this PR directly since the fix is small,
well-scoped, and has clear real-world reproduction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`agent/error_classifier.py`**
- Add `FailoverReason.upstream_rate_limit` — a 429 variant that prefers
  model fallback and does NOT rotate credentials.
- In `_classify_by_status()` (the 429 branch), check for the OpenRouter
  upstream wrapper shape and return the new reason with
  `should_rotate_credential=False`, `should_fallback=True`.
- Surface `metadata.provider_name` in `error_context["upstream_provider"]`
  for observability.
- Add two helpers: `_is_openrouter_upstream_error()` (detection) and
  `_extract_upstream_provider_name()` (metadata lookup).

**`run_agent.py`**
- `_recover_with_credential_pool()` handles the new reason by returning
  `(False, has_retried_429)` without marking the pool entry exhausted —
  defers to the fallback chain.
- Main retry loop eager-fallback gate includes `upstream_rate_limit`,
  and bypasses the `pool_may_recover` check for this reason (the pool
  can't help when the *upstream* is the problem).
- `_try_activate_fallback()` cooldown logic includes the new reason so
  the 60s primary-cooldown behavior still applies.
- Status message updated to name the upstream provider:
  `⚠️ Upstream DeepSeek rate-limited — switching to fallback model...`

**`tests/agent/test_error_classifier.py`**
- 5 new tests covering: upstream 429 classification, account 429 still
  rotates, upstream 429 without `provider_name`, non-OpenRouter 429
  not misclassified, upstream 429 detected via metadata shape alone.
- Updated `test_enum_members_exist` to include the new enum value.

## How to Test

1. **Unit tests** (the primary verification):
   ```
   pytest tests/agent/test_error_classifier.py -q
   pytest tests/agent/test_credential_pool_routing.py -q
   pytest tests/run_agent/test_primary_runtime_restore.py -q
   pytest tests/agent/test_gemini_cloudcode.py -q
   ```
   All pass on my machine (macOS 15, Python 3.11.15): 123 + 10 + 31 +
   85 = 249 tests green.

2. **Reproduce the original bug** (before the fix):
   - Configure OpenRouter with a healthy key but pick a model whose
     upstream provider is currently rate-limited (DeepSeek free tier
     is usually a good candidate).
   - Send a message. The 429 bubbles up.
   - Check `hermes auth list` — the key is marked `exhausted (429)` for
     ~24min.
   - The next session warns about "No auxiliary LLM provider
     configured" and skips context compression.

3. **Verify the fix**:
   - Same setup with this patch applied.
   - On the 429, the log shows:
     `Upstream provider DeepSeek rate-limited via aggregator —
      skipping credential rotation, deferring to fallback chain`
   - `hermes auth list` shows the key as healthy.
   - If a fallback model is configured, it's used automatically.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(credential-pool):`)
- [x] I searched for existing PRs — no duplicates
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (5 new tests covering the
      distinction)
- [x] I've tested on my platform: macOS 15 (Mac Mini M4, Python 3.11.15)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal bug fix, no
      user-visible config/API change)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (error classification is
      platform-independent)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

**Before** (live log from my install at `~/.hermes/logs/agent.log`):

```
2026-04-24 22:40:55 INFO credential_pool: marking OPENROUTER_API_KEY exhausted (status=429), rotating
2026-04-24 22:40:55 INFO credential_pool: no available entries (all exhausted or empty)
2026-04-24 22:41:01 ERROR HTTP 429: Provider returned error | provider=openrouter model=deepseek/deepseek-v4-flash msgs=3 tokens=~4,448
2026-04-24 22:44:32 WARN resolve_provider_client: openrouter requested but OpenRouter credential pool has no usable entries
```

**After** (expected behavior with this patch):

```
INFO run_agent: Upstream provider DeepSeek rate-limited via aggregator — skipping credential rotation, deferring to fallback chain
INFO run_agent: Switching to fallback model (primary cooldown 60s)
```

The credential pool stays healthy; auxiliary features (compression,
vision, summarization) keep working throughout.
