### PR TITLE
fix(cli): sync use_gateway in _reconfigure_provider for tts, browser, and web

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1685,21 +1685,27 @@ def _reconfigure_provider(provider: dict, config: dict):
             return
 
     if provider.get("tts_provider"):
-        config.setdefault("tts", {})["provider"] = provider["tts_provider"]
+        tts_cfg = config.setdefault("tts", {})
+        tts_cfg["provider"] = provider["tts_provider"]
+        tts_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  TTS provider set to: {provider['tts_provider']}")
 
     if "browser_provider" in provider:
         bp = provider["browser_provider"]
+        browser_cfg = config.setdefault("browser", {})
         if bp == "local":
-            config.setdefault("browser", {})["cloud_provider"] = "local"
+            browser_cfg["cloud_provider"] = "local"
             _print_success("  Browser set to local mode")
         elif bp:
-            config.setdefault("browser", {})["cloud_provider"] = bp
+            browser_cfg["cloud_provider"] = bp
             _print_success(f"  Browser cloud provider set to: {bp}")
+        browser_cfg["use_gateway"] = bool(managed_feature)
 
     # Set web search backend in config if applicable
     if provider.get("web_backend"):
-        config.setdefault("web", {})["backend"] = provider["web_backend"]
+        web_cfg = config.setdefault("web", {})
+        web_cfg["backend"] = provider["web_backend"]
+        web_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  Web backend set to: {provider['web_backend']}")
 
     if managed_feature and managed_feature not in ("web", "tts", "browser"):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -2,10 +2,13 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _apply_toolset_change,
     _configure_provider,
+    _reconfigure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
     _save_platform_tools,
@@ -787,3 +790,27 @@ def test_get_effective_configurable_toolsets_dedupes_bundled_plugins():
     assert len(spotify_rows) == 1, spotify_rows
     # Built-in label wins over the plugin label.
     assert spotify_rows[0][1] == "🎵 Spotify"
+
+
+@pytest.mark.parametrize("provider,config_key,expected", [
+    # managed provider → use_gateway True
+    ({"name": "T", "tts_provider": "elevenlabs", "managed_nous_feature": "tts", "env_vars": []}, "tts", True),
+    ({"name": "B", "browser_provider": "browserbase", "managed_nous_feature": "browser", "env_vars": []}, "browser", True),
+    ({"name": "W", "web_backend": "tavily", "managed_nous_feature": "web", "env_vars": []}, "web", True),
+    # self-hosted provider → use_gateway False
+    ({"name": "T", "tts_provider": "elevenlabs", "env_vars": []}, "tts", False),
+    ({"name": "B", "browser_provider": "browserbase", "env_vars": []}, "browser", False),
+    ({"name": "W", "web_backend": "tavily", "env_vars": []}, "web", False),
+])
+def test_reconfigure_provider_syncs_use_gateway(provider, config_key, expected):
+    config = {}
+    _reconfigure_provider(provider, config)
+    assert config[config_key]["use_gateway"] is expected
+
+
+def test_reconfigure_browser_provider_overwrites_stale_use_gateway():
+    # Switching from managed (use_gateway=True) to self-hosted must clear the stale flag.
+    config = {"browser": {"cloud_provider": "managed-browser", "use_gateway": True}}
+    provider = {"name": "Browserbase", "browser_provider": "browserbase", "env_vars": []}
+    _reconfigure_provider(provider, config)
+    assert config["browser"]["use_gateway"] is False


### PR DESCRIPTION
## What does this PR do?

`_reconfigure_provider()` updates `cloud_provider`/`backend`/`tts.provider` when switching tool providers via "hermes setup tools → Reconfigure", but did not update the matching `use_gateway` flag. `_configure_provider()` (the initial-setup path) sets `use_gateway` on all three tool categories. The omission in `_reconfigure_provider` leaves a stale value in `config.yaml`: switching from a Nous-managed provider (`use_gateway=True`) to a self-hosted one keeps `use_gateway=True`, continuing to route requests through the Nous gateway; switching the other way leaves `use_gateway` unset so the managed feature does not activate.

Fix: mirror `_configure_provider`'s `use_gateway = bool(managed_feature)` assignment in the `tts`, `browser`, and `web` blocks of `_reconfigure_provider`. Symmetric across all three tool categories. No behavior change for any provider that does not set `tts_provider`, `browser_provider`, or `web_backend`.

## Related Issue

Fixes #15229

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/tools_config.py`: add `use_gateway` sync in `_reconfigure_provider()` for tts, browser, and web blocks (+8 lines)
- `tests/hermes_cli/test_tools_config.py`: parametrized regression test + stale-flag overwrite test (+29 lines)

## How to Test

```bash
python3.11 -m pytest tests/hermes_cli/test_tools_config.py -v --override-ini="addopts=" -k "use_gateway"
```

## Checklist

### Code
- [x] Contributing Guide okundu
- [x] Conventional Commits
- [x] Duplicate PR yok
- [x] Sadece bu fix
- [x] pytest çalıştırıldı
- [x] Test eklendi
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs güncellendi — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A