### PR TITLE
fix(tui): handle empty bracketed paste fallback

### DIFF
--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -746,8 +746,8 @@ export function TextInput({
         } else {
           v = v.slice(0, c)
         }
-      } else if (inp.length > 0) {
-        const bracketed = inp.includes('[200~')
+      } else if (event.keypress.isPasted || inp.length > 0) {
+        const bracketed = event.keypress.isPasted || inp.includes('[200~')
         const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 
         if (bracketed && emitPaste({ bracketed: true, cursor: c, text, value: v })) {

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -28,7 +28,7 @@ declare module '@hermes/ink' {
   export type InputEvent = {
     readonly input: string
     readonly key: Key
-    readonly keypress: { readonly raw?: string }
+    readonly keypress: { readonly isPasted?: boolean; readonly raw?: string }
   }
 
   export type InputHandler = (input: string, key: Key, event: InputEvent) => void


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI composer path for empty bracketed paste events so image-only clipboard paste can fall through to the existing clipboard image attachment logic.

The Ink parser already marks bracketed paste events with `keypress.isPasted`, including empty paste payloads. The composer was still checking for raw bracketed-paste marker text in `input`, but those markers have already been consumed by the parser. That meant an empty bracketed paste could reach the TUI and then be ignored instead of triggering the `/paste`-style clipboard image fallback.

This keeps the change intentionally small: use the parser's `isPasted` signal in `TextInput`, and expose that field in the local `@hermes/ink` type shim.

Rebased on latest `origin/main` and force-pushed after validation. Current PR commit:

```text
6f1ed9f2 fix(tui): handle empty bracketed paste fallback
```

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: treats `event.keypress.isPasted` as a bracketed paste signal, including empty paste payloads.
- `ui-tui/src/types/hermes-ink.d.ts`: adds `isPasted` to the local `InputEvent.keypress` type shim.

## How to Test

1. Copy an image to the OS clipboard.
2. Run `hermes --tui` in a terminal that emits bracketed paste for image-only clipboard paste.
3. Press the terminal paste binding and confirm the TUI routes the empty paste event into clipboard image attachment instead of doing nothing.

Targeted checks run:

```bash
cd ui-tui
npm test -- src/__tests__/useComposerState.test.ts src/__tests__/clipboard.test.ts
```

Result after rebase:

```text
Test Files  2 passed (2)
Tests  21 passed (21)
```

Full suite run:

```bash
scripts/run_tests.sh
```

The canonical script pins pytest-xdist to `-n 4` and ignores integration/e2e. Result after rebase:

```text
68 failed, 15625 passed, 40 skipped, 181 warnings in 382.93s (0:06:22)
```

The failures are broad existing/current-main test failures outside this TUI paste diff, clustered around gateway approval/config, DingTalk card lifecycle, Discord gateway behavior, provider/config validation, backup/profile restoration, Tirith/security helper behavior, Modal tool resolution, and TUI gateway provider resolution. No failure points at the two changed TUI paste files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: targeted TUI unit tests on Linux/WSL checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — this targets terminal paste behavior seen from macOS and Windows Terminal/WSL paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused test output:

```text
Test Files  2 passed (2)
Tests  21 passed (21)
```

Full suite output summary:

```text
68 failed, 15625 passed, 40 skipped, 181 warnings in 382.93s (0:06:22)
```
