### PR TITLE
fix: fall back to default in _parse_env_var instead of raising ValueError

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -806,19 +806,24 @@ def clear_task_env_overrides(task_id: str):
 # Configuration from environment variables
 
 def _parse_env_var(name: str, default: str, converter=int, type_label: str = "integer"):
-    """Parse an environment variable with *converter*, raising a clear error on bad values.
+    """Parse an environment variable with *converter*, falling back to *default* on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
+    Matches the graceful-fallback pattern used by _safe_parse_import_env().
     """
     raw = os.getenv(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
-        raise ValueError(
-            f"Invalid value for {name}: {raw!r} (expected {type_label}). "
-            f"Check ~/.hermes/.env or environment variables."
+        logger.warning(
+            "Invalid value for %s: %r (expected %s). Falling back to default %r.",
+            name,
+            raw,
+            type_label,
+            default,
         )
+        return converter(default)
 
 
 def _get_env_config() -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

`_parse_env_var()` in `tools/terminal_tool.py` raises `ValueError` when an environment variable has an invalid value (e.g. `TERMINAL_TIMEOUT=5m`, `TERMINAL_SSH_PORT=auto`, `TERMINAL_DOCKER_VOLUMES=not-json`).

This error propagates through `_get_env_config()` and causes **every terminal tool call** to fail with:
```
Command execution failed: ValueError: Invalid value for TERMINAL_TIMEOUT: '5m' (expected integer). Check ~/.hermes/.env or environment variables.
```

The user's terminal commands stop working entirely until they find and fix the malformed env var.

## Root Cause

The same file already has `_safe_parse_import_env()` (line 75) which handles this correctly — it falls back to the default value with a `logger.warning()`. But `_parse_env_var()` (line 808), used for runtime config, raises instead.

## Fix

Change `_parse_env_var()` to match the graceful-degradation pattern used by `_safe_parse_import_env()`:
- Catch the `ValueError`/`JSONDecodeError`
- Log a warning with the invalid value and the fallback
- Return `converter(default)` instead of raising

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `TERMINAL_TIMEOUT=5m` in .env | Every terminal command fails with ValueError | Warning logged, timeout defaults to 180s |
| `TERMINAL_DOCKER_VOLUMES=not-json` | Terminal tool unusable | Warning logged, volumes default to `[]` |
| `TERMINAL_CONTAINER_CPU=high` | Container commands fail | Warning logged, CPU defaults to `1.0` |

## Changes

- `tools/terminal_tool.py`: 9 insertions, 4 deletions
  - `_parse_env_var()`: replaced `raise ValueError(...)` with `logger.warning(...)` + `return converter(default)`
  - Updated docstring to reflect fallback behavior