### PR TITLE
Fix gateway-mode update restart for manual gateways

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5287,6 +5287,78 @@ def cmd_update(args):
         _finalize_update_output(_update_io_state)
 
 
+def _spawn_gateway_mode_manual_restart(killed_pids: set[int]) -> bool:
+    """Start a replacement manual gateway after a gateway-launched update.
+
+    ``hermes update --gateway`` is launched from an existing gateway session,
+    often by a Telegram /update command.  If there is no active service
+    manager, the update path can only stop the old manual gateway process; it
+    cannot tell the user to run ``hermes gateway run`` because the messaging
+    channel was just stopped.  This detached helper waits for the old gateway
+    PIDs to exit, then starts a fresh manual gateway with ``--replace``.
+    """
+    pids = sorted(pid for pid in killed_pids if pid > 0)
+    if not pids:
+        return False
+
+    import shlex
+
+    logs_dir = get_hermes_home() / "logs"
+    try:
+        logs_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    log_path = logs_dir / "gateway.manual.log"
+
+    wait_parts = [
+        f"while kill -0 {pid} 2>/dev/null; do sleep 0.2; done"
+        for pid in pids
+    ]
+    gateway_cmd = " ".join(
+        shlex.quote(part)
+        for part in [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+    )
+    shell_cmd = (
+        f"cd {shlex.quote(str(PROJECT_ROOT))} || exit 126; "
+        + "; ".join(wait_parts)
+        + f"; exec {gateway_cmd} >> {shlex.quote(str(log_path))} 2>&1"
+    )
+
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    try:
+        setsid_bin = shutil.which("setsid")
+        if setsid_bin:
+            subprocess.Popen(
+                [setsid_bin, "bash", "-lc", shell_cmd],
+                cwd=PROJECT_ROOT,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        else:
+            subprocess.Popen(
+                ["bash", "-lc", shell_cmd],
+                cwd=PROJECT_ROOT,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        return True
+    except Exception as exc:
+        print(f"  ⚠ Failed to start replacement gateway: {exc}")
+        return False
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -5884,12 +5956,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"  ✓ Restarted {svc}")
                 if killed_pids:
                     print(f"  → Stopped {len(killed_pids)} manual gateway process(es)")
-                    print("    Restart manually: hermes gateway run")
-                    # Also restart for each profile if needed
-                    if len(killed_pids) > 1:
-                        print(
-                            "    (or: hermes -p <profile> gateway run  for each profile)"
-                        )
+                    if gateway_mode and not restarted_services:
+                        if _spawn_gateway_mode_manual_restart(killed_pids):
+                            print("    Replacement gateway will start automatically")
+                        else:
+                            print("    Restart manually: hermes gateway run")
+                    else:
+                        print("    Restart manually: hermes gateway run")
+                        # Also restart for each profile if needed
+                        if len(killed_pids) > 1:
+                            print(
+                                "    (or: hermes -p <profile> gateway run  for each profile)"
+                            )
 
             if not restarted_services and not killed_pids:
                 # No gateways were running — nothing to do

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -673,6 +673,62 @@ class TestServicePidExclusion:
         # Should show manual stop message since manual PID was killed
         assert "Stopped 1 manual gateway" in captured
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_gateway_mode_update_restarts_manual_gateway(
+        self, mock_run, _mock_which, capsys, monkeypatch,
+    ):
+        """Telegram-launched updates must not leave manual gateways stopped."""
+        args = SimpleNamespace(gateway=True)
+        manual_pid = 42999
+
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        mock_run.side_effect = _make_run_side_effect(commit_count="3")
+
+        with patch.object(
+            gateway_cli, "_get_service_pids", return_value=set()
+        ), patch.object(
+            gateway_cli, "find_gateway_pids", return_value=[manual_pid],
+        ), patch("os.kill") as mock_kill, patch("subprocess.Popen") as mock_popen:
+            cmd_update(args)
+
+        captured = capsys.readouterr().out
+        mock_kill.assert_called_once()
+        assert mock_kill.call_args.args[0] == manual_pid
+        mock_popen.assert_called_once()
+        popen_cmd = mock_popen.call_args.args[0]
+        assert popen_cmd[:2] == ["bash", "-lc"]
+        assert "gateway run --replace" in popen_cmd[2]
+        assert f"kill -0 {manual_pid}" in popen_cmd[2]
+        assert "Replacement gateway will start automatically" in captured
+        assert "Restart manually" not in captured
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_terminal_update_keeps_manual_restart_guidance(
+        self, mock_run, _mock_which, capsys, monkeypatch,
+    ):
+        """Terminal updates should not daemonize a manual gateway unexpectedly."""
+        manual_pid = 42999
+
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        mock_run.side_effect = _make_run_side_effect(commit_count="3")
+
+        with patch.object(
+            gateway_cli, "_get_service_pids", return_value=set()
+        ), patch.object(
+            gateway_cli, "find_gateway_pids", return_value=[manual_pid],
+        ), patch("os.kill"), patch("subprocess.Popen") as mock_popen:
+            cmd_update(SimpleNamespace())
+
+        captured = capsys.readouterr().out
+        mock_popen.assert_not_called()
+        assert "Restart manually: hermes gateway run" in captured
+
 
 class TestGetServicePids:
     """Unit tests for _get_service_pids()."""


### PR DESCRIPTION
## Summary
- Start a detached replacement manual gateway after `hermes update --gateway` stops manual gateway PIDs.
- Keep terminal-launched updates unchanged: they still print manual restart guidance instead of daemonizing unexpectedly.
- Add regression coverage for Telegram/gateway-mode updates and terminal update behavior.

## Tests
- `/Users/oc_runtime/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_update_gateway_restart.py tests/gateway/test_update_command.py -q`

## Context
This fixes a gateway-launched update failure mode where `/update` from Telegram could stop a manual gateway and only print terminal restart guidance, leaving the messaging control channel down.