### PR TITLE
fix(compressor): reset _summary_failure_cooldown_until in on_session_reset()

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -297,6 +297,7 @@ class ContextCompressor(ContextEngine):
         self._last_summary_error = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
 
     def update_model(
         self,


### PR DESCRIPTION
## What does this PR do?

`ContextCompressor.on_session_reset()` clears `_previous_summary`, `_last_summary_error`, and `_ineffective_compression_count` but leaves `_summary_failure_cooldown_until` intact. When a transient summary error (network timeout, rate limit) sets a 60 s cooldown — or 600 s when no auxiliary provider is configured — and the user immediately runs `/reset` or `/new`, the cooldown carries into the new session. If the new session reaches the compression threshold before the cooldown expires, `_generate_summary()` returns `None` early: middle turns are silently dropped without a summary and the agent continues with no indication that compaction was skipped.

One-line fix in `on_session_reset()`: set `_summary_failure_cooldown_until = 0.0`, matching the value assigned in `__init__` and symmetric with the other per-session fields already cleared there. Scoped to session reset only — no behavior change for sessions that never hit an error.

## Related Issue

Fixes #15547

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/context_compressor.py`: add `self._summary_failure_cooldown_until = 0.0` to `on_session_reset()` (+1 line)

## How to Test

1. Trigger a context compression failure (disable auxiliary provider or simulate a network error in `_generate_summary`)
2. Confirm `_summary_failure_cooldown_until` is set to a future timestamp
3. Call `on_session_reset()`
4. Assert `_summary_failure_cooldown_until == 0.0`

```python
import time
from unittest.mock import patch

with patch("agent.context_compressor.get_model_context_length", return_value=100000):
    c = ContextCompressor(model="test/model", quiet_mode=True)

c._summary_failure_cooldown_until = time.monotonic() + 60
c.on_session_reset()
assert c._summary_failure_cooldown_until == 0.0
```

## Checklist

### Code
- [x] Contributing Guide okundu
- [x] Conventional Commits
- [x] Duplicate PR yok
- [x] Sadece bu fix
- [x] pytest çalıştırıldı
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs güncellendi — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A