### PR TITLE
fix(honcho): allow identity command with self-hosted baseUrl

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -278,6 +278,14 @@ def _resolve_api_key(cfg: dict) -> str:
     return host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
 
 
+def _has_honcho_auth_or_local(cfg: dict) -> bool:
+    """Return whether Honcho commands can connect to cloud or self-hosted Honcho."""
+    if _resolve_api_key(cfg):
+        return True
+    host_cfg = (cfg.get("hosts") or {}).get(_host_key()) or {}
+    return bool(host_cfg.get("baseUrl") or cfg.get("baseUrl"))
+
+
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
     suffix = f" [{default}]" if default else ""
     sys.stdout.write(f"  {label}{suffix}: ")
@@ -975,8 +983,8 @@ def cmd_tokens(args) -> None:
 def cmd_identity(args) -> None:
     """Seed AI peer identity or show both peer representations."""
     cfg = _read_config()
-    if not _resolve_api_key(cfg):
-        print("  No API key configured. Run 'hermes honcho setup' first.\n")
+    if not _has_honcho_auth_or_local(cfg):
+        print("  No API key or self-hosted baseUrl configured. Run 'hermes honcho setup' first.\n")
         return
 
     file_path = getattr(args, "file", None)

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -3,6 +3,26 @@
 from types import SimpleNamespace
 
 
+class TestHonchoAuthDetection:
+    def test_accepts_host_base_url_without_api_key(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        assert honcho_cli._has_honcho_auth_or_local(  # pyright: ignore[reportPrivateUsage]
+            {"hosts": {"hermes": {"baseUrl": "http://127.0.0.1:8000"}}}
+        )
+
+    def test_rejects_missing_api_key_and_base_url(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        assert not honcho_cli._has_honcho_auth_or_local({})  # pyright: ignore[reportPrivateUsage]
+
+
 class TestCmdStatus:
     def test_reports_connection_failure_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):
         import plugins.memory.honcho.cli as honcho_cli


### PR DESCRIPTION
## Summary
- allow `hermes honcho identity` to run when Honcho is configured with a self-hosted `baseUrl` but no API key
- preserve the existing API key check for cloud Honcho
- add focused coverage for host-level local baseUrl detection

## Motivation
Self-hosted/local Honcho setups can be no-auth, and other Honcho paths already treat `baseUrl` as sufficient connection configuration. The identity command currently exits early with “No API key configured” before it can connect to a local Honcho server.

## Tests
- `.venv/bin/python -m pytest tests/honcho_plugin/test_cli.py -q`