### PR TITLE
fix: follow latest compression tip on /resume and deflake delegate heartbeat coverage

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1040,69 +1040,34 @@ class SessionDB:
         return result
 
     def resolve_resume_session_id(self, session_id: str) -> str:
-        """Redirect a resume target to the descendant session that holds the messages.
+        """Redirect `/resume` to the latest live compression continuation.
 
-        Context compression ends the current session and forks a new child session
-        (linked via ``parent_session_id``). The flush cursor is reset, so the
-        child is where new messages actually land — the parent ends up with
-        ``message_count = 0`` rows unless messages had already been flushed to
-        it before compression. See #15000.
+        Context compression ends the current session and forks a continuation
+        child linked by ``parent_session_id``. The user-facing "live" session is
+        the latest tip of that compression chain, not necessarily the first node
+        in the chain that happened to accumulate messages.
 
-        This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the first descendant in the chain that has at least one message
-        row. If the original session already has messages, or no descendant
-        has any, the original ``session_id`` is returned unchanged.
+        Why this matters:
+        - a compressed root can retain some already-flushed messages, but future
+          turns still belong to the continuation child
+        - compression can happen multiple times, producing root -> child ->
+          grandchild chains
+        - `/resume` should land on the newest reachable continuation, matching
+          CLI behavior and the operator's mental model of "the session I'm still
+          working in"
 
-        The chain is always walked via the child whose ``started_at`` is
-        latest; that matches the single-chain shape that compression creates.
-        A depth cap (32) guards against accidental loops in malformed data.
+        We therefore project through the compression lineage with
+        ``get_compression_tip()``. That helper only follows true compression
+        continuations (not arbitrary child sessions / subagents) and returns the
+        input unchanged when no such lineage exists.
         """
         if not session_id:
             return session_id
 
-        with self._lock:
-            # If this session already has messages, nothing to redirect.
-            try:
-                row = self._conn.execute(
-                    "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
-                    (session_id,),
-                ).fetchone()
-            except Exception:
-                return session_id
-            if row is not None:
-                return session_id
-
-            # Walk descendants: at each step, pick the most-recently-started
-                # child session; stop once we find one with messages.
-            current = session_id
-            seen = {current}
-            for _ in range(32):
-                try:
-                    child_row = self._conn.execute(
-                        "SELECT id FROM sessions "
-                        "WHERE parent_session_id = ? "
-                        "ORDER BY started_at DESC, id DESC LIMIT 1",
-                        (current,),
-                    ).fetchone()
-                except Exception:
-                    return session_id
-                if child_row is None:
-                    return session_id
-                child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
-                if not child_id or child_id in seen:
-                    return session_id
-                seen.add(child_id)
-                try:
-                    msg_row = self._conn.execute(
-                        "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
-                        (child_id,),
-                    ).fetchone()
-                except Exception:
-                    return session_id
-                if msg_row is not None:
-                    return child_id
-                current = child_id
-        return session_id
+        try:
+            return self.get_compression_tip(session_id) or session_id
+        except Exception:
+            return session_id
 
     def get_messages_as_conversation(self, session_id: str) -> List[Dict[str, Any]]:
         """

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -211,6 +211,45 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_follows_latest_multi_hop_compression_tip(self, tmp_path):
+        """Gateway /resume should follow compression chains to the newest tip."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("compressed_root", "telegram")
+        db.set_session_title("compressed_root", "Compressed Work")
+        db.append_message("compressed_root", "user", "old root message")
+        db.end_session("compressed_root", "compression")
+
+        db.create_session("compressed_child", "telegram", parent_session_id="compressed_root")
+        db.append_message("compressed_child", "user", "middle continuation")
+        db.end_session("compressed_child", "compression")
+
+        db.create_session("compressed_grandchild", "telegram", parent_session_id="compressed_child")
+        db.append_message("compressed_grandchild", "user", "latest continuation")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Compressed Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        runner.session_store.load_transcript.side_effect = (
+            lambda session_id: [{"role": "user", "content": "latest continuation"}]
+            if session_id == "compressed_grandchild"
+            else [{"role": "user", "content": "not-latest"}]
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed session" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "compressed_grandchild"
+        runner.session_store.load_transcript.assert_called_with("compressed_grandchild")
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_clears_running_agent(self, tmp_path):
         """Switching sessions clears any cached running agent."""
         from hermes_state import SessionDB

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -1,14 +1,13 @@
-"""Regression guard for #15000: --resume <id> after compression loses messages.
+"""Regression guards for `/resume` after compression continuation splits.
 
-Context compression ends the current session and forks a new child session
-(linked by ``parent_session_id``). The SQLite flush cursor is reset, so
-only the latest descendant ends up with rows in the ``messages`` table —
-the parent row has ``message_count = 0``. ``hermes --resume <parent_id>``
-used to load zero rows and show a blank chat.
+Context compression ends the current session and forks a continuation child
+(linked by ``parent_session_id``). The live user-facing session is the latest
+compression tip, not merely the first descendant in the chain that happens to
+contain message rows.
 
-``SessionDB.resolve_resume_session_id()`` walks the parent → child chain
-and redirects to the first descendant that actually has messages. These
-tests pin that behaviour.
+``SessionDB.resolve_resume_session_id()`` therefore projects through true
+compression continuations and returns the newest reachable tip. Non-compression
+children (subagents, branches) must not be followed.
 """
 import time
 
@@ -34,29 +33,47 @@ def _make_chain(db: SessionDB, ids_with_parent):
     db._conn.commit()
 
 
-def test_redirects_from_empty_head_to_descendant_with_messages(db):
-    # Reproducer shape from #15000: 6 sessions, only the 5th holds messages.
+def _mark_compressed(db: SessionDB, session_id: str, ended_at: int | None = None):
+    if ended_at is None:
+        row = db._conn.execute(
+            "SELECT started_at FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        started_at = row["started_at"] if hasattr(row, "keys") else row[0]
+        ended_at = int(started_at) + 1
+    db._conn.execute(
+        "UPDATE sessions SET end_reason = 'compression', ended_at = ? WHERE id = ?",
+        (ended_at, session_id),
+    )
+    db._conn.commit()
+
+
+def test_redirects_from_root_to_latest_compression_tip(db):
     _make_chain(db, [
-        ("head",   None),
-        ("mid1",   "head"),
-        ("mid2",   "mid1"),
-        ("mid3",   "mid2"),
-        ("bulk",   "mid3"),    # has messages
-        ("tail",   "bulk"),    # empty tail after another compression
+        ("head", None),
+        ("mid1", "head"),
+        ("mid2", "mid1"),
+        ("mid3", "mid2"),
+        ("bulk", "mid3"),
+        ("tail", "bulk"),
     ])
+    for sid in ["head", "mid1", "mid2", "mid3", "bulk"]:
+        _mark_compressed(db, sid)
     for i in range(5):
         db.append_message("bulk", role="user", content=f"msg {i}")
 
-    assert db.resolve_resume_session_id("head") == "bulk"
+    assert db.resolve_resume_session_id("head") == "tail"
 
 
-def test_returns_self_when_session_has_messages(db):
+def test_returns_latest_tip_even_when_root_has_messages(db):
     _make_chain(db, [("root", None), ("child", "root")])
-    db.append_message("root", role="user", content="hi")
-    assert db.resolve_resume_session_id("root") == "root"
+    db.append_message("root", role="user", content="old root message")
+    _mark_compressed(db, "root")
+    db.append_message("child", role="user", content="latest child message")
+    assert db.resolve_resume_session_id("root") == "child"
 
 
-def test_returns_self_when_no_descendant_has_messages(db):
+def test_returns_self_when_no_compression_lineage_exists(db):
     _make_chain(db, [("root", None), ("child1", "root"), ("child2", "child1")])
     assert db.resolve_resume_session_id("root") == "root"
 
@@ -75,22 +92,28 @@ def test_empty_session_id_passthrough(db):
     assert db.resolve_resume_session_id(None) is None
 
 
-def test_walks_from_middle_of_chain(db):
-    # If the user happens to know an intermediate ID, we still find the msg-bearing descendant.
+def test_walks_from_middle_of_compression_chain(db):
     _make_chain(db, [("a", None), ("b", "a"), ("c", "b"), ("d", "c")])
-    db.append_message("d", role="user", content="x")
+    for sid in ["a", "b", "c"]:
+        _mark_compressed(db, sid)
+    db.append_message("d", role="user", content="latest")
     assert db.resolve_resume_session_id("b") == "d"
     assert db.resolve_resume_session_id("c") == "d"
 
 
-def test_prefers_most_recent_child_when_fork_exists(db):
-    # If a session was somehow forked (two children), pick the latest one.
-    # In practice, compression only produces single-chain shape, but the helper
-    # should degrade gracefully.
+def test_prefers_most_recent_compression_child_when_fork_exists(db):
+    # If malformed data produces two post-compression children, pick the latest one.
     _make_chain(db, [
         ("parent", None),
         ("older_fork", "parent"),
         ("newer_fork", "parent"),
     ])
+    _mark_compressed(db, "parent")
     db.append_message("newer_fork", role="user", content="x")
     assert db.resolve_resume_session_id("parent") == "newer_fork"
+
+
+def test_does_not_follow_non_compression_child_sessions(db):
+    _make_chain(db, [("parent", None), ("subagent_child", "parent")])
+    db.append_message("subagent_child", role="user", content="subagent output")
+    assert db.resolve_resume_session_id("parent") == "parent"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1355,12 +1355,14 @@ class TestDelegateHeartbeat(unittest.TestCase):
 
         child.run_conversation.side_effect = slow_run
 
-        # Patch both the interval AND the idle ceiling so the test proves
-        # the in-tool branch takes effect: with a 0.05s interval and the
-        # default _HEARTBEAT_STALE_CYCLES_IDLE=5, the old behavior would
-        # trip after 0.25s and stop firing. We should see heartbeats
-        # continuing through the full 0.4s run.
-        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.05):
+        # Make the stale-threshold split explicit and assert on the real
+        # behavior we care about: while current_tool is set, the heartbeat
+        # must keep touching the parent and must NOT emit the stale warning
+        # that the idle branch uses to stop propagation.
+        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.05), \
+             patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IDLE", 2), \
+             patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IN_TOOL", 100), \
+             patch("tools.delegate_tool.logger.warning") as mock_warning:
             _run_single_child(
                 task_index=0,
                 goal="Test long-running tool",
@@ -1368,13 +1370,13 @@ class TestDelegateHeartbeat(unittest.TestCase):
                 parent_agent=parent,
             )
 
-        # With the old idle threshold (5 cycles = 0.25s), touch_calls
-        # would cap at ~5. With the in-tool threshold (20 cycles = 1.0s),
-        # we should see substantially more heartbeats over 0.4s.
         self.assertGreater(
-            len(touch_calls), 6,
-            f"Heartbeat stopped too early while child was inside a tool; "
-            f"got {len(touch_calls)} touches over 0.4s at 0.05s interval",
+            len(touch_calls), 0,
+            "Heartbeat never propagated while child was inside a tool",
+        )
+        self.assertFalse(
+            any("appears stale" in str(call.args[0]) for call in mock_warning.call_args_list),
+            f"In-tool child should not be marked stale: {mock_warning.call_args_list}",
         )
 
     def test_heartbeat_still_trips_idle_stale_when_no_tool(self):


### PR DESCRIPTION
### Summary
- make `resolve_resume_session_id()` follow the latest compression continuation tip instead of stopping at the first descendant with messages
- add regression coverage for multi-hop compression chains, roots that still retain messages, and non-compression child sessions
- deflake delegate heartbeat stale-threshold coverage by asserting the real contract instead of relying on brittle wall-clock touch counts

### Why
Compressed sessions can form root -> child -> grandchild chains. The live user-facing session is the latest continuation tip, not simply the first node that has message rows. Resuming to an older node can land the operator in stale context.

The delegate heartbeat failure was a flaky timing-based test, not a confirmed runtime bug. The updated test now checks the real invariant: in-tool subagents must keep propagating activity and must not trip the idle-stale warning path.

### Validation
Ran:
- `.venv/bin/pytest -q tests/gateway/test_resume_command.py tests/hermes_state/test_resolve_resume_session_id.py`
- `.venv/bin/pytest -q tests/tools/test_delegate.py`
- `.venv/bin/pytest -q tests/gateway/test_busy_session_ack.py tests/run_agent/test_memory_sync_interrupted.py`

Observed:
- targeted `/resume` coverage passed
- full `tests/tools/test_delegate.py` passed
- related gateway/memory regression coverage passed

### Notes
- independent review found no blocking issues
- one minor future cleanup option is adding an `id DESC` tiebreaker inside `get_compression_tip()` if maintainers want extra determinism for malformed same-timestamp forks
