### PR TITLE
fix(mattermost): catch network errors in _upload_file()

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -179,14 +179,18 @@ class MattermostAdapter(BasePlatformAdapter):
             content_type=content_type,
         )
         headers = {"Authorization": f"Bearer {self._token}"}
-        async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
-            if resp.status >= 400:
-                body = await resp.text()
-                logger.error("MM file upload → %s: %s", resp.status, body[:200])
-                return None
-            data = await resp.json()
-            infos = data.get("file_infos", [])
-            return infos[0]["id"] if infos else None
+        try:
+            async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM file upload → %s: %s", resp.status, body[:200])
+                    return None
+                data = await resp.json()
+                infos = data.get("file_infos", [])
+                return infos[0]["id"] if infos else None
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.error("MM file upload network error: %s", exc)
+            return None
 
     # ------------------------------------------------------------------
     # Required overrides

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -738,3 +738,49 @@ class TestMattermostMediaTypes:
         assert msg.media_types == ["application/pdf"]
         assert not msg.media_types[0].startswith("image/")
         assert not msg.media_types[0].startswith("audio/")
+
+
+class TestMattermostUploadFile:
+    """_upload_file() returns None on network errors instead of raising."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_upload_file_returns_none_on_client_error(self):
+        import asyncio
+        import aiohttp
+
+        async def _run():
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(side_effect=aiohttp.ClientError("connection reset"))
+            self.adapter._session = mock_session
+            return await self.adapter._upload_file("ch1", b"data", "file.txt")
+
+        assert asyncio.run(_run()) is None
+
+    def test_upload_file_returns_none_on_timeout(self):
+        import asyncio
+
+        async def _run():
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(side_effect=asyncio.TimeoutError())
+            self.adapter._session = mock_session
+            return await self.adapter._upload_file("ch1", b"data", "file.txt")
+
+        assert asyncio.run(_run()) is None
+
+    def test_upload_file_returns_file_id_on_success(self):
+        import asyncio
+
+        async def _run():
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value={"file_infos": [{"id": "abc123"}]})
+            mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+            mock_resp.__aexit__ = AsyncMock(return_value=False)
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(return_value=mock_resp)
+            self.adapter._session = mock_session
+            return await self.adapter._upload_file("ch1", b"data", "file.txt")
+
+        assert asyncio.run(_run()) == "abc123"


### PR DESCRIPTION
## What does this PR do?

`_upload_file()` in `MattermostAdapter` posts multipart form data to `/api/v4/files` but has no exception handler around `self._session.post()`. When the Mattermost server is momentarily unreachable, `aiohttp.ClientError` (connection reset, DNS failure, SSL error) or `asyncio.TimeoutError` (60-second upload timeout exceeded) propagates uncaught through `_send_local_file()` and `_send_url_as_file()` to the gateway — instead of returning `None` as the docstring promises.

The sibling helpers `_api_get()`, `_api_post()`, and `_api_put()` already wrap their session calls in `except aiohttp.ClientError`. `_upload_file()` is the only method in the class missing this guard.

Adds the same `except (aiohttp.ClientError, asyncio.TimeoutError)` block to `_upload_file()`, extended to cover `asyncio.TimeoutError` since the upload timeout (60 s) is double the 30-second timeout used by the other helpers — making a timeout the more likely failure mode for large attachments on a slow connection.

Callers (`_send_local_file`, `_send_url_as_file`) both check `if not file_id` after calling `_upload_file()` and fall back gracefully. That path was unreachable on network errors before this fix; now it works as intended.

## Related Issue

No existing issue — proactive fix.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made
- `gateway/platforms/mattermost.py`: wrap `_upload_file()` session call in `try/except (aiohttp.ClientError, asyncio.TimeoutError)` — symmetric with `_api_get`, `_api_post`, `_api_put`
- `tests/gateway/test_mattermost.py`: add `TestMattermostUploadFile` — three cases: `ClientError` → None, `TimeoutError` → None, success → file ID

## How to Test
```bash
python3.11 -m pytest tests/gateway/test_mattermost.py::TestMattermostUploadFile -v --override-ini="addopts="
```

## Checklist
### Code
- [x] Contributing Guide okundu
- [x] Conventional Commits
- [x] Duplicate PR yok
- [x] Sadece bu fix
- [x] pytest çalıştırıldı
- [x] Test eklendi
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs güncellendi — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A