### PR TITLE
fix(mcp): shorten registered MCP tool names to fit provider limits

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -309,6 +309,51 @@ class TestSchemaConversion:
         assert schema["name"] == "mcp_my_server_get_sum"
         assert "-" not in schema["name"]
 
+    def test_short_name_remains_unchanged(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(name="list_dir")
+        schema = _convert_mcp_schema("my_server", mcp_tool)
+
+        assert schema["name"] == "mcp_my_server_list_dir"
+        assert len(schema["name"]) <= 64
+
+    def test_long_name_shortened_to_64_chars_or_less(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(name="cex_options_list_options_underlying_candlesticks")
+        schema = _convert_mcp_schema("gate_cex_pub", mcp_tool)
+
+        assert len(schema["name"]) <= 64
+        assert schema["name"].startswith("mcp_gate_cex_pub_")
+
+    def test_long_name_shortening_is_deterministic(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(name="tool_" + ("very_long_segment_" * 4) + "alpha")
+
+        schema1 = _convert_mcp_schema("server_name", mcp_tool)
+        schema2 = _convert_mcp_schema("server_name", mcp_tool)
+
+        assert schema1["name"] == schema2["name"]
+        assert len(schema1["name"]) <= 64
+
+    def test_different_long_names_do_not_collide(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        schema1 = _convert_mcp_schema(
+            "server_name",
+            _make_mcp_tool(name="tool_" + ("very_long_segment_" * 4) + "alpha"),
+        )
+        schema2 = _convert_mcp_schema(
+            "server_name",
+            _make_mcp_tool(name="tool_" + ("very_long_segment_" * 4) + "beta"),
+        )
+
+        assert schema1["name"] != schema2["name"]
+        assert len(schema1["name"]) <= 64
+        assert len(schema2["name"]) <= 64
+
 
 # ---------------------------------------------------------------------------
 # Check function
@@ -590,6 +635,42 @@ class TestDiscoverAndRegister:
         assert entry.toolset == "mcp-srv"
 
         _servers.pop("srv", None)
+
+    def test_shortened_registry_name_still_dispatches_original_tool_name(self):
+        from tools.registry import ToolRegistry
+        from tools.mcp_tool import _discover_and_register_server, _servers, MCPServerTask
+
+        mock_registry = ToolRegistry()
+        original_tool_name = "tool_" + ("very_long_segment_" * 4) + "alpha"
+        mock_tools = [_make_mcp_tool(original_tool_name, "Do something")]
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=_make_call_result("ok"))
+
+        async def fake_connect(name, config):
+            server = MCPServerTask(name)
+            server.session = mock_session
+            server._tools = mock_tools
+            return server
+
+        def fake_run(coro, timeout=30):
+            return asyncio.run(coro)
+
+        with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+             patch("tools.mcp_tool._run_on_mcp_loop", side_effect=fake_run), \
+             patch("tools.registry.registry", mock_registry):
+            registered = asyncio.run(
+                _discover_and_register_server("server_name", {"command": "test"})
+            )
+            tool_name = next(name for name in registered if name.startswith("mcp_server_name_tool_"))
+            assert len(tool_name) <= 64
+
+            entry = mock_registry._tools[tool_name]
+            result = json.loads(entry.handler({"value": 1}))
+
+        assert result["result"] == "ok"
+        mock_session.call_tool.assert_called_once_with(original_tool_name, arguments={"value": 1})
+
+        _servers.pop("server_name", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -71,6 +71,7 @@ Thread safety:
 
 import asyncio
 import concurrent.futures
+import hashlib
 import inspect
 import json
 import logging
@@ -2378,6 +2379,22 @@ def sanitize_mcp_name_component(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]", "_", str(value or ""))
 
 
+_MAX_MCP_TOOL_NAME_LENGTH = 64
+_MCP_TOOL_NAME_HASH_LENGTH = 12
+
+
+def shorten_mcp_tool_name(name: str, max_length: int = _MAX_MCP_TOOL_NAME_LENGTH) -> str:
+    """Return a stable MCP registry name that fits provider length limits."""
+    if len(name) <= max_length:
+        return name
+
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:_MCP_TOOL_NAME_HASH_LENGTH]
+    prefix_length = max_length - len(digest) - 1
+    if prefix_length <= 0:
+        return digest[:max_length]
+    return f"{name[:prefix_length]}_{digest}"
+
+
 def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     """Convert an MCP tool listing to the Hermes registry schema format.
 
@@ -2391,7 +2408,7 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     """
     safe_tool_name = sanitize_mcp_name_component(mcp_tool.name)
     safe_server_name = sanitize_mcp_name_component(server_name)
-    prefixed_name = f"mcp_{safe_server_name}_{safe_tool_name}"
+    prefixed_name = shorten_mcp_tool_name(f"mcp_{safe_server_name}_{safe_tool_name}")
     return {
         "name": prefixed_name,
         "description": mcp_tool.description or f"MCP tool {mcp_tool.name} from {server_name}",
@@ -2406,10 +2423,14 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
     with keys: schema, handler_key.
     """
     safe_name = sanitize_mcp_name_component(server_name)
+
+    def _utility_name(suffix: str) -> str:
+        return shorten_mcp_tool_name(f"mcp_{safe_name}_{suffix}")
+
     return [
         {
             "schema": {
-                "name": f"mcp_{safe_name}_list_resources",
+                "name": _utility_name("list_resources"),
                 "description": f"List available resources from MCP server '{server_name}'",
                 "parameters": {
                     "type": "object",
@@ -2420,7 +2441,7 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
         },
         {
             "schema": {
-                "name": f"mcp_{safe_name}_read_resource",
+                "name": _utility_name("read_resource"),
                 "description": f"Read a resource by URI from MCP server '{server_name}'",
                 "parameters": {
                     "type": "object",
@@ -2437,7 +2458,7 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
         },
         {
             "schema": {
-                "name": f"mcp_{safe_name}_list_prompts",
+                "name": _utility_name("list_prompts"),
                 "description": f"List available prompts from MCP server '{server_name}'",
                 "parameters": {
                     "type": "object",
@@ -2448,7 +2469,7 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
         },
         {
             "schema": {
-                "name": f"mcp_{safe_name}_get_prompt",
+                "name": _utility_name("get_prompt"),
                 "description": f"Get a prompt by name from MCP server '{server_name}'",
                 "parameters": {
                     "type": "object",


### PR DESCRIPTION
## Summary
- shorten generated MCP registry names to 64 chars or less with a stable hash suffix
- apply the same length guard to MCP utility tool names
- add regression tests for deterministic shortening, collision resistance, and preserved dispatch to the original MCP tool name

## Why
Some providers and backends reject oversized tool names. This patch keeps generated MCP tool schemas within those limits without breaking dispatch to the original MCP server tool name.

## Test Plan
- `python -m pytest tests/tools/test_mcp_tool.py -q -o 'addopts='`