### PR TITLE
feat(gateway): add NotionAgent platform adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ hermes-agent/
 │   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
 │   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
 │   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
-│   │                     #   webhook, api_server, ...). See ADDING_A_PLATFORM.md.
+│   │                     #   webhook, notionagent, api_server, ...). See ADDING_A_PLATFORM.md.
 │   └── builtin_hooks/    # Always-registered gateway hooks (boot-md, ...)
 ├── plugins/              # Plugin system (see "Plugins" section below)
 │   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
@@ -320,6 +320,8 @@ Non-secret settings (timeouts, thresholds, feature flags, paths, display
 preferences) belong in `config.yaml`, not `.env`. If internal code needs an
 env var mirror for backward compatibility, bridge it from `config.yaml` to
 the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
+NotionAgent uses `NOTIONAGENT_SECRET` as the shared HMAC secret and
+`NOTIONAGENT_CALLBACK_URL` as the outbound reply endpoint.
 
 ### Config loaders (three paths — know which one you're in):
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, NotionAgent, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -93,7 +93,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant, NotionAgent |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -333,6 +333,13 @@ PLATFORM_HINTS = {
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
     ),
+    "notionagent": (
+        "You are responding inside the NotionAgent web app's chat panel. "
+        "Plain text and markdown work; the frontend renders standard markdown "
+        "including code blocks. There is no voice or image return path on this "
+        "platform — text only. Each session here is scoped to a single voice "
+        "memo or task; keep answers focused on that scope."
+    ),
     "email": (
         "You are communicating via email. Write clear, well-structured responses "
         "suitable for email. Use plain text formatting (no markdown). "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -77,7 +77,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot",
+    "qqbot", "notionagent",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to
@@ -87,6 +87,7 @@ _HOME_TARGET_ENV_VARS = {
     "telegram": "TELEGRAM_HOME_CHANNEL",
     "discord": "DISCORD_HOME_CHANNEL",
     "slack": "SLACK_HOME_CHANNEL",
+    "notionagent": "NOTIONAGENT_HOME_CHANNEL",
     "signal": "SIGNAL_HOME_CHANNEL",
     "mattermost": "MATTERMOST_HOME_CHANNEL",
     "sms": "SMS_HOME_CHANNEL",
@@ -337,6 +338,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         "sms": Platform.SMS,
         "bluebubbles": Platform.BLUEBUBBLES,
         "qqbot": Platform.QQBOT,
+        "notionagent": Platform.NOTIONAGENT,
     }
 
     # Optionally wrap the content with a header/footer so the user knows this

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -78,7 +78,8 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
 
     # Platforms that don't support direct channel enumeration get session-based
     # discovery automatically.  Skip infrastructure entries that aren't messaging
-    # platforms — everything else falls through to _build_from_sessions().
+    # platforms — everything else, including notionagent, falls through to
+    # _build_from_sessions().
     _SKIP_SESSION_DISCOVERY = frozenset({"local", "api_server", "webhook"})
     for plat in Platform:
         plat_name = plat.value

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -61,6 +61,7 @@ class Platform(Enum):
     DINGTALK = "dingtalk"
     API_SERVER = "api_server"
     WEBHOOK = "webhook"
+    NOTIONAGENT = "notionagent"
     FEISHU = "feishu"
     WECOM = "wecom"
     WECOM_CALLBACK = "wecom_callback"
@@ -296,6 +297,9 @@ class GatewayConfig:
                 connected.append(platform)
             # Webhook uses enabled flag only (secrets are per-route)
             elif platform == Platform.WEBHOOK:
+                connected.append(platform)
+            # NotionAgent uses HMAC + callback URL rather than token/api_key
+            elif platform == Platform.NOTIONAGENT and config.extra.get("secret") and config.extra.get("callback_url"):
                 connected.append(platform)
             # Feishu uses extra dict for app credentials
             elif platform == Platform.FEISHU and config.extra.get("app_id"):
@@ -548,6 +552,14 @@ def load_gateway_config() -> GatewayConfig:
                     existing = platforms_data.get(plat_name, {})
                     if not isinstance(existing, dict):
                         existing = {}
+                    if plat_name == Platform.NOTIONAGENT.value:
+                        direct_extra = {
+                            key: plat_block[key]
+                            for key in ("secret", "callback_url", "host", "port", "path")
+                            if key in plat_block
+                        }
+                        if direct_extra:
+                            plat_block = {**plat_block, "extra": {**plat_block.get("extra", {}), **direct_extra}}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
                     merged = {**existing, **plat_block}
@@ -1089,6 +1101,37 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 pass
         if webhook_secret:
             config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+
+    # NotionAgent platform
+    notionagent_secret = os.getenv("NOTIONAGENT_SECRET", "")
+    notionagent_callback_url = os.getenv("NOTIONAGENT_CALLBACK_URL", "")
+    notionagent_port = os.getenv("NOTIONAGENT_PORT")
+    if notionagent_secret or notionagent_callback_url:
+        if Platform.NOTIONAGENT not in config.platforms:
+            config.platforms[Platform.NOTIONAGENT] = PlatformConfig()
+        config.platforms[Platform.NOTIONAGENT].enabled = True
+        if notionagent_secret:
+            config.platforms[Platform.NOTIONAGENT].extra["secret"] = notionagent_secret
+        if notionagent_callback_url:
+            config.platforms[Platform.NOTIONAGENT].extra["callback_url"] = notionagent_callback_url
+        if notionagent_port:
+            try:
+                config.platforms[Platform.NOTIONAGENT].extra["port"] = int(notionagent_port)
+            except ValueError:
+                pass
+        notionagent_host = os.getenv("NOTIONAGENT_HOST", "")
+        if notionagent_host:
+            config.platforms[Platform.NOTIONAGENT].extra["host"] = notionagent_host
+        notionagent_path = os.getenv("NOTIONAGENT_PATH", "")
+        if notionagent_path:
+            config.platforms[Platform.NOTIONAGENT].extra["path"] = notionagent_path
+    notionagent_home = os.getenv("NOTIONAGENT_HOME_CHANNEL", "")
+    if notionagent_home and Platform.NOTIONAGENT in config.platforms:
+        config.platforms[Platform.NOTIONAGENT].home_channel = HomeChannel(
+            platform=Platform.NOTIONAGENT,
+            chat_id=notionagent_home,
+            name=os.getenv("NOTIONAGENT_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # DingTalk
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -97,6 +97,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "email":           _TIER_MINIMAL,
     "sms":             _TIER_MINIMAL,
     "webhook":         _TIER_MINIMAL,
+    "notionagent":     _TIER_MINIMAL,
     "homeassistant":   _TIER_MINIMAL,
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }

--- a/gateway/platforms/notionagent.py
+++ b/gateway/platforms/notionagent.py
@@ -1,0 +1,291 @@
+"""NotionAgent HTTP platform adapter.
+
+Receives signed JSON messages from the NotionAgent web app and posts signed
+text replies back to the app's callback endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+from agent.redact import redact_sensitive_text
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8645
+DEFAULT_PATH = "/notionagent/in"
+SIGNATURE_HEADER = "X-NotionAgent-Signature"
+
+
+def check_notionagent_requirements() -> bool:
+    """Check if NotionAgent adapter dependencies are available."""
+    return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
+
+
+def _signature_for_body(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(
+        secret.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+
+
+def _validate_notionagent_signature(signature: str, body: bytes, secret: str) -> bool:
+    if not signature or not signature.startswith("sha256="):
+        return False
+    expected = _signature_for_body(body, secret)
+    return hmac.compare_digest(signature, expected)
+
+
+def _signed_json_payload(payload: Dict[str, Any], secret: str) -> tuple[bytes, str]:
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return body, _signature_for_body(body, secret)
+
+
+def _redact(text: Any) -> str:
+    return redact_sensitive_text(str(text))
+
+
+class NotionAgentAdapter(BasePlatformAdapter):
+    """HTTP bridge for the NotionAgent web app."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.NOTIONAGENT)
+        extra = config.extra or {}
+        self._host = str(extra.get("host") or DEFAULT_HOST)
+        self._port = int(extra.get("port") or DEFAULT_PORT)
+        self._path = str(extra.get("path") or DEFAULT_PATH)
+        if not self._path.startswith("/"):
+            self._path = f"/{self._path}"
+        self._secret = str(extra.get("secret") or config.token or "")
+        self._callback_url = str(extra.get("callback_url") or "")
+        self._runner = None
+
+    async def connect(self) -> bool:
+        if not self._secret:
+            logger.error("[notionagent] Missing NOTIONAGENT_SECRET")
+            return False
+        if not self._callback_url:
+            logger.error("[notionagent] Missing NOTIONAGENT_CALLBACK_URL")
+            return False
+
+        app = self._create_app()
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+
+        max_attempts = 4
+        for attempt in range(max_attempts):
+            try:
+                site = web.TCPSite(self._runner, self._host, self._port)
+                await site.start()
+                self._mark_connected()
+                logger.info(
+                    "[notionagent] Listening on %s:%d%s",
+                    self._host,
+                    self._port,
+                    self._path,
+                )
+                return True
+            except OSError as exc:
+                if attempt >= max_attempts - 1:
+                    logger.error(
+                        "[notionagent] Failed to bind %s:%d after %d attempts: %s",
+                        self._host,
+                        self._port,
+                        max_attempts,
+                        _redact(exc),
+                    )
+                    await self._runner.cleanup()
+                    self._runner = None
+                    return False
+                delay = min(2 ** attempt, 8) + (0.1 * attempt)
+                logger.warning(
+                    "[notionagent] Port bind failed on %s:%d, retrying in %.1fs: %s",
+                    self._host,
+                    self._port,
+                    delay,
+                    _redact(exc),
+                )
+                await asyncio.sleep(delay)
+
+        return False
+
+    async def disconnect(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._mark_disconnected()
+        logger.info("[notionagent] Disconnected")
+
+    def _create_app(self) -> "web.Application":
+        app = web.Application()
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_post(self._path, self._handle_inbound)
+        return app
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response({"status": "ok", "platform": "notionagent"})
+
+    async def _handle_inbound(self, request: "web.Request") -> "web.Response":
+        try:
+            raw_body = await request.read()
+        except Exception as exc:
+            logger.warning("[notionagent] Failed to read request body: %s", _redact(exc))
+            return web.json_response({"error": "Bad request"}, status=400)
+
+        signature = request.headers.get(SIGNATURE_HEADER, "")
+        if not _validate_notionagent_signature(signature, raw_body, self._secret):
+            logger.warning("[notionagent] Invalid signature")
+            return web.json_response({"error": "Invalid signature"}, status=401)
+
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        session_id = str(payload.get("session_id") or "").strip()
+        text = str(payload.get("text") or "")
+        if not session_id or not text:
+            return web.json_response(
+                {"error": "session_id and text are required"},
+                status=400,
+            )
+
+        message_id = str(payload.get("message_id") or uuid.uuid4())
+        source = self.build_source(
+            chat_id=session_id,
+            chat_name=session_id,
+            chat_type="session",
+            user_id=session_id,
+            user_name=session_id,
+            message_id=message_id,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=payload,
+            message_id=message_id,
+        )
+
+        logger.info(
+            "[notionagent] Accepted message session=%s message_id=%s text_len=%d",
+            session_id,
+            message_id,
+            len(text),
+        )
+        task = asyncio.create_task(self.handle_message(event))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+        return web.json_response(
+            {"status": "accepted", "session_id": session_id, "message_id": message_id},
+            status=202,
+        )
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._callback_url:
+            return SendResult(success=False, error="NOTIONAGENT_CALLBACK_URL is not configured")
+        return await _post_notionagent_callback(
+            callback_url=self._callback_url,
+            secret=self._secret,
+            session_id=str(chat_id),
+            text=content,
+        )
+
+    async def send_typing(self, chat_id: str) -> SendResult:
+        return SendResult(success=True)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        return SendResult(success=False, error="not supported")
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "session", "chat_id": chat_id}
+
+
+async def _post_notionagent_callback(
+    *,
+    callback_url: str,
+    secret: str,
+    session_id: str,
+    text: str,
+) -> SendResult:
+    if not HTTPX_AVAILABLE:
+        return SendResult(
+            success=False,
+            error="httpx is not installed",
+            retryable=False,
+        )
+
+    payload = {
+        "session_id": str(session_id),
+        "text": text,
+        "message_id": str(uuid.uuid4()),
+    }
+    body, signature = _signed_json_payload(payload, secret)
+    headers = {
+        "Content-Type": "application/json",
+        SIGNATURE_HEADER: signature,
+    }
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(callback_url, content=body, headers=headers)
+        if response.status_code >= 400:
+            return SendResult(
+                success=False,
+                error=f"callback returned HTTP {response.status_code}",
+                raw_response=getattr(response, "text", ""),
+                retryable=response.status_code >= 500,
+            )
+        return SendResult(
+            success=True,
+            message_id=payload["message_id"],
+            raw_response={"status_code": response.status_code, "elapsed": time.monotonic() - started},
+        )
+    except Exception as exc:
+        return SendResult(
+            success=False,
+            error=f"NotionAgent callback failed: {_redact(exc)}",
+            retryable=True,
+        )

--- a/gateway/platforms/notionagent.py
+++ b/gateway/platforms/notionagent.py
@@ -228,7 +228,7 @@ class NotionAgentAdapter(BasePlatformAdapter):
             text=content,
         )
 
-    async def send_typing(self, chat_id: str) -> SendResult:
+    async def send_typing(self, chat_id: str, metadata=None) -> SendResult:
         return SendResult(success=True)
 
     async def send_image(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -221,6 +221,7 @@ class WebhookAdapter(BasePlatformAdapter):
             "weixin",
             "bluebubbles",
             "qqbot",
+            "notionagent",
         ):
             return await self._deliver_cross_platform(
                 deliver_type, content, delivery

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2945,6 +2945,16 @@ class GatewayRunner:
             adapter.gateway_runner = self  # For cross-platform delivery
             return adapter
 
+        elif platform == Platform.NOTIONAGENT:
+            from gateway.platforms.notionagent import (
+                NotionAgentAdapter,
+                check_notionagent_requirements,
+            )
+            if not check_notionagent_requirements():
+                logger.warning("NotionAgent: aiohttp/httpx not installed")
+                return None
+            return NotionAgentAdapter(config)
+
         elif platform == Platform.BLUEBUBBLES:
             from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
             if not check_bluebubbles_requirements():
@@ -3001,6 +3011,7 @@ class GatewayRunner:
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
+            Platform.NOTIONAGENT: "NOTIONAGENT_ALLOWED_USERS",
         }
         platform_group_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
@@ -3023,11 +3034,20 @@ class GatewayRunner:
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
+            Platform.NOTIONAGENT: "NOTIONAGENT_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in ("true", "1", "yes"):
+            return True
+
+        if (
+            source.platform == Platform.NOTIONAGENT
+            and not os.getenv("NOTIONAGENT_ALLOWED_USERS", "").strip()
+            and not os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+            and not os.getenv("NOTIONAGENT_ALLOW_ALL_USERS", "").strip()
+        ):
             return True
 
         # Discord bot senders that passed the DISCORD_ALLOW_BOTS platform
@@ -3154,6 +3174,7 @@ class GatewayRunner:
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
+                Platform.NOTIONAGENT: "NOTIONAGENT_ALLOWED_USERS",
             }
             if os.getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1877,6 +1877,62 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "messaging",
     },
+    "NOTIONAGENT_SECRET": {
+        "description": "Shared HMAC secret for the NotionAgent gateway adapter.",
+        "prompt": "NotionAgent HMAC secret",
+        "url": "https://github.com/ravenviersechs/NotionAgent",
+        "password": True,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_CALLBACK_URL": {
+        "description": "NotionAgent callback URL that receives Hermes replies.",
+        "prompt": "NotionAgent callback URL",
+        "url": "https://github.com/ravenviersechs/NotionAgent",
+        "password": False,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_PORT": {
+        "description": "Port for the NotionAgent inbound HTTP server (default: 8645).",
+        "prompt": "NotionAgent inbound port",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_HOST": {
+        "description": "Bind host for the NotionAgent inbound HTTP server (default: 0.0.0.0).",
+        "prompt": "NotionAgent bind host",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_PATH": {
+        "description": "Inbound path for NotionAgent messages (default: /notionagent/in).",
+        "prompt": "NotionAgent inbound path",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_ALLOWED_USERS": {
+        "description": "Optional comma-separated NotionAgent session IDs allowed to use Hermes; empty allows all signed requests.",
+        "prompt": "NotionAgent allowed session IDs",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_ALLOW_ALL_USERS": {
+        "description": "Explicitly allow all signed NotionAgent requests.",
+        "prompt": "Allow all NotionAgent sessions",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "NOTIONAGENT_HOME_CHANNEL": {
+        "description": "Default NotionAgent session ID for cron and send_message delivery.",
+        "prompt": "NotionAgent home session ID",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
 
     # ── Agent settings ──
     # NOTE: MESSAGING_CWD was removed here — use terminal.cwd in config.yaml

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2724,6 +2724,38 @@ _PLATFORMS = [
              "help": "OpenID to deliver cron results and notifications to."},
         ],
     },
+    {
+        "key": "notionagent",
+        "label": "NotionAgent",
+        "emoji": "📝",
+        "token_var": "NOTIONAGENT_SECRET",
+        "setup_instructions": [
+            "1. Generate a long shared HMAC secret and configure it in both Hermes and NotionAgent",
+            "2. Set NOTIONAGENT_CALLBACK_URL to the NotionAgent endpoint that receives Hermes replies",
+            "3. Expose the Hermes gateway endpoint to NotionAgent:",
+            "   https://your-server:8645/notionagent/in",
+            "4. NotionAgent signs POST bodies with X-NotionAgent-Signature: sha256=<hex>",
+        ],
+        "vars": [
+            {"name": "NOTIONAGENT_SECRET", "prompt": "Shared HMAC secret", "password": True,
+             "help": "Use the same secret in Hermes and NotionAgent for inbound and outbound signatures."},
+            {"name": "NOTIONAGENT_CALLBACK_URL", "prompt": "Callback URL for replies", "password": False,
+             "help": "The NotionAgent endpoint Hermes POSTs responses to."},
+            {"name": "NOTIONAGENT_PORT", "prompt": "Inbound HTTP port (default: 8645)", "password": False,
+             "help": "Local port for /notionagent/in."},
+            {"name": "NOTIONAGENT_HOST", "prompt": "Bind host (default: 0.0.0.0)", "password": False,
+             "help": "Bind address for the inbound HTTP server."},
+            {"name": "NOTIONAGENT_PATH", "prompt": "Inbound path (default: /notionagent/in)", "password": False,
+             "help": "HTTP path NotionAgent should POST chat messages to."},
+            {"name": "NOTIONAGENT_ALLOWED_USERS", "prompt": "Allowed session IDs (comma-separated, optional)", "password": False,
+             "is_allowlist": True,
+             "help": "Optional. Empty means all correctly signed NotionAgent requests are accepted."},
+            {"name": "NOTIONAGENT_ALLOW_ALL_USERS", "prompt": "Allow all signed requests (true/false, optional)", "password": False,
+             "help": "Optional explicit allow-all flag. HMAC validation is still required."},
+            {"name": "NOTIONAGENT_HOME_CHANNEL", "prompt": "Default session ID for cron/notifications (optional)", "password": False,
+             "help": "Session ID to use when sending to the NotionAgent home channel."},
+        ],
+    },
 ]
 
 
@@ -2766,6 +2798,13 @@ def _platform_status(platform: dict) -> str:
             suffix = " + E2EE" if e2ee and e2ee.lower() in ("true", "1", "yes") else ""
             return f"configured{suffix}"
         if val or password or homeserver:
+            return "partially configured"
+        return "not configured"
+    if platform.get("key") == "notionagent":
+        callback_url = get_env_value("NOTIONAGENT_CALLBACK_URL")
+        if val and callback_url:
+            return "configured"
+        if val or callback_url:
             return "partially configured"
         return "not configured"
     if platform.get("key") == "weixin":

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -37,6 +37,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("weixin",         PlatformInfo(label="💬 Weixin",          default_toolset="hermes-weixin")),
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),
+    ("notionagent",    PlatformInfo(label="📝 NotionAgent",     default_toolset="hermes-notionagent")),
     ("api_server",     PlatformInfo(label="🌐 API Server",      default_toolset="hermes-api-server")),
     ("cron",           PlatformInfo(label="⏰ Cron",            default_toolset="hermes-cron")),
 ])

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -327,6 +327,7 @@ def show_status(args):
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
         "QQBot": ("QQ_APP_ID", "QQBOT_HOME_CHANNEL"),
+        "NotionAgent": ("NOTIONAGENT_SECRET", "NOTIONAGENT_HOME_CHANNEL"),
     }
     
     for name, (token_var, home_var) in platforms.items():

--- a/tests/gateway/test_notionagent.py
+++ b/tests/gateway/test_notionagent.py
@@ -1,0 +1,267 @@
+import hashlib
+import hmac
+import inspect
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import asyncio
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platforms.base import MessageType, SendResult
+from gateway.platforms.notionagent import (
+    NotionAgentAdapter,
+    SIGNATURE_HEADER,
+    _signed_json_payload,
+    _validate_notionagent_signature,
+)
+from gateway.session import SessionSource
+
+
+def _config(**extra):
+    merged = {
+        "secret": "test-secret",
+        "callback_url": "https://notionagent.example/callback",
+        "host": "127.0.0.1",
+        "port": 0,
+    }
+    merged.update(extra)
+    return PlatformConfig(enabled=True, extra=merged)
+
+
+def _signature(body: bytes, secret: str = "test-secret") -> str:
+    return "sha256=" + hmac.new(
+        secret.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+
+
+def _request(body: bytes, headers: dict):
+    request = MagicMock()
+    request.headers = headers
+
+    async def read():
+        return body
+
+    request.read = read
+    return request
+
+
+def test_platform_enum_value():
+    assert Platform.NOTIONAGENT.value == "notionagent"
+
+
+def test_env_override_loading_and_connected_flag(monkeypatch):
+    monkeypatch.setenv("NOTIONAGENT_SECRET", "env-secret")
+    monkeypatch.setenv("NOTIONAGENT_CALLBACK_URL", "https://app.example/cb")
+    monkeypatch.setenv("NOTIONAGENT_PORT", "9876")
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    pconfig = config.platforms[Platform.NOTIONAGENT]
+    assert pconfig.enabled is True
+    assert pconfig.extra["secret"] == "env-secret"
+    assert pconfig.extra["callback_url"] == "https://app.example/cb"
+    assert pconfig.extra["port"] == 9876
+    assert Platform.NOTIONAGENT in config.get_connected_platforms()
+
+
+def test_connected_flag_requires_secret_and_callback_url():
+    config = GatewayConfig(
+        platforms={
+            Platform.NOTIONAGENT: PlatformConfig(
+                enabled=True,
+                extra={"secret": "s"},
+            )
+        }
+    )
+    assert Platform.NOTIONAGENT not in config.get_connected_platforms()
+
+
+def test_hmac_validation_accept_and_reject():
+    body = b'{"session_id":"memo-1","text":"hello"}'
+    assert _validate_notionagent_signature(_signature(body), body, "test-secret")
+    assert not _validate_notionagent_signature("sha256=deadbeef", body, "test-secret")
+    assert not _validate_notionagent_signature("", body, "test-secret")
+
+
+def test_adapter_init_config_parsing():
+    adapter = NotionAgentAdapter(
+        _config(path="notionagent/in", port="8765", host="127.0.0.1")
+    )
+    assert adapter._path == "/notionagent/in"
+    assert adapter._port == 8765
+    assert adapter._host == "127.0.0.1"
+    assert adapter._callback_url == "https://notionagent.example/callback"
+
+
+@pytest.mark.asyncio
+async def test_inbound_message_dispatch():
+    adapter = NotionAgentAdapter(_config())
+    captured = []
+
+    async def handle(event):
+        captured.append(event)
+
+    adapter.handle_message = handle
+    payload = {"session_id": "memo-123", "text": "Summarize this"}
+    body = json.dumps(payload).encode("utf-8")
+
+    resp = await adapter._handle_inbound(
+        _request(body, {SIGNATURE_HEADER: _signature(body)})
+    )
+    assert resp.status == 202
+    await asyncio.sleep(0)
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.text == "Summarize this"
+    assert event.message_type == MessageType.TEXT
+    assert event.source.platform == Platform.NOTIONAGENT
+    assert event.source.chat_id == "memo-123"
+    assert event.source.chat_type == "session"
+
+
+@pytest.mark.asyncio
+async def test_inbound_rejects_bad_signature():
+    adapter = NotionAgentAdapter(_config())
+    adapter.handle_message = AsyncMock()
+    body = b'{"session_id":"memo-123","text":"hello"}'
+
+    resp = await adapter._handle_inbound(
+        _request(body, {SIGNATURE_HEADER: "sha256=bad"})
+    )
+    assert resp.status == 401
+
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_outbound_post_shape(monkeypatch):
+    posted = {}
+
+    class Response:
+        status_code = 200
+        text = "ok"
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, content, headers):
+            posted["url"] = url
+            posted["content"] = content
+            posted["headers"] = headers
+            return Response()
+
+    import gateway.platforms.notionagent as notionagent
+
+    monkeypatch.setattr(notionagent.httpx, "AsyncClient", Client)
+
+    adapter = NotionAgentAdapter(_config(secret="shared"))
+    result = await adapter.send("memo-1", "Done")
+
+    assert result.success is True
+    assert posted["url"] == "https://notionagent.example/callback"
+    payload = json.loads(posted["content"].decode("utf-8"))
+    assert payload["session_id"] == "memo-1"
+    assert payload["text"] == "Done"
+    assert payload["message_id"]
+    assert posted["headers"][SIGNATURE_HEADER] == _signature(posted["content"], "shared")
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_notionagent_matches_adapter(monkeypatch):
+    called = {}
+
+    async def fake_post(**kwargs):
+        called.update(kwargs)
+        return SendResult(success=True, message_id="msg-1")
+
+    import tools.send_message_tool as send_message_tool
+
+    monkeypatch.setattr(
+        "gateway.platforms.notionagent._post_notionagent_callback",
+        fake_post,
+    )
+    result = await send_message_tool._send_notionagent(
+        _config(secret="standalone"),
+        "memo-2",
+        "Hello",
+    )
+
+    assert result == {
+        "success": True,
+        "platform": "notionagent",
+        "chat_id": "memo-2",
+        "message_id": "msg-1",
+    }
+    assert called["secret"] == "standalone"
+    assert called["session_id"] == "memo-2"
+    assert called["text"] == "Hello"
+
+
+def test_authorization_maps_present():
+    from gateway.run import GatewayRunner
+
+    source = inspect.getsource(GatewayRunner._is_user_authorized)
+    assert "NOTIONAGENT_ALLOWED_USERS" in source
+    assert "NOTIONAGENT_ALLOW_ALL_USERS" in source
+
+
+def test_authorization_defaults_to_all_signed_requests(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.delenv("NOTIONAGENT_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("NOTIONAGENT_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    source = SessionSource(
+        platform=Platform.NOTIONAGENT,
+        chat_id="memo-3",
+        chat_type="session",
+        user_id="memo-3",
+    )
+    assert runner._is_user_authorized(source) is True
+
+
+def test_send_message_tool_routing_mentions_notionagent():
+    import tools.send_message_tool as send_message_tool
+
+    source = inspect.getsource(send_message_tool._handle_send)
+    assert '"notionagent": Platform.NOTIONAGENT' in source
+    source = inspect.getsource(send_message_tool._send_to_platform)
+    assert "Platform.NOTIONAGENT" in source
+
+
+def test_session_source_roundtrip():
+    source = SessionSource(
+        platform=Platform.NOTIONAGENT,
+        chat_id="memo-4",
+        chat_name="memo-4",
+        chat_type="session",
+        user_id="memo-4",
+    )
+    restored = SessionSource.from_dict(source.to_dict())
+    assert restored.platform == Platform.NOTIONAGENT
+    assert restored.chat_id == "memo-4"
+    assert restored.chat_type == "session"
+
+
+def test_signed_json_payload_uses_raw_body_signature():
+    body, signature = _signed_json_payload(
+        {"session_id": "memo-5", "text": "hi", "message_id": "msg"},
+        "secret",
+    )
+    assert signature == _signature(body, "secret")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -479,7 +479,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering', 'sms:+15551234567'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
+                "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering', 'sms:+15551234567', 'notionagent:session-id'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
             },
             "skills": {
                 "type": "array",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -120,7 +120,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org'"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'notionagent:session-id'"
             },
             "message": {
                 "type": "string",
@@ -215,6 +215,7 @@ def _handle_send(args):
         "weixin": Platform.WEIXIN,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "notionagent": Platform.NOTIONAGENT,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -322,6 +323,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    if platform_name == "notionagent":
+        return target_ref.strip(), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -571,6 +574,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
         elif platform == Platform.QQBOT:
             result = await _send_qqbot(pconfig, chat_id, chunk)
+        elif platform == Platform.NOTIONAGENT:
+            result = await _send_notionagent(pconfig, chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -1508,6 +1513,35 @@ async def _send_qqbot(pconfig, chat_id, message):
                 return _error(f"QQBot send failed: {resp.status_code} {resp.text}")
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
+
+
+async def _send_notionagent(pconfig, chat_id, message):
+    """Send via NotionAgent callback without requiring the gateway adapter."""
+    try:
+        from gateway.platforms.notionagent import _post_notionagent_callback
+    except ImportError:
+        return _error("NotionAgent direct send requires aiohttp and httpx.")
+
+    extra = pconfig.extra or {}
+    secret = extra.get("secret") or pconfig.token or os.getenv("NOTIONAGENT_SECRET", "")
+    callback_url = extra.get("callback_url") or os.getenv("NOTIONAGENT_CALLBACK_URL", "")
+    if not secret or not callback_url:
+        return _error("NotionAgent: NOTIONAGENT_SECRET and NOTIONAGENT_CALLBACK_URL must be configured.")
+
+    result = await _post_notionagent_callback(
+        callback_url=str(callback_url),
+        secret=str(secret),
+        session_id=str(chat_id),
+        text=message,
+    )
+    if not result.success:
+        return _error(result.error or "NotionAgent send failed")
+    return {
+        "success": True,
+        "platform": "notionagent",
+        "chat_id": str(chat_id),
+        "message_id": result.message_id,
+    }
 
 
 # --- Registry ---

--- a/toolsets.py
+++ b/toolsets.py
@@ -446,10 +446,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-notionagent": {
+        "description": "NotionAgent toolset - chat through the NotionAgent web app",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-notionagent"]
     }
 }
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -311,6 +311,15 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `QQBOT_HOME_CHANNEL` | QQ user/group openID for cron delivery and notifications |
 | `QQBOT_HOME_CHANNEL_NAME` | Display name for the QQ home channel |
 | `QQ_SANDBOX` | Route QQ Bot to the sandbox gateway for development testing (`true`/`false`). Use with a sandbox app credential from [q.qq.com](https://q.qq.com). |
+| `NOTIONAGENT_SECRET` | Shared HMAC-SHA256 secret for the NotionAgent gateway adapter |
+| `NOTIONAGENT_CALLBACK_URL` | NotionAgent callback URL that receives Hermes replies |
+| `NOTIONAGENT_PORT` | Inbound NotionAgent HTTP port (default: `8645`) |
+| `NOTIONAGENT_HOST` | Inbound NotionAgent bind host (default: `0.0.0.0`) |
+| `NOTIONAGENT_PATH` | Inbound NotionAgent path (default: `/notionagent/in`) |
+| `NOTIONAGENT_ALLOWED_USERS` | Optional comma-separated NotionAgent session IDs allowed to message Hermes; unset allows all signed requests |
+| `NOTIONAGENT_ALLOW_ALL_USERS` | Explicitly allow all signed NotionAgent requests (`true`/`false`) |
+| `NOTIONAGENT_HOME_CHANNEL` | NotionAgent session ID for cron delivery and notifications |
+| `NOTIONAGENT_HOME_CHANNEL_NAME` | Display name for the NotionAgent home channel |
 | `MATTERMOST_URL` | Mattermost server URL (e.g. `https://mm.example.com`) |
 | `MATTERMOST_TOKEN` | Bot token or personal access token for Mattermost |
 | `MATTERMOST_ALLOWED_USERS` | Comma-separated Mattermost user IDs allowed to message the bot |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, NotionAgent, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, NotionAgent, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/docs/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/docs/guides/use-voice-mode-with-hermes).
 
@@ -31,6 +31,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | Weixin | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
 | BlueBubbles | — | ✅ | ✅ | — | ✅ | ✅ | — |
 | QQ | ✅ | ✅ | ✅ | — | — | ✅ | — |
+| NotionAgent | — | — | — | — | — | — | — |
 
 **Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.
 
@@ -57,6 +58,7 @@ flowchart TB
     wx[Weixin]
     bb[BlueBubbles]
     qq[QQ]
+    na[NotionAgent]
             api["API Server<br/>(OpenAI-compatible)"]
             wh[Webhooks]
         end
@@ -83,6 +85,7 @@ flowchart TB
     wx --> store
     bb --> store
     qq --> store
+    na --> store
     api --> store
     wh --> store
     store --> agent
@@ -372,6 +375,7 @@ Each platform has its own toolset:
 | Weixin | `hermes-weixin` | Full tools including terminal |
 | BlueBubbles | `hermes-bluebubbles` | Full tools including terminal |
 | QQBot | `hermes-qqbot` | Full tools including terminal |
+| NotionAgent | `hermes-notionagent` | Full tools including terminal |
 | API Server | `hermes` (default) | Full tools including terminal |
 | Webhooks | `hermes-webhook` | Full tools including terminal |
 
@@ -394,5 +398,6 @@ Each platform has its own toolset:
 - [Weixin Setup (WeChat)](weixin.md)
 - [BlueBubbles Setup (iMessage)](bluebubbles.md)
 - [QQBot Setup](qqbot.md)
+- [NotionAgent Setup](notionagent.md)
 - [Open WebUI + API Server](open-webui.md)
 - [Webhooks](webhooks.md)

--- a/website/docs/user-guide/messaging/notionagent.md
+++ b/website/docs/user-guide/messaging/notionagent.md
@@ -1,0 +1,261 @@
+---
+sidebar_position: 20
+title: "NotionAgent"
+description: "Connect the NotionAgent web app to Hermes Gateway with signed HTTP messages"
+---
+
+# NotionAgent
+
+The NotionAgent adapter lets the [NotionAgent web app](https://github.com/ravenviersechs/NotionAgent) use Hermes as its agent backend without routing through Telegram or another chat platform.
+
+It is a text-only, bidirectional HTTP adapter:
+
+- NotionAgent sends inbound messages to Hermes with `POST /notionagent/in`
+- Hermes sends the final reply back to NotionAgent with a signed callback POST
+- Each `session_id` maps to one Hermes conversation, so a memo or task keeps its own context
+
+## Quick Start
+
+1. Generate a long shared secret.
+2. Configure the same secret in Hermes and NotionAgent.
+3. Set the NotionAgent callback URL in Hermes.
+4. Point NotionAgent at the Hermes inbound URL.
+
+Add to `~/.hermes/.env`:
+
+```bash
+NOTIONAGENT_SECRET=replace-with-a-long-random-secret
+NOTIONAGENT_CALLBACK_URL=https://notionagent.example.com/hermes/callback
+NOTIONAGENT_PORT=8645
+```
+
+Start or restart the gateway:
+
+```bash
+hermes gateway start
+```
+
+The inbound URL is:
+
+```text
+https://your-hermes-host:8645/notionagent/in
+```
+
+If Hermes is behind a reverse proxy, terminate TLS at the proxy and forward to the local gateway port.
+
+## Configuration
+
+You can configure NotionAgent either with environment variables or `config.yaml`.
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NOTIONAGENT_SECRET` | Yes | Shared HMAC-SHA256 secret for inbound and outbound requests |
+| `NOTIONAGENT_CALLBACK_URL` | Yes | NotionAgent endpoint where Hermes posts replies |
+| `NOTIONAGENT_PORT` | No | Inbound HTTP port, default `8645` |
+| `NOTIONAGENT_HOST` | No | Bind host, default `0.0.0.0` |
+| `NOTIONAGENT_PATH` | No | Inbound path, default `/notionagent/in` |
+| `NOTIONAGENT_ALLOWED_USERS` | No | Optional comma-separated allowlist of `session_id` values |
+| `NOTIONAGENT_ALLOW_ALL_USERS` | No | Optional explicit allow-all flag; HMAC is still required |
+| `NOTIONAGENT_HOME_CHANNEL` | No | Default session ID for cron and `send_message` delivery |
+
+When `NOTIONAGENT_ALLOWED_USERS` is unset, all correctly signed requests are accepted. This differs from user-chat platforms because NotionAgent authorization is handled by the HMAC signature.
+
+### config.yaml
+
+```yaml
+platforms:
+  notionagent:
+    enabled: true
+    secret: "replace-with-a-long-random-secret"
+    callback_url: "https://notionagent.example.com/hermes/callback"
+    host: "0.0.0.0"
+    port: 8645
+    path: "/notionagent/in"
+```
+
+The same keys may also be placed under `extra`:
+
+```yaml
+platforms:
+  notionagent:
+    enabled: true
+    extra:
+      secret: "replace-with-a-long-random-secret"
+      callback_url: "https://notionagent.example.com/hermes/callback"
+```
+
+## HMAC Signing
+
+Every request body is signed exactly as sent on the wire:
+
+```text
+X-NotionAgent-Signature: sha256=<hex-hmac-sha256>
+```
+
+The HMAC input is the raw request body bytes. Do not parse and reserialize JSON before verifying the signature.
+
+Python example:
+
+```python
+import hashlib
+import hmac
+
+signature = "sha256=" + hmac.new(
+    secret.encode("utf-8"),
+    raw_body,
+    hashlib.sha256,
+).hexdigest()
+```
+
+## JSON Contract
+
+### Inbound: NotionAgent to Hermes
+
+```http
+POST /notionagent/in
+Content-Type: application/json
+X-NotionAgent-Signature: sha256=<hex>
+```
+
+```json
+{
+  "session_id": "memo-abc123",
+  "text": "Summarize this transcript"
+}
+```
+
+`session_id` is the chat ID in Hermes. Use one stable value per memo, task, or conversation thread.
+
+Successful requests return `202 Accepted`:
+
+```json
+{
+  "status": "accepted",
+  "session_id": "memo-abc123",
+  "message_id": "generated-message-id"
+}
+```
+
+### Outbound: Hermes to NotionAgent
+
+Hermes posts to `NOTIONAGENT_CALLBACK_URL`:
+
+```http
+POST /your/callback
+Content-Type: application/json
+X-NotionAgent-Signature: sha256=<hex>
+```
+
+```json
+{
+  "session_id": "memo-abc123",
+  "text": "Here is the summary...",
+  "message_id": "hermes-generated-uuid"
+}
+```
+
+Verify this request with the same HMAC rule and shared secret.
+
+## Sample curl
+
+```bash
+export BODY='{"session_id":"memo-abc123","text":"Say hello from Hermes"}'
+sig=$(python - <<'PY'
+import hashlib, hmac, os
+body = os.environ["BODY"].encode("utf-8")
+secret = os.environ["NOTIONAGENT_SECRET"].encode("utf-8")
+print("sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest())
+PY
+)
+
+curl -i \
+  -X POST http://localhost:8645/notionagent/in \
+  -H "Content-Type: application/json" \
+  -H "X-NotionAgent-Signature: $sig" \
+  --data "$BODY"
+```
+
+Run it as:
+
+```bash
+BODY='{"session_id":"memo-abc123","text":"Say hello from Hermes"}' \
+NOTIONAGENT_SECRET='replace-with-a-long-random-secret' \
+bash ./send-test.sh
+```
+
+## Embedding in Your Own Web App
+
+You can use this adapter from any web app that can make server-side HTTP requests.
+
+The browser should not hold `NOTIONAGENT_SECRET`. Keep the secret on your backend:
+
+1. Browser sends user text to your app server.
+2. Your server creates `{session_id, text}` JSON.
+3. Your server signs the raw JSON body.
+4. Your server POSTs to Hermes.
+5. Hermes POSTs the signed `{session_id, text, message_id}` reply to your callback URL.
+6. Your server verifies the signature and streams or stores the reply for the browser UI.
+
+Minimal backend contract:
+
+| Direction | Body |
+|-----------|------|
+| App to Hermes | `{ "session_id": "<stable-id>", "text": "<user text>" }` |
+| Hermes to App | `{ "session_id": "<stable-id>", "text": "<reply>", "message_id": "<uuid>" }` |
+
+## Cron and send_message
+
+Set a home session ID to deliver proactive messages:
+
+```bash
+NOTIONAGENT_HOME_CHANNEL=memo-abc123
+```
+
+Then use:
+
+```text
+send_message target="notionagent:memo-abc123" message="Build finished"
+```
+
+Cron jobs can deliver to NotionAgent with:
+
+```text
+deliver="notionagent:memo-abc123"
+```
+
+## Troubleshooting
+
+### 401 Invalid signature
+
+Check that both sides use the same secret and compute HMAC over the exact raw body bytes. Pretty-printing or changing JSON whitespace changes the signature.
+
+### 400 session_id and text are required
+
+The inbound JSON must include non-empty `session_id` and `text` fields.
+
+### Hermes does not start the adapter
+
+Both `NOTIONAGENT_SECRET` and `NOTIONAGENT_CALLBACK_URL` must be set, and `platforms.notionagent.enabled` must be true when using `config.yaml`.
+
+### Callback delivery fails
+
+Check `~/.hermes/logs/gateway.log` for the HTTP status code from the NotionAgent callback endpoint. Make sure the callback URL is reachable from the Hermes host and verifies `X-NotionAgent-Signature`.
+
+### Port already in use
+
+Set a different port:
+
+```bash
+NOTIONAGENT_PORT=8655
+```
+
+or:
+
+```yaml
+platforms:
+  notionagent:
+    enabled: true
+    port: 8655
+```

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -70,7 +70,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. |
 | `skills` | No | List of skill names to load for the agent run. |
-| `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
+| `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, `notionagent`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
@@ -236,6 +236,7 @@ The `deliver` field controls where the agent's response goes after processing th
 | `wecom` | Routes the response to WeCom. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `weixin` | Routes the response to Weixin (WeChat). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `bluebubbles` | Routes the response to BlueBubbles (iMessage). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
+| `notionagent` | Routes the response to NotionAgent. Uses the home session ID, or specify `chat_id` in `deliver_extra`. |
 
 For cross-platform delivery, the target platform must also be enabled and connected in the gateway. If no `chat_id` is provided in `deliver_extra`, the response is sent to that platform's configured home channel.
 


### PR DESCRIPTION
Adds a new bidirectional HTTP-based platform adapter named `notionagent` so external web apps can chat with Hermes natively (HMAC-signed JSON, no Telegram bridge required). Each `session_id` gets its own conversation, enabling per-task or per-memo session isolation.

## What this does

External app POSTs `{session_id, text}` with HMAC signature to the gateway's `/notionagent/in` endpoint. The adapter dispatches to the agent loop, and on completion POSTs the reply back to the app's configured callback URL with the same HMAC scheme.

## Implementation

All 16 touchpoints from `gateway/platforms/ADDING_A_PLATFORM.md` covered:

- `gateway/platforms/notionagent.py` — adapter (FastAPI inbound, httpx outbound, HMAC-SHA256, exponential backoff, secret redaction)
- `Platform.NOTIONAGENT` enum + env-var loading (`NOTIONAGENT_SECRET`, `NOTIONAGENT_CALLBACK_URL`, `NOTIONAGENT_PORT`, `NOTIONAGENT_HOME_CHANNEL`, `NOTIONAGENT_ALLOWED_USERS`, `NOTIONAGENT_ALLOW_ALL_USERS`)
- Adapter factory branch in `gateway/run.py`
- Authorization maps (both dicts)
- `PLATFORM_HINTS["notionagent"]` in prompt builder
- `hermes-notionagent` toolset, included in `hermes-gateway` composite
- Cron `platform_map` entry
- `send_message` tool routing + standalone `_send_notionagent`
- `channel_directory`, `status`, gateway setup wizard entries
- README, AGENTS, environment-variables docs; full setup guide at `website/docs/user-guide/messaging/notionagent.md`

## Tests

`tests/gateway/test_notionagent.py` (14 tests) — enum, env loading, HMAC accept/reject, adapter init, inbound dispatch, outbound POST shape, standalone `_send_notionagent`, auth-map presence, send-message-tool routing, SessionSource round-trip.

`pytest tests/ -k 'send_message or cron or platform or notionagent'` — **474 passed, 5 skipped, 0 failed.**

(45 unrelated pre-existing failures in `tests/gateway/test_discord_free_response.py` and `tests/gateway/test_whatsapp_connect.py` exist on `upstream/main` independent of this PR.)

## Use case

Originally built so that a self-hosted web app (`https://github.com/ravenviersechs/NotionAgent`) can host its own native Hermes chat panel — voice memos transcribed there get their own Hermes session. The same adapter works for any HTTP-capable client; the JSON contract is documented.