### PR TITLE
fix(whatsapp): normalize bare numeric chat IDs to JIDs in gateway and bridge

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -661,6 +661,24 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
         return result
 
+    @staticmethod
+    def _normalize_chat_jid(chat_id: str) -> str:
+        """Ensure chat_id has a WhatsApp JID suffix the bridge can decode.
+
+        Baileys' jidDecode() returns undefined for bare numeric IDs, which
+        crashes sock.sendMessage when the bridge tries to destructure
+        ``.user`` from the result. Groups need ``@g.us``, DMs need
+        ``@s.whatsapp.net``. Pass-through anything that already has a ``@``.
+        """
+        if not chat_id:
+            return chat_id
+        if '@' in chat_id:
+            return chat_id
+        # Group JIDs: newer ``120363...`` format, or legacy ``<phone>-<ts>``.
+        if chat_id.startswith('120363') or '-' in chat_id:
+            return f'{chat_id}@g.us'
+        return f'{chat_id}@s.whatsapp.net'
+
     async def send(
         self,
         chat_id: str,
@@ -692,7 +710,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             last_message_id = None
             for chunk in chunks:
                 payload: Dict[str, Any] = {
-                    "chatId": chat_id,
+                    "chatId": self._normalize_chat_jid(chat_id),
                     "message": chunk,
                 }
                 if reply_to and last_message_id is None:
@@ -741,7 +759,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/edit",
                 json={
-                    "chatId": chat_id,
+                    "chatId": self._normalize_chat_jid(chat_id),
                     "messageId": message_id,
                     "message": content,
                 },
@@ -776,7 +794,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error=f"File not found: {file_path}")
 
             payload: Dict[str, Any] = {
-                "chatId": chat_id,
+                "chatId": self._normalize_chat_jid(chat_id),
                 "filePath": file_path,
                 "mediaType": media_type,
             }
@@ -878,7 +896,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
             await self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": chat_id},
+                json={"chatId": self._normalize_chat_jid(chat_id)},
                 timeout=aiohttp.ClientTimeout(total=5)
             )
         except Exception:
@@ -895,7 +913,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{chat_id}",
+                f"http://127.0.0.1:{self._bridge_port}/chat/{self._normalize_chat_jid(chat_id)}",
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -67,6 +67,18 @@ function normalizeWhatsAppId(value) {
   return String(value).replace(':', '@');
 }
 
+function normalizeChatJid(value) {
+  // Baileys jidDecode() returns undefined for bare numeric IDs and crashes
+  // sock.sendMessage. Append @g.us for groups, @s.whatsapp.net for DMs.
+  if (!value) return value;
+  const v = String(value);
+  if (v.includes('@')) return v;
+  // Group JIDs: newer 120363... format, or legacy <phone>-<timestamp>.
+  if (v.startsWith('120363') || v.includes('-')) return v + '@g.us';
+  return v + '@s.whatsapp.net';
+}
+
+
 function getMessageContent(msg) {
   const content = msg?.message || {};
   if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;
@@ -421,7 +433,7 @@ app.post('/send', async (req, res) => {
   }
 
   try {
-    const sent = await sock.sendMessage(chatId, { text: formatOutgoingMessage(message) });
+    const sent = await sock.sendMessage(normalizeChatJid(chatId), { text: formatOutgoingMessage(message) });
 
     // Track sent message ID to prevent echo-back loops
     if (sent?.key?.id) {
@@ -449,8 +461,8 @@ app.post('/edit', async (req, res) => {
   }
 
   try {
-    const key = { id: messageId, fromMe: true, remoteJid: chatId };
-    await sock.sendMessage(chatId, { text: formatOutgoingMessage(message), edit: key });
+    const key = { id: messageId, fromMe: true, remoteJid: normalizeChatJid(chatId) };
+    await sock.sendMessage(normalizeChatJid(chatId), { text: formatOutgoingMessage(message), edit: key });
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -520,7 +532,7 @@ app.post('/send-media', async (req, res) => {
         break;
     }
 
-    const sent = await sock.sendMessage(chatId, msgPayload);
+    const sent = await sock.sendMessage(normalizeChatJid(chatId), msgPayload);
 
     // Track sent message ID to prevent echo-back loops
     if (sent?.key?.id) {
@@ -546,7 +558,7 @@ app.post('/typing', async (req, res) => {
   if (!chatId) return res.status(400).json({ error: 'chatId required' });
 
   try {
-    await sock.sendPresenceUpdate('composing', chatId);
+    await sock.sendPresenceUpdate('composing', normalizeChatJid(chatId));
     res.json({ success: true });
   } catch (err) {
     res.json({ success: false });
@@ -555,7 +567,7 @@ app.post('/typing', async (req, res) => {
 
 // Chat info
 app.get('/chat/:id', async (req, res) => {
-  const chatId = req.params.id;
+  const chatId = normalizeChatJid(req.params.id);
   const isGroup = chatId.endsWith('@g.us');
 
   if (isGroup && sock) {

--- a/tests/gateway/test_whatsapp_jid_normalization.py
+++ b/tests/gateway/test_whatsapp_jid_normalization.py
@@ -1,0 +1,31 @@
+"""Tests for WhatsApp chat JID normalization.
+
+The bridge passes chatId straight to Baileys' sock.sendMessage(), which
+internally calls jidDecode(). Bare numeric IDs return undefined and crash
+the bridge. The gateway must append @g.us / @s.whatsapp.net before sending.
+"""
+
+import pytest
+
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Newer-format group ID (starts with 120363) → @g.us
+        ("120363328279139738", "120363328279139738@g.us"),
+        # Legacy group ID (<phone>-<timestamp>) → @g.us
+        ("60123456789-1234567890", "60123456789-1234567890@g.us"),
+        # DM phone number → @s.whatsapp.net
+        ("60123456789", "60123456789@s.whatsapp.net"),
+        # Already-suffixed JIDs pass through unchanged
+        ("120363328279139738@g.us", "120363328279139738@g.us"),
+        ("60123456789@s.whatsapp.net", "60123456789@s.whatsapp.net"),
+        ("1234567890@lid", "1234567890@lid"),
+        # Empty string returns empty (callers handle their own validation)
+        ("", ""),
+    ],
+)
+def test_normalize_chat_jid(raw, expected):
+    assert WhatsAppAdapter._normalize_chat_jid(raw) == expected


### PR DESCRIPTION
## Summary

Sending a message to a WhatsApp **group** crashes the bridge because the bare numeric `chatId` (e.g. `120363328279139738`) is forwarded straight to Baileys' `sock.sendMessage()`. Internally that calls `jidDecode()`, which returns `undefined` for IDs without an `@<server>` suffix, and the next line destructures `.user` from `undefined` — boom.

Group JIDs need `@g.us`, DMs need `@s.whatsapp.net`. Today nothing on the outbound path appends them.

## Fix — two layers

The bug exists at two distinct surfaces, so the fix is applied at both.

### 1. `gateway/platforms/whatsapp.py`
Normalizes before posting to the bridge HTTP API. Covers all five outbound sites: `send`, `edit_message`, `_send_media_to_bridge`, `send_typing`, `get_chat_info`.

### 2. `scripts/whatsapp-bridge/bridge.js`
Normalizes inside the bridge as well. **This is the load-bearing layer** — agent tools (`send_message`, etc.) and any other client call the bridge HTTP endpoints directly and bypass the Python adapter entirely, so the gateway-only fix doesn't cover them. Covers `/send`, `/edit`, `/send-media`, `/typing`, `/chat/:id`.

## Normalization logic (identical in both layers)

- Already contains `@` → passthrough (covers `@g.us`, `@s.whatsapp.net`, `@lid`)
- Starts with `120363` (newer group format) **or** contains `-` (legacy `<phone>-<ts>` group format) → append `@g.us`
- Otherwise (DM phone number) → append `@s.whatsapp.net`

## Test plan

- [x] Added `tests/gateway/test_whatsapp_jid_normalization.py` covering newer-group, legacy-group, DM, passthrough (`@g.us`, `@s.whatsapp.net`, `@lid`), and empty-string cases
- [x] Verified live on a Pi-hosted gateway: previously a group send crashed the bridge; after both patches, group messages from both the Python adapter **and** the agent's `send_message` tool deliver successfully
- [ ] Run repository test suite in CI

## Commits

- `fix(whatsapp): normalize bare numeric chat IDs to JIDs before sending to bridge` — gateway/platforms/whatsapp.py + tests
- `fix(whatsapp-bridge): normalize bare numeric chat IDs in bridge.js too` — defense-in-depth at the HTTP API