### PR TITLE
fix: make /reasoning session-scoped by default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1984,9 +1984,15 @@ class HermesCLI:
         )
         
         # Reasoning config (OpenRouter reasoning effort level)
-        self.reasoning_config = _parse_reasoning_config(
+        self._global_reasoning_config = _parse_reasoning_config(
             CLI_CONFIG["agent"].get("reasoning_effort", "")
         )
+        self.reasoning_config = (
+            dict(self._global_reasoning_config)
+            if isinstance(self._global_reasoning_config, dict)
+            else None
+        )
+        self._reasoning_session_override_active = False
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
         )
@@ -4686,11 +4692,22 @@ class HermesCLI:
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        self.reasoning_config = (
+            dict(self._global_reasoning_config)
+            if isinstance(self._global_reasoning_config, dict)
+            else None
+        )
+        self._reasoning_session_override_active = False
 
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
             self.agent.reset_session_state()
+            self.agent.reasoning_config = (
+                dict(self.reasoning_config)
+                if isinstance(self.reasoning_config, dict)
+                else None
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
@@ -4789,10 +4806,25 @@ class HermesCLI:
         except Exception:
             pass
 
+        # Resuming a different session is a session boundary, so clear any
+        # session-scoped reasoning override and fall back to the configured
+        # default for the resumed session.
+        self.reasoning_config = (
+            dict(self._global_reasoning_config)
+            if isinstance(self._global_reasoning_config, dict)
+            else None
+        )
+        self._reasoning_session_override_active = False
+
         # Sync the agent if already initialised
         if self.agent:
             self.agent.session_id = target_id
             self.agent.reset_session_state()
+            self.agent.reasoning_config = (
+                dict(self.reasoning_config)
+                if isinstance(self.reasoning_config, dict)
+                else None
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
@@ -6844,15 +6876,17 @@ class HermesCLI:
         """Handle /reasoning — manage effort level and display toggle.
 
         Usage:
-            /reasoning              Show current effort level and display state
-            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
-            /reasoning show|on      Show model thinking/reasoning in output
-            /reasoning hide|off     Hide model thinking/reasoning from output
+            /reasoning                       Show current effort level and display state
+            /reasoning <level>              Set reasoning effort for this session
+            /reasoning <level> --global     Set reasoning effort and persist to config.yaml
+            /reasoning show|on              Show model thinking/reasoning in output
+            /reasoning hide|off             Hide model thinking/reasoning from output
         """
+        from hermes_constants import parse_reasoning_flags
+
         parts = cmd.strip().split(maxsplit=1)
 
         if len(parts) < 2:
-            # Show current state
             rc = self.reasoning_config
             if rc is None:
                 level = "medium (default)"
@@ -6860,13 +6894,15 @@ class HermesCLI:
                 level = "none (disabled)"
             else:
                 level = rc.get("effort", "medium")
+            scope = "session" if getattr(self, "_reasoning_session_override_active", False) else "global"
             display_state = "on ✓" if self.show_reasoning else "off"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
+            _cprint(f"  {_ACCENT}Reasoning scope:   {scope}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide> [--global]{_RST}")
             return
 
-        arg = parts[1].strip().lower()
+        arg, persist_global = parse_reasoning_flags(parts[1].strip().lower())
 
         # Display toggle
         if arg in ("show", "on"):
@@ -6885,7 +6921,6 @@ class HermesCLI:
             _cprint(f"  {_ACCENT}✓ Reasoning display: OFF (saved){_RST}")
             return
 
-        # Effort level change
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
@@ -6893,13 +6928,22 @@ class HermesCLI:
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
             return
 
-        self.reasoning_config = parsed
+        self.reasoning_config = dict(parsed) if isinstance(parsed, dict) else None
         self.agent = None  # Force agent re-init with new reasoning config
 
-        if save_config_value("agent.reasoning_effort", arg):
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
-        else:
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+        if persist_global:
+            saved = save_config_value("agent.reasoning_effort", arg)
+            if saved:
+                self._global_reasoning_config = dict(parsed) if isinstance(parsed, dict) else None
+                self._reasoning_session_override_active = False
+                _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
+            else:
+                self._reasoning_session_override_active = True
+                _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+            return
+
+        self._reasoning_session_override_active = True
+        _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -616,6 +616,7 @@ class GatewayRunner:
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -679,6 +680,8 @@ class GatewayRunner:
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
         self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        # Per-session reasoning overrides from /reasoning command.
+        self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
@@ -1121,6 +1124,16 @@ class GatewayRunner:
                 pass
 
         return model, runtime_kwargs
+
+    @staticmethod
+    def _copy_reasoning_config(config: Optional[dict]) -> Optional[dict]:
+        return dict(config) if isinstance(config, dict) else None
+
+    def _resolve_session_reasoning_config(self, session_key: Optional[str] = None) -> Optional[dict]:
+        global_config = self._load_reasoning_config()
+        self._reasoning_config = self._copy_reasoning_config(global_config)
+        override = self._session_reasoning_overrides.get(session_key) if session_key else None
+        return self._copy_reasoning_config(override if override is not None else global_config)
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
@@ -2330,6 +2343,7 @@ class GatewayRunner:
                         # be garbage-collected.  Otherwise the cache grows
                         # unbounded across the gateway's lifetime.
                         self._evict_cached_agent(key)
+                        self._session_reasoning_overrides.pop(key, None)
                         # Mark as flushed and persist to disk so the flag
                         # survives gateway restarts.
                         with self.session_store._lock:
@@ -4739,6 +4753,7 @@ class GatewayRunner:
                 self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
+                self._session_reasoning_overrides.pop(session_key, None)
                 response = (response or "") + (
                     "\n\n🔄 Session auto-reset — the conversation exceeded the "
                     "maximum context size and could not be compressed further. "
@@ -5023,9 +5038,10 @@ class GatewayRunner:
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 
-        # Clear any session-scoped model override so the next agent picks up
-        # the configured default instead of the previously switched model.
+        # Clear any session-scoped model/reasoning override so the next agent picks up
+        # the configured default instead of the previous session's override.
         self._session_model_overrides.pop(session_key, None)
+        self._session_reasoning_overrides.pop(session_key, None)
 
         # Clear session-scoped dangerous-command approvals and /yolo state.
         # /new is a conversation-boundary operation — approval state from the
@@ -6461,11 +6477,12 @@ class GatewayRunner:
             )
 
         source = event.source
+        session_key = self._session_key_for_source(source)
         task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
 
         # Fire-and-forget the background task
         _task = asyncio.create_task(
-            self._run_background_task(prompt, source, task_id)
+            self._run_background_task(prompt, source, task_id, session_key)
         )
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
@@ -6474,7 +6491,7 @@ class GatewayRunner:
         return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'
 
     async def _run_background_task(
-        self, prompt: str, source: "SessionSource", task_id: str
+        self, prompt: str, source: "SessionSource", task_id: str, session_key: Optional[str] = None
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
@@ -6507,8 +6524,7 @@ class GatewayRunner:
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            reasoning_config = self._load_reasoning_config()
-            self._reasoning_config = reasoning_config
+            reasoning_config = self._resolve_session_reasoning_config(session_key)
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
@@ -6680,7 +6696,7 @@ class GatewayRunner:
                 return
 
             platform_key = _platform_config_key(source.platform)
-            reasoning_config = self._load_reasoning_config()
+            reasoning_config = self._resolve_session_reasoning_config(session_key)
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
             pr = self._provider_routing
@@ -6787,15 +6803,19 @@ class GatewayRunner:
 
         Usage:
             /reasoning              Show current effort level and display state
-            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
-            /reasoning show|on      Show model reasoning in responses
-            /reasoning hide|off     Hide model reasoning from responses
+            /reasoning <level>              Set reasoning effort for this chat session
+            /reasoning <level> --global     Set reasoning effort and persist to config.yaml
+            /reasoning show|on              Show model reasoning in responses
+            /reasoning hide|off             Hide model reasoning from responses
         """
         import yaml
+        from hermes_constants import parse_reasoning_effort, parse_reasoning_flags
 
-        args = event.get_command_args().strip().lower()
+        raw_args = event.get_command_args().strip().lower()
+        args, persist_global = parse_reasoning_flags(raw_args)
         config_path = _hermes_home / "config.yaml"
-        self._reasoning_config = self._load_reasoning_config()
+        session_key = self._session_key_for_source(event.source)
+        reasoning_config = self._resolve_session_reasoning_config(session_key)
         self._show_reasoning = self._load_show_reasoning()
 
         def _save_config_key(key_path: str, value):
@@ -6819,20 +6839,20 @@ class GatewayRunner:
                 return False
 
         if not args:
-            # Show current state
-            rc = self._reasoning_config
-            if rc is None:
+            if reasoning_config is None:
                 level = "medium (default)"
-            elif rc.get("enabled") is False:
+            elif reasoning_config.get("enabled") is False:
                 level = "none (disabled)"
             else:
-                level = rc.get("effort", "medium")
+                level = reasoning_config.get("effort", "medium")
+            scope = "session" if session_key in self._session_reasoning_overrides else "global"
             display_state = "on ✓" if self._show_reasoning else "off"
             return (
                 "🧠 **Reasoning Settings**\n\n"
                 f"**Effort:** `{level}`\n"
+                f"**Scope:** `{scope}`\n"
                 f"**Display:** {display_state}\n\n"
-                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|show|hide>`"
+                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|show|hide> [--global]`"
             )
 
         # Display toggle (per-platform)
@@ -6850,24 +6870,27 @@ class GatewayRunner:
             _save_config_key(f"display.platforms.{platform_key}.show_reasoning", False)
             return f"🧠 ✓ Reasoning display: **OFF** for **{platform_key}**"
 
-        # Effort level change
         effort = args.strip()
-        if effort == "none":
-            parsed = {"enabled": False}
-        elif effort in ("minimal", "low", "medium", "high", "xhigh"):
-            parsed = {"enabled": True, "effort": effort}
-        else:
+        parsed = parse_reasoning_effort(effort)
+        if parsed is None:
             return (
                 f"⚠️ Unknown argument: `{effort}`\n\n"
                 "**Valid levels:** none, minimal, low, medium, high, xhigh\n"
                 "**Display:** show, hide"
             )
 
-        self._reasoning_config = parsed
-        if _save_config_key("agent.reasoning_effort", effort):
-            return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
-        else:
+        self._evict_cached_agent(session_key)
+        if persist_global:
+            saved = _save_config_key("agent.reasoning_effort", effort)
+            if saved:
+                self._reasoning_config = self._copy_reasoning_config(parsed)
+                self._session_reasoning_overrides.pop(session_key, None)
+                return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
+            self._session_reasoning_overrides[session_key] = self._copy_reasoning_config(parsed) or {}
             return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
+
+        self._session_reasoning_overrides[session_key] = self._copy_reasoning_config(parsed) or {}
+        return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)\n_(takes effect on next message)_"
 
     async def _handle_fast_command(self, event: MessageEvent) -> str:
         """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats."""
@@ -7212,6 +7235,11 @@ class GatewayRunner:
             _flush_task.add_done_callback(self._background_tasks.discard)
         except Exception as e:
             logger.debug("Memory flush on resume failed: %s", e)
+
+        # Clear any session-scoped reasoning override for this chat slot.
+        # /resume is a session boundary and should fall back to the resumed
+        # session's configured default unless the user sets a new override.
+        self._session_reasoning_overrides.pop(session_key, None)
 
         # Clear any running agent for this session key
         self._release_running_agent_state(session_key)
@@ -9673,8 +9701,7 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
-            reasoning_config = self._load_reasoning_config()
-            self._reasoning_config = reasoning_config
+            reasoning_config = self._resolve_session_reasoning_config(session_key)
             self._service_tier = self._load_service_tier()
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -141,6 +141,37 @@ def get_subprocess_home() -> str | None:
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 
 
+def parse_reasoning_flags(raw_args: str) -> tuple[str, bool]:
+    """Parse ``--global`` from /reasoning command args.
+
+    Returns ``(argument, is_global)`` where ``argument`` is the remaining value
+    after stripping a standalone ``--global`` token. Unicode dash variants are
+    normalized so Telegram/iOS smart punctuation still works.
+    """
+
+    def _normalize_flag_token(token: str) -> str:
+        if not token:
+            return ""
+        prefix = token[0]
+        if prefix in "\u2012\u2013\u2014\u2015" and token[1:] == "global":
+            return "--global"
+        return token
+
+    tokens = [
+        _normalize_flag_token(part.strip())
+        for part in str(raw_args or "").split()
+        if part.strip()
+    ]
+    persist_global = False
+    remaining: list[str] = []
+    for token in tokens:
+        if token == "--global":
+            persist_global = True
+            continue
+        remaining.append(token)
+    return " ".join(remaining).strip(), persist_global
+
+
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -50,6 +50,24 @@ class TestParseReasoningConfig(unittest.TestCase):
         self.assertEqual(result["effort"], "high")
 
 
+class TestParseReasoningFlags(unittest.TestCase):
+    def test_standalone_global_flag_is_stripped(self):
+        from hermes_constants import parse_reasoning_flags
+
+        self.assertEqual(parse_reasoning_flags("high --global"), ("high", True))
+
+    def test_unicode_dash_global_flag_is_accepted(self):
+        from hermes_constants import parse_reasoning_flags
+
+        self.assertEqual(parse_reasoning_flags("high —global"), ("high", True))
+
+    def test_embedded_global_substring_is_not_treated_as_flag(self):
+        from hermes_constants import parse_reasoning_flags
+
+        self.assertEqual(parse_reasoning_flags("high--global"), ("high--global", False))
+        self.assertEqual(parse_reasoning_flags("high --globalize"), ("high --globalize", False))
+
+
 # ---------------------------------------------------------------------------
 # /reasoning command handler (combined effort + display)
 # ---------------------------------------------------------------------------
@@ -154,6 +172,156 @@ class TestHandleReasoningCommand(unittest.TestCase):
         rc = stub.reasoning_config
         level = rc.get("effort", "medium")
         self.assertEqual(level, "xhigh")
+
+    def test_effort_switch_defaults_to_session_scope(self):
+        from cli import HermesCLI
+
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj._global_reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj.show_reasoning = False
+        cli_obj.agent = object()
+
+        with patch("cli._cprint") as cprint, patch(
+            "cli.save_config_value", side_effect=AssertionError("should not persist")
+        ):
+            HermesCLI._handle_reasoning_command(cli_obj, "/reasoning high")
+
+        self.assertEqual(cli_obj.reasoning_config, {"enabled": True, "effort": "high"})
+        self.assertIsNone(cli_obj.agent)
+        joined = "\n".join(call.args[0] for call in cprint.call_args_list)
+        self.assertIn("session only", joined)
+
+    def test_effort_switch_global_persists_with_flag(self):
+        from cli import HermesCLI
+
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj._global_reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj.show_reasoning = False
+        cli_obj.agent = object()
+
+        with patch("cli._cprint") as cprint, patch(
+            "cli.save_config_value", return_value=True
+        ) as save_config:
+            HermesCLI._handle_reasoning_command(cli_obj, "/reasoning high --global")
+
+        save_config.assert_called_once_with("agent.reasoning_effort", "high")
+        self.assertEqual(cli_obj.reasoning_config, {"enabled": True, "effort": "high"})
+        joined = "\n".join(call.args[0] for call in cprint.call_args_list)
+        self.assertIn("saved to config", joined)
+
+    def test_effort_switch_global_save_failure_stays_session_scoped(self):
+        from cli import HermesCLI
+
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj._global_reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj._reasoning_session_override_active = False
+        cli_obj.show_reasoning = False
+        cli_obj.agent = object()
+
+        with patch("cli._cprint") as cprint, patch(
+            "cli.save_config_value", return_value=False
+        ) as save_config:
+            HermesCLI._handle_reasoning_command(cli_obj, "/reasoning high --global")
+
+        save_config.assert_called_once_with("agent.reasoning_effort", "high")
+        self.assertEqual(cli_obj.reasoning_config, {"enabled": True, "effort": "high"})
+        self.assertEqual(cli_obj._global_reasoning_config, {"enabled": True, "effort": "medium"})
+        self.assertTrue(cli_obj._reasoning_session_override_active)
+        joined = "\n".join(call.args[0] for call in cprint.call_args_list)
+        self.assertIn("session only", joined)
+
+    def test_new_session_clears_session_reasoning_override(self):
+        from cli import HermesCLI
+
+        class _Agent:
+            def __init__(self):
+                self.session_id = "old-session"
+                self.session_start = None
+
+            def reset_session_state(self):
+                return None
+
+            def _invalidate_system_prompt(self):
+                return None
+
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.agent = _Agent()
+        cli_obj.conversation_history = []
+        cli_obj._notify_session_boundary = lambda *_args, **_kwargs: None
+        cli_obj.session_id = "old-session"
+        cli_obj._session_db = None
+        cli_obj._pending_title = None
+        cli_obj._resumed = False
+        cli_obj.model = "gpt-5"
+        cli_obj.max_turns = 90
+        cli_obj.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        cli_obj._global_reasoning_config = {"enabled": True, "effort": "medium"}
+
+        HermesCLI.new_session(cli_obj, silent=True)
+
+        self.assertEqual(
+            cli_obj.reasoning_config,
+            {"enabled": True, "effort": "medium"},
+        )
+        self.assertEqual(
+            cli_obj.agent.reasoning_config,
+            {"enabled": True, "effort": "medium"},
+        )
+
+    def test_resume_clears_session_reasoning_override(self):
+        from cli import HermesCLI
+
+        class _Agent:
+            def __init__(self):
+                self.session_id = "old-session"
+                self.reasoning_config = {"enabled": True, "effort": "xhigh"}
+                self._last_flushed_db_idx = 0
+
+            def reset_session_state(self):
+                return None
+
+            def _invalidate_system_prompt(self):
+                return None
+
+        class _SessionDB:
+            def get_session(self, session_id):
+                return {"id": session_id, "title": "Target"}
+
+            def resolve_resume_session_id(self, session_id):
+                return session_id
+
+            def end_session(self, session_id, reason):
+                return None
+
+            def get_messages_as_conversation(self, session_id):
+                return [{"role": "user", "content": "hello"}]
+
+            def reopen_session(self, session_id):
+                return None
+
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.agent = _Agent()
+        cli_obj.session_id = "old-session"
+        cli_obj._session_db = _SessionDB()
+        cli_obj._pending_title = None
+        cli_obj._resumed = False
+        cli_obj.conversation_history = []
+        cli_obj.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        cli_obj._global_reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj._reasoning_session_override_active = True
+
+        with patch("cli._cprint"), patch(
+            "hermes_cli.main._resolve_session_by_name_or_id", return_value="target-session"
+        ):
+            HermesCLI._handle_resume_command(cli_obj, "/resume target-session")
+
+        self.assertEqual(cli_obj.session_id, "target-session")
+        self.assertEqual(cli_obj.reasoning_config, {"enabled": True, "effort": "medium"})
+        self.assertFalse(cli_obj._reasoning_session_override_active)
+        self.assertEqual(cli_obj.agent.reasoning_config, {"enabled": True, "effort": "medium"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import sys
 import types
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import yaml
@@ -41,6 +41,10 @@ def _make_runner():
     runner.hooks.emit = AsyncMock()
     runner.hooks.loaded_hooks = []
     runner._session_db = None
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
     runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
     return runner
 
@@ -111,12 +115,338 @@ class TestReasoningCommand:
         runner = _make_runner()
         runner._reasoning_config = {"enabled": True, "effort": "medium"}
 
-        result = await runner._handle_reasoning_command(_make_event("/reasoning low"))
+        result = await runner._handle_reasoning_command(_make_event("/reasoning low --global"))
 
         saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert saved["agent"]["reasoning_effort"] == "low"
         assert runner._reasoning_config == {"enabled": True, "effort": "low"}
-        assert "takes effect on next message" in result
+        assert "saved to config" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_defaults_to_session_scope(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+        event = _make_event("/reasoning high")
+        session_key = runner._session_key_for_source(event.source)
+
+        result = await runner._handle_reasoning_command(event)
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "medium"
+        assert runner._session_reasoning_overrides[session_key] == {
+            "enabled": True,
+            "effort": "high",
+        }
+        assert "session only" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_rejects_malformed_global_substrings(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+        event = _make_event("/reasoning high--global")
+        session_key = runner._session_key_for_source(event.source)
+
+        result = await runner._handle_reasoning_command(event)
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "medium"
+        assert session_key not in runner._session_reasoning_overrides
+        assert "Unknown argument" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_global_persists_with_flag(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+        event = _make_event("/reasoning high --global")
+        session_key = runner._session_key_for_source(event.source)
+
+        result = await runner._handle_reasoning_command(event)
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "high"
+        assert session_key not in runner._session_reasoning_overrides
+        assert "saved to config" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_global_falls_back_to_session_override_when_save_fails(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(
+            gateway_run,
+            "atomic_yaml_write",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("disk full")),
+        )
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+        event = _make_event("/reasoning high --global")
+        session_key = runner._session_key_for_source(event.source)
+
+        result = await runner._handle_reasoning_command(event)
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "medium"
+        assert runner._reasoning_config == {"enabled": True, "effort": "medium"}
+        assert runner._session_reasoning_overrides[session_key] == {
+            "enabled": True,
+            "effort": "high",
+        }
+        assert "session only" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_background_command_passes_active_session_key(self):
+        runner = _make_runner()
+        event = _make_event("/background summarize this", platform=Platform.LOCAL, user_id="u1", chat_id="cli")
+        runner._run_background_task = AsyncMock(return_value=None)
+
+        result = await runner._handle_background_command(event)
+        await asyncio.sleep(0)
+
+        session_key = runner._session_key_for_source(event.source)
+        runner._run_background_task.assert_awaited_once()
+        assert runner._run_background_task.await_args.args[3] == session_key
+        assert "Background task started" in result
+
+    @pytest.mark.asyncio
+    async def test_session_expiry_watcher_clears_reasoning_override_for_expired_session(self):
+        key = "agent:main:local:dm"
+        entry = types.SimpleNamespace(session_id="sess-1", memory_flushed=False)
+
+        class _Store:
+            def __init__(self):
+                self._entries = {key: entry}
+                self._lock = self
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def _ensure_loaded(self):
+                return None
+
+            def _is_session_expired(self, current):
+                return current is entry
+
+            def _save(self):
+                return None
+
+        async def _fake_sleep(_seconds):
+            if getattr(_fake_sleep, "seen", 0) == 0:
+                _fake_sleep.seen = 1
+                return None
+            runner._running = False
+            return None
+
+        runner = _make_runner()
+        runner.session_store = _Store()
+        runner._running = True
+        runner._agent_cache = {}
+        runner._session_reasoning_overrides[key] = {"enabled": True, "effort": "high"}
+        runner._async_flush_memories = AsyncMock(return_value=None)
+        runner._cleanup_agent_resources = lambda agent: None
+
+        with patch("gateway.run.asyncio.sleep", side_effect=_fake_sleep):
+            await runner._session_expiry_watcher(interval=1)
+
+        assert key not in runner._session_reasoning_overrides
+        assert entry.memory_flushed is True
+
+    @pytest.mark.asyncio
+    async def test_handle_resume_command_clears_session_reasoning_override(self):
+        runner = _make_runner()
+        event = _make_event("/resume Focus", platform=Platform.LOCAL, user_id="u1", chat_id="cli")
+        session_key = runner._session_key_for_source(event.source)
+        runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
+
+        current_entry = types.SimpleNamespace(session_id="current-session")
+        target_entry = types.SimpleNamespace(session_id="target-session")
+
+        class _Store:
+            def get_or_create_session(self, source):
+                return current_entry
+
+            def switch_session(self, key, target_id):
+                assert key == session_key
+                assert target_id == "target-session"
+                return target_entry
+
+            def load_transcript(self, session_id):
+                assert session_id == "target-session"
+                return [{"role": "user", "content": "hello"}]
+
+        class _Task:
+            def add_done_callback(self, callback):
+                return None
+
+        def _fake_create_task(coro):
+            coro.close()
+            return _Task()
+
+        runner.session_store = _Store()
+        runner._session_db = types.SimpleNamespace(
+            resolve_session_by_title=lambda name: "target-session",
+            get_session_title=lambda session_id: "Focus",
+        )
+        runner._release_running_agent_state = MagicMock()
+        runner._clear_session_boundary_security_state = MagicMock()
+        runner._async_flush_memories = AsyncMock(return_value=None)
+
+        with patch("gateway.run.asyncio.create_task", side_effect=_fake_create_task):
+            result = await runner._handle_resume_command(event)
+
+        assert session_key not in runner._session_reasoning_overrides
+        runner._release_running_agent_state.assert_called_once_with(session_key)
+        runner._clear_session_boundary_security_state.assert_called_once_with(session_key)
+        assert "Resumed session **Focus**" in result
+
+    def test_run_agent_prefers_session_reasoning_override_over_global_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  reasoning_effort: low\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+            },
+        )
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        runner = _make_runner()
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        session_key = "agent:main:local:dm"
+        runner._session_reasoning_overrides[session_key] = {
+            "enabled": True,
+            "effort": "xhigh",
+        }
+
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="session-1",
+                session_key=session_key,
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["reasoning_config"] == {
+            "enabled": True,
+            "effort": "xhigh",
+        }
+
+    def test_run_background_task_prefers_session_reasoning_override(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  reasoning_effort: low\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+            },
+        )
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        class _Adapter:
+            def extract_media(self, response):
+                return [], response
+
+            def extract_images(self, response):
+                return [], response
+
+            async def send(self, *args, **kwargs):
+                return None
+
+            async def send_image(self, *args, **kwargs):
+                return None
+
+            async def send_document(self, *args, **kwargs):
+                return None
+
+        _CapturingAgent.last_init = None
+        runner = _make_runner()
+        runner.adapters[Platform.LOCAL] = _Adapter()
+        runner._run_in_executor_with_context = AsyncMock(side_effect=lambda fn: fn())
+        runner._cleanup_agent_resources = lambda agent: None
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        session_key = "agent:main:local:dm"
+        runner._session_reasoning_overrides[session_key] = {
+            "enabled": True,
+            "effort": "xhigh",
+        }
+
+        asyncio.run(runner._run_background_task("ping", source, "bg-1", session_key))
+
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["reasoning_config"] == {
+            "enabled": True,
+            "effort": "xhigh",
+        }
 
     def test_run_agent_reloads_reasoning_config_per_message(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -96,6 +96,8 @@ def _session(agent=None, **extra):
         "cols": 80,
         "slash_worker": None,
         "show_reasoning": False,
+        "reasoning_config": {},
+        "reasoning_scope": "global",
         "tool_progress_mode": "all",
         **extra,
     }
@@ -471,6 +473,253 @@ def test_config_set_personality_resets_history_and_returns_info(monkeypatch):
     assert session["history"] == []
     assert session["history_version"] == 5
     assert ("session.info", "sid", {"model": "x"}) in emits
+
+
+def test_config_set_reasoning_defaults_to_session_scope(monkeypatch):
+    session = _session(agent=types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "medium"}))
+    writes = []
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_write_config_key", lambda path, value: writes.append((path, value)))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "reasoning", "value": "high"},
+        }
+    )
+
+    assert resp["result"]["value"] == "high"
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "high"}
+    assert writes == []
+
+
+def test_config_set_reasoning_global_persists_with_flag(monkeypatch):
+    session = _session(agent=types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "medium"}))
+    writes = []
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_write_config_key", lambda path, value: writes.append((path, value)))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "reasoning", "value": "high --global"},
+        }
+    )
+
+    assert resp["result"]["value"] == "high"
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "high"}
+    assert writes == [("agent.reasoning_effort", "high")]
+
+
+def test_config_set_reasoning_global_falls_back_to_session_on_write_failure(monkeypatch):
+    session = _session(agent=types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "medium"}))
+    server._sessions["sid"] = session
+    monkeypatch.setattr(
+        server,
+        "_write_config_key",
+        lambda path, value: (_ for _ in ()).throw(RuntimeError("disk full")),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "reasoning", "value": "high --global"},
+        }
+    )
+
+    assert resp["result"]["value"] == "high"
+    assert session["reasoning_scope"] == "session"
+    assert session["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_config_get_reasoning_prefers_session_override(monkeypatch):
+    server._sessions["sid"] = _session(
+        agent=types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "xhigh"}),
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        reasoning_scope="session",
+        show_reasoning=True,
+    )
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"agent": {"reasoning_effort": "low"}, "display": {"show_reasoning": False}},
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.get",
+            "params": {"session_id": "sid", "key": "reasoning"},
+        }
+    )
+
+    assert resp["result"] == {"value": "xhigh", "display": "show"}
+
+
+def test_reset_session_agent_preserves_reasoning_override(monkeypatch):
+    old_agent = types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "xhigh"})
+    new_agent = types.SimpleNamespace(model="x", reasoning_config={"enabled": True, "effort": "medium"})
+    session = _session(
+        agent=old_agent,
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        reasoning_scope="session",
+        history=[{"role": "user", "text": "hi"}],
+        history_version=1,
+    )
+    server._sessions["sid"] = session
+
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: new_agent)
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": getattr(agent, "model", "?")})
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+
+    server._reset_session_agent("sid", session)
+
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+
+def test_session_create_preserves_pending_reasoning_override(monkeypatch):
+    created = {}
+    build_targets = []
+    db_stub = types.SimpleNamespace(create_session=lambda *args, **kwargs: None)
+    agent = types.SimpleNamespace(model="x", reasoning_config={"enabled": True, "effort": "medium"})
+
+    class _DeferredThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            build_targets.append(self._target)
+
+    monkeypatch.setattr(server.threading, "Thread", _DeferredThread)
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key: agent)
+    monkeypatch.setattr(server, "_get_db", lambda: db_stub)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": getattr(agent, "model", "?")})
+    monkeypatch.setattr(server, "_probe_credentials", lambda agent: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+
+    class _Worker:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda key, model: _Worker())
+
+    resp = server.handle_request({"id": "1", "method": "session.create", "params": {}})
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+    created["sid"] = sid
+
+    set_resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": sid, "key": "reasoning", "value": "xhigh"},
+        }
+    )
+    assert set_resp["result"]["value"] == "xhigh"
+    assert session["reasoning_scope"] == "session"
+    assert session["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+    assert len(build_targets) == 1
+    build_targets[0]()
+
+    assert session["agent"] is agent
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "xhigh"}
+    assert session["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+
+def test_session_create_keeps_latest_global_reasoning_if_config_changes_before_build_finishes(monkeypatch):
+    build_targets = []
+    db_stub = types.SimpleNamespace(create_session=lambda *args, **kwargs: None)
+    agent = types.SimpleNamespace(model="x", reasoning_config={"enabled": True, "effort": "medium"})
+    current_global = {"enabled": True, "effort": "medium"}
+
+    class _DeferredThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            build_targets.append(self._target)
+
+    monkeypatch.setattr(server.threading, "Thread", _DeferredThread)
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key: agent)
+    monkeypatch.setattr(server, "_get_db", lambda: db_stub)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": getattr(agent, "model", "?")})
+    monkeypatch.setattr(server, "_probe_credentials", lambda agent: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda: dict(current_global))
+
+    class _Worker:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda key, model: _Worker())
+
+    resp = server.handle_request({"id": "1", "method": "session.create", "params": {}})
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+
+    set_resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": sid, "key": "reasoning", "value": "high --global"},
+        }
+    )
+    assert set_resp["result"]["value"] == "high"
+    current_global["effort"] = "high"
+
+    assert len(build_targets) == 1
+    build_targets[0]()
+
+    assert session["reasoning_scope"] == "global"
+    assert session["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert session["agent"].reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_session_create_keeps_agent_reasoning_none_when_no_global_reasoning_is_configured(monkeypatch):
+    build_targets = []
+    db_stub = types.SimpleNamespace(create_session=lambda *args, **kwargs: None)
+    agent = types.SimpleNamespace(model="x", reasoning_config=None)
+
+    class _DeferredThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            build_targets.append(self._target)
+
+    monkeypatch.setattr(server.threading, "Thread", _DeferredThread)
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key: agent)
+    monkeypatch.setattr(server, "_get_db", lambda: db_stub)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": getattr(agent, "model", "?")})
+    monkeypatch.setattr(server, "_probe_credentials", lambda agent: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda: None)
+
+    class _Worker:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda key, model: _Worker())
+
+    resp = server.handle_request({"id": "1", "method": "session.create", "params": {}})
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+
+    assert len(build_targets) == 1
+    build_targets[0]()
+
+    assert session["agent"] is agent
+    assert session["agent"].reasoning_config is None
+    assert session["reasoning_config"] == {}
 
 
 def test_session_compress_uses_compress_helper(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1191,6 +1191,12 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
 
 
 def _reset_session_agent(sid: str, session: dict) -> dict:
+    reasoning_scope = str(session.get("reasoning_scope") or "global")
+    session_reasoning = (
+        dict(session.get("reasoning_config") or {})
+        if reasoning_scope == "session"
+        else dict(_load_reasoning_config() or {})
+    )
     tokens = _set_session_context(session["session_key"])
     try:
         new_agent = _make_agent(
@@ -1198,7 +1204,10 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         )
     finally:
         _clear_session_context(tokens)
+    if session_reasoning:
+        new_agent.reasoning_config = dict(session_reasoning)
     session["agent"] = new_agent
+    session["reasoning_config"] = dict(session_reasoning)
     session["attached_images"] = []
     session["edit_snapshots"] = {}
     session["image_counter"] = 0
@@ -1259,6 +1268,8 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "cols": cols,
         "slash_worker": None,
         "show_reasoning": _load_show_reasoning(),
+        "reasoning_config": dict(getattr(agent, "reasoning_config", None) or _load_reasoning_config() or {}),
+        "reasoning_scope": "global",
         "tool_progress_mode": _load_tool_progress_mode(),
         "edit_snapshots": {},
         "tool_started_at": {},
@@ -1401,6 +1412,8 @@ def _(rid, params: dict) -> dict:
         "running": False,
         "session_key": key,
         "show_reasoning": _load_show_reasoning(),
+        "reasoning_config": dict(_load_reasoning_config() or {}),
+        "reasoning_scope": "global",
         "slash_worker": None,
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
@@ -1435,6 +1448,19 @@ def _(rid, params: dict) -> dict:
             if db is not None:
                 db.create_session(key, source="tui", model=_resolve_model())
             session["agent"] = agent
+            pending_reasoning_scope = str(session.get("reasoning_scope") or "global")
+            pending_reasoning = session.get("reasoning_config")
+            if pending_reasoning_scope == "session" and isinstance(pending_reasoning, dict):
+                agent.reasoning_config = dict(pending_reasoning)
+                session["reasoning_config"] = dict(pending_reasoning)
+            else:
+                latest_global_reasoning = _load_reasoning_config()
+                if isinstance(latest_global_reasoning, dict):
+                    agent.reasoning_config = dict(latest_global_reasoning)
+                    session["reasoning_config"] = dict(latest_global_reasoning)
+                else:
+                    agent.reasoning_config = None
+                    session["reasoning_config"] = {}
 
             try:
                 worker = _SlashWorker(key, getattr(agent, "model", _resolve_model()))
@@ -2616,9 +2642,9 @@ def _(rid, params: dict) -> dict:
 
     if key == "reasoning":
         try:
-            from hermes_constants import parse_reasoning_effort
+            from hermes_constants import parse_reasoning_effort, parse_reasoning_flags
 
-            arg = str(value or "").strip().lower()
+            arg, persist_global = parse_reasoning_flags(str(value or "").strip().lower())
             if arg in ("show", "on"):
                 _write_config_key("display.show_reasoning", True)
                 if session:
@@ -2633,9 +2659,22 @@ def _(rid, params: dict) -> dict:
             parsed = parse_reasoning_effort(arg)
             if parsed is None:
                 return _err(rid, 4002, f"unknown reasoning value: {value}")
-            _write_config_key("agent.reasoning_effort", arg)
-            if session and session.get("agent") is not None:
-                session["agent"].reasoning_config = parsed
+            if persist_global or not session:
+                try:
+                    _write_config_key("agent.reasoning_effort", arg)
+                except Exception:
+                    if session:
+                        session["reasoning_scope"] = "session"
+                        session["reasoning_config"] = dict(parsed)
+                        if session.get("agent") is not None:
+                            session["agent"].reasoning_config = dict(parsed)
+                        return _ok(rid, {"key": key, "value": arg})
+                    raise
+            if session:
+                session["reasoning_scope"] = "global" if persist_global else "session"
+                session["reasoning_config"] = dict(parsed)
+                if session.get("agent") is not None:
+                    session["agent"].reasoning_config = dict(parsed)
             return _ok(rid, {"key": key, "value": arg})
         except Exception as e:
             return _err(rid, 5001, str(e))
@@ -2805,11 +2844,19 @@ def _(rid, params: dict) -> dict:
         )
     if key == "reasoning":
         cfg = _load_cfg()
-        effort = str(cfg.get("agent", {}).get("reasoning_effort", "medium") or "medium")
-        display = (
-            "show"
-            if bool(cfg.get("display", {}).get("show_reasoning", False))
-            else "hide"
+        session = _sessions.get(params.get("session_id", ""))
+        if session and session.get("reasoning_scope") == "session":
+            reasoning_cfg = session.get("reasoning_config") or {}
+        elif session and session.get("agent") is not None and getattr(session["agent"], "reasoning_config", None):
+            reasoning_cfg = getattr(session["agent"], "reasoning_config", None) or {}
+        else:
+            reasoning_cfg = _load_reasoning_config() or {}
+        if reasoning_cfg.get("enabled") is False:
+            effort = "none"
+        else:
+            effort = str(reasoning_cfg.get("effort", cfg.get("agent", {}).get("reasoning_effort", "medium") or "medium"))
+        display = "show" if session and session.get("show_reasoning", _load_show_reasoning()) else (
+            "show" if bool(cfg.get("display", {}).get("show_reasoning", False)) else "hide"
         )
         return _ok(rid, {"value": effort, "display": display})
     if key == "details_mode":

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -279,7 +279,7 @@ export const sessionCommands: SlashCommand[] = [
     run: (arg, ctx) => {
       if (!arg) {
         return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning' })
+          .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning', session_id: ctx.sid })
           .then(
             ctx.guarded<ConfigGetValueResponse>(
               r => r.value && ctx.transcript.sys(`reasoning: ${r.value} · display ${r.display || 'hide'}`)


### PR DESCRIPTION
## Summary
- make `/reasoning <level>` session-scoped by default across CLI, gateway, and TUI
- add explicit `--global` persistence semantics to match `/model`
- clear/reapply reasoning overrides correctly on session boundaries and background/TUI agent rebuild paths
- add regression coverage for malformed `--global` parsing and TUI session-create races

## Test Plan
- `scripts/run_tests.sh tests/cli/test_reasoning_command.py tests/gateway/test_reasoning_command.py tests/test_tui_gateway_server.py`
- `git diff --check`
- independent reviewer subagent pass (no blocking findings)

## Notes
- push to upstream `origin` was not permitted from this checkout, so the branch was pushed to the existing fork remote and the PR was opened from `Alex-giao:fix/reasoning-session-global`.
