### PR TITLE
feat(skills): add self-modification policy audit

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -493,6 +493,21 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Policy boundary for agent-managed skill create/edit/patch/delete actions.
+  # Defaults preserve the current behavior while recording audit evidence for
+  # self-modification attempts.
+  self_modification:
+    enabled: true
+    audit_enabled: true
+    require_reason: false
+    allowed_actions:
+      - create
+      - edit
+      - patch
+      - delete
+      - write_file
+      - remove_file
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -486,6 +486,85 @@ class TestSkillManageDispatcher:
         assert result["success"] is True
 
 
+class TestSelfModificationPolicy:
+    def test_create_records_allowed_audit_event(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"self_modification": {"audit_enabled": True}}}):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+                reason="Capture a proven workflow.",
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["authorization"]["allowed"] is True
+
+        audit_path = tmp_path / ".skill_mutation_audit.jsonl"
+        event = json.loads(audit_path.read_text(encoding="utf-8").splitlines()[-1])
+        assert event["policy_id"] == "skills.self_modification"
+        assert event["action"] == "create"
+        assert event["skill"] == "test-skill"
+        assert event["allowed"] is True
+        assert event["result_success"] is True
+
+    def test_disabled_policy_blocks_create_and_audits_denial(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"self_modification": {"enabled": False}}}):
+            raw = skill_manage(
+                action="create",
+                name="blocked-skill",
+                content=VALID_SKILL_CONTENT,
+                reason="Should be denied.",
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "self-modifying skills are disabled" in result["error"]
+        assert not (tmp_path / "blocked-skill").exists()
+
+        audit_path = tmp_path / ".skill_mutation_audit.jsonl"
+        event = json.loads(audit_path.read_text(encoding="utf-8").splitlines()[-1])
+        assert event["allowed"] is False
+        assert event["result_success"] is False
+        assert "self-modifying skills are disabled" in event["denies"]
+
+    def test_require_reason_blocks_mutation_without_reason(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"self_modification": {"require_reason": True}}}):
+            raw = skill_manage(
+                action="create",
+                name="needs-reason",
+                content=VALID_SKILL_CONTENT,
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "reason is required by policy" in result["error"]
+        assert not (tmp_path / "needs-reason").exists()
+
+    def test_allowed_actions_policy_blocks_delete(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("keep-me", VALID_SKILL_CONTENT)
+
+            with patch("hermes_cli.config.load_config",
+                       return_value={"skills": {"self_modification": {"allowed_actions": ["create"]}}}):
+                raw = skill_manage(
+                    action="delete",
+                    name="keep-me",
+                    reason="Attempt delete.",
+                )
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "action 'delete' is not allowed by policy" in result["error"]
+        assert (tmp_path / "keep-me" / "SKILL.md").exists()
+
+
 class TestSecurityScanGate:
     """_security_scan_skill is gated by skills.guard_agent_created config flag."""
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -38,9 +38,10 @@ import os
 import re
 import shutil
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, List
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,153 @@ VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 # Subdirectories allowed for write_file/remove_file
 ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+MUTATING_ACTIONS = {"create", "edit", "patch", "delete", "write_file", "remove_file"}
+SELF_MODIFICATION_POLICY_ID = "skills.self_modification"
+
+
+# =============================================================================
+# Self-modification authorization helpers
+# =============================================================================
+
+def _load_self_modification_policy() -> Dict[str, Any]:
+    """Load the MVP policy boundary for agent-managed skill mutations."""
+    policy = {
+        "policy_id": SELF_MODIFICATION_POLICY_ID,
+        "enabled": True,
+        "audit_enabled": True,
+        "require_reason": False,
+        "allowed_actions": sorted(MUTATING_ACTIONS),
+    }
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        configured = cfg.get("skills", {}).get("self_modification", {})
+        if isinstance(configured, dict):
+            for key in ("enabled", "audit_enabled", "require_reason"):
+                if key in configured:
+                    policy[key] = bool(configured[key])
+            if "allowed_actions" in configured:
+                allowed_actions = configured["allowed_actions"]
+                if isinstance(allowed_actions, str):
+                    allowed_actions = [allowed_actions]
+                if isinstance(allowed_actions, list):
+                    policy["allowed_actions"] = sorted(
+                        action for action in allowed_actions if action in MUTATING_ACTIONS
+                    )
+    except Exception:
+        pass
+    return policy
+
+
+def _default_skill_mutation_audit_path() -> Path:
+    """Return the audit log path, keeping tests that patch SKILLS_DIR isolated."""
+    try:
+        if SKILLS_DIR.resolve().parent == HERMES_HOME.resolve():
+            return HERMES_HOME / "skill_mutation_audit.jsonl"
+    except Exception:
+        pass
+    return SKILLS_DIR / ".skill_mutation_audit.jsonl"
+
+
+def _evaluate_self_modification_policy(
+    action: str,
+    reason: Optional[str],
+    policy: Dict[str, Any],
+) -> Tuple[bool, List[str]]:
+    """Evaluate the authorization contract before a skill write/delete action."""
+    denies = []
+    if action not in MUTATING_ACTIONS:
+        denies.append(f"unknown mutating action: {action}")
+    if not policy.get("enabled", True):
+        denies.append("self-modifying skills are disabled")
+    if action not in set(policy.get("allowed_actions", [])):
+        denies.append(f"action '{action}' is not allowed by policy")
+    if policy.get("require_reason") and not (reason or "").strip():
+        denies.append("reason is required by policy")
+    return not denies, denies
+
+
+def _audit_skill_mutation(
+    *,
+    action: str,
+    name: str,
+    reason: Optional[str],
+    policy: Dict[str, Any],
+    allowed: bool,
+    denies: List[str],
+    result: Dict[str, Any],
+) -> None:
+    """Append best-effort audit evidence for allowed and denied skill mutations."""
+    if not policy.get("audit_enabled", True):
+        return
+
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "policy_id": policy.get("policy_id", SELF_MODIFICATION_POLICY_ID),
+        "action": action,
+        "skill": name,
+        "reason": reason,
+        "allowed": allowed,
+        "denies": denies,
+        "result_success": bool(result.get("success")),
+        "result_error": result.get("error"),
+        "allowed_actions": policy.get("allowed_actions", []),
+        "require_reason": bool(policy.get("require_reason", False)),
+    }
+    try:
+        audit_path = _default_skill_mutation_audit_path()
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        with audit_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except Exception:
+        logger.warning("Failed to write skill mutation audit event", exc_info=True)
+
+
+def _authorized_skill_mutation_result(
+    action: str,
+    name: str,
+    reason: Optional[str],
+    handler,
+) -> Dict[str, Any]:
+    """Run a skill mutation through the self-modification policy and audit it."""
+    policy = _load_self_modification_policy()
+    allowed, denies = _evaluate_self_modification_policy(action, reason, policy)
+    if not allowed:
+        result = {
+            "success": False,
+            "error": "Skill self-modification blocked by policy: " + "; ".join(denies),
+            "authorization": {
+                "policy_id": policy.get("policy_id", SELF_MODIFICATION_POLICY_ID),
+                "allowed": False,
+                "denies": denies,
+            },
+        }
+        _audit_skill_mutation(
+            action=action,
+            name=name,
+            reason=reason,
+            policy=policy,
+            allowed=False,
+            denies=denies,
+            result=result,
+        )
+        return result
+
+    result = handler()
+    result.setdefault("authorization", {
+        "policy_id": policy.get("policy_id", SELF_MODIFICATION_POLICY_ID),
+        "allowed": True,
+    })
+    _audit_skill_mutation(
+        action=action,
+        name=name,
+        reason=reason,
+        policy=policy,
+        allowed=True,
+        denies=[],
+        result=result,
+    )
+    return result
 
 
 # =============================================================================
@@ -651,6 +799,7 @@ def skill_manage(
     old_string: str = None,
     new_string: str = None,
     replace_all: bool = False,
+    reason: str = None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
@@ -660,34 +809,46 @@ def skill_manage(
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
+        result = _authorized_skill_mutation_result(
+            action, name, reason, lambda: _create_skill(name, content, category)
+        )
 
     elif action == "edit":
         if not content:
             return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
-        result = _edit_skill(name, content)
+        result = _authorized_skill_mutation_result(
+            action, name, reason, lambda: _edit_skill(name, content)
+        )
 
     elif action == "patch":
         if not old_string:
             return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
         if new_string is None:
             return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
-        result = _patch_skill(name, old_string, new_string, file_path, replace_all)
+        result = _authorized_skill_mutation_result(
+            action, name, reason, lambda: _patch_skill(name, old_string, new_string, file_path, replace_all)
+        )
 
     elif action == "delete":
-        result = _delete_skill(name)
+        result = _authorized_skill_mutation_result(
+            action, name, reason, lambda: _delete_skill(name)
+        )
 
     elif action == "write_file":
         if not file_path:
             return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
         if file_content is None:
             return tool_error("file_content is required for 'write_file'.", success=False)
-        result = _write_file(name, file_path, file_content)
+        result = _authorized_skill_mutation_result(
+            action, name, reason, lambda: _write_file(name, file_path, file_content)
+        )
 
     elif action == "remove_file":
         if not file_path:
             return tool_error("file_path is required for 'remove_file'.", success=False)
-        result = _remove_file(name, file_path)
+        result = _authorized_skill_mutation_result(
+            action, name, reason, lambda: _remove_file(name, file_path)
+        )
 
     else:
         result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
@@ -790,6 +951,13 @@ SKILL_MANAGE_SCHEMA = {
                 "type": "string",
                 "description": "Content for the file. Required for 'write_file'."
             },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Short audit reason for the skill mutation. Required when "
+                    "skills.self_modification.require_reason is enabled."
+                )
+            },
         },
         "required": ["action", "name"],
     },
@@ -812,6 +980,7 @@ registry.register(
         file_content=args.get("file_content"),
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False)),
+        replace_all=args.get("replace_all", False),
+        reason=args.get("reason")),
     emoji="📝",
 )


### PR DESCRIPTION
## What does this PR do?

Adds an MVP authorization and audit boundary around agent-managed skill mutations. The default policy preserves current behavior while creating a concrete place to configure allowed actions, require a mutation reason, and record allow/deny evidence.

## Related Issue

Fixes #8218

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `skills.self_modification` policy loading for `skill_manage` mutations.
- Added pre-execution allow/deny checks for create, edit, patch, delete, write_file, and remove_file.
- Added best-effort JSONL audit events for allowed and denied mutation attempts.
- Added optional `reason` support to the `skill_manage` schema.
- Updated `cli-config.yaml.example` with the new self-modification policy knobs.
- Added tests for allowed audit events, disabled policy denial, required reason, and allowed action filtering.

## How to Test

1. Run `skill_manage(action="create", ...)` with default config and confirm the skill is created with authorization metadata.
2. Set `skills.self_modification.enabled: false` and confirm skill mutations are blocked.
3. Set `skills.self_modification.require_reason: true` and confirm mutations without `reason` are blocked.
4. Inspect the JSONL audit log for allow/deny evidence.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`feat(skills): ...`).
- [x] I searched existing issues/PR context; this addresses #8218.
- [x] My PR contains only changes related to this feature.
- [x] I've run tests and they pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11, Python 3.13 conda env at `D:\conda-envs\hermes-agent`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation/config examples.
- [x] I've updated `cli-config.yaml.example` because this adds config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`, or N/A: N/A.
- [x] I've considered cross-platform impact: audit paths use `pathlib`, tests isolate `HERMES_HOME`/skills directories.
- [x] I've updated tool descriptions/schemas because `skill_manage` now accepts `reason`.

## Tests

- `D:\conda-envs\hermes-agent\python.exe -m pytest .\tests\tools\test_skill_manager_tool.py -q -n 4`