### PR TITLE
feat(honcho): add per-platform peer identity routing

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -125,6 +125,8 @@ For every key, resolution order is: **host block > root > env var > default**.
 | `enabled` | bool | auto | Master toggle. Auto-enables when `apiKey` or `baseUrl` present |
 | `workspace` | string | host key | Honcho workspace ID. Shared environment — all profiles in the same workspace can see the same user identity and related memories |
 | `peerName` | string | — | User peer identity |
+| `peerIdentityStrategy` | string | `"runtime"` | Default user-peer resolution. `"runtime"` uses gateway `user_id` for per-platform/per-user isolation; `"configured"` uses `peerName` for shared cross-channel memory |
+| `peerIdentities` | object | `{}` | Per-platform overrides. Values may be `"runtime"`, `"configured"`, or a custom peer name string |
 | `aiPeer` | string | host key | AI peer identity |
 
 ### Memory & Recall
@@ -149,6 +151,40 @@ For every key, resolution order is: **host block > root > env var > default**.
 | `sessionStrategy` | string | `"per-directory"` | `"per-directory"`, `"per-session"`, `"per-repo"` (git root), `"global"` |
 | `sessionPeerPrefix` | bool | `false` | Prepend peer name to session keys |
 | `sessions` | object | `{}` | Manual directory-to-session-name mappings |
+
+### Peer Identity Resolution
+
+Gateway platforms pass a runtime `user_id` so multi-user bots can isolate each
+person's memory. Personal deployments that use Telegram, WeChat, CLI, and other
+channels as alternate entry points can instead route those channels to the same
+Honcho user peer.
+
+```json
+{
+  "hosts": {
+    "hermes": {
+      "peerName": "kawarox",
+      "peerIdentityStrategy": "configured",
+      "peerIdentities": {
+        "telegram": "configured",
+        "weixin": "configured",
+        "discord": "runtime",
+        "matrix": "matrix-custom-peer"
+      }
+    }
+  }
+}
+```
+
+Rule values:
+
+- `"runtime"`: use the gateway `user_id`, falling back to `peerName`.
+- `"configured"`: use `peerName`, falling back to gateway `user_id`.
+- any other string: use that string as the Honcho user peer for the platform.
+
+Changing the strategy affects the peer used for future Honcho reads and writes.
+Existing conclusions and messages under previous runtime peers are left
+untouched unless you migrate them separately.
 
 #### Session Name Resolution
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -351,11 +351,15 @@ class HonchoMemoryProvider(MemoryProvider):
         from plugins.memory.honcho.session import HonchoSessionManager
 
         client = get_honcho_client(cfg)
+        runtime_user_peer_name = cfg.resolve_runtime_peer_name(
+            platform=kwargs.get("platform"),
+            user_id=kwargs.get("user_id") or None,
+        )
         self._manager = HonchoSessionManager(
             honcho=client,
             config=cfg,
             context_tokens=cfg.context_tokens,
-            runtime_user_peer_name=kwargs.get("user_id") or None,
+            runtime_user_peer_name=runtime_user_peer_name,
         )
 
         # ----- B3: resolve_session_name -----

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -158,12 +158,30 @@ def _resolve_optional_float(*values: Any) -> float | None:
 
 _VALID_OBSERVATION_MODES = {"unified", "directional"}
 _OBSERVATION_MODE_ALIASES = {"shared": "unified", "separate": "directional", "cross": "directional"}
+_VALID_PEER_IDENTITY_STRATEGIES = {"runtime", "configured"}
+_PEER_IDENTITY_ALIASES = {
+    "gateway": "runtime",
+    "user_id": "runtime",
+    "platform": "runtime",
+    "peerName": "configured",
+    "peer_name": "configured",
+    "static": "configured",
+    "honcho": "configured",
+}
 
 
 def _normalize_observation_mode(val: str) -> str:
     """Normalize observation mode values."""
     val = _OBSERVATION_MODE_ALIASES.get(val, val)
     return val if val in _VALID_OBSERVATION_MODES else "directional"
+
+
+def _normalize_peer_identity_strategy(val: str | None) -> str:
+    """Normalize peer identity strategy values."""
+    if not val:
+        return "runtime"
+    val = _PEER_IDENTITY_ALIASES.get(str(val), str(val))
+    return val if val in _VALID_PEER_IDENTITY_STRATEGIES else "runtime"
 
 
 # Observation presets — granular booleans derived from legacy string mode.
@@ -226,6 +244,13 @@ class HonchoClientConfig:
     # Identity
     peer_name: str | None = None
     ai_peer: str = "hermes"
+    # How gateway user_id maps to Honcho's user peer identity.
+    # runtime: gateway user_id scopes memory (multi-user bot default).
+    # configured: peerName scopes memory (personal cross-channel default).
+    # peer_identities can override per platform; values may be "runtime",
+    # "configured", or a custom peer name string.
+    peer_identity_strategy: str = "runtime"
+    peer_identities: dict[str, Any] = field(default_factory=dict)
     # Toggles
     enabled: bool = False
     save_messages: bool = True
@@ -289,6 +314,79 @@ class HonchoClientConfig:
     # stray HONCHO_API_KEY env var.
     explicitly_configured: bool = False
 
+    def resolve_runtime_peer_name(
+        self,
+        *,
+        platform: str | None = None,
+        user_id: str | None = None,
+    ) -> str | None:
+        """Resolve the Honcho user peer for this runtime context.
+
+        Per-platform rules let personal deployments share one Honcho peer
+        across Telegram/WeChat/CLI, while multi-user deployments keep the
+        existing gateway user_id isolation by default.
+
+        Supported rule values:
+          - "runtime": use gateway user_id, falling back to peerName
+          - "configured": use peerName, falling back to gateway user_id
+          - any other string: use that string as a custom peer name
+
+        Dict values are also accepted:
+          - {"strategy": "runtime" | "configured"}
+          - {"peerName": "custom-name"} / {"name": "custom-name"}
+        """
+        rule = self._peer_identity_rule_for_platform(platform)
+        strategy = self.peer_identity_strategy
+        custom_peer: str | None = None
+
+        if isinstance(rule, dict):
+            custom_peer = (
+                rule.get("peerName")
+                or rule.get("peer_name")
+                or rule.get("name")
+                or rule.get("peer")
+            )
+            strategy = _normalize_peer_identity_strategy(
+                rule.get("strategy") or rule.get("mode") or strategy
+            )
+        elif isinstance(rule, str):
+            normalized = _PEER_IDENTITY_ALIASES.get(rule, rule)
+            if normalized in _VALID_PEER_IDENTITY_STRATEGIES:
+                strategy = normalized
+            else:
+                custom_peer = rule
+
+        if custom_peer:
+            return str(custom_peer)
+
+        strategy = _normalize_peer_identity_strategy(strategy)
+        if strategy == "configured":
+            return self.peer_name or user_id
+        return user_id or self.peer_name
+
+    def _peer_identity_rule_for_platform(self, platform: str | None) -> Any | None:
+        """Return the configured identity rule for a platform, if any."""
+        if not self.peer_identities:
+            return None
+
+        candidates: list[str] = []
+        if platform:
+            platform_key = str(platform)
+            candidates.extend(
+                [
+                    platform_key,
+                    platform_key.lower(),
+                    platform_key.replace("-", "_"),
+                    platform_key.replace("_", "-"),
+                ]
+            )
+        candidates.extend(["default", "*"])
+
+        for key in candidates:
+            if key in self.peer_identities:
+                return self.peer_identities[key]
+        return None
+
     @classmethod
     def from_env(
         cls,
@@ -308,6 +406,9 @@ class HonchoClientConfig:
             base_url=base_url,
             timeout=timeout,
             ai_peer=resolved_host,
+            peer_identity_strategy=_normalize_peer_identity_strategy(
+                os.environ.get("HONCHO_PEER_IDENTITY_STRATEGY")
+            ),
             enabled=bool(api_key or base_url),
         )
 
@@ -420,6 +521,16 @@ class HonchoClientConfig:
             timeout=timeout,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
             ai_peer=ai_peer,
+            peer_identity_strategy=_normalize_peer_identity_strategy(
+                host_block.get("peerIdentityStrategy")
+                or raw.get("peerIdentityStrategy")
+                or "runtime"
+            ),
+            peer_identities=(
+                host_block.get("peerIdentities")
+                or raw.get("peerIdentities")
+                or {}
+            ),
             enabled=enabled,
             save_messages=save_messages,
             write_frequency=write_frequency,

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -250,6 +250,7 @@ class TestHonchoUserIdScoping:
         mock_cfg.dialectic_depth_levels = None
         mock_cfg.init_on_session_start = False
         mock_cfg.ai_peer = "hermes"
+        mock_cfg.resolve_runtime_peer_name.return_value = "discord_user_789"
         mock_cfg.resolve_session_name.return_value = "test-sess"
         mock_cfg.session_strategy = "shared"
 
@@ -272,7 +273,88 @@ class TestHonchoUserIdScoping:
             )
 
         assert mock_cfg.peer_name == "static-user"
+        mock_cfg.resolve_runtime_peer_name.assert_called_once_with(
+            platform="discord",
+            user_id="discord_user_789",
+        )
         assert mock_manager_cls.call_args.kwargs["runtime_user_peer_name"] == "discord_user_789"
+
+    def test_configured_peer_identity_strategy_overrides_gateway_user_id(self):
+        """Configured strategy should make read/write context use the shared peerName."""
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+
+        mock_cfg = MagicMock()
+        mock_cfg.enabled = True
+        mock_cfg.api_key = "test-key"
+        mock_cfg.base_url = None
+        mock_cfg.peer_name = "static-user"
+        mock_cfg.recall_mode = "context"
+        mock_cfg.context_tokens = None
+        mock_cfg.raw = {}
+        mock_cfg.dialectic_depth = 1
+        mock_cfg.dialectic_depth_levels = None
+        mock_cfg.init_on_session_start = False
+        mock_cfg.ai_peer = "hermes"
+        mock_cfg.resolve_runtime_peer_name.return_value = "static-user"
+        mock_cfg.resolve_session_name.return_value = "test-sess"
+        mock_cfg.session_strategy = "shared"
+
+        with patch(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            return_value=mock_cfg,
+        ), patch(
+            "plugins.memory.honcho.client.get_honcho_client",
+            return_value=MagicMock(),
+        ), patch(
+            "plugins.memory.honcho.session.HonchoSessionManager",
+        ) as mock_manager_cls:
+            mock_manager = MagicMock()
+            mock_manager.get_or_create.return_value = MagicMock(messages=[])
+            mock_manager_cls.return_value = mock_manager
+            provider.initialize(
+                session_id="test-sess",
+                user_id="discord_user_789",
+                platform="discord",
+            )
+
+        mock_cfg.resolve_runtime_peer_name.assert_called_once_with(
+            platform="discord",
+            user_id="discord_user_789",
+        )
+        assert mock_manager_cls.call_args.kwargs["runtime_user_peer_name"] == "static-user"
+
+    def test_peer_identity_map_supports_per_platform_custom_peer(self):
+        """Per-platform rules can keep runtime ids or route to a custom peer."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(
+            peer_name="shared-user",
+            peer_identity_strategy="configured",
+            peer_identities={
+                "telegram": "runtime",
+                "weixin": "wechat-shared-user",
+                "discord": {"peerName": "discord-custom-user"},
+            },
+        )
+
+        assert (
+            cfg.resolve_runtime_peer_name(platform="telegram", user_id="tg_123")
+            == "tg_123"
+        )
+        assert (
+            cfg.resolve_runtime_peer_name(platform="weixin", user_id="wx_456")
+            == "wechat-shared-user"
+        )
+        assert (
+            cfg.resolve_runtime_peer_name(platform="discord", user_id="dc_789")
+            == "discord-custom-user"
+        )
+        assert (
+            cfg.resolve_runtime_peer_name(platform="cli", user_id=None)
+            == "shared-user"
+        )
 
     def test_session_manager_prefers_runtime_user_id_over_config_peer_name(self):
         """Session manager should isolate gateway users even when config peer_name is static."""
@@ -356,4 +438,3 @@ class TestAIAgentUserIdPropagation:
             agent = object.__new__(AIAgent)
             agent._user_id = None
             assert agent._user_id is None
-


### PR DESCRIPTION
## What does this PR do?

Adds per-platform Honcho user-peer identity routing for gateway contexts.

This is related to #15162 and the Honcho consolidation PR #15381. Those changes add `pinPeerName`, which is a good opt-in fix for the common personal deployment case where every gateway should resolve to the configured `peerName`.

This PR covers the next step: mixed routing. A personal Hermes deployment may want Telegram and WhatsApp to share one Honcho peer, while keeping WeChat or Discord scoped to the platform-native `user_id`.

## Fix

Adds two config fields:

- `peerIdentityStrategy`: global default strategy, preserving existing `runtime` behavior by default.
- `peerIdentities`: per-platform override map.

Supported rule values:

- `runtime`: use gateway `user_id`, falling back to `peerName`.
- `configured`: use `peerName`, falling back to gateway `user_id`.
- any other string: use that string as a custom Honcho peer name for the platform.

Example:

```json
{
  "peerName": "kawarox",
  "peerIdentityStrategy": "configured",
  "peerIdentities": {
    "telegram": "configured",
    "whatsapp": "configured",
    "weixin": "runtime",
    "matrix": "matrix-custom-peer"
  }
}
```

In that setup:

| platform | chosen Honcho user peer |
|----------|--------------------------|
| Telegram | `peerName` (`kawarox`) |
| WhatsApp | `peerName` (`kawarox`) |
| WeChat | gateway `user_id` |
| Matrix | `matrix-custom-peer` |

The resolved peer is passed into `HonchoSessionManager`, so Honcho writes, context injection, dialectic calls, and conclusion/profile operations use the same user peer.

## Files changed

- `plugins/memory/honcho/client.py`
  - Adds `peer_identity_strategy` and `peer_identities` to `HonchoClientConfig`.
  - Adds `resolve_runtime_peer_name()` to resolve global and per-platform rules.
  - Parses `peerIdentityStrategy` and `peerIdentities` from root or host config.
- `plugins/memory/honcho/__init__.py`
  - Resolves the runtime Honcho user peer before creating `HonchoSessionManager`.
- `plugins/memory/honcho/README.md`
  - Documents the new config keys and examples.
- `tests/agent/test_memory_user_id.py`
  - Adds coverage for default runtime behavior, configured-peer routing, and per-platform custom routing.

## Relationship to `pinPeerName`

If maintainers prefer to keep `pinPeerName` as the public API for the all-platform case, this PR can be adjusted to layer per-platform routing on top of it instead of introducing a separate global strategy name:

- `pinPeerName: true` remains the simple global "configured peer wins" mode.
- `peerIdentities` only handles per-platform overrides for mixed gateway deployments.

I left the branch as a draft because #15162/#15381 may land first, and this PR may need a small rebase or API naming adjustment afterward.

## Related issues / PRs

- Related: #14984
- Related: #14401
- Related: #15162
- Related: #15381

## Type of Change

- [x] Feature (non-breaking opt-in configuration)
- [x] Tests (adding or improving test coverage)
- [x] Documentation

## Test plan

- [x] `venv/bin/python -m pytest tests/agent/test_memory_user_id.py -q`

Result: `16 passed`.

## Not in scope

- Migrating existing conclusions/messages between Honcho peers.
- Removing old runtime peers from existing Honcho sessions.
- Changing the default multi-user gateway behavior.
