### PR TITLE
fix(auxiliary): convert Codex tool messages for Responses API

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -365,20 +365,22 @@ class _CodexCompletionsAdapter:
         model = kwargs.get("model", self._model)
 
         # Separate system/instructions from conversation messages.
-        # Convert chat.completions multimodal content blocks to Responses
-        # API format (input_text / input_image instead of text / image_url).
+        # Convert chat.completions messages to Responses input items.  This
+        # must translate assistant tool_calls and role="tool" results into
+        # function_call/function_call_output items; Responses rejects raw
+        # role="tool" messages.
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        conversation_messages: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
-                input_msgs.append({
-                    "role": role,
-                    "content": _convert_content_for_responses(content),
-                })
+                conversation_messages.append(msg)
+
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+        input_msgs = _chat_messages_to_responses_input(conversation_messages)
 
         resp_kwargs: Dict[str, Any] = {
             "model": model,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -259,6 +259,64 @@ class TestAnthropicOAuthFlag:
         assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
 
 
+class TestCodexCompletionsAdapter:
+    def test_converts_tool_messages_to_responses_function_call_output(self):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        captured = {}
+
+        class _Stream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                response = MagicMock()
+                response.output = []
+                response.usage = None
+                return response
+
+        class _Responses:
+            def stream(self, **kwargs):
+                captured.update(kwargs)
+                return _Stream()
+
+        real_client = MagicMock()
+        real_client.responses = _Responses()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.2-codex")
+
+        adapter.create(
+            messages=[
+                {"role": "user", "content": "Use the tool"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {"name": "memory", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_123", "content": "saved"},
+                {"role": "user", "content": "continue"},
+            ]
+        )
+
+        assert {"role": "tool", "content": "saved"} not in captured["input"]
+        assert {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": "saved",
+        } in captured["input"]
+
+
 class TestTryCodex:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (


### PR DESCRIPTION
## Summary
- Reuse the Codex Responses message converter in the auxiliary Codex chat shim.
- Convert chat-style assistant `tool_calls` and `role: "tool"` messages into Responses `function_call` / `function_call_output` input items.
- Add a regression test covering `role: "tool"` conversion for auxiliary Codex calls.

## Why
`flush_memories` can use the auxiliary Codex client. The previous auxiliary shim forwarded chat-style `role: "tool"` messages directly to the Responses API, which rejects them with:

```text
Invalid value: 'tool'. Supported values are: 'assistant', 'system', 'developer', and 'user'.
```

The main Codex Responses adapter already handles this conversion correctly; this patch aligns the auxiliary shim with that behavior.

## Test Plan
- `python -m pytest tests/agent/test_auxiliary_client.py::TestCodexCompletionsAdapter::test_converts_tool_messages_to_responses_function_call_output -q -o 'addopts='`
- `python -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='`
- `python -m pytest tests/run_agent/test_flush_memories_codex.py tests/run_agent/test_run_agent_codex_responses.py tests/agent/transports/test_codex_transport.py -q -o 'addopts='`
