### PR TITLE
fix(tui): proactive mouse disable on ConPTY + /mouse toggle command

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2789,6 +2789,23 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.tui_statusbar", nv)
         return _ok(rid, {"key": key, "value": nv})
 
+    if key == "mouse":
+        raw = str(value or "").strip().lower()
+        display = _load_cfg().get("display") if isinstance(_load_cfg().get("display"), dict) else {}
+        current = bool(display.get("tui_mouse", True))
+
+        if raw in ("", "toggle"):
+            nv = not current
+        elif raw == "on":
+            nv = True
+        elif raw == "off":
+            nv = False
+        else:
+            return _err(rid, 4002, f"unknown mouse value: {value}")
+
+        _write_config_key("display.tui_mouse", nv)
+        return _ok(rid, {"key": key, "value": "on" if nv else "off"})
+
     if key in ("prompt", "personality", "skin"):
         try:
             cfg = _load_cfg()
@@ -2917,6 +2934,10 @@ def _(rid, params: dict) -> dict:
             display.get("tui_statusbar", "top") if isinstance(display, dict) else "top"
         )
         return _ok(rid, {"value": _coerce_statusbar(raw)})
+    if key == "mouse":
+        display = _load_cfg().get("display")
+        on = display.get("tui_mouse", True) if isinstance(display, dict) else True
+        return _ok(rid, {"value": "on" if on else "off"})
     if key == "mtime":
         cfg_path = _hermes_home / "config.yaml"
         try:

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
@@ -53,7 +53,7 @@ export function AlternateScreen(t0: Props) {
       }
 
       writeRaw(
-        ENTER_ALT_SCREEN + ERASE_SCROLLBACK + ERASE_SCREEN + CURSOR_HOME + (mouseTracking ? ENABLE_MOUSE_TRACKING : '')
+        ENTER_ALT_SCREEN + ERASE_SCROLLBACK + ERASE_SCREEN + CURSOR_HOME + (mouseTracking ? ENABLE_MOUSE_TRACKING : DISABLE_MOUSE_TRACKING)
       )
       ink?.setAltScreenActive(true, mouseTracking)
 

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -1121,6 +1121,23 @@ export default class Ink {
       this.repaint()
     }
   }
+
+  /**
+   * Toggle mouse tracking at runtime while the alt screen is active.
+   * Writes the appropriate DEC reset/set sequences so the terminal
+   * (and ConPTY on Windows WSL2) reflects the change immediately.
+   */
+  setAltScreenMouseTracking(enabled: boolean): void {
+    if (this.altScreenMouseTracking === enabled) {
+      return
+    }
+
+    this.altScreenMouseTracking = enabled
+
+    if (this.altScreenActive) {
+      this.options.stdout.write(enabled ? ENABLE_MOUSE_TRACKING : DISABLE_MOUSE_TRACKING)
+    }
+  }
   get isAltScreenActive(): boolean {
     return this.altScreenActive
   }

--- a/ui-tui/src/app.tsx
+++ b/ui-tui/src/app.tsx
@@ -1,18 +1,21 @@
+import { useStore } from '@nanostores/react'
+
 import { GatewayProvider } from './app/gatewayContext.js'
 import { useMainApp } from './app/useMainApp.js'
+import { $uiState } from './app/uiStore.js'
 import { AppLayout } from './components/appLayout.js'
-import { MOUSE_TRACKING } from './config/env.js'
 import type { GatewayClient } from './gatewayClient.js'
 
 export function App({ gw }: { gw: GatewayClient }) {
   const { appActions, appComposer, appProgress, appStatus, appTranscript, gateway } = useMainApp(gw)
+  const { mouseTracking } = useStore($uiState)
 
   return (
     <GatewayProvider value={gateway}>
       <AppLayout
         actions={appActions}
         composer={appComposer}
-        mouseTracking={MOUSE_TRACKING}
+        mouseTracking={mouseTracking}
         progress={appProgress}
         status={appStatus}
         transcript={appTranscript}

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -88,6 +88,7 @@ export interface UiState {
   detailsMode: DetailsMode
   info: null | SessionInfo
   inlineDiffs: boolean
+  mouseTracking: boolean
   sections: SectionVisibility
   showCost: boolean
   showReasoning: boolean

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -85,6 +85,27 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['scroll'],
+    help: 'toggle mouse/wheel tracking [on|off|toggle]',
+    name: 'mouse',
+    run: (arg, ctx) => {
+      const current = ctx.ui.mouseTracking
+      const next = flagFromArg(arg, current)
+
+      if (next === null) {
+        return ctx.transcript.sys('usage: /mouse [on|off|toggle]')
+      }
+
+      patchUiState({ mouseTracking: next })
+      ctx.gateway
+        .rpc<ConfigSetResponse>('config.set', { key: 'mouse', value: next ? 'on' : 'off' })
+        .catch(() => {})
+
+      queueMicrotask(() => ctx.transcript.sys(`mouse tracking ${next ? 'on' : 'off'}`))
+    }
+  },
+
+  {
     aliases: ['new'],
     help: 'start a new session',
     name: 'clear',

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import { ZERO } from '../domain/usage.js'
 import { DEFAULT_THEME } from '../theme.js'
+import { MOUSE_TRACKING } from '../config/env.js'
 
 import type { UiState } from './interfaces.js'
 
@@ -12,6 +13,7 @@ const buildUiState = (): UiState => ({
   detailsMode: 'collapsed',
   info: null,
   inlineDiffs: true,
+  mouseTracking: MOUSE_TRACKING,
   sections: {},
   showCost: false,
   showReasoning: false,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -46,6 +46,7 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
     compact: !!d.tui_compact,
     detailsMode: resolveDetailsMode(d),
     inlineDiffs: d.inline_diffs !== false,
+    mouseTracking: d.tui_mouse !== false,
     sections: resolveSections(d.sections),
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -61,6 +61,7 @@ export interface ConfigDisplayConfig {
   streaming?: boolean
   thinking_mode?: string
   tui_compact?: boolean
+  tui_mouse?: boolean
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
 }
 


### PR DESCRIPTION
## Problem

On Windows WSL2, moving the mouse or using the scroll wheel while the Hermes TUI is active injects raw escape sequences (e.g. `<35;col;row M>`) into the chat transcript as ghost characters. This is reproducible in any terminal that uses ConPTY for WSL2 (Windows Terminal, Termius, etc.).

## Root Cause

ConPTY implicitly enables mouse event injection when the alternate screen buffer (DEC 1049) is entered, even without explicit `?1000h`/ `?1003h` DECSET codes. The TUI enters alt screen on startup; the classic CLI does not.

The `HERMES_TUI_DISABLE_MOUSE` env var correctly prevents Hermes from *sending* mouse enable sequences, but since ConPTY's implicit enable is never explicitly countered, the injection still occurs.

## Fix

Two parts:

1. **ConPTY fix** — Proactively send `DISABLE_MOUSE_TRACKING` after entering the alternate screen when mouse tracking is off (`AlternateScreen.tsx`). This cancels ConPTY's implicit enable immediately.

2. **Runtime toggle** — Add `/mouse [on|off|toggle]` slash command with config persistence (`display.tui_mouse`). The env var `HERMES_TUI_DISABLE_MOUSE` continues to work as the initial default but can now be overridden at runtime. Config persistence means the setting survives restarts.

3. **Runtime Ink API** — Added `setAltScreenMouseTracking(enabled)` to the Ink instance so the toggle can update the terminal immediately mid-session (not just on next alt screen entry).

## Files Changed

| File | Change |
|------|--------|
| `ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx` | Send DISABLE_MOUSE_TRACKING on mount when tracking is off |
| `ui-tui/packages/hermes-ink/src/ink/ink.tsx` | Add setAltScreenMouseTracking() for runtime toggle |
| `ui-tui/src/app/slash/commands/core.ts` | Add /mouse slash command |
| `ui-tui/src/app/interfaces.ts` | Add mouseTracking to UiState |
| `ui-tui/src/app/uiStore.ts` | Initialize mouseTracking from env var |
| `ui-tui/src/app/useConfigSync.ts` | Hydrate from display.tui_mouse config |
| `ui-tui/src/app.tsx` | Wire reactive mouseTracking from store |
| `ui-tui/src/gatewayTypes.ts` | Add tui_mouse to config type |
| `tui_gateway/server.py` | Add config.set/get mouse |

## Credits

Concept inspired by @OutThisLife's PR #13716 which addressed the same root issue.