### PR TITLE
fix(auxiliary): retry without unsupported temperature

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -42,7 +42,6 @@ import time
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urlparse
 
 from openai import OpenAI
 
@@ -118,15 +117,6 @@ def _is_kimi_model(model: Optional[str]) -> bool:
     return bare.startswith("kimi-") or bare == "kimi"
 
 
-def _is_codex_backend(base_url: Optional[str]) -> bool:
-    """True for ChatGPT Codex backend endpoints that reject sampling params."""
-    url = str(base_url or "").strip().lower().rstrip("/")
-    path = urlparse(url).path.rstrip("/")
-    return base_url_hostname(url) == "chatgpt.com" and (
-        path == "/backend-api/codex" or path.startswith("/backend-api/codex/")
-    )
-
-
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
@@ -136,18 +126,13 @@ def _fixed_temperature_for_model(
     Returns:
         ``OMIT_TEMPERATURE`` — caller must remove the ``temperature`` key so the
             provider chooses its own default.  Used for all Kimi / Moonshot
-            models whose gateway selects temperature server-side, and for the
-            ChatGPT Codex backend whose Responses endpoint rejects sampling
-            parameters such as ``temperature``.
+            models whose gateway selects temperature server-side.
         ``float`` — a specific value the caller must use (reserved for future
             models with fixed-temperature contracts).
         ``None`` — no override; caller should use its own default.
     """
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
-        return OMIT_TEMPERATURE
-    if _is_codex_backend(base_url):
-        logger.debug("Omitting temperature for Codex backend model %r", model)
         return OMIT_TEMPERATURE
     return None
 
@@ -1362,6 +1347,21 @@ def _is_auth_error(exc: Exception) -> bool:
         return True
     err_lower = str(exc).lower()
     return "error code: 401" in err_lower or "authenticationerror" in type(exc).__name__.lower()
+
+
+def _is_unsupported_temperature_error(exc: Exception) -> bool:
+    """Detect API errors where the selected model rejects temperature."""
+    err_lower = str(exc).lower()
+    if "temperature" not in err_lower:
+        return False
+    return any(marker in err_lower for marker in (
+        "unsupported parameter",
+        "unsupported_parameter",
+        "not supported",
+        "does not support",
+        "unknown parameter",
+        "unrecognized request argument",
+    ))
 
 
 def _evict_cached_clients(provider: str) -> None:
@@ -2967,11 +2967,34 @@ def call_llm(
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
-    # Handle max_tokens vs max_completion_tokens retry, then payment fallback.
+    # Handle unsupported temperature, then max_tokens vs max_completion_tokens retry,
+    # then payment fallback.
     try:
         return _validate_llm_response(
             client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
+            retry_kwargs = dict(kwargs)
+            retry_kwargs.pop("temperature", None)
+            logger.info(
+                "Auxiliary %s: provider rejected temperature; retrying once without it",
+                task or "call",
+            )
+            try:
+                return _validate_llm_response(
+                    client.chat.completions.create(**retry_kwargs), task)
+            except Exception as retry_err:
+                retry_err_str = str(retry_err)
+                if not (
+                    _is_payment_error(retry_err)
+                    or _is_connection_error(retry_err)
+                    or "max_tokens" in retry_err_str
+                    or "unsupported_parameter" in retry_err_str
+                ):
+                    raise
+                first_err = retry_err
+                kwargs = retry_kwargs
+
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
@@ -3236,6 +3259,28 @@ async def async_call_llm(
         return _validate_llm_response(
             await client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
+            retry_kwargs = dict(kwargs)
+            retry_kwargs.pop("temperature", None)
+            logger.info(
+                "Auxiliary %s (async): provider rejected temperature; retrying once without it",
+                task or "call",
+            )
+            try:
+                return _validate_llm_response(
+                    await client.chat.completions.create(**retry_kwargs), task)
+            except Exception as retry_err:
+                retry_err_str = str(retry_err)
+                if not (
+                    _is_payment_error(retry_err)
+                    or _is_connection_error(retry_err)
+                    or "max_tokens" in retry_err_str
+                    or "unsupported_parameter" in retry_err_str
+                ):
+                    raise
+                first_err = retry_err
+                kwargs = retry_kwargs
+
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -42,6 +42,7 @@ import time
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from openai import OpenAI
 
@@ -117,6 +118,15 @@ def _is_kimi_model(model: Optional[str]) -> bool:
     return bare.startswith("kimi-") or bare == "kimi"
 
 
+def _is_codex_backend(base_url: Optional[str]) -> bool:
+    """True for ChatGPT Codex backend endpoints that reject sampling params."""
+    url = str(base_url or "").strip().lower().rstrip("/")
+    path = urlparse(url).path.rstrip("/")
+    return base_url_hostname(url) == "chatgpt.com" and (
+        path == "/backend-api/codex" or path.startswith("/backend-api/codex/")
+    )
+
+
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
@@ -126,13 +136,18 @@ def _fixed_temperature_for_model(
     Returns:
         ``OMIT_TEMPERATURE`` — caller must remove the ``temperature`` key so the
             provider chooses its own default.  Used for all Kimi / Moonshot
-            models whose gateway selects temperature server-side.
+            models whose gateway selects temperature server-side, and for the
+            ChatGPT Codex backend whose Responses endpoint rejects sampling
+            parameters such as ``temperature``.
         ``float`` — a specific value the caller must use (reserved for future
             models with fixed-temperature contracts).
         ``None`` — no override; caller should use its own default.
     """
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
+        return OMIT_TEMPERATURE
+    if _is_codex_backend(base_url):
+        logger.debug("Omitting temperature for Codex backend model %r", model)
         return OMIT_TEMPERATURE
     return None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,7 +22,6 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
-    _build_call_kwargs,
 )
 
 
@@ -65,32 +64,6 @@ class TestNormalizeAuxProvider:
     def test_maps_github_copilot_acp_aliases(self):
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
-
-
-class TestTemperatureOmission:
-    def test_codex_backend_omits_temperature_even_when_caller_sets_it(self):
-        kwargs = _build_call_kwargs(
-            provider="auto",
-            model="gpt-5.5",
-            messages=[{"role": "user", "content": "remember useful facts"}],
-            temperature=0.3,
-            max_tokens=512,
-            base_url="https://chatgpt.com/backend-api/codex/",
-        )
-
-        assert "temperature" not in kwargs
-
-    def test_non_codex_chatgpt_path_keeps_temperature(self):
-        kwargs = _build_call_kwargs(
-            provider="auto",
-            model="gpt-5.5",
-            messages=[{"role": "user", "content": "remember useful facts"}],
-            temperature=0.3,
-            max_tokens=512,
-            base_url="https://chatgpt.com/not-codex?next=/backend-api/codex",
-        )
-
-        assert kwargs["temperature"] == 0.3
 
 
 class TestReadCodexAccessToken:
@@ -669,6 +642,70 @@ class TestNousAuxiliaryRefresh:
         assert result == {"ok": True}
         assert stale_client.chat.completions.create.await_count == 1
         assert fresh_async_client.chat.completions.create.await_count == 1
+
+
+class TestUnsupportedTemperatureRetry:
+    def test_call_llm_retries_once_without_temperature(self):
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create.side_effect = [
+            RuntimeError(
+                "HTTP 400: Error code: 400 - {'detail': 'Unsupported parameter: temperature'}"
+            ),
+            {"ok": True},
+        ]
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response", side_effect=lambda resp, _task: resp),
+        ):
+            result = call_llm(
+                task="flush_memories",
+                messages=[{"role": "user", "content": "remember this"}],
+                temperature=0.3,
+                max_tokens=500,
+            )
+
+        assert result == {"ok": True}
+        assert client.chat.completions.create.call_count == 2
+        first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert first_kwargs["temperature"] == 0.3
+        assert "temperature" not in retry_kwargs
+        assert retry_kwargs["max_tokens"] == 500
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_retries_once_without_temperature(self):
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create = AsyncMock(side_effect=[
+            RuntimeError(
+                "HTTP 400: Error code: 400 - {'detail': 'Unsupported parameter: temperature'}"
+            ),
+            {"ok": True},
+        ])
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response", side_effect=lambda resp, _task: resp),
+        ):
+            result = await async_call_llm(
+                task="flush_memories",
+                messages=[{"role": "user", "content": "remember this"}],
+                temperature=0.3,
+                max_tokens=500,
+            )
+
+        assert result == {"ok": True}
+        assert client.chat.completions.create.await_count == 2
+        first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert first_kwargs["temperature"] == 0.3
+        assert "temperature" not in retry_kwargs
+        assert retry_kwargs["max_tokens"] == 500
+
 
 # ── Payment / credit exhaustion fallback ─────────────────────────────────
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,7 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
+    _build_call_kwargs,
 )
 
 
@@ -64,6 +65,32 @@ class TestNormalizeAuxProvider:
     def test_maps_github_copilot_acp_aliases(self):
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
+
+
+class TestTemperatureOmission:
+    def test_codex_backend_omits_temperature_even_when_caller_sets_it(self):
+        kwargs = _build_call_kwargs(
+            provider="auto",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "remember useful facts"}],
+            temperature=0.3,
+            max_tokens=512,
+            base_url="https://chatgpt.com/backend-api/codex/",
+        )
+
+        assert "temperature" not in kwargs
+
+    def test_non_codex_chatgpt_path_keeps_temperature(self):
+        kwargs = _build_call_kwargs(
+            provider="auto",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "remember useful facts"}],
+            temperature=0.3,
+            max_tokens=512,
+            base_url="https://chatgpt.com/not-codex?next=/backend-api/codex",
+        )
+
+        assert kwargs["temperature"] == 0.3
 
 
 class TestReadCodexAccessToken:


### PR DESCRIPTION
## Summary
- Retry auxiliary LLM calls once without `temperature` when the provider returns `Unsupported parameter: temperature`
- Preserve normal temperature behavior for models/backends that accept it
- Keep existing Kimi/Moonshot server-managed temperature omission unchanged
- Add sync and async regression coverage for the adaptive retry path

## Why
The observed failure is model-contract specific: the same backend can accept `temperature` for some models (for example gpt-5.4) while rejecting it for others (for example gpt-5.5). Retrying on the concrete unsupported-parameter error avoids turning this into a backend-wide rule.

## Test Plan
- `python -m pytest tests/agent/test_auxiliary_client.py::TestUnsupportedTemperatureRetry tests/agent/test_auxiliary_client.py::TestKimiTemperatureOmitted tests/run_agent/test_flush_memories_codex.py -q -o 'addopts='` → 32 passed
- `python -m pytest tests/agent/test_auxiliary_client.py tests/run_agent/test_flush_memories_codex.py -q -o 'addopts='` → 103 passed
- `git diff --check origin/main...HEAD` → clean

Authored-by: Ash Rowan Vale 🌿 <ash@users.noreply.github.com>
