### PR TITLE
fix(transports): emit reasoning:{effort:none,enabled:false} for custom providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -265,13 +265,27 @@ class ChatCompletionsTransport(ProviderTransport):
             options["num_ctx"] = ollama_ctx
             extra_body["options"] = options
 
-        # Ollama/custom think=false
+        # Ollama/custom: disable provider-side chain-of-thought when requested.
+        # - "think": False is honored by Ollama's native /api/chat path.
+        # - "reasoning": {"effort":"none","enabled":False} is honored by
+        #   Ollama's OAI-compatible /v1/chat/completions path. Some local-OAI
+        #   models (e.g. gemma4:26b-a4b-it-q4_K_M) emit chain-of-thought into
+        #   `message.reasoning` and leave `message.content` empty unless the
+        #   reasoning controls are passed; "think" is silently ignored on the
+        #   OAI route. Sending both keys keeps native + OAI paths covered.
+        # Paperclip LIF-276 (2026-04-25): without this, HermesAgent on local
+        # gemma4 burned `num_predict` on CoT, returned empty content, and timed
+        # out every heartbeat.
         if params.get("is_custom_provider", False):
             if reasoning_config and isinstance(reasoning_config, dict):
                 _effort = (reasoning_config.get("effort") or "").strip().lower()
                 _enabled = reasoning_config.get("enabled", True)
                 if _effort == "none" or _enabled is False:
                     extra_body["think"] = False
+                    extra_body["reasoning"] = {
+                        "effort": "none",
+                        "enabled": False,
+                    }
 
         if is_qwen:
             extra_body["vl_high_resolution_images"] = True

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -117,7 +117,34 @@ class TestChatCompletionsBuildKwargs:
             is_custom_provider=True,
             reasoning_config={"effort": "none"},
         )
+        # Native /api/chat path
         assert kw["extra_body"]["think"] is False
+        # OAI-compatible /v1/chat/completions path: gemma4 family ignores
+        # `think` and emits CoT into message.reasoning unless reasoning is
+        # explicitly disabled. Send both keys to cover both routes.
+        assert kw["extra_body"]["reasoning"] == {"effort": "none", "enabled": False}
+
+    def test_custom_reasoning_disabled_via_enabled_false(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemma4:26b-a4b-it-q4_K_M", messages=msgs,
+            is_custom_provider=True,
+            reasoning_config={"enabled": False},
+        )
+        # enabled=False without effort='none' should still emit both keys
+        assert kw["extra_body"]["think"] is False
+        assert kw["extra_body"]["reasoning"] == {"effort": "none", "enabled": False}
+
+    def test_custom_no_reasoning_keys_when_unset(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="qwen3", messages=msgs,
+            is_custom_provider=True,
+        )
+        # No reasoning_config => no think/reasoning keys injected
+        extra_body = kw.get("extra_body", {})
+        assert "think" not in extra_body
+        assert "reasoning" not in extra_body
 
     def test_max_tokens_with_fn(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]


### PR DESCRIPTION
Deleted