### PR TITLE
fix(security): patch 3 dashboard-plugin vulnerabilities

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -220,7 +220,10 @@ async def host_header_middleware(request: Request, call_next):
 async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
+    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
+        # Plugin API routes (/api/plugins/*) are no longer exempted — they
+        # may access sensitive Hermes internals and must be protected the same
+        # way as every other /api/ endpoint.
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,
@@ -2642,6 +2645,16 @@ def _discover_dashboard_plugins() -> list:
             try:
                 data = json.loads(manifest_file.read_text(encoding="utf-8"))
                 name = data.get("name", child.name)
+                # Validate name: only lowercase letters, digits, hyphens.
+                # Prevents path injection via /api/plugins/<name>/ URL prefix.
+                import re as _re
+                if not _re.fullmatch(r"[a-z0-9][a-z0-9\-]*", name):
+                    _log.warning(
+                        "Skipping plugin at %s: invalid name %r "
+                        "(must match [a-z0-9][a-z0-9-]*)",
+                        manifest_file, name,
+                    )
+                    continue
                 if name in seen_names:
                     continue
                 seen_names.add(name)
@@ -2765,7 +2778,15 @@ def _mount_plugin_api_routes():
         api_file_name = plugin.get("_api_file")
         if not api_file_name:
             continue
-        api_path = Path(plugin["_dir"]) / api_file_name
+        api_path = (Path(plugin["_dir"]) / api_file_name).resolve()
+        base_dir = Path(plugin["_dir"]).resolve()
+        # Block path traversal: api file must stay inside dashboard/ dir.
+        if not api_path.is_relative_to(base_dir):
+            _log.warning(
+                "Plugin %s: api path %r escapes dashboard/ directory — skipped",
+                plugin["name"], api_file_name,
+            )
+            continue
         if not api_path.exists():
             _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
             continue


### PR DESCRIPTION
- auth_middleware: remove blanket /api/plugins/* auth bypass; plugin API routes now require the same Bearer token as all other /api/ paths
- _discover_dashboard_plugins: validate plugin name matches [a-z0-9-]+ to prevent path injection in /api/plugins/<name>/ URL prefix
- _mount_plugin_api_routes: resolve api_path and verify it stays inside dashboard/ dir (is_relative_to check), blocking ../../../ traversal

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [√ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hermes_cli/web_server.py: auth_middleware, _discover_dashboard_plugins, _mount_plugin_api_routes

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

 1. Start Hermes with a dashboard plugin loaded                       
  2. Access /api/plugins/<name>/any-endpoint without Authorization header → should return 401                                                                                            
  3. Try loading a plugin with name="../../../etc" in manifest.json → should be skipped with warning

## Checklist

<!-- Complete these before requesting review. -->
Ubuntu 24.04
### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ √] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

