### PR TITLE
fix(gateway): clear stale scoped locks for reused PIDs

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -124,11 +124,27 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     try:
         raw = cmdline_path.read_bytes()
     except (FileNotFoundError, PermissionError, OSError):
-        return None
+        raw = None
 
-    if not raw:
+    if raw:
+        return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+
+    # macOS does not expose /proc, so fall back to ps.  This is important for
+    # stale-lock detection when kernel start_time is unavailable and a PID has
+    # been reused by a non-Hermes process.
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
         return None
-    return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+    if result.returncode != 0:
+        return None
+    cmdline = result.stdout.strip()
+    return cmdline or None
 
 
 def _looks_like_gateway_process(pid: int) -> bool:
@@ -510,6 +526,13 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     existing.get("start_time") is not None
                     and current_start is not None
                     and current_start != existing.get("start_time")
+                ):
+                    stale = True
+                if (
+                    not stale
+                    and existing.get("start_time") is None
+                    and current_start is None
+                    and not _looks_like_gateway_process(existing_pid)
                 ):
                     stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -366,6 +366,29 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_replaces_reused_pid_when_process_is_not_gateway(self, tmp_path, monkeypatch):
+        """On macOS start_time can be unavailable; a reused PID must not keep a stale gateway lock alive."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["/repo/hermes_cli/main.py", "gateway", "run", "--replace"],
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/System/Library/Speech/localspeechrecognition")
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
     def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
         """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))


### PR DESCRIPTION
## Summary
- Fall back to `ps` for process command-line detection when `/proc` is unavailable, such as on macOS.
- Treat scoped lock records with unavailable start times as stale when the live reused PID no longer looks like a Hermes gateway process.
- Add regression coverage for stale Telegram bot-token locks pointing at a non-Hermes reused PID.

## Test Plan
- `/Users/santimasiri/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_status.py -q`

Local deploy verification:
- Restarted `ai.hermes.gateway` via launchctl.
- Verified Telegram reconnect in logs: `✓ telegram connected`.
