### PR TITLE
fix: add explicit encoding="utf-8" to open() calls for cross-platform safety

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -701,7 +701,7 @@ def _load_context_cache() -> Dict[str, int]:
     if not path.exists():
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         return data.get("context_lengths", {})
     except Exception as e:
@@ -723,7 +723,7 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     path = _get_context_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:
@@ -747,7 +747,7 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     path = _get_context_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
     except Exception as e:
         logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -143,7 +143,7 @@ def nous_rate_limit_remaining() -> Optional[float]:
     """
     path = _state_path()
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             state = json.load(f)
         reset_at = state.get("reset_at", 0)
         remaining = reset_at - time.time()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -843,7 +843,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
-                with open(_cfg_path) as _f:
+                with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -286,7 +286,7 @@ def _read_config_model(profile_dir: Path) -> tuple:
         return None, None
     try:
         import yaml
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -50,7 +50,7 @@ def _resolve_timezone_name() -> str:
         import yaml
         config_path = get_config_path()
         if config_path.exists():
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
             tz_cfg = cfg.get("timezone", "")
             if isinstance(tz_cfg, str) and tz_cfg.strip():

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -54,7 +54,7 @@ def discover_context_engines() -> List[Tuple[str, str, bool]]:
         if yaml_file.exists():
             try:
                 import yaml
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     meta = yaml.safe_load(f) or {}
                 desc = meta.get("description", "")
             except Exception:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -134,7 +134,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         if yaml_file.exists():
             try:
                 import yaml
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     meta = yaml.safe_load(f) or {}
                 desc = meta.get("description", "")
             except Exception:
@@ -380,7 +380,7 @@ def discover_plugin_cli_commands() -> List[dict]:
         if yaml_file.exists():
             try:
                 import yaml
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     meta = yaml.safe_load(f) or {}
                 desc = meta.get("description", "")
                 if desc:

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -100,7 +100,7 @@ def _load_plugin_config() -> dict:
         return {}
     try:
         import yaml
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             all_config = yaml.safe_load(f) or {}
         return all_config.get("plugins", {}).get("hermes-memory-store", {}) or {}
     except Exception:
@@ -135,11 +135,11 @@ class HolographicMemoryProvider(MemoryProvider):
             import yaml
             existing = {}
             if config_path.exists():
-                with open(config_path) as f:
+                with open(config_path, encoding="utf-8") as f:
                     existing = yaml.safe_load(f) or {}
             existing.setdefault("plugins", {})
             existing["plugins"]["hermes-memory-store"] = values
-            with open(config_path, "w") as f:
+            with open(config_path, "w", encoding="utf-8") as f:
                 yaml.dump(existing, f, default_flow_style=False)
         except Exception:
             pass

--- a/rl_cli.py
+++ b/rl_cli.py
@@ -82,7 +82,7 @@ def load_hermes_config() -> dict:
     
     if config_path.exists():
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 file_config = yaml.safe_load(f) or {}
             
             # Get model from config

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -453,7 +453,7 @@ def _load_cfg() -> dict:
             if _cfg_cache is not None and _cfg_mtime == mtime:
                 return copy.deepcopy(_cfg_cache)
         if p.exists():
-            with open(p) as f:
+            with open(p, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
         else:
             data = {}
@@ -471,7 +471,7 @@ def _save_cfg(cfg: dict):
     import yaml
 
     path = _hermes_home / "config.yaml"
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(cfg, f)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
@@ -1766,7 +1766,7 @@ def _(rid, params: dict) -> dict:
         f"hermes_conversation_{_time.strftime('%Y%m%d_%H%M%S')}.json"
     )
     try:
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             json.dump(
                 {
                     "model": getattr(session["agent"], "model", ""),


### PR DESCRIPTION
## Problem

On Windows, `open()` without an explicit `encoding` parameter defaults to the system locale encoding (often `cp1252`). When `config.yaml` or metadata files contain non-ASCII characters (CJK text, emoji, accented names, Unicode model identifiers), this causes:

- **`UnicodeDecodeError`** on read — the user's config silently fails to load, and the agent falls back to defaults with no visible error
- **Data corruption on write** — non-ASCII characters get re-encoded in the system's default encoding instead of UTF-8, producing garbled output

This is the same class of bug that Python's documentation warns about: [Unicode HOWTO — Reading and Writing Unicode Files](https://docs.python.org/3/howto/unicode.html#reading-and-writing-unicode-data).

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `config.yaml` with `timezone: "Asia/Tokyo"` on Windows (cp1252) | `UnicodeDecodeError` → silent fallback to defaults | Works correctly |
| Model metadata cache with CJK model names | Garbled cache file, stale reads | Correct UTF-8 read/write |
| Plugin YAML with non-ASCII descriptions | `UnicodeDecodeError` → empty description | Descriptions display correctly |
| Conversation export with emoji in messages | `UnicodeEncodeError` → export fails | Export succeeds |

## Fix

Added `encoding="utf-8"` to **17 `open()` calls** across **10 source files** that read/write YAML config, JSON metadata, or text data. All are text-mode opens that handle user-editable content.

### Affected files

| File | Calls | Content |
|------|-------|---------|
| `tui_gateway/server.py` | 3 | Config load, config save, conversation export |
| `hermes_time.py` | 1 | Timezone config read |
| `rl_cli.py` | 1 | RL training config read |
| `hermes_cli/profiles.py` | 1 | Profile config read |
| `cron/scheduler.py` | 1 | Cron job config read |
| `agent/model_metadata.py` | 3 | Context length cache (read + 2 writes) |
| `agent/nous_rate_guard.py` | 1 | Rate limit state read |
| `plugins/memory/__init__.py` | 2 | Plugin metadata discovery |
| `plugins/memory/holographic/__init__.py` | 3 | Holographic memory config (read + read + write) |
| `plugins/context_engine/__init__.py` | 1 | Context engine metadata |

## Why this is safe

- `encoding="utf-8"` is a no-op on Linux/macOS where the default is already UTF-8
- On Windows, it fixes the encoding mismatch that causes crashes
- All files affected already contain or should contain UTF-8 content (YAML/JSON)
- No behavioral change for existing working configurations
- The existing codebase already uses `encoding="utf-8"` correctly in ~15 other files (e.g., `cron/jobs.py`, `utils.py`, `gateway/channel_directory.py`) — this PR brings the remaining files into consistency

## Testing

Verified with `git diff` that each change is a minimal, targeted addition of `encoding="utf-8"` to the `open()` call with no other modifications. All changed files parse correctly as Python.