### PR TITLE
fix(cli): preserve /model choice across turns for custom providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3176,7 +3176,14 @@ class HermesCLI:
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
         runtime_model = runtime.get("model")
         if runtime_model and isinstance(runtime_model, str):
-            self.model = runtime_model
+            # Only use runtime model if: model is unset, or model equals provider name
+            should_use_runtime_model = (
+                not self.model or  # No model configured yet
+                self.model == self.provider or  # Model is the provider slug
+                self.model == runtime.get("name")  # Model matches provider display name
+            )
+            if should_use_runtime_model:
+                self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
         # without `hermes model`), fall back to the provider's first catalog

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -92,6 +92,7 @@ AUTHOR_MAP = {
     "104278804+Sertug17@users.noreply.github.com": "Sertug17",
     "112503481+caentzminger@users.noreply.github.com": "caentzminger",
     "258577966+voidborne-d@users.noreply.github.com": "voidborne-d",
+    "xydarcher@uestc.edu.cn": "Readon",
     "sir_even@icloud.com": "sirEven",
     "36056348+sirEven@users.noreply.github.com": "sirEven",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",


### PR DESCRIPTION
Salvages PR #14654 onto current main (branch was 93 commits stale).

## Summary
`_ensure_runtime_credentials()` was unconditionally overwriting the user's model selection with the custom_provider's configured `default_model` on every turn. Running `/model my-ollama:qwen2.5` would silently revert to `llama3.2` on the next message.

## Root cause
The override existed to handle the legitimate case where `hermes chat --model <provider-name>` passes the provider name as the model (PR #7828 / #8118). But it fired unconditionally — including after a `/model` switch that already set a valid model.

## Fix
Only apply the runtime `default_model` when `self.model` is empty or equals the provider slug. Preserves PR #7828's original case; preserves `/model` switches. 8 lines in `cli.py`.

## Validation
E2E reproduced in isolated HERMES_HOME with a custom_provider defining `default_model: llama3.2`:

| Input | Old behavior | New behavior |
|---|---|---|
| `self.model = 'qwen2.5'` (post /model switch) | → llama3.2 (bug) | → qwen2.5 ✓ |
| `self.model = 'my-ollama'` (provider-as-model) | → llama3.2 | → llama3.2 ✓ |
| `self.model = ''` (unset) | → llama3.2 | → llama3.2 ✓ |

Credit to @Readon (original PR #14654). AUTHOR_MAP entry added.