### PR TITLE
fix(delegate): _load_config reads from disk every call, not cached CLI_CONFIG

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2266,28 +2266,50 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config — ALWAYS reads from disk so live updates to
+    ``~/.hermes/config.yaml`` take effect without a gateway / CLI restart.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Previous behaviour read ``cli.CLI_CONFIG`` first, which is populated ONCE
+    at cli.py module import and never refreshed. In long-running gateway
+    processes (Discord/Telegram/Slack) that meant ``delegation.model`` /
+    ``delegation.provider`` changes made to the config file were invisible to
+    running subagents — users would edit the file, restart nothing, and
+    subagent dispatches would silently inherit the parent's model instead of
+    the configured cheaper one. The result was a quiet, expensive fall-back
+    to the session default (typically Opus) for what the user thought were
+    Sonnet/Haiku-routed tasks.
+
+    The YAML file is small (<10 KB) and this function is on the delegation
+    cold path (fired once per delegate_task call, not per token/API hit), so
+    the extra ~5 ms disk read is worth the correctness guarantee. The CLI
+    path still works identically — ``load_config()`` reads the same file
+    ``load_cli_config`` did.
+
+    Fallback order:
+      1. Live ``~/.hermes/config.yaml`` via ``hermes_cli.config.load_config``
+      2. Whatever is frozen in ``cli.CLI_CONFIG`` (if cli was imported — CLI
+         path only; gateway does not import cli.py)
+      3. Empty dict (config file absent/unreadable — children inherit from
+         parent, which is the pre-fix default)
     """
     try:
-        from cli import CLI_CONFIG
+        from hermes_cli.config import load_config
 
-        cfg = CLI_CONFIG.get("delegation", {})
+        full = load_config()
+        cfg = full.get("delegation", {}) or {}
         if cfg:
             return cfg
     except Exception:
         pass
     try:
-        from hermes_cli.config import load_config
+        from cli import CLI_CONFIG
 
-        full = load_config()
-        return full.get("delegation", {})
+        cfg = CLI_CONFIG.get("delegation", {}) or {}
+        if cfg:
+            return cfg
     except Exception:
-        return {}
+        pass
+    return {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_load_config()` in `tools/delegate_tool.py` reads `cli.CLI_CONFIG` before falling back to `hermes_cli.config.load_config()`. Because `CLI_CONFIG` is populated exactly once at `cli.py` module import and never refreshed, long-running gateway processes (Discord / Telegram / Slack) can't see edits made to `~/.hermes/config.yaml`'s `delegation.model` / `delegation.provider` after startup. The result is a silent fall-back: users edit the config, restart nothing, and subagent dispatches silently inherit the parent session's model instead of the configured override.

This flips the fallback order so `load_config()` (which reads the file on every call) is tried first, and `CLI_CONFIG` is only the backup.

## Observed Symptom (production Discord gateway, 2026-04-25)

- Gateway running as `anthropic/claude-opus-4.7`
- `~/.hermes/config.yaml`: `delegation.model: anthropic/claude-sonnet-4.6`, `delegation.provider: openrouter`
- `delegate_task` dispatches returned envelopes with `"model": "anthropic/claude-opus-4.7"` despite the pin
- SQLite `sessions` table confirmed: all child sessions recorded the parent's model, not the configured one

Verified root cause:

1. `_load_config()` returned `CLI_CONFIG["delegation"]`, a dict frozen at April 22 import (when `delegation.model` / `delegation.provider` were still empty strings).
2. `_resolve_delegation_credentials()` read `configured_model = None`, `configured_provider = None`.
3. Hit the "No provider override — child inherits everything from parent" branch (line ~2307).
4. `creds["model"] = None` → `effective_model = model or parent_agent.model` (line ~321 in `_build_child_agent`) → child ran Opus.

## Cost Impact

In the incident that triggered this investigation, ~$700 of unintended Opus burn on Sonnet-suitable mechanical coding work (4 PRs: CSV streaming importer, data migration command, Filament Infolist grouping refactor, doc updates) before the routing miss was diagnosed. A user who's pinned a cheaper model is probably doing so _because_ the task doesn't need Opus; they should not have to kill their gateway just to pick up a config edit.

## Fix

`hermes_cli.config.load_config()` reads `~/.hermes/config.yaml` on every call. Try that first. Only if the disk read fails / returns empty do we fall back to the frozen `CLI_CONFIG`.

Cost of the extra read: a ~10 KB YAML file parsed once per `delegate_task` call (not per API hit, not per token). ~5 ms on a modern machine, on the delegation cold path. Rounding error relative to any LLM API call.

## Diff Semantics

**CLI users:** No change. `load_config()` reads the same file as `load_cli_config`, so whatever `CLI_CONFIG` had, `load_config()` returns an equivalent `delegation` block.

**Gateway users:** Config edits take effect on the next `delegate_task` call instead of requiring a gateway restart.

## Testing

Reproduced in isolation before the fix:
```python
# With stale CLI_CONFIG simulating a long-running gateway:
creds = _resolve_delegation_credentials(_load_config(), parent)
# creds["model"] == None   <- bug
```

After the fix:
```python
# Same setup, but _load_config now reads the live file:
creds = _resolve_delegation_credentials(_load_config(), parent)
# creds["model"] == "anthropic/claude-sonnet-4.6"  <- fixed
```

Full delegate_task flow exercised in `/tmp/trace_delegation_full.py` (not included in commit) confirms the child AIAgent's `self.model` stays `sonnet-4.6` through construction and past the first API call.

## Docstring update

Added a section explaining the fallback order and the historical failure mode so future readers see why disk-first matters.
