### PR TITLE
fix(gateway): respect config.yaml slack.enabled when SLACK_BOT_TOKEN env var is set

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -918,8 +918,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:
         if Platform.SLACK not in config.platforms:
+            # No yaml config for Slack — env-only setup, enable it
             config.platforms[Platform.SLACK] = PlatformConfig()
-        config.platforms[Platform.SLACK].enabled = True
+            config.platforms[Platform.SLACK].enabled = True
+        # If yaml config exists, respect its enabled flag (don't override
+        # explicit enabled: false). Token is still stored so skills that
+        # send Slack messages can use it without activating the gateway adapter.
         config.platforms[Platform.SLACK].token = slack_token
     slack_home = os.getenv("SLACK_HOME_CHANNEL")
     if slack_home and Platform.SLACK in config.platforms:


### PR DESCRIPTION
## Problem

Setting `SLACK_BOT_TOKEN` in the environment (e.g. `.env`) unconditionally enabled the Slack gateway adapter, overriding `slack.enabled: false` in `config.yaml`. This caused a spurious error on every gateway startup:

```
ERROR gateway.platforms.slack: [Slack] SLACK_APP_TOKEN not set
```

This happens because `SLACK_BOT_TOKEN` can be used for purposes other than the Hermes messaging gateway — for example, skills or cron jobs that send Slack notifications don't require Socket Mode and therefore don't need `SLACK_APP_TOKEN`.

## Fix

Move `enabled = True` inside the `if Platform.SLACK not in config.platforms` block so that an explicit `slack.enabled: false` in `config.yaml` is respected. The token is still stored on the config object so skills can access it, but the gateway adapter is not activated.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| `SLACK_BOT_TOKEN` set, no yaml config | Slack enabled ✅ | Slack enabled ✅ |
| `SLACK_BOT_TOKEN` set, `slack.enabled: true` in yaml | Slack enabled ✅ | Slack enabled ✅ |
| `SLACK_BOT_TOKEN` set, `slack.enabled: false` in yaml | Slack enabled ❌ (bug) | Slack disabled ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)