### PR TITLE
fix(gemini): stop splitting one tool call into two when thoughtSignature arrives late

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -638,12 +638,19 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 args_str = json.dumps(fc.get("args") or {}, ensure_ascii=False, sort_keys=True)
             except (TypeError, ValueError):
                 args_str = "{}"
-            thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""
+            # Dedup slots by (part_index, name) only — NOT by thought_signature.
+            # Gemini may send the signature on only some chunks of a tool call
+            # (e.g., on a later args chunk, or only on the first chunk). Including
+            # it in the key splits a single tool call into multiple slots when
+            # the signature changes between chunks, leaving the slot that did
+            # not receive it without a signature on replay → Gemini 3 thinking
+            # models then 400 with "Function call is missing a thought_signature"
+            # because the model that originally emitted the call expects the
+            # signature back.
             call_key = json.dumps(
                 {
                     "part_index": part_index,
                     "name": name,
-                    "thought_signature": thought_signature,
                 },
                 sort_keys=True,
             )

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+from typing import Any, Dict
 
 import pytest
 
@@ -326,3 +327,58 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].index == 0
     assert tool_chunks[1].choices[0].delta.tool_calls[0].index == 1
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
+
+
+def test_stream_event_translation_does_not_split_slot_when_signature_arrives_late():
+    """Regression: Gemini 3 thinking models may send `thoughtSignature` on a
+    later chunk of the same tool call (or only on one chunk). The dedup key
+    must be (part_index, name) only — never including the signature — so a
+    single tool call stays in a single slot regardless of which chunks carry
+    the signature. Otherwise the slot that lacks the signature gets replayed
+    without one and Gemini rejects the request with HTTP 400.
+    """
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: Dict[str, Dict[str, Any]] = {}
+
+    # Chunk 1 — no signature yet.
+    event_a = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "terminal", "args": {}}}
+                    ]
+                },
+            }
+        ]
+    }
+    # Chunk 2 — same tool call, more args, signature now present.
+    event_b = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {"name": "terminal", "args": {"cmd": "ls"}},
+                            "thoughtSignature": "sig-late",
+                        }
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ]
+    }
+
+    chunks_a = translate_stream_event(event_a, model="gemini-3.1-flash", tool_call_indices=tool_call_indices)
+    chunks_b = translate_stream_event(event_b, model="gemini-3.1-flash", tool_call_indices=tool_call_indices)
+
+    a_tool = [c for c in chunks_a if c.choices[0].delta.tool_calls][0].choices[0].delta.tool_calls[0]
+    b_tool = [c for c in chunks_b if c.choices[0].delta.tool_calls][0].choices[0].delta.tool_calls[0]
+
+    # Both chunks must address the SAME slot (same index, same id) — otherwise
+    # the consumer accumulates two tool calls for what is logically one.
+    assert a_tool.index == b_tool.index == 0
+    assert a_tool.id == b_tool.id
+    # The chunk that carried the signature surfaces it via extra_content.
+    assert b_tool.extra_content == {"google": {"thought_signature": "sig-late"}}


### PR DESCRIPTION
## Summary

\`translate_stream_event()\` in \`agent/gemini_native_adapter.py\` keys streaming tool-call slots on \`(part_index, name, thought_signature)\`:

\`\`\`python
# before
thought_signature = part.get(\"thoughtSignature\") if isinstance(part.get(\"thoughtSignature\"), str) else \"\"
call_key = json.dumps(
    {
        \"part_index\": part_index,
        \"name\": name,
        \"thought_signature\": thought_signature,   # ← splits one call into two
    },
    sort_keys=True,
)
\`\`\`

Because \`thought_signature\` is part of the dedup key, a single tool call whose chunks carry the signature **inconsistently** is split into two separate slots:

- slot 0: built from the early chunks → no signature, partial args
- slot 1: built from a later chunk → has signature, fuller args

Both slots are emitted as deltas, so the agent records **two** tool calls for what was logically one. On the next turn the slot without a signature is replayed back to Gemini, which then 400s with:

\`\`\`
Function call is missing a thought_signature in functionCall parts.
\`\`\`

## How this bug surfaces in the wild

Reported by a user running \`gemini-3.1-flash-lite-preview\` through Hermes Desktop:

\`\`\`
HTTP 400: Gemini HTTP 400 (INVALID_ARGUMENT): Function call is missing a
thought_signature in functionCall parts. ... Additional data, function call
\`default_api:terminal\` , position 2.
\`\`\`

Position 2 == the third part of the assistant content. With the bug, after one logical \`terminal\` tool call the model's content has:

- part 0: text (assistant prose)
- part 1: functionCall (slot 0 — partial args, **no signature**)
- part 2: functionCall (slot 1 — full args, has signature)

Gemini sees the part-1 functionCall without a signature and rejects.

## Fix

Dedup on \`(part_index, name)\` only. The signature is still surfaced through the per-chunk \`extra_content\` field, and the downstream streaming accumulator in \`run_agent.py\` already does latest-non-None-wins on \`extra_content\` per slot:

\`\`\`python
# run_agent.py — existing behavior, unchanged
extra = getattr(tc_delta, \"extra_content\", None)
...
if extra is not None:
    if hasattr(extra, \"model_dump\"):
        extra = extra.model_dump()
    entry[\"extra_content\"] = extra      # late-arriving signature wins, single slot
\`\`\`

So whichever chunk carries the signature gets it merged into the **single** slot.

## Test plan

Adds a regression test:

\`\`\`python
def test_stream_event_translation_does_not_split_slot_when_signature_arrives_late():
    ...
    # Chunk 1 — no signature yet.
    event_a = {\"candidates\": [{\"content\": {\"parts\": [
        {\"functionCall\": {\"name\": \"terminal\", \"args\": {}}}
    ]}}]}
    # Chunk 2 — same tool call, signature now present.
    event_b = {\"candidates\": [{\"content\": {\"parts\": [{
        \"functionCall\": {\"name\": \"terminal\", \"args\": {\"cmd\": \"ls\"}},
        \"thoughtSignature\": \"sig-late\",
    }]}}]}
    ...
    # Both chunks must address the SAME slot.
    assert a_tool.index == b_tool.index == 0
    assert a_tool.id == b_tool.id
    # The chunk that carried the signature surfaces it via extra_content.
    assert b_tool.extra_content == {\"google\": {\"thought_signature\": \"sig-late\"}}
\`\`\`

- [x] **Fails on main** with \`assert 0 == 1\` (slot 1 created with the late signature, slot 0 left signature-less).
- [x] **Passes here**.
- [x] All 12 tests in \`tests/agent/test_gemini_native_adapter.py\` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)