### PR TITLE
fix(ui-tui): Shift+Enter inserts newline instead of submitting

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -13,7 +13,8 @@
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@hermes/ink": "file:./packages/hermes-ink",

--- a/ui-tui/patches/ink-text-input+6.0.0.patch
+++ b/ui-tui/patches/ink-text-input+6.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/ink-text-input/build/index.js b/node_modules/ink-text-input/build/index.js
+index ada7cdc..d0bbf63 100644
+--- a/node_modules/ink-text-input/build/index.js
++++ b/node_modules/ink-text-input/build/index.js
+@@ -53,7 +53,7 @@ function TextInput({ value: originalValue, placeholder = '', focus = true, mask,
+             (key.shift && key.tab)) {
+             return;
+         }
+-        if (key.return) {
++        if (key.return && !key.shift) {
+             if (onSubmit) {
+                 onSubmit(originalValue);
+             }


### PR DESCRIPTION
## Summary

In the Hermes TUI, `Alt+Enter` correctly inserts a newline in the text input, but `Shift+Enter` was incorrectly submitting the message instead.

This PR makes `Shift+Enter` insert a newline (like `Alt+Enter`) and limits plain `Enter` to submission only.

## Changes

- **Patched `ink-text-input@6.0.0`** (`ui-tui/node_modules/ink-text-input/build/index.js`): Added `!key.shift` guard to the `key.return` submit handler so Shift+Enter falls through to the newline-insertion path.
- **Added `patch-package`** for reproducible patching across `npm install` runs.
- **`ui-tui/package.json`**: Added `postinstall: patch-package` script.

## Technical detail

`ink-text-input`'s `useInput` handler had:

```js
if (key.return) {   // submits on ANY Enter
    onSubmit(originalValue);
    return;
}
```

Now:

```js
if (key.return && !key.shift) {   // only plain Enter submits
    onSubmit(originalValue);
    return;
}
```

## Testing

Verified manually in the Hermes TUI:
- Plain `Enter` submits the message
- `Shift+Enter` inserts a newline
- `patch-package` applies cleanly after `npm install`
