### PR TITLE
fix(tui): treat backslash and drive paths as navigation in complete.path

### DIFF
--- a/tests/gateway/test_complete_path_at_filter.py
+++ b/tests/gateway/test_complete_path_at_filter.py
@@ -201,6 +201,18 @@ def test_fuzzy_skipped_when_path_has_slash(tmp_path, monkeypatch):
     assert not any("useCompletion.ts" in t for t in texts), texts
 
 
+def test_fuzzy_skipped_when_path_has_backslashes(tmp_path, monkeypatch):
+    """Windows-style `\\` also means navigation, not repo-wide fuzzy search."""
+    monkeypatch.chdir(tmp_path)
+    _nested_fixture(tmp_path)
+
+    texts = [t for t, _, _ in _items(r"@file:ui-tui\src\components\app")]
+
+    assert "@file:ui-tui/src/components/appChrome.tsx" in texts, texts
+    assert "@file:ui-tui/src/components/appLayout.tsx" in texts, texts
+    assert not any("useCompletion.ts" in t for t in texts), texts
+
+
 def test_fuzzy_skipped_when_folder_tag(tmp_path, monkeypatch):
     """`@folder:<name>` still lists directories — fuzzy scanner only walks
     files (git-tracked + untracked), so defer to the dir-listing path."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3568,9 +3568,18 @@ def _(rid, params: dict) -> dict:
         # name with no path separator — `@appChrome` surfaces every file
         # whose basename matches, regardless of directory depth. Matches what
         # editors like Cursor / VS Code do for Cmd-P. Path-ish queries (with
-        # `/`, `./`, `~/`, `/abs`) fall through to the directory-listing
-        # path so explicit navigation intent is preserved.
-        if is_context and path_part and "/" not in path_part and prefix_tag != "folder":
+        # `/`, `\`, or `C:\...`) fall through to the directory-listing path
+        # so explicit navigation intent is preserved.
+        has_path_navigation = (
+            "/" in path_part
+            or "\\" in path_part
+            or (
+                len(path_part) >= 2
+                and path_part[0].isalpha()
+                and path_part[1] == ":"
+            )
+        )
+        if is_context and path_part and not has_path_navigation and prefix_tag != "folder":
             root = os.getcwd()
             ranked: list[tuple[tuple[int, int], str, str]] = []
             for rel in _list_repo_files(root):
@@ -3621,7 +3630,7 @@ def _(rid, params: dict) -> dict:
             # which used to defeat the prefix and let `@folder:` list files.
             if prefix_tag and want_dir != is_dir:
                 continue
-            rel = os.path.relpath(full)
+            rel = os.path.relpath(full).replace(os.sep, "/")
             suffix = "/" if is_dir else ""
 
             if is_context and prefix_tag:
@@ -3630,7 +3639,7 @@ def _(rid, params: dict) -> dict:
                 kind = "folder" if is_dir else "file"
                 text = f"@{kind}:{rel}{suffix}"
             elif word.startswith("~"):
-                text = "~/" + os.path.relpath(full, os.path.expanduser("~")) + suffix
+                text = "~/" + os.path.relpath(full, os.path.expanduser("~")).replace(os.sep, "/") + suffix
             elif word.startswith("./"):
                 text = "./" + rel + suffix
             else:


### PR DESCRIPTION
## Summary

Fix TUI path completion for Windows-style path input in `complete.path`.

The gateway-side completion handler only treated `/` as a path separator when deciding whether to use repo-wide fuzzy basename matching. As a result, queries such as `@file:ui-tui\src\components\app` could be misclassified as bare-name fuzzy queries instead of normal path navigation.

## Root cause

`complete.path` entered the fuzzy branch whenever the query did not contain `/`.

That missed two valid navigation forms:
- backslash-separated paths like `foo\bar`
- Windows drive-prefixed paths like `C:\work\repo`

On Windows, the directory-listing branch also returned completion text with native `\` separators, which broke the existing normalized completion contract used by tests.

## Fix

- treat `\` as a path navigation signal
- treat drive-prefixed paths (`C:`) as path navigation too
- normalize directory-listing completion text to `/` before returning results

This keeps fuzzy basename matching for true bare-name queries such as `@appChrome`, while making Windows-style path input follow the normal directory-listing path.

## Tests

Added a regression test covering:
- `@file:ui-tui\src\components\app`

The test asserts that:
- completion stays in directory-listing mode
- expected direct children are returned
- unrelated fuzzy matches such as `useCompletion.ts` are not included

## Validation

- `tests/gateway/test_complete_path_at_filter.py -k backslashes`
- `tests/gateway/test_complete_path_at_filter.py`
