### PR TITLE
feat(terminal): allow configuring local shell

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1182,12 +1182,18 @@ DEFAULT_CONFIG = {
         #   profile — force HERMES_HOME/home when it exists (old strict
         #             per-profile CLI config isolation)
         "home_mode": "auto",
+        # Optional local shell override for foreground terminal commands,
+        # background processes, and PTY sessions. Supported values are ``bash``,
+        # ``zsh``, or an absolute path to one of those executables. Empty keeps
+        # the historical behavior (bash foreground; compatible $SHELL for
+        # background/PTY). Unsupported or unavailable values fall back safely.
+        "shell": "",
         # Extra files to source in the login shell when building the
         # per-session environment snapshot.  Use this when tools like nvm,
         # pyenv, asdf, or custom PATH entries are registered by files that
         # a bash login shell would skip — most commonly ``~/.bashrc``
         # (bash doesn't source bashrc in non-interactive login mode) or
-        # zsh-specific files like ``~/.zshrc`` / ``~/.zprofile``.
+        # zsh-specific files such as ``~/.zshrc``.
         # Paths support ``~`` / ``${VAR}``. Missing files are silently
         # skipped. When empty, Hermes auto-sources ``~/.profile``,
         # ``~/.bash_profile``, and ``~/.bashrc`` (in that order) if the

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -396,6 +396,10 @@ DEFAULT_CONFIG = {
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         "timeout": 180,
+        # Local backend shell override. Empty means Hermes keeps its historic
+        # bash-first fallback; set to "zsh" or an absolute path to run local
+        # terminal commands through that shell instead.
+        "shell": "",
         # Environment variables to pass through to sandboxed execution
         # (terminal and execute_code).  Skill-declared required_environment_variables
         # are passed through automatically; this list is for non-skill use cases.

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -128,6 +128,21 @@ class TestAtomicSnapshotWrite:
         # The bare $$ temp form must be gone.
         assert ".tmp.$$" not in wrapped
 
+    def test_zsh_temp_path_uses_real_subshell_pid(self):
+        """zsh's ``$$`` is inherited by ``&`` subshells just like bash, while
+        ``$BASHPID`` is unavailable. ``zsh/system`` exposes the real process PID
+        through ``$sysparams[pid]`` and keeps concurrent snapshot writers unique.
+        """
+        env = _TestableEnv()
+        env._shell_kind = "zsh"
+        env._snapshot_ready = True
+
+        wrapped = env._wrap_command("echo hi", "/tmp")
+
+        assert "zmodload zsh/system" in wrapped
+        assert "${sysparams[pid]}" in wrapped
+        assert "$BASHPID" not in wrapped
+
     def test_temp_path_static_part_is_quoted_bashpid_outside(self):
         """The static path portion must be shlex-quoted (Windows/Git-Bash
         ``C:/Users/...`` or spaces) while ``$BASHPID`` stays OUTSIDE the quotes

--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -27,6 +27,20 @@ class TestFindShellPrefersUserShell:
         with patch.dict(os.environ, {"SHELL": str(fake_zsh)}):
             assert _find_shell() == str(fake_zsh)
 
+    def test_configured_shell_overrides_shell_env(self, tmp_path):
+        configured_zsh = tmp_path / "zsh"
+        configured_zsh.touch()
+        configured_zsh.chmod(0o755)
+        user_bash = tmp_path / "bash"
+        user_bash.touch()
+        user_bash.chmod(0o755)
+
+        with patch.dict(os.environ, {"SHELL": str(user_bash)}), patch(
+            "tools.environments.local._resolve_terminal_shell",
+            return_value=(str(configured_zsh), "zsh"),
+        ):
+            assert _find_shell() == str(configured_zsh)
+
     def test_falls_back_when_shell_not_executable(self, tmp_path):
         """$SHELL exists but lacks the execute bit -> fall back to _find_bash
         (returning it would fail at spawn time)."""

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -1,4 +1,4 @@
-"""Tests for terminal.shell_init_files / terminal.auto_source_bashrc.
+"""Tests for configurable local shells and shell init snapshots.
 
 A bash ``-l -c`` invocation does NOT source ``~/.bashrc``, so tools that
 register themselves there (nvm, asdf, pyenv) stay invisible to the
@@ -7,6 +7,8 @@ tests verify the config-driven prelude that fixes that.
 """
 
 import os
+import shutil
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 import pytest
@@ -14,8 +16,60 @@ import pytest
 from tools.environments.local import (
     LocalEnvironment,
     _prepend_shell_init,
+    _read_terminal_shell_config,
     _resolve_shell_init_files,
+    _resolve_terminal_shell,
 )
+
+
+class TestTerminalShellConfig:
+    def test_reads_configured_shell(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"terminal": {"shell": " zsh "}},
+        ):
+            assert _read_terminal_shell_config() == "zsh"
+
+    def test_resolves_named_zsh(self):
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value="zsh",
+        ), patch(
+            "tools.environments.local.shutil.which",
+            side_effect=lambda name: "/usr/bin/zsh" if name == "zsh" else None,
+        ):
+            assert _resolve_terminal_shell() == ("/usr/bin/zsh", "zsh")
+
+    def test_resolves_absolute_zsh_path(self, tmp_path):
+        zsh = tmp_path / "zsh"
+        zsh.write_text("#!/bin/sh\n")
+        zsh.chmod(0o755)
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value=str(zsh),
+        ):
+            assert _resolve_terminal_shell() == (str(zsh), "zsh")
+
+    def test_resolves_zsh_symlink_to_versioned_binary(self, tmp_path):
+        target = tmp_path / "zsh-5.9"
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+        zsh = tmp_path / "zsh"
+        zsh.symlink_to(target)
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value=str(zsh),
+        ):
+            assert _resolve_terminal_shell() == (str(zsh), "zsh")
+
+    def test_rejects_unsupported_shell(self):
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value="fish",
+        ):
+            assert _resolve_terminal_shell() is None
 
 
 class TestResolveShellInitFiles:
@@ -95,6 +149,27 @@ class TestResolveShellInitFiles:
             resolved = _resolve_shell_init_files()
 
         assert resolved == []
+
+    def test_auto_bashrc_does_not_apply_to_zsh(self, tmp_path, monkeypatch):
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text('export MARKER=seen\n')
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            assert _resolve_shell_init_files("zsh") == []
+
+    def test_explicit_init_files_apply_to_zsh(self, tmp_path):
+        custom = tmp_path / "custom.zsh"
+        custom.write_text('export MARKER=seen\n')
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([str(custom)], True),
+        ):
+            assert _resolve_shell_init_files("zsh") == [str(custom)]
 
     def test_auto_source_bashrc_off_suppresses_default(self, tmp_path, monkeypatch):
         bashrc = tmp_path / ".bashrc"
@@ -310,3 +385,77 @@ class TestSnapshotEndToEnd:
         assert str(fake_n_bin) in output
         # bashrc short-circuited on the interactive guard — its export never ran
         assert "FROM_BASHRC=bashrc-should-not-appear" not in output
+
+    @pytest.mark.skipif(shutil.which("zsh") is None, reason="Requires zsh")
+    def test_configured_zsh_snapshot_preserves_state_across_commands(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        init_file = tmp_path / "custom-init.zsh"
+        init_file.write_text(
+            'export HERMES_ZSH_ENV="env-ok"\n'
+            'hermes_zsh_fn() { echo "function-ok"; }\n'
+            "alias hermes_zsh_alias='echo alias-ok'\n"
+            "setopt rcquotes\n"
+        )
+
+        command = (
+            'echo "shell=${ZSH_VERSION:+zsh}"; '
+            'echo "env=$HERMES_ZSH_ENV"; '
+            "hermes_zsh_fn; "
+            "eval hermes_zsh_alias; "
+            '[[ -o rcquotes ]] && echo "option-ok"'
+        )
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value="zsh",
+        ), patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([str(init_file)], False),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            try:
+                first = env.execute(command)
+                second = env.execute(command)
+            finally:
+                env.cleanup()
+
+        for result in (first, second):
+            assert result["returncode"] == 0, result.get("output", "")
+            output = result.get("output", "")
+            assert "shell=zsh" in output
+            assert "env=env-ok" in output
+            assert "function-ok" in output
+            assert "alias-ok" in output
+            assert "option-ok" in output
+
+    @pytest.mark.skipif(shutil.which("zsh") is None, reason="Requires zsh")
+    def test_concurrent_zsh_snapshot_writers_leave_sourceable_snapshot(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value="zsh",
+        ), patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], False),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            try:
+                def write_snapshot(index):
+                    return env.execute(
+                        f'export HERMES_ZSH_RACE_{index}={index}; echo "writer={index}"'
+                    )
+
+                with ThreadPoolExecutor(max_workers=8) as pool:
+                    results = list(pool.map(write_snapshot, range(8)))
+                probe = env.execute('echo "snapshot-parse-ok"')
+            finally:
+                env.cleanup()
+
+        assert all(result["returncode"] == 0 for result in results), results
+        assert probe["returncode"] == 0, probe.get("output", "")
+        assert "snapshot-parse-ok" in probe.get("output", "")

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -13,10 +13,51 @@ import pytest
 
 from tools.environments.local import (
     LocalEnvironment,
+    _find_bash,
     _prepend_shell_init,
+    _read_terminal_shell_config,
     _read_terminal_shell_init_config,
     _resolve_shell_init_files,
 )
+
+
+class TestTerminalShellConfig:
+    def test_reads_configured_shell(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"terminal": {"shell": " zsh "}},
+        ):
+            assert _read_terminal_shell_config() == "zsh"
+
+    def test_find_bash_uses_absolute_configured_shell(self, tmp_path):
+        shell = tmp_path / "custom-shell"
+        shell.write_text("#!/bin/sh\n")
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value=str(shell),
+        ):
+            assert _find_bash() == str(shell)
+
+    def test_find_bash_resolves_named_configured_shell(self):
+        def fake_which(name):
+            return {"zsh": "/usr/bin/zsh", "bash": "/usr/bin/bash"}.get(name)
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value="zsh",
+        ), patch("tools.environments.local.shutil.which", side_effect=fake_which):
+            assert _find_bash() == "/usr/bin/zsh"
+
+    def test_find_bash_falls_back_when_configured_shell_missing(self):
+        def fake_which(name):
+            return "/usr/bin/bash" if name == "bash" else None
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_config",
+            return_value="does-not-exist",
+        ), patch("tools.environments.local.shutil.which", side_effect=fake_which):
+            assert _find_bash() == "/usr/bin/bash"
 
 
 class TestResolveShellInitFiles:
@@ -96,6 +137,28 @@ class TestResolveShellInitFiles:
             resolved = _resolve_shell_init_files()
 
         assert resolved == []
+
+    def test_auto_bashrc_applies_only_to_bash_shells(self, tmp_path, monkeypatch):
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text('export MARKER=seen\n')
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            assert _resolve_shell_init_files("/usr/bin/zsh") == []
+            assert _resolve_shell_init_files("/usr/bin/bash") == [str(bashrc)]
+
+    def test_explicit_list_still_applies_to_non_bash_shells(self, tmp_path):
+        custom = tmp_path / "custom.zsh"
+        custom.write_text('export MARKER=seen\n')
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([str(custom)], True),
+        ):
+            assert _resolve_shell_init_files("/usr/bin/zsh") == [str(custom)]
 
     def test_auto_source_bashrc_off_suppresses_default(self, tmp_path, monkeypatch):
         bashrc = tmp_path / ".bashrc"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -290,7 +290,9 @@ def _cwd_marker(session_id: str) -> str:
 class BaseEnvironment(ABC):
     """Common interface and unified execution flow for all Hermes backends.
 
-    Subclasses implement ``_run_bash()`` and ``cleanup()``.  The base class
+    Subclasses implement ``_run_bash()`` and ``cleanup()``. The method name is
+    retained for backend compatibility, but local execution may use bash or
+    zsh. The base class
     provides ``execute()`` with session snapshot sourcing, CWD tracking,
     interrupt handling, and timeout enforcement.
     """
@@ -300,6 +302,10 @@ class BaseEnvironment(ABC):
 
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
+
+    # Snapshot protocol. Every backend remains bash by default; the local
+    # backend may opt into zsh when terminal.shell is configured explicitly.
+    _shell_kind: str = "bash"
 
     def get_temp_dir(self) -> str:
         """Return the backend temp directory used for session artifacts.
@@ -334,7 +340,7 @@ class BaseEnvironment(ABC):
         timeout: int = 120,
         stdin_data: str | None = None,
     ) -> ProcessHandle:
-        """Spawn a bash process to run *cmd_string*.
+        """Spawn the backend's supported shell to run *cmd_string*.
 
         Returns a ProcessHandle (subprocess.Popen or _ThreadedProcessHandle).
         Must be overridden by every backend.
@@ -350,12 +356,52 @@ class BaseEnvironment(ABC):
     # Session snapshot (init_session)
     # ------------------------------------------------------------------
 
+    def _snapshot_temp_parts(self) -> tuple[str, str]:
+        """Return ``(setup, unique_temp_path)`` for the active shell.
+
+        Bash exposes the real subshell PID as ``$BASHPID``. zsh's ``$$`` has
+        parent-PID semantics in ``&`` subshells, so load the standard
+        ``zsh/system`` module and use ``$sysparams[pid]`` instead.
+        """
+        prefix = self._quote_shell_path(self._snapshot_path + ".tmp.")
+        if self._shell_kind == "zsh":
+            return "zmodload zsh/system 2>/dev/null", prefix + "${sysparams[pid]}"
+        return "", prefix + "$BASHPID"
+
+    def _snapshot_dump_command(self, snap_tmp: str) -> str:
+        """Build an atomic-ready dump of env, functions, aliases and options."""
+        if self._shell_kind == "zsh":
+            return (
+                f"export -p > {snap_tmp} && {{\n"
+                "for __hermes_fn in ${(k)functions}; do\n"
+                "  [[ \"$__hermes_fn\" == _* && \"$__hermes_fn\" != __* ]] && continue\n"
+                f"  functions \"$__hermes_fn\" >> {snap_tmp} 2>/dev/null || true\n"
+                "done\n"
+                f"alias -L >> {snap_tmp} 2>/dev/null || true\n"
+                "setopt | while IFS= read -r __hermes_opt; do\n"
+                f"  print -r -- \"setopt $__hermes_opt\" >> {snap_tmp}\n"
+                "done\n"
+                f"printf '%s\\n' 'set +e' 'set +u' >> {snap_tmp}\n"
+                "}"
+            )
+
+        return (
+            f"export -p > {snap_tmp} && {{\n"
+            "__hermes_fns=$(declare -F | awk '{print $3}' | "
+            "grep -vE '^_[^_]') || true\n"
+            f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns >> {snap_tmp} "
+            "2>/dev/null || true\n"
+            f"alias -p >> {snap_tmp}\n"
+            f"printf '%s\\n' 'shopt -s expand_aliases' 'set +e' 'set +u' >> {snap_tmp}\n"
+            "}"
+        )
+
     def init_session(self):
         """Capture login shell environment into a snapshot file.
 
         Called once after backend construction.  On success, sets
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
-        instead of running with ``bash -l``.
+        instead of starting a login shell for every command.
         """
         # Full capture: env vars, functions, aliases, shell options.
         # Restore configured cwd after login shell profile scripts, which may
@@ -383,41 +429,19 @@ class BaseEnvironment(ABC):
         # source() either sees the old complete snapshot or the new complete
         # one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # The temp name MUST be unique per concurrent writer. ``$$`` keeps the
+        # parent PID in both bash and zsh ``&`` subshells, so it is unsafe here.
+        # Bash uses ``$BASHPID``; zsh loads ``zsh/system`` and uses the current
+        # process PID from ``$sysparams[pid]``. The static path remains quoted
+        # while the dynamic PID expression stays outside the quotes.
+        _snapshot_setup, _snap_tmp = self._snapshot_temp_parts()
+        _dump_snapshot = self._snapshot_dump_command(_snap_tmp)
+        _setup_line = f"{_snapshot_setup} || exit 1\n" if _snapshot_setup else ""
         bootstrap = (
+            f"{_setup_line}"
             f"umask 077\n"
-            f"export -p > {_snap_tmp}\n"
-            # Dump function definitions, filtering out private (``_``-prefixed)
-            # helpers — mainly bash-completion internals (``_git``, ``_make``…)
-            # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
-            # is line-based: it strips the function *header* line but leaves the
-            # orphaned ``{ … }`` body behind, which corrupts the snapshot and
-            # makes every sourced command fail (e.g. exit 127).  Selecting the
-            # wanted names with ``declare -F`` first, then dumping only those
-            # whole definitions, preserves the filter's intent without ever
-            # tearing a function body.  The non-empty guard matters: bare
-            # ``declare -f`` with no name args dumps ALL functions, so an empty
-            # name list (only private funcs present) would otherwise leak the
-            # very functions we meant to drop.
-            f"__hermes_fns=$(declare -F | awk '{{print $3}}' | grep -vE '^_[^_]') || true\n"
-            f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns "
-            f">> {_snap_tmp} 2>/dev/null || true\n"
-            f"alias -p >> {_snap_tmp}\n"
-            f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
-            f"echo 'set +e' >> {_snap_tmp}\n"
-            f"echo 'set +u' >> {_snap_tmp}\n"
-            # Publish atomically only if assembly succeeded; otherwise drop the
-            # partial temp rather than leave it to be sourced or orphaned.
-            f"mv -f {_snap_tmp} {_quoted_snap} || rm -f {_snap_tmp}\n"
+            f"{{ {_dump_snapshot} && mv -f {_snap_tmp} {_quoted_snap}; }} || "
+            f"{{ rm -f {_snap_tmp}; exit 1; }}\n"
             f"builtin cd -- {_quoted_cwd} 2>/dev/null || true\n"
             f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
@@ -439,7 +463,7 @@ class BaseEnvironment(ABC):
         except Exception as exc:
             logger.warning(
                 "init_session failed (session=%s): %s — "
-                "falling back to bash -l per command",
+                "falling back to a login shell per command",
                 self._session_id,
                 exc,
             )
@@ -470,7 +494,7 @@ class BaseEnvironment(ABC):
         return shlex.quote(path)
 
     def _wrap_command(self, command: str, cwd: str) -> str:
-        """Build the full bash script that sources snapshot, cd's, runs command,
+        """Build the shell script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
         escaped = command.replace("'", "'\\''")
 
@@ -478,14 +502,10 @@ class BaseEnvironment(ABC):
         # rewrites ``C:/...`` to ``/c/...`` so MSYS doesn't mangle them).
         _quoted_snap = self._quote_shell_path(self._snapshot_path)
         _quoted_cwd_file = self._quote_shell_path(self._cwd_file)
-        # Use atomic file replacement for env snapshot updates (issue #38249).
-        # Assemble into a per-writer-unique temp file, then mv to atomically
-        # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Use atomic file replacement for snapshot updates (issue #38249).
+        # Shell-specific PID handling keeps concurrent writers unique.
+        _snapshot_setup, _snap_tmp = self._snapshot_temp_parts()
+        _dump_snapshot = self._snapshot_dump_command(_snap_tmp)
 
         parts = []
 
@@ -513,13 +533,13 @@ class BaseEnvironment(ABC):
         # umask. Snapshot files may contain env-carried secrets.
         parts.append("umask 077")
 
-        # Re-dump env vars to snapshot (atomic replacement to avoid races).
-        # Chain mv on the export succeeding so a failed/partial dump never
-        # replaces a good snapshot; drop the temp on failure so it isn't
-        # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
+        # Re-dump env vars and supported shell state atomically. This keeps
+        # functions, aliases, and zsh options loaded during init available after
+        # every execute() call, not only the first one.
         if self._snapshot_ready:
+            setup = f"{_snapshot_setup} && " if _snapshot_setup else ""
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
+                f"{{ {setup}{_dump_snapshot} && mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -604,6 +604,71 @@ def _find_bash() -> str:
     )
 
 
+_CONFIGURABLE_SHELL_KINDS = frozenset({"bash", "zsh"})
+
+
+def _read_terminal_shell_config() -> str:
+    """Return the configured local ``terminal.shell`` override, if any.
+
+    Config loading is best-effort so a missing or malformed config never
+    prevents terminal execution from using its historical fallback.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        terminal_cfg = cfg.get("terminal") or {}
+        shell = terminal_cfg.get("shell") or ""
+        return str(shell).strip()
+    except Exception:
+        return ""
+
+
+def _configured_shell_kind(shell: str) -> str | None:
+    """Classify a configured executable as a supported snapshot shell."""
+    names = {
+        Path(shell).name.lower(),
+        Path(os.path.realpath(shell)).name.lower(),
+    }
+    if names & {"bash", "bash.exe"}:
+        return "bash"
+    if "zsh" in names:
+        return "zsh"
+    return None
+
+
+def _resolve_terminal_shell() -> tuple[str, str] | None:
+    """Resolve ``terminal.shell`` to ``(executable, snapshot kind)``.
+
+    Only bash and zsh are accepted because the foreground session snapshot
+    protocol is shell-specific. Unsupported or unavailable values return
+    ``None`` so callers can preserve their existing fallback behavior.
+    """
+    configured = _read_terminal_shell_config()
+    if not configured:
+        return None
+
+    if os.path.isabs(configured):
+        if not (os.path.isfile(configured) and os.access(configured, os.X_OK)):
+            return None
+        kind = _configured_shell_kind(configured)
+        return (configured, kind) if kind else None
+
+    requested = Path(configured).name.lower()
+    if requested not in {"bash", "bash.exe", "zsh"}:
+        return None
+
+    if requested in {"bash", "bash.exe"}:
+        shell = _find_bash()
+    else:
+        shell = shutil.which(configured)
+        if not shell:
+            return None
+
+    kind = _configured_shell_kind(shell)
+    return (shell, kind) if kind in _CONFIGURABLE_SHELL_KINDS else None
+
+
 # POSIX-sh-family shells that understand the ``[shell, "-lic", "set +m; …"]``
 # invocation spawn_local uses. $SHELL values outside this set (fish, csh/tcsh,
 # nushell, elvish, xonsh, …) would error on that syntax, so _find_shell falls
@@ -640,7 +705,15 @@ def _find_shell() -> str:
 
     On Windows, ``$SHELL`` is typically bash (Git Bash), so behaviour is
     unchanged — we fall through to ``_find_bash``.
+
+    An explicit supported ``terminal.shell`` override takes precedence for
+    both background and foreground local execution. When it is unset or cannot
+    be resolved, this function preserves the existing ``$SHELL`` behavior.
     """
+    configured = _resolve_terminal_shell()
+    if configured:
+        return configured[0]
+
     if not _IS_WINDOWS:
         user_shell = os.environ.get("SHELL")
         if (
@@ -893,20 +966,23 @@ def _read_terminal_shell_init_config() -> tuple[list[str], bool]:
         return [], True
 
 
-def _resolve_shell_init_files() -> list[str]:
-    """Resolve the list of files to source before the login-shell snapshot.
+def _resolve_shell_init_files(shell_kind: str = "bash") -> list[str]:
+    """Resolve files to source before the configured login-shell snapshot.
+
+    Explicit ``terminal.shell_init_files`` applies to every supported shell.
+    Automatic discovery remains bash-only because ``auto_source_bashrc`` names
+    bash startup files and sourcing them in zsh is unsafe.
 
     Expands ``~`` and ``${VAR}`` references and drops anything that doesn't
-    exist on disk, so a missing ``~/.bashrc`` never breaks the snapshot.
-    The ``auto_source_bashrc`` path runs only when the user hasn't supplied
-    an explicit list — once they have, Hermes trusts them.
+    exist on disk, so a missing rc file never breaks the snapshot. Once users
+    supply an explicit list, Hermes trusts it.
     """
     explicit, auto_bashrc = _read_terminal_shell_init_config()
 
     candidates: list[str] = []
     if explicit:
         candidates.extend(explicit)
-    elif auto_bashrc and not _IS_WINDOWS:
+    elif auto_bashrc and shell_kind == "bash" and not _IS_WINDOWS:
         # Build a login-shell-ish source list so tools like n / nvm / asdf /
         # pyenv that self-install into the user's shell rc land on PATH in
         # the captured snapshot.
@@ -959,8 +1035,8 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
-    Spawn-per-call: every execute() spawns a fresh bash process.
-    Session snapshot preserves env vars across calls.
+    Spawn-per-call: every execute() spawns the configured bash or zsh process.
+    Session snapshot preserves environment and supported shell state across calls.
     CWD persists via file-based read after each command.
     """
 
@@ -968,6 +1044,11 @@ class LocalEnvironment(BaseEnvironment):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        configured = _resolve_terminal_shell()
+        if configured:
+            self._shell_path, self._shell_kind = configured
+        else:
+            self._shell_path, self._shell_kind = _find_bash(), "bash"
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -1030,18 +1111,17 @@ class LocalEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        bash = _find_bash()
+        shell = self._shell_path
         # For login-shell invocations (used by init_session to build the
-        # environment snapshot), prepend sources for the user's bashrc /
-        # custom init files so tools registered outside bash_profile
-        # (nvm, asdf, pyenv, …) end up on PATH in the captured snapshot.
-        # Non-login invocations are already sourcing the snapshot and
-        # don't need this.
+        # environment snapshot), prepend explicit shell init files. Automatic
+        # rc discovery remains bash-only; zsh users can list ~/.zshrc or a
+        # custom startup file explicitly via terminal.shell_init_files.
+        # Non-login invocations already source the snapshot.
         if login:
-            init_files = _resolve_shell_init_files()
+            init_files = _resolve_shell_init_files(self._shell_kind)
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+        args = [shell, "-l", "-c", cmd_string] if login else [shell, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -138,9 +138,38 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     return sanitized
 
 
+def _read_terminal_shell_config() -> str:
+    """Return terminal.shell from config.yaml, if configured.
+
+    Best-effort — returns an empty string on any failure so terminal
+    execution keeps the historical bash-first fallback.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        terminal_cfg = cfg.get("terminal") or {}
+        shell = terminal_cfg.get("shell") or ""
+        return str(shell).strip()
+    except Exception:
+        return ""
+
+
 def _find_bash() -> str:
-    """Find bash for command execution."""
+    """Find the local shell for command execution.
+
+    Historically the local backend always used bash. Keep bash as the
+    fallback, but allow users to opt into their normal shell with
+    ``terminal.shell`` (for example ``zsh`` or ``/usr/bin/zsh``).
+    """
     if not _IS_WINDOWS:
+        configured = _read_terminal_shell_config()
+        if configured:
+            if os.path.isabs(configured) and os.path.isfile(configured):
+                return configured
+            found = shutil.which(configured)
+            if found:
+                return found
         return (
             shutil.which("bash")
             or ("/usr/bin/bash" if os.path.isfile("/usr/bin/bash") else None)
@@ -233,7 +262,12 @@ def _read_terminal_shell_init_config() -> tuple[list[str], bool]:
         return [], True
 
 
-def _resolve_shell_init_files() -> list[str]:
+def _is_bash_shell(shell: str) -> bool:
+    """Return whether a shell path/name looks like bash."""
+    return os.path.basename(shell or "") in {"bash", "bash.exe"}
+
+
+def _resolve_shell_init_files(shell: str = "bash") -> list[str]:
     """Resolve the list of files to source before the login-shell snapshot.
 
     Expands ``~`` and ``${VAR}`` references and drops anything that doesn't
@@ -246,7 +280,7 @@ def _resolve_shell_init_files() -> list[str]:
     candidates: list[str] = []
     if explicit:
         candidates.extend(explicit)
-    elif auto_bashrc and not _IS_WINDOWS:
+    elif auto_bashrc and not _IS_WINDOWS and _is_bash_shell(shell):
         # Build a login-shell-ish source list so tools like n / nvm / asdf /
         # pyenv that self-install into the user's shell rc land on PATH in
         # the captured snapshot.
@@ -299,7 +333,7 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
-    Spawn-per-call: every execute() spawns a fresh bash process.
+    Spawn-per-call: every execute() spawns a fresh shell process.
     Session snapshot preserves env vars across calls.
     CWD persists via file-based read after each command.
     """
@@ -340,12 +374,12 @@ class LocalEnvironment(BaseEnvironment):
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
-        # custom init files so tools registered outside bash_profile
+        # custom init files when appropriate so tools registered outside bash_profile
         # (nvm, asdf, pyenv, …) end up on PATH in the captured snapshot.
         # Non-login invocations are already sourcing the snapshot and
         # don't need this.
         if login:
-            init_files = _resolve_shell_init_files()
+            init_files = _resolve_shell_init_files(bash)
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -116,6 +116,7 @@ terminal:
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   home_mode: auto   # auto | real | profile — subprocess HOME policy
+  shell: ""         # local only: bash | zsh | absolute path; empty preserves defaults
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
   modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Container image for Modal backend
@@ -143,6 +144,37 @@ The default. Commands run directly on your machine with no isolation. No special
 terminal:
   backend: local
 ```
+
+#### `terminal.shell`
+
+Local foreground commands use bash by default. Background processes and PTY
+sessions keep the existing behavior of using a compatible `$SHELL` when one is
+available. Set `terminal.shell` to override all three local execution paths:
+
+```yaml
+terminal:
+  backend: local
+  shell: zsh                       # bash | zsh
+  shell_init_files:
+    - "~/.zshrc"                  # optional; explicit files apply to either shell
+```
+
+`terminal.shell` accepts `bash`, `zsh`, or an absolute path to a bash/zsh
+executable (including a symlink named `bash` or `zsh`). Other shells such as
+`fish`, `dash`, `ksh`, and `tcsh` are not accepted because the session snapshot
+protocol is implemented only for bash and zsh. If the setting is empty,
+unsupported, missing, or not executable, Hermes falls back to the historical
+behavior instead of preventing terminal startup.
+
+Hermes runs the selected shell in login mode once to create a per-session
+snapshot, then restores exported variables, public functions, aliases, and the
+supported shell options before later commands. The snapshot uses shell-specific
+function, alias, option, and process-PID handling so concurrent updates remain
+atomic under both bash and zsh.
+
+Automatic startup-file discovery through `auto_source_bashrc` remains bash-only.
+For zsh, list `~/.zshrc` or another startup file explicitly in
+`shell_init_files`. Missing listed files are skipped silently.
 
 By default, local tool subprocesses keep your real OS-user `HOME`. This lets
 external CLIs such as `git`, `ssh`, `gh`, `az`, `npm`, Claude Code, and Codex


### PR DESCRIPTION
## Summary
- Add a `terminal.shell` setting for the local backend. Supported values are `bash`, `zsh`, or an absolute path to one of those executables.
- Apply an explicit shell override consistently to local foreground commands, background processes, and PTY sessions while preserving the existing behavior when the setting is empty or invalid.
- Keep `_find_bash()` Bash-specific and preserve the current `_find_shell()` fallback to a compatible `$SHELL`.
- Make the session snapshot protocol shell-aware: Bash and zsh now use their own function, alias, option, and real-subshell-PID handling.
- Keep automatic profile/bashrc discovery Bash-only; explicit `terminal.shell_init_files` works with either supported shell.
- Document the setting, supported values, fallback behavior, and zsh startup-file behavior.

## Example

```yaml
terminal:
  backend: local
  shell: zsh
  shell_init_files:
    - "~/.zshrc"
```

## Review follow-up
- Rebased the PR onto current `main` and retained the foreground/background shell split introduced since the original PR.
- zsh snapshots use `functions`, `alias -L`, `setopt`, and `zsh/system`'s `${sysparams[pid]}` instead of Bash-only `$BASHPID`, `declare`, `alias -p`, and `shopt` behavior.
- Snapshot rewrites preserve shell state across later commands and continue using atomic per-writer temp files.
- Added real zsh-backed `LocalEnvironment` tests covering exported variables, functions, aliases, options, two consecutive commands, and concurrent snapshot writers.

## Test Plan
- [x] `uv run pytest tests/tools/test_local_shell_init.py tests/tools/test_find_shell.py tests/tools/test_base_environment.py tests/tools/test_process_registry.py tests/tools/test_terminal_config_env_sync.py tests/hermes_cli/test_config.py -o 'addopts=' -q -rs` — 331 passed, 2 platform-specific skips
- [x] Ruff on all changed Python files
- [x] Python compile checks for changed implementation files
- [x] Generated Bash and zsh wrappers pass `bash -n` / `zsh -n`
- [x] Real config-file smoke test selects zsh for both foreground execution and the background resolver
