### PR TITLE
Add editable voice transcript drafts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -720,6 +720,7 @@ DEFAULT_CONFIG = {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
+        "auto_submit": True,           # Submit STT transcripts immediately; false inserts them as editable drafts
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -203,6 +203,21 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
     assert saved["display"]["sections"] == {"tools": "expanded"}
 
 
+def test_voice_transcript_payload_marks_draft_when_auto_submit_disabled(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"auto_submit": False}})
+
+    assert server._voice_transcript_payload("edit me") == {
+        "auto_submit": False,
+        "text": "edit me",
+    }
+
+
+def test_voice_transcript_payload_defaults_to_auto_submit(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {}})
+
+    assert server._voice_transcript_payload("send me") == {"text": "send me"}
+
+
 def test_config_set_section_rejects_unknown_section_or_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3875,6 +3875,20 @@ def _voice_tts_enabled() -> bool:
     return os.environ.get("HERMES_VOICE_TTS", "").strip() == "1"
 
 
+def _voice_transcript_payload(text: str) -> dict:
+    """Build the TUI voice transcript event payload from persisted config.
+
+    ``voice.auto_submit`` defaults to True for backward compatibility. When it
+    is explicitly false, the TUI inserts the transcript into the composer as an
+    editable draft instead of immediately submitting it as the next user turn.
+    """
+    payload = {"text": text}
+    voice_cfg = _load_cfg().get("voice", {})
+    if voice_cfg.get("auto_submit") is False:
+        payload["auto_submit"] = False
+    return payload
+
+
 @method("voice.toggle")
 def _(rid, params: dict) -> dict:
     """CLI parity for the ``/voice`` slash command.
@@ -3975,7 +3989,9 @@ def _(rid, params: dict) -> dict:
 
             voice_cfg = _load_cfg().get("voice", {})
             start_continuous(
-                on_transcript=lambda t: _voice_emit("voice.transcript", {"text": t}),
+                on_transcript=lambda t: _voice_emit(
+                    "voice.transcript", _voice_transcript_payload(t)
+                ),
                 on_status=lambda s: _voice_emit("voice.status", {"state": s}),
                 on_silent_limit=lambda: _voice_emit(
                     "voice.transcript", {"no_speech_limit": True}

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -315,4 +315,29 @@ describe('createGatewayEventHandler', () => {
 
     expect(getTurnState().activity).toMatchObject([{ text: 'boom', tone: 'error' }])
   })
+
+  it('inserts voice transcripts into the composer when auto_submit is false', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { auto_submit: false, text: 'edit this first' }, type: 'voice.transcript' } as any)
+
+    expect(ctx.composer.setInput).toHaveBeenCalledWith('edit this first')
+    expect(ctx.submission.submitRef.current).not.toHaveBeenCalled()
+  })
+
+  it('auto-submits voice transcripts by default for backward compatibility', () => {
+    vi.useFakeTimers()
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: 'send now' }, type: 'voice.transcript' } as any)
+    vi.runAllTimers()
+
+    expect(ctx.composer.setInput).toHaveBeenCalledWith('')
+    expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('send now')
+    vi.useRealTimers()
+  })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -301,16 +301,19 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
-        // CLI parity: _pending_input.put(transcript) unconditionally feeds
-        // the transcript to the agent as its next turn — draft handling
-        // doesn't apply because voice-mode users are speaking, not typing.
-        //
-        // We can't branch on composer input from inside a setInput updater
-        // (React strict mode double-invokes it, duplicating the submit).
-        // Just clear + defer submit so the cleared input is committed before
-        // submit reads it.
-        setInput('')
-        setTimeout(() => submitRef.current(text), 0)
+        // By default we preserve CLI parity: submit the transcript as the
+        // next user turn. When the gateway marks the transcript as a draft,
+        // place it in the composer instead so users can edit before sending.
+        if (ev.payload?.auto_submit === false) {
+          setInput(text)
+        } else {
+          // We can't branch on composer input from inside a setInput updater
+          // (React strict mode double-invokes it, duplicating the submit).
+          // Just clear + defer submit so the cleared input is committed before
+          // submit reads it.
+          setInput('')
+          setTimeout(() => submitRef.current(text), 0)
+        }
 
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -376,7 +376,7 @@ export type GatewayEvent =
   | { payload?: undefined; session_id?: string; type: 'message.start' }
   | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }
   | { payload?: { state?: 'idle' | 'listening' | 'transcribing' }; session_id?: string; type: 'voice.status' }
-  | { payload?: { no_speech_limit?: boolean; text?: string }; session_id?: string; type: 'voice.transcript' }
+  | { payload?: { auto_submit?: boolean; no_speech_limit?: boolean; text?: string }; session_id?: string; type: 'voice.transcript' }
   | { payload: { line: string }; session_id?: string; type: 'gateway.stderr' }
   | { payload?: { cwd?: string; python?: string }; session_id?: string; type: 'gateway.start_timeout' }
   | { payload?: { preview?: string }; session_id?: string; type: 'gateway.protocol_error' }


### PR DESCRIPTION
## Summary
- add a `voice.auto_submit` config option that defaults to `true`
- include `auto_submit: false` on TUI voice transcript events when configured
- insert STT transcripts into the TUI composer for editing instead of submitting immediately when auto-submit is disabled

## Testing
- `npm test -- --run src/__tests__/createGatewayEventHandler.test.ts`
- `./venv/bin/python -m pytest tests/test_tui_gateway_server.py -q`
- `npx eslint src/app/createGatewayEventHandler.ts src/gatewayTypes.ts src/__tests__/createGatewayEventHandler.test.ts`

## Notes
- `npm run type-check` currently fails on an existing unrelated error in `packages/hermes-ink/src/ink/dom.ts` (`string | undefined` passed where `string` is required).
- Full `npm run lint` currently fails on existing unrelated lint issues outside the files changed here.
