### PR TITLE
fix(security): fail-closed when dangerous-command guard cannot be loaded in TUI shell.exec

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5694,3 +5694,97 @@ def test_notification_event_dedup_key_keeps_completions_one_shot():
     assert server._notification_event_dedup_key(first) == server._notification_event_dedup_key(
         replay
     )
+
+
+# --------------------------------------------------------------------------
+# shell.exec — dangerous-command guard must fail closed on ImportError
+# --------------------------------------------------------------------------
+
+
+def test_shell_exec_fails_closed_when_guard_unavailable(monkeypatch):
+    """If tools.approval cannot be imported, shell.exec must refuse to
+    execute the command rather than silently bypassing the guard.
+
+    Regression for the fail-open path where ``except ImportError: pass``
+    let arbitrary commands reach ``subprocess.run`` whenever the
+    dangerous-command screener could not be loaded (missing module,
+    circular import, syntax error in a dependency, partial deploy).
+    """
+    import builtins
+    import subprocess
+
+    original_import = builtins.__import__
+
+    def _refuse_approval(name, globals=None, locals=None, fromlist=(), level=0):
+        # Only intercept the targeted import; everything else flows
+        # through the real importer so the test does not interfere with
+        # unrelated lookups inside ``handle_request``.
+        if name == "tools.approval":
+            raise ImportError("simulated: tools.approval unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    subprocess_calls: list = []
+
+    def _record_run(*args, **kwargs):
+        subprocess_calls.append((args, kwargs))
+        raise AssertionError(
+            "subprocess.run was reached despite the guard being unavailable"
+        )
+
+    monkeypatch.setattr(builtins, "__import__", _refuse_approval)
+    monkeypatch.setattr(subprocess, "run", _record_run)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "shell.exec",
+            "params": {"command": "echo safe"},
+        }
+    )
+
+    assert "error" in resp, f"expected error response, got: {resp!r}"
+    assert resp["error"]["code"] == 4006, (
+        f"expected error code 4006 for unavailable guard, got: "
+        f"{resp['error']['code']!r}"
+    )
+    assert "guard unavailable" in resp["error"]["message"].lower(), (
+        "error message must explain why execution was refused; "
+        f"got: {resp['error']['message']!r}"
+    )
+    assert subprocess_calls == [], (
+        "shell.exec must not invoke subprocess.run when the guard is "
+        f"unavailable; got: {subprocess_calls!r}"
+    )
+
+
+def test_shell_exec_still_runs_when_guard_available(monkeypatch):
+    """Counterpart to ``test_shell_exec_fails_closed_when_guard_unavailable``:
+    when tools.approval imports successfully and the command is not
+    flagged dangerous, shell.exec must reach subprocess.run. Without
+    this guard the fail-closed fix could regress into "refuses
+    everything"."""
+    import subprocess
+    from types import SimpleNamespace
+
+    fake_approval = SimpleNamespace(
+        detect_dangerous_command=lambda cmd: (False, None, "")
+    )
+    monkeypatch.setitem(__import__("sys").modules, "tools.approval", fake_approval)
+
+    def _fake_run(cmd, **kwargs):
+        return SimpleNamespace(stdout="ok\n", stderr="", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "shell.exec",
+            "params": {"command": "echo ok"},
+        }
+    )
+
+    assert "result" in resp, f"expected result response, got: {resp!r}"
+    assert resp["result"]["stdout"] == "ok\n"
+    assert resp["result"]["code"] == 0
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8267,7 +8267,14 @@ def _(rid, params: dict) -> dict:
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        pass
+        # Fail-closed: a missing tools.approval module means we cannot
+        # screen the command for dangerous patterns. Refuse to execute
+        # rather than silently bypassing the guard -- a partial deploy,
+        # circular import, or syntax error in a dependency must not
+        # downgrade shell.exec into an unconditional ``subprocess.run``.
+        return _err(
+            rid, 4006, "dangerous-command guard unavailable; refusing to execute"
+        )
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4577,7 +4577,11 @@ def _(rid, params: dict) -> dict:
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        pass
+        # Fail-closed: if the dangerous-command guard cannot be loaded,
+        # refuse to run the command rather than silently bypassing the check.
+        return _err(
+            rid, 4006, "dangerous-command guard unavailable; refusing to execute"
+        )
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## What does this PR do?

`tui_gateway/server.py` exposes a `shell.exec` JSON-RPC method that
runs shell commands via `subprocess.run(shell=True)`. It tries to
block dangerous commands using `tools.approval.detect_dangerous_command`,
but on `ImportError` it silently falls through to executing the command:

```python
# Before (vulnerable — fail-open)
try:
    from tools.approval import detect_dangerous_command
    is_dangerous, _, desc = detect_dangerous_command(cmd)
    if is_dangerous:
        return _err(rid, 4005, f"blocked: {desc}...")
except ImportError:
    pass  # ← silently disables the guard
```

If `tools.approval` cannot be imported (missing module, circular import,
SyntaxError in a dependency, partial deployment), the dangerous-command
check is silently skipped and arbitrary shell commands are executed.

## Fix

Made the handler fail-closed: if the guard cannot be loaded, refuse
to execute the command rather than silently bypassing the check:

```python
except ImportError:
    return _err(
        rid, 4006, "dangerous-command guard unavailable; refusing to execute"
    )
```

This is consistent with the fail-closed pattern applied to the cron
SSRF check in #10180.

## Type of Change

- [x] 🔒 Security fix (CRITICAL — fail-open command execution)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Fail-closed — safer default when security module unavailable
- [x] No behavior change when `tools.approval` is available