### PR TITLE
fix: harden orchestrator packet write transport

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4882,15 +4882,22 @@ class HermesCLI:
             _cprint(f"  Failed to create branch session: {e}")
             return
 
-        # Copy conversation history to the new session
+        # Copy conversation history to the new session, redacting packet content
+        from run_agent import _scrub_packet_tool_args
         for msg in self.conversation_history:
             try:
+                tool_calls = msg.get("tool_calls")
+                if isinstance(tool_calls, list):
+                    tool_calls = _scrub_packet_tool_args(tool_calls)
+                content = msg.get("content")
+                if isinstance(content, list):
+                    content = _scrub_packet_tool_args(content)
                 self._session_db.append_message(
                     session_id=new_session_id,
                     role=msg.get("role", "user"),
-                    content=msg.get("content"),
+                    content=content,
                     tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
+                    tool_calls=tool_calls,
                     tool_call_id=msg.get("tool_call_id"),
                     reasoning=msg.get("reasoning"),
                 )
@@ -4938,16 +4945,26 @@ class HermesCLI:
         if not self.conversation_history:
             print("(;_;) No conversation to save.")
             return
-        
+
+        from run_agent import _scrub_packet_tool_args
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"hermes_conversation_{timestamp}.json"
-        
+
+        scrubbed_history = []
+        for msg in self.conversation_history:
+            msg = dict(msg)
+            if isinstance(msg.get("tool_calls"), list):
+                msg["tool_calls"] = _scrub_packet_tool_args(msg["tool_calls"])
+            if isinstance(msg.get("content"), list):
+                msg["content"] = _scrub_packet_tool_args(msg["content"])
+            scrubbed_history.append(msg)
+
         try:
             with open(filename, "w", encoding="utf-8") as f:
                 json.dump({
                     "model": self.model,
                     "session_start": self.session_start.isoformat(),
-                    "messages": self.conversation_history,
+                    "messages": scrubbed_history,
                 }, f, indent=2, ensure_ascii=False)
             print(f"(^_^)v Conversation saved to: {filename}")
         except Exception as e:

--- a/run_agent.py
+++ b/run_agent.py
@@ -806,6 +806,81 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+_PACKET_CONTENT_REDACT_MARKER = "[REDACTED: orchestrator_packet_write content]"
+
+
+def _scrub_packet_tool_args(data):
+    """Redact ``content`` from orchestrator_packet_write calls before persistence.
+
+    Called in _flush_messages_to_session_db and _save_session_log so that
+    packet bodies never land in session JSON or the SQLite messages table.
+    Handles OpenAI-style tool_calls_data ({name, arguments}), Anthropic-style
+    content blocks ({type: tool_use, name, input}), and OpenAI Responses API
+    style ({type: function, function: {name, arguments}}).
+    Recurses into nested content arrays so tool_result wrappers are also scrubbed.
+    All other tool calls or blocks are returned unchanged.
+
+    The ``content`` key is preserved with a stable marker value rather than
+    deleted, so session transcripts show that redaction occurred.
+    """
+    if data is None:
+        return None
+    # Recurse into lists (handles top-level tool_calls arrays and nested content arrays)
+    if isinstance(data, list):
+        return [_scrub_packet_tool_args(item) for item in data]
+    if not isinstance(data, dict):
+        return data
+
+    call = data
+    name = call.get("name")
+
+    # OpenAI Responses API style: {"type": "function", "function": {"name": ..., "arguments": ...}}
+    if call.get("type") == "function" and isinstance(call.get("function"), dict):
+        fn = call["function"]
+        if fn.get("name") == "orchestrator_packet_write":
+            args_raw = fn.get("arguments", "{}")
+            if isinstance(args_raw, dict):
+                new_args = dict(args_raw)
+                new_args["content"] = _PACKET_CONTENT_REDACT_MARKER
+                return {**call, "function": {**fn, "arguments": new_args}}
+            try:
+                args = json.loads(args_raw)
+                args["content"] = _PACKET_CONTENT_REDACT_MARKER
+                return {**call, "function": {**fn, "arguments": json.dumps(args)}}
+            except (json.JSONDecodeError, TypeError):
+                return {**call, "function": {**fn, "arguments": json.dumps({"_redacted": True})}}
+        # Not a packet_write Responses API call — recurse into nested content if any
+        content = call.get("content")
+        if isinstance(content, list):
+            return {**call, "content": _scrub_packet_tool_args(content)}
+        return call
+
+    if name == "orchestrator_packet_write":
+        # OpenAI-style: {"name": ..., "arguments": "<json string>"}
+        if "arguments" in call:
+            try:
+                args = json.loads(call.get("arguments", "{}"))
+                args["content"] = _PACKET_CONTENT_REDACT_MARKER
+                return {**call, "arguments": json.dumps(args)}
+            except (json.JSONDecodeError, TypeError):
+                return {**call, "arguments": json.dumps({"_redacted": True})}
+        # Anthropic-style: {"type": "tool_use", "name": ..., "input": {...}}
+        if "input" in call:
+            new_call = dict(call)
+            inp = dict(new_call.get("input") or {})
+            inp["content"] = _PACKET_CONTENT_REDACT_MARKER
+            new_call["input"] = inp
+            return new_call
+        return call
+
+    # Not a packet_write call — recurse into any nested content array
+    # (covers tool_result blocks that may contain nested tool_use blocks)
+    content = call.get("content")
+    if isinstance(content, list):
+        return {**call, "content": _scrub_packet_tool_args(content)}
+    return call
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -3314,6 +3389,9 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                tool_calls_data = _scrub_packet_tool_args(tool_calls_data)
+                # Also scrub Anthropic-format content blocks
+                content = _scrub_packet_tool_args(content) if isinstance(content, list) else content
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
@@ -3832,9 +3910,20 @@ class AIAgent:
             # Clean assistant content for session logs
             cleaned = []
             for msg in messages:
-                if msg.get("role") == "assistant" and msg.get("content"):
-                    msg = dict(msg)
-                    msg["content"] = self._clean_session_content(msg["content"])
+                if msg.get("role") == "assistant":
+                    content = msg.get("content")
+                    if isinstance(content, list):
+                        # Scrub packet content from Anthropic-format blocks
+                        scrubbed = _scrub_packet_tool_args(content)
+                        msg = dict(msg)
+                        msg["content"] = scrubbed
+                    elif content:
+                        msg = dict(msg)
+                        msg["content"] = self._clean_session_content(content)
+                    # Scrub packet content from OpenAI-style tool_calls
+                    if isinstance(msg.get("tool_calls"), list):
+                        msg = dict(msg)
+                        msg["tool_calls"] = _scrub_packet_tool_args(msg["tool_calls"])
                 cleaned.append(msg)
 
             # Guard: never overwrite a larger session log with fewer messages.

--- a/tests/tools/test_orchestrator_packet_tool.py
+++ b/tests/tools/test_orchestrator_packet_tool.py
@@ -1,0 +1,402 @@
+"""Tests for orchestrator_packet_write tool and orchestrator toolset."""
+import json
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Task 1: toolset resolution
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_toolset_exists():
+    from toolsets import resolve_toolset
+    tools = resolve_toolset("orchestrator")
+    assert "orchestrator_packet_write" in tools, (
+        f"Expected 'orchestrator_packet_write' in orchestrator toolset, got: {tools}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 2: tool registration and check_fn
+# ---------------------------------------------------------------------------
+
+def test_tool_is_registered():
+    """orchestrator_packet_write must appear in the tool registry."""
+    import tools.orchestrator_packet_tool  # noqa: F401 — side-effect import
+    from tools.registry import registry
+    entry = registry.get_entry("orchestrator_packet_write")
+    assert entry is not None, "orchestrator_packet_write not found in registry"
+    assert entry.toolset == "orchestrator"
+    assert callable(entry.handler)
+
+
+def test_tool_schema_has_required_fields():
+    import tools.orchestrator_packet_tool as mod
+    schema = mod.ORCHESTRATOR_PACKET_WRITE_SCHEMA
+    props = schema["parameters"]["properties"]
+    assert "filename" in props
+    assert "content" in props
+    assert "overwrite" in props
+    required = schema["parameters"]["required"]
+    assert "filename" in required
+    assert "content" in required
+    assert "overwrite" not in required  # optional, defaults to False
+
+
+def test_check_fn_excludes_worker_profiles():
+    """_orchestrator_profile_only must return False for known worker profiles."""
+    import tools.orchestrator_packet_tool as mod
+    with patch.dict(os.environ, {"HERMES_PROFILE": "orcheapworker"}):
+        assert not mod._orchestrator_profile_only(), (
+            "Worker profile 'orcheapworker' must be excluded"
+        )
+    with patch.dict(os.environ, {"HERMES_PROFILE": "evidence-worker"}):
+        assert not mod._orchestrator_profile_only(), (
+            "Worker profile 'evidence-worker' must be excluded"
+        )
+    with patch.dict(os.environ, {"HERMES_PROFILE": "hs"}):
+        assert mod._orchestrator_profile_only(), (
+            "Orchestrator profile 'hs' must be allowed"
+        )
+
+
+def test_check_fn_allows_unset_profile():
+    """An unset HERMES_PROFILE (dev/test) must be allowed by check_fn."""
+    import tools.orchestrator_packet_tool as mod
+    env = {k: v for k, v in os.environ.items() if k != "HERMES_PROFILE"}
+    with patch.dict(os.environ, env, clear=True):
+        assert mod._orchestrator_profile_only()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: happy-path write
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def packet_dir(tmp_path, monkeypatch):
+    """Redirect all packet writes to a temp directory.
+
+    Sets both HERMES_HOME and HERMES_PACKET_DIR so the canonical-base
+    confinement check accepts the temp location.
+    """
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    d = hermes / "cc-packets"
+    d.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+    monkeypatch.setenv("HERMES_PACKET_DIR", str(d))
+    return d
+
+
+def test_happy_path_write(packet_dir):
+    """Writing a valid packet returns filename, path, sha256, size_bytes."""
+    import tools.orchestrator_packet_tool as mod
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="# Dispatch Packet\n\npacket_id: pkt_20260425_081637_1519\n",
+    ))
+    assert result.get("filename") == "pkt_20260425_081637_1519.md"
+    assert result.get("path", "").endswith("pkt_20260425_081637_1519.md")
+    assert len(result.get("sha256", "")) == 64, "sha256 must be a 64-char hex string"
+    assert isinstance(result.get("size_bytes"), int)
+    assert result.get("size_bytes") > 0
+    assert "error" not in result
+
+
+def test_file_is_written_to_disk(packet_dir):
+    import tools.orchestrator_packet_tool as mod
+    content = "hello packet\n"
+    mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content=content,
+    )
+    written = (packet_dir / "pkt_20260425_081637_1519.md").read_text()
+    assert written == content
+
+
+def test_sha256_matches_content(packet_dir):
+    import hashlib
+    import tools.orchestrator_packet_tool as mod
+    content = "sha256 check content"
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_sha_check.md",
+        content=content,
+    ))
+    expected = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    assert result["sha256"] == expected
+
+
+def test_packet_dir_created_if_missing(tmp_path, monkeypatch):
+    """The tool must create the packet directory if it does not exist."""
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    d = hermes / "new_dir" / "cc-packets"
+    assert not d.exists()
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+    monkeypatch.setenv("HERMES_PACKET_DIR", str(d))
+    import tools.orchestrator_packet_tool as mod
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="content",
+    ))
+    assert "error" not in result
+    assert d.exists()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: security guards
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_filename", [
+    "../etc/passwd",
+    "/etc/passwd",
+    "subdir/file.md",
+    "~/secrets.md",
+    "file name with spaces.md",
+    "file!@#.md",
+    "",
+    "." * 80 + ".md",               # basename exceeds 72-char limit
+    "noextension",                   # no dot → extension group never matches
+    "file..double_dot.md",           # second dot in basename fails regex
+])
+def test_path_traversal_and_invalid_filename_rejected(packet_dir, bad_filename):
+    """All path traversal attempts and invalid filenames must return an error."""
+    import tools.orchestrator_packet_tool as mod
+    result = json.loads(mod.orchestrator_packet_write(
+        filename=bad_filename,
+        content="content",
+    ))
+    assert "error" in result, (
+        f"Expected error for filename={bad_filename!r}, got: {result}"
+    )
+    # Must not create any file
+    assert not any(packet_dir.iterdir()), (
+        f"File was written despite invalid filename {bad_filename!r}"
+    )
+
+
+def test_size_limit_enforced(packet_dir, monkeypatch):
+    """Content exceeding HERMES_PACKET_MAX_BYTES must be rejected."""
+    import importlib
+    monkeypatch.setenv("HERMES_PACKET_MAX_BYTES", "100")
+    import tools.orchestrator_packet_tool as mod
+    importlib.reload(mod)
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="x" * 101,
+    ))
+    assert "error" in result
+    assert "exceeds" in result["error"].lower()
+    assert not any(packet_dir.iterdir())
+
+
+def test_overwrite_false_blocks_second_write(packet_dir):
+    """Second write to the same filename with overwrite=False must fail."""
+    import tools.orchestrator_packet_tool as mod
+    mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="first write",
+    )
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="second write",
+    ))
+    assert "error" in result
+    assert "already exists" in result["error"]
+    # Original content must be intact
+    assert (packet_dir / "pkt_20260425_081637_1519.md").read_text() == "first write"
+
+
+def test_overwrite_true_replaces_file(packet_dir):
+    """With overwrite=True, an existing packet is replaced."""
+    import tools.orchestrator_packet_tool as mod
+    mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="first write",
+    )
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content="second write",
+        overwrite=True,
+    ))
+    assert "error" not in result
+    assert (packet_dir / "pkt_20260425_081637_1519.md").read_text() == "second write"
+
+
+# ---------------------------------------------------------------------------
+# Default packet directory: ~/.local/state/life/cc-packets/
+# ---------------------------------------------------------------------------
+
+def test_default_packet_dir_is_xdg_state_life(monkeypatch):
+    """_packet_dir() must return ~/.local/state/life/cc-packets/ when no env vars are set."""
+    import tools.orchestrator_packet_tool as mod
+    env = {k: v for k, v in os.environ.items() if k not in ("HERMES_PACKET_DIR", "HERMES_HOME")}
+    with patch.dict(os.environ, env, clear=True):
+        result = mod._packet_dir()
+    expected = Path.home() / ".local" / "state" / "life" / "cc-packets"
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_raw_packet_dir_default_matches_packet_dir(monkeypatch):
+    """_raw_packet_dir() and _packet_dir() must agree on the default."""
+    import tools.orchestrator_packet_tool as mod
+    env = {k: v for k, v in os.environ.items() if k not in ("HERMES_PACKET_DIR", "HERMES_HOME")}
+    with patch.dict(os.environ, env, clear=True):
+        raw = mod._raw_packet_dir()
+        resolved = mod._packet_dir()
+    assert raw == resolved, f"_raw_packet_dir={raw} != _packet_dir={resolved}"
+
+
+def test_hermes_packet_dir_env_overrides_default(tmp_path, monkeypatch):
+    """HERMES_PACKET_DIR inside HERMES_HOME must override the default."""
+    import tools.orchestrator_packet_tool as mod
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    override = hermes / "custom-packets"
+    override.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+    monkeypatch.setenv("HERMES_PACKET_DIR", str(override))
+    assert mod._packet_dir() == override.resolve()
+
+
+def test_no_base64_writer_in_native_path():
+    """The native orchestrator_packet_write path must not invoke hermes_packet_writer.py."""
+    import inspect
+    import tools.orchestrator_packet_tool as mod
+    source = inspect.getsource(mod)
+    assert "base64" not in source, (
+        "base64 must not appear in orchestrator_packet_tool — native path must not use the compat writer"
+    )
+    assert "hermes_packet_writer" not in source, (
+        "hermes_packet_writer must not be imported or called from the native packet tool"
+    )
+
+
+def test_result_never_contains_content(packet_dir):
+    """The JSON result must never echo back the content field."""
+    import tools.orchestrator_packet_tool as mod
+    secret = "SECRET_PAYLOAD_DATA"
+    result_str = mod.orchestrator_packet_write(
+        filename="pkt_20260425_081637_1519.md",
+        content=secret,
+    )
+    assert secret not in result_str, (
+        "content must never appear in the tool return value"
+    )
+
+
+def test_symlink_target_is_rejected(packet_dir, tmp_path):
+    """A symlink planted at the target path must be rejected, not followed."""
+    import tools.orchestrator_packet_tool as mod
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("original")
+    symlink_path = packet_dir / "pkt_symlink_attack.md"
+    symlink_path.symlink_to(outside_file)
+
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_symlink_attack.md",
+        content="ATTACKER_PAYLOAD",
+    ))
+    assert "error" in result, (
+        f"Expected error when target is a symlink, got: {result}"
+    )
+    assert outside_file.read_text() == "original", (
+        "Symlink follow must not have written to the target outside pkt_dir"
+    )
+
+
+def test_symlink_target_with_overwrite_is_still_rejected(packet_dir, tmp_path):
+    """overwrite=True must not bypass the symlink rejection."""
+    import tools.orchestrator_packet_tool as mod
+    outside_file = tmp_path / "outside2.txt"
+    outside_file.write_text("untouched")
+    (packet_dir / "pkt_overwrite_sym.md").symlink_to(outside_file)
+
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_overwrite_sym.md",
+        content="PAYLOAD",
+        overwrite=True,
+    ))
+    assert "error" in result
+    assert outside_file.read_text() == "untouched"
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: canonical base confinement + symlinked parent rejection
+# ---------------------------------------------------------------------------
+
+def test_symlink_parent_dir_is_rejected(tmp_path, monkeypatch):
+    """A symlink in the packet directory's ancestor chain must be rejected."""
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+
+    # Plant a symlink where the packet dir would live: hermes/link -> real_dir
+    real_dir = tmp_path / "real_packets"
+    real_dir.mkdir()
+    link = hermes / "cc-packets-link"
+    link.symlink_to(real_dir)  # the directory itself is a symlink
+
+    monkeypatch.setenv("HERMES_PACKET_DIR", str(link))
+    import tools.orchestrator_packet_tool as mod
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_attack.md",
+        content="ATTACKER_PAYLOAD",
+    ))
+    assert "error" in result, f"Expected error for symlinked packet dir, got: {result}"
+    assert "symlink" in result["error"].lower()
+    # Real directory must be untouched
+    assert not any(real_dir.iterdir())
+
+
+def test_in_base_symlinked_parent_is_rejected(tmp_path, monkeypatch):
+    """Symlinked HERMES_PACKET_DIR that resolves INSIDE HERMES_HOME must still be rejected.
+
+    This is the confinement gap fixed in round-4: _packet_dir() calls .resolve()
+    which eliminates symlinks before _symlinked_component sees the path.  The fix
+    checks _raw_packet_dir() (pre-resolution) so a symlink resolving inside the
+    allowed base is still caught.
+    """
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    real_packets = hermes / "real-packets"
+    real_packets.mkdir()
+    link = hermes / "cc-link"
+    link.symlink_to(real_packets)  # symlink resolves INSIDE HERMES_HOME
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+    monkeypatch.setenv("HERMES_PACKET_DIR", str(link))
+
+    import tools.orchestrator_packet_tool as mod
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_inbase_attack.md",
+        content="INBASE_PAYLOAD",
+    ))
+    assert "error" in result, (
+        f"Expected error for in-base symlinked packet dir, got: {result}"
+    )
+    assert "symlink" in result["error"].lower()
+    assert not any(real_packets.iterdir()), "No file must be written to the real target"
+
+
+def test_hostile_env_override_outside_hermes_home_is_rejected(tmp_path, monkeypatch):
+    """HERMES_PACKET_DIR pointing outside HERMES_HOME must be rejected."""
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+
+    outside = tmp_path / "outside_dir"
+    outside.mkdir()
+    monkeypatch.setenv("HERMES_PACKET_DIR", str(outside))
+
+    import tools.orchestrator_packet_tool as mod
+    result = json.loads(mod.orchestrator_packet_write(
+        filename="pkt_escape.md",
+        content="ESCAPE_PAYLOAD",
+    ))
+    assert "error" in result, f"Expected error for hostile HERMES_PACKET_DIR, got: {result}"
+    assert not any(outside.iterdir()), "No file must be written to the hostile directory"

--- a/tests/tools/test_run_agent_packet_redaction.py
+++ b/tests/tools/test_run_agent_packet_redaction.py
@@ -1,0 +1,334 @@
+"""Tests for orchestrator_packet_write content redaction in run_agent persistence."""
+import json
+import inspect
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Task 3: _scrub_packet_tool_args helper — unit tests
+# ---------------------------------------------------------------------------
+
+def test_scrub_removes_content_from_packet_write_call():
+    """content value must be replaced with redaction marker in orchestrator_packet_write arguments."""
+    from run_agent import _scrub_packet_tool_args, _PACKET_CONTENT_REDACT_MARKER
+    tool_calls = [
+        {
+            "name": "orchestrator_packet_write",
+            "arguments": json.dumps({
+                "filename": "pkt_20260425_081637_1519.md",
+                "content": "TOP_SECRET_PACKET_BODY",
+                "overwrite": False,
+            }),
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    result_str = json.dumps(scrubbed)
+    assert "TOP_SECRET_PACKET_BODY" not in result_str, (
+        "raw content must be absent from persisted tool_calls arguments"
+    )
+    args = json.loads(scrubbed[0]["arguments"])
+    assert args["filename"] == "pkt_20260425_081637_1519.md"
+    # content key must exist with the stable marker, not be deleted
+    assert "content" in args, "content key must be preserved with redaction marker"
+    assert args["content"] == _PACKET_CONTENT_REDACT_MARKER
+    assert _PACKET_CONTENT_REDACT_MARKER in result_str
+
+
+def test_scrub_leaves_other_tools_unchanged():
+    """_scrub_packet_tool_args must not modify non-packet-write calls."""
+    from run_agent import _scrub_packet_tool_args
+    tool_calls = [
+        {"name": "terminal", "arguments": json.dumps({"command": "ls -la"})},
+        {"name": "read_file", "arguments": json.dumps({"path": "/tmp/x.txt"})},
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    assert json.dumps(scrubbed) == json.dumps(tool_calls)
+
+
+def test_scrub_handles_empty_list():
+    from run_agent import _scrub_packet_tool_args
+    assert _scrub_packet_tool_args([]) == []
+    assert _scrub_packet_tool_args(None) is None
+
+
+def test_scrub_handles_malformed_arguments_safely():
+    """Malformed JSON in arguments must be fully redacted, not crash."""
+    from run_agent import _scrub_packet_tool_args
+    tool_calls = [
+        {
+            "name": "orchestrator_packet_write",
+            "arguments": "NOT_VALID_JSON{content: secret}",
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    result_str = json.dumps(scrubbed)
+    assert "secret" not in result_str
+
+
+def test_scrub_handles_mixed_list():
+    """A list containing both packet-write and other calls is handled correctly."""
+    from run_agent import _scrub_packet_tool_args
+    secret = "MIXED_LIST_SECRET"
+    tool_calls = [
+        {"name": "terminal", "arguments": json.dumps({"command": "echo hi"})},
+        {
+            "name": "orchestrator_packet_write",
+            "arguments": json.dumps({"filename": "p.md", "content": secret}),
+        },
+        {"name": "read_file", "arguments": json.dumps({"path": "/tmp/y.txt"})},
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    result_str = json.dumps(scrubbed)
+    assert secret not in result_str
+    assert json.loads(scrubbed[0]["arguments"])["command"] == "echo hi"
+    assert json.loads(scrubbed[2]["arguments"])["path"] == "/tmp/y.txt"
+
+
+def test_scrub_handles_anthropic_content_blocks():
+    """_scrub_packet_tool_args must also scrub Anthropic-format tool_use blocks."""
+    from run_agent import _scrub_packet_tool_args, _PACKET_CONTENT_REDACT_MARKER
+    secret = "ANTHROPIC_CONTENT_SECRET"
+    blocks = [
+        {
+            "type": "tool_use",
+            "id": "toolu_001",
+            "name": "orchestrator_packet_write",
+            "input": {"filename": "p.md", "content": secret},
+        },
+        {
+            "type": "text",
+            "text": "some text",
+        },
+    ]
+    scrubbed = _scrub_packet_tool_args(blocks)
+    result_str = json.dumps(scrubbed)
+    assert secret not in result_str
+    # filename must survive
+    assert scrubbed[0]["input"]["filename"] == "p.md"
+    # content key must exist with marker, not be deleted
+    assert "content" in scrubbed[0]["input"], "content key must be preserved with redaction marker"
+    assert scrubbed[0]["input"]["content"] == _PACKET_CONTENT_REDACT_MARKER
+    assert _PACKET_CONTENT_REDACT_MARKER in result_str
+    # non-packet block unchanged
+    assert scrubbed[1]["text"] == "some text"
+
+
+# ---------------------------------------------------------------------------
+# Task 3: persistence integration — source inspection tests
+#
+# These tests use inspect.getsource to verify that _scrub_packet_tool_args
+# is wired into the persistence functions. They:
+# - FAIL before _scrub_packet_tool_args is added (ImportError)
+# - FAIL after helper is added but before wiring (AssertionError: not in source)
+# - PASS after wiring (helper appears in function source)
+# ---------------------------------------------------------------------------
+
+
+def test_flush_messages_sqlite_row_excludes_content():
+    """_flush_messages_to_session_db source must reference _scrub_packet_tool_args."""
+    from run_agent import _scrub_packet_tool_args, AIAgent
+    source = inspect.getsource(AIAgent._flush_messages_to_session_db)
+    assert "_scrub_packet_tool_args" in source, (
+        "_scrub_packet_tool_args is not wired into _flush_messages_to_session_db. "
+        "Add `tool_calls_data = _scrub_packet_tool_args(tool_calls_data)` after "
+        "tool_calls_data is built (run_agent.py:3189)."
+    )
+
+
+def test_save_session_log_json_excludes_content():
+    """_save_session_log source must reference _scrub_packet_tool_args."""
+    from run_agent import _scrub_packet_tool_args, AIAgent
+    source = inspect.getsource(AIAgent._save_session_log)
+    assert "_scrub_packet_tool_args" in source, (
+        "_scrub_packet_tool_args is not wired into _save_session_log. "
+        "Add scrubbing call in the cleaned messages loop (run_agent.py:3704+)."
+    )
+
+
+def test_resume_path_delegates_to_scrubbing_helpers():
+    """_persist_session must delegate to _flush_messages_to_session_db or _save_session_log."""
+    from run_agent import _scrub_packet_tool_args, AIAgent
+    source = inspect.getsource(AIAgent._persist_session)
+    assert (
+        "_flush_messages_to_session_db" in source
+        or "_save_session_log" in source
+    ), (
+        "_persist_session must delegate to _flush_messages_to_session_db or "
+        "_save_session_log — otherwise transcript redaction is bypassed on the resume path."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: cli.py save_conversation and branch copy redaction
+# ---------------------------------------------------------------------------
+
+def _read_cli_source() -> str:
+    """Read cli.py source without importing (avoids prompt_toolkit dependency)."""
+    from pathlib import Path
+    cli_path = Path(__file__).parents[2] / "cli.py"
+    return cli_path.read_text(encoding="utf-8")
+
+
+def test_save_conversation_redacts_packet_content():
+    """HermesCLI.save_conversation source must reference _scrub_packet_tool_args."""
+    source = _read_cli_source()
+    # Verify the reference appears inside the save_conversation method
+    start = source.find("def save_conversation(self):")
+    assert start != -1, "save_conversation method not found in cli.py"
+    # Find the next method definition to bound the search
+    next_def = source.find("\n    def ", start + 1)
+    snippet = source[start:next_def] if next_def != -1 else source[start:]
+    assert "_scrub_packet_tool_args" in snippet, (
+        "_scrub_packet_tool_args is not called in HermesCLI.save_conversation. "
+        "Raw packet content would persist in exported conversation JSON files."
+    )
+
+
+def test_branch_command_redacts_packet_content():
+    """HermesCLI._handle_branch_command source must reference _scrub_packet_tool_args."""
+    source = _read_cli_source()
+    start = source.find("def _handle_branch_command(self,")
+    assert start != -1, "_handle_branch_command method not found in cli.py"
+    next_def = source.find("\n    def ", start + 1)
+    snippet = source[start:next_def] if next_def != -1 else source[start:]
+    assert "_scrub_packet_tool_args" in snippet, (
+        "_scrub_packet_tool_args is not called in HermesCLI._handle_branch_command. "
+        "Raw packet content would persist in the branch session database copy."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 4: recursive scrubbing of nested content arrays
+# ---------------------------------------------------------------------------
+
+def test_scrub_recurses_into_tool_result_content():
+    """Nested tool_use blocks inside tool_result content arrays must be scrubbed."""
+    from run_agent import _scrub_packet_tool_args, _PACKET_CONTENT_REDACT_MARKER
+    secret = "NESTED_CONTENT_SECRET"
+    blocks = [
+        {
+            "type": "tool_result",
+            "tool_use_id": "toolu_001",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "orchestrator_packet_write",
+                    "input": {"filename": "p.md", "content": secret},
+                }
+            ],
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(blocks)
+    result_str = json.dumps(scrubbed)
+    assert secret not in result_str, (
+        "content inside a nested tool_use within tool_result must be scrubbed"
+    )
+    inner = scrubbed[0]["content"][0]
+    assert inner["input"]["filename"] == "p.md"
+    # content key must exist with marker, not be deleted
+    assert "content" in inner["input"], "content key must be preserved with redaction marker"
+    assert inner["input"]["content"] == _PACKET_CONTENT_REDACT_MARKER
+    assert _PACKET_CONTENT_REDACT_MARKER in result_str
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Responses API shape: {type: "function", function: {name, arguments}}
+# ---------------------------------------------------------------------------
+
+def test_scrub_responses_api_json_string_arguments():
+    """Responses API shape with JSON-string arguments must have content replaced with marker."""
+    from run_agent import _scrub_packet_tool_args, _PACKET_CONTENT_REDACT_MARKER
+    secret = "RESPONSES_API_SECRET"
+    tool_calls = [
+        {
+            "type": "function",
+            "id": "call_abc123",
+            "function": {
+                "name": "orchestrator_packet_write",
+                "arguments": json.dumps({
+                    "filename": "pkt_test.md",
+                    "content": secret,
+                    "overwrite": False,
+                }),
+            },
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    result_str = json.dumps(scrubbed)
+    assert secret not in result_str, (
+        "raw content must be absent from Responses API shape arguments"
+    )
+    fn = scrubbed[0]["function"]
+    args = json.loads(fn["arguments"])
+    assert args["filename"] == "pkt_test.md"
+    # content key must exist with marker, not be deleted
+    assert "content" in args, "content key must be preserved with redaction marker"
+    assert args["content"] == _PACKET_CONTENT_REDACT_MARKER
+    assert _PACKET_CONTENT_REDACT_MARKER in result_str
+    # non-content fields on the call must be preserved
+    assert scrubbed[0]["id"] == "call_abc123"
+    assert scrubbed[0]["type"] == "function"
+
+
+def test_scrub_responses_api_dict_arguments():
+    """Responses API shape where arguments is already a dict must have content replaced with marker."""
+    from run_agent import _scrub_packet_tool_args, _PACKET_CONTENT_REDACT_MARKER
+    secret = "RESPONSES_API_DICT_SECRET"
+    tool_calls = [
+        {
+            "type": "function",
+            "function": {
+                "name": "orchestrator_packet_write",
+                "arguments": {
+                    "filename": "pkt_dict.md",
+                    "content": secret,
+                },
+            },
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    result_str = json.dumps(scrubbed)
+    assert secret not in result_str
+    fn = scrubbed[0]["function"]
+    # arguments stays as dict when input was dict
+    assert fn["arguments"]["filename"] == "pkt_dict.md"
+    # content key must exist with marker, not be deleted
+    assert "content" in fn["arguments"], "content key must be preserved with redaction marker"
+    assert fn["arguments"]["content"] == _PACKET_CONTENT_REDACT_MARKER
+    assert _PACKET_CONTENT_REDACT_MARKER in result_str
+
+
+def test_scrub_responses_api_malformed_arguments():
+    """Malformed JSON string in Responses API arguments must be fully redacted, not crash."""
+    from run_agent import _scrub_packet_tool_args
+    tool_calls = [
+        {
+            "type": "function",
+            "function": {
+                "name": "orchestrator_packet_write",
+                "arguments": "NOT_VALID_JSON{content: secret_value}",
+            },
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    result_str = json.dumps(scrubbed)
+    assert "secret_value" not in result_str
+    fn = scrubbed[0]["function"]
+    args = json.loads(fn["arguments"])
+    assert args.get("_redacted") is True
+
+
+def test_scrub_responses_api_non_packet_call_unchanged():
+    """Responses API shape for a non-packet-write tool must not be modified."""
+    from run_agent import _scrub_packet_tool_args
+    tool_calls = [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "arguments": json.dumps({"command": "ls -la"}),
+            },
+        }
+    ]
+    scrubbed = _scrub_packet_tool_args(tool_calls)
+    assert json.dumps(scrubbed) == json.dumps(tool_calls)

--- a/tools/orchestrator_packet_tool.py
+++ b/tools/orchestrator_packet_tool.py
@@ -1,0 +1,262 @@
+"""orchestrator_packet_write — confined packet writer for orchestrator dispatch."""
+
+import errno
+import hashlib
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_FILENAME_RE = re.compile(r'^[a-zA-Z0-9_-]{1,72}\.[a-zA-Z0-9]{1,10}$')
+_PACKET_DIR_ENV = "HERMES_PACKET_DIR"
+_PACKET_MAX_BYTES_ENV = "HERMES_PACKET_MAX_BYTES"
+_DEFAULT_MAX_BYTES = 128 * 1024  # 128 KiB
+
+# Profiles explicitly blocked from writing dispatch packets (exact lowercase match).
+# Exact set comparison avoids brittle substring matching.
+_BLOCKED_PACKET_WRITE_PROFILES = frozenset({"orcheapworker", "evidence-worker"})
+
+
+def _canonical_packet_base() -> Path:
+    """Return the resolved canonical base that HERMES_PACKET_DIR must reside within."""
+    from hermes_constants import get_hermes_home
+    return get_hermes_home().resolve()
+
+
+def _packet_dir() -> Path:
+    """Return the packet directory, enforcing confinement within the canonical base.
+
+    Raises ValueError if HERMES_PACKET_DIR resolves outside the canonical base.
+    """
+    raw = os.environ.get(_PACKET_DIR_ENV, "")
+    if raw:
+        candidate = Path(raw).expanduser().resolve()
+        base = _canonical_packet_base()
+        try:
+            candidate.relative_to(base)
+        except ValueError:
+            raise ValueError(
+                f"HERMES_PACKET_DIR resolves to {str(candidate)!r} which is outside "
+                f"the canonical base {str(base)!r}. "
+                f"Set HERMES_HOME to configure an alternate deployment root."
+            )
+        return candidate
+    return Path.home() / ".local" / "state" / "life" / "cc-packets"
+
+
+def _symlinked_component(path: Path) -> str | None:
+    """Return the first symlinked path component in *path*, or None.
+
+    *path* must be the raw (user-supplied, pre-resolution) path.  Passing an
+    already-resolved path defeats this check because resolution silently
+    eliminates symlinks before inspection.
+
+    Walks from *path* up to the filesystem root checking each component with
+    os.lstat so that a symlinked parent directory is caught before the write
+    reaches os.open.  Returns the offending component as a string, or None if
+    the entire ancestor chain is symlink-free.
+    """
+    current = Path(os.path.abspath(path))  # anchor without resolving symlinks
+    while True:
+        try:
+            if current.is_symlink():
+                return str(current)
+        except OSError:
+            pass
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def _raw_packet_dir() -> Path:
+    """Return HERMES_PACKET_DIR expanded but NOT resolved — for pre-resolution symlink checking.
+
+    Unlike _packet_dir(), this function does not call .resolve(), so symlinked
+    components in the path remain detectable by _symlinked_component().
+    """
+    raw = os.environ.get(_PACKET_DIR_ENV, "")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".local" / "state" / "life" / "cc-packets"
+
+
+def _max_bytes() -> int:
+    raw = os.environ.get(_PACKET_MAX_BYTES_ENV, "")
+    try:
+        return int(raw) if raw else _DEFAULT_MAX_BYTES
+    except ValueError:
+        return _DEFAULT_MAX_BYTES
+
+
+def _orchestrator_profile_only() -> bool:
+    """Return True only for profiles that may materialise dispatch packets."""
+    profile = os.environ.get("HERMES_PROFILE", "").lower()
+    return profile not in _BLOCKED_PACKET_WRITE_PROFILES
+
+
+def orchestrator_packet_write(
+    filename: str,
+    content: str,
+    overwrite: bool = False,
+) -> str:
+    """Write a dispatch packet to the confined cc-packets directory."""
+    # Basename-only guard: reject anything containing a separator
+    if (
+        os.sep in filename
+        or "/" in filename
+        or filename.startswith("~")
+        or os.path.isabs(filename)
+    ):
+        return json.dumps({
+            "error": (
+                f"filename must be a basename only (no path separators): {filename!r}"
+            )
+        })
+
+    # Pattern validation
+    if not _FILENAME_RE.match(filename):
+        return json.dumps({
+            "error": (
+                f"filename {filename!r} is invalid. "
+                "Must match [a-zA-Z0-9_-]{{1,72}}.<ext> "
+                "(e.g. pkt_20260425_081637_1519.md). "
+                "No spaces, no special characters."
+            )
+        })
+
+    # Size check
+    content_bytes = content.encode("utf-8")
+    max_bytes = _max_bytes()
+    if len(content_bytes) > max_bytes:
+        return json.dumps({
+            "error": (
+                f"content is {len(content_bytes):,} bytes which exceeds the "
+                f"size limit ({max_bytes:,} bytes). "
+                "Split into smaller packets or reduce content."
+            )
+        })
+
+    # Reject symlinked parents using the RAW (pre-resolution) path.
+    # _packet_dir() calls .resolve() which silently eliminates symlinks, so
+    # checking the resolved path would miss a symlinked component that resolves
+    # inside the allowed base.  We must inspect the original path chain first.
+    sym = _symlinked_component(_raw_packet_dir())
+    if sym:
+        return json.dumps({
+            "error": (
+                f"A component of the packet directory is a symlink ({sym!r}). "
+                "Refusing to write to prevent directory-traversal via symlink chains."
+            )
+        })
+
+    # Resolve packet directory — raises ValueError if outside canonical base
+    try:
+        pkt_dir = _packet_dir()
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    pkt_dir.mkdir(parents=True, exist_ok=True)
+    target = pkt_dir / filename
+
+    # sha256 computed before open so a write failure never produces a stale hash
+    sha256 = hashlib.sha256(content_bytes).hexdigest()
+
+    # Atomic open: O_NOFOLLOW rejects symlinks; O_EXCL makes the overwrite
+    # check and the create atomic, eliminating the TOCTOU window.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW
+    if not overwrite:
+        flags |= os.O_EXCL
+    try:
+        fd = os.open(str(target), flags, 0o600)
+    except FileExistsError:
+        return json.dumps({
+            "error": (
+                f"{filename!r} already exists in the packet directory. "
+                "Pass overwrite=true to replace it."
+            )
+        })
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            return json.dumps({
+                "error": (
+                    f"{filename!r} resolves to a symlink and cannot be written to. "
+                    "Remove the symlink and retry."
+                )
+            })
+        raise
+
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content_bytes)
+    except Exception:
+        raise
+
+    # content is intentionally excluded from the return value
+    return json.dumps({
+        "filename": filename,
+        "path": str(target),
+        "sha256": sha256,
+        "size_bytes": len(content_bytes),
+    })
+
+
+ORCHESTRATOR_PACKET_WRITE_SCHEMA = {
+    "name": "orchestrator_packet_write",
+    "description": (
+        "Write a dispatch packet to the confined cc-packets directory "
+        "(~/.local/state/life/cc-packets/ by default, overridable via HERMES_PACKET_DIR). "
+        "Returns sha256 of the written content. "
+        "Content is never echoed in the return value."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "filename": {
+                "type": "string",
+                "description": (
+                    "Basename only — no slashes or path separators. "
+                    "Pattern: [a-zA-Z0-9_-]{1..72}.<ext> "
+                    "(e.g. pkt_20260425_081637_1519.md)."
+                ),
+            },
+            "content": {
+                "type": "string",
+                "description": (
+                    "Full text content of the packet. Never echoed in the return value."
+                ),
+            },
+            "overwrite": {
+                "type": "boolean",
+                "description": "If true, replace an existing packet. Default false.",
+                "default": False,
+            },
+        },
+        "required": ["filename", "content"],
+    },
+}
+
+
+def _handle_orchestrator_packet_write(args: dict, **kw) -> str:
+    return orchestrator_packet_write(
+        filename=args.get("filename", ""),
+        content=args.get("content", ""),
+        overwrite=bool(args.get("overwrite", False)),
+    )
+
+
+registry.register(
+    name="orchestrator_packet_write",
+    toolset="orchestrator",
+    schema=ORCHESTRATOR_PACKET_WRITE_SCHEMA,
+    handler=_handle_orchestrator_packet_write,
+    emoji="📦",
+    description="Write a dispatch packet to the confined cc-packets directory.",
+    check_fn=_orchestrator_profile_only,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -450,9 +450,23 @@ TOOLSETS = {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
         "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook"]
-    }
+    },
+
+    "orchestrator": {
+        "description": "Orchestrator-only tools for confined packet dispatch and routing",
+        "tools": ["orchestrator_packet_write"],
+        "includes": [],
+        # Excluded from resolve_toolset("all") — requires explicit profile/config binding.
+        # Added to _TOOLSETS_EXCLUDED_FROM_ALL below.
+    },
 }
 
+
+# Toolsets excluded from the "all" / "*" expansion.
+# These require explicit profile or config binding and must never be silently
+# injected into broad tool lists — they are activated only when a profile's
+# platform_toolsets entry names them directly.
+_TOOLSETS_EXCLUDED_FROM_ALL: frozenset = frozenset({"orchestrator"})
 
 
 def get_toolset(name: str) -> Optional[Dict[str, Any]]:
@@ -523,6 +537,8 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     if name in {"all", "*"}:
         all_tools: Set[str] = set()
         for toolset_name in get_toolset_names():
+            if toolset_name in _TOOLSETS_EXCLUDED_FROM_ALL:
+                continue
             # Use a fresh visited set per branch to avoid cross-branch contamination
             resolved = resolve_toolset(toolset_name, visited.copy())
             all_tools.update(resolved)


### PR DESCRIPTION
## Summary

- Add native `orchestrator_packet_write` tool wired into toolsets/CLI
- Default packet dir is `~/.local/state/life/cc-packets/` with `HERMES_PACKET_DIR` override support
- Redact packet content in session persistence as `[REDACTED: orchestrator_packet_write content]`
- Add tests for packet tool and session redaction

## Test Evidence

```
venv/bin/python -m pytest tests/tools/test_orchestrator_packet_tool.py tests/tools/test_run_agent_packet_redaction.py -v
→ 48 passed
```

```
venv/bin/python -m pytest tests/tools/test_checkpoint_manager.py -v
→ 53 passed
```

Live fresh-session smoke after Hermes restart: `packet_write_smoke_ok`; session JSON scoped raw body hits 0, marker hits 1; no `hermes_packet_writer.py` / `--content-base64` in the packet-write record; guard log had `orchestrator_packet_write` events and no scoped block.

## Remaining Risk

- Full test suite not run
- Future improvement: add true session persistence round-trip test beyond source/string coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)