### PR TITLE
fix: prevent concurrent gateway updates from clobbering shared IPC state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7821,9 +7821,18 @@ class GatewayRunner:
             )
 
         pending_path = _hermes_home / ".update_pending.json"
+        claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
         session_key = self._session_key_for_source(event.source)
+
+        if pending_path.exists() or claimed_path.exists():
+            self._schedule_update_notification_watch()
+            return (
+                "⚕ Hermes update is already running for this profile. "
+                "I'll keep streaming progress in the original chat."
+            )
+
         pending = {
             "platform": event.source.platform.value,
             "chat_id": event.source.chat_id,

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -215,6 +215,84 @@ class TestHandleUpdateCommand:
         assert not (hermes_home / ".update_exit_code").exists()
 
     @pytest.mark.asyncio
+    async def test_rejects_duplicate_update_when_pending_marker_exists(self, tmp_path):
+        """A second /update must not overwrite the active update metadata."""
+        runner = _make_runner()
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="99999")
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending_path = hermes_home / ".update_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "11111",
+            "user_id": "orig-user",
+            "session_key": "agent:main:telegram:dm:11111",
+            "timestamp": "2026-04-25T10:00:00",
+        }))
+
+        mock_watch = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch.object(runner, "_schedule_update_notification_watch", mock_watch), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
+
+        assert "already running" in result.lower()
+        mock_popen.assert_not_called()
+        mock_watch.assert_called_once()
+        data = json.loads(pending_path.read_text())
+        assert data["chat_id"] == "11111"
+        assert data["user_id"] == "orig-user"
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_update_when_claimed_marker_exists(self, tmp_path):
+        """A claimed in-flight update must also block a second /update."""
+        runner = _make_runner()
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="99999")
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        claimed_path = hermes_home / ".update_pending.claimed.json"
+        claimed_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "22222",
+            "user_id": "orig-user",
+            "session_key": "agent:main:telegram:dm:22222",
+            "timestamp": "2026-04-25T10:00:00",
+        }))
+
+        mock_watch = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch.object(runner, "_schedule_update_notification_watch", mock_watch), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
+
+        assert "already running" in result.lower()
+        mock_popen.assert_not_called()
+        mock_watch.assert_called_once()
+        data = json.loads(claimed_path.read_text())
+        assert data["chat_id"] == "22222"
+        assert data["user_id"] == "orig-user"
+
+    @pytest.mark.asyncio
     async def test_spawns_setsid(self, tmp_path):
         """Uses setsid when available."""
         runner = _make_runner()


### PR DESCRIPTION
## Summary

Prevent duplicate gateway `/update` requests from starting a second detached update process while another update is still active.

The gateway update flow uses profile-global IPC files:

- `.update_pending.json`
- `.update_pending.claimed.json`
- `.update_output.txt`
- `.update_exit_code`
- `.update_prompt.json`
- `.update_response`

Before this change, a second `/update` call could overwrite the active update metadata and spawn another detached update process against the same shared IPC files. That could misroute progress/prompts/final notifications and clobber the original run state.

## What changed

- Add an early guard in `GatewayRunner._handle_update_command()`
- If either `.update_pending.json` or `.update_pending.claimed.json` already exists, do not spawn another update process
- Reuse the existing watcher so the current update continues streaming in its original chat
- Return a user-facing message that an update is already running

## Why this is a bug fix

The update IPC design is single-active-run per profile. The watcher and `hermes update --gateway` prompt bridge both assume a single shared set of marker files. The handler was missing the admission guard that enforces that invariant.

## Tests

Added regression coverage for both active-marker states:

- `test_rejects_duplicate_update_when_pending_marker_exists`
- `test_rejects_duplicate_update_when_claimed_marker_exists`

Local/targeted result:

- `tests/gateway/test_update_command.py`: `28 passed`

## Risk

Low.


