### PR TITLE
fix(model-normalize): add xiaomi to preserve-dots allowlist (#15619)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7249,6 +7249,8 @@ class AIAgent:
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        Xiaomi/MiMo keeps dots in version strings (e.g. mimo-v2.5-pro); the
+        API rejects the hyphenated form with HTTP 400 (#15619).
         AWS Bedrock uses dotted inference-profile IDs
         (e.g. ``global.anthropic.claude-opus-4-7``,
         ``us.anthropic.claude-sonnet-4-5-20250929-v1:0``) and rejects
@@ -7259,7 +7261,7 @@ class AIAgent:
         if (getattr(self, "provider", "") or "").lower() in {
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",
-            "zai", "bedrock",
+            "zai", "bedrock", "xiaomi",
         }:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
@@ -7272,6 +7274,9 @@ class AIAgent:
             # AWS Bedrock runtime endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
             or "bedrock-runtime." in base
+            # Xiaomi MiMo models use dots in version strings (mimo-v2.5-pro)
+            # and reject the hyphenated form with HTTP 400.
+            or "xiaomimimo.com" in base
         )
 
     def _is_qwen_portal(self) -> bool:

--- a/tests/agent/test_xiaomi_preserve_dots.py
+++ b/tests/agent/test_xiaomi_preserve_dots.py
@@ -9,8 +9,6 @@ Issue: #15619
 """
 from types import SimpleNamespace
 
-import pytest
-
 
 # ---------------------------------------------------------------------------
 # _anthropic_preserve_dots — flag tests

--- a/tests/agent/test_xiaomi_preserve_dots.py
+++ b/tests/agent/test_xiaomi_preserve_dots.py
@@ -1,0 +1,89 @@
+"""Tests for Xiaomi/MiMo dot-preservation in model name normalization.
+
+Xiaomi's MiMo models use dots in their version strings (e.g. mimo-v2.5-pro).
+The Anthropic-compatible SDK layer converts dots to hyphens by default, producing
+``mimo-v2-5-pro`` — a name the Xiaomi API rejects with HTTP 400. The fix adds
+"xiaomi" to the _anthropic_preserve_dots() allowlist so dots survive intact.
+
+Issue: #15619
+"""
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _anthropic_preserve_dots — flag tests
+# ---------------------------------------------------------------------------
+
+
+class TestXiaomiPreserveDots:
+    """AIAgent._anthropic_preserve_dots returns True for Xiaomi endpoints."""
+
+    def test_xiaomi_provider_name_preserves_dots(self):
+        """Explicit ``provider="xiaomi"`` activates dot-preservation."""
+        from run_agent import AIAgent
+        agent = SimpleNamespace(provider="xiaomi", base_url="")
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_xiaomi_provider_case_insensitive(self):
+        """Provider matching is case-insensitive."""
+        from run_agent import AIAgent
+        for variant in ("Xiaomi", "XIAOMI", "XiaoMi"):
+            agent = SimpleNamespace(provider=variant, base_url="")
+            assert AIAgent._anthropic_preserve_dots(agent) is True, variant
+
+    def test_xiaomimimo_base_url_preserves_dots(self):
+        """Defense-in-depth: a xiaomimimo.com base URL triggers preservation
+        even if provider is not explicitly set to ``xiaomi``."""
+        from run_agent import AIAgent
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+        )
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_unrelated_provider_does_not_preserve_dots(self):
+        """Canary: adding ``xiaomi`` must not accidentally enable dots for
+        unrelated providers — ``claude-sonnet-4.6`` still normalises on the
+        native Anthropic API."""
+        from run_agent import AIAgent
+        agent = SimpleNamespace(provider="anthropic", base_url="https://api.anthropic.com")
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
+    def test_unrelated_base_url_does_not_preserve_dots(self):
+        """The xiaomimimo.com heuristic must not trigger for other .com URLs."""
+        from run_agent import AIAgent
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://api.openai.com/v1",
+        )
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
+
+# ---------------------------------------------------------------------------
+# normalize_model_name — end-to-end model-name tests
+# ---------------------------------------------------------------------------
+
+
+class TestXiaomiModelNameNormalization:
+    """normalize_model_name preserves dots for MiMo model names when
+    preserve_dots=True, confirming the fix resolves the HTTP 400 in #15619."""
+
+    def test_mimo_v25_pro_preserved(self):
+        """The exact model from the bug report survives normalization."""
+        from agent.anthropic_adapter import normalize_model_name
+        assert normalize_model_name("mimo-v2.5-pro", preserve_dots=True) == "mimo-v2.5-pro"
+
+    def test_mimo_v25_pro_mangled_without_flag(self):
+        """Without preserve_dots the dot is still converted (existing behaviour
+        for providers that need it, e.g. raw Anthropic)."""
+        from agent.anthropic_adapter import normalize_model_name
+        assert normalize_model_name("mimo-v2.5-pro", preserve_dots=False) == "mimo-v2-5-pro"
+
+    def test_mimo_variant_names_preserved(self):
+        """Other MiMo variant names with dots are also preserved."""
+        from agent.anthropic_adapter import normalize_model_name
+        for model in ("mimo-v2.0-standard", "mimo-v3.1-ultra"):
+            result = normalize_model_name(model, preserve_dots=True)
+            assert result == model, f"expected {model!r}, got {result!r}"


### PR DESCRIPTION
## Summary
- Add `"xiaomi"` to the `_anthropic_preserve_dots()` provider allowlist in `run_agent.py`
- Add `"xiaomimimo.com"` to the base-URL heuristic (defense-in-depth for deployments where `provider=` is not explicitly set)
- Add 8 tests covering provider-name match, case-insensitivity, base-URL match, negative canaries, and end-to-end `normalize_model_name` behavior

## The bug

Xiaomi's MiMo models use dots in their version strings (e.g. `mimo-v2.5-pro`). The Anthropic SDK adapter converts dots to hyphens by default, producing `mimo-v2-5-pro`, which the Xiaomi API rejects with:

```
HTTP 400: Not supported model mimo-v2-5-pro
```

The `_anthropic_preserve_dots()` method controls this behavior with a provider allowlist. Xiaomi was absent from the list, while structurally identical providers — MiniMax (`MiniMax-M2.7`), ZAI/Zhipu (`glm-4.7`), AWS Bedrock (`global.anthropic.claude-opus-4-7`) — were already included.

## The fix

Added `"xiaomi"` to the provider-name set and `"xiaomimimo.com"` to the base-URL heuristic, mirroring the pattern used for Bedrock (commit `f77be22c`) and MiniMax. One-line change in `run_agent.py` — no logic change, only extending the allowlist.

## Test plan
- [x] **Before**: 3 tests fail (`test_xiaomi_provider_name_preserves_dots`, `test_xiaomi_provider_case_insensitive`, `test_xiaomimimo_base_url_preserves_dots`) — all with `AssertionError: assert False is True`
- [x] **After**: 8 passed, 0 failed
- [x] **Regression guard**: reverted the fix → 3 failures with exact expected error; restored → 8/8 passed
- [x] `tests/agent/test_bedrock_integration.py` — 55 passed, unchanged
- [x] `tests/agent/test_anthropic_adapter.py` — same 10 pre-existing failures as clean `origin/main`, zero new

## Related
- Fixes #15619

🤖 Generated with [Claude Code](https://claude.com/claude-code)