### PR TITLE
feat(datagen): add optional TOON encoding for tool results

### DIFF
--- a/datagen-config-examples/trajectory_compression.yaml
+++ b/datagen-config-examples/trajectory_compression.yaml
@@ -20,6 +20,11 @@ compression:
   # This is factored into calculations when determining what to compress
   summary_target_tokens: 750
 
+  # Optionally compact JSON-array tool results into a TOON-style table before
+  # deciding whether expensive summary compression is needed.
+  toon_encode_tool_results: false
+  toon_min_rows: 2
+
 # Protected turns that should NEVER be compressed
 protected_turns:
   # Always protect the first system message (tool definitions)

--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -117,6 +117,8 @@ class TestCompressionConfig:
         assert config.summary_target_tokens == 750
         assert config.protect_last_n_turns == 4
         assert config.skip_under_target is True
+        assert config.toon_encode_tool_results is False
+        assert config.toon_min_rows == 2
 
     def test_from_yaml(self, tmp_path):
         yaml_content = """\
@@ -126,6 +128,8 @@ tokenizer:
 compression:
   target_max_tokens: 10000
   summary_target_tokens: 500
+  toon_encode_tool_results: true
+  toon_min_rows: 3
 protected_turns:
   first_system: true
   first_human: false
@@ -154,6 +158,8 @@ metrics:
         assert config.trust_remote_code is False
         assert config.target_max_tokens == 10000
         assert config.summary_target_tokens == 500
+        assert config.toon_encode_tool_results is True
+        assert config.toon_min_rows == 3
         assert config.protect_first_human is False
         assert config.protect_last_n_turns == 6
         assert config.summarization_model == "gpt-4"
@@ -201,11 +207,13 @@ class TestTrajectoryMetrics:
         m.compressed_turns = 10
         m.turns_removed = 10
         m.was_compressed = True
+        m.toon_encoded_tool_results = 2
         d = m.to_dict()
         assert d["original_tokens"] == 10000
         assert d["compressed_tokens"] == 5000
         assert d["compression_ratio"] == 0.5
         assert d["was_compressed"] is True
+        assert d["toon_encoded_tool_results"] == 2
         assert d["compression_region"]["start_idx"] == -1
 
     def test_default_values(self):
@@ -478,6 +486,69 @@ class TestTokenCounting:
         tc.tokenizer.encode = MagicMock(side_effect=Exception("fail"))
         # Should fallback to len(text) // 4
         assert tc.count_tokens("12345678") == 2
+
+
+class TestToolResultToonEncoding:
+    def test_uniform_json_array_tool_result_is_encoded(self):
+        config = CompressionConfig(
+            toon_encode_tool_results=True,
+            target_max_tokens=10000,
+        )
+        tc = _make_compressor(config)
+        tool_result = json.dumps([
+            {"very_long_field_name": "alpha", "score_value": 0.91, "ok": True},
+            {"very_long_field_name": "beta", "score_value": 0.82, "ok": False},
+            {"very_long_field_name": "gamma", "score_value": 0.73, "ok": True},
+        ])
+        trajectory = [
+            {"from": "human", "value": "Find records."},
+            {"from": "tool", "value": tool_result},
+        ]
+
+        compressed, metrics = tc.compress_trajectory(trajectory)
+
+        encoded_value = compressed[1]["value"]
+        assert encoded_value.startswith("[TOON_ENCODED_TOOL_RESULT]")
+        assert "rows[3]{very_long_field_name,score_value,ok}" in encoded_value
+        assert "alpha|0.91|true" in encoded_value
+        assert metrics.toon_encoded_tool_results == 1
+        assert metrics.skipped_under_target is True
+        assert metrics.tokens_saved > 0
+
+    def test_heterogeneous_json_array_is_not_encoded(self):
+        config = CompressionConfig(toon_encode_tool_results=True)
+        tc = _make_compressor(config)
+
+        encoded = tc._toon_encode_json_array('[{"a":1},{"b":2}]')
+
+        assert encoded is None
+
+    def test_process_entry_includes_metrics_for_encoding_without_summary(self):
+        config = CompressionConfig(
+            toon_encode_tool_results=True,
+            target_max_tokens=10000,
+            metrics_per_trajectory=True,
+        )
+        tc = _make_compressor(config)
+        entry = {
+            "conversations": [
+                {"from": "human", "value": "Fetch rows."},
+                {
+                    "from": "tool",
+                    "value": json.dumps([
+                        {"repeated_key": "one", "another_repeated_key": 1},
+                        {"repeated_key": "two", "another_repeated_key": 2},
+                        {"repeated_key": "three", "another_repeated_key": 3},
+                    ]),
+                },
+            ]
+        }
+
+        processed, _ = tc.process_entry(entry)
+
+        assert "compression_metrics" in processed
+        assert processed["compression_metrics"]["was_compressed"] is False
+        assert processed["compression_metrics"]["toon_encoded_tool_results"] == 1
 
 
 class TestGenerateSummary:

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -89,6 +89,8 @@ class CompressionConfig:
     # Compression targets
     target_max_tokens: int = 15250
     summary_target_tokens: int = 750
+    toon_encode_tool_results: bool = False
+    toon_min_rows: int = 2
     
     # Protected turns
     protect_first_system: bool = True
@@ -139,6 +141,11 @@ class CompressionConfig:
         if 'compression' in data:
             config.target_max_tokens = data['compression'].get('target_max_tokens', config.target_max_tokens)
             config.summary_target_tokens = data['compression'].get('summary_target_tokens', config.summary_target_tokens)
+            config.toon_encode_tool_results = data['compression'].get(
+                'toon_encode_tool_results',
+                config.toon_encode_tool_results,
+            )
+            config.toon_min_rows = data['compression'].get('toon_min_rows', config.toon_min_rows)
         
         # Protected turns
         if 'protected_turns' in data:
@@ -201,6 +208,7 @@ class TrajectoryMetrics:
     
     summarization_api_calls: int = 0
     summarization_errors: int = 0
+    toon_encoded_tool_results: int = 0
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -221,6 +229,7 @@ class TrajectoryMetrics:
             "skipped_under_target": self.skipped_under_target,
             "summarization_api_calls": self.summarization_api_calls,
             "summarization_errors": self.summarization_errors,
+            "toon_encoded_tool_results": self.toon_encoded_tool_results,
         }
 
 
@@ -243,6 +252,7 @@ class AggregateMetrics:
     
     total_summarization_calls: int = 0
     total_summarization_errors: int = 0
+    total_toon_encoded_tool_results: int = 0
     
     # Distribution stats
     compression_ratios: List[float] = field(default_factory=list)
@@ -264,6 +274,7 @@ class AggregateMetrics:
         self.total_turns_removed += metrics.turns_removed
         self.total_summarization_calls += metrics.summarization_api_calls
         self.total_summarization_errors += metrics.summarization_errors
+        self.total_toon_encoded_tool_results += metrics.toon_encoded_tool_results
         
         if metrics.was_compressed:
             self.trajectories_compressed += 1
@@ -320,6 +331,9 @@ class AggregateMetrics:
                 "total_api_calls": self.total_summarization_calls,
                 "total_errors": self.total_summarization_errors,
                 "success_rate": round(1 - (self.total_summarization_errors / max(self.total_summarization_calls, 1)), 4),
+            },
+            "tool_result_encoding": {
+                "toon_encoded_tool_results": self.total_toon_encoded_tool_results,
             },
             "processing": {
                 "start_time": self.processing_start_time,
@@ -478,6 +492,110 @@ class TrajectoryCompressor:
     def count_turn_tokens(self, trajectory: List[Dict[str, str]]) -> List[int]:
         """Count tokens for each turn in a trajectory."""
         return [self.count_tokens(turn.get("value", "")) for turn in trajectory]
+
+    @staticmethod
+    def _is_tool_turn(turn: Dict[str, Any]) -> bool:
+        """Return whether a turn is a tool response in supported trajectory shapes."""
+        return turn.get("from") == "tool" or turn.get("role") == "tool"
+
+    @staticmethod
+    def _tool_result_text_key(turn: Dict[str, Any]) -> Optional[str]:
+        """Find the text field used by a tool response."""
+        if "value" in turn:
+            return "value"
+        if "content" in turn:
+            return "content"
+        return None
+
+    @staticmethod
+    def _is_toon_field_name(value: Any) -> bool:
+        """Reject field names that would make the compact table ambiguous."""
+        return (
+            isinstance(value, str)
+            and value != ""
+            and not any(char in value for char in "{}|,\n\r")
+        )
+
+    @staticmethod
+    def _toon_cell(value: Any) -> str:
+        """Render one scalar-ish value for a compact TOON-style table cell."""
+        if value is None:
+            text = ""
+        elif isinstance(value, bool):
+            text = "true" if value else "false"
+        elif isinstance(value, (int, float)):
+            text = str(value)
+        elif isinstance(value, str):
+            text = value
+        else:
+            text = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        return (
+            text
+            .replace("\\", "\\\\")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n")
+            .replace("|", "\\|")
+        )
+
+    def _toon_encode_json_array(self, value: str) -> Optional[str]:
+        """Encode a JSON array of uniform objects as a compact TOON-style table."""
+        if not isinstance(value, str):
+            return None
+
+        try:
+            rows = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(rows, list) or len(rows) < self.config.toon_min_rows:
+            return None
+        if not rows or not all(isinstance(row, dict) for row in rows):
+            return None
+
+        fields = list(rows[0].keys())
+        if not fields or not all(self._is_toon_field_name(field) for field in fields):
+            return None
+
+        field_set = set(fields)
+        if any(set(row.keys()) != field_set for row in rows):
+            return None
+
+        encoded_lines = [
+            "[TOON_ENCODED_TOOL_RESULT]",
+            f"rows[{len(rows)}]{{{','.join(fields)}}}",
+        ]
+        encoded_lines.extend(
+            "|".join(self._toon_cell(row[field]) for field in fields)
+            for row in rows
+        )
+        encoded_lines.append("[/TOON_ENCODED_TOOL_RESULT]")
+        encoded = "\n".join(encoded_lines)
+
+        if len(encoded) >= len(value):
+            return None
+        return encoded
+
+    def _preprocess_tool_results(
+        self,
+        trajectory: List[Dict[str, str]],
+        metrics: TrajectoryMetrics,
+    ) -> List[Dict[str, str]]:
+        """Optionally compact JSON-array tool results before token budgeting."""
+        if not self.config.toon_encode_tool_results:
+            return trajectory
+
+        processed = []
+        for turn in trajectory:
+            updated_turn = turn.copy()
+            key = self._tool_result_text_key(updated_turn)
+            if self._is_tool_turn(updated_turn) and key:
+                encoded = self._toon_encode_json_array(updated_turn.get(key, ""))
+                if encoded:
+                    updated_turn[key] = encoded
+                    metrics.toon_encoded_tool_results += 1
+            processed.append(updated_turn)
+
+        return processed
     
     def _find_protected_indices(self, trajectory: List[Dict[str, str]]) -> Tuple[set, int, int]:
         """
@@ -731,17 +849,20 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         metrics = TrajectoryMetrics()
         metrics.original_turns = len(trajectory)
         
-        # Count tokens per turn
+        metrics.original_tokens = self.count_trajectory_tokens(trajectory)
+        trajectory = self._preprocess_tool_results(trajectory, metrics)
+
+        # Count tokens per turn after optional lossless tool-result compaction.
         turn_tokens = self.count_turn_tokens(trajectory)
         total_tokens = sum(turn_tokens)
-        metrics.original_tokens = total_tokens
         
         # Check if compression needed
         if total_tokens <= self.config.target_max_tokens:
             metrics.skipped_under_target = True
             metrics.compressed_tokens = total_tokens
             metrics.compressed_turns = len(trajectory)
-            metrics.compression_ratio = 1.0
+            metrics.tokens_saved = metrics.original_tokens - metrics.compressed_tokens
+            metrics.compression_ratio = metrics.compressed_tokens / max(metrics.original_tokens, 1)
             return trajectory, metrics
         
         # Find protected regions
@@ -752,6 +873,8 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             # Nothing to compress, return as-is
             metrics.compressed_tokens = total_tokens
             metrics.compressed_turns = len(trajectory)
+            metrics.tokens_saved = metrics.original_tokens - metrics.compressed_tokens
+            metrics.compression_ratio = metrics.compressed_tokens / max(metrics.original_tokens, 1)
             metrics.still_over_limit = total_tokens > self.config.target_max_tokens
             return trajectory, metrics
         
@@ -838,17 +961,20 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         metrics = TrajectoryMetrics()
         metrics.original_turns = len(trajectory)
         
-        # Count tokens per turn
+        metrics.original_tokens = self.count_trajectory_tokens(trajectory)
+        trajectory = self._preprocess_tool_results(trajectory, metrics)
+
+        # Count tokens per turn after optional lossless tool-result compaction.
         turn_tokens = self.count_turn_tokens(trajectory)
         total_tokens = sum(turn_tokens)
-        metrics.original_tokens = total_tokens
         
         # Check if compression needed
         if total_tokens <= self.config.target_max_tokens:
             metrics.skipped_under_target = True
             metrics.compressed_tokens = total_tokens
             metrics.compressed_turns = len(trajectory)
-            metrics.compression_ratio = 1.0
+            metrics.tokens_saved = metrics.original_tokens - metrics.compressed_tokens
+            metrics.compression_ratio = metrics.compressed_tokens / max(metrics.original_tokens, 1)
             return trajectory, metrics
         
         # Find protected regions
@@ -858,6 +984,8 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         if compress_start >= compress_end:
             metrics.compressed_tokens = total_tokens
             metrics.compressed_turns = len(trajectory)
+            metrics.tokens_saved = metrics.original_tokens - metrics.compressed_tokens
+            metrics.compression_ratio = metrics.compressed_tokens / max(metrics.original_tokens, 1)
             metrics.still_over_limit = total_tokens > self.config.target_max_tokens
             return trajectory, metrics
         
@@ -940,7 +1068,9 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         result["conversations"] = compressed_trajectory
         
         # Add compression metadata if enabled
-        if self.config.metrics_per_trajectory and metrics.was_compressed:
+        if self.config.metrics_per_trajectory and (
+            metrics.was_compressed or metrics.toon_encoded_tool_results
+        ):
             result["compression_metrics"] = metrics.to_dict()
         
         return result, metrics
@@ -967,7 +1097,9 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         result["conversations"] = compressed_trajectory
         
         # Add compression metadata if enabled
-        if self.config.metrics_per_trajectory and metrics.was_compressed:
+        if self.config.metrics_per_trajectory and (
+            metrics.was_compressed or metrics.toon_encoded_tool_results
+        ):
             result["compression_metrics"] = metrics.to_dict()
         
         return result, metrics


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in TOON-style compaction pass for uniform JSON-array tool results before trajectory token budgeting. This reduces token waste in datagen trajectories without changing default behavior.

## Related Issue

Fixes #7110

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `trajectory_compressor.py` with `toon_encode_tool_results` and `toon_min_rows` config fields.
- Added TOON-style encoding for tool turns whose content is a JSON array of uniform objects.
- Added per-trajectory and aggregate metrics for encoded tool results.
- Updated `datagen-config-examples/trajectory_compression.yaml` with the new knobs.
- Added unit tests for config parsing, encoding behavior, and metrics emission.

## How to Test

1. Enable `compression.toon_encode_tool_results: true` in a trajectory compression config.
2. Run trajectory compression on data containing tool responses shaped as JSON arrays of objects with the same fields.
3. Confirm encoded outputs are marked with `TOON_ENCODED_TOOL_RESULT` and compression metrics include `toon_encoded_tool_results`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`feat(datagen): ...`).
- [x] I searched existing issues/PR context; this addresses #7110.
- [x] My PR contains only changes related to this feature.
- [x] I've run tests and they pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11, Python 3.13 conda env at `D:\conda-envs\hermes-agent`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation/config examples.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A: N/A, this config lives in `datagen-config-examples/trajectory_compression.yaml`.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`, or N/A: N/A.
- [x] I've considered cross-platform impact, or N/A: pure Python text/JSON processing.
- [x] I've updated tool descriptions/schemas, or N/A: N/A.

## Tests

- `D:\conda-envs\hermes-agent\python.exe -m pytest .\tests\test_trajectory_compressor.py -q -n 4`
