### PR TITLE
fix(cron): require exact silent marker for delivery suppression

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -109,9 +109,9 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
-# Sentinel: when a cron agent has nothing new to report, it can start its
-# response with this marker to suppress delivery.  Output is still saved
-# locally for audit.
+# Sentinel: when a cron agent has nothing new to report, it can respond
+# with exactly this marker to suppress delivery. Output is still saved
+# locally for audit; any explanatory content must still be delivered.
 SILENT_MARKER = "[SILENT]"
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
@@ -1254,11 +1254,11 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     logger.info("Output saved to: %s", output_file)
 
                 # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
+                # If the agent responded with exactly [SILENT], skip delivery
+                # (but output is already saved above). Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                if should_deliver and success and deliver_content.strip() == SILENT_MARKER:
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -212,6 +212,10 @@ class TestTickWorkdirPartition:
         workdir_job = {"id": "a", "name": "A", "workdir": str(tmp_path)}
         parallel_job = {"id": "b", "name": "B", "workdir": None}
 
+        lock_dir = tmp_path / "cron-lock"
+        lock_dir.mkdir()
+        monkeypatch.setattr(sched, "_LOCK_DIR", lock_dir)
+        monkeypatch.setattr(sched, "_LOCK_FILE", lock_dir / ".tick.lock")
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [workdir_job, parallel_job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -829,7 +829,12 @@ class TestRunJobSessionPersistence:
 
         fake_db = MagicMock()
 
+        lock_dir = tmp_path / "cron"
+        lock_dir.mkdir()
+
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._LOCK_DIR", lock_dir), \
+             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"), \
              patch("cron.scheduler.get_due_jobs", return_value=[job]), \
              patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.mark_job_run") as mock_mark, \
@@ -1164,6 +1169,15 @@ class TestRunJobSkillBacked:
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_tick_lock(self, tmp_path):
+        """Point the tick file lock at a per-test temp dir to avoid live cron contention."""
+        lock_dir = tmp_path / "cron"
+        lock_dir.mkdir()
+        with patch("cron.scheduler._LOCK_DIR", lock_dir), \
+             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"):
+            yield
+
     def _make_job(self):
         return {
             "id": "monitor-job",
@@ -1184,18 +1198,21 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
-    def test_silent_with_note_suppresses_delivery(self):
+    def test_silent_with_note_delivers_content(self):
+        """Only an exact [SILENT] response suppresses delivery; content still reports."""
+        response = "[SILENT] No changes detected"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
 
-    def test_silent_trailing_suppresses_delivery(self):
-        """Agent appended [SILENT] after explanation text — must still suppress."""
+    def test_silent_trailing_delivers_content(self):
+        """A report that mentions [SILENT] must not be swallowed."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
@@ -1204,11 +1221,25 @@ class TestSilentDelivery:
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
 
-    def test_silent_is_case_insensitive(self):
+    def test_lowercase_silent_with_note_delivers_content(self):
+        """The cron contract is exact: lowercase or explanatory text is content."""
+        response = "[silent] nothing new"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
+
+    def test_whitespace_wrapped_silent_suppresses_delivery(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "\n  [SILENT]\t", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):


### PR DESCRIPTION
## Summary
- only suppress cron delivery when the final response is exactly `[SILENT]` after trimming whitespace
- deliver reports that mention `[SILENT]` alongside content instead of swallowing them
- isolate cron tick-lock tests from live/local cron contention

## Test Plan
- [x] python -m pytest tests/cron/test_scheduler.py::TestSilentDelivery -q -n0
- [x] python -m pytest tests/cron/test_scheduler.py::TestSilentDelivery -q
- [x] python -m pytest tests/cron/test_scheduler.py -q
- [x] python -m pytest tests/cron -q -x --tb=short

Note: attempted full `python -m pytest tests/ -q` locally, but this checkout stalled at xdist node startup under the current WSL/gateway environment; cron-focused regression coverage is green.