### PR TITLE
feat(qqbot): add heartbeat ACK timeout and zombie connection detection

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -103,6 +103,9 @@ from gateway.platforms.qqbot.constants import (
     RATE_LIMIT_DELAY,
     QUICK_DISCONNECT_THRESHOLD,
     MAX_QUICK_DISCONNECT_COUNT,
+    HEARTBEAT_ACK_TIMEOUT_COUNT,
+    ZOMBIE_IDLE_THRESHOLD,
+    HEALTH_MONITOR_INTERVAL,
     MAX_MESSAGE_LENGTH,
     DEDUP_WINDOW_SECONDS,
     DEDUP_MAX_SIZE,
@@ -208,6 +211,13 @@ class QQAdapter(BasePlatformAdapter):
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
         self._upload_cache: Dict[str, Dict[str, Any]] = {}
 
+        # Heartbeat / liveness tracking
+        self._last_heartbeat_ack_time: float = 0.0
+        self._last_inbound_time: float = 0.0
+        self._consecutive_ack_misses: int = 0
+        self._heartbeat_awaiting_ack: bool = False
+        self._health_monitor_task: Optional[asyncio.Task] = None
+
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------
@@ -262,7 +272,10 @@ class QQAdapter(BasePlatformAdapter):
             # 4. Start listeners
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+            self._health_monitor_task = asyncio.create_task(self._health_monitor())
             self._mark_connected()
+            self._last_inbound_time = time.monotonic()
+            self._last_heartbeat_ack_time = time.monotonic()
             logger.info("[%s] Connected", self._log_tag)
             return True
         except Exception as exc:
@@ -293,6 +306,14 @@ class QQAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             self._heartbeat_task = None
+
+        if self._health_monitor_task:
+            self._health_monitor_task.cancel()
+            try:
+                await self._health_monitor_task
+            except asyncio.CancelledError:
+                pass
+            self._health_monitor_task = None
 
         await self._cleanup()
         self._release_platform_lock()
@@ -568,6 +589,10 @@ class QQAdapter(BasePlatformAdapter):
         await asyncio.sleep(delay)
 
         self._heartbeat_interval = 30.0  # reset until Hello
+        self._last_heartbeat_ack_time = 0.0
+        self._last_inbound_time = 0.0
+        self._consecutive_ack_misses = 0
+        self._heartbeat_awaiting_ack = False
         try:
             await self._ensure_token()
             gateway_url = await self._get_gateway_url()
@@ -599,21 +624,92 @@ class QQAdapter(BasePlatformAdapter):
                 raise RuntimeError("WebSocket closed")
 
     async def _heartbeat_loop(self) -> None:
-        """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).
+        """Send periodic heartbeats with ACK timeout detection.
 
-        The interval is set from the Hello (op 10) event's heartbeat_interval.
-        QQ's default is ~41s; we send at 80% of the interval to stay safe.
+        Sends op 1 heartbeat at 80% of the server's heartbeat_interval.
+        Tracks consecutive ACK misses.  After HEARTBEAT_ACK_TIMEOUT_COUNT
+        consecutive misses, closes the WebSocket so _listen_loop's existing
+        reconnect logic takes over.
         """
         try:
             while self._running:
                 await asyncio.sleep(self._heartbeat_interval)
                 if not self._ws or self._ws.closed:
                     continue
+
+                # Check if the previous heartbeat was acknowledged.
+                if self._heartbeat_awaiting_ack:
+                    self._consecutive_ack_misses += 1
+                    logger.warning(
+                        "[%s] Heartbeat ACK missed (%d/%d)",
+                        self._log_tag,
+                        self._consecutive_ack_misses,
+                        HEARTBEAT_ACK_TIMEOUT_COUNT,
+                    )
+                    if self._consecutive_ack_misses >= HEARTBEAT_ACK_TIMEOUT_COUNT:
+                        logger.error(
+                            "[%s] %d consecutive heartbeat ACKs missed -- "
+                            "connection is dead, forcing reconnect",
+                            self._log_tag,
+                            HEARTBEAT_ACK_TIMEOUT_COUNT,
+                        )
+                        self._heartbeat_awaiting_ack = False
+                        self._consecutive_ack_misses = 0
+                        await self._force_ws_close()
+                        continue
+
                 try:
                     # d should be the latest sequence number received, or null
                     await self._ws.send_json({"op": 1, "d": self._last_seq})
+                    self._heartbeat_awaiting_ack = True
                 except Exception as exc:
                     logger.debug("[%s] Heartbeat failed: %s", self._log_tag, exc)
+        except asyncio.CancelledError:
+            pass
+
+    async def _force_ws_close(self) -> None:
+        """Force-close the WebSocket to trigger _listen_loop's reconnect path.
+
+        Used by the heartbeat ACK timeout and zombie detection to kill a
+        dead/half-open connection.  The close propagates as an exception in
+        _read_events, which _listen_loop already handles with backoff/reconnect.
+        """
+        if self._ws and not self._ws.closed:
+            try:
+                await self._ws.close(code=4000, message=b"heartbeat timeout")
+            except Exception:
+                pass
+
+    async def _health_monitor(self) -> None:
+        """Periodically check connection liveness.
+
+        If no inbound frames have been received for ZOMBIE_IDLE_THRESHOLD seconds,
+        the WebSocket is likely half-open (network middleware silently dropped it).
+        Force-close to trigger _listen_loop's reconnect.
+        """
+        try:
+            while self._running:
+                await asyncio.sleep(HEALTH_MONITOR_INTERVAL)
+                if not self._running:
+                    break
+
+                # _last_inbound_time == 0 means we haven't received anything yet
+                # (pre-Hello or just reconnected).  Skip the check.
+                if self._last_inbound_time <= 0:
+                    continue
+
+                idle_seconds = time.monotonic() - self._last_inbound_time
+                if idle_seconds > ZOMBIE_IDLE_THRESHOLD:
+                    logger.warning(
+                        "[%s] No inbound frames for %.0fs (threshold %.0fs) -- "
+                        "zombie connection detected, forcing reconnect",
+                        self._log_tag,
+                        idle_seconds,
+                        ZOMBIE_IDLE_THRESHOLD,
+                    )
+                    await self._force_ws_close()
+                    # Reset so the monitor doesn't re-trigger before new frames arrive.
+                    self._last_inbound_time = 0.0
         except asyncio.CancelledError:
             pass
 
@@ -703,6 +799,8 @@ class QQAdapter(BasePlatformAdapter):
 
     def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
         """Route inbound WebSocket payloads (dispatch synchronously, spawn async handlers)."""
+        self._last_inbound_time = time.monotonic()
+
         op = payload.get("op")
         t = payload.get("t")
         s = payload.get("s")
@@ -750,6 +848,9 @@ class QQAdapter(BasePlatformAdapter):
 
         # op 11 = Heartbeat ACK
         if op == 11:
+            self._last_heartbeat_ack_time = time.monotonic()
+            self._heartbeat_awaiting_ack = False
+            self._consecutive_ack_misses = 0
             return
 
         logger.debug("[%s] Unknown op: %s", self._log_tag, op)

--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -44,6 +44,11 @@ RATE_LIMIT_DELAY = 60  # seconds
 QUICK_DISCONNECT_THRESHOLD = 5.0  # seconds
 MAX_QUICK_DISCONNECT_COUNT = 3
 
+# Heartbeat ACK timeout & zombie detection
+HEARTBEAT_ACK_TIMEOUT_COUNT = 3  # consecutive missed ACKs before forced reconnect
+ZOMBIE_IDLE_THRESHOLD = 120.0  # seconds without inbound frames → zombie
+HEALTH_MONITOR_INTERVAL = 30.0  # seconds between liveness checks
+
 ONBOARD_POLL_INTERVAL = 2.0  # seconds between poll_bind_result calls
 ONBOARD_API_TIMEOUT = 10.0
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -389,8 +389,19 @@ class TestDispatchPayload:
 
     def test_op11_heartbeat_ack(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
-        # Should not raise
+        adapter._heartbeat_awaiting_ack = True
+        adapter._consecutive_ack_misses = 2
         adapter._dispatch_payload({"op": 11, "t": "HEARTBEAT_ACK", "s": 42})
+        # ACK should reset tracking state
+        assert adapter._heartbeat_awaiting_ack is False
+        assert adapter._consecutive_ack_misses == 0
+        assert adapter._last_heartbeat_ack_time > 0
+
+    def test_dispatch_updates_last_inbound_time(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        assert adapter._last_inbound_time == 0.0
+        adapter._dispatch_payload({"op": 99, "d": {}})
+        assert adapter._last_inbound_time > 0
 
     def test_seq_tracking(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
@@ -582,3 +593,104 @@ class TestWaitForReconnection:
         assert not result.success
         assert result.retryable is True
         assert "Not connected" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat ACK timeout & liveness tracking
+# ---------------------------------------------------------------------------
+
+class TestHeartbeatAckTracking:
+    """Tests for heartbeat ACK timeout detection and zombie connection monitoring."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    def test_init_liveness_defaults(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        assert adapter._last_heartbeat_ack_time == 0.0
+        assert adapter._last_inbound_time == 0.0
+        assert adapter._consecutive_ack_misses == 0
+        assert adapter._heartbeat_awaiting_ack is False
+        assert adapter._health_monitor_task is None
+
+    def test_op11_resets_miss_count(self):
+        """Receiving an ACK resets the consecutive miss counter."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._consecutive_ack_misses = 5
+        adapter._heartbeat_awaiting_ack = True
+        adapter._dispatch_payload({"op": 11, "d": None})
+        assert adapter._consecutive_ack_misses == 0
+        assert adapter._heartbeat_awaiting_ack is False
+
+    def test_dispatch_updates_inbound_time_on_any_op(self):
+        """Every dispatched payload should update _last_inbound_time."""
+        import time
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        before = time.monotonic()
+        adapter._dispatch_payload({"op": 0, "t": "READY", "s": 1, "d": {}})
+        assert adapter._last_inbound_time >= before
+
+    def test_force_ws_close_closes_websocket(self):
+        """_force_ws_close should close an open WebSocket."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        ws = mock.AsyncMock()
+        ws.closed = False
+        adapter._ws = ws
+
+        asyncio.run(adapter._force_ws_close())
+        ws.close.assert_awaited_once()
+        call_kwargs = ws.close.call_args
+        assert call_kwargs.kwargs.get("code") == 4000 or call_kwargs[1].get("code") == 4000
+
+    def test_force_ws_close_noop_when_no_ws(self):
+        """_force_ws_close should be safe when no WebSocket exists."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        # Should not raise
+        asyncio.run(adapter._force_ws_close())
+
+    def test_force_ws_close_noop_when_already_closed(self):
+        """_force_ws_close should skip if WebSocket is already closed."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        ws = mock.AsyncMock()
+        ws.closed = True
+        adapter._ws = ws
+
+        asyncio.run(adapter._force_ws_close())
+        ws.close.assert_not_awaited()
+
+    def test_reconnect_resets_liveness_state(self):
+        """_reconnect should reset all liveness tracking variables."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._last_heartbeat_ack_time = 999.0
+        adapter._last_inbound_time = 888.0
+        adapter._consecutive_ack_misses = 3
+        adapter._heartbeat_awaiting_ack = True
+        adapter._heartbeat_interval = 10.0
+
+        # Mock dependencies to prevent actual network calls
+        adapter._ensure_token = mock.AsyncMock()
+        adapter._get_gateway_url = mock.AsyncMock(return_value="wss://fake")
+        adapter._open_ws = mock.AsyncMock()
+        adapter._acquire_platform_lock = mock.MagicMock(return_value=True)
+        adapter._release_platform_lock = mock.MagicMock()
+
+        result = asyncio.run(adapter._reconnect(backoff_idx=0))
+
+        assert result is True
+        assert adapter._last_heartbeat_ack_time == 0.0
+        assert adapter._last_inbound_time == 0.0
+        assert adapter._consecutive_ack_misses == 0
+        assert adapter._heartbeat_awaiting_ack is False
+
+    def test_constants_imported(self):
+        """Verify the new constants are importable."""
+        from gateway.platforms.qqbot.constants import (
+            HEARTBEAT_ACK_TIMEOUT_COUNT,
+            ZOMBIE_IDLE_THRESHOLD,
+            HEALTH_MONITOR_INTERVAL,
+        )
+        assert HEARTBEAT_ACK_TIMEOUT_COUNT >= 1
+        assert ZOMBIE_IDLE_THRESHOLD > 0
+        assert HEALTH_MONITOR_INTERVAL > 0


### PR DESCRIPTION
  ## What does this PR do?                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                   
  Adds heartbeat ACK timeout detection and zombie connection monitoring to the QQ Bot adapter. Currently the adapter sends WebSocket heartbeats (op 1) but never checks if the server responds with ACKs (op 11). If the network silently drops packets (half-open TCP, middlebox  
  interference), the bot appears connected but is actually dead with no recovery path.                                                                                                                                                                                             
                                                                  
  This PR adds two complementary detection mechanisms:                                                                                                                                                                                                                             
  1. **Heartbeat ACK tracking** — counts consecutive missed ACKs; after 3 misses (~99s), force-closes the WebSocket                                                                                                                                                                
  2. **Zombie connection detection** — monitors inbound frame activity; if no frames received for 120s, force-closes                                                                                                                                                               
                                                                                                                                                                                                                                                                                   
  Both paths converge on closing the WebSocket, which triggers the existing `_listen_loop` reconnect logic with backoff. No duplicate reconnection code.                                                                                                                           
                                                                                                                                                                                                                                                                                   
  ## Related Issue                                                
                                                                                                                                                                                                                                                                                   
  N/A                                                             
                                                                                                                                                                                                                                                                                   
  ## Type of Change                                               
                                                                                                                                                                                                                                                                                   
  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)                                                                                                                                                                                                               
  - [ ] 🔒 Security fix                                                                                                                                                                                                                                                            
  - [ ] 📝 Documentation update                                                                                                                                                                                                                                                    
  - [ ] ✅ Tests (adding or improving test coverage)                                                                                                                                                                                                                               
  - [ ] ♻️  Refactor (no behavior change)                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                   
  ## Changes Made                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                   
  - `gateway/platforms/qqbot/constants.py` — added `HEARTBEAT_ACK_TIMEOUT_COUNT`, `ZOMBIE_IDLE_THRESHOLD`, `HEALTH_MONITOR_INTERVAL`
  - `gateway/platforms/qqbot/adapter.py` — heartbeat ACK tracking in `_heartbeat_loop`, new `_force_ws_close` helper, new `_health_monitor` zombie detector, state reset in `_reconnect`, lifecycle integration in `connect`/`disconnect`                                          
  - `tests/gateway/test_qqbot.py` — 9 new test cases covering ACK tracking, inbound time updates, force-close, reconnect state reset, and constants                                                                                                                                
                                                                                                                                                                                                                                                                                   
  ## How to Test                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                   
  1. Run `python3 -m pytest tests/gateway/test_qqbot.py -v` — all tests pass (5 pre-existing failures due to missing `pytest-asyncio`, unrelated to this change)
  2. Simulate network block: observe logs for `Heartbeat ACK missed` → `forcing reconnect`                                                                                                                                                                                         
  3. Verify `_health_monitor` triggers after prolonged idle (>120s no inbound frames)                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                   
  ## Checklist                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                   
  ### Code                                                        

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)                                                                                                                                               
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate                                                                                                                                                      
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)                                                                                                                                                                                         
  - [x] I've run `pytest tests/ -q` and all tests pass                                                                                                                                                                                                                             
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)                                                                                                                                                                                 
  - [x] I've tested on my platform: macOS Darwin 25.4.0                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                   
  ### Documentation & Housekeeping                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                   
  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A                                                                                                                                                                                             
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A                                                                                                                                                                              
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A                                                                         
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                   
  ## Screenshots / Logs                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                   
  Control flow summary:                                           
                                                                                                                                                                                                                                                                                   
  | Scenario | Detection | Trigger | Action |                     
  |----------|-----------|---------|--------|                                                                                                                                                                                                                                      
  | Heartbeat ACK timeout | `_heartbeat_loop` | 3 consecutive missed op 11 (~99s) | `_force_ws_close()` → `_listen_loop` reconnect |                                                                                                                                               
  | Zombie connection | `_health_monitor` | 120s no inbound frames | `_force_ws_close()` → `_listen_loop` reconnect |                                                                                                                                                              
  | Normal disconnect | `_listen_loop` | WebSocket close/error | Existing reconnect logic |                                