### PR TITLE
feat(cli): add affordance gap logging command

### DIFF
--- a/hermes_cli/affordance_gaps.py
+++ b/hermes_cli/affordance_gaps.py
@@ -1,0 +1,131 @@
+"""Affordance gap logging for post-task reflection.
+
+This module is intentionally small: it gives the agent and CLI a structured
+place to record missing capabilities before the full reflection lifecycle is
+wired into the core agent loop.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+
+GAP_LOG_FILE = "affordance_gaps.jsonl"
+
+
+@dataclass
+class AffordanceGap:
+    goal: str
+    missing_capability: str
+    failure_description: str = ""
+    available_tools: list[str] = field(default_factory=list)
+    session_id: str | None = None
+    source: str = "manual"
+    failure_mode: str = "missing_affordance"
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "failure_mode": self.failure_mode,
+            "goal": self.goal,
+            "missing_capability": self.missing_capability,
+            "failure_description": self.failure_description,
+            "available_tools": self.available_tools,
+            "session_id": self.session_id,
+            "source": self.source,
+        }
+
+
+def default_gap_log_path() -> Path:
+    return get_hermes_home() / GAP_LOG_FILE
+
+
+def log_affordance_gap(
+    *,
+    goal: str,
+    missing_capability: str,
+    failure_description: str = "",
+    available_tools: Iterable[str] | None = None,
+    session_id: str | None = None,
+    source: str = "manual",
+    log_path: Path | None = None,
+) -> dict[str, Any]:
+    """Append one missing-affordance event to the persistent gap log."""
+    if not goal or not goal.strip():
+        raise ValueError("goal is required")
+    if not missing_capability or not missing_capability.strip():
+        raise ValueError("missing_capability is required")
+
+    gap = AffordanceGap(
+        goal=goal.strip(),
+        missing_capability=missing_capability.strip(),
+        failure_description=(failure_description or "").strip(),
+        available_tools=sorted({tool.strip() for tool in (available_tools or []) if tool and tool.strip()}),
+        session_id=session_id,
+        source=source or "manual",
+    )
+    target = log_path or default_gap_log_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(gap.to_dict(), ensure_ascii=False) + "\n")
+    return gap.to_dict()
+
+
+def load_affordance_gaps(
+    *,
+    limit: int = 20,
+    log_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Load recent gap events, newest first. Invalid JSONL rows are skipped."""
+    target = log_path or default_gap_log_path()
+    if not target.exists():
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for line in target.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            rows.append(parsed)
+
+    if limit <= 0:
+        return list(reversed(rows))
+    return list(reversed(rows))[:limit]
+
+
+def format_affordance_gaps(gaps: list[dict[str, Any]]) -> str:
+    """Render gap events as compact CLI text."""
+    if not gaps:
+        return "No affordance gaps logged."
+
+    lines = []
+    for idx, gap in enumerate(gaps, start=1):
+        timestamp = gap.get("timestamp", "")
+        goal = gap.get("goal", "")
+        missing = gap.get("missing_capability", "")
+        failure = gap.get("failure_description", "")
+        session_id = gap.get("session_id")
+        tools = gap.get("available_tools") or []
+        lines.append(f"{idx}. {missing}")
+        if goal:
+            lines.append(f"   Goal: {goal}")
+        if failure:
+            lines.append(f"   Failure: {failure}")
+        if tools:
+            lines.append(f"   Available tools: {', '.join(tools)}")
+        if session_id:
+            lines.append(f"   Session: {session_id}")
+        if timestamp:
+            lines.append(f"   Logged: {timestamp}")
+    return "\n".join(lines)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6791,6 +6791,31 @@ def cmd_logs(args):
     )
 
 
+def cmd_gaps(args):
+    """Review or manually record affordance gaps."""
+    from hermes_cli.affordance_gaps import (
+        format_affordance_gaps,
+        load_affordance_gaps,
+        log_affordance_gap,
+    )
+
+    action = getattr(args, "gaps_action", None) or "list"
+    if action == "log":
+        gap = log_affordance_gap(
+            goal=args.goal,
+            missing_capability=args.missing_capability,
+            failure_description=getattr(args, "failure", "") or "",
+            available_tools=getattr(args, "tool", None) or [],
+            session_id=getattr(args, "session_id", None),
+            source="cli",
+        )
+        print(f"Logged affordance gap: {gap['missing_capability']}")
+        return
+
+    gaps = load_affordance_gaps(limit=getattr(args, "limit", 20))
+    print(format_affordance_gaps(gaps))
+
+
 def main():
     """Main entry point for hermes CLI."""
     parser = argparse.ArgumentParser(
@@ -6825,6 +6850,7 @@ Examples:
     hermes logs -f                Follow agent.log in real time
     hermes logs errors            View errors.log
     hermes logs --since 1h        Lines from the last hour
+    hermes gaps list              Review logged missing capabilities
     hermes debug share             Upload debug report for support
     hermes update                 Update to latest version
 
@@ -9011,6 +9037,34 @@ Examples:
         help="Filter by component: gateway, agent, tools, cli, cron",
     )
     logs_parser.set_defaults(func=cmd_logs)
+
+    # =========================================================================
+    # gaps command
+    # =========================================================================
+    gaps_parser = subparsers.add_parser(
+        "gaps",
+        help="Review missing-capability affordance gaps",
+        description="Record and review missing affordances discovered during task execution.",
+    )
+    gaps_sub = gaps_parser.add_subparsers(dest="gaps_action")
+    gaps_list = gaps_sub.add_parser("list", help="List recent affordance gaps")
+    gaps_list.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of recent gaps to show (default: 20)",
+    )
+    gaps_log = gaps_sub.add_parser("log", help="Manually log an affordance gap")
+    gaps_log.add_argument("--goal", required=True, help="Task goal that could not be completed")
+    gaps_log.add_argument(
+        "--missing-capability",
+        required=True,
+        help="Tool, skill, knowledge, or permission that was missing",
+    )
+    gaps_log.add_argument("--failure", default="", help="Short failure description")
+    gaps_log.add_argument("--tool", action="append", default=[], help="Available tool at time of failure")
+    gaps_log.add_argument("--session-id", help="Session id associated with the gap")
+    gaps_parser.set_defaults(func=cmd_gaps)
 
     # =========================================================================
     # Parse and execute

--- a/tests/hermes_cli/test_affordance_gaps.py
+++ b/tests/hermes_cli/test_affordance_gaps.py
@@ -1,0 +1,77 @@
+"""Tests for affordance gap logging."""
+
+import json
+
+import pytest
+
+from hermes_cli.affordance_gaps import (
+    format_affordance_gaps,
+    load_affordance_gaps,
+    log_affordance_gap,
+)
+
+
+def test_log_and_load_affordance_gap(tmp_path):
+    log_path = tmp_path / "affordance_gaps.jsonl"
+
+    event = log_affordance_gap(
+        goal="Summarize a video",
+        missing_capability="video transcript fetcher",
+        failure_description="No tool could retrieve the transcript.",
+        available_tools=["web", "web", "memory"],
+        session_id="session-1",
+        source="test",
+        log_path=log_path,
+    )
+
+    assert event["failure_mode"] == "missing_affordance"
+    assert event["available_tools"] == ["memory", "web"]
+
+    loaded = load_affordance_gaps(log_path=log_path)
+    assert len(loaded) == 1
+    assert loaded[0]["goal"] == "Summarize a video"
+    assert loaded[0]["missing_capability"] == "video transcript fetcher"
+
+
+def test_load_skips_invalid_jsonl_rows(tmp_path):
+    log_path = tmp_path / "affordance_gaps.jsonl"
+    log_path.write_text(
+        "\n".join([
+            "{bad json",
+            json.dumps({"goal": "ok", "missing_capability": "tool"}),
+        ]),
+        encoding="utf-8",
+    )
+
+    loaded = load_affordance_gaps(log_path=log_path)
+
+    assert loaded == [{"goal": "ok", "missing_capability": "tool"}]
+
+
+def test_format_affordance_gaps_empty():
+    assert format_affordance_gaps([]) == "No affordance gaps logged."
+
+
+def test_format_affordance_gaps_includes_key_fields():
+    output = format_affordance_gaps([
+        {
+            "timestamp": "2026-04-25T00:00:00+00:00",
+            "goal": "Do the task",
+            "missing_capability": "browser auth",
+            "failure_description": "Could not access the site.",
+            "available_tools": ["web"],
+            "session_id": "abc",
+        }
+    ])
+
+    assert "browser auth" in output
+    assert "Goal: Do the task" in output
+    assert "Session: abc" in output
+
+
+def test_log_requires_goal_and_missing_capability(tmp_path):
+    with pytest.raises(ValueError, match="goal is required"):
+        log_affordance_gap(goal="", missing_capability="tool", log_path=tmp_path / "gaps.jsonl")
+
+    with pytest.raises(ValueError, match="missing_capability is required"):
+        log_affordance_gap(goal="goal", missing_capability="", log_path=tmp_path / "gaps.jsonl")


### PR DESCRIPTION
## What does this PR do?

Adds the first small infrastructure slice for post-task reflection: a structured affordance gap log plus CLI commands to record and review missing-capability failures. This does not wire automatic reflection into the agent loop yet; it creates the persistent artifact that later reflection hooks can write to.

## Related Issue

Starts #483

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `hermes_cli/affordance_gaps.py` for structured JSONL logging, loading, validation, and CLI formatting.
- Added `hermes gaps list` to review recent missing-capability events.
- Added `hermes gaps log` to manually record an affordance gap with goal, missing capability, failure text, tools, and session id.
- Added unit tests for logging, invalid JSONL handling, validation, and formatting.

## How to Test

1. Run `hermes gaps log --goal "Summarize a video" --missing-capability "video transcript fetcher" --failure "No transcript source"`.
2. Run `hermes gaps list`.
3. Confirm the logged gap appears and is persisted in `affordance_gaps.jsonl`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`feat(cli): ...`).
- [x] I searched existing issues/PR context; this starts #483.
- [x] My PR contains only changes related to this feature.
- [x] I've run tests and they pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11, Python 3.13 conda env at `D:\conda-envs\hermes-agent`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation, or N/A: N/A for this small CLI surface; usage is covered in command help and PR test steps.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A: N/A, no config keys added.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`, or N/A: N/A.
- [x] I've considered cross-platform impact: uses `pathlib` and JSONL only.
- [x] I've updated tool descriptions/schemas, or N/A: N/A.

## Tests

- `D:\conda-envs\hermes-agent\python.exe -m pytest .\tests\hermes_cli\test_affordance_gaps.py -q -n 4`
- `D:\conda-envs\hermes-agent\python.exe -m py_compile .\hermes_cli\affordance_gaps.py .\hermes_cli\main.py`