### PR TITLE
fix: preserve reasoning_content round-trip for DeepSeek V4 thinking mode

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -347,7 +347,7 @@ class ChatCompletionsTransport(ProviderTransport):
         reasoning_content = getattr(msg, "reasoning_content", None)
 
         provider_data: Dict[str, Any] = {}
-        if reasoning_content:
+        if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
         rd = getattr(msg, "reasoning_details", None)
         if rd:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3156,6 +3156,9 @@ class AIAgent:
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        api_key=self.api_key,
+                        base_url=self.base_url,
+                        api_mode=self.api_mode,
                         parent_session_id=self.session_id,
                     )
                     review_agent._memory_write_origin = "background_review"
@@ -6229,6 +6232,12 @@ class AIAgent:
                 content=full_content,
                 tool_calls=mock_tool_calls,
                 reasoning_content=full_reasoning,
+                # Ensure reasoning field is also populated so
+                # _extract_reasoning and _build_assistant_message
+                # can find it via either reasoning or reasoning_content.
+                # DeepSeek thinking mode requires reasoning_content on
+                # every tool-call turn; without it, the API returns 400.
+                reasoning=full_reasoning,
             )
             mock_choice = SimpleNamespace(
                 index=0,
@@ -7625,11 +7634,13 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
+            elif getattr(assistant_message, "tool_calls", None) and self._needs_deepseek_tool_reasoning():
                 # DeepSeek thinking mode requires reasoning_content on every
                 # assistant tool-call message. Without it, replaying the
                 # persisted message causes HTTP 400. Include empty string
                 # as a defensive compatibility fallback (refs #15250).
+                # IMPORTANT: check assistant_message.tool_calls, NOT msg["tool_calls"]
+                # — tool_calls is added to msg much later at ~line 7705.
                 msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:


### PR DESCRIPTION
## Problem

DeepSeek V4 thinking mode requires `reasoning_content` to be passed back to the API on every assistant message during tool-call turns. When this field is missing, DeepSeek returns HTTP 400:

> The `reasoning_content` in the thinking mode must be passed back to the API.

This is an **ecosystem-wide issue** — 147+ GitHub issues across opencode, continue.dev, litellm, Claude Code, and others as of April 25, 2026.

Ref: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls

## Changes

### 1. `run_agent.py:_build_assistant_message()` — fix fallback condition (line 7637)

`msg.get("tool_calls")` was always falsy because `tool_calls` isn't added to the `msg` dict until ~70 lines later. `assistant_message` (the `NormalizedResponse`) already has it populated from the API response.

### 2. `run_agent.py` — streaming mock_message reasoning field (line 6240)

The streaming path's `SimpleNamespace` mock was missing the `reasoning` field, so code paths that check `reasoning` instead of `reasoning_content` would fail to find it.

### 3. `chat_completions.py:350` — falsy check drops empty string

DeepSeek may return `reasoning_content=""` (empty string) in tool-call-only responses. Python treats `""` as falsy, so the old check dropped it entirely. The API requires it preserved as empty string.

### 4. `run_agent.py:_spawn_background_review()` — missing provider config (bonus fix)

Passes `api_key`, `base_url`, and `api_mode` to the child review agent, fixing "Auxiliary background review failed: No LLM provider configured" for custom providers like `deepseek-v4-flash`.
