### PR TITLE
feat(tui): add /detach slash command for background agent execution

### DIFF
--- a/tui_gateway/detach_runner.py
+++ b/tui_gateway/detach_runner.py
@@ -1,0 +1,101 @@
+"""Headless agent runner for detached TUI sessions.
+
+Spawned by ``session.detach`` as a fully-detached subprocess
+(``start_new_session=True``).  Reads configuration from a JSON file written
+by the gateway, runs the agent to completion, and persists results to the
+session database so ``hermes --tui --resume`` can pick them up later.
+
+Usage::
+
+    python -m tui_gateway.detach_runner <task_id>
+"""
+
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+def _task_dir() -> Path:
+    return get_hermes_home() / "detach-tasks"
+
+
+def _config_path(task_id: str) -> Path:
+    return _task_dir() / f"{task_id}.json"
+
+
+def _result_path(task_id: str) -> Path:
+    return _task_dir() / f"{task_id}.result.json"
+
+
+def _write_result(task_id: str, success: bool, text: str) -> None:
+    _result_path(task_id).write_text(
+        json.dumps(
+            {"task_id": task_id, "success": success, "text": text, "ts": time.time()},
+            ensure_ascii=False,
+        )
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: python -m tui_gateway.detach_runner <task_id>", file=sys.stderr)
+        sys.exit(1)
+
+    task_id = sys.argv[1]
+    cfg_path = _config_path(task_id)
+
+    if not cfg_path.exists():
+        print(f"[detach-runner] config not found: {cfg_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"[detach-runner] failed to read config: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    session_key = cfg.get("session_key", "")
+    user_message = cfg.get("user_message", "")
+    conversation_history = cfg.get("conversation_history", [])
+    agent_kwargs = cfg.get("agent_kwargs", {})
+
+    # Set session context so tools and DB writes land correctly.
+    from tui_gateway.server import _set_session_context, _clear_session_context
+
+    tokens = _set_session_context(session_key)
+    try:
+        from run_agent import AIAgent
+
+        agent = AIAgent(**agent_kwargs)
+        result = agent.run_conversation(
+            user_message,
+            conversation_history=conversation_history or None,
+        )
+
+        response = (
+            result.get("final_response", str(result))
+            if isinstance(result, dict)
+            else str(result)
+        )
+        _write_result(task_id, success=True, text=response)
+    except Exception as exc:
+        trace = traceback.format_exc()
+        print(f"[detach-runner] agent error: {trace}", file=sys.stderr)
+        _write_result(task_id, success=False, text=f"error: {exc}")
+    finally:
+        _clear_session_context(tokens)
+
+        # Clean up the config file; result file is kept for debugging.
+        try:
+            cfg_path.unlink()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1875,6 +1875,101 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "interrupted"})
 
 
+@method("session.detach")
+def _(rid, params: dict) -> dict:
+    sid = params.get("session_id", "")
+    session = _sessions.get(sid)
+    if not session:
+        return _err(rid, 4001, "session not found")
+
+    session_key = session.get("session_key", "")
+    is_running = session.get("running", False)
+
+    if is_running:
+        # Agent is mid-turn.  Snapshot pre-turn history, spawn a detached
+        # process to re-run the turn, then interrupt the in-gateway agent.
+        task_id = f"dt_{uuid.uuid4().hex[:8]}"
+
+        with session["history_lock"]:
+            history_snapshot = list(session["history"])
+
+        # Find the last user message to re-run in the detached process.
+        user_message = ""
+        for msg in reversed(history_snapshot):
+            if msg.get("role") == "user":
+                user_message = msg.get("content", "")
+                break
+
+        if not user_message:
+            return _err(rid, 4010, "no user message to detach")
+
+        agent_kwargs = _background_agent_kwargs(session["agent"], task_id)
+        # Keep the original session_id so DB writes land in the right row.
+        agent_kwargs["session_id"] = session_key
+
+        task_dir = os.path.join(_hermes_home, "detach-tasks")
+        os.makedirs(task_dir, exist_ok=True)
+
+        cfg_path = os.path.join(task_dir, f"{task_id}.json")
+        cfg = {
+            "session_key": session_key,
+            "user_message": user_message,
+            "conversation_history": history_snapshot,
+            "agent_kwargs": agent_kwargs,
+        }
+
+        with open(cfg_path, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, ensure_ascii=False)
+
+        subprocess.Popen(
+            [sys.executable, "-m", "tui_gateway.detach_runner", task_id],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+            cwd=os.getcwd(),
+            env=os.environ.copy(),
+        )
+
+        # Interrupt the in-gateway agent so it stops competing with the
+        # detached process for tool execution / file writes.
+        if hasattr(session["agent"], "interrupt"):
+            session["agent"].interrupt()
+
+        # Close the session (pops from _sessions, cleans up slash worker).
+        _sessions.pop(sid, None)
+        try:
+            from tools.approval import unregister_gateway_notify
+            unregister_gateway_notify(session_key)
+        except Exception:
+            pass
+        try:
+            worker = session.get("slash_worker")
+            if worker:
+                worker.close()
+        except Exception:
+            pass
+
+        return _ok(rid, {"running": True, "session_key": session_key, "task_id": task_id})
+
+    # Session is idle — just close it and tell the TUI to exit.
+    _sessions.pop(sid, None)
+    try:
+        from tools.approval import unregister_gateway_notify
+        unregister_gateway_notify(session_key)
+    except Exception:
+        pass
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        pass
+
+    return _ok(rid, {"running": False, "session_key": session_key})
+
+
 # ── Delegation: subagent tree observability + controls ───────────────
 # Powers the TUI's /agents overlay (see ui-tui/src/components/agentsOverlay).
 # The registry lives in tools/delegate_tool — these handlers are thin

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -4,6 +4,7 @@ import type {
   BtwStartResponse,
   ConfigGetValueResponse,
   ConfigSetResponse,
+  DetachResponse,
   ImageAttachResponse,
   SessionBranchResponse,
   SessionCompressResponse,
@@ -351,6 +352,28 @@ export const sessionCommands: SlashCommand[] = [
 
         ctx.transcript.panel('Usage', sections)
       })
+    }
+  },
+
+  {
+    help: 'detach: leave agent running in background, free the terminal',
+    name: 'detach',
+    run: (_arg, ctx) => {
+      ctx.gateway.rpc<DetachResponse>('session.detach', { session_id: ctx.sid }).then(
+        ctx.guarded<DetachResponse>(r => {
+          if (!r?.session_key) {
+            return ctx.transcript.sys('nothing to detach')
+          }
+
+          if (r.running) {
+            ctx.transcript.sys(`detaching session ${r.session_key}...`)
+            ctx.transcript.sys(`agent continues in background (task ${r.task_id})`)
+          }
+
+          ctx.transcript.sys(`resume with: hermes --tui --resume ${r.session_key}`)
+          setTimeout(() => ctx.session.die(), 1500)
+        })
+      )
     }
   }
 ]

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -369,6 +369,12 @@ export interface SpawnTreeSaveResponse {
   session_id?: string
 }
 
+export interface DetachResponse {
+  running?: boolean
+  session_key?: string
+  task_id?: string
+}
+
 export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }


### PR DESCRIPTION
## What does this PR do?

Adds a `/detach` slash command to the Hermes TUI that allows users to detach from the interactive session while the agent continues processing in the background.

**Problem:** When running `hermes chat --tui` (or `hermes --tui`), there is no way to detach and free the terminal while the agent keeps running. Users must keep the terminal open or use external tools like `tmux`. Existing commands (`/background`, `/branch`, `/btw`) don't cover this use case — they keep the TUI occupied.

**Solution:** On `/detach`, the gateway spawns a fully-detached subprocess (`start_new_session=True`) that independently runs the agent to completion using the session's pre-turn history snapshot. The TUI exits cleanly. Session state is persisted to SQLite via the existing `AIAgent.run_conversation()` → `_flush_messages_to_session_db()` pipeline, so `hermes --tui --resume <session_key>` can recover the results later.

> **Note:** This PR implements only the `/detach` command (MVP scope). Re-attach via `hermes attach` subcommand or messaging platform integration is not included and can be added in a follow-up PR.

## Related Issue

Fixes #11347

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`tui_gateway/detach_runner.py`** (new, ~100 lines): Headless agent runner spawned as a detached subprocess. Reads JSON config from `$HERMES_HOME/detach-tasks/<task_id>.json`, constructs `AIAgent`, runs `run_conversation()`, writes result file on completion.
- **`tui_gateway/server.py`** (+85 lines): Adds `@method("session.detach")` RPC handler. When agent is mid-turn: snapshots `session["history"]`, extracts last user message, generates agent kwargs via `_background_agent_kwargs()`, writes config JSON, spawns detached process, interrupts in-gateway agent, closes session. When idle: closes session directly, returns resume hint.
- **`ui-tui/src/app/slash/commands/session.ts`** (+25 lines): Adds `detach` command to `sessionCommands` array. Calls `session.detach` RPC, displays detach confirmation with `hermes --tui --resume <key>` hint, then calls `ctx.session.die()` after 1.5s delay.
- **`ui-tui/src/gatewayTypes.ts`** (+6 lines): Adds `DetachResponse` interface (`running`, `session_key`, `task_id`).

### Architecture

User types `/detach` then TUI sends `session.detach` RPC to gateway. Gateway snapshots session history and agent config, writes JSON config to `~/.hermes/detach-tasks/<task_id>.json`, spawns detached subprocess (`python -m tui_gateway.detach_runner <task_id>` with `start_new_session=True`, `stdin/stdout/stderr=DEVNULL`), interrupts in-gateway agent, closes session, returns `{session_key, task_id, running}` to TUI. TUI shows "detaching... resume with: `hermes --tui --resume <key>`" and exits after 1.5s. Detached process runs agent to completion, persists to SQLite. User re-attaches with `hermes --tui --resume <session_key>`.

## How to Test

1. Start `hermes chat --tui` (or `hermes --tui`)
2. Send a message to the agent
3. While the agent is running (or idle), type `/detach`
4. Verify the TUI exits with a message showing the resume command
5. Verify the detached process is running: `ps aux | grep detach_runner`
6. Wait for the task to complete (check `~/.hermes/detach-tasks/` for result files)
7. Resume the session: `hermes --tui --resume <session_key>`
8. Verify the session history includes the background agent's response

**Idle detach test:** Start `hermes --tui`, type `/detach` without sending any message first. TUI should exit cleanly with a resume hint.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tui): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture changes)
- [ ] I've considered cross-platform impact — uses `start_new_session=True` which is Unix-only; Windows (`CREATE_NEW_PROCESS_GROUP`) would need a follow-up
- [x] I've updated tool descriptions/schemas — N/A (no tool changes)

## Screenshots / Logs

```
hermes> /detach
detaching session 20260426_120000_abc123...
agent continues in background (task dt_abc12345)
resume with: hermes --tui --resume 20260426_120000_abc123
```
