### PR TITLE
fix(cli): support IPv6 loopback and 0.0.0.0 for model auto-detection

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -117,7 +117,7 @@ def _get_model_config() -> Dict[str, Any]:
             cfg["default"] = cfg["model"]
         default = (cfg.get("default") or "").strip()
         base_url = (cfg.get("base_url") or "").strip()
-        is_local = "localhost" in base_url or "127.0.0.1" in base_url
+        is_local = _loopback_hostname(base_url_hostname(base_url))
         is_fallback = not default
         if is_local and is_fallback and base_url:
             detected = _auto_detect_local_model(base_url)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,6 +1,44 @@
 from hermes_cli import runtime_provider as rp
 
 
+def test_get_model_config_auto_detects_ipv6_loopback_local_model(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {"model": {"base_url": "http://[::1]:11434/v1", "default": ""}},
+    )
+    called = []
+    monkeypatch.setattr(
+        rp,
+        "_auto_detect_local_model",
+        lambda base_url: called.append(base_url) or "llama3",
+    )
+
+    resolved = rp._get_model_config()
+
+    assert resolved["default"] == "llama3"
+    assert called == ["http://[::1]:11434/v1"]
+
+
+def test_get_model_config_auto_detects_zero_bind_local_model(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {"model": {"base_url": "http://0.0.0.0:5000/v1", "default": ""}},
+    )
+    called = []
+    monkeypatch.setattr(
+        rp,
+        "_auto_detect_local_model",
+        lambda base_url: called.append(base_url) or "qwen-local",
+    )
+
+    resolved = rp._get_model_config()
+
+    assert resolved["default"] == "qwen-local"
+    assert called == ["http://0.0.0.0:5000/v1"]
+
+
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     class _Entry:
         access_token = "pool-token"


### PR DESCRIPTION
## Summary

Fix local model auto-detection in `hermes_cli.runtime_provider._get_model_config()` for local endpoints that are not spelled as `localhost` or `127.0.0.1`.

Before this change, fallback model probing only triggered when `model.base_url` contained those two substrings. That meant common local setups such as:

- `http://[::1]:11434/v1`
- `http://0.0.0.0:5000/v1`

were treated as non-local, so `_auto_detect_local_model()` was never called and `model.default` stayed empty.

This patch replaces the raw substring heuristic with the existing loopback-hostname helper, so local detection is consistent across loopback forms.

## User impact

Users running local backends over IPv6 loopback or a `0.0.0.0` bind can now rely on the same single-model fallback behavior that already worked for `localhost` and `127.0.0.1`.

## Changes

- use `base_url_hostname()` + `_loopback_hostname()` in `_get_model_config()`
- add regression tests for:
  - `http://[::1]:11434/v1`
  - `http://0.0.0.0:5000/v1`

## Tests

Passed:

- `tests/hermes_cli/test_runtime_provider_resolution.py -k "ipv6_loopback_local_model or zero_bind_local_model"`

