### PR TITLE
Support image icons for dashboard plugins

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1663,6 +1663,29 @@ class TestDashboardPluginManifestExtensions:
         assert "hidden" not in entry["tab"]
         assert "override" not in entry["tab"]
 
+    def test_image_icon_manifest_is_carried_through(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "image-icon", {
+            "name": "image-icon",
+            "label": "Image Icon",
+            "icon": {
+                "type": "image",
+                "src": "dist/image-icon.png",
+                "alt": "Image icon logo",
+            },
+            "tab": {"path": "/image-icon"},
+            "entry": "dist/index.js",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "image-icon")
+        assert entry["icon"] == {
+            "type": "image",
+            "src": "dist/image-icon.png",
+            "alt": "Image icon logo",
+        }
+
     def test_slots_filters_non_string_entries(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         self._write_plugin(tmp_path, "mixed-slots", {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -144,6 +144,32 @@ function resolveIcon(name: string): ComponentType<{ className?: string }> {
   return ICON_MAP[name] ?? Puzzle;
 }
 
+function isImageIconSpec(
+  icon: PluginManifest["icon"],
+): icon is { type: "image"; src: string; alt?: string } {
+  return (
+    typeof icon === "object" &&
+    icon !== null &&
+    icon.type === "image" &&
+    typeof icon.src === "string" &&
+    icon.src.length > 0
+  );
+}
+
+function resolvePluginImageIcon(
+  manifest: PluginManifest,
+): NavItem["imageIcon"] | undefined {
+  if (!isImageIconSpec(manifest.icon)) return undefined;
+  const src = manifest.icon.src;
+  const isAbsolute = /^(https?:|data:|\/)/.test(src);
+  return {
+    src: isAbsolute
+      ? src
+      : `/dashboard-plugins/${manifest.name}/${src.replace(/^\/+/, "")}`,
+    alt: manifest.icon.alt ?? `${manifest.label} icon`,
+  };
+}
+
 function buildNavItems(builtIn: NavItem[], manifests: PluginManifest[]): NavItem[] {
   const items = [...builtIn];
 
@@ -154,7 +180,10 @@ function buildNavItems(builtIn: NavItem[], manifests: PluginManifest[]): NavItem
     const pluginItem: NavItem = {
       path: manifest.tab.path,
       label: manifest.label,
-      icon: resolveIcon(manifest.icon),
+      icon: resolveIcon(
+        typeof manifest.icon === "string" ? manifest.icon : "Puzzle",
+      ),
+      imageIcon: resolvePluginImageIcon(manifest),
     };
 
     const pos = manifest.tab.position ?? "end";
@@ -421,7 +450,7 @@ export default function App() {
               aria-label={t.app.navigation}
             >
               <ul className="flex flex-col">
-                {navItems.map(({ path, label, labelKey, icon: Icon }) => {
+                {navItems.map(({ path, label, labelKey, icon: Icon, imageIcon }) => {
                   const navLabel = labelKey
                     ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
                     : label;
@@ -449,7 +478,17 @@ export default function App() {
                       >
                         {({ isActive }) => (
                           <>
-                            <Icon className="h-3.5 w-3.5 shrink-0" />
+                            {imageIcon ? (
+                              <img
+                                src={imageIcon.src}
+                                alt=""
+                                aria-hidden="true"
+                                className="h-4 w-4 shrink-0 object-contain"
+                                title={imageIcon.alt}
+                              />
+                            ) : (
+                              <Icon className="h-3.5 w-3.5 shrink-0" />
+                            )}
                             <span className="truncate">{navLabel}</span>
 
                             <span
@@ -645,6 +684,10 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
 
 interface NavItem {
   icon: ComponentType<{ className?: string }>;
+  imageIcon?: {
+    alt: string;
+    src: string;
+  };
   label: string;
   labelKey?: string;
   path: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -507,11 +507,19 @@ export interface DashboardThemesResponse {
 
 // ── Dashboard plugin types ─────────────────────────────────────────────
 
+export type PluginIconResponse =
+  | string
+  | {
+      type: "image";
+      src: string;
+      alt?: string;
+    };
+
 export interface PluginManifestResponse {
   name: string;
   label: string;
   description: string;
-  icon: string;
+  icon: PluginIconResponse;
   version: string;
   tab: {
     path: string;

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -2,11 +2,19 @@
 
 import type { ComponentType } from "react";
 
+export type PluginIcon =
+  | string
+  | {
+      type: "image";
+      src: string;
+      alt?: string;
+    };
+
 export interface PluginManifest {
   name: string;
   label: string;
   description: string;
-  icon: string;
+  icon: PluginIcon;
   version: string;
   tab: {
     path: string;

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -396,7 +396,7 @@ Write the JS bundle (a plain IIFE — no build step needed):
 })();
 ```
 
-Refresh the dashboard — your tab appears in the nav bar, after **Skills**.
+Refresh the dashboard — your tab appears in the left sidebar, after **Skills**.
 
 :::tip Skip React.createElement
 If you prefer JSX, use any bundler (esbuild, Vite, rollup) with React as an external and IIFE output. The only hard requirement is that the final file is a single JS file loadable via `<script>`. React is never bundled; it comes from `SDK.React`.
@@ -431,7 +431,11 @@ None of them are required; include only the layers you need.
   "name": "my-plugin",
   "label": "My Plugin",
   "description": "What this plugin does",
-  "icon": "Sparkles",
+  "icon": {
+    "type": "image",
+    "src": "dist/my-plugin-icon.png",
+    "alt": "My Plugin logo"
+  },
   "version": "1.0.0",
   "tab": {
     "path": "/my-plugin",
@@ -451,7 +455,7 @@ None of them are required; include only the layers you need.
 | `name` | Yes | Unique plugin identifier. Lowercase, hyphens ok. Used in URLs and registration. |
 | `label` | Yes | Display name shown in the nav tab. |
 | `description` | No | Short description (shown in dashboard admin surfaces). |
-| `icon` | No | Lucide icon name. Defaults to `Puzzle`. Unknown names fall back to `Puzzle`. |
+| `icon` | No | Lucide icon name (for example `"Sparkles"`) or an image icon object (`{"type":"image","src":"dist/logo.png","alt":"Logo"}`). Relative image paths resolve from the plugin's `dashboard/` directory via `/dashboard-plugins/<name>/<path>`. Defaults to `Puzzle`; unknown Lucide names fall back to `Puzzle`. |
 | `version` | No | Semver string. Defaults to `0.0.0`. |
 | `tab.path` | Yes | URL path for the tab (e.g. `/my-plugin`). |
 | `tab.position` | No | Where to insert the tab. `"end"` (default), `"after:<path>"`, or `"before:<path>"` — value after the colon is the **path segment** of the target tab (no leading slash). Examples: `"after:skills"`, `"before:config"`. |
@@ -464,7 +468,21 @@ None of them are required; include only the layers you need.
 
 #### Available icons
 
-Plugins use Lucide icon names. The dashboard maps these by name — unknown names silently fall back to `Puzzle`.
+Plugins can use Lucide icon names or image icons. For product marks in the left sidebar, prefer an image icon object in the manifest:
+
+```json
+{
+  "icon": {
+    "type": "image",
+    "src": "dist/product-logo.png",
+    "alt": "Product logo"
+  }
+}
+```
+
+`src` may be an absolute URL, a data URL, a root-relative URL, or a path relative to the plugin's `dashboard/` directory. Relative paths are served from `/dashboard-plugins/<name>/<path>`.
+
+For Lucide icons, the dashboard maps names by string — unknown names silently fall back to `Puzzle`.
 
 Currently mapped: `Activity`, `BarChart3`, `Clock`, `Code`, `Database`, `Eye`, `FileText`, `Globe`, `Heart`, `KeyRound`, `MessageSquare`, `Package`, `Puzzle`, `Settings`, `Shield`, `Sparkles`, `Star`, `Terminal`, `Wrench`, `Zap`.
 


### PR DESCRIPTION
Adds support for dashboard plugin manifests to specify image icons in addition to Lucide icon names. This lets product plugins render their logo in the left sidebar while keeping the existing Lucide fallback behavior.\n\nChanges:\n- Accepts manifest icon objects like { type: 'image', src, alt } in web/plugin types.\n- Renders relative image icon paths through /dashboard-plugins/<name>/<path>.\n- Documents the image icon protocol in the dashboard extension guide.\n- Adds a backend discovery regression test proving image icon objects are carried through.\n\nVerification:\n- npm run build (web)\n- npx eslint src/App.tsx src/lib/api.ts src/plugins/types.ts\n- source venv/bin/activate && pytest tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions -q