### PR TITLE
fix(toolsets): discover plugins before reading registry in _get_plugin_toolset_names

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -562,6 +562,13 @@ def _get_plugin_toolset_names() -> Set[str]:
     ``TOOLSETS`` dict — i.e. they were added by plugins at load time.
     """
     try:
+        # Ensure plugins are discovered before querying the registry.
+        # Without this, the registry may be empty if this function is called
+        # before the agent's plugin-loading phase, causing plugin toolsets
+        # (e.g. "wiki" from hermes-wiki) to be silently excluded from the
+        # resolved tool list even when the plugin is installed and registered.
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
         from tools.registry import registry
         return {
             toolset_name


### PR DESCRIPTION
## Summary

Plugin-registered toolsets are silently excluded from the resolved tool list when `_get_plugin_toolset_names()` in `toolsets.py` runs before the agent's plugin-loading phase. The registry is empty, so no plugin toolsets are reported.

## Reproduction

1. Install a plugin that registers a toolset via `ctx.register_tool()` — e.g. a `hermes-wiki` plugin that registers a `wiki_search` tool under a `wiki` toolset.
2. Add `wiki` to `platform_toolsets` in `config.yaml`.
3. Restart the gateway.
4. Inspect the LLM's tool list during a conversation — `wiki_search` is absent, though the plugin has loaded successfully and `hermes tools list` reports the toolset as registered.

## Root cause

`_get_plugin_toolset_names()` queries `registry.get_registered_toolset_names()` directly, without first calling `discover_plugins()`. If the function runs before plugins have been loaded, the registry returns nothing and plugin toolsets are filtered out of the resolved platform toolsets.

## Fix

Call `discover_plugins()` at the top of `_get_plugin_toolset_names()` so the registry is populated before it's queried. The call is inside the existing `try/except`, so failures in plugin discovery still return `set()` gracefully — unchanged behaviour on the error path.

## Verification

Tested on v0.10.0 with a plugin that registers a `wiki` toolset:

- `validate_toolset('wiki')` → `True`
- `'wiki' in all_toolsets` → `True`
- `resolve_toolset('wiki')` tools → `['wiki_search']`
- `'wiki_search'` now appears in the LLM's resolved tools
- Telegram platform enabled toolsets includes `'wiki'`

Before the fix, `resolve_toolset('wiki')` returned `[]` and `'wiki'` was absent from the platform's enabled toolsets.

## Notes

Happy to adjust the placement if maintainers prefer a more central fix — e.g. calling `discover_plugins()` from a higher-level init path so plugin discovery is guaranteed earlier in the lifecycle rather than lazily on first toolset resolution. The change here is minimal and local to the symptom.