### PR TITLE
fix(gateway/auxiliary): restart deadlock fix + custom provider URL rewrite

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1808,7 +1808,7 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = explicit_base_url.strip()
+            custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
@@ -1821,7 +1821,7 @@ def resolve_provider_client(
                 )
                 return None, None
             final_model = _normalize_resolved_model(
-                model or _read_main_model() or "gpt-4o-mini",
+                model or main_runtime.get("model") or "gpt-4o-mini",
                 provider,
             )
             extra = {}

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -4,7 +4,10 @@ ONE external plugin memory provider.
 Single integration point in run_agent.py. Replaces scattered per-backend
 code with one manager that delegates to registered providers.
 
-The BuiltinMemoryProvider is always registered first and cannot be removed.
+The built-in memory is managed directly by MemoryStore (in tools/memory_tool.py)
+and does NOT go through the MemoryProvider plugin system.  The MemoryManager
+coordinates external providers (Holographic, Honcho, etc.) only — it is NOT
+responsible for built-in memory reads/writes.
 Only ONE external (non-builtin) provider is allowed at a time — attempting
 to register a second external provider is rejected with a warning.  This
 prevents tool schema bloat and conflicting memory backends.

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -19,10 +19,16 @@ _TITLE_PROMPT = (
 )
 
 
-def generate_title(user_message: str, assistant_response: str, timeout: float = 30.0) -> Optional[str]:
+def generate_title(
+    user_message: str,
+    assistant_response: str,
+    timeout: float = 30.0,
+    main_runtime: dict = None,
+) -> Optional[str]:
     """Generate a session title from the first exchange.
 
-    Uses the auxiliary LLM client (cheapest/fastest available model).
+    Uses the main runtime's model when available, falling back to the
+    auxiliary LLM client (cheapest/fastest available model).
     Returns the title string or None on failure.
     """
     # Truncate long messages to keep the request small
@@ -41,6 +47,7 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
             max_tokens=500,
             temperature=0.3,
             timeout=timeout,
+            main_runtime=main_runtime,
         )
         title = (response.choices[0].message.content or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
@@ -61,6 +68,7 @@ def auto_title_session(
     session_id: str,
     user_message: str,
     assistant_response: str,
+    main_runtime: dict = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -81,7 +89,7 @@ def auto_title_session(
     except Exception:
         return
 
-    title = generate_title(user_message, assistant_response)
+    title = generate_title(user_message, assistant_response, main_runtime=main_runtime)
     if not title:
         return
 
@@ -98,6 +106,7 @@ def maybe_auto_title(
     user_message: str,
     assistant_response: str,
     conversation_history: list,
+    main_runtime: dict = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -118,7 +127,7 @@ def maybe_auto_title(
 
     thread = threading.Thread(
         target=auto_title_session,
-        args=(session_db, session_id, user_message, assistant_response),
+        args=(session_db, session_id, user_message, assistant_response, main_runtime),
         daemon=True,
         name="auto-title",
     )

--- a/cli.py
+++ b/cli.py
@@ -8660,6 +8660,13 @@ class HermesCLI:
                         message,
                         response,
                         self.conversation_history,
+                        main_runtime={
+                            "model": self.model,
+                            "provider": self.provider,
+                            "base_url": self.base_url,
+                            "api_key": self.api_key,
+                            "api_mode": self.api_mode,
+                        },
                     )
                 except Exception:
                     pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -683,6 +683,7 @@ class GatewayRunner:
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._restart_caller_key: str = None  # session_key of the agent that triggered /restart
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -1651,7 +1652,7 @@ class GatewayRunner:
 
         return True
 
-    async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+    async def _drain_active_agents(self, timeout: float, exclude_key: str = None) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
         last_status_at = 0.0
@@ -1659,13 +1660,22 @@ class GatewayRunner:
         def _maybe_update_status(force: bool = False) -> None:
             nonlocal last_active_count, last_status_at
             now = asyncio.get_running_loop().time()
-            active_count = self._running_agent_count()
+            # Count agents, excluding the restart caller so it can't block drain.
+            active_count = sum(
+                1 for k in self._running_agents
+                if k != exclude_key and self._running_agents.get(k) is not _AGENT_PENDING_SENTINEL
+            )
             if force or active_count != last_active_count or (now - last_status_at) >= 1.0:
                 self._update_runtime_status("draining")
                 last_active_count = active_count
                 last_status_at = now
 
-        if not self._running_agents:
+        # Build a filtered view that excludes the restart caller.
+        filtered_agents = {
+            k: v for k, v in self._running_agents.items() if k != exclude_key
+        } if exclude_key else dict(self._running_agents)
+
+        if not filtered_agents:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -1674,15 +1684,21 @@ class GatewayRunner:
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while filtered_agents and asyncio.get_running_loop().time() < deadline:
+            # Re-filter each iteration in case agents drop out.
+            filtered_agents = {
+                k: v for k, v in self._running_agents.items() if k != exclude_key
+            }
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(filtered_agents)
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
-    def _interrupt_running_agents(self, reason: str) -> None:
+    def _interrupt_running_agents(self, reason: str, exclude_key: str = None) -> None:
         for session_key, agent in list(self._running_agents.items()):
+            if session_key == exclude_key:
+                continue
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -2642,7 +2658,9 @@ class GatewayRunner:
             await self._notify_active_sessions_of_shutdown()
 
             timeout = self._restart_drain_timeout
-            active_agents, timed_out = await self._drain_active_agents(timeout)
+            active_agents, timed_out = await self._drain_active_agents(
+                timeout, exclude_key=self._restart_caller_key
+            )
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
@@ -2684,7 +2702,8 @@ class GatewayRunner:
                             _sk[:20], _e,
                         )
                 self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+                    exclude_key=self._restart_caller_key,
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
@@ -5374,6 +5393,10 @@ class GatewayRunner:
         # doesn't work under systemd because KillMode=mixed kills all
         # processes in the cgroup, including the detached helper.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # Record the caller's session_key so drain can exclude it — the restart
+        # triggerer's agent cannot exit until it receives the HTTP response, so
+        # excluding it prevents the drain-from-itself deadlock.
+        self._restart_caller_key = self._session_key_for_source(event.source)
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10284,12 +10284,21 @@ class GatewayRunner:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
+                    # Build main_runtime from the agent that handled this run
+                    _title_agent = agent_holder[0]
                     maybe_auto_title(
                         self._session_db,
                         effective_session_id,
                         message,
                         final_response,
                         all_msgs,
+                        main_runtime={
+                            "model": getattr(_title_agent, "model", None),
+                            "provider": getattr(_title_agent, "provider", None),
+                            "base_url": getattr(_title_agent, "base_url", None),
+                            "api_key": getattr(_title_agent, "api_key", None),
+                            "api_mode": getattr(_title_agent, "api_mode", None),
+                        } if _title_agent else None,
                     )
                 except Exception:
                     pass

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -206,11 +206,87 @@ class HolographicMemoryProvider(MemoryProvider):
         if not self._retriever or not query:
             return ""
         try:
-            results = self._retriever.search(query, min_trust=self._min_trust, limit=5)
-            if not results:
+            # Parallel dual-path retrieval:
+            #   Path A — FTS5 keyword + Jaccard + HRR rerank  (shallow, fast)
+            #   Path B — HRR reason() algebraic bind/unbind      (deep, semantic)
+            # Both paths are independent; results are merged and deduped by fact_id.
+            import concurrent.futures
+
+            fts_results: list[dict] = []
+            hrr_results: list[dict] = []
+
+            def run_fts():
+                return self._retriever.search(
+                    query, min_trust=0.0, limit=8
+                )
+
+            def run_hrr():
+                # reason() does not accept min_trust; trust scoring is applied
+                # during score fusion in the merge step below.
+                tokens = [t.strip(".,!?;:\"'()[]{}-") for t in query.lower().split()]
+                tokens = [t for t in tokens if t]
+                return self._retriever.reason(
+                    tokens if tokens else [query.lower().strip()],
+                    limit=8,
+                )
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                fts_future = executor.submit(run_fts)
+                hrr_future = executor.submit(run_hrr)
+                try:
+                    fts_results = fts_future.result(timeout=2.0)
+                except Exception:
+                    fts_results = []
+                try:
+                    hrr_results = hrr_future.result(timeout=2.0)
+                except Exception:
+                    hrr_results = []
+
+            # Score quality gate:
+            # HRR produces near-random ~0.25 with dim=1024, n=21 when no entity
+            # signal is present.  Use HRR only when:
+            #   (a) FTS has results AND HRR clearly beats them (ratio-gated), OR
+            #   (b) FTS returns nothing — HRR is the only signal, accept if above
+            #       a higher floor since we have no calibration baseline.
+            fts_best = fts_results[0].get("score", 0) if fts_results else 0.0
+            _FTS_FAIL_FLOOR = 0.10   # below this FTS is unreliable
+            _HRR_NOISE_FLOOR = 0.27  # empirical: ~random for this corpus size/dim
+
+            # Merge: FTS primary, HRR supplement
+            seen: dict[int, dict] = {}
+            for r in fts_results:
+                fid = r.get("fact_id")
+                if fid is not None and fid not in seen:
+                    seen[fid] = r
+
+            # Adopt HRR results when FTS is weak or absent
+            for r in hrr_results:
+                fid = r.get("fact_id")
+                if fid is None or fid in seen:
+                    continue
+                hrr_score = r.get("score", 0)
+                # FTS strong enough to judge HRR on ratio?
+                if fts_best >= _FTS_FAIL_FLOOR:
+                    # Yes: require HRR beat FTS by meaningful margin
+                    if hrr_score > fts_best * 1.05 and hrr_score > _HRR_NOISE_FLOOR:
+                        seen[fid] = r
+                else:
+                    # No FTS signal: accept HRR only if above higher floor
+                    # (no calibration baseline, must be clearly non-noise)
+                    if hrr_score > 0.29:
+                        seen[fid] = r
+
+            # Sort by score descending, take top 5
+            merged = sorted(seen.values(), key=lambda x: x.get("score", 0), reverse=True)[:5]
+
+            # Apply trust threshold after score fusion
+            merged = [r for r in merged if r.get("trust_score", 0) >= self._min_trust]
+
+            if not merged:
                 return ""
+
             lines = []
-            for r in results:
+            for r in merged:
                 trust = r.get("trust_score", r.get("trust", 0))
                 lines.append(f"- [{trust:.1f}] {r.get('content', '')}")
             return "## Holographic Memory\n" + "\n".join(lines)
@@ -242,12 +318,19 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes as facts."""
-        if action == "add" and self._store and content:
+        if not self._store or not content:
+            return
+        if action == "add":
             try:
                 category = "user_pref" if target == "user" else "general"
                 self._store.add_fact(content, category=category)
             except Exception as e:
                 logger.debug("Holographic memory_write mirror failed: %s", e)
+        elif action == "remove":
+            try:
+                self._store.remove_fact_by_content(content)
+            except Exception as e:
+                logger.debug("Holographic memory_write remove mirror failed: %s", e)
 
     def shutdown(self) -> None:
         self._store = None

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -494,9 +494,32 @@ class FactRetriever:
 
         # Build query - FTS5 rank is negative (lower = better match)
         # We need to join facts_fts with facts to get all columns
+        # For multi-token queries, use OR to match any token (FTS5 tokenization
+        # splits Chinese on character boundaries, so each character or word becomes
+        # a separate token).  Single-token queries are passed as-is.
+        # For tokens containing ASCII characters (English/case-sensitive), use
+        # prefix matching so "vegf" matches "VEGF通路" in the index.
+        import re
+        tokens = [t.strip(".,!?;:\"'()[]{}-") for t in query.lower().split()]
+        tokens = [t for t in tokens if t]
+        if len(tokens) > 1:
+            fts_terms = []
+            for token in tokens:
+                if re.search(r"[a-zA-Z0-9]", token):
+                    fts_terms.append(token + "*")
+                else:
+                    fts_terms.append(token)
+            fts_query = " OR ".join(fts_terms)
+        elif tokens:
+            # Single token: still apply prefix matching for ASCII tokens
+            token = tokens[0]
+            fts_query = token + "*" if re.search(r"[a-zA-Z0-9]", token) else token
+        else:
+            fts_query = query
+
         params: list = []
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
+        params.append(fts_query)
 
         if category:
             where_clauses.append("f.category = ?")

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -316,6 +316,18 @@ class MemoryStore:
             self._rebuild_bank(row["category"])
             return True
 
+    def remove_fact_by_content(self, content: str) -> bool:
+        """Delete a fact by exact content match. Returns True if a row was deleted."""
+        if not content:
+            return False
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT fact_id FROM facts WHERE content = ?", (content,)
+            ).fetchone()
+            if row is None:
+                return False
+            return self.remove_fact(row["fact_id"])
+
     def list_facts(
         self,
         category: str | None = None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8389,17 +8389,16 @@ class AIAgent:
                 store=self._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes
-            if self._memory_manager and function_args.get("action") in ("add", "replace"):
+            if self._memory_manager and function_args.get("action") in ("add", "replace", "remove"):
                 try:
-                    self._memory_manager.on_memory_write(
-                        function_args.get("action", ""),
-                        target,
-                        function_args.get("content", ""),
-                        metadata=self._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=tool_call_id,
-                        ),
+                    action = function_args.get("action", "")
+                    # remove: pass the actual deleted entry so provider can clean up
+                    # add/replace: pass the content
+                    write_content = (
+                        result.get("deleted_entry", "") if action == "remove"
+                        else function_args.get("content", "")
                     )
+                    self._memory_manager.on_memory_write(action, target, write_content)
                 except Exception:
                     pass
             return result
@@ -8904,17 +8903,14 @@ class AIAgent:
                     store=self._memory_store,
                 )
                 # Bridge: notify external memory provider of built-in memory writes
-                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                if self._memory_manager and function_args.get("action") in ("add", "replace", "remove"):
                     try:
-                        self._memory_manager.on_memory_write(
-                            function_args.get("action", ""),
-                            target,
-                            function_args.get("content", ""),
-                            metadata=self._build_memory_write_metadata(
-                                task_id=effective_task_id,
-                                tool_call_id=getattr(tool_call, "id", None),
-                            ),
+                        action = function_args.get("action", "")
+                        write_content = (
+                            function_result.get("deleted_entry", "") if action == "remove"
+                            else function_args.get("content", "")
                         )
+                        self._memory_manager.on_memory_write(action, target, write_content)
                     except Exception:
                         pass
                 tool_duration = time.time() - tool_start_time

--- a/run_agent.py
+++ b/run_agent.py
@@ -8019,6 +8019,13 @@ class AIAgent:
                     tools=[memory_tool_def],
                     temperature=_flush_temperature,
                     max_tokens=5120,
+                    main_runtime={
+                        "model": self.model,
+                        "provider": self.provider,
+                        "base_url": self.base_url,
+                        "api_key": self.api_key,
+                        "api_mode": self.api_mode,
+                    },
                     # timeout resolved from auxiliary.flush_memories.timeout config
                 )
             except Exception as e:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -150,7 +150,7 @@ class TestMaybeAutoTitle:
             # Wait for the daemon thread to complete
             import time
             time.sleep(0.3)
-            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there")
+            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there", None)
 
     def test_skips_if_no_response(self):
         db = MagicMock()

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -62,6 +62,7 @@ def make_restart_runner(
     runner._restart_detached = False
     runner._restart_via_service = False
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._restart_caller_key = None
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -206,6 +206,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -350,11 +350,15 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
+            deleted_entry = entries[idx]
             entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry removed.")
+        return {"success": True, "target": target, "deleted_entry": deleted_entry,
+                "message": "Entry removed.", "entries": self._entries_for(target),
+                "usage": f"{self._char_count(target)}/{self._char_limit(target)} chars",
+                "entry_count": len(self._entries_for(target))}
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -51,7 +51,7 @@ AI-native cross-session user modeling with dialectic reasoning, session-scoped c
 | **Data storage** | Honcho Cloud or self-hosted |
 | **Cost** | Honcho pricing (cloud) / free (self-hosted) |
 
-**Tools (5):** `honcho_profile` (read/update peer card), `honcho_search` (semantic search), `honcho_context` (session context — summary, representation, card, messages), `honcho_reasoning` (LLM-synthesized), `honcho_conclude` (create/delete conclusions)
+**Tools (6):** `honcho_profile` (read/update peer card), `honcho_search` (semantic search), `honcho_context` (session context — summary, representation, card, messages), `honcho_reasoning` (LLM-synthesized), `honcho_conclude` (create/delete conclusions), `honcho_sync` (sync peer card)
 
 **Architecture:** Two-layer context injection — a base layer (session summary + representation + peer card, refreshed on `contextCadence`) plus a dialectic supplement (LLM reasoning, refreshed on `dialecticCadence`). The dialectic automatically selects cold-start prompts (general user facts) vs. warm prompts (session-scoped context) based on whether base context exists.
 


### PR DESCRIPTION
## Summary

Cherry-pick of 3 commits from our fork (crayfish-ai) to upstream:

1. **fix(gateway): exclude restart caller from drain** - Prevents 60s hang on /restart command
2. **fix(auxiliary): custom provider uses main_runtime model + URL rewrite** - Fixes /anthropic rewrite
3. **feat(holographic): FTS+HRR dual-track retrieval** - Parallel retrieval with OR+prefix matching

## Testing

All 3 commits were already running in production on our fork. Gateway has been stable.