### PR TITLE
fix(cli): preserve user model selection across turns for custom_providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3175,7 +3175,7 @@ class HermesCLI:
         # (e.g. "my-provider") as the model string to the API instead of
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
         runtime_model = runtime.get("model")
-        if runtime_model and isinstance(runtime_model, str):
+        if runtime_model and isinstance(runtime_model, str) and not getattr(self, "_user_switched_model", False):
             self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
@@ -5116,6 +5116,7 @@ class HermesCLI:
 
         old_model = self.model
         self.model = result.new_model
+        self._user_switched_model = True
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
         if result.api_key:
@@ -5336,6 +5337,7 @@ class HermesCLI:
         # overwrite the switch on the next turn (it re-resolves from this).
         old_model = self.model
         self.model = result.new_model
+        self._user_switched_model = True
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
         if result.api_key:


### PR DESCRIPTION
## What this PR does

Fixes #12467 — when using `custom_providers` in config.yaml, switching
models with `/model` is silently reverted on the next turn because
`_ensure_runtime_credentials()` unconditionally overwrites `self.model`
with the `model:` field from the active custom provider entry.

## Root cause

In `cli.py`, `_ensure_runtime_credentials()` contains:

    runtime_model = runtime.get("model")
    if runtime_model and isinstance(runtime_model, str):
        self.model = runtime_model  # ← overwrites user's switch every turn

## Fix

Added a `_user_switched_model` flag that is set to `True` by
`_handle_model_switch()` when the user explicitly switches models.
The override is skipped when this flag is set:

    if runtime_model and isinstance(runtime_model, str) and not getattr(self, "_user_switched_model", False):
        self.model = runtime_model

This mirrors the existing `requested_provider` protection pattern
already used in the same function.

## Testing

Verified locally on macOS with Hermes Agent v0.9.0:
- `/model` switch now persists across all subsequent turns
- Default model resolution on startup is unaffected
- `hermes chat --model <provider-name>` shortcut continues to work