### PR TITLE
fix(env): pass -- to cd for hyphen-prefixed workdirs

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -57,24 +57,31 @@ class TestWrapCommand:
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "~")
 
-        assert "cd ~" in wrapped
-        assert "cd '~'" not in wrapped
+        assert "cd -- ~" in wrapped
+        assert "cd -- '~'" not in wrapped
 
     def test_tilde_subpath_with_spaces_uses_home_and_quotes_suffix(self):
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "~/my repo")
 
-        assert "cd $HOME/'my repo'" in wrapped
-        assert "cd ~/my repo" not in wrapped
+        assert "cd -- $HOME/'my repo'" in wrapped
+        assert "cd -- ~/my repo" not in wrapped
 
     def test_tilde_slash_maps_to_home(self):
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "~/")
 
-        assert "cd $HOME" in wrapped
-        assert "cd ~/" not in wrapped
+        assert "cd -- $HOME" in wrapped
+        assert "cd -- ~/" not in wrapped
+
+    def test_hyphen_prefixed_workdir_is_passed_after_double_dash(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("pwd", "-demo")
+
+        assert "builtin cd -- -demo || exit 126" in wrapped
 
     def test_cd_failure_exit_126(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -393,7 +393,8 @@ class BaseEnvironment(ABC):
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
         quoted_cwd = self._quote_cwd_for_cd(cwd)
-        parts.append(f"builtin cd {quoted_cwd} || exit 126")
+        # ``--`` keeps hyphen-prefixed directory names from being parsed as options.
+        parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")


### PR DESCRIPTION

**Summary**
Fixes a path-handling issue in the command wrapper where work directories starting with a hyphen (`-`) could be misinterpreted as options by the shell `cd` builtin.

---

**Problem**
`BaseEnvironment._wrap_command()` previously generated:

```
builtin cd {quoted_cwd}
```

While `shlex.quote()` correctly prevents shell injection, it does not prevent `cd` from interpreting operands starting with `-` (e.g. `-demo`) as options instead of directory paths. This could cause valid paths to fail.

---

**Solution**
Explicitly separate options from operands by adding `--`:

```
builtin cd -- {quoted_cwd} || exit 126
```

This ensures that all subsequent arguments are treated strictly as paths, not options.

---

**Changes**

* Updated `cd` wrapper in:

  * `tools/environments/base.py`
* Updated existing expectations for `~` handling to align with new behavior
* Added regression test for hyphen-prefixed directories:

  * `test_hyphen_prefixed_workdir_is_passed_after_double_dash`

---

**Tests**
Ran targeted test:

```
uv run --extra dev pytest tests/tools/test_base_environment.py::TestWrapCommand::test_hyphen_prefixed_workdir_is_passed_after_double_dash
```

Result:

* ✅ Passed
* ⚠️ 1 warning (pytest event loop deprecation, unrelated)

Full test output reference: 

---

**Risk Assessment**

* Low risk
* No behavioral changes outside `cd` handling
* No API changes
* Strictly improves correctness for edge-case paths

---

**Checklist**

* [x] Bug fix (non-breaking change)
* [x] Added regression test
* [x] Updated existing tests
* [x] Verified test passes
* [x] No unrelated changes included

---

