### PR TITLE
fix: patch correct module binding in test_release_clients_does_not_touch_terminal_or_browser

### DIFF
--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1162,8 +1162,7 @@ class TestAgentCacheIdleResume:
     def test_release_clients_does_not_touch_terminal_or_browser(self, monkeypatch):
         """release_clients must not call cleanup_vm or cleanup_browser."""
         from run_agent import AIAgent
-        from tools import terminal_tool as _tt
-        from tools import browser_tool as _bt
+        import run_agent as _ra
 
         agent = AIAgent(
             model="anthropic/claude-sonnet-4", api_key="test",
@@ -1175,15 +1174,18 @@ class TestAgentCacheIdleResume:
 
         vm_calls: list = []
         browser_calls: list = []
-        original_vm = _tt.cleanup_vm
-        original_browser = _bt.cleanup_browser
-        _tt.cleanup_vm = lambda tid: vm_calls.append(tid)
-        _bt.cleanup_browser = lambda tid: browser_calls.append(tid)
+        # AIAgent calls the ``cleanup_vm`` / ``cleanup_browser`` names bound
+        # into the ``run_agent`` module at import time, so patch those
+        # references (not the original tools.terminal_tool / tools.browser_tool).
+        original_vm = _ra.cleanup_vm
+        original_browser = _ra.cleanup_browser
+        _ra.cleanup_vm = lambda tid: vm_calls.append(tid)
+        _ra.cleanup_browser = lambda tid: browser_calls.append(tid)
         try:
             agent.release_clients()
         finally:
-            _tt.cleanup_vm = original_vm
-            _bt.cleanup_browser = original_browser
+            _ra.cleanup_vm = original_vm
+            _ra.cleanup_browser = original_browser
             try:
                 agent.close()
             except Exception:

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -888,8 +888,7 @@ class TestAgentCacheIdleResume:
     def test_release_clients_does_not_touch_terminal_or_browser(self, monkeypatch):
         """release_clients must not call cleanup_vm or cleanup_browser."""
         from run_agent import AIAgent
-        from tools import terminal_tool as _tt
-        from tools import browser_tool as _bt
+        import run_agent as _ra
 
         agent = AIAgent(
             model="anthropic/claude-sonnet-4", api_key="test",
@@ -901,15 +900,18 @@ class TestAgentCacheIdleResume:
 
         vm_calls: list = []
         browser_calls: list = []
-        original_vm = _tt.cleanup_vm
-        original_browser = _bt.cleanup_browser
-        _tt.cleanup_vm = lambda tid: vm_calls.append(tid)
-        _bt.cleanup_browser = lambda tid: browser_calls.append(tid)
+        # AIAgent calls the ``cleanup_vm`` / ``cleanup_browser`` names bound
+        # into the ``run_agent`` module at import time, so patch those
+        # references (not the original tools.terminal_tool / tools.browser_tool).
+        original_vm = _ra.cleanup_vm
+        original_browser = _ra.cleanup_browser
+        _ra.cleanup_vm = lambda tid: vm_calls.append(tid)
+        _ra.cleanup_browser = lambda tid: browser_calls.append(tid)
         try:
             agent.release_clients()
         finally:
-            _tt.cleanup_vm = original_vm
-            _bt.cleanup_browser = original_browser
+            _ra.cleanup_vm = original_vm
+            _ra.cleanup_browser = original_browser
             try:
                 agent.close()
             except Exception:


### PR DESCRIPTION
The test `test_release_clients_does_not_touch_terminal_or_browser` patches `tools.terminal_tool.cleanup_vm` and `tools.browser_tool.cleanup_browser`, but the production code in `run_agent.py` uses module-level names imported at the top of the file:

```python
from tools.terminal_tool import cleanup_vm
from tools.browser_tool import cleanup_browser
```

So `release_clients()` calls `cleanup_vm` / `cleanup_browser` resolved in the `run_agent` namespace — not the original `tools.*` modules. The monkeypatches on `_tt.cleanup_vm` / `_bt.cleanup_browser` would never intercept those calls.

The test currently passes only because `release_clients()` does not invoke either function. If a future change added such a call, the existing patches would silently miss it.

**Fix:** Patch `run_agent.cleanup_vm` and `run_agent.cleanup_browser` instead, consistent with the approach already used in `test_close_vs_release_full_teardown_difference` in the same file.

All 5 tests in `TestAgentCacheIdleResume` pass.

Closes #15489