### PR TITLE
fix(tui): add visible markdown table separators

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { AUDIO_DIRECTIVE_RE, INLINE_RE, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
+import {
+  AUDIO_DIRECTIVE_RE,
+  formatTableDivider,
+  getTableColumnWidths,
+  INLINE_RE,
+  MEDIA_LINE_RE,
+  stripInlineMarkup
+} from '../components/markdown.js'
 
 const matches = (text: string) => [...text.matchAll(INLINE_RE)].map(m => m[0])
 
@@ -60,6 +67,20 @@ describe('stripInlineMarkup', () => {
   it('leaves ~!/~? kaomoji alone and still handles real subscript', () => {
     expect(stripInlineMarkup('Yay ~! nice work ~!')).toBe('Yay ~! nice work ~!')
     expect(stripInlineMarkup('H~2~O and CO~2~')).toBe('H_2O and CO_2')
+  })
+})
+
+describe('table formatting helpers', () => {
+  it('computes widths from rendered plain-text cell content', () => {
+    expect(getTableColumnWidths([
+      ['Name', 'Status'],
+      ['**Ada**', '`ok`'],
+      ['Longer name', 'needs review']
+    ])).toEqual([11, 12])
+  })
+
+  it('builds visible pipe divider lines for each column', () => {
+    expect(formatTableDivider([4, 6])).toBe('|------|--------|')
   })
 })
 

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1,5 +1,5 @@
-import { Box, Link, Text } from '@hermes/ink'
-import { memo, type ReactNode, useMemo } from 'react'
+import { Box, Link, stringWidth, Text } from '@hermes/ink'
+import { Fragment, memo, type ReactNode, useMemo } from 'react'
 
 import { ensureEmojiPresentation } from '../lib/emoji.js'
 import { highlightLine, isHighlightable } from '../lib/syntax.js'
@@ -94,21 +94,37 @@ export const stripInlineMarkup = (v: string) =>
     .replace(/\^([^^\s][^^]*?)\^/g, '^$1')
     .replace(/~([A-Za-z0-9]{1,8})~/g, '_$1')
 
+export const getTableColumnWidths = (rows: string[][]) =>
+  rows[0]!.map((_, ci) => Math.max(...rows.map(r => stringWidth(stripInlineMarkup(r[ci] ?? '')))))
+
+export const formatTableDivider = (widths: number[]) => `|${widths.map(w => '-'.repeat(w + 2)).join('|')}|`
+
+const tableCellPadding = (cell: string, width: number) => ' '.repeat(Math.max(0, width - stringWidth(stripInlineMarkup(cell))))
+
 const renderTable = (k: number, rows: string[][], t: Theme) => {
-  const widths = rows[0]!.map((_, ci) => Math.max(...rows.map(r => stripInlineMarkup(r[ci] ?? '').length)))
+  const widths = getTableColumnWidths(rows)
+  const divider = formatTableDivider(widths)
 
   return (
     <Box flexDirection="column" key={k} paddingLeft={2}>
       {rows.map((row, ri) => (
-        <Box key={ri}>
-          {widths.map((w, ci) => (
-            <Text color={ri === 0 ? t.color.amber : undefined} key={ci}>
-              <MdInline t={t} text={row[ci] ?? ''} />
-              {' '.repeat(Math.max(0, w - stripInlineMarkup(row[ci] ?? '').length))}
-              {ci < widths.length - 1 ? '  ' : ''}
-            </Text>
-          ))}
-        </Box>
+        <Fragment key={ri}>
+          <Box>
+            <Text color={t.color.dim}>|</Text>
+            {widths.map((w, ci) => (
+              <Box key={ci}>
+                <Text> </Text>
+                <Text color={ri === 0 ? t.color.amber : undefined}>
+                  <MdInline t={t} text={row[ci] ?? ''} />
+                  {tableCellPadding(row[ci] ?? '', w)}
+                </Text>
+                <Text> </Text>
+                <Text color={t.color.dim}>|</Text>
+              </Box>
+            ))}
+          </Box>
+          {ri === 0 ? <Text color={t.color.dim}>{divider}</Text> : null}
+        </Fragment>
       ))}
     </Box>
   )


### PR DESCRIPTION
## Why change
TUI markdown tables currently render as aligned plain text with no visible separators, so rows can blend into surrounding prose. This adds explicit pipe borders plus a visible header divider, matching issue #15534's low-risk usability fix.

## Files changed
- `ui-tui/src/components/markdown.tsx`
- `ui-tui/src/__tests__/markdown.test.ts`

## Verification run
- `cd ui-tui && npm run build --prefix packages/hermes-ink`
- `cd ui-tui && npm test -- --run src/__tests__/markdown.test.ts`
- `cd ui-tui && npx eslint src/components/markdown.tsx src/__tests__/markdown.test.ts`

## Risk level
Low. TUI-only markdown table rendering change with focused tests for new formatting helpers.

Closes #15534
