### PR TITLE
fix(gateway): macOS launchd plist registers Login Item as "hermes" not "python"

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2038,12 +2038,23 @@ def generate_launchd_plist() -> str:
         dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
-    prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
-    ]
+    # Build ProgramArguments array, including --profile when using a named profile.
+    #
+    # macOS Background Task Management uses basename(ProgramArguments[0]) as the
+    # display name in System Settings → Login Items & Extensions and in the
+    # "Background Items Added" notification. Using the venv's `hermes` console
+    # script (a thin shebang wrapper around the same interpreter) lets macOS
+    # attribute the entry to "hermes" instead of "python". Falls back to
+    # `python -m hermes_cli.main` if the console script isn't present.
+    hermes_bin = Path(venv_bin) / "hermes"
+    if hermes_bin.exists():
+        prog_args = [f"<string>{hermes_bin}</string>"]
+    else:
+        prog_args = [
+            f"<string>{python_path}</string>",
+            "<string>-m</string>",
+            "<string>hermes_cli.main</string>",
+        ]
     if profile_arg:
         for part in profile_arg.split():
             prog_args.append(f"<string>{part}</string>")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1271,6 +1271,54 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
+    def test_launchd_plist_uses_hermes_console_script_when_present(self, tmp_path, monkeypatch):
+        """ProgramArguments[0] should be the venv `hermes` script so macOS Login Items
+        attributes the entry to "hermes" rather than "python".
+        """
+        venv = tmp_path / "venv"
+        venv_bin = venv / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").write_text("")
+        hermes_bin = venv_bin / "hermes"
+        hermes_bin.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path / ".hermes")
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: venv)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(venv_bin / "python"))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert f"<string>{hermes_bin}</string>" in plist
+        # No python -m hermes_cli.main invocation when the console script exists.
+        assert "<string>-m</string>" not in plist
+        assert "<string>hermes_cli.main</string>" not in plist
+
+    def test_launchd_plist_falls_back_to_python_module_when_console_script_missing(
+        self, tmp_path, monkeypatch
+    ):
+        """When the venv lacks the `hermes` console script, fall back to the
+        python -m hermes_cli.main invocation so installation still works.
+        """
+        venv = tmp_path / "venv"
+        venv_bin = venv / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").write_text("")
+        # Intentionally do NOT create venv_bin/hermes.
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path / ".hermes")
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: venv)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(venv_bin / "python"))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert f"<string>{venv_bin / 'python'}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## What

Make `generate_launchd_plist()` produce a plist whose `ProgramArguments[0]` is the venv's `hermes` console script instead of `…/venv/bin/python -m hermes_cli.main`. Falls back to the previous `python -m hermes_cli.main` form when the console script is missing.

## Why

macOS Background Task Management uses `basename(ProgramArguments[0])` as the display name in **System Settings → General → Login Items & Extensions** and in the system notification banner that fires after `hermes gateway install`:

> "python" is an item that can run in the background. You can manage this in Login Items & Extensions.

Users cannot tell which background item belongs to Hermes — especially when other Python-based launch agents are installed — and disabling the entry from System Settings is opaque. With this change, macOS displays the entry as **"hermes"**, which matches the binary the user invoked, the plist `Label`, and the pattern already used elsewhere in the project (the proposed `hindsight` memory plugin plist in #8973 invokes `${HERMES_VENV}/bin/hindsight-embed` for the same reason).

The runtime behavior is identical: `<venv>/bin/hermes` is a Python entry-point script with a shebang pointing at the same `<venv>/bin/python3`, so the same interpreter loads `hermes_cli.main` either way.

This pattern is the documented best practice; see [macblog.org — Manage and enforce custom Login and Background items in macOS Ventura](https://macblog.org/manage-custom-login-items/):

> I've seen some launchd configurations that use the `ProgramArguments` array to first specify the path to an interpreter, then the path to a script… **That's wrong, and it causes macOS to attribute the interpreter as the launched process.**
>
> **Don't do this. You should set the path to the script's interpreter in its shebang, then make the script itself executable.**

Fixes #15636.

## How to test

### Automated

```bash
pytest tests/hermes_cli/test_gateway_service.py -k launchd_plist -v
```

Two new tests cover both branches:

- `test_launchd_plist_uses_hermes_console_script_when_present` — when `<venv>/bin/hermes` exists, `ProgramArguments[0]` is the script and there is no `python -m hermes_cli.main` invocation.
- `test_launchd_plist_falls_back_to_python_module_when_console_script_missing` — when the console script is absent, the original `python -m hermes_cli.main` form is preserved.

Existing `test_launchd_plist_includes_profile` continues to pass (profile arg still threaded through `ProgramArguments`).

### Manual (macOS)

```bash
hermes gateway uninstall          # if previously installed
hermes gateway install
hermes gateway status
```

Expected:

- Notification banner reads "**hermes** is an item that can run in the background."
- **System Settings → General → Login Items & Extensions** lists the entry as **hermes**.
- `hermes gateway status` reports `✓ Service installed and loaded` and does **not** report "Service definition is stale".
- Telegram/Discord/cron functionality unchanged.

## Platforms tested

- macOS 15.7.1 (Sequoia, Apple Silicon), Python 3.11.14 in venv. Telegram gateway and cron jobs verified working post-install.
- Linux/systemd path is untouched by this change (the fix is scoped to `generate_launchd_plist()`).

## Related issues

- Fixes #15636 — the bug report this PR addresses.
- Aligns with #8973 — the hindsight plist already uses the named-binary pattern proposed here.
- Narrower than #6350 — that issue requests fully customizable scripts; this PR doesn't require that, just the correct binary name.
- Compatible with #8125 — `launchd_plist_is_current()` will continue to detect drift correctly because both the generator and the comparison use the same fresh output.