### PR TITLE
fix: handle exceptions in /api/skills endpoint (#15486)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1900,7 +1900,10 @@ async def get_skills():
     from hermes_cli.skills_config import get_disabled_skills
     config = load_config()
     disabled = get_disabled_skills(config)
-    skills = _find_all_skills(skip_disabled=True)
+    try:
+        skills = _find_all_skills(skip_disabled=True)
+    except Exception:
+        skills = []
     for s in skills:
         s["enabled"] = s["name"] not in disabled
     return skills


### PR DESCRIPTION
## Problem

The `/api/skills` endpoint calls `_find_all_skills()` without a try/except. If skill discovery raises (corrupted skills directory, permission error, etc.), the endpoint returns a 500 Internal Server Error with no useful error message.

## Fix

Wrap the `_find_all_skills()` call in a try/except block and return an empty list on failure. This matches the pattern used by `_list_all_skills()` in `skills_config.py` which already handles exceptions gracefully.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Skills dir has bad permissions | 500 Internal Server Error | `[]` (empty list) |
| Corrupted skill file | 500 Internal Server Error | `[]` (empty list) |

Fixes NousResearch/hermes-agent#15486