### PR TITLE
fix(setup): skip AUXILIARY_VISION_MODEL write when input is blank

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -867,7 +867,8 @@ def setup_model_provider(config: dict, *, quick: bool = False):
                     )
                 else:
                     _selected_vision_model = prompt("  Vision model (blank = use main/custom default)").strip()
-                save_env_value("AUXILIARY_VISION_MODEL", _selected_vision_model)
+                if _selected_vision_model:
+                    save_env_value("AUXILIARY_VISION_MODEL", _selected_vision_model)
                 print_success(
                     f"Vision configured with {_base_url}"
                     + (f" ({_selected_vision_model})" if _selected_vision_model else "")

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -527,3 +527,20 @@ def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys
 
     captured = capsys.readouterr()
     assert "Run 'hermes chat' manually" in captured.out
+
+
+class TestVisionModelBlankGuard:
+    """Regression: blank vision model input must not overwrite existing .env value."""
+
+    def test_save_env_value_overwrites_with_empty(self, tmp_path, monkeypatch):
+        """Proves save_env_value has no internal guard — caller must guard."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("AUXILIARY_VISION_MODEL=custom-model\n")
+        monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: env_path)
+
+        from hermes_cli.config import save_env_value
+        save_env_value("AUXILIARY_VISION_MODEL", "")
+
+        # save_env_value DOES overwrite — this is by design.
+        # The guard must be at the call site in setup.py.
+        assert "AUXILIARY_VISION_MODEL=\n" in env_path.read_text()


### PR DESCRIPTION
## Summary

- Guard the `save_env_value("AUXILIARY_VISION_MODEL", ...)` call with `if _selected_vision_model:` so blank input at the non-OpenAI vision model prompt doesn't nuke existing values in `.env`

## Root Cause

The non-native-OpenAI vision path unconditionally called `save_env_value` with the prompt result. `save_env_value` has no internal guard against empty strings — it faithfully writes `AUXILIARY_VISION_MODEL=` to `.env`, destroying any existing custom model.

The native OpenAI path was safe (uses `prompt_choice` which always returns a value).

## Test plan

- [x] Regression test documents that `save_env_value` has no internal guard
- [x] Full setup test suite: 20 passed