### PR TITLE
fix: recalculate token budgets on model switch in ContextCompressor

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -318,6 +318,13 @@ class ContextCompressor(ContextEngine):
             int(context_length * self.threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
         )
+        # Recalculate token budgets for the new context length so the
+        # compressor stays calibrated after a model switch (e.g. 200K → 32K).
+        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
+        self.tail_token_budget = target_tokens
+        self.max_summary_tokens = min(
+            int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
 
     def __init__(
         self,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -847,6 +847,32 @@ class TestTokenBudgetTailProtection:
         assert isinstance(pruned, int)
 
 
+class TestUpdateModelBudgets:
+    """Regression: update_model() must recalculate token budgets."""
+
+    def test_tail_budget_recalculated(self):
+        """tail_token_budget must change after switching to a different context length."""
+        from unittest.mock import patch
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            comp = ContextCompressor("model-a", threshold_percent=0.50, quiet_mode=True)
+        old_tail = comp.tail_token_budget
+        old_max_summary = comp.max_summary_tokens
+
+        comp.update_model("model-b", context_length=32_000)
+        assert comp.tail_token_budget != old_tail, "tail_token_budget should change"
+        assert comp.tail_token_budget < old_tail, "smaller context → smaller budget"
+        assert comp.max_summary_tokens != old_max_summary, "max_summary_tokens should change"
+
+    def test_budgets_proportional(self):
+        """Budgets should be proportional to context_length after update."""
+        from unittest.mock import patch
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            comp = ContextCompressor("model-a", threshold_percent=0.50, quiet_mode=True)
+        comp.update_model("model-b", context_length=10_000)
+        assert comp.tail_token_budget == int(comp.threshold_tokens * comp.summary_target_ratio)
+        assert comp.max_summary_tokens == min(int(10_000 * 0.05), 4000)
+
+
 class TestTruncateToolCallArgsJson:
     """Regression tests for #11762.
 


### PR DESCRIPTION
## Summary

Salvage of #14630 by @vominh1919, rebased onto current main with merge conflicts resolved.

- `update_model()` recalculated `threshold_tokens` but left `tail_token_budget` and `max_summary_tokens` at their `__init__` values
- After switching from a 1M context model (Opus 4.6) to 96K (gemma-3-4b-it), the tail budget stayed at 100,000 tokens — **104% of the new context window**
- Adds budget recalculation in `update_model()` mirroring the `__init__` logic
- 2 regression tests in `TestUpdateModelBudgets`

## Verified live

1. On **main** (unfixed): started hermes on Opus 4.6, `/model gemma-3-4b-it`, `/compress` → logs showed `tail_budget=100000 max_summary=12000` (stale from 1M init)
2. On **this branch** (fixed): same flow → logs showed `tail_budget=13107 max_summary=6553` (correctly recalculated for 131K context)

## Test plan

- [x] `pytest tests/agent/test_context_compressor.py -n0 -q` — 52 passed
- [x] Live E2E: hermes chat → 4 messages → `/model gemma-3-4b` → `/compress` → verified budgets recalculated in agent.log
- [x] Edge cases verified: same-size switch (no-op), scale-up (ceiling cap works), tiny model below MINIMUM_CONTEXT_LENGTH floor (pre-existing, not introduced by this PR)