### PR TITLE
feat(cli): add --insecure-chat flag for non-loopback WS chat clients

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6754,6 +6754,7 @@ def cmd_dashboard(args):
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
         embedded_chat=embedded_chat,
+        insecure_chat=getattr(args, "insecure_chat", False),
     )
 
 
@@ -8938,6 +8939,14 @@ Examples:
         "--insecure",
         action="store_true",
         help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
+    )
+    dashboard_parser.add_argument(
+        "--insecure-chat",
+        action="store_true",
+        help=(
+            "Allow WebSocket chat connections from any client IP when --tui is enabled. "
+            "By default chat WS only accepts loopback clients. Use with --host."
+        ),
     )
     dashboard_parser.add_argument(
         "--tui",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -77,6 +77,9 @@ _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
 _DASHBOARD_EMBEDDED_CHAT_ENABLED = False
 
+# Allow WebSocket chat connections from any client IP when --insecure-chat is set.
+_DASHBOARD_INSECURE_CHAT_ENABLED = False
+
 # Simple rate limiter for the reveal endpoint
 _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
@@ -2390,7 +2393,7 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not _DASHBOARD_INSECURE_CHAT_ENABLED:
         await ws.close(code=4403)
         return
 
@@ -2498,7 +2501,7 @@ async def gateway_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not _DASHBOARD_INSECURE_CHAT_ENABLED:
         await ws.close(code=4403)
         return
 
@@ -2531,7 +2534,7 @@ async def pub_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not _DASHBOARD_INSECURE_CHAT_ENABLED:
         await ws.close(code=4403)
         return
 
@@ -2561,7 +2564,7 @@ async def events_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not _DASHBOARD_INSECURE_CHAT_ENABLED:
         await ws.close(code=4403)
         return
 
@@ -3133,12 +3136,16 @@ def start_server(
     allow_public: bool = False,
     *,
     embedded_chat: bool = False,
+    insecure_chat: bool = False,
 ):
     """Start the web UI server."""
     import uvicorn
 
     global _DASHBOARD_EMBEDDED_CHAT_ENABLED
     _DASHBOARD_EMBEDDED_CHAT_ENABLED = embedded_chat
+
+    global _DASHBOARD_INSECURE_CHAT_ENABLED
+    _DASHBOARD_INSECURE_CHAT_ENABLED = insecure_chat
 
     _LOCALHOST = ("127.0.0.1", "localhost", "::1")
     if host not in _LOCALHOST and not allow_public:

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -23,6 +23,9 @@ This starts a local web server and opens `http://127.0.0.1:9119` in your browser
 | `--port` | `9119` | Port to run the web server on |
 | `--host` | `127.0.0.1` | Bind address |
 | `--no-open` | — | Don't auto-open the browser |
+| `--tui` | — | Enable the in-browser **Chat** tab (embedded TUI via PTY/WebSocket) |
+| `--insecure` | — | Allow binding to non-localhost (see [security warning](#security)) |
+| `--insecure-chat` | — | Allow WebSocket chat connections from any client IP (requires `--tui`) |
 
 ```bash
 # Custom port
@@ -62,7 +65,7 @@ The status page auto-refreshes every 5 seconds.
 
 ### Chat
 
-The **Chat** tab embeds the full Hermes TUI (the same interface you get from `hermes --tui`) directly in the browser. Everything you can do in the terminal TUI — slash commands, model picker, tool-call cards, markdown streaming, clarify/sudo/approval prompts, skin theming — works identically here, because the dashboard is running the real TUI binary and rendering its ANSI output through [xterm.js](https://xtermjs.org/) with its WebGL renderer for pixel-perfect cell layout.
+The **Chat** tab embeds the full Hermes TUI (the same interface you get from `hermes --tui`) directly in the browser. It is **only available when the dashboard is started with `--tui`**. Everything you can do in the terminal TUI — slash commands, model picker, tool-call cards, markdown streaming, clarify/sudo/approval prompts, skin theming — works identically here, because the dashboard is running the real TUI binary and rendering its ANSI output through [xterm.js](https://xtermjs.org/) with its WebGL renderer for pixel-perfect cell layout.
 
 **How it works:**
 
@@ -81,6 +84,15 @@ The **Chat** tab embeds the full Hermes TUI (the same interface you get from `he
 - POSIX kernel (Linux, macOS, or WSL). Native Windows Python is not supported — use WSL.
 
 Close the browser tab and the PTY is reaped cleanly on the server. Re-opening spawns a fresh session.
+
+**Non-localhost access:**
+
+By default, the chat WebSocket endpoints (`/api/pty`, `/api/ws`, `/api/pub`, `/api/events`) only accept connections from loopback addresses (`127.0.0.1`, `::1`, `localhost`). This prevents unauthorized remote clients from spawning a TUI session on your machine. If you bind the dashboard to a non-localhost address (e.g., a Tailscale IP or `0.0.0.0` with `--insecure`), pass `--insecure-chat` as well to allow WebSocket chat connections from any client IP:
+
+```bash
+# Bind to e.g. Tailscale IP and allow remote chat clients
+hermes dashboard --tui --insecure --insecure-chat --host 100.x.x.x
+```
 
 ### Config
 


### PR DESCRIPTION
## What does this PR do?

The embedded TUI Chat tab (hermes dashboard --tui) rejects WebSocket connections from non-loopback IPs to prevent unauthorized remote access to the PTY. This is correct for localhost-only use, but blocks usage over Tailscale, VPNs, or LAN when the dashboard is intentionally bound to a non-loopback address with --insecure.

Add --insecure-chat which, when combined with --tui, skips the ws.client.host loopback check on all chat WebSocket endpoints:
- /api/pty
- /api/ws
- /api/pub
- /api/events

Update the web-dashboard docs to document the new flag, clarify that the Chat tab only appears when --tui is passed.

## Related Issue

#15731

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)


## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Add --insecure-chat flag parsing: hermes_cli/main.py
- Skip checks when --insecure-chat flag is passed: hermes_cli/web_server.py
- Document new flag, clarify that --tui flag in hermes dashboard command: website/docs/user-guide/features/web-dashboard.md

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. run  hermes dashboard --tui --host 0.0.0.0 --insecure --insecure-chat
2. go to chat tab in Hermes web dashboard (use non-loopback ip address of the host)
3. confirm you can chat with the agent

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

