### PR TITLE
fix(codex-responses): use output_text for assistant message content (#15687)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -44,22 +44,29 @@ _TOOL_CALL_LEAK_PATTERN = re.compile(
 # Multimodal content helpers
 # ---------------------------------------------------------------------------
 
-def _chat_content_to_responses_parts(content: Any) -> List[Dict[str, Any]]:
+def _chat_content_to_responses_parts(
+    content: Any, *, role: str = "user"
+) -> List[Dict[str, Any]]:
     """Convert chat-style multimodal content to Responses API input parts.
 
     Input:  ``[{"type":"text"|"image_url", ...}]`` (native OpenAI Chat format)
-    Output: ``[{"type":"input_text"|"input_image", ...}]`` (Responses format)
+    Output: ``[{"type":"input_text"|"output_text"|"input_image", ...}]``
+
+    The Responses API requires ``"output_text"`` for assistant message content
+    and ``"input_text"`` for user message content.  Pass ``role="assistant"``
+    when converting assistant-turn content.
 
     Returns an empty list when ``content`` is not a list or contains no
     recognized parts — callers fall back to the string path.
     """
+    text_type = "output_text" if role == "assistant" else "input_text"
     if not isinstance(content, list):
         return []
     converted: List[Dict[str, Any]] = []
     for part in content:
         if isinstance(part, str):
             if part:
-                converted.append({"type": "input_text", "text": part})
+                converted.append({"type": text_type, "text": part})
             continue
         if not isinstance(part, dict):
             continue
@@ -67,7 +74,7 @@ def _chat_content_to_responses_parts(content: Any) -> List[Dict[str, Any]]:
         if ptype in {"text", "input_text", "output_text"}:
             text = part.get("text")
             if isinstance(text, str) and text:
-                converted.append({"type": "input_text", "text": text})
+                converted.append({"type": text_type, "text": text})
             continue
         if ptype in {"image_url", "input_image"}:
             image_ref = part.get("image_url")
@@ -233,9 +240,11 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
         if role in {"user", "assistant"}:
             content = msg.get("content", "")
             if isinstance(content, list):
-                content_parts = _chat_content_to_responses_parts(content)
+                content_parts = _chat_content_to_responses_parts(content, role=role)
                 content_text = "".join(
-                    p.get("text", "") for p in content_parts if p.get("type") == "input_text"
+                    p.get("text", "")
+                    for p in content_parts
+                    if p.get("type") in {"input_text", "output_text"}
                 )
             else:
                 content_parts = []
@@ -429,13 +438,15 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 content = ""
             if isinstance(content, list):
                 # Multimodal content from ``_chat_messages_to_responses_input``
-                # is already in Responses format (``input_text`` / ``input_image``).
-                # Validate each part and pass through.
+                # is already in Responses format (``input_text``/``output_text``/
+                # ``input_image``).  Validate each part and pass through,
+                # preserving the role-correct text type.
+                text_type = "output_text" if role == "assistant" else "input_text"
                 validated: List[Dict[str, Any]] = []
                 for part_idx, part in enumerate(content):
                     if isinstance(part, str):
                         if part:
-                            validated.append({"type": "input_text", "text": part})
+                            validated.append({"type": text_type, "text": part})
                         continue
                     if not isinstance(part, dict):
                         raise ValueError(
@@ -446,7 +457,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                         text = part.get("text", "")
                         if not isinstance(text, str):
                             text = str(text or "")
-                        validated.append({"type": "input_text", "text": text})
+                        validated.append({"type": text_type, "text": text})
                     elif ptype in {"input_image", "image_url"}:
                         image_ref = part.get("image_url", "")
                         detail = part.get("detail")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1516,3 +1516,114 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #15687: assistant message content must use output_text
+# ---------------------------------------------------------------------------
+
+
+def test_chat_content_to_responses_parts_user_uses_input_text():
+    """User message content parts must carry type='input_text'."""
+    from agent.codex_responses_adapter import _chat_content_to_responses_parts
+
+    parts = _chat_content_to_responses_parts(
+        [{"type": "text", "text": "hello"}, "world"],
+        role="user",
+    )
+    assert len(parts) == 2
+    assert all(p["type"] == "input_text" for p in parts)
+    assert parts[0]["text"] == "hello"
+    assert parts[1]["text"] == "world"
+
+
+def test_chat_content_to_responses_parts_assistant_uses_output_text():
+    """Assistant message content parts must carry type='output_text'."""
+    from agent.codex_responses_adapter import _chat_content_to_responses_parts
+
+    parts = _chat_content_to_responses_parts(
+        [{"type": "text", "text": "sure"}, "more text"],
+        role="assistant",
+    )
+    assert len(parts) == 2
+    assert all(p["type"] == "output_text" for p in parts), parts
+    assert parts[0]["text"] == "sure"
+    assert parts[1]["text"] == "more text"
+
+
+def test_chat_content_to_responses_parts_default_role_is_user():
+    """Omitting role defaults to user (input_text) to preserve backward compat."""
+    from agent.codex_responses_adapter import _chat_content_to_responses_parts
+
+    parts = _chat_content_to_responses_parts([{"type": "text", "text": "hi"}])
+    assert parts[0]["type"] == "input_text"
+
+
+def test_chat_content_to_responses_parts_empty_list():
+    """Empty list returns empty list for both user and assistant roles."""
+    from agent.codex_responses_adapter import _chat_content_to_responses_parts
+
+    assert _chat_content_to_responses_parts([], role="user") == []
+    assert _chat_content_to_responses_parts([], role="assistant") == []
+
+
+def test_chat_content_to_responses_parts_non_list_returns_empty():
+    """Non-list content returns empty list regardless of role."""
+    from agent.codex_responses_adapter import _chat_content_to_responses_parts
+
+    assert _chat_content_to_responses_parts("plain string", role="assistant") == []
+    assert _chat_content_to_responses_parts(None, role="assistant") == []
+
+
+def test_chat_messages_to_responses_input_assistant_multimodal_uses_output_text():
+    """_chat_messages_to_responses_input must emit output_text for assistant
+    messages that have list-format content — the root-cause repro for #15687."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "The answer is 4."}],
+        },
+        {"role": "user", "content": "Thanks"},
+    ]
+    items = _chat_messages_to_responses_input(messages)
+
+    user_items = [it for it in items if it.get("role") == "user"]
+    assistant_items = [it for it in items if it.get("role") == "assistant"]
+
+    # User parts must use input_text
+    for item in user_items:
+        if isinstance(item.get("content"), list):
+            for part in item["content"]:
+                assert part["type"] == "input_text", f"user part should be input_text: {part}"
+
+    # Assistant parts must use output_text (the bug: they were input_text before)
+    for item in assistant_items:
+        if isinstance(item.get("content"), list):
+            for part in item["content"]:
+                assert part["type"] == "output_text", f"assistant part should be output_text: {part}"
+
+
+def test_preflight_codex_input_preserves_output_text_for_assistant():
+    """_preflight_codex_input_items must use output_text for assistant message
+    content, not coerce everything to input_text."""
+    from agent.codex_responses_adapter import _preflight_codex_input_items
+
+    raw = [
+        {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hi there"}],
+        },
+    ]
+    normalized = _preflight_codex_input_items(raw)
+
+    user_item = next(it for it in normalized if it.get("role") == "user")
+    asst_item = next(it for it in normalized if it.get("role") == "assistant")
+
+    assert user_item["content"][0]["type"] == "input_text"
+    assert asst_item["content"][0]["type"] == "output_text", (
+        "assistant content must use output_text — was being coerced to input_text (bug #15687)"
+    )


### PR DESCRIPTION
## Summary
- `_chat_content_to_responses_parts()` was hardcoding `\"input_text\"` for all roles; the Responses API only allows `\"output_text\"` and `\"refusal\"` inside assistant messages
- Add a `role` keyword arg to derive the correct text type; fix the call site and the validation pass in `_preflight_codex_input_items()`
- Add 7 regression tests covering both roles, the edge cases, and the root-cause repro scenario

## The bug

`_chat_content_to_responses_parts()` in `agent/codex_responses_adapter.py` unconditionally emits `{"type": "input_text", ...}` parts.  When `_chat_messages_to_responses_input()` processes an assistant message whose `content` field is a list (structured/multimodal content — occurs after ~100 turns or when the model produces tool calls alongside text), the resulting parts get type `input_text`.  The Responses API rejects this with:

```
Error code: 400 — 'input_text' is invalid for input[N].content[M] on assistant messages.
Supported values are: 'output_text' and 'refusal'.
```

The `_preflight_codex_input_items()` validation pass had the same issue: it normalised all text parts to `input_text` regardless of role, so even correctly-typed `output_text` parts got coerced before the API call.

## The fix

```python
# Before
def _chat_content_to_responses_parts(content: Any) -> ...:
    ...
    converted.append({"type": "input_text", "text": part})

# After
def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> ...:
    text_type = "output_text" if role == "assistant" else "input_text"
    ...
    converted.append({"type": text_type, "text": part})
```

Call site passes `role=role`; `content_text` extraction is widened to match both `"input_text"` and `"output_text"`.  `_preflight_codex_input_items()` derives `text_type` per item role before the inner validation loop.

## Test plan
- [x] **Before**: reverted fix → `test_chat_content_to_responses_parts_assistant_uses_output_text`, `test_chat_messages_to_responses_input_assistant_multimodal_uses_output_text`, and `test_preflight_codex_input_preserves_output_text_for_assistant` all fail with `AssertionError: 'input_text' == 'output_text'`
- [x] **After**: 57 passed (50 existing + 7 new) in `tests/run_agent/test_run_agent_codex_responses.py`
- [x] **Regression guard**: confirmed test failures match the exact bug repro before restoring fix
- [x] Adjacent suite `tests/agent/` — 1936 passed, 16 pre-existing failures (anthropic_adapter + bedrock_adapter) reproduce identically on clean `origin/main`

## Related
- Fixes #15687

🤖 Generated with [Claude Code](https://claude.com/claude-code)