### PR TITLE
fix: prevent Hindsight retain work during interpreter shutdown

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -105,6 +105,8 @@ def _get_loop() -> asyncio.AbstractEventLoop:
 def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
     """Schedule *coro* on the shared loop and block until done."""
     loop = _get_loop()
+    if loop.is_closed():
+        raise RuntimeError("Hindsight event loop is closed (interpreter shutting down)")
     future = asyncio.run_coroutine_threadsafe(coro, loop)
     return future.result(timeout=timeout)
 
@@ -419,6 +421,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._session_id = ""
         self._parent_session_id = ""
         self._document_id = ""
+        self._shutting_down = False
 
         # Tags
         self._tags: list[str] | None = None
@@ -1088,6 +1091,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         Respects retain_every_n_turns for batching.
         """
+        if self._shutting_down:
+            logger.debug("sync_turn: skipped (shutting down)")
+            return
         if not self._auto_retain:
             logger.debug("sync_turn: skipped (auto_retain disabled)")
             return
@@ -1224,6 +1230,7 @@ class HindsightMemoryProvider(MemoryProvider):
         return tool_error(f"Unknown tool: {tool_name}")
 
     def shutdown(self) -> None:
+        self._shutting_down = True
         logger.debug("Hindsight shutdown: waiting for background threads")
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():


### PR DESCRIPTION
## Fixes #15497

## Problem
The `HindsightMemoryProvider` can still submit async retain work after provider shutdown has started. During interpreter teardown, `asyncio.run_coroutine_threadsafe()` fails with `RuntimeError: cannot schedule new futures after interpreter shutdown`.

## Root Cause
`shutdown()` joins existing threads but has **no guard flag** to prevent `sync_turn()` from accepting new work.

## Fix
1. Added `self._shutting_down = False` in `__init__()` — initializes the guard flag
2. Added early-return guard in `sync_turn()` — checks `self._shutting_down` before doing any work
3. Set `self._shutting_down = True` at top of `shutdown()` — marks provider as shutting down before joining threads
4. Defense-in-depth in `_run_sync()` — checks `loop.is_closed()` before calling `asyncio.run_coroutine_threadsafe()`

## Files Changed
- `plugins/memory/hindsight/__init__.py` — 7 lines added, 0 removed