### PR TITLE
fix(compression): pass provider to context length resolver in feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2399,6 +2399,7 @@ class AIAgent:
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                provider=getattr(self, "provider", ""),
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -184,6 +184,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        provider="openrouter",
     )
 
 
@@ -206,6 +207,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
+        provider="openrouter",
     )
 
 
@@ -258,6 +260,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        provider="",
     )
 
 


### PR DESCRIPTION
## Problem

`_check_compression_model_feasibility` calls `get_model_context_length(aux_model, base_url=..., api_key=...)` **without `provider=`**. For Codex OAuth users:

1. `_infer_provider_from_url("chatgpt.com")` returns `"openai"` — not `"openai-codex"`
2. The `if effective_provider == "openai-codex":` branch in `get_model_context_length` never fires
3. Falls through to `lookup_models_dev_context("openai", "gpt-5.5")` → returns **1,050,000**
4. Actual Codex OAuth limit is **272,000** (resolved correctly when `provider="openai-codex"` is passed)

**User evidence** (paste.rs/vsra3, GPT 5.5 via Codex OAuth Pro):
```
Session hygiene: 426 messages, ~213,995 tokens — auto-compressing (threshold: 85% of 1,050,000 = 892,500 tokens)
```
The 1,050,000 is wrong — should be 272,000.

**Consequence**: Compression threshold set at 892K instead of 231K. Conversations never trigger compression. When gateway hygiene eventually forces it, the Codex endpoint drops the oversized streaming summarization request (`peer closed connection without sending complete message body`), producing 15+ `Context compression failed after 3 attempts` errors in a row.

## Fix

One line: forward `self.provider` to `get_model_context_length`:
```python
provider=getattr(self, "provider", ""),
```

This ensures provider-specific resolution branches fire correctly:
- Codex OAuth → 272K (via `_resolve_codex_oauth_context_length`)
- Copilot → live `/models` API (`max_prompt_tokens`)
- Nous → suffix-match via OpenRouter cache

## Test

3 existing tests updated for the new `provider=` kwarg. All 18 feasibility tests pass.