### PR TITLE
fix(tui): close AIAgent on session teardown to prevent FD leak

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -506,6 +506,7 @@ AUTHOR_MAP = {
     "chenzeshi@live.com": "chen1749144759",
     "mor.aleksandr@yahoo.com": "MorAlekss",
     "ash@users.noreply.github.com": "ash",
+    "psikonetik@gmail.com": "el-analista",
 }
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1794,6 +1794,12 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
     try:
+        agent = session.get("agent")
+        if agent and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
         worker = session.get("slash_worker")
         if worker:
             worker.close()


### PR DESCRIPTION
## Summary

- **Root cause**: `session.close` in `tui_gateway/server.py` only closed the `slash_worker` subprocess but never called `agent.close()` on the `AIAgent` instance. In the long-lived TUI gateway process, this left `httpx` clients to be finalized by GC instead of being properly closed.
- **Symptom**: When the OS recycled a closed file descriptor number for a new active connection, the stale GC finalizer would close the live socket, causing intermittent `[Errno 9] Bad file descriptor` errors on subsequent LLM API calls.
- **Fix**: Call `agent.close()` (which properly shuts down the httpx transport pool and TCP sockets) before closing the slash_worker.

This only affects the TUI gateway. The regular CLI creates one AIAgent per process and exits cleanly, so it never hits this race.

## Test plan

- [ ] Start TUI gateway, open multiple sessions, close them, open new ones — verify no EBADF errors on API calls
- [ ] Verify `agent.close()` is called by checking that httpx connection pool is drained (no CLOSE_WAIT sockets to the provider after session close)
- [ ] Long-running soak: leave TUI running for 24h with periodic session cycling, confirm zero FD leak