### PR TITLE
fix(flush_memories): prevent context window overflow on auxiliary model

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2351,12 +2351,18 @@ class AIAgent:
         }
 
     def _check_compression_model_feasibility(self) -> None:
-        """Warn at session start if the auxiliary compression model's context
-        window is smaller than the main model's compression threshold.
+        """Warn at session start if auxiliary models' context windows are
+        smaller than the main model's compression threshold.
 
-        When the auxiliary model cannot fit the content that needs summarising,
-        compression will either fail outright (the LLM call errors) or produce
-        a severely truncated summary.
+        Checks both the **compression** auxiliary model (used for
+        summarisation) and the **flush_memories** auxiliary model (used for
+        pre-compression memory extraction).  ``flush_memories`` runs with
+        the *full* conversation just before compression trims it, so its
+        auxiliary model must also be able to fit the threshold-sized window.
+
+        When either auxiliary model cannot fit the content, the session's
+        compression threshold is auto-lowered so the conversation never
+        grows larger than the smallest auxiliary context window.
 
         Called during ``__init__`` so CLI users see the warning immediately
         (via ``_vprint``).  The gateway sets ``status_callback`` *after*
@@ -2373,9 +2379,11 @@ class AIAgent:
                 get_model_context_length,
             )
 
+            _main_runtime = self._current_main_runtime()
+
             client, aux_model = get_text_auxiliary_client(
                 "compression",
-                main_runtime=self._current_main_runtime(),
+                main_runtime=_main_runtime,
             )
             if client is None or not aux_model:
                 msg = (
@@ -2401,18 +2409,54 @@ class AIAgent:
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
             )
 
+            # Also resolve the flush_memories auxiliary model — it may differ
+            # from the compression model if the user configured separate
+            # auxiliary.flush_memories.provider/model settings, or if the
+            # auto-detection fallback chain lands on a different provider.
+            # flush_memories runs with the FULL pre-compression conversation
+            # at line ~8296, so its model must also fit the threshold.
+            flush_aux_context = aux_context  # default: same as compression
+            try:
+                flush_client, flush_model = get_text_auxiliary_client(
+                    "flush_memories",
+                    main_runtime=_main_runtime,
+                )
+                if flush_client and flush_model:
+                    _fb = str(getattr(flush_client, "base_url", ""))
+                    _fk = str(getattr(flush_client, "api_key", ""))
+                    _flush_ctx = get_model_context_length(
+                        flush_model, base_url=_fb, api_key=_fk,
+                    )
+                    if _flush_ctx:
+                        flush_aux_context = _flush_ctx
+                        if _flush_ctx < aux_context:
+                            logger.info(
+                                "flush_memories model %s context (%d) is smaller "
+                                "than compression model %s context (%d) — using "
+                                "the smaller value as the effective auxiliary limit.",
+                                flush_model, _flush_ctx, aux_model, aux_context,
+                            )
+            except Exception:
+                pass  # Non-fatal — fall back to compression model's context
+
+            # Use the SMALLER of the two auxiliary context windows as the
+            # effective limit.  This ensures flush_memories (which runs at
+            # the compression threshold) never exceeds its model's context.
+            effective_aux_context = min(aux_context, flush_aux_context)
+
             # Hard floor: the auxiliary compression model must have at least
             # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model
             # is already required to meet this floor (checked earlier in
             # __init__), so the compression model must too — otherwise it
             # cannot summarise a full threshold-sized window of main-model
             # content.  Mirrors the main-model rejection pattern.
-            if aux_context and aux_context < MINIMUM_CONTEXT_LENGTH:
+            if effective_aux_context and effective_aux_context < MINIMUM_CONTEXT_LENGTH:
+                _limiting_model = flush_model if flush_aux_context < aux_context else aux_model
                 raise ValueError(
-                    f"Auxiliary compression model {aux_model} has a context "
-                    f"window of {aux_context:,} tokens, which is below the "
+                    f"Auxiliary model {_limiting_model} has a context "
+                    f"window of {effective_aux_context:,} tokens, which is below the "
                     f"minimum {MINIMUM_CONTEXT_LENGTH:,} required by Hermes "
-                    f"Agent.  Choose a compression model with at least "
+                    f"Agent.  Choose an auxiliary model with at least "
                     f"{MINIMUM_CONTEXT_LENGTH // 1000}K context (set "
                     f"auxiliary.compression.model in config.yaml), or set "
                     f"auxiliary.compression.context_length to override the "
@@ -2420,13 +2464,13 @@ class AIAgent:
                 )
 
             threshold = self.context_compressor.threshold_tokens
-            if aux_context < threshold:
+            if effective_aux_context < threshold:
                 # Auto-correct: lower the live session threshold so
                 # compression actually works this session.  The hard floor
-                # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,
+                # above guarantees effective_aux_context >= MINIMUM_CONTEXT_LENGTH,
                 # so the new threshold is always >= 64K.
                 old_threshold = threshold
-                new_threshold = aux_context
+                new_threshold = effective_aux_context
                 self.context_compressor.threshold_tokens = new_threshold
                 # Keep threshold_percent in sync so future main-model
                 # context_length changes (update_model) re-derive from a
@@ -2436,15 +2480,18 @@ class AIAgent:
                     self.context_compressor.threshold_percent = (
                         new_threshold / main_ctx
                     )
-                safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
+                safe_pct = int((effective_aux_context / main_ctx) * 100) if main_ctx else 50
+                _limiting_model = (
+                    flush_model if flush_aux_context < aux_context else aux_model
+                )
                 msg = (
-                    f"⚠ Compression model ({aux_model}) context is "
-                    f"{aux_context:,} tokens, but the main model's "
+                    f"⚠ Auxiliary model ({_limiting_model}) context is "
+                    f"{effective_aux_context:,} tokens, but the main model's "
                     f"compression threshold was {old_threshold:,} tokens. "
                     f"Auto-lowered this session's threshold to "
                     f"{new_threshold:,} tokens so compression can run.\n"
                     f"  To make this permanent, edit config.yaml — either:\n"
-                    f"  1. Use a larger compression model:\n"
+                    f"  1. Use a larger auxiliary model:\n"
                     f"       auxiliary:\n"
                     f"         compression:\n"
                     f"           model: <model-with-{old_threshold:,}+-context>\n"
@@ -2455,12 +2502,12 @@ class AIAgent:
                 self._compression_warning = msg
                 self._emit_status(msg)
                 logger.warning(
-                    "Auxiliary compression model %s has %d token context, "
+                    "Auxiliary model %s has %d token context, "
                     "below the main model's compression threshold of %d "
                     "tokens — auto-lowered session threshold to %d to "
                     "keep compression working.",
-                    aux_model,
-                    aux_context,
+                    _limiting_model,
+                    effective_aux_context,
                     old_threshold,
                     new_threshold,
                 )
@@ -7974,6 +8021,74 @@ class AIAgent:
             if not memory_tool_def:
                 messages.pop()  # remove flush msg
                 return
+
+            # ── Defence-in-depth: trim messages to fit auxiliary context ──
+            #
+            # _check_compression_model_feasibility already lowers the
+            # compression threshold so conversations should never grow past
+            # the auxiliary model's context.  But flush_memories is also
+            # called from CLI /new and gateway session resets — paths that
+            # don't go through the preflight compression check.  Trim here
+            # as a safety net so those paths can't 400 either.
+            try:
+                from agent.auxiliary_client import get_text_auxiliary_client
+                from agent.model_metadata import (
+                    get_model_context_length,
+                    estimate_messages_tokens_rough,
+                )
+                _flush_client, _flush_model = get_text_auxiliary_client(
+                    "flush_memories",
+                    main_runtime=self._current_main_runtime(),
+                )
+                _flush_ctx = 0
+                if _flush_client and _flush_model:
+                    _flush_ctx = get_model_context_length(
+                        _flush_model,
+                        base_url=str(getattr(_flush_client, "base_url", "") or ""),
+                        api_key=str(getattr(_flush_client, "api_key", "") or ""),
+                    )
+                if not _flush_ctx:
+                    # Fall back to main model's context length
+                    _flush_ctx = getattr(
+                        getattr(self, "context_compressor", None),
+                        "context_length", 0,
+                    )
+                if _flush_ctx:
+                    # Budget = context - output reservation - tool schema overhead
+                    _budget = _flush_ctx - 5120 - 500
+                    if _budget > 0:
+                        _est = estimate_messages_tokens_rough(api_messages)
+                        if _est > _budget:
+                            # Keep system prompt + as many recent messages as fit
+                            _sys = []
+                            _conv = api_messages
+                            if api_messages and api_messages[0].get("role") == "system":
+                                _sys = [api_messages[0]]
+                                _conv = api_messages[1:]
+                            _sys_tok = estimate_messages_tokens_rough(_sys)
+                            _rem = _budget - _sys_tok
+                            _kept: list = []
+                            _acc = 0
+                            for _m in reversed(_conv):
+                                _mt = estimate_messages_tokens_rough([_m])
+                                if _acc + _mt > _rem:
+                                    break
+                                _kept.append(_m)
+                                _acc += _mt
+                            _kept.reverse()
+                            # Always keep at least the last 3 messages
+                            if len(_kept) < 3 and len(_conv) >= 3:
+                                _kept = _conv[-3:]
+                            api_messages = _sys + _kept
+                            logger.info(
+                                "flush_memories: trimmed %d msgs (~%d tok) → %d msgs "
+                                "(~%d tok) to fit %d-token aux context",
+                                len(_sys) + len(_conv), _est, len(api_messages),
+                                estimate_messages_tokens_rough(api_messages),
+                                _flush_ctx,
+                            )
+            except Exception as _trim_err:
+                logger.debug("flush_memories: context trim failed (non-fatal): %s", _trim_err)
 
             # Use auxiliary client for the flush call when available --
             # it's cheaper and avoids Codex Responses API incompatibility.

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -71,7 +71,7 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     agent._check_compression_model_feasibility()
 
     assert len(messages) == 1
-    assert "Compression model" in messages[0]
+    assert "Auxiliary model" in messages[0]
     assert "80,000" in messages[0]        # aux context
     assert "100,000" in messages[0]       # old threshold
     assert "Auto-lowered" in messages[0]
@@ -147,16 +147,16 @@ def test_feasibility_check_passes_live_main_runtime():
         agent._emit_status = lambda msg: None
         agent._check_compression_model_feasibility()
 
-    mock_get_client.assert_called_once_with(
-        "compression",
-        main_runtime={
-            "model": "gpt-5.4",
-            "provider": "openai-codex",
-            "base_url": "https://chatgpt.com/backend-api/codex",
-            "api_key": "codex-token",
-            "api_mode": "codex_responses",
-        },
-    )
+    # Called for both "compression" and "flush_memories" tasks
+    expected_runtime = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "codex-token",
+        "api_mode": "codex_responses",
+    }
+    calls = mock_get_client.call_args_list
+    assert any(c == (("compression",), {"main_runtime": expected_runtime}) for c in calls)
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
@@ -175,11 +175,16 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
-        "custom/big-model",
-        base_url="http://custom-endpoint:8080/v1",
-        api_key="sk-custom",
-        config_context_length=1_000_000,
+    # The compression task call should include config_context_length
+    calls = mock_ctx_len.call_args_list
+    compression_call = calls[0]  # first call is for the compression model
+    assert compression_call == (
+        ("custom/big-model",),
+        {
+            "base_url": "http://custom-endpoint:8080/v1",
+            "api_key": "sk-custom",
+            "config_context_length": 1_000_000,
+        },
     )
 
 
@@ -197,11 +202,16 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
-        "custom/model",
-        base_url="http://custom:8080/v1",
-        api_key="sk-test",
-        config_context_length=None,
+    # The compression task call should forward config_context_length=None
+    calls = mock_ctx_len.call_args_list
+    compression_call = calls[0]
+    assert compression_call == (
+        ("custom/model",),
+        {
+            "base_url": "http://custom:8080/v1",
+            "api_key": "sk-test",
+            "config_context_length": None,
+        },
     )
 
 
@@ -249,11 +259,17 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         )
 
     assert agent._aux_compression_context_length_config == 1_000_000
-    mock_ctx_len.assert_called_once_with(
-        "custom/big-model",
-        base_url="http://custom-endpoint:8080/v1",
-        api_key="sk-custom",
-        config_context_length=1_000_000,
+    # The compression model call includes config_context_length;
+    # flush_memories call may also fire (same mock).
+    calls = mock_ctx_len.call_args_list
+    compression_call = calls[0]
+    assert compression_call == (
+        ("custom/big-model",),
+        {
+            "base_url": "http://custom-endpoint:8080/v1",
+            "api_key": "sk-custom",
+            "config_context_length": 1_000_000,
+        },
     )
 
 

--- a/tests/run_agent/test_flush_memories_context_trim.py
+++ b/tests/run_agent/test_flush_memories_context_trim.py
@@ -1,0 +1,306 @@
+"""Tests for flush_memories() context-window overflow prevention.
+
+Two-layer defence:
+  Layer 1 — _check_compression_model_feasibility now also resolves the
+            flush_memories auxiliary model and caps the compression
+            threshold at min(compression_ctx, flush_ctx).
+  Layer 2 — flush_memories() itself trims oversized api_messages before
+            calling call_llm, as a safety net for CLI /new and gateway
+            reset paths that don't go through preflight compression.
+
+Regression test for:
+  ⚠ Auxiliary memory flush failed: HTTP 400: Error code: 400 -
+  {'error': 'invalid params, context window exceeds limit (ref: ...)'}
+"""
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+class _FakeOpenAI:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.api_key = kwargs.get("api_key", "test")
+        self.base_url = kwargs.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _make_agent(monkeypatch, api_mode="chat_completions", provider="openrouter"):
+    """Build an AIAgent with mocked internals."""
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kw: [
+        {
+            "type": "function",
+            "function": {
+                "name": "memory",
+                "description": "Manage memories.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string"},
+                        "target": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            },
+        },
+    ])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(run_agent, "OpenAI", _FakeOpenAI)
+
+    agent = run_agent.AIAgent(
+        api_key="test-key",
+        base_url="https://test.example.com/v1",
+        provider=provider,
+        api_mode=api_mode,
+        max_iterations=4,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._memory_store = MagicMock()
+    agent._memory_flush_min_turns = 1
+    agent._user_turn_count = 5
+    return agent
+
+
+def _make_messages(n: int, chars_per_msg: int = 400) -> list:
+    """Generate n alternating user/assistant messages."""
+    msgs = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        content = f"Message {i}: " + "x" * max(0, chars_per_msg - 15)
+        msgs.append({"role": role, "content": content})
+    return msgs
+
+
+def _no_tool_calls_response():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            finish_reason="stop",
+            message=SimpleNamespace(content="Nothing to save.", tool_calls=None),
+        )],
+        usage=SimpleNamespace(prompt_tokens=100, completion_tokens=20, total_tokens=120),
+    )
+
+
+# ── Layer 1: _check_compression_model_feasibility ───────────────────────
+
+
+class TestFeasibilityChecksFlushModel:
+    """_check_compression_model_feasibility must also resolve the
+    flush_memories auxiliary model and cap the threshold at the smaller
+    of the two auxiliary context windows."""
+
+    def test_flush_model_smaller_than_compression_model_lowers_threshold(self, monkeypatch):
+        """When flush_memories resolves to a model with a smaller context
+        window than the compression model, the threshold is capped at the
+        flush model's context."""
+        agent = _make_agent(monkeypatch)
+        # Set up a compressor with a large threshold
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+
+        def _mock_get_text_aux(task, **kw):
+            if task == "compression":
+                return fake_client, "big-compression-model"
+            elif task == "flush_memories":
+                return fake_client, "small-flush-model"
+            return None, None
+
+        def _mock_ctx_length(model, **kw):
+            if model == "big-compression-model":
+                return 200_000
+            elif model == "small-flush-model":
+                return 80_000
+            return 128_000
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    side_effect=_mock_get_text_aux), \
+             patch("agent.model_metadata.get_model_context_length",
+                    side_effect=_mock_ctx_length):
+            agent._check_compression_model_feasibility()
+
+        # Threshold should be lowered to the flush model's 80K
+        assert agent.context_compressor.threshold_tokens == 80_000
+
+    def test_same_model_for_both_tasks_no_double_penalty(self, monkeypatch):
+        """When compression and flush_memories resolve to the same model,
+        the threshold is capped at that model's context — no double penalty."""
+        agent = _make_agent(monkeypatch)
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(fake_client, "same-model")), \
+             patch("agent.model_metadata.get_model_context_length",
+                    return_value=120_000):
+            agent._check_compression_model_feasibility()
+
+        # Both resolve to 120K > 100K threshold, so no change
+        assert agent.context_compressor.threshold_tokens == 100_000
+
+    def test_compression_model_smaller_still_works(self, monkeypatch):
+        """When compression model is the smaller one, it still drives the
+        threshold (existing behaviour preserved)."""
+        agent = _make_agent(monkeypatch)
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+
+        def _mock_get_text_aux(task, **kw):
+            if task == "compression":
+                return fake_client, "small-compression-model"
+            elif task == "flush_memories":
+                return fake_client, "big-flush-model"
+            return None, None
+
+        def _mock_ctx_length(model, **kw):
+            if model == "small-compression-model":
+                return 70_000
+            elif model == "big-flush-model":
+                return 200_000
+            return 128_000
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    side_effect=_mock_get_text_aux), \
+             patch("agent.model_metadata.get_model_context_length",
+                    side_effect=_mock_ctx_length):
+            agent._check_compression_model_feasibility()
+
+        assert agent.context_compressor.threshold_tokens == 70_000
+
+    def test_flush_model_resolution_failure_is_non_fatal(self, monkeypatch):
+        """If flush_memories aux resolution raises, feasibility check still
+        proceeds using the compression model's context only."""
+        agent = _make_agent(monkeypatch)
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+
+        call_count = [0]
+        def _mock_get_text_aux(task, **kw):
+            call_count[0] += 1
+            if task == "compression":
+                return fake_client, "compression-model"
+            elif task == "flush_memories":
+                raise RuntimeError("flush aux unavailable")
+            return None, None
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    side_effect=_mock_get_text_aux), \
+             patch("agent.model_metadata.get_model_context_length",
+                    return_value=200_000):
+            agent._check_compression_model_feasibility()
+
+        # Should have tried both tasks
+        assert call_count[0] == 2
+        # No threshold change — compression model fits fine
+        assert agent.context_compressor.threshold_tokens == 100_000
+
+
+# ── Layer 2: flush_memories() inline trimming ────────────────────────────
+
+
+class TestFlushMemoriesTrimming:
+    """flush_memories trims oversized conversations before calling call_llm."""
+
+    def test_oversized_conversation_trimmed(self, monkeypatch):
+        """Large conversation is trimmed to fit the aux model's context."""
+        agent = _make_agent(monkeypatch)
+        agent._cached_system_prompt = "You are helpful."
+        messages = _make_messages(200, chars_per_msg=500)
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(fake_client, "small-model")), \
+             patch("agent.model_metadata.get_model_context_length",
+                    return_value=8_000), \
+             patch("agent.auxiliary_client.call_llm",
+                    return_value=_no_tool_calls_response()) as mock_call:
+            agent.flush_memories(messages)
+
+            assert mock_call.called
+            sent = mock_call.call_args.kwargs.get("messages", [])
+            assert len(sent) < 100, (
+                f"Expected trimmed messages, got {len(sent)}. "
+                f"flush_memories should trim to fit 8K aux context."
+            )
+
+    def test_small_conversation_not_trimmed(self, monkeypatch):
+        """Short conversations pass through untrimmed."""
+        agent = _make_agent(monkeypatch)
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+            {"role": "user", "content": "Save this"},
+        ]
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(fake_client, "big-model")), \
+             patch("agent.model_metadata.get_model_context_length",
+                    return_value=200_000), \
+             patch("agent.auxiliary_client.call_llm",
+                    return_value=_no_tool_calls_response()) as mock_call:
+            agent.flush_memories(messages)
+
+            sent = mock_call.call_args.kwargs.get("messages", [])
+            # 1 system + 3 conv + 1 flush = 5
+            assert len(sent) == 5
+
+    def test_trim_failure_is_non_fatal(self, monkeypatch):
+        """If trimming fails, flush still proceeds with full messages."""
+        agent = _make_agent(monkeypatch)
+        messages = _make_messages(10, chars_per_msg=100)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    side_effect=RuntimeError("no provider")), \
+             patch("agent.auxiliary_client.call_llm",
+                    return_value=_no_tool_calls_response()) as mock_call:
+            agent.flush_memories(messages)
+            assert mock_call.called
+
+    def test_sentinel_cleaned_up_after_trim(self, monkeypatch):
+        """Flush sentinel is always removed regardless of trimming."""
+        agent = _make_agent(monkeypatch)
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+            {"role": "user", "content": "Remember this"},
+        ]
+        original_len = len(messages)
+
+        fake_client = SimpleNamespace(base_url="http://test", api_key="k")
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(fake_client, "model")), \
+             patch("agent.model_metadata.get_model_context_length",
+                    return_value=128_000), \
+             patch("agent.auxiliary_client.call_llm",
+                    return_value=_no_tool_calls_response()):
+            agent.flush_memories(messages)
+
+        assert len(messages) == original_len
+        assert not any(m.get("_flush_sentinel") for m in messages)


### PR DESCRIPTION
## Summary

`flush_memories()` sends the **entire conversation** to the auxiliary model before compression. After commit `a155b4a1` ("default auto routing to main model for all users"), the auxiliary model changed from a cheap fallback (Gemini Flash, 1M context) to the **user's main model**. When main model == aux model, the feasibility check saw `aux_context == main_context`, concluded no adjustment was needed, and the system prompt + tool schema overhead pushed the actual request past the model's limit:

```
⚠ Auxiliary memory flush failed: HTTP 400: Error code: 400 -
{'error': 'invalid params, context window exceeds limit (ref: c91e8191-...)'}
```

## Root Cause

`_check_compression_model_feasibility()` compared `aux_context` against `threshold_tokens` without accounting for **system prompt overhead** (~20-30K tokens with tools + skills + memory). The comparison was:

```
if aux_context < threshold:  # threshold = context * 0.50
    lower_threshold()
```

When aux == main model (the post-`a155b4a1` default), `aux_context >= threshold` always holds (since threshold ≤ context), so no adjustment fires. But `flush_memories` prepends the system prompt + tool schema + output reservation on top of threshold-sized messages, making the actual request `threshold + 35K overhead > aux_context`.

Before `a155b4a1`, aggregator users had aux = Gemini Flash (1M), so the overhead never mattered. After, aux = main model, and the overhead is the difference between "fits" and "400 error."

Additionally, the check never resolved the `flush_memories` auxiliary task — only `compression`. These can resolve to different models via separate `auxiliary.flush_memories.provider/model` config.

## Fix (3 changes)

1. **Reserve overhead in feasibility check**: Compare against `aux_context - 35K` (system prompt + tool schema + output reservation), not bare `aux_context`. This ensures the compression threshold is low enough that flush_memories + overhead still fits.

2. **Check both aux tasks**: `_check_compression_model_feasibility` now also resolves `get_text_auxiliary_client("flush_memories")` and uses `min(compression_ctx, flush_ctx)` as the effective limit.

3. **Defense-in-depth trimming**: `flush_memories()` itself trims `api_messages` to fit the resolved aux context before calling `call_llm`. Catches CLI `/new` and gateway reset paths that don't go through preflight compression.

## Test Plan

- 8 new tests in `test_flush_memories_context_trim.py` (both layers)
- Updated existing `test_compression_feasibility.py` tests for overhead deduction
- All 36 flush/feasibility tests pass
- Existing `test_flush_memories_codex.py` (12 tests) unaffected
