### PR TITLE
feat(gateway): per-platform default model routing via config.platform_models

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1120,11 +1120,50 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
+        # Platform-based default model routing (config.platform_models).
+        # Only applies when there is no /model session override — the user's
+        # explicit /model command always wins.  Reads platform_models.<platform>
+        # from config; resolves a custom_providers name (e.g. "bailian") via
+        # resolve_runtime_provider("custom:bailian") which handles env-var
+        # expansion and credential lookup.  Silent no-op if field missing.
+        platform_runtime = None
+        platform_model_override = None
+        if not override and resolved_session_key:
+            try:
+                cfg = user_config if user_config is not None else _load_gateway_config()
+                pm = cfg.get("platform_models") if isinstance(cfg, dict) else None
+                parsed = _parse_session_key(resolved_session_key) if pm else None
+                platform = parsed.get("platform") if parsed else None
+                entry = pm.get(platform) if (isinstance(pm, dict) and platform) else None
+                if isinstance(entry, dict):
+                    prov_name = str(entry.get("provider") or "").strip()
+                    mdl = str(entry.get("model") or "").strip()
+                    if prov_name:
+                        from hermes_cli.runtime_provider import resolve_runtime_provider
+                        requested = prov_name if prov_name.startswith("custom:") else f"custom:{prov_name}"
+                        platform_runtime = resolve_runtime_provider(requested=requested)
+                        platform_model_override = mdl or platform_runtime.get("model")
+                        logger.debug(
+                            "Platform model routing: platform=%s provider=%s model=%s",
+                            platform, requested, platform_model_override,
+                        )
+            except Exception as _pm_exc:
+                logger.debug("platform_models routing skipped: %s", _pm_exc)
+                platform_runtime = None
+
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
             )
+        elif platform_runtime:
+            # Apply platform default (provider/api_key/base_url/api_mode + model).
+            for _k in ("provider", "api_key", "base_url", "api_mode"):
+                _v = platform_runtime.get(_k)
+                if _v is not None:
+                    runtime_kwargs[_k] = _v
+            if platform_model_override:
+                model = platform_model_override
 
         # When the config has no model.default but a provider was resolved
         # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -96,6 +96,160 @@ class TestGatewayEmptyModelFallback:
         assert model == ""
 
 
+class TestPlatformModelsRouting:
+    """Test config.platform_models — per-platform default model/provider routing."""
+
+    def test_platform_models_routes_to_correct_provider_and_model(self):
+        """When platform_models matches the session platform, use that provider+model."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+
+        cfg = {
+            "model": {"default": "gpt-5.4"},
+            "platform_models": {
+                "weixin": {"provider": "qwen", "model": "qwen3.6-plus"},
+            },
+        }
+
+        fake_runtime = {
+            "provider": "custom:qwen",
+            "api_key": "qwen-key",
+            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "api_mode": "chat_completions",
+            "model": "qwen3.6-plus",
+        }
+
+        with patch(
+            "gateway.run._resolve_gateway_model", return_value="gpt-5.4"
+        ), patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"provider": "openai-codex"},
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ):
+            model, kwargs = runner._resolve_session_agent_runtime(
+                session_key="agent:main:weixin:dm:u1",
+                user_config=cfg,
+            )
+
+        assert model == "qwen3.6-plus"
+        assert kwargs["provider"] == "custom:qwen"
+        assert kwargs["api_key"] == "qwen-key"
+        assert kwargs["base_url"] == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        assert kwargs["api_mode"] == "chat_completions"
+
+    def test_session_override_wins_over_platform_models(self):
+        """Session /model override takes precedence over platform_models."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {
+            "agent:main:weixin:dm:u1": {
+                "model": "override-model",
+                "provider": "override-prov",
+                "api_key": "override-key",
+            }
+        }
+
+        cfg = {
+            "model": {"default": "gpt-5.4"},
+            "platform_models": {
+                "weixin": {"provider": "qwen", "model": "qwen3.6-plus"},
+            },
+        }
+
+        with patch("gateway.run._resolve_gateway_model", return_value="gpt-5.4"):
+            model, kwargs = runner._resolve_session_agent_runtime(
+                session_key="agent:main:weixin:dm:u1",
+                user_config=cfg,
+            )
+
+        # Session override should win — platform_models ignored
+        assert model == "override-model"
+        assert kwargs["provider"] == "override-prov"
+        assert kwargs["api_key"] == "override-key"
+
+    def test_platform_models_missing_key_is_silent_noop(self):
+        """When session platform isn't in platform_models, fall through gracefully."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+
+        cfg = {
+            "model": {"default": "gpt-5.4"},
+            "platform_models": {
+                "weixin": {"provider": "qwen", "model": "qwen3.6-plus"},
+            },
+        }
+
+        with patch("gateway.run._resolve_gateway_model", return_value="gpt-5.4"), patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"provider": "openai-codex"},
+        ):
+            model, kwargs = runner._resolve_session_agent_runtime(
+                session_key="agent:main:dingtalk:dm:u1",
+                user_config=cfg,
+            )
+
+        # Should fall through to global default — no error
+        assert model == "gpt-5.4"
+        assert kwargs["provider"] == "openai-codex"
+
+    def test_no_platform_models_section_is_noop(self):
+        """When config has no platform_models key, behave as before."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+
+        cfg = {"model": {"default": "gpt-5.4"}}
+
+        with patch("gateway.run._resolve_gateway_model", return_value="gpt-5.4"), patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"provider": "openai-codex"},
+        ):
+            model, kwargs = runner._resolve_session_agent_runtime(
+                session_key="agent:main:weixin:dm:u1",
+                user_config=cfg,
+            )
+
+        assert model == "gpt-5.4"
+
+    def test_platform_models_resolution_failure_is_caught(self):
+        """If resolve_runtime_provider explodes, the block degrades silently."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+
+        cfg = {
+            "model": {"default": "gpt-5.4"},
+            "platform_models": {
+                "weixin": {"provider": "nonexistent-prov", "model": "should-not-matter"},
+            },
+        }
+
+        with patch("gateway.run._resolve_gateway_model", return_value="gpt-5.4"), patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"provider": "openai-codex"},
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=RuntimeError("simulated credential failure"),
+        ):
+            model, kwargs = runner._resolve_session_agent_runtime(
+                session_key="agent:main:weixin:dm:u1",
+                user_config=cfg,
+            )
+
+        # Exception caught — falls through to global default
+        assert model == "gpt-5.4"
+        assert kwargs["provider"] == "openai-codex"
+
+
 class TestResolveGatewayModel:
     """Test _resolve_gateway_model reads model from config correctly."""
 

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -240,6 +240,33 @@ After adding a new provider via `hermes model`, start a new chat session — `/m
 | Switch to different configured provider | `/model provider:model` (inside session) |
 :::
 
+#### Different default models per platform
+
+You can assign different default models to different messaging platforms (WeChat, DingTalk, Telegram, etc.) via `platform_models` in `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  default: gpt-5.4
+  provider: openai-codex
+
+platform_models:
+  weixin:
+    provider: bailian
+    model: qwen3.6-plus
+  dingtalk:
+    provider: deepseek-pro
+    model: deepseek-v4-pro
+```
+
+Each platform entry accepts a `provider` (must match a name from `custom_providers`) and a `model`. The gateway resolves the provider's credentials (API key, base URL, API mode) automatically from your existing configuration.
+
+**Precedence (highest to lowest):**
+1. Session `/model` override — always wins
+2. `platform_models.<platform>` — per-platform default
+3. Global `model.default` / `model.provider` — fallback
+
+If a platform isn't listed or the `platform_models` section is absent, the global default applies. Failures (missing provider, invalid key) are caught silently and fall back to the global default — they never break the gateway.
+
 #### API key not working
 
 **Cause:** Key is missing, expired, incorrectly set, or for the wrong provider.


### PR DESCRIPTION
## Summary

Allow users to configure different default models per IM platform (WeChat, DingTalk, Telegram, Discord, etc.) via `config.yaml`.

## Problem

Currently Hermes uses a single global default model for all platforms. Users who want DingTalk conversations to use DeepSeek v4 while WeChat uses Qwen 3.6 have no way to set this — they must manually `/model` switch in each session. When sessions expire and are recreated, the override is lost.

## Solution

Adds a `platform_models` section to `config.yaml`:

```yaml
platform_models:
  weixin:
    provider: bailian
    model: qwen3.6-plus
  dingtalk:
    provider: deepseek-pro
    model: deepseek-v4-pro
```

The gateway reads this during session/agent creation. Platform defaults only apply when no explicit `/model` session override is active — the user's manual override always wins.

## Implementation

- 39 lines added to `gateway/run.py` in `GatewayRunner._create_agent_for_session()`
- Uses existing `resolve_runtime_provider()` for provider resolution (supports env-var expansion and credential lookup)
- Silent no-op when `platform_models` field is missing from config
- All exceptions are caught and logged at debug level — routing failures never break the gateway