### PR TITLE
Fix DeepSeek reasoning_content echo on fresh tool calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7625,12 +7625,6 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
-                # DeepSeek thinking mode requires reasoning_content on every
-                # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
-                msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
@@ -7703,6 +7697,15 @@ class AIAgent:
                     tc_dict["extra_content"] = extra
                 tool_calls.append(tc_dict)
             msg["tool_calls"] = tool_calls
+
+        if msg.get("tool_calls") and "reasoning_content" not in msg and (
+            self._needs_kimi_tool_reasoning()
+            or self._needs_deepseek_tool_reasoning()
+        ):
+            # Kimi and DeepSeek thinking mode require reasoning_content on every
+            # assistant tool-call message. Persisting an empty string here keeps
+            # fresh tool-call turns replay-safe, not just already-poisoned history.
+            msg["reasoning_content"] = ""
 
         return msg
 

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -23,6 +23,8 @@ Refs #15250 / #15353.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from run_agent import AIAgent
@@ -184,6 +186,41 @@ class TestCopyReasoningContentForApi:
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert "reasoning_content" not in api_msg
+
+
+class TestBuildAssistantMessageReasoningContent:
+    """_build_assistant_message pins replay-safe reasoning_content on fresh tool turns."""
+
+    def test_deepseek_tool_call_without_reasoning_content_gets_empty_string(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        agent._extract_reasoning = lambda assistant_message: None
+        agent._strip_think_blocks = lambda s: s
+        agent.verbose_logging = False
+        agent.reasoning_callback = None
+        agent.stream_delta_callback = None
+        agent._stream_callback = None
+        agent._split_responses_tool_id = lambda raw_id: (None, None)
+        agent._deterministic_call_id = lambda name, args, idx: f"call_{idx}"
+        agent._derive_responses_function_call_id = (
+            lambda call_id, response_item_id=None: f"fc_{call_id}"
+        )
+
+        assistant_message = SimpleNamespace(
+            content="",
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id="call_1",
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+        assert msg["reasoning_content"] == ""
+        assert msg["tool_calls"][0]["id"] == "call_1"
 
 
 class TestNeedsKimiToolReasoning:


### PR DESCRIPTION
Summary:
- persist `reasoning_content=""` on fresh assistant tool-call turns for DeepSeek/Kimi-style thinking providers
- keep poisoned-history replay fallback in `_copy_reasoning_content_for_api`
- add a regression test covering `_build_assistant_message` for DeepSeek tool-call replies without explicit `reasoning_content`

Root cause:
`_build_assistant_message()` checked the DeepSeek fallback inside the `hasattr(assistant_message, "reasoning_content")` block. On fresh tool-call responses where the SDK object didn't expose that attribute at all, the fallback never ran, so the persisted assistant tool-call message was saved without `reasoning_content`. On the next replay, DeepSeek thinking mode rejected the request with HTTP 400:

`The reasoning_content in the thinking mode must be passed back to the API.`

What changed:
- move the empty-string fallback to run after `tool_calls` are materialized into `msg`
- apply the same creation-time protection to both `_needs_deepseek_tool_reasoning()` and `_needs_kimi_tool_reasoning()`
- keep explicit `reasoning_content` untouched when providers return it

Verification:
- `python -m pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -q`
- local minimal reproduction before fix: `_build_assistant_message(..., tool_calls=...)` produced no `reasoning_content`
- local minimal reproduction after fix: fresh tool-call assistant message includes `reasoning_content: ""`
