### PR TITLE
fix: DeepSeek V4 compatibility fixes + boot agent model config

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -151,6 +151,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
+    "deepseek": "deepseek-v4-pro",
 }
 
 # Vision-specific model overrides for direct providers.

--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -46,9 +46,29 @@ def _run_boot_agent(content: str) -> None:
     """Spawn a one-shot agent session to execute the boot instructions."""
     try:
         from run_agent import AIAgent
+        import yaml as _y
+
+        # Read model config so the boot agent uses the correct model/provider
+        cfg_path = HERMES_HOME / "config.yaml"
+        model_name = ""
+        provider_name = ""
+        base_url = ""
+        api_key = ""
+        if cfg_path.exists():
+            with open(cfg_path, encoding="utf-8") as _f:
+                cfg = _y.safe_load(_f) or {}
+            model_cfg = cfg.get("model", {})
+            model_name = model_cfg.get("default", "")
+            provider_name = model_cfg.get("provider", "")
+            base_url = model_cfg.get("base_url", "")
+            api_key = model_cfg.get("api_key", "")
 
         prompt = _build_boot_prompt(content)
         agent = AIAgent(
+            model=model_name,
+            provider=provider_name,
+            base_url=base_url or None,
+            api_key=api_key or None,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3173,6 +3173,8 @@ class AIAgent:
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        api_key=self.api_key,
+                        base_url=self.base_url,
                         parent_session_id=self.session_id,
                     )
                     review_agent._memory_write_origin = "background_review"
@@ -7642,12 +7644,16 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
+            elif self._needs_deepseek_tool_reasoning():
                 # DeepSeek thinking mode requires reasoning_content on every
-                # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
+                # assistant message (not just tool-call turns). Include empty
+                # string as a defensive compatibility fallback (refs #15250).
                 msg["reasoning_content"] = ""
+        elif self._needs_deepseek_tool_reasoning():
+            # DeepSeek V4 always returns reasoning_content in thinking mode,
+            # but if the response object somehow lacks the attribute, inject
+            # an empty string to prevent HTTP 400 on replay.
+            msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
@@ -7774,6 +7780,16 @@ class AIAgent:
         if source_msg.get("tool_calls") and (
             self._needs_kimi_tool_reasoning()
             or self._needs_deepseek_tool_reasoning()
+        ):
+            api_msg["reasoning_content"] = ""
+
+        # DeepSeek V4 thinking mode requires reasoning_content on ALL
+        # assistant messages (not just tool-call turns). Messages from a
+        # previous provider (e.g. glm-5.1) won't have this field, so we
+        # inject an empty string as a compatibility shim.
+        if (
+            "reasoning_content" not in api_msg
+            and self._needs_deepseek_tool_reasoning()
         ):
             api_msg["reasoning_content"] = ""
 


### PR DESCRIPTION
Three independent fixes for DeepSeek V4 users and custom endpoint setups:

### 1. fix(auxiliary): add deepseek-v4-pro to API_KEY_PROVIDER_AUX_MODELS
Pure data addition: maps provider 'deepseek' → 'deepseek-v4-pro' for auxiliary tasks (compression, vision, session_search). Without this, aux tasks can't use DeepSeek.

### 2. fix(boot-md): pass user model config to boot agent
Boot agent was spawned without model/provider/api_key, falling back to defaults that may not work for users with custom API endpoints. Now reads config.yaml model section and passes it through.

### 3. fix(run_agent): pass api_key/base_url to review agent + DeepSeek V4 reasoning fix
- Review agent missing api_key/base_url passthrough → 401 on custom endpoints
- DeepSeek V4 thinking mode requires `reasoning_content` on **all** assistant messages (not just tool-call turns), otherwise replay causes HTTP 400. Extends existing #15250 fix.
- Cross-provider shim: injects empty `reasoning_content` when replaying messages from a different provider (e.g. GLM → DeepSeek switch).