### PR TITLE
Add Kanban dashboard tab and harden Web UI smokes

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3321,7 +3321,7 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             chat_topic=chat_topic,
             is_bot=getattr(message.author, "bot", False),
-            guild_id=str(message.guild.id) if message.guild else None,
+            guild_id=str(message.guild.id) if getattr(message, "guild", None) else None,
             parent_chat_id=parent_channel_id,
             message_id=str(message.id),
         )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -20,7 +20,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import get_compatible_custom_providers, get_hermes_home, load_config
 
 ColumnId = Literal["backlog", "running", "review", "done", "trash"]
 TaskStatus = Literal["idle", "running", "review", "done", "failed", "stopped"]
@@ -80,6 +80,7 @@ class KanbanCard(BaseModel):
     id: str = Field(default_factory=_new_id)
     title: str
     prompt: str
+    model: str | None = None
     column: ColumnId = "backlog"
     status: TaskStatus = "idle"
     workspace_path: str | None = None
@@ -100,6 +101,13 @@ class KanbanCard(BaseModel):
             raise ValueError("value must not be blank")
         return trimmed
 
+    @field_validator("model")
+    @classmethod
+    def _empty_model_to_none(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
+
 
 class KanbanBoard(BaseModel):
     version: int = 1
@@ -111,11 +119,15 @@ class BoardResponse(BaseModel):
     board: KanbanBoard
     columns: list[dict[str, str]]
     default_workspace_path: str
+    active_model: str
+    active_provider: str
+    model_options: list[str]
 
 
 class CardCreateRequest(BaseModel):
     title: str = Field(min_length=1)
     prompt: str = Field(min_length=1)
+    model: str | None = None
     workspace_path: str | None = None
 
     @field_validator("title", "prompt")
@@ -126,10 +138,18 @@ class CardCreateRequest(BaseModel):
             raise ValueError("value must not be blank")
         return trimmed
 
+    @field_validator("model")
+    @classmethod
+    def _empty_model_to_none(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
+
 
 class CardUpdateRequest(BaseModel):
     title: str | None = None
     prompt: str | None = None
+    model: str | None = None
     column: ColumnId | None = None
     workspace_path: str | None = None
 
@@ -143,9 +163,24 @@ class CardUpdateRequest(BaseModel):
             raise ValueError("value must not be blank")
         return trimmed
 
+    @field_validator("model")
+    @classmethod
+    def _empty_model_to_none(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
+
 
 class CardStartRequest(BaseModel):
     workspace_path: str | None = None
+    model: str | None = None
+
+    @field_validator("model")
+    @classmethod
+    def _empty_model_to_none(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
 
 
 class CardLogResponse(BaseModel):
@@ -220,6 +255,45 @@ def _logs_dir() -> Path:
     return path
 
 
+def _configured_model_info() -> tuple[str, str]:
+    config = load_config()
+    model_config = config.get("model", "")
+    if isinstance(model_config, dict):
+        model = str(model_config.get("default") or model_config.get("model") or model_config.get("name") or "")
+        provider = str(model_config.get("provider") or "")
+    else:
+        model = str(model_config or "")
+        provider = ""
+    provider = provider or os.getenv("HERMES_INFERENCE_PROVIDER", "auto")
+    return model, provider
+
+
+def _model_options(active_model: str, active_provider: str) -> list[str]:
+    options: list[str] = []
+
+    def add(model: Any) -> None:
+        value = str(model or "").strip()
+        if value and value not in options:
+            options.append(value)
+
+    add(active_model)
+    try:
+        from hermes_cli.models import _PROVIDER_MODELS
+        for model in _PROVIDER_MODELS.get(active_provider, [])[:40]:
+            add(model)
+    except Exception:
+        pass
+
+    try:
+        config = load_config()
+        for entry in get_compatible_custom_providers(config):
+            add(entry.get("model"))
+    except Exception:
+        pass
+
+    return options
+
+
 def _finish_card(card_id: str, return_code: int) -> None:
     with _RUNNING_LOCK:
         _RUNNING.pop(card_id, None)
@@ -280,10 +354,14 @@ def _terminate_process(card: KanbanCard) -> None:
 
 @router.get("/board", response_model=BoardResponse)
 async def get_board() -> BoardResponse:
+    active_model, active_provider = _configured_model_info()
     return BoardResponse(
         board=store.load(),
         columns=COLUMNS,
         default_workspace_path=_default_workspace(),
+        active_model=active_model,
+        active_provider=active_provider,
+        model_options=_model_options(active_model, active_provider),
     )
 
 
@@ -292,7 +370,12 @@ async def create_card(body: CardCreateRequest) -> KanbanCard:
     workspace = body.workspace_path.strip() if body.workspace_path else None
     if workspace:
         _workspace_path(workspace)
-    card = KanbanCard(title=body.title, prompt=body.prompt, workspace_path=workspace)
+    card = KanbanCard(
+        title=body.title,
+        prompt=body.prompt,
+        model=body.model,
+        workspace_path=workspace,
+    )
     return store.upsert_card(card)
 
 
@@ -305,6 +388,8 @@ async def update_card(card_id: str, body: CardUpdateRequest) -> KanbanCard:
         card.title = body.title
     if body.prompt is not None:
         card.prompt = body.prompt
+    if "model" in body.model_fields_set:
+        card.model = body.model
     if body.column is not None:
         card.column = body.column
         if body.column == "done":
@@ -335,6 +420,7 @@ async def start_card(card_id: str, body: CardStartRequest) -> KanbanCard:
 
     workspace_raw = body.workspace_path or card.workspace_path or _default_workspace()
     workspace = _workspace_path(workspace_raw)
+    model = body.model or card.model
     log_path = _logs_dir() / f"{card.id}-{int(_now())}.log"
     command = [
         sys.executable,
@@ -344,9 +430,13 @@ async def start_card(card_id: str, body: CardStartRequest) -> KanbanCard:
         "-Q",
         "--source",
         "kanban",
+    ]
+    if model:
+        command.extend(["--model", model])
+    command.extend([
         "-q",
         card.prompt,
-    ]
+    ])
     env = os.environ.copy()
     env.setdefault("HERMES_ACCEPT_HOOKS", "1")
 
@@ -375,6 +465,7 @@ async def start_card(card_id: str, body: CardStartRequest) -> KanbanCard:
     card.status = "running"
     card.column = "running"
     card.workspace_path = str(workspace)
+    card.model = model
     card.pid = process.pid
     card.log_path = str(log_path)
     card.started_at = _now()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1,0 +1,452 @@
+"""Native Hermes Kanban board backend.
+
+The board is deliberately scoped to Hermes concepts: cards launch Hermes
+sessions in a workspace, persist lightweight lifecycle state, and expose git
+diffs for review.  No external board/runtime code is required.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from hermes_cli.config import get_hermes_home
+
+ColumnId = Literal["backlog", "running", "review", "done", "trash"]
+TaskStatus = Literal["idle", "running", "review", "done", "failed", "stopped"]
+
+COLUMNS: list[dict[str, str]] = [
+    {"id": "backlog", "title": "Backlog"},
+    {"id": "running", "title": "Running"},
+    {"id": "review", "title": "Review"},
+    {"id": "done", "title": "Done"},
+    {"id": "trash", "title": "Trash"},
+]
+
+_RUNNING: dict[str, subprocess.Popen[str]] = {}
+_RUNNING_LOCK = threading.Lock()
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def _workspace_path(path: str) -> Path:
+    if not path.strip():
+        raise HTTPException(status_code=400, detail="workspace_path is required")
+    candidate = Path(path).expanduser().resolve()
+    if not candidate.exists() or not candidate.is_dir():
+        raise HTTPException(status_code=400, detail="Workspace path must be an existing directory")
+    return candidate
+
+
+def _run_git(workspace: Path, *args: str, timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(workspace), *args],
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _is_git_repo(workspace: Path) -> bool:
+    result = _run_git(workspace, "rev-parse", "--is-inside-work-tree", timeout=5)
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _tail_text(path: Path, *, lines: int = 80) -> str:
+    if not path.exists():
+        return ""
+    data = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(data[-lines:])
+
+
+class KanbanCard(BaseModel):
+    id: str = Field(default_factory=_new_id)
+    title: str
+    prompt: str
+    column: ColumnId = "backlog"
+    status: TaskStatus = "idle"
+    workspace_path: str | None = None
+    pid: int | None = None
+    log_path: str | None = None
+    last_activity: str | None = None
+    error: str | None = None
+    created_at: float = Field(default_factory=_now)
+    updated_at: float = Field(default_factory=_now)
+    started_at: float | None = None
+    finished_at: float | None = None
+
+    @field_validator("title", "prompt")
+    @classmethod
+    def _non_empty_trimmed(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("value must not be blank")
+        return trimmed
+
+
+class KanbanBoard(BaseModel):
+    version: int = 1
+    cards: list[KanbanCard] = Field(default_factory=list)
+    updated_at: float = Field(default_factory=_now)
+
+
+class BoardResponse(BaseModel):
+    board: KanbanBoard
+    columns: list[dict[str, str]]
+    default_workspace_path: str
+
+
+class CardCreateRequest(BaseModel):
+    title: str = Field(min_length=1)
+    prompt: str = Field(min_length=1)
+    workspace_path: str | None = None
+
+    @field_validator("title", "prompt")
+    @classmethod
+    def _non_empty_trimmed(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("value must not be blank")
+        return trimmed
+
+
+class CardUpdateRequest(BaseModel):
+    title: str | None = None
+    prompt: str | None = None
+    column: ColumnId | None = None
+    workspace_path: str | None = None
+
+    @field_validator("title", "prompt")
+    @classmethod
+    def _non_empty_trimmed(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("value must not be blank")
+        return trimmed
+
+
+class CardStartRequest(BaseModel):
+    workspace_path: str | None = None
+
+
+class CardLogResponse(BaseModel):
+    card_id: str
+    log: str
+    log_path: str | None
+
+
+class CardDiffResponse(BaseModel):
+    card_id: str
+    workspace_path: str | None
+    is_git_repo: bool
+    summary: str
+    diff: str
+
+
+class KanbanStore:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or get_hermes_home() / "kanban" / "board.json"
+        self._lock = threading.RLock()
+
+    def load(self) -> KanbanBoard:
+        with self._lock:
+            if not self.path.exists():
+                return KanbanBoard()
+            try:
+                return KanbanBoard.model_validate_json(self.path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                raise RuntimeError(f"Unable to read Kanban board at {self.path}: {exc}") from exc
+
+    def save(self, board: KanbanBoard) -> KanbanBoard:
+        with self._lock:
+            board.updated_at = _now()
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_suffix(".json.tmp")
+            tmp.write_text(board.model_dump_json(indent=2), encoding="utf-8")
+            tmp.replace(self.path)
+            return board
+
+    def get_card(self, card_id: str) -> tuple[KanbanBoard, KanbanCard]:
+        board = self.load()
+        for card in board.cards:
+            if card.id == card_id:
+                return board, card
+        raise HTTPException(status_code=404, detail="Kanban card not found")
+
+    def upsert_card(self, card: KanbanCard) -> KanbanCard:
+        board = self.load()
+        for idx, existing in enumerate(board.cards):
+            if existing.id == card.id:
+                card.updated_at = _now()
+                board.cards[idx] = card
+                self.save(board)
+                return card
+        card.updated_at = _now()
+        board.cards.append(card)
+        self.save(board)
+        return card
+
+
+store = KanbanStore()
+router = APIRouter()
+
+
+def _default_workspace() -> str:
+    return str(Path.cwd().resolve())
+
+
+def _logs_dir() -> Path:
+    path = get_hermes_home() / "kanban" / "logs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _finish_card(card_id: str, return_code: int) -> None:
+    with _RUNNING_LOCK:
+        _RUNNING.pop(card_id, None)
+
+    try:
+        board, card = store.get_card(card_id)
+    except HTTPException:
+        return
+
+    card.pid = None
+    card.finished_at = _now()
+    card.updated_at = _now()
+    if card.status == "stopped":
+        if not card.last_activity:
+            card.last_activity = "Hermes task stopped."
+        store.save(board)
+        return
+    if return_code == 0:
+        card.status = "review"
+        card.column = "review"
+        card.error = None
+        card.last_activity = "Hermes task finished; ready for review."
+    else:
+        card.status = "failed"
+        card.column = "review"
+        card.error = f"Hermes task exited with code {return_code}"
+        tail = _tail_text(Path(card.log_path)) if card.log_path else ""
+        card.last_activity = tail.splitlines()[-1] if tail else card.error
+    store.save(board)
+
+
+def _watch_process(card_id: str, process: subprocess.Popen[str]) -> None:
+    return_code = process.wait()
+    _finish_card(card_id, return_code)
+
+
+def _terminate_process(card: KanbanCard) -> None:
+    process: subprocess.Popen[str] | None
+    with _RUNNING_LOCK:
+        process = _RUNNING.pop(card.id, None)
+
+    if process and process.poll() is None:
+        if os.name == "nt":
+            process.terminate()
+        else:
+            os.killpg(process.pid, signal.SIGTERM)
+        return
+
+    if card.pid:
+        try:
+            if os.name == "nt":
+                os.kill(card.pid, signal.SIGTERM)
+            else:
+                os.killpg(card.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+
+@router.get("/board", response_model=BoardResponse)
+async def get_board() -> BoardResponse:
+    return BoardResponse(
+        board=store.load(),
+        columns=COLUMNS,
+        default_workspace_path=_default_workspace(),
+    )
+
+
+@router.post("/cards", response_model=KanbanCard)
+async def create_card(body: CardCreateRequest) -> KanbanCard:
+    workspace = body.workspace_path.strip() if body.workspace_path else None
+    if workspace:
+        _workspace_path(workspace)
+    card = KanbanCard(title=body.title, prompt=body.prompt, workspace_path=workspace)
+    return store.upsert_card(card)
+
+
+@router.put("/cards/{card_id}", response_model=KanbanCard)
+async def update_card(card_id: str, body: CardUpdateRequest) -> KanbanCard:
+    _, card = store.get_card(card_id)
+    if card.status == "running":
+        raise HTTPException(status_code=409, detail="Cannot edit a running card")
+    if body.title is not None:
+        card.title = body.title
+    if body.prompt is not None:
+        card.prompt = body.prompt
+    if body.column is not None:
+        card.column = body.column
+        if body.column == "done":
+            card.status = "done"
+        elif body.column == "backlog" and card.status in {"review", "failed", "stopped"}:
+            card.status = "idle"
+    if body.workspace_path is not None:
+        workspace = body.workspace_path.strip()
+        card.workspace_path = str(_workspace_path(workspace)) if workspace else None
+    return store.upsert_card(card)
+
+
+@router.delete("/cards/{card_id}")
+async def delete_card(card_id: str) -> dict[str, bool]:
+    board, card = store.get_card(card_id)
+    if card.status == "running":
+        raise HTTPException(status_code=409, detail="Stop the card before deleting it")
+    board.cards = [c for c in board.cards if c.id != card_id]
+    store.save(board)
+    return {"ok": True}
+
+
+@router.post("/cards/{card_id}/start", response_model=KanbanCard)
+async def start_card(card_id: str, body: CardStartRequest) -> KanbanCard:
+    _, card = store.get_card(card_id)
+    if card.status == "running":
+        raise HTTPException(status_code=409, detail="Card is already running")
+
+    workspace_raw = body.workspace_path or card.workspace_path or _default_workspace()
+    workspace = _workspace_path(workspace_raw)
+    log_path = _logs_dir() / f"{card.id}-{int(_now())}.log"
+    command = [
+        sys.executable,
+        "-m",
+        "hermes_cli.main",
+        "chat",
+        "-Q",
+        "--source",
+        "kanban",
+        "-q",
+        card.prompt,
+    ]
+    env = os.environ.copy()
+    env.setdefault("HERMES_ACCEPT_HOOKS", "1")
+
+    log_handle = log_path.open("w", encoding="utf-8")
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=str(workspace),
+            env=env,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=os.name != "nt",
+        )
+    except Exception as exc:
+        log_handle.close()
+        card.status = "failed"
+        card.column = "review"
+        card.error = str(exc)
+        card.last_activity = f"Failed to start Hermes task: {exc}"
+        return store.upsert_card(card)
+    finally:
+        # The child owns the descriptor; the parent should not keep it open.
+        log_handle.close()
+
+    card.status = "running"
+    card.column = "running"
+    card.workspace_path = str(workspace)
+    card.pid = process.pid
+    card.log_path = str(log_path)
+    card.started_at = _now()
+    card.finished_at = None
+    card.error = None
+    card.last_activity = "Hermes task started."
+    updated = store.upsert_card(card)
+
+    with _RUNNING_LOCK:
+        _RUNNING[card.id] = process
+    watcher = threading.Thread(target=_watch_process, args=(card.id, process), daemon=True)
+    watcher.start()
+    return updated
+
+
+@router.post("/cards/{card_id}/stop", response_model=KanbanCard)
+async def stop_card(card_id: str) -> KanbanCard:
+    _, card = store.get_card(card_id)
+    if card.status != "running":
+        return card
+    _terminate_process(card)
+    card.status = "stopped"
+    card.column = "review"
+    card.pid = None
+    card.finished_at = _now()
+    card.last_activity = "Hermes task stopped."
+    return store.upsert_card(card)
+
+
+@router.get("/cards/{card_id}/log", response_model=CardLogResponse)
+async def get_card_log(card_id: str, lines: int = 120) -> CardLogResponse:
+    _, card = store.get_card(card_id)
+    log_path = Path(card.log_path) if card.log_path else None
+    return CardLogResponse(
+        card_id=card.id,
+        log=_tail_text(log_path, lines=max(1, min(lines, 500))) if log_path else "",
+        log_path=card.log_path,
+    )
+
+
+@router.get("/cards/{card_id}/diff", response_model=CardDiffResponse)
+async def get_card_diff(card_id: str) -> CardDiffResponse:
+    _, card = store.get_card(card_id)
+    if not card.workspace_path:
+        return CardDiffResponse(
+            card_id=card.id,
+            workspace_path=None,
+            is_git_repo=False,
+            summary="No workspace path is attached to this card.",
+            diff="",
+        )
+
+    workspace = _workspace_path(card.workspace_path)
+    if not _is_git_repo(workspace):
+        return CardDiffResponse(
+            card_id=card.id,
+            workspace_path=str(workspace),
+            is_git_repo=False,
+            summary="Workspace is not a git repository.",
+            diff="",
+        )
+
+    summary = _run_git(workspace, "status", "--short", timeout=10)
+    diff = _run_git(workspace, "diff", "--", timeout=20)
+    return CardDiffResponse(
+        card_id=card.id,
+        workspace_path=str(workspace),
+        is_git_repo=True,
+        summary=summary.stdout.strip() or "Working tree is clean.",
+        diff=diff.stdout,
+    )
+
+
+def include_kanban_routes(app: Any) -> None:
+    app.include_router(router, prefix="/api/kanban", tags=["kanban"])

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -342,6 +342,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "human_delay": "display",
     "dashboard": "display",
     "code_execution": "agent",
+    "prompt_caching": "compression",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -65,6 +65,10 @@ _log = logging.getLogger(__name__)
 
 app = FastAPI(title="Hermes Agent", version=__version__)
 
+from hermes_cli.kanban import include_kanban_routes
+
+include_kanban_routes(app)
+
 # ---------------------------------------------------------------------------
 # Session token for protecting sensitive endpoints (reveal).
 # Generated fresh on every server start — dies when the process exits.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,6 +26,7 @@ from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
+_FTS5_WARNING_EMITTED = False
 
 T = TypeVar("T")
 
@@ -148,6 +149,7 @@ class SessionDB:
 
         self._lock = threading.Lock()
         self._write_count = 0
+        self._fts5_available = False
         self._conn = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
@@ -367,11 +369,28 @@ class SessionDB:
         except sqlite3.OperationalError:
             pass  # Index already exists
 
-        # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
+        # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in
+        # executescript with IF NOT EXISTS reliably). FTS5 is an optional
+        # SQLite extension, so installations without it must still be able to
+        # open the state database and use non-search dashboard features.
         try:
             cursor.execute("SELECT * FROM messages_fts LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_SQL)
+            self._fts5_available = True
+        except sqlite3.OperationalError as exc:
+            try:
+                cursor.executescript(FTS_SQL)
+                self._fts5_available = True
+            except sqlite3.OperationalError as create_exc:
+                if "no such module: fts5" not in str(create_exc).lower():
+                    raise
+                self._fts5_available = False
+                global _FTS5_WARNING_EMITTED
+                if not _FTS5_WARNING_EMITTED:
+                    logger.warning(
+                        "SQLite FTS5 extension is unavailable; session search "
+                        "will use a slower LIKE fallback."
+                    )
+                    _FTS5_WARNING_EMITTED = True
 
         self._conn.commit()
 
@@ -1226,6 +1245,59 @@ class SessionDB:
                 return True
         return False
 
+    @staticmethod
+    def _like_query_from_search_query(query: str) -> str:
+        """Convert sanitized FTS-style input into a substring query."""
+        query = query.replace('"', " ").replace("*", " ")
+        query = re.sub(r"(?i)\b(AND|OR|NOT)\b", " ", query)
+        return re.sub(r"\s+", " ", query).strip()
+
+    def _search_messages_like(
+        self,
+        query: str,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Fallback message search for SQLite builds without FTS5."""
+        raw_query = self._like_query_from_search_query(query)
+        if not raw_query:
+            return []
+
+        like_where = ["m.content LIKE ?"]
+        like_params: list = [f"%{raw_query}%"]
+        if source_filter is not None:
+            like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+            like_params.extend(source_filter)
+        if exclude_sources is not None:
+            like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            like_params.extend(exclude_sources)
+        if role_filter:
+            like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            like_params.extend(role_filter)
+
+        like_sql = f"""
+            SELECT m.id, m.session_id, m.role,
+                   substr(m.content,
+                          max(1, instr(m.content, ?) - 40),
+                          120) AS snippet,
+                   m.content, m.timestamp, m.tool_name,
+                   s.source, s.model, s.started_at AS session_started
+            FROM messages m
+            JOIN sessions s ON s.id = m.session_id
+            WHERE {' AND '.join(like_where)}
+            ORDER BY m.timestamp DESC
+            LIMIT ? OFFSET ?
+        """
+        like_params.extend([limit, offset])
+        # instr() parameter goes first in the bound list.
+        like_params = [raw_query] + like_params
+        with self._lock:
+            like_cursor = self._conn.execute(like_sql, like_params)
+            return [dict(row) for row in like_cursor.fetchall()]
+
     def search_messages(
         self,
         query: str,
@@ -1254,94 +1326,87 @@ class SessionDB:
         if not query:
             return []
 
-        # Build WHERE clauses dynamically
-        where_clauses = ["messages_fts MATCH ?"]
-        params: list = [query]
+        if not self._fts5_available:
+            matches = self._search_messages_like(
+                query,
+                source_filter=source_filter,
+                exclude_sources=exclude_sources,
+                role_filter=role_filter,
+                limit=limit,
+                offset=offset,
+            )
+        else:
+            matches = None
 
-        if source_filter is not None:
-            source_placeholders = ",".join("?" for _ in source_filter)
-            where_clauses.append(f"s.source IN ({source_placeholders})")
-            params.extend(source_filter)
+        if matches is None:
+            # Build WHERE clauses dynamically
+            where_clauses = ["messages_fts MATCH ?"]
+            params: list = [query]
 
-        if exclude_sources is not None:
-            exclude_placeholders = ",".join("?" for _ in exclude_sources)
-            where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
-            params.extend(exclude_sources)
-
-        if role_filter:
-            role_placeholders = ",".join("?" for _ in role_filter)
-            where_clauses.append(f"m.role IN ({role_placeholders})")
-            params.extend(role_filter)
-
-        where_sql = " AND ".join(where_clauses)
-        params.extend([limit, offset])
-
-        sql = f"""
-            SELECT
-                m.id,
-                m.session_id,
-                m.role,
-                snippet(messages_fts, 0, '>>>', '<<<', '...', 40) AS snippet,
-                m.content,
-                m.timestamp,
-                m.tool_name,
-                s.source,
-                s.model,
-                s.started_at AS session_started
-            FROM messages_fts
-            JOIN messages m ON m.id = messages_fts.rowid
-            JOIN sessions s ON s.id = m.session_id
-            WHERE {where_sql}
-            ORDER BY rank
-            LIMIT ? OFFSET ?
-        """
-
-        with self._lock:
-            try:
-                cursor = self._conn.execute(sql, params)
-            except sqlite3.OperationalError:
-                # FTS5 query syntax error despite sanitization — return empty
-                # unless query contains CJK (fall back to LIKE below)
-                if not self._contains_cjk(query):
-                    return []
-                matches = []
-            else:
-                matches = [dict(row) for row in cursor.fetchall()]
-
-        # LIKE fallback for CJK queries: FTS5 default tokenizer splits CJK
-        # characters individually, causing multi-character queries to fail.
-        if not matches and self._contains_cjk(query):
-            raw_query = query.strip('"').strip()
-            like_where = ["m.content LIKE ?"]
-            like_params: list = [f"%{raw_query}%"]
             if source_filter is not None:
-                like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
-                like_params.extend(source_filter)
+                source_placeholders = ",".join("?" for _ in source_filter)
+                where_clauses.append(f"s.source IN ({source_placeholders})")
+                params.extend(source_filter)
+
             if exclude_sources is not None:
-                like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
-                like_params.extend(exclude_sources)
+                exclude_placeholders = ",".join("?" for _ in exclude_sources)
+                where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
+                params.extend(exclude_sources)
+
             if role_filter:
-                like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
-                like_params.extend(role_filter)
-            like_sql = f"""
-                SELECT m.id, m.session_id, m.role,
-                       substr(m.content,
-                              max(1, instr(m.content, ?) - 40),
-                              120) AS snippet,
-                       m.content, m.timestamp, m.tool_name,
-                       s.source, s.model, s.started_at AS session_started
-                FROM messages m
+                role_placeholders = ",".join("?" for _ in role_filter)
+                where_clauses.append(f"m.role IN ({role_placeholders})")
+                params.extend(role_filter)
+
+            where_sql = " AND ".join(where_clauses)
+            params.extend([limit, offset])
+
+            sql = f"""
+                SELECT
+                    m.id,
+                    m.session_id,
+                    m.role,
+                    snippet(messages_fts, 0, '>>>', '<<<', '...', 40) AS snippet,
+                    m.content,
+                    m.timestamp,
+                    m.tool_name,
+                    s.source,
+                    s.model,
+                    s.started_at AS session_started
+                FROM messages_fts
+                JOIN messages m ON m.id = messages_fts.rowid
                 JOIN sessions s ON s.id = m.session_id
-                WHERE {' AND '.join(like_where)}
-                ORDER BY m.timestamp DESC
+                WHERE {where_sql}
+                ORDER BY rank
                 LIMIT ? OFFSET ?
             """
-            like_params.extend([limit, offset])
-            # instr() parameter goes first in the bound list
-            like_params = [raw_query] + like_params
+
             with self._lock:
-                like_cursor = self._conn.execute(like_sql, like_params)
-                matches = [dict(row) for row in like_cursor.fetchall()]
+                try:
+                    cursor = self._conn.execute(sql, params)
+                except sqlite3.OperationalError as exc:
+                    if "no such module: fts5" in str(exc).lower():
+                        self._fts5_available = False
+                    # FTS5 query syntax error despite sanitization — return empty
+                    # unless query contains CJK or FTS5 is unavailable.
+                    if self._fts5_available and not self._contains_cjk(query):
+                        return []
+                    matches = []
+                else:
+                    matches = [dict(row) for row in cursor.fetchall()]
+
+        # LIKE fallback for CJK queries: FTS5 default tokenizer splits CJK
+        # characters individually, causing multi-character queries to fail. The
+        # same fallback handles SQLite builds where FTS5 is absent entirely.
+        if not matches and (self._contains_cjk(query) or not self._fts5_available):
+            matches = self._search_messages_like(
+                query,
+                source_filter=source_filter,
+                exclude_sources=exclude_sources,
+                role_filter=role_filter,
+                limit=limit,
+                offset=offset,
+            )
 
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.
@@ -1653,4 +1718,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,7 @@ AUTHOR_MAP = {
     "teknium1@gmail.com": "teknium1",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "adam.manning@pro-serveinc.com": "amanning3390",
     "343873859@qq.com": "DrStrangerUJN",
     "uzmpsk.dilekakbas@gmail.com": "dlkakbs",
     "jefferson@heimdallstrategy.com": "Mind-Dragon",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -12,6 +12,16 @@ from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
 
+@pytest.fixture(autouse=True)
+def _isolate_scheduler_tick_lock(tmp_path):
+    """Use a per-test tick lock so xdist workers cannot skip each other."""
+    lock_dir = tmp_path / "cron"
+    lock_dir.mkdir()
+    with patch("cron.scheduler._LOCK_DIR", lock_dir), \
+         patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"):
+        yield
+
+
 class TestResolveOrigin:
     def test_full_origin(self):
         job = {
@@ -1556,15 +1566,6 @@ class TestSendMediaViaAdapter:
 
 class TestParallelTick:
     """Verify that tick() runs due jobs concurrently and isolates ContextVars."""
-
-    @pytest.fixture(autouse=True)
-    def _isolate_tick_lock(self, tmp_path):
-        """Point the tick file lock at a per-test temp dir to avoid xdist contention."""
-        lock_dir = tmp_path / "cron"
-        lock_dir.mkdir()
-        with patch("cron.scheduler._LOCK_DIR", lock_dir), \
-             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"):
-            yield
 
     def test_parallel_jobs_run_concurrently(self):
         """Two jobs launched in the same tick should overlap in time."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -363,6 +363,16 @@ class TestFTS5Search:
         snippets = [r.get("snippet", "") for r in results]
         assert any("docker" in s.lower() or "Docker" in s for s in snippets)
 
+    def test_search_falls_back_when_fts5_unavailable(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Fallback search still works")
+        db._fts5_available = False
+
+        results = db.search_messages("Fallback search")
+
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
     def test_search_empty_query(self, db):
         assert db.search_messages("") == []
         assert db.search_messages("   ") == []
@@ -1911,4 +1921,3 @@ class TestAutoMaintenance:
         assert marker is not None
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
-

--- a/tests/test_kanban.py
+++ b/tests/test_kanban.py
@@ -45,6 +45,40 @@ def test_create_card_validates_workspace(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert kanban.store.load().cards[0].id == card.id
 
 
+def test_create_card_stores_trimmed_model(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    card = asyncio.run(kanban.create_card(
+        CardCreateRequest(
+            title="Model task",
+            prompt="Run on a specific model",
+            model=" anthropic/claude-sonnet-4.6 ",
+            workspace_path=str(workspace),
+        )
+    ))
+
+    assert card.model == "anthropic/claude-sonnet-4.6"
+    assert kanban.store.load().cards[0].model == "anthropic/claude-sonnet-4.6"
+
+
+def test_update_card_clears_model(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    card = kanban.store.upsert_card(
+        KanbanCard(
+            title="Switch back",
+            prompt="Use the dashboard default again",
+            model="anthropic/claude-sonnet-4.6",
+        )
+    )
+
+    updated = asyncio.run(kanban.update_card(card.id, CardUpdateRequest(model="")))
+
+    assert updated.model is None
+    assert kanban.store.load().cards[0].model is None
+
+
 def test_create_card_rejects_missing_workspace(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
 
@@ -117,6 +151,81 @@ def test_start_card_records_start_failure(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert updated.status == "failed"
     assert updated.column == "review"
     assert updated.error == "boom"
+
+
+def test_start_card_passes_model_to_chat_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    monkeypatch.setattr(kanban, "get_hermes_home", lambda: tmp_path / "hermes-home")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    card = kanban.store.upsert_card(
+        KanbanCard(
+            title="Launch with model",
+            prompt="Use the selected model",
+            model="anthropic/claude-sonnet-4.6",
+            workspace_path=str(workspace),
+        )
+    )
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+        def wait(self):
+            return 0
+
+    class NoopThread:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured["cwd"] = kwargs["cwd"]
+        return FakeProcess()
+
+    monkeypatch.setattr(kanban.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(kanban.threading, "Thread", NoopThread)
+
+    updated = asyncio.run(kanban.start_card(card.id, CardStartRequest()))
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[command.index("--model") + 1] == "anthropic/claude-sonnet-4.6"
+    assert command[command.index("-q") + 1] == "Use the selected model"
+    assert captured["cwd"] == str(workspace)
+    assert updated.status == "running"
+    assert updated.model == "anthropic/claude-sonnet-4.6"
+
+
+def test_board_exposes_configured_model_options(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+
+    def fake_load_config():
+        return {
+            "model": {"provider": "nous", "default": "nous/deephermes-3-mistral-24b-preview"},
+            "providers": {
+                "local": {
+                    "name": "Local",
+                    "base_url": "http://localhost:1234/v1",
+                    "model": "local/hermes",
+                }
+            },
+        }
+
+    monkeypatch.setattr(kanban, "load_config", fake_load_config)
+
+    response = asyncio.run(kanban.get_board())
+
+    assert response.active_provider == "nous"
+    assert response.active_model == "nous/deephermes-3-mistral-24b-preview"
+    assert "nous/deephermes-3-mistral-24b-preview" in response.model_options
+    assert "local/hermes" in response.model_options
 
 
 def test_finish_does_not_overwrite_stopped_card(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):

--- a/tests/test_kanban.py
+++ b/tests/test_kanban.py
@@ -1,0 +1,141 @@
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from hermes_cli import kanban
+from hermes_cli.kanban import (
+    CardCreateRequest,
+    CardDiffResponse,
+    CardStartRequest,
+    CardUpdateRequest,
+    KanbanCard,
+    KanbanStore,
+)
+
+
+def test_kanban_store_round_trips_board(tmp_path: Path):
+    store = KanbanStore(tmp_path / "board.json")
+    card = KanbanCard(title="Build thing", prompt="Implement the thing")
+
+    store.upsert_card(card)
+
+    loaded = store.load()
+    assert loaded.cards[0].id == card.id
+    assert loaded.cards[0].title == "Build thing"
+    assert loaded.cards[0].status == "idle"
+
+
+def test_create_card_validates_workspace(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    card = asyncio.run(kanban.create_card(
+        CardCreateRequest(
+            title="Native task",
+            prompt="Run inside this workspace",
+            workspace_path=str(workspace),
+        )
+    ))
+
+    assert card.workspace_path == str(workspace)
+    assert kanban.store.load().cards[0].id == card.id
+
+
+def test_create_card_rejects_missing_workspace(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(kanban.create_card(
+            CardCreateRequest(
+                title="Bad workspace",
+                prompt="This should not be saved",
+                workspace_path=str(tmp_path / "missing"),
+            )
+        ))
+
+    assert exc.value.status_code == 400
+    assert kanban.store.load().cards == []
+
+
+def test_update_card_rejects_blank_prompt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    card = kanban.store.upsert_card(KanbanCard(title="Keep title", prompt="Keep prompt"))
+
+    with pytest.raises(ValueError):
+        CardUpdateRequest(prompt="   ")
+
+    loaded = kanban.store.load().cards[0]
+    assert loaded.id == card.id
+    assert loaded.prompt == "Keep prompt"
+
+
+def test_card_diff_reports_git_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True)
+    (workspace / "notes.txt").write_text("hello\n", encoding="utf-8")
+
+    card = kanban.store.upsert_card(
+        KanbanCard(
+            title="Review changes",
+            prompt="Inspect the diff",
+            workspace_path=str(workspace),
+        )
+    )
+
+    response = asyncio.run(kanban.get_card_diff(card.id))
+
+    assert isinstance(response, CardDiffResponse)
+    assert response.is_git_repo is True
+    assert "notes.txt" in response.summary
+
+
+def test_start_card_records_start_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    card = kanban.store.upsert_card(
+        KanbanCard(
+            title="Launch failure",
+            prompt="This launch is patched to fail",
+            workspace_path=str(workspace),
+        )
+    )
+
+    def fail_popen(*_args, **_kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(kanban.subprocess, "Popen", fail_popen)
+
+    updated = asyncio.run(kanban.start_card(card.id, CardStartRequest()))
+
+    assert updated.status == "failed"
+    assert updated.column == "review"
+    assert updated.error == "boom"
+
+
+def test_finish_does_not_overwrite_stopped_card(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(kanban, "store", KanbanStore(tmp_path / "board.json"))
+    card = kanban.store.upsert_card(
+        KanbanCard(
+            title="Stopped",
+            prompt="Do not resurrect as failed",
+            status="stopped",
+            column="review",
+            pid=123,
+            last_activity="Hermes task stopped.",
+        )
+    )
+
+    kanban._finish_card(card.id, -15)
+
+    loaded = kanban.store.load().cards[0]
+    assert loaded.status == "stopped"
+    assert loaded.column == "review"
+    assert loaded.pid is None
+    assert loaded.last_activity == "Hermes task stopped."

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -109,7 +109,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
-  { path: "/kanban", label: "Kanban", icon: Columns3 },
+  { path: "/kanban", labelKey: "kanban", label: "Kanban", icon: Columns3 },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/config", labelKey: "config", label: "Config", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
   Shield,
   Sparkles,
   Star,
+  Columns3,
   Terminal,
   Wrench,
   X,
@@ -57,6 +58,7 @@ import SessionsPage from "@/pages/SessionsPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import CronPage from "@/pages/CronPage";
+import KanbanPage from "@/pages/KanbanPage";
 import SkillsPage from "@/pages/SkillsPage";
 import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
@@ -85,6 +87,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/analytics": AnalyticsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
+  "/kanban": KanbanPage,
   "/skills": SkillsPage,
   "/config": ConfigPage,
   "/env": EnvPage,
@@ -106,6 +109,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/kanban", label: "Kanban", icon: Columns3 },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/config", labelKey: "config", label: "Config", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
@@ -137,6 +141,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Heart,
   Star,
   Code,
+  Columns3,
   Eye,
 };
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -72,6 +72,7 @@ export const en: Translations = {
       config: "Config",
       cron: "Cron",
       documentation: "Documentation",
+      kanban: "Kanban",
       keys: "Keys",
       logs: "Logs",
       sessions: "Sessions",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -72,6 +72,7 @@ export interface Translations {
       config: string;
       cron: string;
       documentation: string;
+      kanban: string;
       keys: string;
       logs: string;
       sessions: string;

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -71,6 +71,7 @@ export const zh: Translations = {
       config: "配置",
       cron: "定时任务",
       documentation: "文档",
+      kanban: "看板",
       keys: "密钥",
       logs: "日志",
       sessions: "会话",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -136,6 +136,46 @@ export const api = {
   searchSessions: (q: string) =>
     fetchJSON<SessionSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(q)}`),
 
+  // Kanban
+  getKanbanBoard: () => fetchJSON<KanbanBoardResponse>("/api/kanban/board"),
+  createKanbanCard: (card: { title: string; prompt: string; workspace_path?: string }) =>
+    fetchJSON<KanbanCard>("/api/kanban/cards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(card),
+    }),
+  updateKanbanCard: (
+    id: string,
+    card: Partial<Pick<KanbanCard, "title" | "prompt" | "column" | "workspace_path">>,
+  ) =>
+    fetchJSON<KanbanCard>(`/api/kanban/cards/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(card),
+    }),
+  deleteKanbanCard: (id: string) =>
+    fetchJSON<{ ok: boolean }>(`/api/kanban/cards/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    }),
+  startKanbanCard: (id: string, workspace_path?: string) =>
+    fetchJSON<KanbanCard>(`/api/kanban/cards/${encodeURIComponent(id)}/start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workspace_path }),
+    }),
+  stopKanbanCard: (id: string) =>
+    fetchJSON<KanbanCard>(`/api/kanban/cards/${encodeURIComponent(id)}/stop`, {
+      method: "POST",
+    }),
+  getKanbanCardLog: (id: string, lines = 160) =>
+    fetchJSON<KanbanCardLogResponse>(
+      `/api/kanban/cards/${encodeURIComponent(id)}/log?lines=${lines}`,
+    ),
+  getKanbanCardDiff: (id: string) =>
+    fetchJSON<KanbanCardDiffResponse>(
+      `/api/kanban/cards/${encodeURIComponent(id)}/diff`,
+    ),
+
   // OAuth provider management
   getOAuthProviders: () =>
     fetchJSON<OAuthProvidersResponse>("/api/providers/oauth"),
@@ -256,6 +296,57 @@ export interface StatusResponse {
   latest_config_version: number;
   release_date: string;
   version: string;
+}
+
+export type KanbanColumnId = "backlog" | "running" | "review" | "done" | "trash";
+export type KanbanTaskStatus = "idle" | "running" | "review" | "done" | "failed" | "stopped";
+
+export interface KanbanColumn {
+  id: KanbanColumnId;
+  title: string;
+}
+
+export interface KanbanCard {
+  id: string;
+  title: string;
+  prompt: string;
+  column: KanbanColumnId;
+  status: KanbanTaskStatus;
+  workspace_path: string | null;
+  pid: number | null;
+  log_path: string | null;
+  last_activity: string | null;
+  error: string | null;
+  created_at: number;
+  updated_at: number;
+  started_at: number | null;
+  finished_at: number | null;
+}
+
+export interface KanbanBoard {
+  version: number;
+  cards: KanbanCard[];
+  updated_at: number;
+}
+
+export interface KanbanBoardResponse {
+  board: KanbanBoard;
+  columns: KanbanColumn[];
+  default_workspace_path: string;
+}
+
+export interface KanbanCardLogResponse {
+  card_id: string;
+  log: string;
+  log_path: string | null;
+}
+
+export interface KanbanCardDiffResponse {
+  card_id: string;
+  workspace_path: string | null;
+  is_git_repo: boolean;
+  summary: string;
+  diff: string;
 }
 
 export interface SessionInfo {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -138,7 +138,7 @@ export const api = {
 
   // Kanban
   getKanbanBoard: () => fetchJSON<KanbanBoardResponse>("/api/kanban/board"),
-  createKanbanCard: (card: { title: string; prompt: string; workspace_path?: string }) =>
+  createKanbanCard: (card: { title: string; prompt: string; model?: string; workspace_path?: string }) =>
     fetchJSON<KanbanCard>("/api/kanban/cards", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -146,7 +146,7 @@ export const api = {
     }),
   updateKanbanCard: (
     id: string,
-    card: Partial<Pick<KanbanCard, "title" | "prompt" | "column" | "workspace_path">>,
+    card: Partial<Pick<KanbanCard, "title" | "prompt" | "model" | "column" | "workspace_path">>,
   ) =>
     fetchJSON<KanbanCard>(`/api/kanban/cards/${encodeURIComponent(id)}`, {
       method: "PUT",
@@ -157,11 +157,11 @@ export const api = {
     fetchJSON<{ ok: boolean }>(`/api/kanban/cards/${encodeURIComponent(id)}`, {
       method: "DELETE",
     }),
-  startKanbanCard: (id: string, workspace_path?: string) =>
+  startKanbanCard: (id: string, workspace_path?: string, model?: string | null) =>
     fetchJSON<KanbanCard>(`/api/kanban/cards/${encodeURIComponent(id)}/start`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ workspace_path }),
+      body: JSON.stringify({ workspace_path, model }),
     }),
   stopKanbanCard: (id: string) =>
     fetchJSON<KanbanCard>(`/api/kanban/cards/${encodeURIComponent(id)}/stop`, {
@@ -310,6 +310,7 @@ export interface KanbanCard {
   id: string;
   title: string;
   prompt: string;
+  model: string | null;
   column: KanbanColumnId;
   status: KanbanTaskStatus;
   workspace_path: string | null;
@@ -333,6 +334,9 @@ export interface KanbanBoardResponse {
   board: KanbanBoard;
   columns: KanbanColumn[];
   default_workspace_path: string;
+  active_model: string;
+  active_provider: string;
+  model_options: string[];
 }
 
 export interface KanbanCardLogResponse {

--- a/web/src/pages/KanbanPage.tsx
+++ b/web/src/pages/KanbanPage.tsx
@@ -1,0 +1,565 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  FileDiff,
+  Loader2,
+  Play,
+  RefreshCw,
+  Square,
+  Terminal,
+  Trash2,
+} from "lucide-react";
+import { H2 } from "@nous-research/ui";
+import { api } from "@/lib/api";
+import type {
+  KanbanCard,
+  KanbanCardDiffResponse,
+  KanbanCardLogResponse,
+  KanbanColumn,
+  KanbanColumnId,
+  KanbanTaskStatus,
+} from "@/lib/api";
+import { cn, timeAgo } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+const STATUS_LABEL: Record<KanbanTaskStatus, string> = {
+  idle: "Idle",
+  running: "Running",
+  review: "Review",
+  done: "Done",
+  failed: "Failed",
+  stopped: "Stopped",
+};
+
+const STATUS_STYLE: Record<KanbanTaskStatus, string> = {
+  idle: "border-muted-foreground/30 text-muted-foreground",
+  running: "border-warning/40 bg-warning/10 text-warning",
+  review: "border-foreground/30 bg-foreground/10 text-foreground",
+  done: "border-success/40 bg-success/10 text-success",
+  failed: "border-destructive/40 bg-destructive/10 text-destructive",
+  stopped: "border-muted-foreground/30 bg-muted text-muted-foreground",
+};
+
+function byUpdatedAt(a: KanbanCard, b: KanbanCard) {
+  return b.updated_at - a.updated_at;
+}
+
+function StatusBadge({ status }: { status: KanbanTaskStatus }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center border px-2 py-0.5 font-compressed text-[0.62rem] tracking-[0.14em] uppercase",
+        STATUS_STYLE[status],
+      )}
+    >
+      {status === "running" && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+      {status === "done" && <CheckCircle2 className="mr-1 h-3 w-3" />}
+      {status === "failed" && <AlertCircle className="mr-1 h-3 w-3" />}
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function BoardCard({
+  card,
+  selected,
+  onSelect,
+  onStart,
+  onStop,
+}: {
+  card: KanbanCard;
+  selected: boolean;
+  onSelect: () => void;
+  onStart: () => void;
+  onStop: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "group w-full border bg-card/70 p-3 text-left transition-colors",
+        "hover:bg-card focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        selected ? "border-foreground/55" : "border-border",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="min-w-0 text-sm font-semibold normal-case tracking-normal text-foreground">
+          {card.title}
+        </h3>
+        <StatusBadge status={card.status} />
+      </div>
+      <p className="mt-2 line-clamp-3 text-xs normal-case leading-relaxed tracking-normal text-muted-foreground">
+        {card.prompt}
+      </p>
+      <div className="mt-3 flex items-center justify-between gap-2 text-[0.65rem] text-muted-foreground">
+        <span className="min-w-0 truncate font-mono-ui">
+          {card.workspace_path ?? "workspace unset"}
+        </span>
+        <span className="shrink-0">{timeAgo(card.updated_at)}</span>
+      </div>
+      {card.last_activity && (
+        <div className="mt-2 border-t border-border pt-2 text-[0.68rem] normal-case leading-snug tracking-normal text-muted-foreground/90">
+          {card.last_activity}
+        </div>
+      )}
+      <div className="mt-3 flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+        {card.status === "running" ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7"
+            onClick={(event) => {
+              event.stopPropagation();
+              onStop();
+            }}
+          >
+            <Square className="h-3 w-3" />
+            Stop
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            className="h-7"
+            onClick={(event) => {
+              event.stopPropagation();
+              onStart();
+            }}
+          >
+            <Play className="h-3 w-3" />
+            Start
+          </Button>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function DetailPanel({
+  card,
+  diff,
+  log,
+  busy,
+  onRefresh,
+  onStart,
+  onStop,
+  onSave,
+  onMove,
+  onDelete,
+}: {
+  card: KanbanCard | null;
+  diff: KanbanCardDiffResponse | null;
+  log: KanbanCardLogResponse | null;
+  busy: boolean;
+  onRefresh: () => void;
+  onStart: () => void;
+  onStop: () => void;
+  onSave: (values: { title: string; prompt: string; workspace_path: string }) => void;
+  onMove: (column: KanbanColumnId) => void;
+  onDelete: () => void;
+}) {
+  const [editTitle, setEditTitle] = useState("");
+  const [editPrompt, setEditPrompt] = useState("");
+  const [editWorkspace, setEditWorkspace] = useState("");
+
+  useEffect(() => {
+    setEditTitle(card?.title ?? "");
+    setEditPrompt(card?.prompt ?? "");
+    setEditWorkspace(card?.workspace_path ?? "");
+  }, [card?.id, card?.prompt, card?.title, card?.workspace_path]);
+
+  if (!card) {
+    return (
+      <Card className="lg:sticky lg:top-20">
+        <CardHeader>
+          <CardTitle>Task</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm normal-case tracking-normal text-muted-foreground">
+          Select a card.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="lg:sticky lg:top-20">
+      <CardHeader className="gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <CardTitle className="truncate">{card.title}</CardTitle>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <StatusBadge status={card.status} />
+              {card.pid && <Badge variant="outline">PID {card.pid}</Badge>}
+            </div>
+          </div>
+          <Button size="icon" variant="ghost" onClick={onRefresh} disabled={busy} aria-label="Refresh card">
+            <RefreshCw className={cn("h-4 w-4", busy && "animate-spin")} />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="mb-1 font-compressed text-[0.7rem] uppercase tracking-[0.16em] text-muted-foreground">
+            Edit Card
+          </div>
+          <Input
+            value={editTitle}
+            onChange={(event) => setEditTitle(event.target.value)}
+            disabled={card.status === "running"}
+            className="normal-case tracking-normal"
+          />
+          <textarea
+            value={editPrompt}
+            onChange={(event) => setEditPrompt(event.target.value)}
+            disabled={card.status === "running"}
+            className={cn(
+              "min-h-28 w-full resize-y border border-input bg-transparent px-3 py-2",
+              "text-sm normal-case tracking-normal text-foreground",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            )}
+          />
+          <Input
+            value={editWorkspace}
+            onChange={(event) => setEditWorkspace(event.target.value)}
+            disabled={card.status === "running"}
+            className="font-mono-ui text-xs normal-case tracking-normal"
+          />
+          <Button
+            variant="outline"
+            disabled={
+              card.status === "running" ||
+              !editTitle.trim() ||
+              !editPrompt.trim() ||
+              !editWorkspace.trim()
+            }
+            onClick={() =>
+              onSave({
+                title: editTitle,
+                prompt: editPrompt,
+                workspace_path: editWorkspace,
+              })
+            }
+          >
+            Save
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          {card.status === "running" ? (
+            <Button variant="outline" onClick={onStop}>
+              <Square className="h-4 w-4" />
+              Stop
+            </Button>
+          ) : (
+            <Button onClick={onStart}>
+              <Play className="h-4 w-4" />
+              Start
+            </Button>
+          )}
+          <Button variant="outline" onClick={() => onMove("done")}>
+            <CheckCircle2 className="h-4 w-4" />
+            Done
+          </Button>
+          <Button variant="outline" onClick={() => onMove("backlog")}>
+            Backlog
+          </Button>
+          <Button variant="outline" onClick={() => onMove("trash")}>
+            Trash
+          </Button>
+          <Button variant="destructive" onClick={onDelete}>
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </Button>
+        </div>
+
+        <section>
+          <div className="mb-2 flex items-center gap-2 font-compressed text-[0.7rem] uppercase tracking-[0.16em] text-muted-foreground">
+            <Terminal className="h-3.5 w-3.5" />
+            Log
+          </div>
+          <pre className="max-h-52 overflow-auto border border-border bg-black/35 p-3 text-[0.7rem] normal-case leading-relaxed tracking-normal text-muted-foreground">
+            {log?.log || "No log yet."}
+          </pre>
+        </section>
+
+        <section>
+          <div className="mb-2 flex items-center gap-2 font-compressed text-[0.7rem] uppercase tracking-[0.16em] text-muted-foreground">
+            <FileDiff className="h-3.5 w-3.5" />
+            Diff
+          </div>
+          <div className="mb-2 border border-border bg-background/40 px-2 py-1 text-xs normal-case tracking-normal text-muted-foreground">
+            {diff?.summary ?? "No diff loaded."}
+          </div>
+          <pre className="max-h-64 overflow-auto border border-border bg-black/35 p-3 text-[0.7rem] normal-case leading-relaxed tracking-normal text-muted-foreground">
+            {diff?.diff || "No patch."}
+          </pre>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function KanbanPage() {
+  const [columns, setColumns] = useState<KanbanColumn[]>([]);
+  const [cards, setCards] = useState<KanbanCard[]>([]);
+  const [defaultWorkspace, setDefaultWorkspace] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [workspace, setWorkspace] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [log, setLog] = useState<KanbanCardLogResponse | null>(null);
+  const [diff, setDiff] = useState<KanbanCardDiffResponse | null>(null);
+
+  const selectedCard = useMemo(
+    () => cards.find((card) => card.id === selectedId) ?? null,
+    [cards, selectedId],
+  );
+
+  const groupedCards = useMemo(() => {
+    const groups = new Map<KanbanColumnId, KanbanCard[]>();
+    for (const column of columns) groups.set(column.id, []);
+    for (const card of cards) {
+      groups.get(card.column)?.push(card);
+    }
+    for (const group of groups.values()) group.sort(byUpdatedAt);
+    return groups;
+  }, [cards, columns]);
+
+  const refreshBoard = useCallback(async () => {
+    const response = await api.getKanbanBoard();
+    setColumns(response.columns);
+    setCards(response.board.cards);
+    setDefaultWorkspace(response.default_workspace_path);
+    setWorkspace((current) => current || response.default_workspace_path);
+    if (!selectedId && response.board.cards.length > 0) {
+      setSelectedId(response.board.cards[0].id);
+    }
+  }, [selectedId]);
+
+  const refreshDetail = useCallback(async (cardId: string) => {
+    const [nextLog, nextDiff] = await Promise.all([
+      api.getKanbanCardLog(cardId),
+      api.getKanbanCardDiff(cardId),
+    ]);
+    setLog(nextLog);
+    setDiff(nextDiff);
+  }, []);
+
+  const runAction = useCallback(async (action: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await action();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    runAction(refreshBoard);
+  }, [refreshBoard, runAction]);
+
+  useEffect(() => {
+    if (!selectedCard) {
+      setLog(null);
+      setDiff(null);
+      return;
+    }
+    runAction(() => refreshDetail(selectedCard.id));
+  }, [selectedCard?.id, refreshDetail, runAction]);
+
+  useEffect(() => {
+    if (!cards.some((card) => card.status === "running")) return;
+    const id = window.setInterval(() => {
+      refreshBoard().catch(() => {});
+      if (selectedId) refreshDetail(selectedId).catch(() => {});
+    }, 4000);
+    return () => window.clearInterval(id);
+  }, [cards, refreshBoard, refreshDetail, selectedId]);
+
+  function replaceCard(card: KanbanCard) {
+    setCards((current) => current.map((item) => (item.id === card.id ? card : item)));
+    setSelectedId(card.id);
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <H2 className="blend-lighter">Kanban</H2>
+          <div className="mt-1 text-xs normal-case tracking-normal text-muted-foreground">
+            {cards.length} cards · {cards.filter((card) => card.status === "running").length} running
+          </div>
+        </div>
+        <Button variant="outline" onClick={() => runAction(refreshBoard)} disabled={busy}>
+          <RefreshCw className={cn("h-4 w-4", busy && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <div className="border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm normal-case tracking-normal text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>New Card</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 lg:grid-cols-[1fr_1.6fr_1fr_auto]">
+          <Input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Title"
+            className="normal-case tracking-normal"
+          />
+          <textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Prompt"
+            className={cn(
+              "min-h-9 resize-y border border-input bg-transparent px-3 py-2",
+              "text-sm normal-case tracking-normal text-foreground placeholder:text-muted-foreground",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            )}
+          />
+          <Input
+            value={workspace}
+            onChange={(event) => setWorkspace(event.target.value)}
+            placeholder={defaultWorkspace || "Workspace path"}
+            className="font-mono-ui text-xs normal-case tracking-normal"
+          />
+          <Button
+            disabled={busy || !title.trim() || !prompt.trim()}
+            onClick={() =>
+              runAction(async () => {
+                const card = await api.createKanbanCard({
+                  title,
+                  prompt,
+                  workspace_path: workspace || defaultWorkspace,
+                });
+                setCards((current) => [card, ...current]);
+                setSelectedId(card.id);
+                setTitle("");
+                setPrompt("");
+              })
+            }
+          >
+            Add
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          {columns.map((column) => {
+            const items = groupedCards.get(column.id) ?? [];
+            return (
+              <section key={column.id} className="min-w-0 border border-border bg-background/25">
+                <div className="flex items-center justify-between border-b border-border px-3 py-2">
+                  <h2 className="font-expanded text-xs font-bold uppercase tracking-[0.12em] text-foreground">
+                    {column.title}
+                  </h2>
+                  <Badge variant="outline">{items.length}</Badge>
+                </div>
+                <div className="flex min-h-72 flex-col gap-2 p-2">
+                  {items.map((card) => (
+                    <BoardCard
+                      key={card.id}
+                      card={card}
+                      selected={card.id === selectedId}
+                      onSelect={() => setSelectedId(card.id)}
+                      onStart={() =>
+                        runAction(async () => {
+                          const updated = await api.startKanbanCard(card.id, card.workspace_path ?? workspace);
+                          replaceCard(updated);
+                          await refreshDetail(updated.id);
+                        })
+                      }
+                      onStop={() =>
+                        runAction(async () => {
+                          const updated = await api.stopKanbanCard(card.id);
+                          replaceCard(updated);
+                          await refreshDetail(updated.id);
+                        })
+                      }
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+
+        <DetailPanel
+          card={selectedCard}
+          log={log}
+          diff={diff}
+          busy={busy}
+          onRefresh={() =>
+            selectedCard &&
+            runAction(async () => {
+              await refreshBoard();
+              await refreshDetail(selectedCard.id);
+            })
+          }
+          onStart={() =>
+            selectedCard &&
+            runAction(async () => {
+              const updated = await api.startKanbanCard(
+                selectedCard.id,
+                selectedCard.workspace_path ?? workspace,
+              );
+              replaceCard(updated);
+              await refreshDetail(updated.id);
+            })
+          }
+          onStop={() =>
+            selectedCard &&
+            runAction(async () => {
+              const updated = await api.stopKanbanCard(selectedCard.id);
+              replaceCard(updated);
+              await refreshDetail(updated.id);
+            })
+          }
+          onSave={(values) =>
+            selectedCard &&
+            runAction(async () => {
+              const updated = await api.updateKanbanCard(selectedCard.id, values);
+              replaceCard(updated);
+              await refreshDetail(updated.id);
+            })
+          }
+          onMove={(column) =>
+            selectedCard &&
+            runAction(async () => {
+              const updated = await api.updateKanbanCard(selectedCard.id, { column });
+              replaceCard(updated);
+              await refreshDetail(updated.id);
+            })
+          }
+          onDelete={() =>
+            selectedCard &&
+            runAction(async () => {
+              await api.deleteKanbanCard(selectedCard.id);
+              setCards((current) => current.filter((card) => card.id !== selectedCard.id));
+              setSelectedId(null);
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/KanbanPage.tsx
+++ b/web/src/pages/KanbanPage.tsx
@@ -16,6 +16,7 @@ import type {
   KanbanCard,
   KanbanCardDiffResponse,
   KanbanCardLogResponse,
+  KanbanBoardResponse,
   KanbanColumn,
   KanbanColumnId,
   KanbanTaskStatus,
@@ -25,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Select, SelectOption } from "@/components/ui/select";
 
 const STATUS_LABEL: Record<KanbanTaskStatus, string> = {
   idle: "Idle",
@@ -64,6 +66,40 @@ function StatusBadge({ status }: { status: KanbanTaskStatus }) {
   );
 }
 
+function ModelSelect({
+  value,
+  onValueChange,
+  options,
+  activeModel,
+  disabled,
+  className,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  options: string[];
+  activeModel: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const fallbackLabel = activeModel ? `Dashboard default (${activeModel})` : "Dashboard default";
+
+  return (
+    <Select
+      value={value}
+      onValueChange={onValueChange}
+      disabled={disabled}
+      className={className}
+    >
+      <SelectOption value="">{fallbackLabel}</SelectOption>
+      {options.map((option) => (
+        <SelectOption key={option} value={option}>
+          {option}
+        </SelectOption>
+      ))}
+    </Select>
+  );
+}
+
 function BoardCard({
   card,
   selected,
@@ -97,9 +133,10 @@ function BoardCard({
         {card.prompt}
       </p>
       <div className="mt-3 flex items-center justify-between gap-2 text-[0.65rem] text-muted-foreground">
-        <span className="min-w-0 truncate font-mono-ui">
-          {card.workspace_path ?? "workspace unset"}
-        </span>
+        <div className="min-w-0 space-y-1">
+          <div className="truncate font-mono-ui">{card.workspace_path ?? "workspace unset"}</div>
+          <div className="truncate font-mono-ui">{card.model ?? "dashboard default model"}</div>
+        </div>
         <span className="shrink-0">{timeAgo(card.updated_at)}</span>
       </div>
       {card.last_activity && (
@@ -152,6 +189,8 @@ function DetailPanel({
   onSave,
   onMove,
   onDelete,
+  activeModel,
+  modelOptions,
 }: {
   card: KanbanCard | null;
   diff: KanbanCardDiffResponse | null;
@@ -160,19 +199,16 @@ function DetailPanel({
   onRefresh: () => void;
   onStart: () => void;
   onStop: () => void;
-  onSave: (values: { title: string; prompt: string; workspace_path: string }) => void;
+  onSave: (values: { title: string; prompt: string; model: string; workspace_path: string }) => void;
   onMove: (column: KanbanColumnId) => void;
   onDelete: () => void;
+  activeModel: string;
+  modelOptions: string[];
 }) {
-  const [editTitle, setEditTitle] = useState("");
-  const [editPrompt, setEditPrompt] = useState("");
-  const [editWorkspace, setEditWorkspace] = useState("");
-
-  useEffect(() => {
-    setEditTitle(card?.title ?? "");
-    setEditPrompt(card?.prompt ?? "");
-    setEditWorkspace(card?.workspace_path ?? "");
-  }, [card?.id, card?.prompt, card?.title, card?.workspace_path]);
+  const [editTitle, setEditTitle] = useState(card?.title ?? "");
+  const [editPrompt, setEditPrompt] = useState(card?.prompt ?? "");
+  const [editModel, setEditModel] = useState(card?.model ?? "");
+  const [editWorkspace, setEditWorkspace] = useState(card?.workspace_path ?? "");
 
   if (!card) {
     return (
@@ -196,6 +232,7 @@ function DetailPanel({
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <StatusBadge status={card.status} />
               {card.pid && <Badge variant="outline">PID {card.pid}</Badge>}
+              {card.model && <Badge variant="outline">{card.model}</Badge>}
             </div>
           </div>
           <Button size="icon" variant="ghost" onClick={onRefresh} disabled={busy} aria-label="Refresh card">
@@ -225,6 +262,13 @@ function DetailPanel({
               "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
             )}
           />
+          <ModelSelect
+            value={editModel}
+            onValueChange={setEditModel}
+            options={modelOptions}
+            activeModel={activeModel}
+            disabled={card.status === "running"}
+          />
           <Input
             value={editWorkspace}
             onChange={(event) => setEditWorkspace(event.target.value)}
@@ -243,6 +287,7 @@ function DetailPanel({
               onSave({
                 title: editTitle,
                 prompt: editPrompt,
+                model: editModel,
                 workspace_path: editWorkspace,
               })
             }
@@ -313,7 +358,11 @@ export default function KanbanPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [prompt, setPrompt] = useState("");
+  const [model, setModel] = useState("");
   const [workspace, setWorkspace] = useState("");
+  const [activeModel, setActiveModel] = useState("");
+  const [activeProvider, setActiveProvider] = useState("");
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [log, setLog] = useState<KanbanCardLogResponse | null>(null);
@@ -323,6 +372,8 @@ export default function KanbanPage() {
     () => cards.find((card) => card.id === selectedId) ?? null,
     [cards, selectedId],
   );
+  const selectedLog = selectedCard && log?.card_id === selectedCard.id ? log : null;
+  const selectedDiff = selectedCard && diff?.card_id === selectedCard.id ? diff : null;
 
   const groupedCards = useMemo(() => {
     const groups = new Map<KanbanColumnId, KanbanCard[]>();
@@ -334,16 +385,23 @@ export default function KanbanPage() {
     return groups;
   }, [cards, columns]);
 
-  const refreshBoard = useCallback(async () => {
-    const response = await api.getKanbanBoard();
+  const applyBoardResponse = useCallback((response: KanbanBoardResponse) => {
     setColumns(response.columns);
     setCards(response.board.cards);
     setDefaultWorkspace(response.default_workspace_path);
+    setActiveModel(response.active_model);
+    setActiveProvider(response.active_provider);
+    setModelOptions(response.model_options);
     setWorkspace((current) => current || response.default_workspace_path);
     if (!selectedId && response.board.cards.length > 0) {
       setSelectedId(response.board.cards[0].id);
     }
   }, [selectedId]);
+
+  const refreshBoard = useCallback(async () => {
+    const response = await api.getKanbanBoard();
+    applyBoardResponse(response);
+  }, [applyBoardResponse]);
 
   const refreshDetail = useCallback(async (cardId: string) => {
     const [nextLog, nextDiff] = await Promise.all([
@@ -367,17 +425,39 @@ export default function KanbanPage() {
   }, []);
 
   useEffect(() => {
-    runAction(refreshBoard);
-  }, [refreshBoard, runAction]);
+    let cancelled = false;
+    api
+      .getKanbanBoard()
+      .then((response) => {
+        if (!cancelled) applyBoardResponse(response);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [applyBoardResponse]);
 
   useEffect(() => {
-    if (!selectedCard) {
-      setLog(null);
-      setDiff(null);
-      return;
-    }
-    runAction(() => refreshDetail(selectedCard.id));
-  }, [selectedCard?.id, refreshDetail, runAction]);
+    if (!selectedId) return;
+    let cancelled = false;
+    Promise.all([
+      api.getKanbanCardLog(selectedId),
+      api.getKanbanCardDiff(selectedId),
+    ])
+      .then(([nextLog, nextDiff]) => {
+        if (cancelled) return;
+        setLog(nextLog);
+        setDiff(nextDiff);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
 
   useEffect(() => {
     if (!cards.some((card) => card.status === "running")) return;
@@ -400,6 +480,7 @@ export default function KanbanPage() {
           <H2 className="blend-lighter">Kanban</H2>
           <div className="mt-1 text-xs normal-case tracking-normal text-muted-foreground">
             {cards.length} cards · {cards.filter((card) => card.status === "running").length} running
+            {activeModel && <> · {activeProvider}/{activeModel}</>}
           </div>
         </div>
         <Button variant="outline" onClick={() => runAction(refreshBoard)} disabled={busy}>
@@ -418,7 +499,7 @@ export default function KanbanPage() {
         <CardHeader>
           <CardTitle>New Card</CardTitle>
         </CardHeader>
-        <CardContent className="grid gap-3 lg:grid-cols-[1fr_1.6fr_1fr_auto]">
+        <CardContent className="grid gap-3 lg:grid-cols-[1fr_1.6fr_1fr_1fr_auto]">
           <Input
             value={title}
             onChange={(event) => setTitle(event.target.value)}
@@ -435,6 +516,12 @@ export default function KanbanPage() {
               "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
             )}
           />
+          <ModelSelect
+            value={model}
+            onValueChange={setModel}
+            options={modelOptions}
+            activeModel={activeModel}
+          />
           <Input
             value={workspace}
             onChange={(event) => setWorkspace(event.target.value)}
@@ -448,12 +535,14 @@ export default function KanbanPage() {
                 const card = await api.createKanbanCard({
                   title,
                   prompt,
+                  model: model || undefined,
                   workspace_path: workspace || defaultWorkspace,
                 });
                 setCards((current) => [card, ...current]);
                 setSelectedId(card.id);
                 setTitle("");
                 setPrompt("");
+                setModel("");
               })
             }
           >
@@ -483,7 +572,11 @@ export default function KanbanPage() {
                       onSelect={() => setSelectedId(card.id)}
                       onStart={() =>
                         runAction(async () => {
-                          const updated = await api.startKanbanCard(card.id, card.workspace_path ?? workspace);
+                          const updated = await api.startKanbanCard(
+                            card.id,
+                            card.workspace_path ?? workspace,
+                            card.model,
+                          );
                           replaceCard(updated);
                           await refreshDetail(updated.id);
                         })
@@ -504,9 +597,10 @@ export default function KanbanPage() {
         </div>
 
         <DetailPanel
+          key={selectedCard?.id ?? "empty"}
           card={selectedCard}
-          log={log}
-          diff={diff}
+          log={selectedLog}
+          diff={selectedDiff}
           busy={busy}
           onRefresh={() =>
             selectedCard &&
@@ -521,6 +615,7 @@ export default function KanbanPage() {
               const updated = await api.startKanbanCard(
                 selectedCard.id,
                 selectedCard.workspace_path ?? workspace,
+                selectedCard.model,
               );
               replaceCard(updated);
               await refreshDetail(updated.id);
@@ -558,6 +653,8 @@ export default function KanbanPage() {
               setSelectedId(null);
             })
           }
+          activeModel={activeModel}
+          modelOptions={modelOptions}
         />
       </div>
     </div>

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -8,7 +8,9 @@ The Kanban dashboard tab lets you queue and monitor Hermes work from the web UI.
 hermes dashboard
 ```
 
-Open the **Kanban** tab, enter a title, prompt, and workspace path, then click **Add**. The workspace path must point to an existing directory.
+Open the **Kanban** tab, enter a title, prompt, optional model override, and workspace path, then click **Add**. The workspace path must point to an existing directory.
+
+The model selector defaults to the dashboard's active Hermes model. Choosing a model on a card stores that override with the card and passes it to `hermes chat --model` whenever the card starts.
 
 ## Card Lifecycle
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1,0 +1,45 @@
+# Kanban
+
+The Kanban dashboard tab lets you queue and monitor Hermes work from the web UI. Cards are native Hermes tasks: starting a card runs `hermes chat` in the selected workspace, records the task log under your Hermes home directory, and moves the card to review when the process exits.
+
+## Start
+
+```bash
+hermes dashboard
+```
+
+Open the **Kanban** tab, enter a title, prompt, and workspace path, then click **Add**. The workspace path must point to an existing directory.
+
+## Card Lifecycle
+
+Cards move through five columns:
+
+| Column | Meaning |
+| --- | --- |
+| Backlog | Planned work that has not started |
+| Running | A Hermes process is active for the card |
+| Review | The task finished, stopped, or failed and needs inspection |
+| Done | Work has been accepted |
+| Trash | Archived board items |
+
+The detail panel shows the prompt, workspace, latest log output, and git diff for the card workspace. If the workspace is a git repository, the diff panel reports `git status --short` and the current unstaged patch.
+
+## Storage
+
+Board data is stored at:
+
+```text
+~/.hermes/kanban/board.json
+```
+
+Task logs are stored at:
+
+```text
+~/.hermes/kanban/logs/
+```
+
+These paths are profile-aware and follow the active Hermes home.
+
+## Security
+
+Kanban uses the same dashboard session-token protection as other sensitive dashboard endpoints. Task launch uses argument lists rather than shell interpolation, and workspace paths are resolved before execution. The dashboard still runs local Hermes processes with your account permissions, so review prompts before starting cards.

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -165,6 +165,15 @@ Create and manage scheduled cron jobs that run agent prompts on a recurring sche
 - **Trigger now** — immediately execute a job outside its normal schedule
 - **Delete** — permanently remove a cron job
 
+### Kanban
+
+Create and monitor dashboard task cards that run Hermes in a selected workspace.
+
+- **Create** — add a card with a title, prompt, and workspace path
+- **Run / Stop** — launch or terminate the Hermes process attached to a card
+- **Review** — inspect the task log and git diff for the card workspace
+- **Archive** — move accepted work to Done or delete cards that are no longer needed
+
 ### Skills
 
 Browse, search, and toggle skills and toolsets. Skills are loaded from `~/.hermes/skills/` and grouped by category.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -82,6 +82,8 @@ const sidebars: SidebarsConfig = {
           items: [
             'user-guide/features/web-dashboard',
             'user-guide/features/extending-the-dashboard',
+            'user-guide/features/kanban',
+            'user-guide/features/dashboard-plugins',
           ],
         },
         {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -83,7 +83,6 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/web-dashboard',
             'user-guide/features/extending-the-dashboard',
             'user-guide/features/kanban',
-            'user-guide/features/dashboard-plugins',
           ],
         },
         {


### PR DESCRIPTION
## Summary
- Add a native Kanban dashboard tab with persistent cards, agent start/stop controls, logs, diffs, and Hermes-styled UI
- Wire Kanban API routes into the Web UI and document the feature in the user guide
- Harden dashboard reliability for SQLite builds without FTS5 and merge singleton config categories
- Stabilize Cron scheduler tests by isolating per-test tick locks under xdist

## Verification
- scripts/run_tests.sh tests/test_kanban.py tests/test_hermes_state.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_pty_bridge.py tests/cron/test_jobs.py tests/cron/test_scheduler.py
- npm run build (web)
- Live dashboard smoke on http://127.0.0.1:9121: /api/status, /api/sessions, /chat, Kanban create/move/list, Cron create/pause/delete
