### PR TITLE
fix(telegram): fallback to document when photo dimensions exceed limits

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1796,6 +1796,23 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            error_str = str(e)
+            # Check for dimension-related errors - fallback to document mode
+            if "Photo_invalid_dimensions" in error_str or "PHOTO_INVALID_DIMENSIONS" in error_str:
+                logger.info(
+                    "[%s] Image dimensions exceed Telegram photo limits, sending as document: %s",
+                    self.name,
+                    image_path,
+                )
+                # Fallback to sending as document (file) - no dimension limits, only 50MB size limit
+                return await self.send_document(
+                    chat_id=chat_id,
+                    file_path=image_path,
+                    caption=caption,
+                    file_name=os.path.basename(image_path),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
             logger.error(
                 "[%s] Failed to send Telegram local image, falling back to base adapter: %s",
                 self.name,


### PR DESCRIPTION
## Problem

Telegram's `send_photo` API has dimension limits — the sum of width + height must not exceed 10000px. When sending large screenshots or tall images (e.g., full-page screenshots), the API returns `Photo_invalid_dimensions` error.

## Solution

Catch the `Photo_invalid_dimensions` error in `send_image_file()` and automatically fallback to `send_document()` which:
- Has no dimension limits
- Only has a 50MB size limit
- Sends the image as a file attachment instead of a photo

This is similar to the existing 5MB URL fallback (commit 542faf22) but handles **local files with dimension issues** instead of URL size issues.

## Related

- Similar approach to #542faf22 which handles >5MB URL images
- Complements the existing download-retry fallback for URLs

## Testing

Tested with a full-page screenshot (height > 5000px) that previously failed with `Photo_invalid_dimensions`. After this fix, the image was successfully sent as a document file.