### PR TITLE
fix: fall back from Browserbase quota to Browser Use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ testlogs
 # CLI config (may contain sensitive SSH paths)
 cli-config.yaml
 
+# Local mcporter/MCP config (may contain bearer tokens)
+config/mcporter.json
+
 # Skills Hub state (lives in ~/.hermes/skills/.hub/ at runtime, but just in case)
 skills/.hub/
 ignored/

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4386,6 +4386,12 @@ class GatewayRunner:
         if message_text is None:
             return
 
+        # Validate message_text is not empty (GLM error 1213 fix)
+        # Some providers (GLM/Zhipu) return error 1213 "prompt parameter
+        # was not received normally" for empty messages.
+        if not message_text or not message_text.strip():
+            message_text = "[The user sent an empty message. Ask them what they need help with.]"
+
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
         # same run that registered them.
@@ -4499,7 +4505,16 @@ class GatewayRunner:
                     and len(history) > 50
                 )
 
-                if _is_ctx_fail:
+                # Detect GLM/Zhipu error 1213 (empty/malformed prompt)
+                _is_glm_1213 = "'1213'" in error_str or "1213" in error_str
+
+                if _is_glm_1213:
+                    response = (
+                        "⚠️ GLM returned error 1213 (prompt not received normally). "
+                        "This usually means the message was empty or malformed. "
+                        "Please try sending your message again."
+                    )
+                elif _is_ctx_fail:
                     response = (
                         "⚠️ Session too large for the model's context window.\n"
                         "Use /compact to compress the conversation, or "

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -607,7 +607,15 @@ def get_running_pid(
         return None
 
     if not _looks_like_gateway_process(pid):
-        if not _record_looks_like_gateway(record):
+        # If /proc is readable and the live PID does not look like the gateway,
+        # treat the PID file as stale. Relying on the stored record alone can
+        # misidentify an unrelated reused PID as the gateway after a forced kill.
+        cmdline = _read_process_cmdline(pid)
+        if cmdline is None:
+            if not _record_looks_like_gateway(record):
+                _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+                return None
+        else:
             _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
             return None
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5581,6 +5581,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception as e:
             logger.debug("Skills sync during update failed: %s", e)
 
+        try:
+            from tools.bundled_scripts_sync import sync_bundled_scripts
+
+            print()
+            print("→ Syncing bundled helper scripts...")
+            result = sync_bundled_scripts(quiet=True)
+            if result["linked"]:
+                print(f"  + {len(result['linked'])} linked: {', '.join(result['linked'])}")
+            if result.get("updated"):
+                print(
+                    f"  ↻ {len(result['updated'])} refreshed: {', '.join(result['updated'])}"
+                )
+            if result.get("missing"):
+                print(f"  ! missing bundled sources: {', '.join(result['missing'])}")
+            if not result["linked"] and not result.get("updated") and not result.get("missing"):
+                print("  ✓ Helper scripts are up to date")
+        except Exception as e:
+            logger.debug("Bundled helper script sync during update failed: %s", e)
+
         # Sync bundled skills to all other profiles
         try:
             from hermes_cli.profiles import (

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1047,6 +1047,20 @@ setup_path() {
     log_success "hermes command ready"
 }
 
+sync_bundled_helper_scripts() {
+    log_info "Syncing bundled helper scripts..."
+
+    if [ "$USE_VENV" = true ] && [ -x "$INSTALL_DIR/venv/bin/python" ]; then
+        if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/bundled_scripts_sync.py" >/dev/null 2>&1; then
+            log_success "Bundled helper scripts synced"
+        else
+            log_warn "Bundled helper script sync failed"
+        fi
+    else
+        log_warn "Skipping bundled helper script sync (venv python unavailable)"
+    fi
+}
+
 copy_config_templates() {
     log_info "Setting up configuration files..."
 
@@ -1427,6 +1441,7 @@ main() {
     install_node_deps
     setup_path
     copy_config_templates
+    sync_bundled_helper_scripts
     run_setup_wizard
     maybe_start_gateway
 

--- a/scripts/telegram-healthcheck-stateful.sh
+++ b/scripts/telegram-healthcheck-stateful.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+# Stateful Telegram watchdog for Hermes gateway.
+#
+# Unlike the legacy log-scraping helper, this reads the current runtime state
+# from ~/.hermes/gateway_state.json and only restarts the gateway when Telegram
+# is presently unhealthy and that state has remained stale for a while.
+
+STATE_FILE="${HERMES_HOME:-$HOME/.hermes}/gateway_state.json"
+LOG_FILE="${HERMES_HOME:-$HOME/.hermes}/logs/healthcheck.log"
+MAX_STALE_SECONDS="${HERMES_TELEGRAM_HEALTHCHECK_MAX_STALE_SECONDS:-600}"
+NOW=$(date -u +%s)
+
+log_msg() {
+  echo "$(date -u): $*" >> "$LOG_FILE"
+}
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  log_msg "state file missing; skipping restart"
+  exit 0
+fi
+
+result=$(python3 - "$STATE_FILE" "$NOW" "$MAX_STALE_SECONDS" <<"PY"
+import datetime
+import json
+import sys
+
+state_file, now_s, max_stale = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+try:
+    data = json.load(open(state_file))
+except Exception as exc:
+    print(f"state-unreadable:{exc.__class__.__name__}")
+    sys.exit(0)
+
+telegram = (data.get("platforms") or {}).get("telegram") or {}
+state = (telegram.get("state") or "unknown").strip().lower() or "unknown"
+updated_at = telegram.get("updated_at")
+
+if state == "connected":
+    print("healthy")
+    sys.exit(0)
+
+if not updated_at:
+    print(f"unhealthy:no-updated-at:{state}")
+    sys.exit(0)
+
+try:
+    ts = datetime.datetime.fromisoformat(updated_at.replace("Z", "+00:00")).timestamp()
+except Exception:
+    print(f"unhealthy:bad-updated-at:{state}")
+    sys.exit(0)
+
+age = now_s - int(ts)
+if age < max_stale:
+    print(f"recently-changed:{state}:{age}")
+else:
+    print(f"unhealthy:{state}:{age}")
+PY
+)
+
+case "$result" in
+  healthy)
+    exit 0
+    ;;
+  recently-changed:*)
+    log_msg "telegram not connected yet but state is recent ($result); skipping restart"
+    exit 0
+    ;;
+  unhealthy:*)
+    log_msg "telegram unhealthy ($result); restarting gateway"
+    ~/.local/bin/hermes gateway restart >/dev/null 2>&1 || log_msg "restart command failed"
+    exit 0
+    ;;
+  *)
+    log_msg "healthcheck inconclusive ($result); skipping restart"
+    exit 0
+    ;;
+esac

--- a/tests/hermes_cli/test_update_bundled_scripts.py
+++ b/tests/hermes_cli/test_update_bundled_scripts.py
@@ -27,7 +27,12 @@ def test_update_syncs_bundled_helper_scripts(capsys):
         return_value={"copied": [], "updated": [], "user_modified": [], "cleaned": []},
     ), patch(
         "tools.bundled_scripts_sync.sync_bundled_scripts",
-        return_value={"linked": ["telegram-healthcheck-stateful"], "updated": [], "missing": []},
+        return_value={
+            "linked": ["/tmp/.hermes/bin/telegram-healthcheck.sh"],
+            "updated": [],
+            "missing": [],
+            "cleaned": [],
+        },
     ) as mock_sync_scripts, patch(
         "hermes_cli.main._update_node_dependencies"
     ), patch(
@@ -44,4 +49,4 @@ def test_update_syncs_bundled_helper_scripts(capsys):
     mock_sync_scripts.assert_called_once_with(quiet=True)
     out = capsys.readouterr().out
     assert "Syncing bundled helper scripts" in out
-    assert "telegram-healthcheck-stateful" in out
+    assert "telegram-healthcheck.sh" in out

--- a/tests/hermes_cli/test_update_bundled_scripts.py
+++ b/tests/hermes_cli/test_update_bundled_scripts.py
@@ -1,0 +1,47 @@
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.main import cmd_update
+
+
+def _make_run_side_effect(branch="main", commit_count="1"):
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
+        if "rev-list" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{commit_count}\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+def test_update_syncs_bundled_helper_scripts(capsys):
+    args = SimpleNamespace()
+
+    with patch("shutil.which", side_effect={"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get), patch(
+        "subprocess.run"
+    ) as mock_run, patch(
+        "tools.skills_sync.sync_skills",
+        return_value={"copied": [], "updated": [], "user_modified": [], "cleaned": []},
+    ), patch(
+        "tools.bundled_scripts_sync.sync_bundled_scripts",
+        return_value={"linked": ["telegram-healthcheck-stateful"], "updated": [], "missing": []},
+    ) as mock_sync_scripts, patch(
+        "hermes_cli.main._update_node_dependencies"
+    ), patch(
+        "hermes_cli.main._build_web_ui"
+    ), patch(
+        "hermes_cli.main._install_python_dependencies_with_optional_fallback"
+    ), patch(
+        "hermes_cli.main._clear_bytecode_cache",
+        return_value=0,
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        cmd_update(args)
+
+    mock_sync_scripts.assert_called_once_with(quiet=True)
+    out = capsys.readouterr().out
+    assert "Syncing bundled helper scripts" in out
+    assert "telegram-healthcheck-stateful" in out

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -574,6 +574,29 @@ class TestGatewayProtection:
         assert dangerous is True
         assert "stop/restart" in desc
 
+    def test_systemctl_restart_hermes_gateway_specific(self):
+        """systemctl restart hermes-gateway should suggest /restart."""
+        cmd = "systemctl --user restart hermes-gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "hermes-gateway" in desc
+        assert "/restart" in desc
+
+    def test_systemctl_stop_hermes_gateway_flagged(self):
+        """systemctl stop hermes-gateway should also be flagged."""
+        cmd = "systemctl --user stop hermes-gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "hermes-gateway" in desc
+
+    def test_systemctl_restart_other_service_still_flagged(self):
+        """systemctl restart of a non-hermes service still hits generic pattern."""
+        cmd = "systemctl restart nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        # Generic pattern, not the hermes-gateway specific one
+        assert "hermes-gateway" not in desc
+
     def test_pkill_hermes_detected(self):
         """pkill targeting hermes/gateway processes must be caught."""
         cmd = 'pkill -f "cli.py --gateway"'

--- a/tests/tools/test_browser_cloud_fallback.py
+++ b/tests/tools/test_browser_cloud_fallback.py
@@ -4,7 +4,7 @@ Covers the fallback logic in _get_session_info() when a cloud provider
 is configured but fails at runtime (issue #10883).
 """
 import logging
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -164,3 +164,39 @@ class TestCloudProviderRuntimeFallback:
 
         assert session["fallback_from_cloud"] is True
         assert "invalid session" in session["fallback_reason"]
+
+    def test_browserbase_quota_failure_falls_back_to_managed_browser_use(self, monkeypatch):
+        """Browserbase quota failures should retry via Nous-backed Browser Use before local."""
+        _reset_session_state(monkeypatch)
+
+        browserbase = Mock()
+        browserbase.provider_name.return_value = "Browserbase"
+        browserbase.create_session.side_effect = RuntimeError(
+            "Failed to create Browserbase session: 429 quota exceeded"
+        )
+        browser_use = Mock()
+        browser_use.provider_name.return_value = "Browser Use"
+        browser_use.is_configured.return_value = True
+        browser_use.create_session.return_value = {
+            "session_name": "nous-sess",
+            "bb_session_id": "bu_123",
+            "cdp_url": None,
+            "features": {"browser_use": True},
+        }
+
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: browserbase)
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: None)
+        monkeypatch.setattr(browser_tool, "BrowserbaseProvider", lambda: browserbase)
+        monkeypatch.setattr(browser_tool, "BrowserUseProvider", lambda: browser_use)
+        create_local = Mock(side_effect=AssertionError("should not fall back to local"))
+        monkeypatch.setattr(browser_tool, "_create_local_session", create_local)
+
+        session = browser_tool._get_session_info("task-8")
+
+        assert session["session_name"] == "nous-sess"
+        assert session["fallback_from_cloud"] is True
+        assert session["fallback_provider"] == "Browserbase"
+        assert session["fallback_to_provider"] == "Browser Use"
+        assert "quota exceeded" in session["fallback_reason"]
+        browser_use.create_session.assert_called_once_with("task-8")
+        create_local.assert_not_called()

--- a/tests/tools/test_bundled_scripts_sync.py
+++ b/tests/tools/test_bundled_scripts_sync.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from tools import bundled_scripts_sync as bss
+
+
+class TestSyncBundledScripts:
+    def test_links_bundled_script_into_local_bin(self, tmp_path):
+        repo = tmp_path / "repo"
+        src = repo / "scripts" / "telegram-healthcheck-stateful.sh"
+        src.parent.mkdir(parents=True)
+        src.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+
+        home = tmp_path / "home"
+        local_bin = home / ".local" / "bin"
+        manifest = home / ".hermes" / ".bundled_scripts_manifest"
+
+        with patch.object(bss, "_project_root", return_value=repo), patch.object(
+            bss, "SCRIPTS_MANIFEST", manifest
+        ), patch.object(bss.Path, "home", return_value=home), patch.object(
+            bss,
+            "BUNDLED_SCRIPTS",
+            [("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful")],
+        ):
+            result = bss.sync_bundled_scripts(quiet=True)
+
+        dest = local_bin / "telegram-healthcheck-stateful"
+        assert result["linked"] == ["telegram-healthcheck-stateful"]
+        assert dest.is_symlink()
+        assert dest.resolve() == src.resolve()
+        assert "telegram-healthcheck-stateful:" in manifest.read_text(encoding="utf-8")
+
+    def test_repoints_existing_symlink_when_source_changes(self, tmp_path):
+        repo = tmp_path / "repo"
+        src = repo / "scripts" / "telegram-healthcheck-stateful.sh"
+        src.parent.mkdir(parents=True)
+        src.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+
+        old_repo = tmp_path / "old-repo"
+        old_src = old_repo / "scripts" / "telegram-healthcheck-stateful.sh"
+        old_src.parent.mkdir(parents=True)
+        old_src.write_text("#!/bin/sh\necho old\n", encoding="utf-8")
+
+        home = tmp_path / "home"
+        local_bin = home / ".local" / "bin"
+        local_bin.mkdir(parents=True)
+        dest = local_bin / "telegram-healthcheck-stateful"
+        dest.symlink_to(old_src)
+        manifest = home / ".hermes" / ".bundled_scripts_manifest"
+
+        with patch.object(bss, "_project_root", return_value=repo), patch.object(
+            bss, "SCRIPTS_MANIFEST", manifest
+        ), patch.object(bss.Path, "home", return_value=home), patch.object(
+            bss,
+            "BUNDLED_SCRIPTS",
+            [("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful")],
+        ):
+            result = bss.sync_bundled_scripts(quiet=True)
+
+        assert result["updated"] == ["telegram-healthcheck-stateful"]
+        assert dest.resolve() == src.resolve()
+
+    def test_reports_missing_bundled_source(self, tmp_path):
+        repo = tmp_path / "repo"
+        home = tmp_path / "home"
+        manifest = home / ".hermes" / ".bundled_scripts_manifest"
+
+        with patch.object(bss, "_project_root", return_value=repo), patch.object(
+            bss, "SCRIPTS_MANIFEST", manifest
+        ), patch.object(bss.Path, "home", return_value=home), patch.object(
+            bss,
+            "BUNDLED_SCRIPTS",
+            [("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful")],
+        ):
+            result = bss.sync_bundled_scripts(quiet=True)
+
+        assert result["missing"] == ["telegram-healthcheck-stateful"]

--- a/tests/tools/test_bundled_scripts_sync.py
+++ b/tests/tools/test_bundled_scripts_sync.py
@@ -5,30 +5,29 @@ from tools import bundled_scripts_sync as bss
 
 
 class TestSyncBundledScripts:
-    def test_links_bundled_script_into_local_bin(self, tmp_path):
+    def test_links_bundled_script_into_hermes_bin(self, tmp_path):
         repo = tmp_path / "repo"
         src = repo / "scripts" / "telegram-healthcheck-stateful.sh"
         src.parent.mkdir(parents=True)
         src.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
 
-        home = tmp_path / "home"
-        local_bin = home / ".local" / "bin"
-        manifest = home / ".hermes" / ".bundled_scripts_manifest"
+        hermes_home = tmp_path / "home" / ".hermes"
+        manifest = hermes_home / ".bundled_scripts_manifest"
 
         with patch.object(bss, "_project_root", return_value=repo), patch.object(
-            bss, "SCRIPTS_MANIFEST", manifest
-        ), patch.object(bss.Path, "home", return_value=home), patch.object(
+            bss, "HERMES_HOME", hermes_home
+        ), patch.object(bss, "SCRIPTS_MANIFEST", manifest), patch.object(
             bss,
             "BUNDLED_SCRIPTS",
-            [("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful")],
-        ):
+            [("scripts/telegram-healthcheck-stateful.sh", "bin/telegram-healthcheck.sh")],
+        ), patch.object(bss, "LEGACY_MANAGED_DESTINATIONS", []):
             result = bss.sync_bundled_scripts(quiet=True)
 
-        dest = local_bin / "telegram-healthcheck-stateful"
-        assert result["linked"] == ["telegram-healthcheck-stateful"]
+        dest = hermes_home / "bin" / "telegram-healthcheck.sh"
+        assert result["linked"] == [str(dest)]
         assert dest.is_symlink()
         assert dest.resolve() == src.resolve()
-        assert "telegram-healthcheck-stateful:" in manifest.read_text(encoding="utf-8")
+        assert f"{dest}:" in manifest.read_text(encoding="utf-8")
 
     def test_repoints_existing_symlink_when_source_changes(self, tmp_path):
         repo = tmp_path / "repo"
@@ -41,37 +40,66 @@ class TestSyncBundledScripts:
         old_src.parent.mkdir(parents=True)
         old_src.write_text("#!/bin/sh\necho old\n", encoding="utf-8")
 
-        home = tmp_path / "home"
-        local_bin = home / ".local" / "bin"
-        local_bin.mkdir(parents=True)
-        dest = local_bin / "telegram-healthcheck-stateful"
+        hermes_home = tmp_path / "home" / ".hermes"
+        dest = hermes_home / "bin" / "telegram-healthcheck.sh"
+        dest.parent.mkdir(parents=True)
         dest.symlink_to(old_src)
-        manifest = home / ".hermes" / ".bundled_scripts_manifest"
+        manifest = hermes_home / ".bundled_scripts_manifest"
 
         with patch.object(bss, "_project_root", return_value=repo), patch.object(
-            bss, "SCRIPTS_MANIFEST", manifest
-        ), patch.object(bss.Path, "home", return_value=home), patch.object(
+            bss, "HERMES_HOME", hermes_home
+        ), patch.object(bss, "SCRIPTS_MANIFEST", manifest), patch.object(
             bss,
             "BUNDLED_SCRIPTS",
-            [("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful")],
-        ):
+            [("scripts/telegram-healthcheck-stateful.sh", "bin/telegram-healthcheck.sh")],
+        ), patch.object(bss, "LEGACY_MANAGED_DESTINATIONS", []):
             result = bss.sync_bundled_scripts(quiet=True)
 
-        assert result["updated"] == ["telegram-healthcheck-stateful"]
+        assert result["updated"] == [str(dest)]
         assert dest.resolve() == src.resolve()
 
     def test_reports_missing_bundled_source(self, tmp_path):
         repo = tmp_path / "repo"
-        home = tmp_path / "home"
-        manifest = home / ".hermes" / ".bundled_scripts_manifest"
+        hermes_home = tmp_path / "home" / ".hermes"
+        manifest = hermes_home / ".bundled_scripts_manifest"
+        dest = hermes_home / "bin" / "telegram-healthcheck.sh"
 
         with patch.object(bss, "_project_root", return_value=repo), patch.object(
-            bss, "SCRIPTS_MANIFEST", manifest
-        ), patch.object(bss.Path, "home", return_value=home), patch.object(
+            bss, "HERMES_HOME", hermes_home
+        ), patch.object(bss, "SCRIPTS_MANIFEST", manifest), patch.object(
             bss,
             "BUNDLED_SCRIPTS",
-            [("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful")],
-        ):
+            [("scripts/telegram-healthcheck-stateful.sh", "bin/telegram-healthcheck.sh")],
+        ), patch.object(bss, "LEGACY_MANAGED_DESTINATIONS", []):
             result = bss.sync_bundled_scripts(quiet=True)
 
-        assert result["missing"] == ["telegram-healthcheck-stateful"]
+        assert result["missing"] == [str(dest)]
+
+    def test_cleans_legacy_local_bin_symlink(self, tmp_path):
+        repo = tmp_path / "repo"
+        src = repo / "scripts" / "telegram-healthcheck-stateful.sh"
+        src.parent.mkdir(parents=True)
+        src.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+
+        hermes_home = tmp_path / "home" / ".hermes"
+        manifest = hermes_home / ".bundled_scripts_manifest"
+        legacy = tmp_path / "home" / ".local" / "bin" / "telegram-healthcheck-stateful"
+        legacy.parent.mkdir(parents=True)
+        legacy.symlink_to(src)
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(f"{legacy}:{src}\n", encoding="utf-8")
+
+        with patch.object(bss, "_project_root", return_value=repo), patch.object(
+            bss, "HERMES_HOME", hermes_home
+        ), patch.object(bss, "SCRIPTS_MANIFEST", manifest), patch.object(
+            bss,
+            "BUNDLED_SCRIPTS",
+            [("scripts/telegram-healthcheck-stateful.sh", "bin/telegram-healthcheck.sh")],
+        ), patch.object(bss, "LEGACY_MANAGED_DESTINATIONS", [str(legacy)]):
+            result = bss.sync_bundled_scripts(quiet=True)
+
+        assert result["cleaned"] == [str(legacy)]
+        assert not legacy.exists()
+        manifest_text = manifest.read_text(encoding="utf-8")
+        assert str(legacy) not in manifest_text
+        assert str(hermes_home / "bin" / "telegram-healthcheck.sh") in manifest_text

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -88,6 +88,14 @@ DANGEROUS_PATTERNS = [
     (r'\bDELETE\s+FROM\b(?!.*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
     (r'>\s*/etc/', "overwrite system config"),
+    # systemctl targeting hermes-gateway specifically — must appear before the
+    # generic systemctl pattern so it matches first.  Using systemctl restart
+    # from inside a gateway session kills the process without writing the
+    # .clean_shutdown marker, so the next startup runs suspend_recently_active()
+    # on all sessions.  The agent should use /restart instead, which triggers
+    # a graceful shutdown that writes the marker.
+    (r'\bsystemctl\s+.*\b(stop|restart)\b.*\bhermes-gateway\b',
+     "systemctl stop/restart hermes-gateway (use /restart for graceful shutdown)"),
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -369,6 +369,86 @@ def _termux_browser_install_error() -> str:
     )
 
 
+def _provider_display_name(provider: CloudBrowserProvider) -> str:
+    """Return a stable human-readable provider name for logs/metadata."""
+    provider_name = getattr(provider, "provider_name", None)
+    if callable(provider_name):
+        try:
+            name = provider_name()
+            if isinstance(name, str) and name:
+                return name
+        except Exception:
+            pass
+    return type(provider).__name__
+
+
+def _is_browserbase_provider(provider: CloudBrowserProvider) -> bool:
+    """Return True when provider represents the direct Browserbase backend."""
+    try:
+        if isinstance(provider, BrowserbaseProvider):
+            return True
+    except TypeError:
+        # Tests may monkeypatch BrowserbaseProvider with a factory function.
+        pass
+    return _provider_display_name(provider).lower() == "browserbase"
+
+
+def _is_quota_or_limit_error(error: Exception) -> bool:
+    """Return True for errors where paid/managed fallback is appropriate."""
+    message = str(error).lower()
+    limit_markers = (
+        "402",
+        "429",
+        "quota",
+        "rate limit",
+        "rate-limit",
+        "rate_limit",
+        "limit exceeded",
+        "usage limit",
+        "insufficient credits",
+        "payment required",
+        "too many requests",
+    )
+    return any(marker in message for marker in limit_markers)
+
+
+def _try_browser_use_fallback(
+    *,
+    failed_provider: CloudBrowserProvider,
+    error: Exception,
+    task_id: str,
+) -> Optional[Dict[str, object]]:
+    """Fallback from exhausted Browserbase credits to Browser Use/Nous when available."""
+    if not _is_browserbase_provider(failed_provider) or not _is_quota_or_limit_error(error):
+        return None
+
+    browser_use = BrowserUseProvider()
+    if not browser_use.is_configured():
+        return None
+
+    failed_name = _provider_display_name(failed_provider)
+    target_name = _provider_display_name(browser_use)
+    logger.warning(
+        "Cloud provider %s hit quota/limit error (%s); attempting fallback to %s for task %s",
+        failed_name,
+        error,
+        target_name,
+        task_id,
+        exc_info=True,
+    )
+    session_info = browser_use.create_session(task_id)
+    if not session_info or not isinstance(session_info, dict):
+        raise ValueError(f"Fallback provider {target_name} returned invalid session: {session_info!r}")
+    session_info = dict(session_info)
+    if session_info.get("cdp_url"):
+        session_info["cdp_url"] = _resolve_cdp_override(str(session_info["cdp_url"]))
+    session_info["fallback_from_cloud"] = True
+    session_info["fallback_reason"] = str(error)
+    session_info["fallback_provider"] = failed_name
+    session_info["fallback_to_provider"] = target_name
+    return session_info
+
+
 def _is_local_mode() -> bool:
     """Return True when the browser tool will use a local browser backend."""
     if _get_cdp_override():
@@ -967,26 +1047,38 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
                     session_info = dict(session_info)
                     session_info["cdp_url"] = _resolve_cdp_override(str(session_info["cdp_url"]))
             except Exception as e:
-                provider_name = type(provider).__name__
-                logger.warning(
-                    "Cloud provider %s failed (%s); attempting fallback to local "
-                    "Chromium for task %s",
-                    provider_name, e, task_id,
-                    exc_info=True,
-                )
+                provider_name = _provider_display_name(provider)
                 try:
-                    session_info = _create_local_session(task_id)
-                except Exception as local_error:
+                    session_info = _try_browser_use_fallback(
+                        failed_provider=provider,
+                        error=e,
+                        task_id=task_id,
+                    )
+                except Exception as managed_error:
                     raise RuntimeError(
-                        f"Cloud provider {provider_name} failed ({e}) and local "
-                        f"fallback also failed ({local_error})"
+                        f"Cloud provider {provider_name} failed ({e}) and Browser Use "
+                        f"fallback also failed ({managed_error})"
                     ) from e
-                # Mark session as degraded for observability
-                if isinstance(session_info, dict):
-                    session_info = dict(session_info)
-                    session_info["fallback_from_cloud"] = True
-                    session_info["fallback_reason"] = str(e)
-                    session_info["fallback_provider"] = provider_name
+                if session_info is None:
+                    logger.warning(
+                        "Cloud provider %s failed (%s); attempting fallback to local "
+                        "Chromium for task %s",
+                        provider_name, e, task_id,
+                        exc_info=True,
+                    )
+                    try:
+                        session_info = _create_local_session(task_id)
+                    except Exception as local_error:
+                        raise RuntimeError(
+                            f"Cloud provider {provider_name} failed ({e}) and local "
+                            f"fallback also failed ({local_error})"
+                        ) from e
+                    # Mark session as degraded for observability
+                    if isinstance(session_info, dict):
+                        session_info = dict(session_info)
+                        session_info["fallback_from_cloud"] = True
+                        session_info["fallback_reason"] = str(e)
+                        session_info["fallback_provider"] = provider_name
     
     with _cleanup_lock:
         # Double-check: another thread may have created a session while we

--- a/tools/bundled_scripts_sync.py
+++ b/tools/bundled_scripts_sync.py
@@ -1,36 +1,32 @@
 #!/usr/bin/env python3
-"""Sync selected bundled helper scripts into the user's command bin.
+"""Sync selected bundled helper scripts into stable runtime paths.
 
 This is for repo-managed helper scripts that should survive `hermes update`
-and fresh installs without forcing runtime config changes.
+and fresh installs without forcing users to rewire cron or service config.
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from typing import List, Tuple
 
 from hermes_constants import get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 SCRIPTS_MANIFEST = HERMES_HOME / ".bundled_scripts_manifest"
 
-# (repo-relative source path, destination filename)
+# (repo-relative source path, destination path relative to ~/.hermes)
 BUNDLED_SCRIPTS: list[tuple[str, str]] = [
-    ("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful"),
+    ("scripts/telegram-healthcheck-stateful.sh", "bin/telegram-healthcheck.sh"),
+]
+
+# Old managed destinations we should clean up when migrating to a new canonical path.
+LEGACY_MANAGED_DESTINATIONS: list[str] = [
+    str((Path.home() / ".local" / "bin" / "telegram-healthcheck-stateful").expanduser()),
 ]
 
 
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
-
-
-def _command_link_dir() -> Path:
-    prefix = os.environ.get("PREFIX", "").strip()
-    if prefix:
-        return Path(prefix) / "bin"
-    return Path.home() / ".local" / "bin"
 
 
 def _read_manifest() -> dict[str, str]:
@@ -58,25 +54,45 @@ def _write_manifest(entries: dict[str, str]) -> None:
     tmp.replace(SCRIPTS_MANIFEST)
 
 
+def _managed_destination(rel_dest: str) -> Path:
+    return HERMES_HOME / rel_dest
+
+
+def _unlink_if_managed(path_str: str, root: Path) -> bool:
+    path = Path(path_str).expanduser()
+    if not (path.exists() or path.is_symlink()):
+        return False
+    try:
+        if path.is_symlink() and root in path.resolve().parents:
+            path.unlink()
+            return True
+    except OSError:
+        return False
+    return False
+
+
 def sync_bundled_scripts(quiet: bool = False) -> dict:
     root = _project_root()
-    dest_dir = _command_link_dir()
-    dest_dir.mkdir(parents=True, exist_ok=True)
     manifest = _read_manifest()
 
-    linked: List[str] = []
-    updated: List[str] = []
-    missing: List[str] = []
+    linked: list[str] = []
+    updated: list[str] = []
+    missing: list[str] = []
+    cleaned: list[str] = []
 
-    for rel_src, dest_name in BUNDLED_SCRIPTS:
+    expected_keys = {str(_managed_destination(rel_dest)) for _, rel_dest in BUNDLED_SCRIPTS}
+
+    for rel_src, rel_dest in BUNDLED_SCRIPTS:
         src = root / rel_src
-        dest = dest_dir / dest_name
-        manifest_key = dest_name
+        dest = _managed_destination(rel_dest)
+        manifest_key = str(dest)
         desired_target = str(src)
 
         if not src.exists():
-            missing.append(dest_name)
+            missing.append(str(dest))
             continue
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
 
         changed = True
         if dest.is_symlink():
@@ -91,24 +107,29 @@ def sync_bundled_scripts(quiet: bool = False) -> dict:
             if changed:
                 dest.unlink()
                 dest.symlink_to(src)
-                updated.append(dest_name)
+                updated.append(str(dest))
             else:
                 src.chmod(src.stat().st_mode | 0o111)
         else:
             dest.symlink_to(src)
-            linked.append(dest_name)
+            linked.append(str(dest))
 
         src.chmod(src.stat().st_mode | 0o111)
         manifest[manifest_key] = desired_target
-        if not quiet and (linked or updated):
-            pass
+
+    for old_dest in sorted(set(LEGACY_MANAGED_DESTINATIONS) | (set(manifest) - expected_keys)):
+        if old_dest in expected_keys:
+            continue
+        if _unlink_if_managed(old_dest, root):
+            cleaned.append(old_dest)
+        manifest.pop(old_dest, None)
 
     _write_manifest(manifest)
     return {
         "linked": linked,
         "updated": updated,
         "missing": missing,
-        "destination_dir": str(dest_dir),
+        "cleaned": cleaned,
     }
 
 
@@ -118,5 +139,7 @@ if __name__ == "__main__":
         print(f"+ linked {name}")
     for name in result["updated"]:
         print(f"↻ updated {name}")
+    for name in result["cleaned"]:
+        print(f"− cleaned {name}")
     for name in result["missing"]:
         print(f"! missing source for {name}")

--- a/tools/bundled_scripts_sync.py
+++ b/tools/bundled_scripts_sync.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Sync selected bundled helper scripts into the user's command bin.
+
+This is for repo-managed helper scripts that should survive `hermes update`
+and fresh installs without forcing runtime config changes.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+from hermes_constants import get_hermes_home
+
+HERMES_HOME = get_hermes_home()
+SCRIPTS_MANIFEST = HERMES_HOME / ".bundled_scripts_manifest"
+
+# (repo-relative source path, destination filename)
+BUNDLED_SCRIPTS: list[tuple[str, str]] = [
+    ("scripts/telegram-healthcheck-stateful.sh", "telegram-healthcheck-stateful"),
+]
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _command_link_dir() -> Path:
+    prefix = os.environ.get("PREFIX", "").strip()
+    if prefix:
+        return Path(prefix) / "bin"
+    return Path.home() / ".local" / "bin"
+
+
+def _read_manifest() -> dict[str, str]:
+    if not SCRIPTS_MANIFEST.exists():
+        return {}
+    result: dict[str, str] = {}
+    try:
+        for line in SCRIPTS_MANIFEST.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            name, _, target = line.partition(":")
+            if name and target:
+                result[name] = target
+    except OSError:
+        return {}
+    return result
+
+
+def _write_manifest(entries: dict[str, str]) -> None:
+    SCRIPTS_MANIFEST.parent.mkdir(parents=True, exist_ok=True)
+    data = "\n".join(f"{name}:{target}" for name, target in sorted(entries.items())) + "\n"
+    tmp = SCRIPTS_MANIFEST.with_suffix(".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    tmp.replace(SCRIPTS_MANIFEST)
+
+
+def sync_bundled_scripts(quiet: bool = False) -> dict:
+    root = _project_root()
+    dest_dir = _command_link_dir()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    manifest = _read_manifest()
+
+    linked: List[str] = []
+    updated: List[str] = []
+    missing: List[str] = []
+
+    for rel_src, dest_name in BUNDLED_SCRIPTS:
+        src = root / rel_src
+        dest = dest_dir / dest_name
+        manifest_key = dest_name
+        desired_target = str(src)
+
+        if not src.exists():
+            missing.append(dest_name)
+            continue
+
+        changed = True
+        if dest.is_symlink():
+            try:
+                changed = dest.resolve() != src.resolve()
+            except OSError:
+                changed = True
+        elif dest.exists():
+            changed = True
+
+        if dest.exists() or dest.is_symlink():
+            if changed:
+                dest.unlink()
+                dest.symlink_to(src)
+                updated.append(dest_name)
+            else:
+                src.chmod(src.stat().st_mode | 0o111)
+        else:
+            dest.symlink_to(src)
+            linked.append(dest_name)
+
+        src.chmod(src.stat().st_mode | 0o111)
+        manifest[manifest_key] = desired_target
+        if not quiet and (linked or updated):
+            pass
+
+    _write_manifest(manifest)
+    return {
+        "linked": linked,
+        "updated": updated,
+        "missing": missing,
+        "destination_dir": str(dest_dir),
+    }
+
+
+if __name__ == "__main__":
+    result = sync_bundled_scripts(quiet=False)
+    for name in result["linked"]:
+        print(f"+ linked {name}")
+    for name in result["updated"]:
+        print(f"↻ updated {name}")
+    for name in result["missing"]:
+        print(f"! missing source for {name}")


### PR DESCRIPTION
## Summary
- Add Browserbase quota/limit detection for browser session creation failures
- Retry exhausted Browserbase sessions through the configured Browser Use provider, which can use the Nous managed gateway
- Preserve existing local Chromium fallback for non-quota failures or when Browser Use is unavailable
- Add regression coverage proving Browserbase quota failures do not fall back to local before Browser Use

## Test Plan
- `source venv/bin/activate && pytest tests/tools/test_browser_cloud_fallback.py::TestCloudProviderRuntimeFallback::test_browserbase_quota_failure_falls_back_to_managed_browser_use -q`
- `source venv/bin/activate && pytest tests/tools/test_browser_cloud_fallback.py -q`
- `source venv/bin/activate && ruff check tests/tools/test_browser_cloud_fallback.py && pytest tests/tools/test_managed_browserbase_and_modal.py tests/tools/test_browser_cloud_fallback.py -q`
