### PR TITLE
fix: honor custom-provider context length on model switch

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -543,9 +543,54 @@ def resolve_display_context_length(
     about Codex OAuth, Copilot, Nous, and falls back to models.dev for the
     rest.
 
+    For custom providers, also honor per-model ``custom_providers[].models``
+    context_length overrides so the /model success message matches the actual
+    runtime context window Hermes will use.
+
     Prefer the provider-aware value; fall back to ``model_info.context_window``
     only if the resolver returns nothing.
     """
+    config_context_length = None
+    try:
+        from hermes_cli.config import load_config, get_compatible_custom_providers
+
+        cfg = load_config()
+        custom_providers = get_compatible_custom_providers(cfg)
+        normalized_provider = (provider or "").strip().lower()
+        normalized_base_url = (base_url or "").strip().rstrip("/")
+        model_context_length = None
+        global_context_length = None
+
+        model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+        if isinstance(model_cfg, dict):
+            global_context_length = model_cfg.get("context_length")
+
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            entry_name = str(entry.get("name", "") or "").strip().lower()
+            entry_base_url = str(entry.get("base_url", "") or "").strip().rstrip("/")
+            if normalized_provider and entry_name != normalized_provider:
+                continue
+            if normalized_base_url and entry_base_url and entry_base_url != normalized_base_url:
+                continue
+
+            models = entry.get("models", {})
+            if isinstance(models, dict):
+                model_cfg = models.get(model, {})
+                if isinstance(model_cfg, dict):
+                    model_context_length = model_cfg.get("context_length")
+            break
+
+        chosen_context_length = model_context_length
+        if chosen_context_length is None:
+            chosen_context_length = global_context_length
+
+        if chosen_context_length is not None:
+            config_context_length = int(chosen_context_length)
+    except Exception:
+        config_context_length = None
+
     try:
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length(
@@ -553,6 +598,7 @@ def resolve_display_context_length(
             base_url=base_url or "",
             api_key=api_key or "",
             provider=provider or None,
+            config_context_length=config_context_length,
         )
         if ctx:
             return int(ctx)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1762,46 +1762,52 @@ class AIAgent:
                 )
                 _config_context_length = None
 
+        # Check custom_providers per-model context_length. This takes priority
+        # over the global model.context_length because model-specific overrides
+        # are the most precise source of truth for custom endpoints.
+        try:
+            from hermes_cli.config import get_compatible_custom_providers
+            _custom_providers = get_compatible_custom_providers(_agent_cfg)
+        except Exception:
+            _custom_providers = _agent_cfg.get("custom_providers")
+            if not isinstance(_custom_providers, list):
+                _custom_providers = []
+        for _cp_entry in _custom_providers:
+            if not isinstance(_cp_entry, dict):
+                continue
+            _cp_name = str(_cp_entry.get("name", "") or "").strip().lower()
+            _provider_name = str(getattr(self, "provider", "") or "").strip().lower()
+            _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+            if _provider_name and _cp_name and _cp_name != _provider_name:
+                continue
+            if _cp_url and _cp_url != self.base_url.rstrip("/"):
+                continue
+            _cp_models = _cp_entry.get("models", {})
+            if isinstance(_cp_models, dict):
+                _cp_model_cfg = _cp_models.get(self.model, {})
+                if isinstance(_cp_model_cfg, dict):
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is not None:
+                        try:
+                            _config_context_length = int(_cp_ctx)
+                        except (TypeError, ValueError):
+                            logger.warning(
+                                "Invalid context_length for model %r in "
+                                "custom_providers: %r — must be a plain "
+                                "integer (e.g. 256000, not '256K'). "
+                                "Falling back to auto-detection.",
+                                self.model, _cp_ctx,
+                            )
+                            print(
+                                f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
+                                f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+                                f"  Falling back to auto-detected context window.\n",
+                                file=sys.stderr,
+                            )
+            break
+
         # Store for reuse in switch_model (so config override persists across model switches)
         self._config_context_length = _config_context_length
-
-        # Check custom_providers per-model context_length
-        if _config_context_length is None:
-            try:
-                from hermes_cli.config import get_compatible_custom_providers
-                _custom_providers = get_compatible_custom_providers(_agent_cfg)
-            except Exception:
-                _custom_providers = _agent_cfg.get("custom_providers")
-                if not isinstance(_custom_providers, list):
-                    _custom_providers = []
-            for _cp_entry in _custom_providers:
-                if not isinstance(_cp_entry, dict):
-                    continue
-                _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                if _cp_url and _cp_url == self.base_url.rstrip("/"):
-                    _cp_models = _cp_entry.get("models", {})
-                    if isinstance(_cp_models, dict):
-                        _cp_model_cfg = _cp_models.get(self.model, {})
-                        if isinstance(_cp_model_cfg, dict):
-                            _cp_ctx = _cp_model_cfg.get("context_length")
-                            if _cp_ctx is not None:
-                                try:
-                                    _config_context_length = int(_cp_ctx)
-                                except (TypeError, ValueError):
-                                    logger.warning(
-                                        "Invalid context_length for model %r in "
-                                        "custom_providers: %r — must be a plain "
-                                        "integer (e.g. 256000, not '256K'). "
-                                        "Falling back to auto-detection.",
-                                        self.model, _cp_ctx,
-                                    )
-                                    print(
-                                        f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
-                                        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                                        f"  Falling back to auto-detected context window.\n",
-                                        file=sys.stderr,
-                                    )
-                    break
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -2141,12 +2147,50 @@ class AIAgent:
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
+
+            _resolved_config_context_length = getattr(self, "_config_context_length", None)
+            try:
+                from hermes_cli.config import load_config, get_compatible_custom_providers
+
+                _switch_cfg = load_config()
+                _switch_custom_providers = get_compatible_custom_providers(_switch_cfg)
+                _global_context_length = None
+                _switch_model_cfg = _switch_cfg.get("model", {}) if isinstance(_switch_cfg, dict) else {}
+                if isinstance(_switch_model_cfg, dict):
+                    _global_context_length = _switch_model_cfg.get("context_length")
+
+                _per_model_context_length = None
+                for _cp_entry in _switch_custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_name = str(_cp_entry.get("name", "") or "").strip().lower()
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").strip().rstrip("/")
+                    if _cp_name and _cp_name != str(self.provider or "").strip().lower():
+                        continue
+                    if _cp_url and _cp_url != str(self.base_url or "").strip().rstrip("/"):
+                        continue
+
+                    _cp_models = _cp_entry.get("models", {})
+                    if isinstance(_cp_models, dict):
+                        _cp_model_cfg = _cp_models.get(self.model, {})
+                        if isinstance(_cp_model_cfg, dict):
+                            _per_model_context_length = _cp_model_cfg.get("context_length")
+                    break
+
+                if _per_model_context_length is not None:
+                    _resolved_config_context_length = int(_per_model_context_length)
+                elif _global_context_length is not None:
+                    _resolved_config_context_length = int(_global_context_length)
+            except Exception:
+                pass
+
+            self._config_context_length = _resolved_config_context_length
             new_context_length = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=_resolved_config_context_length,
             )
             self.context_compressor.update_model(
                 model=self.model,

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -1,4 +1,4 @@
-"""Regression test for /model context-length display on provider-capped models.
+"""Regression tests for /model context-length display.
 
 Bug (April 2026): `/model gpt-5.5` on openai-codex (ChatGPT OAuth) showed
 "Context: 1,050,000 tokens" because the display code used the raw models.dev
@@ -6,9 +6,9 @@ Bug (April 2026): `/model gpt-5.5` on openai-codex (ChatGPT OAuth) showed
 of the provider-aware resolver. The agent was actually running at 272K — Codex
 OAuth's enforced cap — so the display was lying to the user.
 
-Fix: ``resolve_display_context_length()`` prefers
-``agent.model_metadata.get_model_context_length`` (which knows about Codex OAuth,
-Copilot, Nous, etc.) and falls back to models.dev only if that returns nothing.
+Another bug: custom providers with per-model ``custom_providers[].models``
+``context_length`` overrides still showed the fallback/provider-detected value
+(e.g. 128K) in /model output instead of the configured context window.
 """
 from __future__ import annotations
 
@@ -88,3 +88,36 @@ class TestResolveDisplayContextLength:
                 model_info=fake_mi,
             )
         assert ctx == 128_000
+
+    def test_custom_provider_per_model_context_length_is_forwarded(self):
+        fake_mi = _FakeModelInfo(128_000)
+        fake_cfg = {
+            "model": {
+                "provider": "cpa",
+                "context_length": 1_048_576,
+            },
+            "custom_providers": [
+                {
+                    "name": "cpa",
+                    "base_url": "http://proxy.example/v1",
+                    "models": {
+                        "gemma-4-31b-it": {"context_length": 262_144},
+                    },
+                }
+            ],
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg), patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=fake_cfg["custom_providers"],
+        ), patch(
+            "agent.model_metadata.get_model_context_length", return_value=262_144
+        ) as mock_ctx:
+            ctx = resolve_display_context_length(
+                "gemma-4-31b-it",
+                "cpa",
+                base_url="http://proxy.example/v1",
+                model_info=fake_mi,
+            )
+
+        assert ctx == 262_144
+        assert mock_ctx.call_args.kwargs["config_context_length"] == 262_144

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -1,4 +1,4 @@
-"""Tests that switch_model preserves config_context_length."""
+"""Tests that switch_model preserves and re-resolves config context length."""
 
 from unittest.mock import MagicMock, patch
 
@@ -72,3 +72,45 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_re_resolves_custom_provider_per_model_context_length():
+    """Switching between models on the same custom provider must refresh the
+    per-model context length instead of reusing the previous model's value."""
+    agent = _make_agent_with_compressor(config_context_length=1_048_576)
+    agent.provider = "cpa"
+    agent.base_url = "http://proxy.example/v1"
+
+    fake_cfg = {
+        "model": {
+            "provider": "cpa",
+            "default": "gemini-3-flash-preview",
+            "base_url": "http://proxy.example/v1",
+            "context_length": 1_048_576,
+        },
+        "custom_providers": [
+            {
+                "name": "cpa",
+                "base_url": "http://proxy.example/v1",
+                "models": {
+                    "gemini-3-flash-preview": {"context_length": 1_048_576},
+                    "gemma-4-31b-it": {"context_length": 262_144},
+                },
+            }
+        ],
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=fake_cfg), patch(
+        "hermes_cli.config.get_compatible_custom_providers",
+        return_value=fake_cfg["custom_providers"],
+    ), patch("agent.model_metadata.get_model_context_length", return_value=262_144) as mock_ctx_len:
+        agent.switch_model(
+            "gemma-4-31b-it",
+            "cpa",
+            api_key="sk-new",
+            base_url="http://proxy.example/v1",
+        )
+
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") == 262_144
+    assert agent._config_context_length == 262_144


### PR DESCRIPTION
## Summary
- honor custom provider per-model context_length in /model success output
- prefer custom_providers per-model context_length over global model.context_length during agent init
- re-resolve config context length on switch_model so switching between custom-provider models refreshes the compressor correctly
- add regression coverage for display and switch_model paths

## Testing
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_model_switch_context_display.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_invalid_context_length_warning.py -q -o addopts=`

## Context
This fixes custom OpenAI-compatible providers where config.yaml sets per-model context lengths under `custom_providers[].models`. Before this patch, `/model` could display 128K instead of the configured limit, and `switch_model` could keep using the previous model's context length after a session-only model switch.