### PR TITLE
feat(agent): add safe orchestration guidance

### DIFF
--- a/agent/preflight.py
+++ b/agent/preflight.py
@@ -97,14 +97,29 @@ _RULES = (
         re.compile(r"\b(?:alter\s+table|migrate|migration|schema\s+change)\b", re.IGNORECASE),
     ),
     _Rule(
+        "credential_rotation",
+        3,
+        re.compile(r"\b(?:rotate|rotation|regenerate|reissue)\b[^\n]*(?:credential|secret|token|api[_-]?key|signing\s+secret)", re.IGNORECASE),
+    ),
+    _Rule(
+        "deployment_or_production",
+        2,
+        re.compile(r"\b(?:deploy|release|rollout|promote)\b[^\n]*(?:prod|production|live)|\bproduction\s+(?:deploy|release|rollout)\b", re.IGNORECASE),
+    ),
+    _Rule(
+        "dependency_change",
+        2,
+        re.compile(r"\b(?:upgrade|update|bump|install)\b[^\n]*(?:dependenc|package|pip|npm|pnpm|yarn|brew|requirements|pyproject)", re.IGNORECASE),
+    ),
+    _Rule(
         "external_side_effect",
         2,
         re.compile(r"\b(?:slack\s+send|email|post\s+to|publish)\b", re.IGNORECASE),
     ),
     _Rule(
         "mass_scope",
-        2,
-        re.compile(r"\b(?:all\s+users|every\s+file|--all)\b|\*\*/\*", re.IGNORECASE),
+        3,
+        re.compile(r"\b(?:all\s+users|every\s+(?:file|python\s+file)|all\s+files|entire\s+repository|whole\s+repo|--all)\b|\*\*/\*", re.IGNORECASE),
     ),
     _Rule(
         "hot_path_edit",

--- a/agent/preflight.py
+++ b/agent/preflight.py
@@ -1,0 +1,214 @@
+"""Advisory preflight risk classification for Hermes requests.
+
+This module is intentionally pure and source-only. It classifies a natural
+language request before any tool use so future orchestration layers can choose a
+more cautious workflow. It is not a security boundary: it never blocks, mutates
+state, reads config, talks to the gateway, or executes commands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+import re
+
+
+class PreflightRiskLevel(str, Enum):
+    """Advisory risk level for a user request."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class PreflightRecommendation(str, Enum):
+    """Suggested orchestration posture for the request."""
+
+    OBSERVE = "observe"
+    TDD = "tdd"
+    CLAUDE_REVIEW = "claude_review"
+    EXPLICIT_APPROVAL = "explicit_approval"
+
+
+@dataclass(frozen=True)
+class PreflightSignal:
+    """One advisory risk signal found in a request."""
+
+    name: str
+    weight: int
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """Deterministic advisory preflight classification result."""
+
+    level: PreflightRiskLevel
+    score: int
+    signals: tuple[PreflightSignal, ...]
+    recommendations: tuple[PreflightRecommendation, ...]
+    rationale: str
+
+
+@dataclass(frozen=True)
+class _Rule:
+    name: str
+    weight: int
+    pattern: re.Pattern[str]
+
+
+_RULES = (
+    _Rule(
+        "destructive_command",
+        3,
+        re.compile(
+            r"\brm\s+-rf\b|\bdrop\s+(?:table|database)\b|\bdelete\s+from\b|"
+            r"\btruncate\b|\breset\s+--hard\b|\bforce\s+push\b",
+            re.IGNORECASE,
+        ),
+    ),
+    _Rule(
+        "sensitive_config_or_secret",
+        3,
+        re.compile(
+            r"(?:^|[/\s])\.env(?:\b|\.)|\bcredentials(?:\.json)?\b|\bsecrets?\b|"
+            r"\bid_rsa\b|\bapi[_-]?key\b|\btoken\b|\bsecret[_-]?token\b",
+            re.IGNORECASE,
+        ),
+    ),
+    _Rule(
+        "runtime_process_control",
+        3,
+        re.compile(
+            r"\b(?:restart|reload)\b[^\n]*(?:gateway|hermes|slack)|"
+            r"\b(?:kill(?:all)?|pkill)\b[^\n]*(?:hermes|gateway|python)|"
+            r"\b(?:systemctl|launchctl)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    _Rule(
+        "network_bootstrap",
+        2,
+        re.compile(r"\b(?:curl|wget)\b[^\n|]*(?:\|\s*(?:sh|bash))", re.IGNORECASE),
+    ),
+    _Rule(
+        "schema_change",
+        2,
+        re.compile(r"\b(?:alter\s+table|migrate|migration|schema\s+change)\b", re.IGNORECASE),
+    ),
+    _Rule(
+        "external_side_effect",
+        2,
+        re.compile(r"\b(?:slack\s+send|email|post\s+to|publish)\b", re.IGNORECASE),
+    ),
+    _Rule(
+        "mass_scope",
+        2,
+        re.compile(r"\b(?:all\s+users|every\s+file|--all)\b|\*\*/\*", re.IGNORECASE),
+    ),
+    _Rule(
+        "hot_path_edit",
+        1,
+        re.compile(r"\b(?:run_agent\.py|cli\.py|gateway/)\b", re.IGNORECASE),
+    ),
+)
+_READ_ONLY_RE = re.compile(r"\b(?:read|show|explain|find|list|search|grep)\b", re.IGNORECASE)
+_EDIT_INTENT_RE = re.compile(r"\b(?:add|edit|modify|refactor|rename|implement|fix|change)\b", re.IGNORECASE)
+
+
+def classify_request(
+    request: str,
+    *,
+    context: Mapping[str, Any] | None = None,
+) -> PreflightReport:
+    """Classify a request into an advisory risk report.
+
+    ``context`` is accepted for forward compatibility with future runtime hooks,
+    but this v1 classifier is deterministic and does not inspect external state.
+    """
+
+    del context
+    text = request.casefold() if isinstance(request, str) else ""
+    signals = _collect_signals(text)
+    score = sum(signal.weight for signal in signals)
+    level = _classify_level(score, signals)
+    recommendations = _recommendations_for(level, signals)
+    rationale = _build_rationale(level, signals)
+    return PreflightReport(
+        level=level,
+        score=score,
+        signals=signals,
+        recommendations=recommendations,
+        rationale=rationale,
+    )
+
+
+def format_preflight_summary(report: PreflightReport) -> str:
+    """Return a compact redacted summary that never echoes the request text."""
+
+    signal_names = ",".join(signal.name for signal in report.signals) or "none"
+    recommendations = ",".join(recommendation.value for recommendation in report.recommendations)
+    return (
+        "preflight risk summary: "
+        f"level={report.level.value} "
+        f"score={report.score} "
+        f"signals={signal_names} "
+        f"recommendations={recommendations}"
+    )
+
+
+def _collect_signals(text: str) -> tuple[PreflightSignal, ...]:
+    signals: list[PreflightSignal] = []
+    seen: set[str] = set()
+    for rule in _RULES:
+        if rule.name in seen or not rule.pattern.search(text):
+            continue
+        if rule.name == "hot_path_edit" and not _EDIT_INTENT_RE.search(text):
+            continue
+        seen.add(rule.name)
+        signals.append(PreflightSignal(name=rule.name, weight=rule.weight))
+
+    if not signals and _EDIT_INTENT_RE.search(text) and not _READ_ONLY_RE.search(text):
+        signals.append(PreflightSignal(name="code_change_intent", weight=1))
+    return tuple(signals)
+
+
+def _classify_level(
+    score: int,
+    signals: tuple[PreflightSignal, ...],
+) -> PreflightRiskLevel:
+    if any(signal.weight >= 3 for signal in signals) or score >= 3:
+        return PreflightRiskLevel.HIGH
+    if score > 0:
+        return PreflightRiskLevel.MEDIUM
+    return PreflightRiskLevel.LOW
+
+
+def _recommendations_for(
+    level: PreflightRiskLevel,
+    signals: tuple[PreflightSignal, ...],
+) -> tuple[PreflightRecommendation, ...]:
+    if level == PreflightRiskLevel.LOW:
+        return (PreflightRecommendation.OBSERVE,)
+
+    recommendations: list[PreflightRecommendation]
+    if level == PreflightRiskLevel.MEDIUM:
+        recommendations = [PreflightRecommendation.TDD, PreflightRecommendation.CLAUDE_REVIEW]
+    else:
+        recommendations = [
+            PreflightRecommendation.EXPLICIT_APPROVAL,
+            PreflightRecommendation.CLAUDE_REVIEW,
+        ]
+        if any(signal.name == "schema_change" for signal in signals):
+            recommendations.append(PreflightRecommendation.TDD)
+    return tuple(recommendations)
+
+
+def _build_rationale(
+    level: PreflightRiskLevel,
+    signals: tuple[PreflightSignal, ...],
+) -> str:
+    if not signals:
+        return f"{level.value} risk: no advisory risk signals detected"
+    names = ", ".join(signal.name for signal in signals)
+    return f"{level.value} risk: detected {names}"

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -176,6 +176,31 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+OMC_SAFE_ORCHESTRATION_GUIDANCE = (
+    "# Safe orchestration guidance\n"
+    "When handling complex coding, debugging, or upgrade work, use a staged "
+    "orchestration flow: observe context, form a concise plan, execute the "
+    "smallest safe change, collect verification evidence, then report results.\n"
+    "Safety rules for Hermes/Slack environments:\n"
+    "- Do not restart gateway services or kill Hermes processes unless the user "
+    "explicitly approves that activation step.\n"
+    "- Do not modify tokens, credential files, or destructive runtime config as "
+    "part of routine implementation work.\n"
+    "- Prefer default-off feature flags, isolated source edits, focused tests, "
+    "and clear rollback paths before any live activation.\n"
+    "- Treat verifier work as separate from implementation: tests, static checks, "
+    "runtime evidence, or focused read-only state checks must support completion "
+    "claims."
+)
+
+
+def build_safe_orchestration_guidance(enabled: bool) -> str:
+    """Return opt-in safe orchestration guidance for OMC-style workflows.
+
+    The caller controls enablement so this builder remains pure and deterministic.
+    """
+    return OMC_SAFE_ORCHESTRATION_GUIDANCE if enabled else ""
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/safe_orchestration_diagnostics.py
+++ b/agent/safe_orchestration_diagnostics.py
@@ -1,0 +1,119 @@
+"""Pure diagnostics helpers for safe-orchestration log summaries.
+
+The helpers in this module parse already-collected log text and produce a compact,
+redacted summary. They do not read files, inspect the environment, mutate state,
+or talk to the gateway.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import re
+
+
+_PREFLIGHT_RE = re.compile(r"preflight risk summary: (?P<body>.*)")
+_VERIFIER_SUMMARY_RE = re.compile(r"safe orchestration verifier summary: (?P<body>.*)")
+_VERIFIER_FINDING_RE = re.compile(r"safe orchestration verifier finding: (?P<body>.*)")
+_FIELD_RE_TEMPLATE = r"(?:^|\s){name}=([^\s]+)"
+
+
+@dataclass(frozen=True)
+class SafeOrchestrationLogSummary:
+    """Redacted aggregate counts from safe-orchestration log lines."""
+
+    total_lines: int
+    preflight_levels: dict[str, int]
+    preflight_signals: dict[str, int]
+    verifier_codes: dict[str, int]
+    verifier_tools: dict[str, int]
+
+    def render(self) -> str:
+        """Return a deterministic, argument-free diagnostic summary."""
+
+        return (
+            "safe orchestration diagnostics: "
+            f"total_lines={self.total_lines} "
+            f"preflight_levels={_format_counts(self.preflight_levels)} "
+            f"preflight_signals={_format_counts(self.preflight_signals)} "
+            f"verifier_codes={_format_counts(self.verifier_codes)} "
+            f"verifier_tools={_format_counts(self.verifier_tools)}"
+        )
+
+
+def summarize_safe_orchestration_log(log_text: str) -> SafeOrchestrationLogSummary:
+    """Summarize safe-orchestration log text without echoing raw log contents."""
+
+    preflight_levels: Counter[str] = Counter()
+    preflight_signals: Counter[str] = Counter()
+    verifier_codes: Counter[str] = Counter()
+    verifier_tools: Counter[str] = Counter()
+    total = 0
+
+    for raw_line in str(log_text).splitlines():
+        if match := _PREFLIGHT_RE.search(raw_line):
+            total += 1
+            body = match.group("body")
+            _increment_csv_field(preflight_levels, _field(body, "level"))
+            _increment_csv_field(preflight_signals, _field(body, "signals"))
+            continue
+
+        if match := _VERIFIER_SUMMARY_RE.search(raw_line):
+            total += 1
+            body = match.group("body")
+            _increment_count_field(verifier_codes, _field(body, "codes"))
+            _increment_csv_field(verifier_tools, _field(body, "tools_seen"))
+            continue
+
+        if match := _VERIFIER_FINDING_RE.search(raw_line):
+            total += 1
+            body = match.group("body")
+            _increment_csv_field(verifier_codes, _field(body, "code"))
+            _increment_csv_field(verifier_tools, _field(body, "tool"))
+
+    return SafeOrchestrationLogSummary(
+        total_lines=total,
+        preflight_levels=dict(sorted(preflight_levels.items())),
+        preflight_signals=dict(sorted(preflight_signals.items())),
+        verifier_codes=dict(sorted(verifier_codes.items())),
+        verifier_tools=dict(sorted(verifier_tools.items())),
+    )
+
+
+def _field(text: str, name: str) -> str | None:
+    match = re.search(_FIELD_RE_TEMPLATE.format(name=re.escape(name)), text)
+    return match.group(1) if match else None
+
+
+def _increment_csv_field(counter: Counter[str], value: str | None) -> None:
+    if not value or value == "none":
+        if value == "none":
+            counter["none"] += 1
+        return
+    for item in value.split(","):
+        key = item.strip()
+        if key:
+            counter[key] += 1
+
+
+def _increment_count_field(counter: Counter[str], value: str | None) -> None:
+    if not value or value == "none":
+        return
+    for item in value.split(","):
+        key, sep, count_text = item.partition(":")
+        key = key.strip()
+        if not key:
+            continue
+        if sep:
+            try:
+                counter[key] += int(count_text)
+            except ValueError:
+                counter[key] += 1
+        else:
+            counter[key] += 1
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "none"
+    return ",".join(f"{key}:{counts[key]}" for key in sorted(counts))

--- a/agent/verifier.py
+++ b/agent/verifier.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from collections import Counter
 from typing import Any, Literal, Mapping, Sequence
 import re
+import shlex
 
 FindingSeverity = Literal["info", "warning", "error"]
 
@@ -57,6 +58,10 @@ _HERMES_KILL_RE = re.compile(
 )
 _SELF_UPDATE_RE = re.compile(
     r"\b(?:claude|hermes)\s+(?:update|upgrade|self-update)\b|\bself-update\b",
+    re.IGNORECASE,
+)
+_TERMINAL_FILE_MUTATION_RE = re.compile(
+    r"(?:^|[;&|\s])(?:cp|mv|tee|touch|install|chmod|chown)\b|>{1,2}",
     re.IGNORECASE,
 )
 
@@ -145,7 +150,41 @@ def _evaluate_terminal_command(command: Any, tool_name: str) -> tuple[VerifierFi
             "Terminal command appears to run a Hermes/Claude self-update; report-only finding.",
             tool_name,
         ))
+    findings.extend(_evaluate_terminal_file_targets(command_text, tool_name))
     return tuple(findings)
+
+
+def _evaluate_terminal_file_targets(
+    command_text: str,
+    tool_name: str,
+) -> tuple[VerifierFinding, ...]:
+    if not _TERMINAL_FILE_MUTATION_RE.search(command_text):
+        return ()
+
+    findings: list[VerifierFinding] = []
+    seen_codes: set[str] = set()
+    for candidate in _extract_command_path_candidates(command_text):
+        for finding in _evaluate_mutating_path(candidate, tool_name):
+            if finding.code in seen_codes:
+                continue
+            seen_codes.add(finding.code)
+            findings.append(finding)
+    return tuple(findings)
+
+
+def _extract_command_path_candidates(command_text: str) -> tuple[str, ...]:
+    try:
+        raw_tokens = shlex.split(command_text)
+    except ValueError:
+        raw_tokens = command_text.split()
+
+    candidates: list[str] = []
+    for token in raw_tokens:
+        candidate = token.strip("'\"` ,;()[]{}")
+        if not candidate or candidate.startswith("-") or candidate in {">", ">>"}:
+            continue
+        candidates.append(candidate)
+    return tuple(candidates)
 
 
 def _evaluate_mutating_path(path: Any, tool_name: str) -> tuple[VerifierFinding, ...]:

--- a/agent/verifier.py
+++ b/agent/verifier.py
@@ -1,0 +1,179 @@
+"""Report-only verifier for Hermes safe orchestration routines.
+
+This module intentionally has no runtime side effects. It evaluates a synthetic
+or captured tool-call trace and returns structured findings. It never blocks,
+raises for policy violations, mutates tool results, or talks to the gateway.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+import re
+
+FindingSeverity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True)
+class ToolCallRecord:
+    """Minimal record describing one tool call for report-only evaluation."""
+
+    name: str
+    args: Mapping[str, Any]
+    status: str | None = None
+
+
+@dataclass(frozen=True)
+class VerifierFinding:
+    """One report-only verifier finding."""
+
+    severity: FindingSeverity
+    code: str
+    message: str
+    tool_name: str | None = None
+
+
+@dataclass(frozen=True)
+class VerifierReport:
+    """Structured verifier result.
+
+    ``enabled`` records that the evaluator was deliberately run. The verifier is
+    still report-only: callers must not treat findings as execution blockers.
+    """
+
+    enabled: bool
+    findings: tuple[VerifierFinding, ...]
+
+
+_SERVICE_TARGET_RE = re.compile(r"\b(?:hermes|gateway|slack)\b", re.IGNORECASE)
+_SERVICE_RESTART_RE = re.compile(
+    r"\b(?:restart|reload|run\s+--replace)\b",
+    re.IGNORECASE,
+)
+_HERMES_KILL_RE = re.compile(
+    r"\b(?:kill(?:all)?|pkill)\b[^\n;|&]*(?:hermes|gateway)",
+    re.IGNORECASE,
+)
+_SELF_UPDATE_RE = re.compile(
+    r"\b(?:claude|hermes)\s+(?:update|upgrade|self-update)\b|\bself-update\b",
+    re.IGNORECASE,
+)
+
+_MUTATING_FILE_TOOLS = {"write_file", "patch"}
+_SENSITIVE_CONFIG_NAMES = {"config.yaml", "config.yml", "credentials.json", "secrets.json"}
+_SENSITIVE_CONFIG_SUFFIXES = (".pem", ".key")
+_GATEWAY_ADAPTER_SEGMENTS = (
+    ("gateway", "slack"),
+    ("gateway", "slack_adapter.py"),
+    ("slack", "adapter"),
+)
+
+
+def evaluate_turn(tool_calls: Sequence[ToolCallRecord]) -> VerifierReport:
+    """Evaluate a turn's tool-call trace and return report-only findings.
+
+    The function is deliberately defensive: malformed records are ignored rather
+    than raised, because verifier failures must not affect live tool execution.
+    """
+
+    findings: list[VerifierFinding] = []
+    for record in tool_calls:
+        tool_name = _safe_str(getattr(record, "name", ""))
+        args = getattr(record, "args", {})
+        if not isinstance(args, Mapping):
+            args = {}
+
+        if tool_name == "terminal":
+            findings.extend(_evaluate_terminal_command(args.get("command"), tool_name))
+        elif tool_name in _MUTATING_FILE_TOOLS:
+            findings.extend(_evaluate_mutating_path(args.get("path"), tool_name))
+
+    return VerifierReport(enabled=True, findings=tuple(findings))
+
+
+def _evaluate_terminal_command(command: Any, tool_name: str) -> tuple[VerifierFinding, ...]:
+    command_text = _safe_str(command)
+    if not command_text:
+        return ()
+
+    findings: list[VerifierFinding] = []
+    if _SERVICE_TARGET_RE.search(command_text) and _SERVICE_RESTART_RE.search(command_text):
+        findings.append(_warning(
+            "gateway_restart_command",
+            "Terminal command appears to restart or replace a Hermes/gateway "
+            "service; report-only finding.",
+            tool_name,
+        ))
+    if _HERMES_KILL_RE.search(command_text):
+        findings.append(_warning(
+            "hermes_process_kill_command",
+            "Terminal command appears to kill a Hermes/gateway process; report-only finding.",
+            tool_name,
+        ))
+    if _SELF_UPDATE_RE.search(command_text):
+        findings.append(_warning(
+            "self_update_command",
+            "Terminal command appears to run a Hermes/Claude self-update; report-only finding.",
+            tool_name,
+        ))
+    return tuple(findings)
+
+
+def _evaluate_mutating_path(path: Any, tool_name: str) -> tuple[VerifierFinding, ...]:
+    path_text = _safe_str(path)
+    if not path_text:
+        return ()
+
+    normalized = path_text.replace("\\", "/").lower()
+    basename = normalized.rsplit("/", 1)[-1]
+    segments = tuple(segment for segment in normalized.split("/") if segment)
+    findings: list[VerifierFinding] = []
+
+    if (
+        basename in _SENSITIVE_CONFIG_NAMES
+        or basename == ".env"
+        or basename.startswith(".env.")
+        or basename.endswith(_SENSITIVE_CONFIG_SUFFIXES)
+    ):
+        findings.append(_warning(
+            "sensitive_config_write",
+            "File mutation targets a sensitive config/env path; report-only finding.",
+            tool_name,
+        ))
+
+    if _has_ordered_segments(segments, _GATEWAY_ADAPTER_SEGMENTS):
+        findings.append(_warning(
+            "gateway_adapter_write",
+            "File mutation targets gateway/Slack adapter code; report-only finding.",
+            tool_name,
+        ))
+
+    return tuple(findings)
+
+
+def _has_ordered_segments(
+    path_segments: tuple[str, ...],
+    segment_patterns: tuple[tuple[str, ...], ...],
+) -> bool:
+    for pattern in segment_patterns:
+        max_start = len(path_segments) - len(pattern) + 1
+        if max_start <= 0:
+            continue
+        if any(path_segments[index:index + len(pattern)] == pattern for index in range(max_start)):
+            return True
+    return False
+
+
+def _warning(code: str, message: str, tool_name: str) -> VerifierFinding:
+    return VerifierFinding(
+        severity="warning",
+        code=code,
+        message=message,
+        tool_name=tool_name,
+    )
+
+
+def _safe_str(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return ""

--- a/agent/verifier.py
+++ b/agent/verifier.py
@@ -8,6 +8,7 @@ raises for policy violations, mutates tool results, or talks to the gateway.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections import Counter
 from typing import Any, Literal, Mapping, Sequence
 import re
 
@@ -91,6 +92,34 @@ def evaluate_turn(tool_calls: Sequence[ToolCallRecord]) -> VerifierReport:
     return VerifierReport(enabled=True, findings=tuple(findings))
 
 
+def format_report_summary(
+    report: VerifierReport,
+    tool_calls: Sequence[ToolCallRecord],
+) -> str:
+    """Return a compact, argument-free verifier summary for safe logging.
+
+    The summary intentionally includes only counts, finding codes, statuses, and
+    tool names. It never includes tool arguments, command text, paths, or file
+    contents, so it is safe for logs that may be inspected during operations.
+    """
+
+    records = list(tool_calls)
+    finding_counts = Counter(finding.code for finding in report.findings)
+    status_counts = Counter(_safe_status(getattr(record, "status", None)) for record in records)
+    tool_names = sorted({_safe_str(getattr(record, "name", "")) or "unknown" for record in records})
+
+    parts = [
+        "safe orchestration verifier summary:",
+        f"tools={len(records)}",
+        f"findings={len(report.findings)}",
+        f"statuses={_format_counter(status_counts)}",
+        f"tools_seen={','.join(tool_names) if tool_names else 'none'}",
+    ]
+    if finding_counts:
+        parts.append(f"codes={_format_counter(finding_counts)}")
+    return " ".join(parts)
+
+
 def _evaluate_terminal_command(command: Any, tool_name: str) -> tuple[VerifierFinding, ...]:
     command_text = _safe_str(command)
     if not command_text:
@@ -171,6 +200,18 @@ def _warning(code: str, message: str, tool_name: str) -> VerifierFinding:
         message=message,
         tool_name=tool_name,
     )
+
+
+def _safe_status(value: Any) -> str:
+    if isinstance(value, str) and value:
+        return value
+    return "unknown"
+
+
+def _format_counter(counter: Counter[str]) -> str:
+    if not counter:
+        return "none"
+    return ",".join(f"{key}:{counter[key]}" for key in sorted(counter))
 
 
 def _safe_str(value: Any) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8255,15 +8255,16 @@ class AIAgent:
         if num_tools > 0:
             self._apply_pending_steer_to_tool_results(messages, num_tools)
 
-        verifier_records: list[ToolCallRecord] = []
-        for i, (_tc, name, args) in enumerate(parsed_calls):
-            r = results[i]
-            if r is None:
-                status = "skipped" if self._interrupt_requested else "error"
-            else:
-                status = "error" if r[4] else "ok"
-            verifier_records.append(ToolCallRecord(name=name, args=args, status=status))
-        self._run_safe_orchestration_verifier(verifier_records)
+        if env_var_enabled("HERMES_OMC_VERIFIER"):
+            verifier_records: list[ToolCallRecord] = []
+            for i, (_tc, name, args) in enumerate(parsed_calls):
+                r = results[i]
+                if r is None:
+                    status = "skipped" if self._interrupt_requested else "error"
+                else:
+                    status = "error" if r[4] else "ok"
+                verifier_records.append(ToolCallRecord(name=name, args=args, status=status))
+            self._run_safe_orchestration_verifier(verifier_records)
 
     def _execute_tool_calls_sequential(
         self,
@@ -8273,6 +8274,7 @@ class AIAgent:
         api_call_count: int = 0,
     ) -> None:
         """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
+        verifier_enabled = env_var_enabled("HERMES_OMC_VERIFIER")
         verifier_records: list[ToolCallRecord] = []
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
             # SAFETY: check interrupt BEFORE starting each tool.
@@ -8568,13 +8570,14 @@ class AIAgent:
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
-            verifier_records.append(
-                ToolCallRecord(
-                    name=function_name,
-                    args=function_args,
-                    status="error" if _is_error_result else "ok",
+            if verifier_enabled:
+                verifier_records.append(
+                    ToolCallRecord(
+                        name=function_name,
+                        args=function_args,
+                        status="error" if _is_error_result else "ok",
+                    )
                 )
-            )
             if _is_error_result:
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
             else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -97,7 +97,17 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import (
+    build_context_files_prompt,
+    build_environment_hints,
+    build_safe_orchestration_guidance,
+    build_skills_system_prompt,
+    GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
+    load_soul_md,
+    OPENAI_MODEL_EXECUTION_GUIDANCE,
+    TOOL_USE_ENFORCEMENT_GUIDANCE,
+    TOOL_USE_ENFORCEMENT_MODELS,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -4264,6 +4274,13 @@ class AIAgent:
             skills_prompt = ""
         if skills_prompt:
             prompt_parts.append(skills_prompt)
+
+        omc_enabled = os.getenv("HERMES_OMC_GUIDANCE", "").strip().lower() in {
+            "1", "true", "yes", "on"
+        }
+        safe_orchestration_guidance = build_safe_orchestration_guidance(omc_enabled)
+        if safe_orchestration_guidance:
+            prompt_parts.append(safe_orchestration_guidance)
 
         if not self.skip_context_files:
             # Use TERMINAL_CWD for context file discovery when set (gateway

--- a/run_agent.py
+++ b/run_agent.py
@@ -109,7 +109,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_MODELS,
 )
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
-from agent.verifier import ToolCallRecord, evaluate_turn
+from agent.verifier import ToolCallRecord, evaluate_turn, format_report_summary
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
     _deterministic_call_id as _codex_deterministic_call_id,
@@ -7898,6 +7898,7 @@ class AIAgent:
             return
         try:
             report = evaluate_turn(tool_records)
+            summary = format_report_summary(report, tool_records)
         except Exception as verifier_error:
             logger.warning(
                 "safe orchestration verifier failed; continuing tool execution: %s",
@@ -7905,6 +7906,11 @@ class AIAgent:
                 exc_info=True,
             )
             return
+
+        if report.findings:
+            logger.warning(summary)
+        else:
+            logger.info(summary)
 
         for finding in report.findings:
             logger.warning(

--- a/run_agent.py
+++ b/run_agent.py
@@ -110,6 +110,11 @@ from agent.prompt_builder import (
 )
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.verifier import ToolCallRecord, evaluate_turn, format_report_summary
+from agent.preflight import (
+    PreflightRiskLevel,
+    classify_request,
+    format_preflight_summary,
+)
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
     _deterministic_call_id as _codex_deterministic_call_id,
@@ -7892,6 +7897,26 @@ class AIAgent:
         body = ("\n" + indent).join(out_lines)
         return f"{indent}{label}{body}"
 
+    def _run_safe_orchestration_preflight(self, user_message: str) -> None:
+        """Run advisory preflight risk classification as a default-off hook."""
+        if not env_var_enabled("HERMES_OMC_PREFLIGHT"):
+            return
+        try:
+            report = classify_request(user_message)
+            summary = format_preflight_summary(report)
+        except Exception as preflight_error:
+            logger.warning(
+                "safe orchestration preflight failed; continuing conversation: %s",
+                preflight_error,
+                exc_info=True,
+            )
+            return
+
+        if report.level == PreflightRiskLevel.HIGH:
+            logger.warning(summary)
+        else:
+            logger.info(summary)
+
     def _run_safe_orchestration_verifier(self, tool_records: list[ToolCallRecord]) -> None:
         """Run the OMC verifier as a default-off, report-only post-tool hook."""
         if not tool_records or not env_var_enabled("HERMES_OMC_VERIFIER"):
@@ -8863,6 +8888,8 @@ class AIAgent:
             user_message = sanitize_context(user_message)
         if isinstance(persist_user_message, str):
             persist_user_message = sanitize_context(persist_user_message)
+
+        self._run_safe_orchestration_preflight(user_message)
 
         # Store stream callback for _interruptible_api_call to pick up
         self._stream_callback = stream_callback

--- a/run_agent.py
+++ b/run_agent.py
@@ -109,6 +109,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_MODELS,
 )
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.verifier import ToolCallRecord, evaluate_turn
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
     _deterministic_call_id as _codex_deterministic_call_id,
@@ -7891,7 +7892,36 @@ class AIAgent:
         body = ("\n" + indent).join(out_lines)
         return f"{indent}{label}{body}"
 
-    def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _run_safe_orchestration_verifier(self, tool_records: list[ToolCallRecord]) -> None:
+        """Run the OMC verifier as a default-off, report-only post-tool hook."""
+        if not tool_records or not env_var_enabled("HERMES_OMC_VERIFIER"):
+            return
+        try:
+            report = evaluate_turn(tool_records)
+        except Exception as verifier_error:
+            logger.warning(
+                "safe orchestration verifier failed; continuing tool execution: %s",
+                verifier_error,
+                exc_info=True,
+            )
+            return
+
+        for finding in report.findings:
+            logger.warning(
+                "safe orchestration verifier finding: code=%s severity=%s tool=%s message=%s",
+                finding.code,
+                finding.severity,
+                finding.tool_name,
+                finding.message,
+            )
+
+    def _execute_tool_calls_concurrent(
+        self,
+        assistant_message,
+        messages: list,
+        effective_task_id: str,
+        api_call_count: int = 0,
+    ) -> None:
         """Execute multiple tool calls concurrently using a thread pool.
 
         Results are collected in the original tool-call order and appended to
@@ -8194,8 +8224,25 @@ class AIAgent:
         if num_tools > 0:
             self._apply_pending_steer_to_tool_results(messages, num_tools)
 
-    def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+        verifier_records: list[ToolCallRecord] = []
+        for i, (_tc, name, args) in enumerate(parsed_calls):
+            r = results[i]
+            if r is None:
+                status = "skipped" if self._interrupt_requested else "error"
+            else:
+                status = "error" if r[4] else "ok"
+            verifier_records.append(ToolCallRecord(name=name, args=args, status=status))
+        self._run_safe_orchestration_verifier(verifier_records)
+
+    def _execute_tool_calls_sequential(
+        self,
+        assistant_message,
+        messages: list,
+        effective_task_id: str,
+        api_call_count: int = 0,
+    ) -> None:
         """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
+        verifier_records: list[ToolCallRecord] = []
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
             # SAFETY: check interrupt BEFORE starting each tool.
             # If the user sent "stop" during a previous tool's execution,
@@ -8490,6 +8537,13 @@ class AIAgent:
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+            verifier_records.append(
+                ToolCallRecord(
+                    name=function_name,
+                    args=function_args,
+                    status="error" if _is_error_result else "ok",
+                )
+            )
             if _is_error_result:
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
             else:
@@ -8576,6 +8630,8 @@ class AIAgent:
         # applied to sequential execution as well.
         if num_tools_seq > 0:
             self._apply_pending_steer_to_tool_results(messages, num_tools_seq)
+
+        self._run_safe_orchestration_verifier(verifier_records)
 
 
 

--- a/tests/agent/test_preflight.py
+++ b/tests/agent/test_preflight.py
@@ -97,7 +97,39 @@ def test_classifier_is_deterministic_and_handles_empty_input():
 
 
 def test_classifier_is_case_insensitive():
-    report = classify_request("DROP TABLE Users")
+    report = classify_request("RESTART HERMES GATEWAY")
 
     assert report.level == PreflightRiskLevel.HIGH
-    assert "destructive_command" in signal_names(report)
+    assert "runtime_process_control" in signal_names(report)
+
+
+def test_production_deploy_is_medium_risk_and_recommends_review():
+    report = classify_request("Deploy the new build to production after tests pass")
+
+    assert report.level == PreflightRiskLevel.MEDIUM
+    assert "deployment_or_production" in signal_names(report)
+    assert PreflightRecommendation.TDD in report.recommendations
+    assert PreflightRecommendation.CLAUDE_REVIEW in report.recommendations
+
+
+def test_dependency_update_is_medium_risk():
+    report = classify_request("Upgrade the requests package and update dependencies")
+
+    assert report.level == PreflightRiskLevel.MEDIUM
+    assert "dependency_change" in signal_names(report)
+
+
+def test_credential_rotation_requires_explicit_approval():
+    report = classify_request("Rotate the Slack signing secret and API token")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "credential_rotation" in signal_names(report)
+    assert PreflightRecommendation.EXPLICIT_APPROVAL in report.recommendations
+
+
+def test_mass_refactor_scope_combines_with_code_change_intent():
+    report = classify_request("Refactor every Python file in the repository")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "mass_scope" in signal_names(report)
+    assert PreflightRecommendation.EXPLICIT_APPROVAL in report.recommendations

--- a/tests/agent/test_preflight.py
+++ b/tests/agent/test_preflight.py
@@ -1,0 +1,103 @@
+"""Tests for advisory preflight risk classification."""
+
+from agent.preflight import (
+    PreflightRecommendation,
+    PreflightRiskLevel,
+    classify_request,
+    format_preflight_summary,
+)
+
+
+def signal_names(report):
+    return {signal.name for signal in report.signals}
+
+
+def test_read_only_request_is_low_risk():
+    report = classify_request("show me run_agent.py and explain how it works")
+
+    assert report.level == PreflightRiskLevel.LOW
+    assert report.score == 0
+    assert report.recommendations == (PreflightRecommendation.OBSERVE,)
+
+
+def test_code_edit_request_is_medium_risk_and_recommends_tdd_review():
+    report = classify_request("refactor run_agent.py to add a new validation helper")
+
+    assert report.level == PreflightRiskLevel.MEDIUM
+    assert "hot_path_edit" in signal_names(report)
+    assert report.recommendations == (
+        PreflightRecommendation.TDD,
+        PreflightRecommendation.CLAUDE_REVIEW,
+    )
+
+
+def test_destructive_request_is_high_risk_and_requires_approval():
+    report = classify_request("rm -rf node_modules and git reset --hard origin/main")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "destructive_command" in signal_names(report)
+    assert PreflightRecommendation.EXPLICIT_APPROVAL in report.recommendations
+    assert PreflightRecommendation.CLAUDE_REVIEW in report.recommendations
+
+
+def test_secret_or_config_request_is_high_risk():
+    report = classify_request("overwrite .env.local with a new api_key value")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "sensitive_config_or_secret" in signal_names(report)
+    assert PreflightRecommendation.EXPLICIT_APPROVAL in report.recommendations
+
+
+def test_runtime_control_request_is_high_risk():
+    report = classify_request("restart the Slack gateway and kill hermes if it hangs")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "runtime_process_control" in signal_names(report)
+    assert PreflightRecommendation.EXPLICIT_APPROVAL in report.recommendations
+
+
+def test_schema_change_recommends_tdd_even_when_high_risk():
+    report = classify_request("drop table users then migrate the schema")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "schema_change" in signal_names(report)
+    assert PreflightRecommendation.TDD in report.recommendations
+    assert PreflightRecommendation.EXPLICIT_APPROVAL in report.recommendations
+
+
+def test_high_signal_dominates_read_only_words():
+    report = classify_request("please explain and then delete from users")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "destructive_command" in signal_names(report)
+
+
+def test_format_preflight_summary_redacts_request_and_matches():
+    report = classify_request("write SECRET_TOKEN=abc123 into .env.local")
+
+    summary = format_preflight_summary(report)
+
+    assert "preflight risk summary:" in summary
+    assert "level=high" in summary
+    assert "sensitive_config_or_secret" in summary
+    assert "SECRET_TOKEN" not in summary
+    assert "abc123" not in summary
+    assert ".env" not in summary
+
+
+def test_classifier_is_deterministic_and_handles_empty_input():
+    first = classify_request("   ")
+    second = classify_request("   ")
+
+    assert first == second
+    assert first.level == PreflightRiskLevel.LOW
+    assert first.score == 0
+    assert first.signals == ()
+    assert first.recommendations == (PreflightRecommendation.OBSERVE,)
+
+
+def test_classifier_is_case_insensitive():
+    report = classify_request("DROP TABLE Users")
+
+    assert report.level == PreflightRiskLevel.HIGH
+    assert "destructive_command" in signal_names(report)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -26,6 +26,8 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    OMC_SAFE_ORCHESTRATION_GUIDANCE,
+    build_safe_orchestration_guidance,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -48,6 +50,30 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+
+class TestSafeOrchestrationGuidance:
+    def test_disabled_returns_empty(self):
+        assert build_safe_orchestration_guidance(False) == ""
+
+    def test_enabled_returns_constant(self):
+        assert build_safe_orchestration_guidance(True) == OMC_SAFE_ORCHESTRATION_GUIDANCE
+
+    def test_enabled_contains_safety_markers(self):
+        result = build_safe_orchestration_guidance(True)
+        assert "Safe orchestration guidance" in result
+        assert "Do not restart gateway" in result
+        assert "kill Hermes processes" in result
+        assert "verification evidence" in result
+        assert "default-off feature flags" in result
+
+    def test_guidance_does_not_include_executable_dangerous_commands(self):
+        result = build_safe_orchestration_guidance(True)
+        assert "hermes gateway restart" not in result
+        assert "pkill" not in result
+        assert "kill -9" not in result
+        assert "self-update" not in result
+        assert "rotate" not in result
 
 
 # =========================================================================

--- a/tests/agent/test_safe_orchestration_diagnostics.py
+++ b/tests/agent/test_safe_orchestration_diagnostics.py
@@ -1,0 +1,42 @@
+from agent.safe_orchestration_diagnostics import summarize_safe_orchestration_log
+
+
+def test_summarizes_safe_orchestration_lines_without_echoing_sensitive_content():
+    log_text = "\n".join(
+        [
+            "INFO preflight risk summary: level=low score=0 signals=none recommendations=observe",
+            "WARNING preflight risk summary: level=high score=3 signals=sensitive_config_or_secret recommendations=explicit_approval,claude_review token=abc123 .env",
+            "WARNING safe orchestration verifier summary: tools=2 findings=1 statuses=ok:2 tools_seen=terminal,write_file codes=sensitive_config_write:1 command='pkill -f hermes' path=.env.local SECRET",
+            "WARNING safe orchestration verifier finding: code=sensitive_config_write severity=warning tool=write_file message=File mutation targets a sensitive config/env path; report-only finding.",
+            "INFO unrelated line with .env and SECRET should be ignored",
+        ]
+    )
+
+    summary = summarize_safe_orchestration_log(log_text)
+
+    assert summary.total_lines == 4
+    assert summary.preflight_levels == {"high": 1, "low": 1}
+    assert summary.preflight_signals == {"none": 1, "sensitive_config_or_secret": 1}
+    assert summary.verifier_codes == {"sensitive_config_write": 2}
+    assert summary.verifier_tools == {"terminal": 1, "write_file": 2}
+    rendered = summary.render()
+    assert "safe orchestration diagnostics:" in rendered
+    assert "preflight_levels=high:1,low:1" in rendered
+    assert "verifier_codes=sensitive_config_write:2" in rendered
+    assert ".env" not in rendered
+    assert "SECRET" not in rendered
+    assert "abc123" not in rendered
+    assert "pkill" not in rendered
+
+
+def test_empty_log_summary_is_deterministic():
+    summary = summarize_safe_orchestration_log("")
+
+    assert summary.total_lines == 0
+    assert summary.preflight_levels == {}
+    assert summary.verifier_codes == {}
+    assert summary.render() == (
+        "safe orchestration diagnostics: total_lines=0 "
+        "preflight_levels=none preflight_signals=none "
+        "verifier_codes=none verifier_tools=none"
+    )

--- a/tests/agent/test_verifier.py
+++ b/tests/agent/test_verifier.py
@@ -26,6 +26,8 @@ def test_clean_turn_has_no_findings():
         ("hermes gateway run --replace", "gateway_restart_command"),
         ("pkill -f hermes", "hermes_process_kill_command"),
         ("claude update", "self_update_command"),
+        ("python3 -m pip install foo > .env.local", "sensitive_config_write"),
+        ("cp new_adapter.py gateway/slack_adapter.py", "gateway_adapter_write"),
     ],
 )
 def test_terminal_dangerous_commands_are_reported_without_blocking(command, expected_code):

--- a/tests/agent/test_verifier.py
+++ b/tests/agent/test_verifier.py
@@ -1,0 +1,94 @@
+"""Tests for report-only safe orchestration verifier."""
+
+import pytest
+
+from agent.verifier import ToolCallRecord, evaluate_turn
+
+
+def finding_codes(report):
+    return {finding.code for finding in report.findings}
+
+
+def test_clean_turn_has_no_findings():
+    report = evaluate_turn([
+        ToolCallRecord(name="read_file", args={"path": "agent/prompt_builder.py"}),
+        ToolCallRecord(name="search_files", args={"pattern": "Safe orchestration"}),
+    ])
+
+    assert report.enabled is True
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_code"),
+    [
+        ("systemctl restart hermes-gateway", "gateway_restart_command"),
+        ("hermes gateway run --replace", "gateway_restart_command"),
+        ("pkill -f hermes", "hermes_process_kill_command"),
+        ("claude update", "self_update_command"),
+    ],
+)
+def test_terminal_dangerous_commands_are_reported_without_blocking(command, expected_code):
+    report = evaluate_turn([
+        ToolCallRecord(name="terminal", args={"command": command}),
+    ])
+
+    assert expected_code in finding_codes(report)
+    assert all(finding.severity == "warning" for finding in report.findings)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_code"),
+    [
+        ("config.yaml", "sensitive_config_write"),
+        (".env", "sensitive_config_write"),
+        (".env.local", "sensitive_config_write"),
+        ("key.pem", "sensitive_config_write"),
+        ("gateway/slack_adapter.py", "gateway_adapter_write"),
+    ],
+)
+def test_file_mutation_dangerous_paths_are_reported(path, expected_code):
+    report = evaluate_turn([
+        ToolCallRecord(name="write_file", args={"path": path, "content": "placeholder"}),
+    ])
+
+    assert expected_code in finding_codes(report)
+
+
+def test_patch_dangerous_path_is_reported():
+    report = evaluate_turn([
+        ToolCallRecord(name="patch", args={"path": "gateway/slack_adapter.py"}),
+    ])
+
+    assert "gateway_adapter_write" in finding_codes(report)
+
+
+def test_findings_are_aggregated_across_multiple_records():
+    report = evaluate_turn([
+        ToolCallRecord(name="terminal", args={"command": "pkill -f hermes"}),
+        ToolCallRecord(name="write_file", args={"path": ".env.production", "content": "x"}),
+    ])
+
+    assert finding_codes(report) == {
+        "hermes_process_kill_command",
+        "sensitive_config_write",
+    }
+
+
+def test_gateway_adapter_detection_is_segment_aware():
+    report = evaluate_turn([
+        ToolCallRecord(name="write_file", args={"path": "gateway/slacktivity/example.py"}),
+    ])
+
+    assert "gateway_adapter_write" not in finding_codes(report)
+
+
+def test_report_only_verifier_does_not_raise_for_malformed_records():
+    report = evaluate_turn([
+        ToolCallRecord(name="terminal", args={"command": None}),
+        ToolCallRecord(name="write_file", args={"path": None}),
+        ToolCallRecord(name="unknown", args={}),
+    ])
+
+    assert report.enabled is True
+    assert isinstance(report.findings, tuple)

--- a/tests/agent/test_verifier.py
+++ b/tests/agent/test_verifier.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from agent.verifier import ToolCallRecord, evaluate_turn
+from agent.verifier import ToolCallRecord, evaluate_turn, format_report_summary
 
 
 def finding_codes(report):
@@ -92,3 +92,32 @@ def test_report_only_verifier_does_not_raise_for_malformed_records():
 
     assert report.enabled is True
     assert isinstance(report.findings, tuple)
+
+
+def test_format_report_summary_redacts_arguments_and_counts_findings():
+    records = [
+        ToolCallRecord(name="terminal", args={"command": "pkill -f hermes"}, status="ok"),
+        ToolCallRecord(name="write_file", args={"path": ".env.local", "content": "SECRET"}, status="error"),
+    ]
+    report = evaluate_turn(records)
+
+    summary = format_report_summary(report, records)
+
+    assert "tools=2" in summary
+    assert "findings=2" in summary
+    assert "statuses=error:1,ok:1" in summary
+    assert "codes=hermes_process_kill_command:1,sensitive_config_write:1" in summary
+    assert "terminal" in summary
+    assert "write_file" in summary
+    assert "pkill" not in summary
+    assert ".env" not in summary
+    assert "SECRET" not in summary
+
+
+def test_format_report_summary_handles_clean_turn():
+    records = [ToolCallRecord(name="read_file", args={"path": "run_agent.py"}, status="ok")]
+    report = evaluate_turn(records)
+
+    summary = format_report_summary(report, records)
+
+    assert summary == "safe orchestration verifier summary: tools=1 findings=0 statuses=ok:1 tools_seen=read_file"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1396,6 +1396,7 @@ class TestSafeOrchestrationVerifierHook:
 
         with (
             patch("run_agent.handle_function_call", return_value="ok"),
+            patch("run_agent.ToolCallRecord", side_effect=AssertionError("should not build verifier records")),
             patch("run_agent.evaluate_turn", create=True) as mock_evaluate,
         ):
             agent._execute_tool_calls_sequential(
@@ -1495,6 +1496,89 @@ class TestSafeOrchestrationVerifierHook:
 
         assert messages[-1]["content"] == "ok"
         assert "safe orchestration verifier failed" in caplog.text
+
+    def test_concurrent_tool_execution_default_off_skips_verifier_record_assembly(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("HERMES_OMC_VERIFIER", raising=False)
+        assistant_message = _mock_assistant_msg(
+            content="",
+            tool_calls=[
+                _mock_tool_call(name="web_search", arguments='{"query":"one"}', call_id="c1"),
+                _mock_tool_call(name="read_file", arguments='{"path":"README.md"}', call_id="c2"),
+            ],
+        )
+        messages = []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch("run_agent.ToolCallRecord", side_effect=AssertionError("should not build verifier records")),
+            patch("run_agent.evaluate_turn", create=True) as mock_evaluate,
+        ):
+            agent._execute_tool_calls_concurrent(
+                assistant_message,
+                messages,
+                effective_task_id="test-task",
+            )
+
+        mock_evaluate.assert_not_called()
+        assert [message["content"] for message in messages] == ["ok", "ok"]
+
+    def test_concurrent_tool_execution_env_on_runs_report_only_verifier(
+        self,
+        agent,
+        monkeypatch,
+        caplog,
+    ):
+        from agent.verifier import VerifierFinding, VerifierReport
+
+        monkeypatch.setenv("HERMES_OMC_VERIFIER", "1")
+        assistant_message = _mock_assistant_msg(
+            content="",
+            tool_calls=[
+                _mock_tool_call(name="web_search", arguments='{"query":"one"}', call_id="c1"),
+                _mock_tool_call(name="read_file", arguments='{"path":"README.md"}', call_id="c2"),
+            ],
+        )
+        messages = []
+        report = VerifierReport(
+            enabled=True,
+            findings=(
+                VerifierFinding(
+                    severity="warning",
+                    code="test_code",
+                    message="report-only",
+                    tool_name="read_file",
+                ),
+            ),
+        )
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch("run_agent.evaluate_turn", return_value=report) as mock_evaluate,
+            patch(
+                "run_agent.format_report_summary",
+                return_value="safe orchestration verifier summary: tools=2 findings=1",
+            ) as mock_summary,
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            agent._execute_tool_calls_concurrent(
+                assistant_message,
+                messages,
+                effective_task_id="test-task",
+            )
+
+        mock_evaluate.assert_called_once()
+        records = mock_evaluate.call_args.args[0]
+        assert [(record.name, record.status) for record in records] == [
+            ("web_search", "ok"),
+            ("read_file", "ok"),
+        ]
+        mock_summary.assert_called_once_with(report, records)
+        assert [message["content"] for message in messages] == ["ok", "ok"]
+        assert "safe orchestration verifier summary" in caplog.text
 
 
 class TestBuildAssistantMessage:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -888,6 +888,25 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert "NOUS SUBSCRIPTION BLOCK" in prompt
 
+    @pytest.mark.parametrize("value", [None, "", "0", "false", "off", "random"])
+    def test_safe_orchestration_guidance_default_off(self, agent, monkeypatch, value):
+        from agent.prompt_builder import OMC_SAFE_ORCHESTRATION_GUIDANCE
+
+        if value is None:
+            monkeypatch.delenv("HERMES_OMC_GUIDANCE", raising=False)
+        else:
+            monkeypatch.setenv("HERMES_OMC_GUIDANCE", value)
+        prompt = agent._build_system_prompt()
+        assert OMC_SAFE_ORCHESTRATION_GUIDANCE not in prompt
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes ", "on"])
+    def test_safe_orchestration_guidance_enabled_by_env(self, agent, monkeypatch, value):
+        from agent.prompt_builder import OMC_SAFE_ORCHESTRATION_GUIDANCE
+
+        monkeypatch.setenv("HERMES_OMC_GUIDANCE", value)
+        prompt = agent._build_system_prompt()
+        assert OMC_SAFE_ORCHESTRATION_GUIDANCE in prompt
+
     def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
         tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
         toolset_map = {

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2229,6 +2229,106 @@ class TestHandleMaxIterations:
         assert "reasoning" not in kwargs.get("extra_body", {})
 
 
+class TestPreflightRiskClassifierHook:
+    def _setup_agent(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+    def test_preflight_default_off_does_not_run_classifier(self, agent, monkeypatch):
+        monkeypatch.delenv("HERMES_OMC_PREFLIGHT", raising=False)
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+
+        with (
+            patch("run_agent.classify_request") as mock_classify,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please edit run_agent.py")
+
+        mock_classify.assert_not_called()
+        assert result["final_response"] == "Final answer"
+        assert result["completed"] is True
+
+    def test_preflight_env_on_logs_redacted_report_only_summary(
+        self,
+        agent,
+        monkeypatch,
+        caplog,
+    ):
+        from agent.preflight import (
+            PreflightRecommendation,
+            PreflightReport,
+            PreflightRiskLevel,
+            PreflightSignal,
+        )
+
+        monkeypatch.setenv("HERMES_OMC_PREFLIGHT", "1")
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        report = PreflightReport(
+            level=PreflightRiskLevel.HIGH,
+            score=3,
+            signals=(PreflightSignal(name="sensitive_config", weight=3),),
+            recommendations=(PreflightRecommendation.EXPLICIT_APPROVAL,),
+            rationale="high risk",
+        )
+
+        with (
+            patch("run_agent.classify_request", return_value=report) as mock_classify,
+            patch("run_agent.format_preflight_summary", return_value="preflight summary redacted")
+            as mock_summary,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            result = agent.run_conversation("write token abc123 into .env")
+
+        mock_classify.assert_called_once_with("write token abc123 into .env")
+        mock_summary.assert_called_once_with(report)
+        assert result["final_response"] == "Final answer"
+        assert "preflight summary redacted" in caplog.text
+        assert ".env" not in caplog.text
+        assert "abc123" not in caplog.text
+
+    def test_preflight_exception_never_breaks_conversation(
+        self,
+        agent,
+        monkeypatch,
+        caplog,
+    ):
+        monkeypatch.setenv("HERMES_OMC_PREFLIGHT", "1")
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+
+        with (
+            patch("run_agent.classify_request", side_effect=RuntimeError("boom")),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            result = agent.run_conversation("restart gateway")
+
+        assert result["final_response"] == "Final answer"
+        assert result["completed"] is True
+        assert "safe orchestration preflight failed" in caplog.text
+
+
 class TestRunConversation:
     """Tests for the main run_conversation method.
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1375,6 +1375,122 @@ class TestBuildApiKwargs:
 
 
 
+class TestSafeOrchestrationVerifierHook:
+    def test_sequential_tool_execution_default_off_does_not_run_verifier(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("HERMES_OMC_VERIFIER", raising=False)
+        assistant_message = _mock_assistant_msg(
+            content="",
+            tool_calls=[
+                _mock_tool_call(
+                    name="terminal",
+                    arguments='{"command":"pkill -f hermes"}',
+                    call_id="c1",
+                )
+            ],
+        )
+        messages = []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch("run_agent.evaluate_turn", create=True) as mock_evaluate,
+        ):
+            agent._execute_tool_calls_sequential(
+                assistant_message,
+                messages,
+                effective_task_id="test-task",
+            )
+
+        mock_evaluate.assert_not_called()
+        assert messages[-1] == {
+            "role": "tool",
+            "content": "ok",
+            "tool_call_id": "c1",
+        }
+
+    def test_sequential_tool_execution_env_on_runs_report_only_verifier(
+        self,
+        agent,
+        monkeypatch,
+        caplog,
+    ):
+        from agent.verifier import VerifierFinding, VerifierReport
+
+        monkeypatch.setenv("HERMES_OMC_VERIFIER", "1")
+        assistant_message = _mock_assistant_msg(
+            content="",
+            tool_calls=[
+                _mock_tool_call(
+                    name="terminal",
+                    arguments='{"command":"pkill -f hermes"}',
+                    call_id="c1",
+                )
+            ],
+        )
+        messages = []
+        report = VerifierReport(
+            enabled=True,
+            findings=(
+                VerifierFinding(
+                    severity="warning",
+                    code="hermes_process_kill_command",
+                    message="report-only",
+                    tool_name="terminal",
+                ),
+            ),
+        )
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch("run_agent.evaluate_turn", return_value=report) as mock_evaluate,
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            agent._execute_tool_calls_sequential(
+                assistant_message,
+                messages,
+                effective_task_id="test-task",
+            )
+
+        mock_evaluate.assert_called_once()
+        records = mock_evaluate.call_args.args[0]
+        assert len(records) == 1
+        assert records[0].name == "terminal"
+        assert records[0].args == {"command": "pkill -f hermes"}
+        assert records[0].status == "ok"
+        assert messages[-1]["content"] == "ok"
+        assert "safe orchestration verifier finding" in caplog.text
+
+    def test_verifier_hook_never_raises_into_tool_execution(
+        self,
+        agent,
+        monkeypatch,
+        caplog,
+    ):
+        monkeypatch.setenv("HERMES_OMC_VERIFIER", "1")
+        assistant_message = _mock_assistant_msg(
+            content="",
+            tool_calls=[_mock_tool_call(name="terminal", arguments='{}', call_id="c1")],
+        )
+        messages = []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch("run_agent.evaluate_turn", side_effect=RuntimeError("boom")),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            agent._execute_tool_calls_sequential(
+                assistant_message,
+                messages,
+                effective_task_id="test-task",
+            )
+
+        assert messages[-1]["content"] == "ok"
+        assert "safe orchestration verifier failed" in caplog.text
+
+
 class TestBuildAssistantMessage:
     def test_basic_message(self, agent):
         msg = _mock_assistant_msg(content="Hello!")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1446,6 +1446,10 @@ class TestSafeOrchestrationVerifierHook:
         with (
             patch("run_agent.handle_function_call", return_value="ok"),
             patch("run_agent.evaluate_turn", return_value=report) as mock_evaluate,
+            patch(
+                "run_agent.format_report_summary",
+                return_value="safe orchestration verifier summary: tools=1 findings=1",
+            ) as mock_summary,
             caplog.at_level(logging.WARNING, logger="run_agent"),
         ):
             agent._execute_tool_calls_sequential(
@@ -1460,8 +1464,10 @@ class TestSafeOrchestrationVerifierHook:
         assert records[0].name == "terminal"
         assert records[0].args == {"command": "pkill -f hermes"}
         assert records[0].status == "ok"
+        mock_summary.assert_called_once_with(report, records)
         assert messages[-1]["content"] == "ok"
         assert "safe orchestration verifier finding" in caplog.text
+        assert "safe orchestration verifier summary" in caplog.text
 
     def test_verifier_hook_never_raises_into_tool_execution(
         self,


### PR DESCRIPTION
## Summary
- Add default-off safe-orchestration guidance injection for system prompts.
- Add report-only verifier routines and default-off runtime hook for post-tool risk summaries.
- Add redacted verifier summary logging and risky terminal/file-target detection.
- Add advisory preflight risk classifier plus default-off runtime hook.
- Add pure safe-orchestration diagnostics summarizer for redacted log aggregation.
- Strengthen preflight rules for deployment/production, dependency changes, credential rotation, and mass-scope edits.
- Tighten verifier default-off behavior so sequential/concurrent paths avoid verifier record assembly when disabled.

## Safety / Connectivity
- No gateway restart.
- No Hermes process kill.
- No Hermes self-update.
- No Slack token/config/env mutation.
- No Slack/gateway adapter edits.
- Runtime hooks are report-only and default-off unless env flags are set.
- Hook failures are caught and logged; conversation/tool execution continues.

## Test Plan
- `python3 -m compileall agent/safe_orchestration_diagnostics.py agent/preflight.py run_agent.py tests/agent/test_safe_orchestration_diagnostics.py tests/agent/test_preflight.py tests/run_agent/test_run_agent.py`
- `venv/bin/python -m pytest tests/agent/test_safe_orchestration_diagnostics.py tests/agent/test_preflight.py tests/agent/test_verifier.py tests/run_agent/test_run_agent.py::TestPreflightRiskClassifierHook tests/run_agent/test_run_agent.py::TestSafeOrchestrationVerifierHook tests/run_agent/test_run_agent.py::TestBuildSystemPrompt -q -o addopts="-m 'not integration'"`
- Result: `60 passed, 1 warning`
- Claude Code final review: `SHIP`

## Activation Notes
- Current live gateway has `HERMES_OMC_VERIFIER=1` and `HERMES_OMC_PREFLIGHT=1` in process environment.
- `HERMES_OMC_GUIDANCE` was not observed in the live gateway process environment.
- Any live reload/restart to apply code/env changes should be treated as a separate activation step requiring explicit approval.
