### PR TITLE
fix(agent): extract usageMetadata from Gemini streaming events

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -551,6 +551,7 @@ def _make_stream_chunk(
     tool_call_delta: Optional[Dict[str, Any]] = None,
     finish_reason: Optional[str] = None,
     reasoning: str = "",
+    usage: Optional[SimpleNamespace] = None,
 ) -> _GeminiStreamChunk:
     delta_kwargs: Dict[str, Any] = {
         "role": "assistant",
@@ -586,7 +587,7 @@ def _make_stream_chunk(
         created=int(time.time()),
         model=model,
         choices=[choice],
-        usage=None,
+        usage=usage,
     )
 
 
@@ -679,7 +680,19 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
         mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
-        chunks.append(_make_stream_chunk(model=model, finish_reason=mapped))
+        usage_meta = event.get("usageMetadata") or {}
+        usage = None
+        if usage_meta:
+            usage = SimpleNamespace(
+                prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
+                completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+                total_tokens=int(usage_meta.get("totalTokenCount") or 0),
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
+                ),
+            )
+        chunks.append(_make_stream_chunk(model=model, finish_reason=mapped, usage=usage))
+
     return chunks
 
 

--- a/tests/agent/test_gemini_streaming_usage.py
+++ b/tests/agent/test_gemini_streaming_usage.py
@@ -1,0 +1,227 @@
+"""Tests for Gemini native streaming usageMetadata extraction (issue #15253).
+
+The bug: translate_stream_event() never extracts usageMetadata from SSE events,
+so all Gemini streaming sessions show input_tokens=0, output_tokens=0.
+
+The fix: attach usage from usageMetadata to the finish-reason chunk, mirroring
+the non-streaming translate_gemini_response().
+"""
+
+
+def test_stream_event_with_usage_metadata_attaches_to_finish_chunk():
+    """When a streaming event includes usageMetadata, it should be attached
+    to the finish_reason chunk (the last chunk emitted)."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 42,
+            "candidatesTokenCount": 7,
+            "totalTokenCount": 49,
+            "cachedContentTokenCount": 10,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    assert len(chunks) == 2  # content chunk + finish chunk
+
+    # First chunk (content) should have no usage
+    assert chunks[0].usage is None
+
+    # Second chunk (finish) should carry usage from the event
+    finish_chunk = chunks[-1]
+    assert finish_chunk.choices[0].finish_reason == "stop"
+    assert finish_chunk.usage is not None
+    assert finish_chunk.usage.prompt_tokens == 42
+    assert finish_chunk.usage.completion_tokens == 7
+    assert finish_chunk.usage.total_tokens == 49
+    assert finish_chunk.usage.prompt_tokens_details.cached_tokens == 10
+
+
+def test_stream_event_with_usage_metadata_and_tool_calls():
+    """Usage should be attached to the finish chunk even when tool calls are present."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}}
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 100,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 120,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    # Should have tool call chunk + finish chunk
+    finish_chunk = chunks[-1]
+    assert finish_chunk.choices[0].finish_reason == "tool_calls"
+    assert finish_chunk.usage is not None
+    assert finish_chunk.usage.prompt_tokens == 100
+    assert finish_chunk.usage.completion_tokens == 20
+    assert finish_chunk.usage.total_tokens == 120
+
+
+def test_stream_event_without_usage_metadata_has_no_usage():
+    """When usageMetadata is absent (intermediate chunks), usage stays None."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "thinking"}]},
+            }
+        ],
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    assert len(chunks) == 1
+    assert chunks[0].usage is None
+
+
+def test_stream_event_with_empty_usage_metadata_has_no_usage():
+    """When usageMetadata is present but empty, usage should be None
+    (don't attach a zero-usage namespace when Gemini sends an empty dict)."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {},
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    finish_chunk = chunks[-1]
+    # Empty usageMetadata dict -> no usage attached (no data to report)
+    assert finish_chunk.usage is None
+
+
+def test_stream_event_usage_with_missing_fields_defaults_to_zero():
+    """When usageMetadata is partially present, missing fields default to 0."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 50,
+            "totalTokenCount": 60,
+            # candidatesTokenCount and cachedContentTokenCount missing
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    finish_chunk = chunks[-1]
+    assert finish_chunk.usage is not None
+    assert finish_chunk.usage.prompt_tokens == 50
+    assert finish_chunk.usage.completion_tokens == 0  # missing -> 0
+    assert finish_chunk.usage.total_tokens == 60
+    assert finish_chunk.usage.prompt_tokens_details.cached_tokens == 0  # missing -> 0
+
+
+def test_stream_event_with_reasoning_and_usage():
+    """Usage should appear on finish chunk even when reasoning (thought) parts are present."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"thought": True, "text": "Let me think..."},
+                        {"text": "The answer is 42."},
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 30,
+            "candidatesTokenCount": 15,
+            "totalTokenCount": 45,
+            "cachedContentTokenCount": 5,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    # reasoning + content + finish
+    assert len(chunks) == 3
+    finish_chunk = chunks[-1]
+    assert finish_chunk.choices[0].finish_reason == "stop"
+    assert finish_chunk.usage is not None
+    assert finish_chunk.usage.prompt_tokens == 30
+    assert finish_chunk.usage.completion_tokens == 15
+    assert finish_chunk.usage.prompt_tokens_details.cached_tokens == 5
+
+def test_stream_event_with_explicit_zero_usage_metadata():
+    """When usageMetadata has all zero values, we should still attach it
+    (distinct from None -- tells the caller we got usage data)."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hi"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 0,
+            "candidatesTokenCount": 0,
+            "totalTokenCount": 0,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    finish_chunk = chunks[-1]
+    assert finish_chunk.usage is not None
+    assert finish_chunk.usage.prompt_tokens == 0
+    assert finish_chunk.usage.completion_tokens == 0
+    assert finish_chunk.usage.total_tokens == 0
+
+
+def test_stream_event_usage_only_on_finish_not_content():
+    """usageMetadata is ignored on intermediate chunks (no finishReason).
+    Only the finish chunk should carry usage."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    # Intermediate chunk: has usageMetadata but no finishReason
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "thinking"}]},
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 6,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    # No finish chunk, so no usage attached at all
+    for chunk in chunks:
+        assert chunk.usage is None


### PR DESCRIPTION
## Problem

Gemini's streaming API includes `usageMetadata` on the final SSE event (alongside `finishReason`), but `translate_stream_event()` was ignoring it. This caused all Gemini streaming sessions to report `input_tokens=0, output_tokens=0` — complete cost blindness for the most popular provider.

The non-streaming path (`translate_gemini_response()`) already correctly extracts `usageMetadata` at lines 514-522. The streaming path had no equivalent logic.

## Fix

- Added `usage` parameter to `_make_stream_chunk()` (was hardcoded to `None`)
- In `translate_stream_event()`, extract `usageMetadata` from the event dict and build a `SimpleNamespace` usage object (same shape as the non-streaming path)
- Usage is attached only to the finish-reason chunk (matching OpenAI streaming semantics where the final chunk carries usage)
- Intermediate content/tool_call/reasoning chunks keep `usage=None`

## Testing

8 new tests in `tests/agent/test_gemini_streaming_usage.py`:

| Test | Covers |
|------|--------|
| `test_stream_event_with_usage_metadata_attaches_to_finish_chunk` | Happy path: usage on finish chunk |
| `test_stream_event_with_usage_metadata_and_tool_calls` | Usage works with tool calls |
| `test_stream_event_without_usage_metadata_has_no_usage` | Intermediate chunks: no usage |
| `test_stream_event_with_empty_usage_metadata_has_no_usage` | Empty `{}` dict: usage=None |
| `test_stream_event_usage_with_missing_fields_defaults_to_zero` | Partial usageMetadata defaults to 0 |
| `test_stream_event_with_reasoning_and_usage` | Reasoning + usage together |
| `test_stream_event_with_explicit_zero_usage_metadata` | All-zero values still attach (distinct from None) |
| `test_stream_event_usage_only_on_finish_not_content` | usageMetadata on non-finish chunks ignored |

All 19 tests pass (11 existing + 8 new). No regressions.

Closes #15253