### PR TITLE
fix(fallback): trigger eager fallback on 503/529 provider overload

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -611,7 +611,7 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in (503, 529):
-        return result_fn(FailoverReason.overloaded, retryable=True)
+        return result_fn(FailoverReason.overloaded, retryable=True, should_fallback=True)
 
     # Other 4xx — non-retryable
     if 400 <= status_code < 500:

--- a/run_agent.py
+++ b/run_agent.py
@@ -11144,6 +11144,21 @@ class AIAgent:
                                 primary_recovery_attempted = False
                                 continue
 
+                    # Eager fallback for provider overload (503/529).
+                    # Provider-side overload cannot be fixed by credential rotation,
+                    # so bypass the pool check and switch to a fallback immediately.
+                    # Fixes #11314 / #10210.
+                    if (
+                        classified.reason == FailoverReason.overloaded
+                        and self._fallback_index < len(self._fallback_chain)
+                    ):
+                        self._emit_status("⚠️ Provider overloaded — switching to fallback provider...")
+                        if self._try_activate_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+
                     # ── Nous Portal: record rate limit & skip retries ─────
                     # When Nous returns a 429, record the reset time to a
                     # shared file so ALL sessions (cron, gateway, auxiliary)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -283,11 +283,15 @@ class TestClassifyApiError:
         e = MockAPIError("Service Unavailable", status_code=503)
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
+        assert result.should_fallback is True
+        assert result.retryable is True
 
     def test_529_anthropic_overloaded(self):
         e = MockAPIError("Overloaded", status_code=529)
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
+        assert result.should_fallback is True
+        assert result.retryable is True
 
     # ── Model not found ──
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -5,6 +5,13 @@ the new list-based ``fallback_providers`` config format and chain
 advancement through multiple providers.
 """
 
+import sys
+import types
+
+# Prevent heavy imports from failing in lightweight test environments.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit


### PR DESCRIPTION
(Continuation of #11492 — rebased on main, couldn't reopen the old PR after force-push.)

---

When a provider returns 503/529 (overloaded), Hermes should fall back to another provider. Currently it doesn't — two small things are missing:

1. `error_classifier.py`: 503/529 doesn't set `should_fallback=True`
2. `run_agent.py`: even if it did, the credential-pool check would block fallback (rotation can't fix provider overload)

## Fix

1. **error_classifier**: `503/529` → `should_fallback=True` (1 line)
2. **run_agent**: new eager-fallback block for overloaded, after the rate-limit block. Bypasses pool check entirely.

Why a separate block: overloaded isn't a rate limit, and credential rotation can't fix a saturated provider. Separate = zero risk to existing rate-limit/billing logic.

## What this does NOT touch

- `is_rate_limited` tuple — unchanged (still only rate_limit + billing)
- `_pool_may_recover_from_rate_limit` — unchanged
- Nous rate guard — unchanged
- Compression / context-overflow — unchanged
- All existing fallback and retry paths — preserved

## Related

- Fixes #10210
- Complements #14055 (message-pattern path vs status-code path)
- Builds on #11314 (`_pool_may_recover_from_rate_limit`)

4 files, +27/-1 lines.