### PR TITLE
fix(cli,gateway): guard /usage against missing context_compressor (#14715)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7736,11 +7736,16 @@ class HermesCLI:
         completion = agent.session_completion_tokens
         total = agent.session_total_tokens
 
-        compressor = agent.context_compressor
-        last_prompt = compressor.last_prompt_tokens
-        ctx_len = compressor.context_length
-        pct = min(100, (last_prompt / ctx_len * 100)) if ctx_len else 0
-        compressions = compressor.compression_count
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is not None:
+            last_prompt = int(getattr(compressor, "last_prompt_tokens", 0) or 0)
+            ctx_len = int(getattr(compressor, "context_length", 0) or 0)
+            pct = min(100.0, (last_prompt / ctx_len * 100)) if ctx_len else 0.0
+            compressions = int(getattr(compressor, "compression_count", 0) or 0)
+            ctx_summary = f"{last_prompt:,} / {ctx_len:,} ({pct:.0f}%)"
+        else:
+            compressions = 0
+            ctx_summary = f"{int(prompt or total or 0):,} prompt tokens (no compressor)"
 
         msg_count = len(self.conversation_history)
         cost_result = estimate_usage_cost(
@@ -7778,7 +7783,7 @@ class HermesCLI:
         else:
             print(f"  Total cost:              {'n/a':>10}")
         print(f"  {'─' * 40}")
-        print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
+        print(f"  Current context:  {ctx_summary}")
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
         if cost_result.status == "unknown":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10351,12 +10351,16 @@ class GatewayRunner:
                 pass
 
             # Context window and compressions
-            ctx = agent.context_compressor
-            if ctx.last_prompt_tokens:
-                pct = min(100, ctx.last_prompt_tokens / ctx.context_length * 100) if ctx.context_length else 0
-                lines.append(f"Context: {ctx.last_prompt_tokens:,} / {ctx.context_length:,} ({pct:.0f}%)")
-            if ctx.compression_count:
-                lines.append(f"Compressions: {ctx.compression_count}")
+            ctx = getattr(agent, "context_compressor", None)
+            if ctx is not None:
+                last_prompt = int(getattr(ctx, "last_prompt_tokens", 0) or 0)
+                ctx_len = int(getattr(ctx, "context_length", 0) or 0)
+                if last_prompt:
+                    pct = min(100, last_prompt / ctx_len * 100) if ctx_len else 0
+                    lines.append(f"Context: {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
+                comp_count = int(getattr(ctx, "compression_count", 0) or 0)
+                if comp_count:
+                    lines.append(f"Compressions: {comp_count}")
 
             if account_lines:
                 lines.append("")


### PR DESCRIPTION
## Summary

Both `cli.py::_show_usage()` and `gateway/run.py::_handle_usage_command()` access `agent.context_compressor` without checking for `None`, then immediately dereference attributes on it. When the compressor hasn't been initialised — e.g. the agent was created with `skip_context_files=True`, errored before compressor setup, or is in a minimal gateway session — `/usage` crashes with:

```
AttributeError: 'NoneType' object has no attribute 'last_prompt_tokens'
```

## Changes

### `cli.py` — `_show_usage()`
- Use `getattr(agent, "context_compressor", None)` instead of direct attribute access
- When compressor exists: show full context window breakdown (unchanged)
- When compressor is `None`: show total prompt token count with a "\(no compressor\)" note, set compressions to 0

### `gateway/run.py` — `_handle_usage_command()`
- Same `getattr()` guard around `agent.context_compressor`
- Skip context-window and compression lines when compressor is absent (the rest of the usage output still works)

## Verification

- `python3 -c "import ast; ast.parse(open('cli.py').read())"` — OK
- `python3 -c "import ast; ast.parse(open('gateway/run.py').read())"` — OK

Fixes #14715
Supersedes #14723 (which targeted the pre-restructure file layout)