### PR TITLE
fix(runtime): honor providers transport/api_mode for named custom providers

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -349,6 +349,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
+            resolved_api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
@@ -360,9 +361,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
-                    api_mode = _parse_api_mode(entry.get("api_mode"))
-                    if api_mode:
-                        result["api_mode"] = api_mode
+                    if resolved_api_mode:
+                        result["api_mode"] = resolved_api_mode
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -378,9 +378,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
-                        api_mode = _parse_api_mode(entry.get("api_mode"))
-                        if api_mode:
-                            result["api_mode"] = api_mode
+                        if resolved_api_mode:
+                            result["api_mode"] = resolved_api_mode
                         return result
 
     # Fall back to custom_providers: list (legacy format)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -719,6 +719,88 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_uses_transport_from_providers_dict(monkeypatch):
+    """providers dict transport should propagate into runtime api_mode."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "dir-key")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "anthropic-proxy": {
+                    "base_url": "https://proxy.example.com/messages",
+                    "api_key": "***",
+                    "default_model": "claude-proxy",
+                    "name": "Anthropic Proxy",
+                    "transport": "anthropic_messages",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://proxy.example.com/messages"
+    assert resolved["api_key"] == "dir-key"
+    assert resolved["requested_provider"] == "anthropic-proxy"
+    assert resolved["source"] == "custom_provider:Anthropic Proxy"
+    assert resolved["model"] == "claude-proxy"
+
+
+def test_named_custom_provider_uses_api_mode_from_providers_dict(monkeypatch):
+    """providers dict api_mode should propagate into runtime api_mode."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "dir-key")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "responses-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "api_key": "***",
+                    "default_model": "gpt-5-mini",
+                    "name": "Responses Proxy",
+                    "api_mode": "codex_responses",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="responses-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "dir-key"
+    assert resolved["requested_provider"] == "responses-proxy"
+    assert resolved["source"] == "custom_provider:Responses Proxy"
+    assert resolved["model"] == "gpt-5-mini"
+
+
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- honor `providers.*.transport` when resolving named custom providers
- keep explicit `api_mode` support for the same path
- add regression coverage for both config forms

## Why
Config migration can preserve named custom provider transport in the new `providers:` dict. Before this patch, runtime resolution only read `api_mode`, so migrated entries that relied on `transport` silently fell back to the wrong runtime mode.

## Test Plan
- `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -o 'addopts='`