### PR TITLE
feat: Hermes-native prompt controls and safer session prune (#15597)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1812,6 +1812,8 @@ class HermesCLI:
         checkpoints: bool = False,
         pass_session_id: bool = False,
         ignore_rules: bool = False,
+        system_prompt_override: str = None,
+        append_system_prompt: str = None,
     ):
         """
         Initialize the Hermes CLI.
@@ -1977,6 +1979,21 @@ class HermesCLI:
             or CLI_CONFIG["agent"].get("system_prompt", "")
         )
         self.personalities = CLI_CONFIG["agent"].get("personalities", {})
+
+        # ── Per-turn ephemeral prompt controls (#15597) ──
+        # ``system_prompt_override`` replaces the cached base system prompt for the
+        # turn without mutating SOUL.md, the cached base prompt, or anything in the
+        # session DB. ``--append-system-prompt`` is layered on top of the existing
+        # ``self.system_prompt`` (which is already an append-style ephemeral prompt
+        # sourced from env/config/personalities). Keeping these as separate fields
+        # — instead of stomping ``self.system_prompt`` — preserves CLI commands
+        # like ``/personality`` that mutate ``self.system_prompt`` at runtime.
+        self.system_prompt_override: Optional[str] = (
+            system_prompt_override if system_prompt_override else None
+        )
+        self.append_system_prompt: Optional[str] = (
+            append_system_prompt if append_system_prompt else None
+        )
         
         # Ephemeral prefill messages (few-shot priming, never persisted)
         self.prefill_messages = _load_prefill_messages(
@@ -3351,7 +3368,12 @@ class HermesCLI:
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
-                ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
+                ephemeral_system_prompt=(
+                    ((self.system_prompt + "\n\n" + self.append_system_prompt).strip())
+                    if (self.system_prompt and self.append_system_prompt)
+                    else (self.append_system_prompt or self.system_prompt or None)
+                ),
+                ephemeral_system_prompt_override=self.system_prompt_override,
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
                 service_tier=self.service_tier,
@@ -10859,6 +10881,8 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    system_prompt_override: str = None,
+    append_system_prompt: str = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -10969,6 +10993,8 @@ def main(
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
+        system_prompt_override=system_prompt_override,
+        append_system_prompt=append_system_prompt,
     )
 
     if parsed_skills:

--- a/cli.py
+++ b/cli.py
@@ -2122,6 +2122,20 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
+    def _clear_turn_prompt_controls(self) -> None:
+        """Clear one-turn prompt overrides/addenda after a completed turn.
+
+        ``self.system_prompt`` is the durable CLI/session overlay (for example
+        from personalities). The operator flags introduced in #15597 are
+        intentionally one-turn controls, so after a turn completes we clear the
+        transient fields and reset the live agent back to the durable overlay.
+        """
+        self.system_prompt_override = None
+        self.append_system_prompt = None
+        if self.agent:
+            self.agent.ephemeral_system_prompt_override = None
+            self.agent.ephemeral_system_prompt = self.system_prompt if self.system_prompt else None
+
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
         now = time.monotonic()
@@ -8613,6 +8627,8 @@ class HermesCLI:
                 # but guard against edge cases.
                 agent_thread.join(timeout=30)
 
+            self._clear_turn_prompt_controls()
+
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).
             if self._prompt_start_time is not None:
@@ -11108,6 +11124,7 @@ def main(
                         user_message=effective_query,
                         conversation_history=cli.conversation_history,
                     )
+                    cli._clear_turn_prompt_controls()
                     # Sync session_id if mid-run compression created a
                     # continuation session. The exit line below reports
                     # session_id to stderr for automation wrappers; without

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1190,6 +1190,12 @@ def cmd_chat(args):
     _append_sys_prompt = getattr(args, "append_system_prompt", None)
 
     if use_tui:
+        if _sys_prompt_override or _append_sys_prompt:
+            print(
+                "Error: --system-prompt, --system-prompt-file, and --append-system-prompt are not yet supported with --tui. "
+                "Use classic CLI mode for now."
+            )
+            sys.exit(2)
         _launch_tui(
             getattr(args, "resume", None),
             tui_dev=getattr(args, "tui_dev", False),
@@ -8617,6 +8623,8 @@ Examples:
             if args.dry_run:
                 count = db.prune_sessions(older_than_days=days, source=args.source, dry_run=True)
                 print(f"Would prune {count} session(s){source_msg} older than {days} days.")
+                if args.vacuum:
+                    print("Note: --vacuum is ignored during --dry-run.")
                 return
             if not args.yes:
                 if not _confirm_prompt(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1170,6 +1170,25 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # --system-prompt / --system-prompt-file: ephemeral per-turn override (#15597).
+    # Mutually exclusive — bail early before launching the agent.
+    _sys_prompt_override = getattr(args, "system_prompt", None)
+    _sys_prompt_file = getattr(args, "system_prompt_file", None)
+    if _sys_prompt_override and _sys_prompt_file:
+        print(
+            "Error: --system-prompt and --system-prompt-file are mutually exclusive. "
+            "Pass exactly one."
+        )
+        sys.exit(2)
+    if _sys_prompt_file:
+        try:
+            with open(_sys_prompt_file, "r", encoding="utf-8") as _fh:
+                _sys_prompt_override = _fh.read()
+        except OSError as e:
+            print(f"Error: --system-prompt-file could not be read: {e}")
+            sys.exit(2)
+    _append_sys_prompt = getattr(args, "append_system_prompt", None)
+
     if use_tui:
         _launch_tui(
             getattr(args, "resume", None),
@@ -1196,6 +1215,8 @@ def cmd_chat(args):
         "max_turns": getattr(args, "max_turns", None),
         "ignore_rules": getattr(args, "ignore_rules", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False),
+        "system_prompt_override": _sys_prompt_override,
+        "append_system_prompt": _append_sys_prompt,
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -7044,6 +7065,38 @@ For more help on a command:
         help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",
     )
     chat_parser.add_argument(
+        "--system-prompt",
+        dest="system_prompt",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "Per-turn system prompt override. Replaces the cached base system prompt "
+            "for this turn only — does not mutate SOUL.md, the cached base prompt, or "
+            "the persisted session system prompt."
+        ),
+    )
+    chat_parser.add_argument(
+        "--system-prompt-file",
+        dest="system_prompt_file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Per-turn system prompt override read from PATH. Same isolation guarantees "
+            "as --system-prompt. Mutually exclusive with --system-prompt."
+        ),
+    )
+    chat_parser.add_argument(
+        "--append-system-prompt",
+        dest="append_system_prompt",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "Per-turn system prompt addendum. Appended to the cached base system prompt "
+            "(or to --system-prompt/--system-prompt-file when provided) without mutating "
+            "either source. Useful for layering ephemeral persona/context onto a session."
+        ),
+    )
+    chat_parser.add_argument(
         "--tui",
         action="store_true",
         default=False,
@@ -8427,6 +8480,16 @@ Examples:
     )
     sessions_prune.add_argument("--source", help="Only prune sessions from this source")
     sessions_prune.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show how many sessions would be pruned without deleting anything",
+    )
+    sessions_prune.add_argument(
+        "--vacuum",
+        action="store_true",
+        help="Run VACUUM after pruning to reclaim disk space",
+    )
+    sessions_prune.add_argument(
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )
 
@@ -8551,6 +8614,10 @@ Examples:
         elif action == "prune":
             days = args.older_than
             source_msg = f" from '{args.source}'" if args.source else ""
+            if args.dry_run:
+                count = db.prune_sessions(older_than_days=days, source=args.source, dry_run=True)
+                print(f"Would prune {count} session(s){source_msg} older than {days} days.")
+                return
             if not args.yes:
                 if not _confirm_prompt(
                     f"Delete all ended sessions older than {days} days{source_msg}? [y/N] "
@@ -8559,6 +8626,11 @@ Examples:
                     return
             count = db.prune_sessions(older_than_days=days, source=args.source)
             print(f"Pruned {count} session(s).")
+            if args.vacuum and count > 0:
+                db.vacuum()
+                print("VACUUM complete.")
+            elif args.vacuum:
+                print("Skipped VACUUM because nothing was pruned.")
 
         elif action == "rename":
             resolved_session_id = db.resolve_session_id(args.session_id)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6915,6 +6915,24 @@ For more help on a command:
         help="Skip auto-injection of AGENTS.md, SOUL.md, .cursorrules, memory, and preloaded skills",
     )
     parser.add_argument(
+        "--system-prompt",
+        default=None,
+        metavar="TEXT",
+        help="Per-turn system prompt override for chat mode (no-subcommand path supported)",
+    )
+    parser.add_argument(
+        "--system-prompt-file",
+        default=None,
+        metavar="PATH",
+        help="Read per-turn system prompt override from PATH for chat mode",
+    )
+    parser.add_argument(
+        "--append-system-prompt",
+        default=None,
+        metavar="TEXT",
+        help="Per-turn system prompt addendum for chat mode",
+    )
+    parser.add_argument(
         "--tui",
         action="store_true",
         default=False,
@@ -7073,7 +7091,7 @@ For more help on a command:
     chat_parser.add_argument(
         "--system-prompt",
         dest="system_prompt",
-        default=None,
+        default=argparse.SUPPRESS,
         metavar="TEXT",
         help=(
             "Per-turn system prompt override. Replaces the cached base system prompt "
@@ -7084,7 +7102,7 @@ For more help on a command:
     chat_parser.add_argument(
         "--system-prompt-file",
         dest="system_prompt_file",
-        default=None,
+        default=argparse.SUPPRESS,
         metavar="PATH",
         help=(
             "Per-turn system prompt override read from PATH. Same isolation guarantees "
@@ -7094,7 +7112,7 @@ For more help on a command:
     chat_parser.add_argument(
         "--append-system-prompt",
         dest="append_system_prompt",
-        default=None,
+        default=argparse.SUPPRESS,
         metavar="TEXT",
         help=(
             "Per-turn system prompt addendum. Appended to the cached base system prompt "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1501,16 +1501,19 @@ class SessionDB:
             return True
         return self._execute_write(_do)
 
-    def prune_sessions(self, older_than_days: int = 90, source: str = None) -> int:
-        """Delete sessions older than N days. Returns count of deleted sessions.
+    def prune_sessions(self, older_than_days: int = 90, source: str = None, dry_run: bool = False) -> int:
+        """Delete sessions older than N days. Returns count of matching/deleted sessions.
 
-        Only prunes ended sessions (not active ones).  Child sessions outside
-        the prune window are orphaned (parent_session_id set to NULL) rather
-        than cascade-deleted.
+        Only prunes ended sessions (not active ones). Child sessions whose
+        parent is being deleted are orphaned (parent_session_id set to NULL)
+        rather than cascade-deleted.
+
+        When ``dry_run`` is true, no rows are deleted; the return value is the
+        number of sessions that would be pruned.
         """
         cutoff = time.time() - (older_than_days * 86400)
 
-        def _do(conn):
+        def _matching_session_ids(conn):
             if source:
                 cursor = conn.execute(
                     """SELECT id FROM sessions
@@ -1522,12 +1525,18 @@ class SessionDB:
                     "SELECT id FROM sessions WHERE started_at < ? AND ended_at IS NOT NULL",
                     (cutoff,),
                 )
-            session_ids = set(row["id"] for row in cursor.fetchall())
+            return set(row["id"] for row in cursor.fetchall())
+
+        if dry_run:
+            with self._lock:
+                return len(_matching_session_ids(self._conn))
+
+        def _do(conn):
+            session_ids = _matching_session_ids(conn)
 
             if not session_ids:
                 return 0
 
-            # Orphan any sessions whose parent is about to be deleted
             placeholders = ",".join("?" * len(session_ids))
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "

--- a/run_agent.py
+++ b/run_agent.py
@@ -848,6 +848,7 @@ class AIAgent:
         verbose_logging: bool = False,
         quiet_mode: bool = False,
         ephemeral_system_prompt: str = None,
+        ephemeral_system_prompt_override: str = None,
         log_prefix_chars: int = 100,
         log_prefix: str = "",
         providers_allowed: List[str] = None,
@@ -910,6 +911,9 @@ class AIAgent:
             verbose_logging (bool): Enable verbose logging for debugging (default: False)
             quiet_mode (bool): Suppress progress output for clean CLI experience (default: False)
             ephemeral_system_prompt (str): System prompt used during agent execution but NOT saved to trajectories (optional)
+            ephemeral_system_prompt_override (str): When set, replaces the cached base system prompt for the duration of
+                the turn without mutating ``_cached_system_prompt`` or any persisted session prompt. ``ephemeral_system_prompt``
+                is still appended on top, matching the cached-base + append layering used by the standard path.
             log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 100)
             log_prefix (str): Prefix to add to all log messages for identification in parallel processing (default: "")
             providers_allowed (List[str]): OpenRouter providers to allow (optional)
@@ -947,6 +951,12 @@ class AIAgent:
         self.verbose_logging = verbose_logging
         self.quiet_mode = quiet_mode
         self.ephemeral_system_prompt = ephemeral_system_prompt
+        # Per-turn system prompt override (replaces the cached base prompt for the
+        # API call without mutating self._cached_system_prompt or anything persisted
+        # in the session DB). When set, ``ephemeral_system_prompt`` is appended on
+        # top of this override, mirroring the layered behaviour of the cached base
+        # prompt + ephemeral append. See ``_effective_system_prompt``.
+        self.ephemeral_system_prompt_override = ephemeral_system_prompt_override
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
         self._user_id = user_id  # Platform user identifier (gateway sessions)
         self._user_name = user_name
@@ -1486,6 +1496,13 @@ class AIAgent:
         if self.ephemeral_system_prompt and not self.quiet_mode:
             prompt_preview = self.ephemeral_system_prompt[:60] + "..." if len(self.ephemeral_system_prompt) > 60 else self.ephemeral_system_prompt
             print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
+        if self.ephemeral_system_prompt_override and not self.quiet_mode:
+            override_preview = (
+                self.ephemeral_system_prompt_override[:60] + "..."
+                if len(self.ephemeral_system_prompt_override) > 60
+                else self.ephemeral_system_prompt_override
+            )
+            print(f"🔒 System prompt override: '{override_preview}' (cached base prompt unchanged)")
         
         # Show prompt caching status
         if self._use_prompt_caching and not self.quiet_mode:
@@ -4728,13 +4745,31 @@ class AIAgent:
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
-        
+
         Called after context compression events. Also reloads memory from disk
         so the rebuilt prompt captures any writes from this session.
         """
         self._cached_system_prompt = None
         if self._memory_store:
             self._memory_store.load_from_disk()
+
+    def _effective_system_prompt(self, cached_system_prompt: Optional[str]) -> str:
+        """Compose the system prompt actually sent to the API for this turn.
+
+        Layering (issue #15597):
+          1. ``ephemeral_system_prompt_override`` — when set, replaces the cached
+             base prompt for this call without touching ``_cached_system_prompt``
+             or anything persisted to the session DB.
+          2. Otherwise, the cached base prompt assembled by ``_build_system_prompt``.
+          3. ``ephemeral_system_prompt`` is appended on top in either case.
+        """
+        if self.ephemeral_system_prompt_override:
+            base = self.ephemeral_system_prompt_override
+        else:
+            base = cached_system_prompt or ""
+        if self.ephemeral_system_prompt:
+            base = (base + "\n\n" + self.ephemeral_system_prompt).strip()
+        return base
 
     @staticmethod
     def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
@@ -9138,9 +9173,7 @@ class AIAgent:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 
-            effective_system = self._cached_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            effective_system = self._effective_system_prompt(self._cached_system_prompt)
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
             if self.prefill_messages:
@@ -9823,10 +9856,10 @@ class AIAgent:
             # Build the final system message: cached prompt + ephemeral system prompt.
             # Ephemeral additions are API-call-time only (not persisted to session DB).
             # External recall context is injected into the user message, not the system
-            # prompt, so the stable cache prefix remains unchanged.
-            effective_system = active_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            # prompt, so the stable cache prefix remains unchanged. ``_effective_system_prompt``
+            # also honours ``ephemeral_system_prompt_override`` (issue #15597), which
+            # replaces the cached base prompt for this call only.
+            effective_system = self._effective_system_prompt(active_system_prompt)
             # NOTE: Plugin context from pre_llm_call hooks is injected into the
             # user message (see injection block above), NOT the system prompt.
             # This is intentional — system prompt modifications break the prompt
@@ -10767,6 +10800,11 @@ class AIAgent:
                                 _sanitized_ephemeral = _strip_non_ascii(self.ephemeral_system_prompt)
                                 if _sanitized_ephemeral != self.ephemeral_system_prompt:
                                     self.ephemeral_system_prompt = _sanitized_ephemeral
+                                    _system_sanitized = True
+                            if isinstance(getattr(self, "ephemeral_system_prompt_override", None), str):
+                                _sanitized_override = _strip_non_ascii(self.ephemeral_system_prompt_override)
+                                if _sanitized_override != self.ephemeral_system_prompt_override:
+                                    self.ephemeral_system_prompt_override = _sanitized_override
                                     _system_sanitized = True
 
                             _headers_sanitized = False

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -159,6 +159,22 @@ class TestSingleQueryState:
         assert hasattr(cli, "_interrupt_queue")
         assert hasattr(cli, "_pending_input")
 
+    def test_clear_turn_prompt_controls_preserves_durable_system_prompt(self):
+        cli = _make_cli()
+        cli.system_prompt = "durable overlay"
+        cli.system_prompt_override = "override"
+        cli.append_system_prompt = "append"
+        cli.agent = MagicMock()
+        cli.agent.ephemeral_system_prompt_override = "override"
+        cli.agent.ephemeral_system_prompt = "override\n\nappend"
+
+        cli._clear_turn_prompt_controls()
+
+        assert cli.system_prompt_override is None
+        assert cli.append_system_prompt is None
+        assert cli.agent.ephemeral_system_prompt_override is None
+        assert cli.agent.ephemeral_system_prompt == "durable overlay"
+
 
 class TestHistoryDisplay:
     def test_history_numbers_only_visible_messages_and_summarizes_tools(self, capsys):

--- a/tests/hermes_cli/test_chat_system_prompt_flags.py
+++ b/tests/hermes_cli/test_chat_system_prompt_flags.py
@@ -124,3 +124,20 @@ def test_chat_rejects_prompt_flags_in_tui_mode(monkeypatch, capsys):
 
     assert raised
     assert "not yet supported with --tui" in capsys.readouterr().out
+
+
+def test_top_level_chat_path_accepts_system_prompt_flags(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setitem(sys.modules, "cli", type("C", (), {"main": lambda **kwargs: captured.update(kwargs)}))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "--system-prompt", "top level override", "chat", "-q", "hi", "-Q"],
+    )
+
+    main_mod.main()
+
+    assert captured["system_prompt_override"] == "top level override"

--- a/tests/hermes_cli/test_chat_system_prompt_flags.py
+++ b/tests/hermes_cli/test_chat_system_prompt_flags.py
@@ -83,3 +83,44 @@ def test_chat_rejects_mutually_exclusive_system_prompt_flags(monkeypatch, capsys
 
     assert raised
     assert "mutually exclusive" in capsys.readouterr().out
+
+
+def test_chat_rejects_prompt_flags_in_tui_mode(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+
+    args = argparse.Namespace(
+        yolo=False,
+        ignore_user_config=False,
+        ignore_rules=False,
+        source=None,
+        system_prompt="inline override",
+        system_prompt_file=None,
+        append_system_prompt=None,
+        model=None,
+        provider=None,
+        toolsets=None,
+        skills=None,
+        verbose=False,
+        quiet=True,
+        query="hi",
+        image=None,
+        resume=None,
+        worktree=False,
+        checkpoints=False,
+        pass_session_id=False,
+        max_turns=None,
+        tui=True,
+        tui_dev=False,
+    )
+
+    try:
+        main_mod.cmd_chat(args)
+        raised = False
+    except SystemExit as exc:
+        raised = True
+        assert exc.code == 2
+
+    assert raised
+    assert "not yet supported with --tui" in capsys.readouterr().out

--- a/tests/hermes_cli/test_chat_system_prompt_flags.py
+++ b/tests/hermes_cli/test_chat_system_prompt_flags.py
@@ -1,0 +1,85 @@
+import argparse
+import sys
+from pathlib import Path
+
+
+def test_chat_passes_system_prompt_flags_to_cli_main(monkeypatch, tmp_path):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("override from file", encoding="utf-8")
+
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setitem(sys.modules, "cli", type("C", (), {"main": lambda **kwargs: captured.update(kwargs)}))
+
+    args = argparse.Namespace(
+        yolo=False,
+        ignore_user_config=False,
+        ignore_rules=False,
+        source=None,
+        system_prompt=None,
+        system_prompt_file=str(prompt_file),
+        append_system_prompt="append me",
+        model=None,
+        provider=None,
+        toolsets=None,
+        skills=None,
+        verbose=False,
+        quiet=True,
+        query="hi",
+        image=None,
+        resume=None,
+        worktree=False,
+        checkpoints=False,
+        pass_session_id=False,
+        max_turns=None,
+        tui=False,
+        tui_dev=False,
+    )
+
+    main_mod.cmd_chat(args)
+
+    assert captured["system_prompt_override"] == "override from file"
+    assert captured["append_system_prompt"] == "append me"
+
+
+def test_chat_rejects_mutually_exclusive_system_prompt_flags(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+
+    args = argparse.Namespace(
+        yolo=False,
+        ignore_user_config=False,
+        ignore_rules=False,
+        source=None,
+        system_prompt="inline override",
+        system_prompt_file="/tmp/ignored.txt",
+        append_system_prompt=None,
+        model=None,
+        provider=None,
+        toolsets=None,
+        skills=None,
+        verbose=False,
+        quiet=True,
+        query="hi",
+        image=None,
+        resume=None,
+        worktree=False,
+        checkpoints=False,
+        pass_session_id=False,
+        max_turns=None,
+        tui=False,
+        tui_dev=False,
+    )
+
+    try:
+        main_mod.cmd_chat(args)
+        raised = False
+    except SystemExit as exc:
+        raised = True
+        assert exc.code == 2
+
+    assert raised
+    assert "mutually exclusive" in capsys.readouterr().out

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -115,3 +115,63 @@ def test_sessions_prune_handles_eoferror_on_confirm(monkeypatch, capsys):
 
     output = capsys.readouterr().out
     assert "Cancelled" in output
+
+
+def test_sessions_prune_dry_run_calls_db_without_deleting(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def prune_sessions(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return 7
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "prune", "--older-than", "30", "--source", "telegram", "--dry-run"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured["kwargs"] == {"older_than_days": 30, "source": "telegram", "dry_run": True}
+    assert "Would prune 7 session(s) from 'telegram' older than 30 days." in output
+
+
+def test_sessions_prune_vacuum_runs_only_after_real_prune(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {"vacuum": 0}
+
+    class FakeDB:
+        def prune_sessions(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return 3
+
+        def vacuum(self):
+            captured["vacuum"] += 1
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "prune", "--yes", "--vacuum"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured["kwargs"] == {"older_than_days": 90, "source": None}
+    assert captured["vacuum"] == 1
+    assert "VACUUM complete." in output

--- a/tests/run_agent/test_ephemeral_system_prompt_override.py
+++ b/tests/run_agent/test_ephemeral_system_prompt_override.py
@@ -1,0 +1,21 @@
+from run_agent import AIAgent
+
+
+def test_effective_system_prompt_uses_override_without_mutating_cached_prompt():
+    agent = AIAgent.__new__(AIAgent)
+    agent.ephemeral_system_prompt_override = "override"
+    agent.ephemeral_system_prompt = "append"
+
+    cached = "cached-base"
+    effective = AIAgent._effective_system_prompt(agent, cached)
+
+    assert effective == "override\n\nappend"
+    assert cached == "cached-base"
+
+
+def test_effective_system_prompt_falls_back_to_cached_prompt_when_no_override():
+    agent = AIAgent.__new__(AIAgent)
+    agent.ephemeral_system_prompt_override = None
+    agent.ephemeral_system_prompt = "append"
+
+    assert AIAgent._effective_system_prompt(agent, "cached-base") == "cached-base\n\nappend"


### PR DESCRIPTION
## Summary
- add one-turn operator prompt controls for chat entrypoints
- add `sessions prune --dry-run` and optional `--vacuum`
- reject unsupported prompt flags in TUI instead of silently ignoring them
- extend tests for prompt isolation, top-level chat parsing, and prune behavior

## Test Plan
- pytest -q tests/test_cli_main.py tests/test_session_prune.py tests/test_run_agent.py

Closes #15597
