### PR TITLE
fix(compressor): re-derive tail_token_budget and max_summary_tokens in update_model()

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -318,6 +318,15 @@ class ContextCompressor(ContextEngine):
             int(context_length * self.threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
         )
+        # Re-derive token budgets from the new threshold — mirrors __init__.
+        # Without this, switching to a model with a very different context window
+        # leaves tail_token_budget stale: too large protects the entire history
+        # as "tail" (nothing left to summarize); too small aggressively compresses
+        # recent turns and can lose the active task.
+        self.tail_token_budget = int(self.threshold_tokens * self.summary_target_ratio)
+        self.max_summary_tokens = min(
+            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
 
     def __init__(
         self,


### PR DESCRIPTION
## What does this PR do?

`ContextCompressor.update_model()` correctly updates `context_length` and `threshold_tokens` when the active model changes, but does not re-derive `tail_token_budget` and `max_summary_tokens`. Both are computed from those same values in `__init__` — omitting the re-derivation leaves them stale after a model switch to one with a significantly different context window.

**Large → small context switch** (e.g. gemini 1M → local 8K): `tail_token_budget` stays at ~100 K. `_find_tail_cut_by_tokens()` treats the entire conversation as "tail" (soft ceiling is never reached), leaving almost nothing in the middle region to summarize. Compression silently does nothing.

**Small → large context switch** (e.g. local 8K → claude-sonnet 200K): `tail_token_budget` stays at ~800 tokens. The tail is drastically under-protected; recent turns and the active task are aggressively summarized away.

Fix: mirror the two `__init__` assignments at the end of `update_model()` using the already-updated `self.threshold_tokens` and `self.context_length`. Symmetric with `__init__` lines 365–369. No behavior change when the context length is unchanged.

## Related Issue

Fixes #15558

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/context_compressor.py`: add `tail_token_budget` and `max_summary_tokens` re-derivation to `update_model()` (+9 lines)

## How to Test

```python
from unittest.mock import patch
with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
    c = ContextCompressor(model="big/model", quiet_mode=True)

assert c.tail_token_budget == int(c.threshold_tokens * c.summary_target_ratio)

c.update_model(model="small/model", context_length=8_000)
assert c.tail_token_budget == int(c.threshold_tokens * c.summary_target_ratio)
assert c.max_summary_tokens == min(int(8_000 * 0.05), 12_000)
```

## Checklist

### Code
- [x] Contributing Guide okundu
- [x] Conventional Commits
- [x] Duplicate PR yok
- [x] Sadece bu fix
- [x] pytest çalıştırıldı
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs güncellendi — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A