### PR TITLE
fix(terminal): use monotonic timestamps for env inactivity cleanup

### DIFF
--- a/tests/tools/test_terminal_inactivity_cleanup.py
+++ b/tests/tools/test_terminal_inactivity_cleanup.py
@@ -1,0 +1,105 @@
+"""Regression tests for monotonic terminal inactivity bookkeeping."""
+
+import json
+import sys
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_env_config(**overrides):
+    config = {
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+    config.update(overrides)
+    return config
+
+
+class _DummyEnv:
+    def __init__(self):
+        self.cleaned = 0
+
+    def cleanup(self):
+        self.cleaned += 1
+
+
+def test_cleanup_inactive_envs_ignores_wall_clock_jumps(monkeypatch):
+    """Idle reaping should key off monotonic elapsed time, not wall clock."""
+    import tools.terminal_tool as terminal_tool_module
+
+    env = _DummyEnv()
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.process_registry",
+        SimpleNamespace(
+            process_registry=SimpleNamespace(
+                has_active_processes=lambda _task_id: False
+            )
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.file_tools",
+        SimpleNamespace(clear_file_ops_cache=lambda _task_id: None),
+    )
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {"task-1": env},
+    )
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_last_activity",
+        {"task-1": 1000.0},
+    )
+    monkeypatch.setattr(terminal_tool_module, "_creation_locks", {})
+    monkeypatch.setattr(terminal_tool_module, "_creation_locks_lock", threading.Lock())
+    monkeypatch.setattr(terminal_tool_module, "_env_lock", threading.Lock())
+    monkeypatch.setattr(terminal_tool_module, "_activity_now", lambda: 1100.0)
+    monkeypatch.setattr(terminal_tool_module.time, "time", lambda: 10_000_000.0)
+
+    terminal_tool_module._cleanup_inactive_envs(lifetime_seconds=300)
+
+    assert "task-1" in terminal_tool_module._active_environments
+    assert terminal_tool_module._last_activity["task-1"] == 1000.0
+    assert env.cleaned == 0
+
+
+def test_existing_env_refresh_uses_monotonic_activity_timestamp(monkeypatch):
+    """Reusing an env should stamp _last_activity from the monotonic helper."""
+    import tools.terminal_tool as terminal_tool_module
+
+    env = MagicMock()
+    env.execute.return_value = {"output": "done", "returncode": 0}
+    last_activity = {"default": 0.0}
+
+    monkeypatch.setattr(terminal_tool_module, "_activity_now", lambda: 123.0)
+    monkeypatch.setattr(terminal_tool_module.time, "time", lambda: 99_999.0)
+
+    with patch(
+        "tools.terminal_tool._get_env_config",
+        return_value=_make_env_config(),
+    ), patch(
+        "tools.terminal_tool._start_cleanup_thread",
+        lambda: None,
+    ), patch(
+        "tools.terminal_tool._check_all_guards",
+        return_value={"approved": True},
+    ), patch(
+        "tools.terminal_tool._active_environments",
+        {"default": env},
+    ), patch(
+        "tools.terminal_tool._last_activity",
+        last_activity,
+    ):
+        result = json.loads(terminal_tool_module.terminal_tool(command="echo hello"))
+        assert result["error"] is None
+        assert last_activity["default"] == 123.0

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -765,6 +765,11 @@ _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
 
+
+def _activity_now() -> float:
+    """Return a monotonic timestamp for in-process inactivity bookkeeping."""
+    return time.monotonic()
+
 # Per-task environment overrides registry.
 # Allows environments (e.g., TerminalBench2Env) to specify a custom Docker/Modal
 # image for a specific task_id BEFORE the agent loop starts. When the terminal or
@@ -1040,7 +1045,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
 def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     """Clean up environments that have been inactive for longer than lifetime_seconds."""
-    current_time = time.time()
+    current_time = _activity_now()
 
     # Check the process registry -- skip cleanup for sandboxes with active
     # background processes (their _last_activity gets refreshed to keep them alive).
@@ -1501,7 +1506,7 @@ def terminal_tool(
         # instead of each creating their own (wasting Modal resources).
         with _env_lock:
             if effective_task_id in _active_environments:
-                _last_activity[effective_task_id] = time.time()
+                _last_activity[effective_task_id] = _activity_now()
                 env = _active_environments[effective_task_id]
                 needs_creation = False
             else:
@@ -1518,7 +1523,7 @@ def terminal_tool(
                 # Double-check after acquiring the per-task lock
                 with _env_lock:
                     if effective_task_id in _active_environments:
-                        _last_activity[effective_task_id] = time.time()
+                        _last_activity[effective_task_id] = _activity_now()
                         env = _active_environments[effective_task_id]
                         needs_creation = False
 
@@ -1578,7 +1583,7 @@ def terminal_tool(
 
                     with _env_lock:
                         _active_environments[effective_task_id] = new_env
-                        _last_activity[effective_task_id] = time.time()
+                        _last_activity[effective_task_id] = _activity_now()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 


### PR DESCRIPTION

**PR Description**

Terminal environment cleanup was using wall-clock time for `_last_activity` bookkeeping. That makes cleanup decisions vulnerable to clock changes such as NTP adjustments, VM suspend/resume, or manual time changes.

This PR switches the in-memory inactivity tracking to monotonic time so cleanup is based on elapsed time rather than the system clock.

### What changed

* Added an `_activity_now()` helper backed by `time.monotonic()`
* Updated terminal environment activity refresh paths to use that helper
* Updated inactive environment cleanup to compare monotonic timestamps
* Added focused regression coverage for clock-jump behavior and env reuse activity refresh

### Why

`time.time()` can move forwards or backwards. For idle cleanup, that can produce incorrect behavior:

* a forward wall-clock jump may clean up an active environment too early
* a backward wall-clock jump may keep an inactive environment around longer than intended

`time.monotonic()` is the correct source for elapsed-time decisions inside a running process.

### Files changed

```text
tools/terminal_tool.py
tests/tools/test_terminal_inactivity_cleanup.py
```

### Tests



```bash
scripts/run_tests.sh tests/tools/test_terminal_inactivity_cleanup.py tests/tools/test_terminal_tool.py
```


```text
12 passed
```

