### PR TITLE
fix(config): honor model.context_window as context_length alias

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4294,8 +4294,12 @@ class GatewayRunner:
                     elif isinstance(_model_cfg, dict):
                         _hyg_model = _model_cfg.get("default") or _model_cfg.get("model") or _hyg_model
                         # Read explicit context_length override from model config
-                        # (same as run_agent.py lines 995-1005)
+                        # (same as run_agent.py). Accept context_window as a
+                        # compatibility alias for users who mirror provider
+                        # metadata into config.yaml.
                         _raw_ctx = _model_cfg.get("context_length")
+                        if _raw_ctx is None:
+                            _raw_ctx = _model_cfg.get("context_window")
                         if _raw_ctx is not None:
                             try:
                                 _hyg_config_context_length = int(_raw_ctx)
@@ -4959,6 +4963,8 @@ class GatewayRunner:
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
                     raw_ctx = model_cfg.get("context_length")
+                    if raw_ctx is None:
+                        raw_ctx = model_cfg.get("context_window")
                     if raw_ctx is not None:
                         try:
                             config_context_length = int(raw_ctx)
@@ -4990,7 +4996,7 @@ class GatewayRunner:
         if config_context_length is not None:
             ctx_source = "config"
         elif context_length == DEFAULT_FALLBACK_CONTEXT:
-            ctx_source = "default — set model.context_length in config to override"
+            ctx_source = "default — set model.context_length or model.context_window in config to override"
         else:
             ctx_source = "detected"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1740,10 +1740,14 @@ class AIAgent:
                 _aux_context_config = None
         self._aux_compression_context_length_config = _aux_context_config
 
-        # Read explicit context_length override from model config
+        # Read explicit context_length override from model config. Accept
+        # context_window as a compatibility alias because users commonly copy
+        # provider metadata keys into config.yaml.
         _model_cfg = _agent_cfg.get("model", {})
         if isinstance(_model_cfg, dict):
             _config_context_length = _model_cfg.get("context_length")
+            if _config_context_length is None:
+                _config_context_length = _model_cfg.get("context_window")
         else:
             _config_context_length = None
         if _config_context_length is not None:

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -393,3 +393,96 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
     assert FakeCompressAgent.last_instance is not None
     FakeCompressAgent.last_instance.shutdown_memory_provider.assert_called_once()
     FakeCompressAgent.last_instance.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_honors_context_window_alias(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        init_count = 0
+
+        def __init__(self, **kwargs):
+            type(self).init_count += 1
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  default: test-model\n"
+        "  context_window: 1000000\n",
+        encoding="utf-8",
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:dm:123",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.load_transcript.return_value = _make_large_history_tokens(120_000)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **kwargs: kwargs.get("config_context_length") or 128_000,
+    )
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            user_id="u1",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert FakeCompressAgent.init_count == 0

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -52,6 +52,15 @@ class TestFormatSessionInfo:
         assert "32K" in info
         assert "config" in info
 
+    def test_context_window_alias(self, runner, tmp_path):
+        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: test-model\n  context_window: 1000000\n",
+                                  "test-model",
+                                  {"provider": "custom", "base_url": "", "api_key": ""})
+        with p1, p2, p3:
+            info = runner._format_session_info()
+        assert "1.0M" in info
+        assert "config" in info
+
     def test_default_fallback_hint(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: unknown-model-xyz\n",
                                   "unknown-model-xyz",
@@ -59,7 +68,7 @@ class TestFormatSessionInfo:
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "128K" in info
-        assert "model.context_length" in info
+        assert "model.context_length or model.context_window" in info
 
     def test_local_endpoint_shown(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -68,6 +68,17 @@ def test_string_numeric_context_length_works():
         assert "Invalid" not in str(c)
 
 
+def test_context_window_alias_works():
+    """model.context_window should behave like model.context_length."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({"default": "gpt5.4", "provider": "custom",
+                              "base_url": "http://localhost:4000/v1",
+                              "context_window": 256000})
+    assert agent._config_context_length == 256000
+    for c in mock_logger.warning.call_args_list:
+        assert "Invalid" not in str(c)
+
+
 def test_custom_providers_invalid_context_length_warns():
     """Invalid context_length in custom_providers should warn."""
     custom_providers = [


### PR DESCRIPTION
**PR Description**

This PR makes `model.context_window` work as a compatibility alias for `model.context_length` in explicit config override paths.

Hermes already accepts `context_window` in model metadata parsing, but a few manual config-reading paths only checked `model.context_length`. As a result, users who configured:

```yaml
model:
  context_window: 1000000
```

could still see Hermes fall back to the detected/default context value instead of using the configured override.

This caused incorrect context behavior in agent initialization and gateway status/hygiene flows.

### What was fixed

The following paths now read `model.context_window` when `model.context_length` is not set:

* agent initialization in `run_agent.py`
* gateway session hygiene context resolution in `gateway/run.py`
* gateway session info/status formatting in `gateway/run.py`

`model.context_length` still takes precedence when both values are present.

### Why this matters

Without this alias, users may believe they configured a larger context window, while Hermes silently ignores it in some runtime paths.

That can lead to:

* incorrect context size shown in gateway/session info
* premature context pressure or compression behavior
* hygiene logic making decisions based on the wrong context limit

### Behavior

Priority order is now:

```text
model.context_length
model.context_window
detected/default context value
```

Invalid values continue to use the existing warning/fallback behavior.

### Tests

Added regression coverage for the affected paths:

* `test_context_window_alias_works`
* `test_context_window_alias`
* `test_session_hygiene_honors_context_window_alias`



```bash
scripts/run_tests.sh tests/run_agent/test_invalid_context_length_warning.py tests/gateway/test_session_info.py tests/gateway/test_session_hygiene.py
```

Result:

```text
36 passed, 4 warnings
```


