### PR TITLE
fix(update): poll is-active instead of one-shot sleep(3) after gateway restart

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6046,6 +6046,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             import signal as _signal
 
+            def _wait_for_service_active(
+                scope_cmd_: list, svc_name_: str, timeout: float = 10.0,
+            ) -> bool:
+                """Poll ``systemctl is-active`` until the unit reports active.
+
+                systemd's Stopped -> Started transition after a graceful exit
+                (or a hard restart) is not instantaneous; a one-shot check
+                races that window and falsely reports the unit as down.
+                Poll every 0.5s up to ``timeout`` seconds before giving up.
+                """
+                deadline = _time.monotonic() + max(timeout, 0.5)
+                while True:
+                    try:
+                        _verify = subprocess.run(
+                            scope_cmd_ + ["is-active", svc_name_],
+                            capture_output=True, text=True, timeout=5,
+                        )
+                        if _verify.stdout.strip() == "active":
+                            return True
+                    except (FileNotFoundError, subprocess.TimeoutExpired):
+                        pass
+                    if _time.monotonic() >= deadline:
+                        return False
+                    _time.sleep(0.5)
+
             # Drain budget for graceful SIGUSR1 restarts.  The gateway drains
             # for up to ``agent.restart_drain_timeout`` (default 60s) before
             # exiting with code 75; we wait slightly longer so the drain
@@ -6152,14 +6177,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                             if _graceful_ok:
                                 # Gateway exited 75; systemd should relaunch
-                                # via Restart=on-failure.  Verify the new
-                                # process came up.
-                                _time.sleep(3)
-                                verify = subprocess.run(
-                                    scope_cmd + ["is-active", svc_name],
-                                    capture_output=True, text=True, timeout=5,
-                                )
-                                if verify.stdout.strip() == "active":
+                                # via Restart=on-failure.  Poll is-active for
+                                # up to ~10s because the unit's Stopped ->
+                                # Started transition can take a few seconds
+                                # after the old PID exits, and a one-shot
+                                # check races that window.
+                                if _wait_for_service_active(
+                                    scope_cmd, svc_name, timeout=10.0,
+                                ):
                                     restarted_services.append(svc_name)
                                     continue
                                 # Process exited but wasn't respawned (older
@@ -6185,14 +6210,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 # Verify the service actually survived the
                                 # restart.  systemctl restart returns 0 even
                                 # if the new process crashes immediately.
-                                _time.sleep(3)
-                                verify = subprocess.run(
-                                    scope_cmd + ["is-active", svc_name],
-                                    capture_output=True,
-                                    text=True,
-                                    timeout=5,
-                                )
-                                if verify.stdout.strip() == "active":
+                                if _wait_for_service_active(
+                                    scope_cmd, svc_name, timeout=10.0,
+                                ):
                                     restarted_services.append(svc_name)
                                 else:
                                     # Retry once — transient startup failures
@@ -6207,14 +6227,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                         text=True,
                                         timeout=15,
                                     )
-                                    _time.sleep(3)
-                                    verify2 = subprocess.run(
-                                        scope_cmd + ["is-active", svc_name],
-                                        capture_output=True,
-                                        text=True,
-                                        timeout=5,
-                                    )
-                                    if verify2.stdout.strip() == "active":
+                                    if _wait_for_service_active(
+                                        scope_cmd, svc_name, timeout=10.0,
+                                    ):
                                         restarted_services.append(svc_name)
                                         print(f"  ✓ {svc_name} recovered on retry")
                                     else:


### PR DESCRIPTION
`hermes update` no longer prints a spurious `⚠ hermes-gateway drained but didn't relaunch — forcing restart` warning and no longer kicks the gateway a second time on every update.

## Root cause
The auto-restart path verified unit health with `time.sleep(3)` + a single `systemctl is-active` call. systemd's Stopped -> Started transition after a graceful SIGUSR1 exit (exit 75) can take slightly longer than 3s, so the one-shot check races that window. The verify saw not-yet-`active`, printed the warning, fell through to a redundant `systemctl restart`, which succeeded — so the unit ended up healthy but adapters (Discord, WhatsApp) got restarted twice.

Confirmed in the wild via journalctl on one of Teknium's update runs:
```
05:53:39  systemd: Main process exited, code=exited, status=75/TEMPFAIL
05:53:42  systemd: Stopped → Started hermes-gateway.service  ← 3s gap
```
hermes update's `sleep(3) + is-active` check landed in the middle of that gap.

## Changes
- `hermes_cli/main.py`: replace three `sleep(3) + is-active` sites in `cmd_update` with a local `_wait_for_service_active()` helper that polls `is-active` every 0.5s for up to 10s. Behaviour unchanged when the unit is healthy (returns on first poll) or truly dead (bounded by 10s). Only the race window around a clean restart is now handled correctly.

## Validation
| | Before | After |
|---|---|---|
| Healthy restart | sleep(3) + one-shot check (races 3s window) | polls until active, returns immediately when ready |
| Truly failed restart | sleep(3) + one check, reports failure | up to 10s polling, reports failure |
| Existing tests | 41/41 pass (mocks return `active`) | 41/41 pass |

`tests/hermes_cli/test_update_gateway_restart.py` — 41/41 passed.