### PR TITLE
feat: add `hermes -z <prompt>` one-shot mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6836,6 +6836,19 @@ For more help on a command:
         "--version", "-V", action="store_true", help="Show version and exit"
     )
     parser.add_argument(
+        "-z",
+        "--oneshot",
+        metavar="PROMPT",
+        default=None,
+        help=(
+            "One-shot mode: send a single prompt and print ONLY the final "
+            "response text to stdout. No banner, no spinner, no tool "
+            "previews, no session_id line. Tools, memory, rules, and "
+            "AGENTS.md in the CWD are loaded as normal; approvals are "
+            "auto-bypassed. Intended for scripts / pipes."
+        ),
+    )
+    parser.add_argument(
         "--resume",
         "-r",
         metavar="SESSION",
@@ -9114,6 +9127,13 @@ Examples:
                 "shell-hook registration failed at CLI startup",
                 exc_info=True,
             )
+
+    # Handle top-level --oneshot / -z: single-shot mode, stdout = final
+    # response only, nothing else. Bypasses cli.py entirely.
+    if getattr(args, "oneshot", None):
+        from hermes_cli.oneshot import run_oneshot
+
+        sys.exit(run_oneshot(args.oneshot))
 
     # Handle top-level --resume / --continue as shortcut to chat
     if (args.resume or args.continue_last) and args.command is None:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -90,6 +90,18 @@ def _run_agent(prompt: str) -> str:
         quiet_mode=True,
         platform="cli",
         credential_pool=runtime.get("credential_pool"),
+        # Interactive callbacks are intentionally NOT wired beyond this
+        # one.  In oneshot mode there's no user sitting at a terminal:
+        #   - clarify  → returns a synthetic "pick a default" instruction
+        #                so the agent continues instead of stalling on
+        #                the tool's built-in "not available" error
+        #   - sudo password prompt → terminal_tool gates on
+        #                HERMES_INTERACTIVE which we never set
+        #   - shell-hook approval → auto-approved via HERMES_ACCEPT_HOOKS=1
+        #                (set above); also falls back to deny on non-tty
+        #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
+        #   - skill secret capture → returns gracefully when no callback set
+        clarify_callback=_oneshot_clarify_callback,
     )
 
     # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
@@ -99,3 +111,17 @@ def _run_agent(prompt: str) -> str:
     agent.tool_gen_callback = None
 
     return agent.chat(prompt) or ""
+
+
+def _oneshot_clarify_callback(question: str, choices=None) -> str:
+    """Clarify is disabled in oneshot mode — tell the agent to pick a
+    default and proceed instead of stalling or erroring."""
+    if choices:
+        return (
+            f"[oneshot mode: no user available. Pick the best option from "
+            f"{choices} using your own judgment and continue.]"
+        )
+    return (
+        "[oneshot mode: no user available. Make the most reasonable "
+        "assumption you can and continue.]"
+    )

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -1,0 +1,101 @@
+"""Oneshot (-z) mode: send a prompt, get the final content block, exit.
+
+Bypasses cli.py entirely.  No banner, no spinner, no session_id line,
+no stderr chatter.  Just the agent's final text to stdout.
+
+Toolsets = whatever the user has configured for "cli" in `hermes tools`.
+Rules / memory / AGENTS.md / preloaded skills = same as a normal chat turn.
+Approvals = auto-bypassed (HERMES_YOLO_MODE=1 is set for the call).
+Working directory = the user's CWD (AGENTS.md etc. resolve from there as usual).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+
+
+def run_oneshot(prompt: str) -> int:
+    """Execute a single prompt and print only the final content block.
+
+    Returns the exit code.  Caller should sys.exit() with the return.
+    """
+    # Silence every stdlib logger for the duration.  AIAgent, tools, and
+    # provider adapters all log to stderr through the root logger; file
+    # handlers added by setup_logging() keep working (they're attached to
+    # the root logger's handler list, not affected by level), but no
+    # bytes reach the terminal.
+    logging.disable(logging.CRITICAL)
+
+    # Auto-approve any shell / tool approvals.  Non-interactive by
+    # definition — a prompt would hang forever.
+    os.environ["HERMES_YOLO_MODE"] = "1"
+    os.environ["HERMES_ACCEPT_HOOKS"] = "1"
+
+    # Redirect stderr AND stdout to devnull for the entire call tree.
+    # We'll print the final response to the real stdout at the end.
+    real_stdout = sys.stdout
+    devnull = open(os.devnull, "w")
+
+    try:
+        with redirect_stdout(devnull), redirect_stderr(devnull):
+            response = _run_agent(prompt)
+    finally:
+        try:
+            devnull.close()
+        except Exception:
+            pass
+
+    if response:
+        real_stdout.write(response)
+        if not response.endswith("\n"):
+            real_stdout.write("\n")
+        real_stdout.flush()
+    return 0
+
+
+def _run_agent(prompt: str) -> str:
+    """Build an AIAgent exactly like a normal CLI chat turn would, then
+    run a single conversation.  Returns the final response string."""
+    # Imports are local so they don't run when hermes is invoked for
+    # other commands (keeps top-level CLI startup cheap).
+    from hermes_cli.config import load_config
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.tools_config import _get_platform_tools
+    from run_agent import AIAgent
+
+    cfg = load_config()
+    runtime = resolve_runtime_provider()
+
+    # Resolve the model the user has configured for normal chat use.
+    model_cfg = cfg.get("model") or {}
+    if isinstance(model_cfg, str):
+        model = model_cfg
+    else:
+        model = model_cfg.get("default") or model_cfg.get("model") or ""
+
+    # Pull in whatever toolsets the user has enabled for "cli".
+    # sorted() gives stable ordering; set→list for AIAgent's signature.
+    toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
+
+    agent = AIAgent(
+        api_key=runtime.get("api_key"),
+        base_url=runtime.get("base_url"),
+        provider=runtime.get("provider"),
+        api_mode=runtime.get("api_mode"),
+        model=model,
+        enabled_toolsets=toolsets_list,
+        quiet_mode=True,
+        platform="cli",
+        credential_pool=runtime.get("credential_pool"),
+    )
+
+    # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
+    # display callbacks that would bypass our stdout capture.
+    agent.suppress_status_output = True
+    agent.stream_delta_callback = None
+    agent.tool_gen_callback = None
+
+    return agent.chat(prompt) or ""


### PR DESCRIPTION
## Summary
Adds `hermes -z <prompt>` — single prompt in, final response text out, nothing else on stdout or stderr.

Bypasses cli.py entirely (no banner, spinner, tool previews, session_id line). Goes straight to `AIAgent.chat()` with the user's configured CLI toolsets, memory, rules, AGENTS.md from the CWD. Approvals auto-bypassed. Interactive surfaces with no user to answer are handled explicitly (see table below).

Intended for scripts / pipes.

## Changes
- `hermes_cli/oneshot.py` (new, ~130 lines): silences logging, redirects stdout/stderr to devnull for the call, builds AIAgent with config model + CLI toolsets + wired clarify fallback, writes only the final response.
- `hermes_cli/main.py`: top-level `-z/--oneshot PROMPT` flag, dispatched before subcommand routing.

## Interactive surfaces
| Surface | Handling |
|---|---|
| clarify tool | Callback injected: tells agent to pick the best default and continue |
| sudo password | `terminal_tool` gates on `HERMES_INTERACTIVE`; we never set it → sudo fails gracefully |
| shell-hook approval | `HERMES_ACCEPT_HOOKS=1` auto-approves; non-tty falls back to deny anyway |
| dangerous-command approval | `HERMES_YOLO_MODE=1` short-circuits before `input()` |
| skill secret capture | Tool returns gracefully when no callback wired |
| streaming display callbacks | Nulled + stdout/stderr → devnull |

## Validation
```
$ hermes -z 'Say exactly the word banana.'
banana
$ hermes -z 'Run pwd and reply with ONLY its output.'  # from /tmp
/tmp
$ hermes -z 'Use clarify to ask red or blue, reply with only what you got.'
red
```
All three: exit 0, stderr empty, stdout only the content.