### PR TITLE
fix(discord): show command in approval message

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2892,22 +2892,38 @@ class DiscordAdapter(BasePlatformAdapter):
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
 
-            # Discord embed description limit is 4096; show full command up to that
-            max_desc = 4088
-            cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
-            embed = discord.Embed(
-                title="⚠️ Command Approval Required",
-                description=f"```\n{cmd_display}\n```",
-                color=discord.Color.orange(),
+            command_text = str(command or "").strip()
+            if not command_text:
+                command_text = "(command text missing - deny unless you can verify the request elsewhere)"
+            reason_text = str(description or "dangerous command").strip()
+
+            # Put the command in normal message content, not an embed. The
+            # buttons can still render when embeds are collapsed or hidden, so
+            # the approval context must live in the same visible message text.
+            max_content_cmd = 1400
+            content_cmd = (
+                command_text
+                if len(command_text) <= max_content_cmd
+                else command_text[: max_content_cmd - 3] + "..."
             )
-            embed.add_field(name="Reason", value=description, inline=False)
+            max_content_reason = 350
+            content_reason = (
+                reason_text
+                if len(reason_text) <= max_content_reason
+                else reason_text[: max_content_reason - 3] + "..."
+            )
+            content = (
+                "⚠️ **Command Approval Required**\n"
+                f"```sh\n{content_cmd}\n```\n"
+                f"Reason: {content_reason}"
+            )
 
             view = ExecApprovalView(
                 session_key=session_key,
                 allowed_user_ids=self._allowed_user_ids,
             )
 
-            msg = await channel.send(embed=embed, view=view)
+            msg = await channel.send(content=content, view=view)
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:

--- a/tests/gateway/test_discord_approval_buttons.py
+++ b/tests/gateway/test_discord_approval_buttons.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(
+        View=type("View", (), {"__init__": lambda self, *a, **k: None}),
+        button=lambda *a, **k: (lambda fn: fn),
+        Button=object,
+    )
+    discord_mod.ButtonStyle = SimpleNamespace(
+        green=1,
+        grey=2,
+        blurple=3,
+        red=4,
+    )
+    discord_mod.Color = SimpleNamespace(
+        orange=lambda: 1,
+        green=lambda: 2,
+        blue=lambda: 3,
+        red=lambda: 4,
+        purple=lambda: 5,
+    )
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from gateway.platforms import discord as discord_platform  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_includes_plain_text_command_preview(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    sent_msg = SimpleNamespace(id=1234)
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    view = object()
+    monkeypatch.setattr(discord_platform, "ExecApprovalView", MagicMock(return_value=view))
+
+    result = await adapter.send_exec_approval(
+        chat_id="555",
+        command="rm -rf /important",
+        session_key="agent:main:discord:group:555:999",
+        description="dangerous deletion",
+    )
+
+    assert result.success is True
+    assert result.message_id == "1234"
+    channel.send.assert_awaited_once()
+    kwargs = channel.send.call_args.kwargs
+    assert kwargs["view"] is view
+    assert "embed" not in kwargs
+    assert "rm -rf /important" in kwargs["content"]
+    assert "dangerous deletion" in kwargs["content"]


### PR DESCRIPTION
## What does this PR do?

Discord exec approval buttons could render without the command context being visible when the approval prompt relied on an embed. This moves the approval command preview and reason into the normal Discord message content and keeps the existing buttons attached to that same message, so users do not have to approve or deny blindly.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/discord.py` so Discord approval prompts send the command preview and reason as normal message content with the existing approval buttons.
- Added `tests/gateway/test_discord_approval_buttons.py` to guard that the command/reason are present in plain message content and that no duplicate embed is sent.

## How to Test

1. Trigger a dangerous command approval from a Discord gateway session.
2. Confirm the Discord message shows the command and reason directly above the approval buttons.
3. Run `pytest -n 4 tests/gateway/test_discord_approval_buttons.py tests/gateway/test_discord_send.py`.
4. Run `/home/gille/.hermes/hermes-agent/.venv/bin/python -m pytest -n 4 tests/` from a clean worktree.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

```
pytest -n 4 tests/gateway/test_discord_approval_buttons.py tests/gateway/test_discord_send.py
16 passed in 0.87s
```

Full suite run from clean worktree `/tmp/hermes-discord-approval-tests`:

```
/home/gille/.hermes/hermes-agent/.venv/bin/python -m pytest -n 4 tests/
73 failed, 15583 passed, 41 skipped, 187 warnings in 318.74s (0:05:18)
```

The full-suite failures are broad across existing gateway/config/DingTalk/Discord/mock-related tests rather than concentrated in this approval change. The new Discord approval regression test passed in both the focused run and the full run.