### PR TITLE
fix(gateway/base): respect voice.auto_tts config for inbound voice messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2221,17 +2221,22 @@ class BasePlatformAdapter(ABC):
                         and not media_files
                         and event.source.chat_id not in self._auto_tts_disabled_chats):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
-                        if check_tts_requirements():
-                            import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
-                            if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
-                            )
-                            tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
+                        from hermes_cli.config import load_config
+                        voice_cfg = load_config().get("voice", {})
+                        if not voice_cfg.get("auto_tts", False):
+                            logger.debug("[%s] Auto-TTS skipped: voice.auto_tts is false in config", self.name)
+                        else:
+                            from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                            if check_tts_requirements():
+                                import json as _json
+                                speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+                                if not speech_text:
+                                    raise ValueError("Empty text after markdown cleanup")
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                                tts_data = _json.loads(tts_result_str)
+                                _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 


### PR DESCRIPTION
## Problem

When a user sends a voice message to the Hermes gateway (Telegram, Discord, etc.), the gateway unconditionally triggers text-to-speech for the reply — even when `voice.auto_tts: false` is explicitly set in `config.yaml`.

This happens because the auto-TTS block in `gateway/platforms/base.py` only checks:
1. `event.message_type == MessageType.VOICE`
2. `chat_id not in self._auto_tts_disabled_chats` (per-chat override from `/voice off`)

It never consults the global `voice.auto_tts` flag from the configuration file, so users who set `auto_tts: false` still receive robotic Edge TTS replies every time they send a voice message.

## Why the texts differ

The gateway strips markdown (`*`, `_`, `` ` ``, `#`, `[]`, `()`) before synthesizing speech, so the spoken text never matches the text message. This creates a confusing "double reply" experience where the user hears one version and reads another.

## Root cause (architectural)

`auto_tts` was originally designed for the **CLI entry point**, where it is properly respected. The **Gateway entry point** added auto-TTS later as a "voice-first UX" feature but only checked the per-chat `_auto_tts_disabled_chats` set — it never reads the global `voice.auto_tts` value. This is a divergence between two entry points in the same codebase.

## Fix

Before calling `text_to_speech_tool()`, check `load_config().get("voice", {}).get("auto_tts", False)` and skip TTS generation when the global config is disabled.

## Files changed

- `gateway/platforms/base.py` — Added config check inside the `MessageType.VOICE` auto-TTS block.

## How to verify

1. Set `voice.auto_tts: false` in `~/.hermes/config.yaml`
2. Restart gateway (`hermes gateway restart`)
3. Send a voice message to the bot from Telegram
4. The bot should reply with **text only**, no voice attachment

---

Fixes the behavior reported where `auto_tts: false` is silently ignored by the gateway.
