### PR TITLE
feat(background_review): add configurable background review routing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5061,11 +5061,47 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
-        """Open prompt_toolkit-native /model picker modal."""
+    def _prompt_hidden_input(self, prompt_text: str) -> str | None:
+        """Prompt for hidden input safely inside or outside prompt_toolkit."""
+        import getpass
+
+        result = [None]
+
+        def _ask():
+            try:
+                value = getpass.getpass(prompt_text)
+                result[0] = value if value != "" else None
+            except (KeyboardInterrupt, EOFError):
+                pass
+
+        if self._app:
+            from prompt_toolkit.application import run_in_terminal
+            was_visible = self._status_bar_visible
+            self._status_bar_visible = False
+            self._app.invalidate()
+            try:
+                run_in_terminal(_ask)
+            finally:
+                self._status_bar_visible = was_visible
+                self._app.invalidate()
+        else:
+            _ask()
+        return result[0]
+
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        user_provs=None,
+        custom_provs=None,
+        picker_kind: str = "model",
+    ) -> None:
+        """Open prompt_toolkit-native model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
         self._model_picker_state = {
+            "kind": picker_kind,
             "stage": "provider",
             "providers": providers,
             "selected": default_idx,
@@ -5187,6 +5223,92 @@ class HermesCLI:
         else:
             _cprint("    (session only — add --global to persist)")
 
+    def _apply_review_model_switch_result(self, result) -> None:
+        if not result.success:
+            _cprint(f"  ✗ {result.error_message}")
+            return
+
+        save_config_value("agent.review_model.model", result.new_model)
+        save_config_value("agent.review_model.provider", result.target_provider)
+        save_config_value("agent.review_model.base_url", result.base_url or "")
+        save_config_value("agent.review_model.api_key", result.api_key or "")
+        save_config_value("agent.review_model.api_mode", result.api_mode or "")
+
+        if self.agent is not None:
+            self.agent._review_model_model = result.new_model
+            self.agent._review_model_provider = result.target_provider
+            self.agent._review_model_base_url = result.base_url or ""
+            self.agent._review_model_api_key = result.api_key or ""
+            self.agent._review_model_api_mode = result.api_mode or ""
+
+        provider_label = result.provider_label or result.target_provider
+        _cprint(f"  ✓ Review model configured: {result.new_model}")
+        _cprint(f"    Provider: {provider_label}")
+        if result.base_url:
+            _cprint(f"    Base URL: {result.base_url}")
+        if result.warning_message:
+            _cprint(f"    ⚠ {result.warning_message}")
+        _cprint("    Saved to config.yaml")
+
+    def _reset_review_model_config(self) -> None:
+        save_config_value("agent.review_model.model", "default")
+        save_config_value("agent.review_model.provider", "")
+        save_config_value("agent.review_model.base_url", "")
+        save_config_value("agent.review_model.api_key", "")
+        save_config_value("agent.review_model.api_mode", "")
+
+        if self.agent is not None:
+            self.agent._review_model_model = "default"
+            self.agent._review_model_provider = ""
+            self.agent._review_model_base_url = ""
+            self.agent._review_model_api_key = ""
+            self.agent._review_model_api_mode = ""
+
+        _cprint("  ✓ Review model reset to default")
+        _cprint("    Background review will inherit the primary agent runtime.")
+
+    def _configure_review_model_custom_endpoint(self) -> None:
+        from hermes_cli.providers import determine_api_mode
+
+        provider = self._prompt_text_input("  Review provider slug [custom]: ") or "custom"
+        base_url = self._prompt_text_input("  Review base URL: ")
+        if not base_url:
+            _cprint("  ✗ Base URL is required.")
+            return
+
+        model = self._prompt_text_input("  Review model name: ")
+        if not model:
+            _cprint("  ✗ Model name is required.")
+            return
+
+        api_key = self._prompt_hidden_input("  Review API key (optional): ") or ""
+        api_mode = self._prompt_text_input("  API mode [auto]: ") or ""
+        if not api_mode:
+            try:
+                api_mode = determine_api_mode(provider, base_url)
+            except Exception:
+                api_mode = ""
+
+        save_config_value("agent.review_model.model", model)
+        save_config_value("agent.review_model.provider", provider)
+        save_config_value("agent.review_model.base_url", base_url)
+        save_config_value("agent.review_model.api_key", api_key)
+        save_config_value("agent.review_model.api_mode", api_mode)
+
+        if self.agent is not None:
+            self.agent._review_model_model = model
+            self.agent._review_model_provider = provider
+            self.agent._review_model_base_url = base_url
+            self.agent._review_model_api_key = api_key
+            self.agent._review_model_api_mode = api_mode
+
+        _cprint(f"  ✓ Review model configured: {model}")
+        _cprint(f"    Provider: {provider}")
+        _cprint(f"    Base URL: {base_url}")
+        if api_mode:
+            _cprint(f"    API mode: {api_mode}")
+        _cprint("    Saved to config.yaml")
+
     def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
         state = self._model_picker_state
         if not state:
@@ -5195,7 +5317,23 @@ class HermesCLI:
         stage = state.get("stage")
         if stage == "provider":
             providers = state.get("providers") or []
-            if selected >= len(providers):
+            picker_kind = state.get("kind")
+            if picker_kind == "review-model":
+                default_idx = len(providers)
+                custom_idx = len(providers) + 1
+                cancel_idx = len(providers) + 2
+                if selected == default_idx:
+                    self._close_model_picker()
+                    self._reset_review_model_config()
+                    return
+                if selected == custom_idx:
+                    self._close_model_picker()
+                    self._configure_review_model_custom_endpoint()
+                    return
+                if selected >= cancel_idx:
+                    self._close_model_picker()
+                    return
+            elif selected >= len(providers):
                 self._close_model_picker()
                 return
             provider_data = providers[selected]
@@ -5246,7 +5384,10 @@ class HermesCLI:
                     custom_providers=state.get("custom_provs"),
                 )
                 self._close_model_picker()
-                self._apply_model_switch_result(result, persist_global)
+                if state.get("kind") == "review-model":
+                    self._apply_review_model_switch_result(result)
+                else:
+                    self._apply_model_switch_result(result, persist_global)
                 return
             self._close_model_picker()
 
@@ -5416,15 +5557,98 @@ class HermesCLI:
         else:
             _cprint("    (session only — add --global to persist)")
 
+    def _handle_review_model_switch(self, cmd_original: str):
+        """Handle /review-model command — configure background review routing."""
+        from hermes_cli.model_switch import switch_model, parse_model_flags, list_authenticated_providers
+        from hermes_cli.providers import get_label
+
+        parts = cmd_original.split(None, 1)
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
+        model_input, explicit_provider, _persist_global = parse_model_flags(raw_args)
+
+        user_provs = None
+        custom_provs = None
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = get_compatible_custom_providers(cfg)
+            review_cfg = (cfg.get("agent") or {}).get("review_model") or {}
+        except Exception:
+            review_cfg = {}
+
+        current_model = review_cfg.get("model") or "default"
+        current_provider = review_cfg.get("provider") or self.provider or "unknown"
+        current_base_url = review_cfg.get("base_url") or self.base_url or ""
+        current_api_key = review_cfg.get("api_key") or self.api_key or ""
+
+        normalized_model_input = (model_input or "").strip().lower()
+        if normalized_model_input in {"default", "primary", "inherit"} and not explicit_provider:
+            self._reset_review_model_config()
+            return
+        if normalized_model_input in {"custom", "custom-endpoint"} and not explicit_provider:
+            self._configure_review_model_custom_endpoint()
+            return
+
+        if not model_input and not explicit_provider:
+            model_display = current_model
+            provider_display = get_label(current_provider) if current_provider and current_provider != "unknown" else current_provider
+            try:
+                providers = list_authenticated_providers(
+                    current_provider=current_provider if current_provider != "unknown" else (self.provider or ""),
+                    user_providers=user_provs,
+                    custom_providers=custom_provs,
+                    max_models=50,
+                )
+            except Exception:
+                providers = []
+
+            if not providers:
+                _cprint("  No authenticated providers found.")
+                _cprint("")
+                _cprint("  /review-model default                  inherit the primary model")
+                _cprint("  /review-model custom                   configure custom endpoint")
+                _cprint("  /review-model <name>                   configure review model")
+                _cprint("  /review-model <name> --provider <slug> configure review model/provider")
+                return
+
+            self._open_model_picker(
+                providers,
+                model_display,
+                provider_display,
+                user_provs=user_provs,
+                custom_provs=custom_provs,
+                picker_kind="review-model",
+            )
+            return
+
+        if explicit_provider and not model_input:
+            _cprint("  ✗ Specify a model when using --provider.")
+            _cprint("    Usage: /review-model <model> --provider <slug>")
+            return
+
+        result = switch_model(
+            raw_input=model_input,
+            current_provider=current_provider if current_provider != "unknown" else (self.provider or ""),
+            current_model=current_model if current_model != "default" else (self.model or ""),
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+            is_global=True,
+            explicit_provider=explicit_provider,
+            user_providers=user_provs,
+            custom_providers=custom_provs,
+        )
+        self._apply_review_model_switch_result(result)
+
     def _should_handle_model_command_inline(self, text: str, has_images: bool = False) -> bool:
-        """Return True when /model should be handled immediately on the UI thread."""
+        """Return True when a model-picker command should run on the UI thread."""
         if not text or has_images or not _looks_like_slash_command(text):
             return False
         try:
             from hermes_cli.commands import resolve_command
             base = text.split(None, 1)[0].lower().lstrip('/')
             cmd = resolve_command(base)
-            return bool(cmd and cmd.name == "model")
+            return bool(cmd and cmd.name in {"model", "review-model"})
         except Exception:
             return False
 
@@ -6027,6 +6251,8 @@ class HermesCLI:
             self._handle_resume_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
+        elif canonical == "review-model":
+            self._handle_review_model_switch(cmd_original)
         elif canonical == "gquota":
             self._handle_gquota_command(cmd_original)
 
@@ -9248,8 +9474,8 @@ class HermesCLI:
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
-                # Handle /model directly on the UI thread so interactive pickers
-                # can safely use prompt_toolkit terminal handoff helpers.
+                # Handle picker-based model commands directly on the UI thread
+                # so prompt_toolkit terminal handoff helpers remain safe.
                 if self._should_handle_model_command_inline(text, has_images=has_images):
                     if not self.process_command(text):
                         self._should_exit = True
@@ -9418,6 +9644,8 @@ class HermesCLI:
                 return
             if state.get("stage") == "provider":
                 max_idx = len(state.get("providers") or [])
+                if state.get("kind") == "review-model":
+                    max_idx += 2
             else:
                 max_idx = len(state.get("model_list") or []) + 1
             state["selected"] = min(max_idx, state.get("selected", 0) + 1)
@@ -10261,9 +10489,11 @@ class HermesCLI:
             state = cli_ref._model_picker_state
             if not state:
                 return []
+            picker_kind = state.get("kind", "model")
+            picker_label = "Review Model Picker" if picker_kind == "review-model" else "Model Picker"
             stage = state.get("stage", "provider")
             if stage == "provider":
-                title = "⚙ Model Picker — Select Provider"
+                title = f"⚙ {picker_label} — Select Provider"
                 choices = []
                 _providers = state.get("providers")
                 for p in _providers if isinstance(_providers, list) else []:
@@ -10272,12 +10502,15 @@ class HermesCLI:
                     if p.get("is_current"):
                         label += "  ← current"
                     choices.append(label)
+                if picker_kind == "review-model":
+                    choices.append("Use primary model (default)")
+                    choices.append("Custom endpoint...")
                 choices.append("Cancel")
                 hint = f"Current: {state.get('current_model', 'unknown')} on {state.get('current_provider', 'unknown')}"
             else:
                 provider_data = state.get("provider_data") or {}
                 model_list = state.get("model_list") or []
-                title = f"⚙ Model Picker — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
+                title = f"⚙ {picker_label} — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
                 choices = list(model_list) + ["← Back", "Cancel"]
                 if model_list:
                     hint = f"Select a model ({len(model_list)} available)"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -104,6 +104,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration", args_hint="[model] [--provider name] [--global]"),
+    CommandDef("review-model", "Configure the background review model", "Configuration",
+               cli_only=True, args_hint="[model] [--provider name]"),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -389,6 +389,16 @@ DEFAULT_CONFIG = {
         # (60+ tool iterations with tiny output) before users assume the
         # bot is dead and /restart.
         "gateway_notify_interval": 180,
+        # Optional runtime for background memory/skill review.  "default"
+        # inherits the primary AIAgent runtime.  When set, review runs try
+        # this runtime first and fall back to the primary runtime on failure.
+        "review_model": {
+            "model": "default",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+        },
     },
     
     "terminal": {
@@ -752,6 +762,14 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Optional per-memory-review runtime override. Empty/null fields inherit
+        # agent.review_model, then the primary agent runtime.
+        "review": {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key_env": None,
+        },
     },
 
     # Subagent delegation — override the provider:model used by delegate_task
@@ -820,6 +838,14 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # Optional per-skill-review runtime override. Empty/null fields inherit
+        # agent.review_model, then the primary agent runtime.
+        "review": {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key_env": None,
+        },
     },
 
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1573,6 +1573,43 @@ class AIAgent:
         # broad pseudo-public config object on the agent instance.
         self._aux_compression_context_length_config = None
 
+        # Review-model runtime for memory/skills post-turn review.
+        # agent.review_model.model == "default" means inherit the primary runtime.
+        self._review_model_model = "default"
+        self._review_model_provider = ""
+        self._review_model_base_url = ""
+        self._review_model_api_key = ""
+        self._review_model_api_mode = ""
+        self._memory_review_runtime_config = {}
+        self._skills_review_runtime_config = {}
+        try:
+            _agent_cfg_for_review = _agent_cfg.get("agent", {})
+            if isinstance(_agent_cfg_for_review, dict):
+                _review_cfg = _agent_cfg_for_review.get("review_model", {})
+                if isinstance(_review_cfg, dict):
+                    _configured_review_model = _review_cfg.get("model", "default")
+                    if isinstance(_configured_review_model, str) and _configured_review_model.strip():
+                        self._review_model_model = _configured_review_model.strip()
+                    for _attr, _cfg_key in (
+                        ("_review_model_provider", "provider"),
+                        ("_review_model_base_url", "base_url"),
+                        ("_review_model_api_key", "api_key"),
+                        ("_review_model_api_mode", "api_mode"),
+                    ):
+                        _value = _review_cfg.get(_cfg_key, "")
+                        if isinstance(_value, str) and _value.strip():
+                            setattr(self, _attr, _value.strip())
+
+            _memory_cfg_for_review = _agent_cfg.get("memory", {})
+            if isinstance(_memory_cfg_for_review, dict) and isinstance(_memory_cfg_for_review.get("review"), dict):
+                self._memory_review_runtime_config = dict(_memory_cfg_for_review["review"])
+
+            _skills_cfg_for_review = _agent_cfg.get("skills", {})
+            if isinstance(_skills_cfg_for_review, dict) and isinstance(_skills_cfg_for_review.get("review"), dict):
+                self._skills_review_runtime_config = dict(_skills_cfg_for_review["review"])
+        except Exception:
+            pass
+
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -3143,6 +3180,71 @@ class AIAgent:
         else:
             prompt = self._SKILL_REVIEW_PROMPT
 
+        configured_model = getattr(self, "_review_model_model", "default")
+        configured_model = configured_model.strip() if isinstance(configured_model, str) else "default"
+        review_model = self.model if (not configured_model or configured_model.lower() == "default") else configured_model
+        review_provider = getattr(self, "_review_model_provider", "") or self.provider
+        review_base_url = getattr(self, "_review_model_base_url", "") or self.base_url
+        review_api_key = getattr(self, "_review_model_api_key", "") or self.api_key
+        review_api_mode = getattr(self, "_review_model_api_mode", "")
+
+        def _configured(value: Any) -> bool:
+            return value is not None and not (isinstance(value, str) and not value.strip())
+
+        review_blocks = []
+        if review_memory:
+            review_blocks.append(getattr(self, "_memory_review_runtime_config", {}) or {})
+        if review_skills:
+            review_blocks.append(getattr(self, "_skills_review_runtime_config", {}) or {})
+
+        for block in review_blocks:
+            if not isinstance(block, dict):
+                continue
+            if _configured(block.get("model")):
+                value = block["model"].strip() if isinstance(block["model"], str) else block["model"]
+                review_model = self.model if isinstance(value, str) and value.lower() == "default" else value
+                break
+        for block in review_blocks:
+            if isinstance(block, dict) and _configured(block.get("provider")):
+                review_provider = block["provider"].strip() if isinstance(block["provider"], str) else block["provider"]
+                break
+        for block in review_blocks:
+            if isinstance(block, dict) and _configured(block.get("base_url")):
+                review_base_url = block["base_url"].strip() if isinstance(block["base_url"], str) else block["base_url"]
+                break
+        for block in review_blocks:
+            if not isinstance(block, dict) or not _configured(block.get("api_key_env")):
+                continue
+            env_name = block["api_key_env"].strip() if isinstance(block["api_key_env"], str) else str(block["api_key_env"])
+            env_key = os.environ.get(env_name, "")
+            if env_key:
+                review_api_key = env_key
+                break
+
+        if not review_api_mode and (review_provider != self.provider or review_base_url != self.base_url):
+            try:
+                from hermes_cli.providers import determine_api_mode
+                review_api_mode = determine_api_mode(review_provider, review_base_url)
+            except Exception:
+                review_api_mode = self.api_mode
+        elif not review_api_mode:
+            review_api_mode = self.api_mode
+
+        parent_review_runtime = {
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "api_key": self.api_key,
+            "api_mode": self.api_mode,
+        }
+        requested_review_runtime = {
+            "model": review_model,
+            "provider": review_provider,
+            "base_url": review_base_url,
+            "api_key": review_api_key,
+            "api_mode": review_api_mode,
+        }
+
         def _run_review():
             import contextlib
             review_agent = None
@@ -3150,26 +3252,57 @@ class AIAgent:
                 with open(os.devnull, "w") as _devnull, \
                      contextlib.redirect_stdout(_devnull), \
                      contextlib.redirect_stderr(_devnull):
-                    review_agent = AIAgent(
-                        model=self.model,
-                        max_iterations=8,
-                        quiet_mode=True,
-                        platform=self.platform,
-                        provider=self.provider,
-                        parent_session_id=self.session_id,
-                    )
-                    review_agent._memory_write_origin = "background_review"
-                    review_agent._memory_write_context = "background_review"
-                    review_agent._memory_store = self._memory_store
-                    review_agent._memory_enabled = self._memory_enabled
-                    review_agent._user_profile_enabled = self._user_profile_enabled
-                    review_agent._memory_nudge_interval = 0
-                    review_agent._skill_nudge_interval = 0
+                    def _run_once(runtime_cfg: Dict[str, str]) -> None:
+                        nonlocal review_agent
+                        review_agent = AIAgent(
+                            model=runtime_cfg.get("model", "") or self.model,
+                            max_iterations=8,
+                            quiet_mode=True,
+                            platform=self.platform,
+                            provider=runtime_cfg.get("provider", "") or self.provider,
+                            base_url=runtime_cfg.get("base_url", "") or self.base_url,
+                            api_key=runtime_cfg.get("api_key", "") or self.api_key,
+                            api_mode=runtime_cfg.get("api_mode", "") or self.api_mode,
+                            parent_session_id=self.session_id,
+                        )
+                        review_agent._memory_write_origin = "background_review"
+                        review_agent._memory_write_context = "background_review"
+                        review_agent._memory_store = self._memory_store
+                        review_agent._memory_enabled = self._memory_enabled
+                        review_agent._user_profile_enabled = self._user_profile_enabled
+                        review_agent._memory_nudge_interval = 0
+                        review_agent._skill_nudge_interval = 0
+                        review_agent.run_conversation(
+                            user_message=prompt,
+                            conversation_history=messages_snapshot,
+                        )
 
-                    review_agent.run_conversation(
-                        user_message=prompt,
-                        conversation_history=messages_snapshot,
-                    )
+                    try:
+                        _run_once(requested_review_runtime)
+                    except Exception as review_error:
+                        # If a custom review runtime fails (model/provider/base_url/api_key),
+                        # fall back to the primary runtime for this session.
+                        if requested_review_runtime != parent_review_runtime:
+                            logger.warning(
+                                "Background review runtime failed (model=%s provider=%s base_url=%s): %s. "
+                                "Falling back to primary runtime (model=%s provider=%s base_url=%s).",
+                                requested_review_runtime.get("model", ""),
+                                requested_review_runtime.get("provider", ""),
+                                requested_review_runtime.get("base_url", ""),
+                                review_error,
+                                parent_review_runtime.get("model", ""),
+                                parent_review_runtime.get("provider", ""),
+                                parent_review_runtime.get("base_url", ""),
+                            )
+                            if review_agent is not None:
+                                try:
+                                    review_agent.close()
+                                except Exception:
+                                    pass
+                                review_agent = None
+                            _run_once(parent_review_runtime)
+                        else:
+                            raise
 
                 # Scan the review agent's messages for successful tool actions
                 # and surface a compact summary to the user. Tool messages

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -95,6 +95,7 @@ class TestResolveCommand:
         assert resolve_command("background").name == "background"
         assert resolve_command("copy").name == "copy"
         assert resolve_command("agents").name == "agents"
+        assert resolve_command("review-model").name == "review-model"
 
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
@@ -112,6 +113,7 @@ class TestResolveCommand:
 
     def test_unknown_returns_none(self):
         assert resolve_command("nonexistent") is None
+        assert resolve_command("provider") is None
         assert resolve_command("") is None
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -60,6 +60,31 @@ class TestEnsureHermesHome:
             assert soul_path.read_text(encoding="utf-8") == "custom soul"
 
 
+class TestReviewModelConfig:
+    def test_default_config_includes_agent_review_model(self):
+        review_model = DEFAULT_CONFIG["agent"]["review_model"]
+
+        assert review_model == {
+            "model": "default",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+        }
+        assert DEFAULT_CONFIG["memory"]["review"] == {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key_env": None,
+        }
+        assert DEFAULT_CONFIG["skills"]["review"] == {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key_env": None,
+        }
+
+
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):


### PR DESCRIPTION
## What does this PR do?

Adds configurable runtime routing for background memory/skill review runs.

Hermes currently runs background review using the primary `AIAgent` runtime. This PR adds a user-facing `agent.review_model` configuration and `/review-model` cli slash command so users can route background review to a cheaper or specialized model.

It also supports advanced scoped overrides via `memory.review` and `skills.review`, allowing memory and skill reviews to use different review runtimes when needed. Empty scoped fields inherit from `agent.review_model`, which then falls back to the primary agent runtime.

Reliability is preserved by falling back to the primary runtime if the configured review runtime fails.

## Notes

This incorporates the core routing idea from #13647 while keeping this PR's existing CLI UX and unified `agent.review_model` config as the default user-facing path.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent.review_model` defaults in `hermes_cli/config.py`.
- Added `/review-model` CLI command in `hermes_cli/commands.py` and `cli.py`.
- Added review-model selection, reset, custom endpoint, and persistence under `agent.review_model.*`.
- Updated `AIAgent._spawn_background_review()` in `run_agent.py` to try the configured review runtime first and fall back to the primary
runtime on failure.
- Added tests for command registration, config defaults, `/review-model` persistence, provider validation, and background review fallback
behavior.

## How to Test

1. Run targeted tests:
   ```bash
   scripts/run_tests.sh tests/cli/test_review_model_command.py tests/run_agent/test_background_review_summary.py tests/hermes_cli/
test_commands.py tests/hermes_cli/test_config.py

2. Start Hermes CLI and configure a review model:

   /review-model <model> --provider <provider>
3. Reset review routing back to the primary runtime:

   /review-model default

## Checklist

### Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
  (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted test run:

scripts/run_tests.sh tests/cli/test_review_model_command.py tests/run_agent/test_background_review_summary.py tests/hermes_cli/test_commands.py
tests/hermes_cli/test_config.py
180 passed