### PR TITLE
fix(gemini): emit thoughtSignature sentinel for cross-provider tool_calls in native adapter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -242,8 +242,12 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
         }
     }
     thought_signature = _tool_call_extra_signature(tool_call)
-    if thought_signature:
-        part["thoughtSignature"] = thought_signature
+    # Fallback sentinel for cross-provider tool_calls (e.g. fallback from
+    # xAI/Anthropic to Gemini, where the original tool_call carries no
+    # Gemini thoughtSignature). Mirrors gemini_cloudcode_adapter.py:106.
+    # Without this, Gemini 3 thinking models reject replayed history with
+    # 400 INVALID_ARGUMENT on the missing thoughtSignature.
+    part["thoughtSignature"] = thought_signature or "skip_thought_signature_validator"
     return part
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -52,6 +52,43 @@ def test_build_native_request_preserves_thought_signature_on_tool_replay():
     assert parts[0]["thoughtSignature"] == "sig-123"
 
 
+def test_build_native_request_emits_sentinel_for_cross_provider_tool_call():
+    """Cross-provider tool_calls (xAI/Anthropic -> Gemini fallback) carry no
+    Gemini thoughtSignature.  Without a sentinel, Gemini 3 thinking models
+    reject the request with 400 INVALID_ARGUMENT.  The native adapter must
+    emit the same ``skip_thought_signature_validator`` sentinel that the
+    Cloud Code Assist adapter already uses for the same scenario.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                        # No extra_content — this tool_call originated from a
+                        # non-Gemini provider during fallback.
+                    }
+                ],
+            },
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    parts = request["contents"][0]["parts"]
+    assert parts[0]["functionCall"]["name"] == "get_weather"
+    assert parts[0]["thoughtSignature"] == "skip_thought_signature_validator"
+
+
 def test_build_native_request_uses_original_function_name_for_tool_result():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## Summary

The native Google AI Studio adapter (`agent/gemini_native_adapter.py`) drops cross-provider tool_calls onto Gemini 3 thinking models with `400 INVALID_ARGUMENT`. This fixes it by emitting the same `"skip_thought_signature_validator"` sentinel the Cloud Code Assist adapter already uses for the same scenario.

## Repro

When Hermes fails over from a non-Gemini provider (xAI, Anthropic, etc.) to Gemini mid-conversation, the existing assistant tool_calls in history carry no `extra_content.google.thought_signature` because the originating provider never emits one. On replay, `_translate_tool_call_to_gemini` then omits `thoughtSignature` entirely, and Gemini 3 thinking models 400:

```
HTTP 400 INVALID_ARGUMENT
Function call is missing a thought_signature in functionCall parts.
This is required for tools to work correctly, and missing thought_signature
may lead to degraded model performance.
Additional data, function call `default_api:<tool_name>`, position N.
```

This is reproducible with a 2-turn synthetic conversation against `generativelanguage.googleapis.com/v1beta` with `gemini-3-pro-preview` (and presumably other v3 thinking variants):

```python
contents = [
    {"role": "user", "parts": [{"text": "What's the weather in Doha?"}]},
    {"role": "model", "parts": [{
        "functionCall": {"name": "get_weather", "args": {"city": "Doha"}}
        # NO thoughtSignature
    }]},
    {"role": "user", "parts": [{
        "functionResponse": {"name": "get_weather", "response": {"output": "32C, sunny"}}
    }]},
]
# -> 400 INVALID_ARGUMENT
```

## Fix

The Cloud Code Assist sibling adapter already handles this exact case by always emitting a sentinel:

https://github.com/NousResearch/hermes-agent/blob/main/agent/gemini_cloudcode_adapter.py#L106

```python
"thoughtSignature": "skip_thought_signature_validator",
```

with the comment *"Sentinel signature — matches opencode-gemini-auth's approach. Without this, Code Assist rejects function calls that originated outside its own chain."* Originally added in #11270.

This PR mirrors that fallback in the native adapter so the two paths behave identically when replaying cross-provider history. When a real `thought_signature` exists (single-provider Gemini conversation), it is still preferred — the sentinel is only used when none was captured.

```diff
     thought_signature = _tool_call_extra_signature(tool_call)
-    if thought_signature:
-        part["thoughtSignature"] = thought_signature
+    # Fallback sentinel for cross-provider tool_calls (e.g. fallback from
+    # xAI/Anthropic to Gemini, where the original tool_call carries no
+    # Gemini thoughtSignature). Mirrors gemini_cloudcode_adapter.py:106.
+    # Without this, Gemini 3 thinking models reject replayed history with
+    # 400 INVALID_ARGUMENT on the missing thoughtSignature.
+    part["thoughtSignature"] = thought_signature or "skip_thought_signature_validator"
```

## Verification

**Unit test added:** `test_build_native_request_emits_sentinel_for_cross_provider_tool_call`
Asserts that a tool_call with no `extra_content` produces a part with `thoughtSignature == "skip_thought_signature_validator"`. The pre-existing `test_build_native_request_preserves_thought_signature_on_tool_replay` still passes — real signatures are preferred, sentinel is only the fallback.

**Live test (control + fix) against v1beta `gemini-3-pro-preview`:**

| Scenario | Result |
|---|---|
| No `thoughtSignature` (the bug) | **HTTP 400 INVALID_ARGUMENT** with the exact error string above |
| `thoughtSignature: "skip_thought_signature_validator"` (this fix) | **HTTP 200**, model continues the conversation normally |

## Test plan

- [x] `pytest tests/agent/test_gemini_native_adapter.py` — 12 passed
- [x] Live `gemini-3-pro-preview` request with sentinel returns 200
- [x] Live `gemini-3-pro-preview` request without any `thoughtSignature` returns 400 (control)
- [ ] Sanity-check that real Gemini-originated `thoughtSignature` values are still preserved end-to-end on a multi-turn Gemini-only conversation (pre-existing test covers this; not re-run live)

## Notes

- No behavior change for single-provider Gemini conversations: real signatures are still preferred.
- No behavior change for non-thinking Gemini models that ignore `thoughtSignature` — they accept the sentinel as a no-op (matches Cloud Code Assist adapter behavior).
- Same sentinel string as the Cloud Code Assist adapter, so the two paths stay aligned.
