### PR TITLE
fix(anthropic): send thinking=disabled explicitly on third-party endpoints (#15700)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,6 +17,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
+from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
@@ -351,8 +352,11 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return False  # No base_url = direct Anthropic API
-    normalized = normalized.rstrip("/").lower()
-    if "anthropic.com" in normalized:
+    try:
+        host = urlparse(normalized).hostname or ""
+    except Exception:
+        host = ""
+    if host == "anthropic.com" or host.endswith(".anthropic.com"):
         return False  # Direct Anthropic API — OAuth applies
     return True  # Any other endpoint is a third-party proxy
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1823,6 +1823,12 @@ def build_anthropic_kwargs(
                 # Anthropic requires temperature=1 when thinking is enabled on older models
                 kwargs["temperature"] = 1
                 kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+        elif reasoning_config.get("enabled") is False and _is_third_party_anthropic_endpoint(base_url):
+            # Third-party Anthropic-compatible endpoints (e.g. DeepSeek /anthropic)
+            # default to thinking mode when the `thinking` parameter is absent.
+            # Native Anthropic disables thinking by default, so the key is omitted
+            # there — but third-party implementations must be told explicitly.
+            kwargs["thinking"] = {"type": "disabled"}
 
     # ── Strip sampling params on 4.7+ ─────────────────────────────────
     # Opus 4.7 rejects any non-default temperature/top_p/top_k with a 400.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1092,6 +1092,20 @@ class TestBuildAnthropicKwargs:
         )
         assert kwargs.get("thinking") == {"type": "disabled"}
 
+    def test_reasoning_disabled_proxy_hostname_containing_anthropic_com(self):
+        """A proxy whose hostname contains 'anthropic.com' as a substring
+        (e.g. anthropic.com.proxy.company.com) must still be classified as
+        a third-party endpoint and receive thinking=disabled."""
+        kwargs = build_anthropic_kwargs(
+            model="some-model",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            base_url="https://anthropic.com.proxy.company.com/anthropic",
+        )
+        assert kwargs.get("thinking") == {"type": "disabled"}
+
     def test_reasoning_disabled_kimi_coding_omits_thinking(self):
         """Kimi /coding skips the thinking parameter entirely — neither enabled
         nor disabled should be sent there."""

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1062,6 +1062,60 @@ class TestBuildAnthropicKwargs:
             max_tokens=4096,
             reasoning_config={"enabled": False},
         )
+        # Native Anthropic disables thinking by default — key should be absent.
+        assert "thinking" not in kwargs
+
+    def test_reasoning_disabled_third_party_sends_explicit_disabled(self):
+        """Third-party Anthropic-compat endpoints (e.g. DeepSeek /anthropic)
+        default to thinking mode when the parameter is absent, so Hermes must
+        send thinking={'type': 'disabled'} explicitly — see #15700."""
+        kwargs = build_anthropic_kwargs(
+            model="deepseek-v4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            base_url="https://api.deepseek.com/anthropic",
+        )
+        assert kwargs.get("thinking") == {"type": "disabled"}
+
+    def test_reasoning_disabled_third_party_any_provider(self):
+        """The explicit-disable behaviour applies to any non-Anthropic endpoint,
+        not just DeepSeek."""
+        kwargs = build_anthropic_kwargs(
+            model="some-model",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            base_url="https://third-party.example.com/anthropic",
+        )
+        assert kwargs.get("thinking") == {"type": "disabled"}
+
+    def test_reasoning_disabled_kimi_coding_omits_thinking(self):
+        """Kimi /coding skips the thinking parameter entirely — neither enabled
+        nor disabled should be sent there."""
+        kwargs = build_anthropic_kwargs(
+            model="some-model",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            base_url="https://api.kimi.com/coding",
+        )
+        assert "thinking" not in kwargs
+
+    def test_reasoning_none_third_party_omits_thinking(self):
+        """When reasoning_config is None on a third-party endpoint, the thinking
+        key must not be sent — only explicit enabled=False triggers the disable."""
+        kwargs = build_anthropic_kwargs(
+            model="deepseek-v4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            base_url="https://api.deepseek.com/anthropic",
+        )
         assert "thinking" not in kwargs
 
     def test_default_max_tokens_uses_model_output_limit(self):


### PR DESCRIPTION
## Summary
- Third-party Anthropic-compatible endpoints (e.g. DeepSeek `/anthropic`) default to thinking mode when the `thinking` parameter is absent; native Anthropic disables thinking by default
- When `reasoning_config.enabled = False`, Hermes now sends `thinking: {"type": "disabled"}` for third-party endpoints so they don't default to thinking on
- Kimi `/coding` and native Anthropic are unaffected

## The bug

`build_anthropic_kwargs` sets `thinking` only when thinking is enabled. For native Anthropic that is correct — thinking is disabled by default. But DeepSeek's `/anthropic` endpoint treats the absent parameter as "thinking enabled", causing every request with `enabled=False` to fail with HTTP 400:

```
The content[].thinking in the thinking mode must be passed back to the API.
```

## The fix

Added an `elif` branch inside the existing `reasoning_config` block at `agent/anthropic_adapter.py`:

```python
elif reasoning_config.get("enabled") is False and _is_third_party_anthropic_endpoint(base_url):
    kwargs["thinking"] = {"type": "disabled"}
```

`_is_third_party_anthropic_endpoint` returns `True` for any non-`anthropic.com` base URL. Kimi `/coding` is already excluded by the outer `not _is_kimi_coding` guard.

## Test plan
- [x] **Before**: 2 of 4 new tests fail (`assert None == {'type': 'disabled'}`) — regression guard confirmed
- [x] **After**: all 4 new tests pass
- [x] **Regression guard**: reverted fix → `test_reasoning_disabled_third_party_sends_explicit_disabled` and `test_reasoning_disabled_third_party_any_provider` both fail with `AssertionError: assert None == {'type': 'disabled'}`; restored → 0 failures
- [x] `tests/agent/test_anthropic_adapter.py` — 131 passed, 10 pre-existing baseline failures (unchanged)
- [x] `tests/agent/test_kimi_coding_anthropic_thinking.py` — 8 passed (unchanged)
- [x] Existing `test_reasoning_disabled` still passes (native Anthropic still omits the key)

**New test cases:**
- `test_reasoning_disabled_third_party_sends_explicit_disabled` — DeepSeek endpoint gets `{"type": "disabled"}`
- `test_reasoning_disabled_third_party_any_provider` — any non-Anthropic endpoint gets `{"type": "disabled"}`
- `test_reasoning_disabled_kimi_coding_omits_thinking` — Kimi `/coding` gets neither enabled nor disabled
- `test_reasoning_none_third_party_omits_thinking` — `reasoning_config=None` on third-party endpoint still omits `thinking`

## Related
- Fixes #15700

🤖 Generated with [Claude Code](https://claude.com/claude-code)