### PR TITLE
feat: add /sessions and /continue commands, fix session sort order

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4538,7 +4538,7 @@ class HermesCLI:
             return []
         try:
             sessions = self._session_db.list_sessions_rich(
-                source="cli",
+                
                 exclude_sources=["tool"],
                 limit=limit,
             )
@@ -4815,6 +4815,25 @@ class HermesCLI:
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 
+
+    def _handle_continue_command(self) -> None:
+        """Handle /continue — resume the most recent session (no args needed)."""
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        recent = self._list_recent_sessions(limit=1)
+        if not recent:
+            _cprint("  No previous session found to continue.")
+            return
+
+        target_id = recent[0]["id"]
+        if target_id == self.session_id:
+            _cprint("  Already on the most recent session.")
+            return
+
+        # Delegate to /resume with the resolved ID
+        self._handle_resume_command(f"/resume {target_id}")
     def _handle_branch_command(self, cmd_original: str) -> None:
         """Handle /branch [name] — fork the current session into a new independent copy.
 
@@ -6023,8 +6042,12 @@ class HermesCLI:
                     _cprint("  Session database not available.")
         elif canonical == "new":
             self.new_session()
+        elif canonical == "sessions":
+            self._show_recent_sessions(reason="sessions", limit=20)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "continue":
+            self._handle_continue_command()
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "gquota":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -97,8 +97,12 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
+    CommandDef("sessions", "Browse recent sessions (interactive list)", "Session",
+               aliases=("ss",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("continue", "Resume the most recent session (no args needed)", "Session",
+               aliases=("c",)),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -848,7 +848,7 @@ class SessionDB:
                 ) AS last_active
             FROM sessions s
             {where_sql}
-            ORDER BY s.started_at DESC
+            ORDER BY last_active DESC
             LIMIT ? OFFSET ?
         """
         params.extend([limit, offset])


### PR DESCRIPTION
## Summary

- Add `/sessions` (alias `/ss`) command to browse recent sessions interactively
- Add `/continue` (alias `/c`) command to resume the most recent session with one keystroke
- Fix: `/sessions` now shows all sources (CLI, Web, Gateway, API) instead of only CLI sessions
- Fix: Session list sorted by last active time instead of creation time

## Motivation

After a CLI crash (e.g., `Ctrl+C`), users lose context and cannot easily resume their last conversation. The existing `/sessions` command has two issues:

1. Hardcoded `source="cli"` filter excludes Web/Gateway sessions
2. Sorting by `started_at` pushes recently active sessions to the bottom

## Changes

- **`hermes_cli/commands.py`**: Add `sessions` (alias `ss`) and `continue` (alias `c`) command definitions
- **`cli.py`**: Remove `source="cli"` filter, add `_handle_continue_command()`, add dispatch for both commands
- **`hermes_state.py`**: Change `ORDER BY s.started_at DESC` → `ORDER BY last_active DESC`