### PR TITLE
Fix(gateway): make thread participation state writes atomic

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -8,7 +8,9 @@ and thread participation tracking.
 import asyncio
 import json
 import logging
+import os
 import re
+import tempfile
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
@@ -233,7 +235,32 @@ class ThreadParticipationTracker:
         if len(thread_list) > self._max_tracked:
             thread_list = thread_list[-self._max_tracked:]
             self._threads = set(thread_list)
-        path.write_text(json.dumps(thread_list), encoding="utf-8")
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent),
+            prefix=f".{path.stem}_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(thread_list, handle)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+        except OSError:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            logger.warning(
+                "[ThreadParticipationTracker] Failed to persist %s thread state to %s",
+                self._platform,
+                path,
+                exc_info=True,
+            )
 
     def mark(self, thread_id: str) -> None:
         """Mark *thread_id* as participated and persist."""

--- a/tests/gateway/test_discord_thread_persistence.py
+++ b/tests/gateway/test_discord_thread_persistence.py
@@ -82,3 +82,19 @@ class TestDiscordThreadPersistence:
             # ThreadParticipationTracker should return empty set, not crash
             tracker = ThreadParticipationTracker("discord")
             assert "$test" not in tracker
+
+    def test_persist_failure_keeps_existing_state_file_valid(self, tmp_path):
+        """Failed persistence must not corrupt the previous on-disk state."""
+        from gateway.platforms.helpers import ThreadParticipationTracker
+
+        state_file = tmp_path / "discord_threads.json"
+        state_file.write_text(json.dumps(["stable-thread"]), encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            tracker = ThreadParticipationTracker("discord")
+            with patch("gateway.platforms.helpers.os.replace", side_effect=OSError("disk full")):
+                tracker.mark("fresh-thread")
+
+        assert set(json.loads(state_file.read_text(encoding="utf-8"))) == {"stable-thread"}
+        assert "stable-thread" in tracker
+        assert "fresh-thread" in tracker

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -541,6 +541,26 @@ class TestThreadPersistence:
         data = json.loads(state_path.read_text())
         assert len(data) == 5
 
+    def test_persist_failure_keeps_existing_state_file_valid(self, tmp_path, monkeypatch):
+        """Failed persistence must not corrupt the previous matrix thread state."""
+        from gateway.platforms.helpers import ThreadParticipationTracker
+
+        state_path = tmp_path / "matrix_threads.json"
+        state_path.write_text(json.dumps(["$stable_thread"]), encoding="utf-8")
+        monkeypatch.setattr(
+            ThreadParticipationTracker,
+            "_state_path",
+            lambda self: state_path,
+        )
+        tracker = ThreadParticipationTracker("matrix")
+
+        with patch("gateway.platforms.helpers.os.replace", side_effect=OSError("disk full")):
+            tracker.mark("$fresh_thread")
+
+        assert set(json.loads(state_path.read_text(encoding="utf-8"))) == {"$stable_thread"}
+        assert "$stable_thread" in tracker
+        assert "$fresh_thread" in tracker
+
 
 # ---------------------------------------------------------------------------
 # DM mention-thread feature


### PR DESCRIPTION
## Summary

`ThreadParticipationTracker` (used by the Discord and Matrix gateway adapters) was persisting state with a non-atomic `Path.write_text()`. If the write was interrupted or failed partway through, `discord_threads.json` / `matrix_threads.json` could be left truncated or invalid, and on the next restart the bot would lose prior thread participation state — silently regressing thread-routing behavior.

This PR switches the writer to an atomic temp-file + `fsync` + `os.replace()` pattern and makes persistence best-effort so a transient filesystem error can't abort the live message handler.

## Problem

`ThreadParticipationTracker._save()` sits on a live gateway message path. Two concrete failure modes:

1. **Corruption on partial writes.** A direct `Path.write_text()` is not atomic — a crash, OOM, or shutdown mid-write can leave the JSON file truncated. On next startup the tracker loads invalid state and effectively forgets which threads it was participating in.
2. **Message-flow crash on persist failure.** Any `OSError` from the persist call propagated up into the message handler, so a transient filesystem hiccup could break message processing rather than just logging and moving on.

Both failure modes are silent regressions — there's no error surfaced to the user, the bot just stops behaving correctly in threads.

## Fix

Scope is intentionally narrow — only the persistence path in `ThreadParticipationTracker._save()`:

- Write to a sibling temp file, `flush()` + `os.fsync()`, then `os.replace()` onto the final path. This guarantees the on-disk file is either the previous valid state or the fully written new state — never a partial write.
- If persistence fails for any reason, log a warning and keep the in-memory state usable for the current run. The previous valid on-disk snapshot is preserved.
- No schema changes, no API changes, no behavior change on the success path.

## How to test

```bash
scripts/run_tests.sh \
  tests/gateway/test_discord_thread_persistence.py \
  tests/gateway/test_matrix_mention.py
```

Result:

```
55 passed
```

The new regression tests assert, for both the Discord and Matrix state files, that a simulated failed persist does **not** corrupt the previously valid on-disk JSON.


## Files changed

- `gateway/platforms/helpers.py` — atomic temp-file + fsync + replace in `ThreadParticipationTracker._save()`, best-effort error handling
- `tests/gateway/test_discord_thread_persistence.py` — regression test for Discord state file corruption
- `tests/gateway/test_matrix_mention.py` — regression test for Matrix state file corruption



