### PR TITLE
fix(gateway): support require_mention toggle for Feishu group chats

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3626,9 +3626,14 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Gate group messages based on policy and optional @mention requirement."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        # Bypass mention check when require_mention is disabled or chat is in free_response list
+        if not self._feishu_require_mention() or (
+            chat_id and chat_id in self._feishu_free_response_chats()
+        ):
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:
@@ -3643,6 +3648,24 @@ class FeishuAdapter(BasePlatformAdapter):
             bot=self._bot_identity(),
         )
         return self._post_mentions_bot(normalized.mentions)
+
+    def _feishu_require_mention(self) -> bool:
+        """Return whether group chats should require an explicit bot mention."""
+        configured = self.config.extra.get("require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return True  # default: require mention (backward compatible)
+
+    def _feishu_free_response_chats(self) -> set:
+        """Return chat IDs where no @mention is required."""
+        raw = self.config.extra.get("free_response_channels")
+        if raw is None:
+            raw = os.getenv("FEISHU_FREE_RESPONSE_CHATS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
 
     def _is_self_sent_bot_message(self, event: Any) -> bool:
         """Return True only for Feishu events emitted by this Hermes bot."""


### PR DESCRIPTION
## Summary

Feishu is the only platform adapter that ignores the `require_mention` config option. This PR adds support for it, allowing users to configure the bot to respond in group chats without requiring an @mention.

## Problem

Setting `require_mention: false` in `config.yaml` under the Feishu platform block has no effect because `feishu.py` never reads that config value — `_should_accept_group_message()` is hardcoded to always require @mention. All other platforms (Telegram, Discord, Slack, WhatsApp, DingTalk, Matrix) implement this feature.

Related open issues: #15226, #5465, #10275, #9835

## Changes

**`gateway/platforms/feishu.py`** — 24 lines added, 1 line modified:

- **Modified `_should_accept_group_message()`** (line 3628): Added early-return bypass before the mention-check logic — if `_feishu_require_mention()` returns `False` or the `chat_id` is in `_feishu_free_response_chats()`, the message is accepted immediately.

- **Added `_feishu_require_mention()`**: Reads `self.config.extra.get("require_mention")`, handles string/bool types, defaults to `True` for backward compatibility.

- **Added `_feishu_free_response_chats()`**: Reads `self.config.extra.get("free_response_channels")` with `FEISHU_FREE_RESPONSE_CHATS` env var fallback. Supports both list and comma-separated string formats for per-chat granularity.

## Design decisions

- Pattern aligns with `telegram.py` implementation exactly
- DMs (`chat_type == "p2p"`) are unaffected — the mention gate only applies to group messages
- `@_all` (Feishu's @everyone) passthrough is preserved
- Defaults to `True` (require mention) for backward compatibility — existing users are not affected
- No changes to `config.yaml` or `gateway/config.py` needed — the generic bridging loop already passes `require_mention` into `feishu`'s `config.extra`

## Test Plan

- [x] Running in production with `require_mention: false` — bot responds to all group messages without @mention
- [x] DMs continue to work normally
- [ ] Unit tests for new methods (happy to add if maintainers want)

Closes #15226