### PR TITLE
feat: add DeepSeek-V4 thinking mode via unified thinking_mode parameter

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -110,8 +110,12 @@ class ChatCompletionsTransport(ProviderTransport):
             # Temperature
             fixed_temperature: Any — from _fixed_temperature_for_model()
             omit_temperature: bool
-            # Reasoning
-            supports_reasoning: bool
+            # Reasoning / Thinking (mode string unifies multiple providers)
+            #   "generic" — extra_body.reasoning (OpenRouter, Nous, GitHub Models)
+            #   "kimi"    — top-level reasoning_effort + extra_body.thinking (Kimi/Moonshot)
+            #   "deepseek" — top-level reasoning_effort + extra_body.thinking (DeepSeek direct API)
+            supports_reasoning: bool      # kept for backward compat; consumers should prefer thinking_mode
+            thinking_mode: str | None     # one of None, "generic", "kimi", "deepseek"
             github_reasoning_extra: dict | None
             # Claude on OpenRouter/Nous max output
             anthropic_max_output: int | None
@@ -203,20 +207,12 @@ class ChatCompletionsTransport(ProviderTransport):
         elif anthropic_max_out is not None:
             api_kwargs["max_tokens"] = anthropic_max_out
 
-        # Kimi: top-level reasoning_effort (unless thinking disabled)
-        if is_kimi:
-            _kimi_thinking_off = bool(
-                reasoning_config
-                and isinstance(reasoning_config, dict)
-                and reasoning_config.get("enabled") is False
-            )
-            if not _kimi_thinking_off:
-                _kimi_effort = "medium"
-                if reasoning_config and isinstance(reasoning_config, dict):
-                    _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in ("low", "medium", "high"):
-                        _kimi_effort = _e
-                api_kwargs["reasoning_effort"] = _kimi_effort
+        # ── Thinking / Reasoning parameters ────────────────────────────
+        # Unified via thinking_mode so each provider uses a single branch.
+        # Backward compat: if thinking_mode is not set, falls back to
+        # is_kimi / supports_reasoning flags.
+        thinking_mode = params.get("thinking_mode")
+        supports_reasoning = params.get("supports_reasoning", False)
 
         # extra_body assembly
         extra_body: Dict[str, Any] = {}
@@ -229,18 +225,49 @@ class ChatCompletionsTransport(ProviderTransport):
         if provider_prefs and is_openrouter:
             extra_body["provider"] = provider_prefs
 
-        # Kimi extra_body.thinking
-        if is_kimi:
-            _kimi_thinking_enabled = True
-            if reasoning_config and isinstance(reasoning_config, dict):
-                if reasoning_config.get("enabled") is False:
-                    _kimi_thinking_enabled = False
+        # ── Kimi: top-level reasoning_effort + extra_body.thinking ─────
+        if thinking_mode == "kimi" or (thinking_mode is None and is_kimi):
+            _k_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _k_thinking_off:
+                _k_effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("low", "medium", "high"):
+                        _k_effort = _e
+                api_kwargs["reasoning_effort"] = _k_effort
             extra_body["thinking"] = {
-                "type": "enabled" if _kimi_thinking_enabled else "disabled",
+                "type": "enabled" if not _k_thinking_off else "disabled",
             }
 
-        # Reasoning
-        if params.get("supports_reasoning", False):
+        # ── DeepSeek: top-level reasoning_effort + extra_body.thinking ─
+        # DeepSeek V4-Pro/V4-Flash use {high, max} for effort and require
+        # thinking.type in extra_body.  Temperature/top_p are not supported
+        # while thinking is active.
+        elif thinking_mode == "deepseek":
+            _ds_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _ds_thinking_off:
+                _ds_effort = "max"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("high", "max"):
+                        _ds_effort = _e
+                api_kwargs["reasoning_effort"] = _ds_effort
+                # DeepSeek does not support temperature/top_p with thinking
+                api_kwargs.pop("temperature", None)
+            extra_body["thinking"] = {
+                "type": "enabled" if not _ds_thinking_off else "disabled",
+            }
+
+        # ── Generic reasoning (OpenRouter / Nous / GitHub Models) ─────
+        if supports_reasoning:
             if is_github_models:
                 gh_reasoning = params.get("github_reasoning_extra")
                 if gh_reasoning is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7401,11 +7401,15 @@ class AIAgent:
         )
         _is_nous = "nousresearch" in self._base_url_lower
         _is_nvidia = "integrate.api.nvidia.com" in self._base_url_lower
+        # thinking_mode replaces is_kimi — the transport branch selects Kimi
+        # or DeepSeek semantics from a single string value.  is_kimi is kept
+        # here only for the max_tokens default (32000) in build_kwargs.
         _is_kimi = (
             base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _thinking_mode = self._thinking_provider()
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7465,6 +7469,7 @@ class AIAgent:
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=self._max_tokens_param,
             reasoning_config=self.reasoning_config,
+            thinking_mode=_thinking_mode,
             request_overrides=self.request_overrides,
             session_id=getattr(self, "session_id", None),
             model_lower=(self.model or "").lower(),
@@ -7486,6 +7491,28 @@ class AIAgent:
             github_reasoning_extra=self._github_models_reasoning_extra_body() if _is_gh else None,
             anthropic_max_output=_ant_max,
         )
+
+    def _thinking_provider(self) -> str | None:
+        """Return a thinking_mode identifier for directly-routed providers
+        that use thinking/reasoning_effort (Kimi, DeepSeek, etc.).
+
+        Returns None for aggregator routes (OpenRouter, Nous, GitHub Models)
+        that use the generic extra_body.reasoning path instead.
+
+        Design intent:
+          Each provider uses exactly one branch for thinking params.
+          Adding a new provider means one elif here + one elif in the
+          transport's build_kwargs.  No flag proliferation.
+        """
+        if (
+            base_url_host_matches(self._base_url_lower, "api.kimi.com")
+            or base_url_host_matches(self._base_url_lower, "moonshot.ai")
+            or base_url_host_matches(self._base_url_lower, "moonshot.cn")
+        ):
+            return "kimi"
+        if base_url_host_matches(self._base_url_lower, "api.deepseek.com"):
+            return "deepseek"
+        return None
 
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -289,6 +289,100 @@ class TestChatCompletionsKimi:
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
 
+class TestChatCompletionsDeepSeek:
+    """DeepSeek thinking mode via the thinking_mode='deepseek' parameter."""
+
+    def test_deepseek_thinking_enabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            thinking_mode="deepseek",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+        assert kw["reasoning_effort"] == "max"
+
+    def test_deepseek_thinking_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            thinking_mode="deepseek",
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in kw
+
+    def test_deepseek_thinking_custom_effort(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            thinking_mode="deepseek",
+            reasoning_config={"effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+        assert kw["reasoning_effort"] == "high"
+
+    def test_deepseek_thinking_removes_temperature(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "Hi"}],
+            thinking_mode="deepseek",
+            fixed_temperature=0.7,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "temperature" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+class TestChatCompletionsThinkingModeUnified:
+    """Test that thinking_mode='kimi' works the same as the old is_kimi=True flag."""
+
+    def test_kimi_via_thinking_mode_effort(self, transport):
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=[{"role": "user", "content": "Hi"}],
+            thinking_mode="kimi",
+            reasoning_config={"effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_kimi_via_thinking_mode_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=[{"role": "user", "content": "Hi"}],
+            thinking_mode="kimi",
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "reasoning_effort" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_thinking_mode_none_falls_back_to_is_kimi(self, transport):
+        """When thinking_mode is not set, is_kimi flag still works."""
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "medium"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_generic_thinking_mode_none_with_supports_reasoning(self, transport):
+        """When thinking_mode is None, supports_reasoning flag still works."""
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-v4",
+            messages=[{"role": "user", "content": "Hi"}],
+            supports_reasoning=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw.get("extra_body", {}).get("reasoning") == {"enabled": True, "effort": "medium"}
+
+
 class TestChatCompletionsValidate:
 
     def test_none(self, transport):


### PR DESCRIPTION
## Summary

Add support for DeepSeek V4-Pro / V4-Flash thinking mode when using the DeepSeek direct API (api.deepseek.com).

## Design Intent

Introduce a single string-valued `thinking_mode` parameter to replace the pattern of adding one boolean flag per provider. Each provider uses exactly one branch in the transport's `build_kwargs`:

| thinking_mode | Behavior |
|---|---|
| kimi | Top-level reasoning_effort + extra_body.thinking (low/medium/high) |
| deepseek | Top-level reasoning_effort + extra_body.thinking (high/max) |
| None | Falls back to is_kimi / supports_reasoning for backward compatibility |

Adding a new thinking-capable provider requires only one elif in run_agent.py + one elif in chat_completions.py -- no flag proliferation.

## DeepSeek-specific behavior

- Sets reasoning_effort: max (default) or high
- Sets extra_body: {thinking: {type: enabled}}
- Automatically removes temperature when thinking is active (DeepSeek docs: temperature/top_p unsupported with thinking)
- Can be disabled via reasoning_config: {enabled: false}

## Files changed

- agent/transports/chat_completions.py -- Unified thinking_mode branch for Kimi + DeepSeek, backward compat with is_kimi/supports_reasoning
- run_agent.py -- New _thinking_provider() method replacing scattered boolean detection
- tests/agent/transports/test_chat_completions.py -- 8 new tests

## Testing

- All 49 chat_completions tests pass (41 existing + 8 new)
- Full test suite: 4282 passed, 2 pre-existing failures unrelated
- Real API call verified against api.deepseek.com with deepseek-v4-pro