### PR TITLE
fix(state): resume compression continuation tip

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2915,22 +2915,19 @@ class SessionDB:
         }
 
     def resolve_resume_session_id(self, session_id: str) -> str:
-        """Redirect a resume target to the descendant session that holds the messages.
+        """Redirect a resume target to the live continuation session.
 
-        Context compression ends the current session and forks a new child session
-        (linked via ``parent_session_id``). The flush cursor is reset, so the
-        child is where new messages actually land — the parent ends up with
-        ``message_count = 0`` rows unless messages had already been flushed to
-        it before compression. See #15000.
+        Context compression ends the current session and forks a child session
+        linked via ``parent_session_id``. Users often resume the original root
+        ID they saw before compression, but post-compression turns are written
+        to the continuation child. Resume must therefore follow the compression
+        chain to its tip even when the root already has pre-compression message
+        rows.
 
-        This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the first descendant in the chain that has at least one message
-        row. If the original session already has messages, or no descendant
-        has any, the original ``session_id`` is returned unchanged.
-
-        The chain is always walked via the child whose ``started_at`` is
-        latest; that matches the single-chain shape that compression creates.
-        A depth cap (32) guards against accidental loops in malformed data.
+        If the target is not part of a compression chain, preserve the legacy
+        fallback: for an empty placeholder session, walk descendants until the
+        first child with message rows is found. If nothing suitable exists, the
+        original ``session_id`` is returned unchanged.
         """
         if not session_id:
             return session_id
@@ -2954,7 +2951,7 @@ class SessionDB:
             session_id = tip
 
         with self._lock:
-            # If this session already has messages, nothing to redirect.
+            # If this non-compression session already has messages, nothing to redirect.
             try:
                 row = self._conn.execute(
                     "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
@@ -2966,7 +2963,7 @@ class SessionDB:
                 return session_id
 
             # Walk descendants: at each step, pick the most-recently-started
-                # child session; stop once we find one with messages.
+            # child session; stop once we find one with messages.
             current = session_id
             seen = {current}
             for _ in range(32):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1040,28 +1040,32 @@ class SessionDB:
         return result
 
     def resolve_resume_session_id(self, session_id: str) -> str:
-        """Redirect a resume target to the descendant session that holds the messages.
+        """Redirect a resume target to the live continuation session.
 
-        Context compression ends the current session and forks a new child session
-        (linked via ``parent_session_id``). The flush cursor is reset, so the
-        child is where new messages actually land — the parent ends up with
-        ``message_count = 0`` rows unless messages had already been flushed to
-        it before compression. See #15000.
+        Context compression ends the current session and forks a child session
+        linked via ``parent_session_id``. Users often resume the original root
+        ID they saw before compression, but post-compression turns are written
+        to the continuation child. Resume must therefore follow the compression
+        chain to its tip even when the root already has pre-compression message
+        rows.
 
-        This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the first descendant in the chain that has at least one message
-        row. If the original session already has messages, or no descendant
-        has any, the original ``session_id`` is returned unchanged.
-
-        The chain is always walked via the child whose ``started_at`` is
-        latest; that matches the single-chain shape that compression creates.
-        A depth cap (32) guards against accidental loops in malformed data.
+        If the target is not part of a compression chain, preserve the legacy
+        fallback: for an empty placeholder session, walk descendants until the
+        first child with message rows is found. If nothing suitable exists, the
+        original ``session_id`` is returned unchanged.
         """
         if not session_id:
             return session_id
 
+        try:
+            tip = self.get_compression_tip(session_id)
+        except Exception:
+            tip = session_id
+        if tip and tip != session_id:
+            return tip
+
         with self._lock:
-            # If this session already has messages, nothing to redirect.
+            # If this non-compression session already has messages, nothing to redirect.
             try:
                 row = self._conn.execute(
                     "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
@@ -1073,7 +1077,7 @@ class SessionDB:
                 return session_id
 
             # Walk descendants: at each step, pick the most-recently-started
-                # child session; stop once we find one with messages.
+            # child session; stop once we find one with messages.
             current = session_id
             seen = {current}
             for _ in range(32):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3284,6 +3284,19 @@ class TestCompressionChainProjection:
         assert db.get_compression_tip("mid1") == "tip1"
         assert db.get_compression_tip("tip1") == "tip1"
 
+    def test_resolve_resume_session_id_returns_compression_tip_even_when_parent_has_messages(self, db):
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        assert db.get_messages_as_conversation("root1")
+        assert db.resolve_resume_session_id("root1") == "tip1"
+
+    def test_resolve_resume_session_id_returns_self_for_uncompressed_session_with_messages(self, db):
+        db.create_session("solo", "cli")
+        db.append_message("solo", "user", "standalone")
+
+        assert db.resolve_resume_session_id("solo") == "solo"
+
     def test_get_compression_tip_returns_self_for_uncompressed(self, db):
         db.create_session("solo", "cli")
         assert db.get_compression_tip("solo") == "solo"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1523,6 +1523,19 @@ class TestCompressionChainProjection:
         assert db.get_compression_tip("mid1") == "tip1"
         assert db.get_compression_tip("tip1") == "tip1"
 
+    def test_resolve_resume_session_id_returns_compression_tip_even_when_parent_has_messages(self, db):
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        assert db.get_messages_as_conversation("root1")
+        assert db.resolve_resume_session_id("root1") == "tip1"
+
+    def test_resolve_resume_session_id_returns_self_for_uncompressed_session_with_messages(self, db):
+        db.create_session("solo", "cli")
+        db.append_message("solo", "user", "standalone")
+
+        assert db.resolve_resume_session_id("solo") == "solo"
+
     def test_get_compression_tip_returns_self_for_uncompressed(self, db):
         db.create_session("solo", "cli")
         assert db.get_compression_tip("solo") == "solo"


### PR DESCRIPTION
## What does this PR do?

Fixes resume behavior for compressed sessions by redirecting resume targets to the live compression continuation tip.

After context compression, post-compression turns live in a child continuation session. Users may still resume the original root session id they saw before compression. `SessionDB.resolve_resume_session_id()` previously returned that root unchanged whenever the root already had pre-compression message rows, which can omit post-compaction turns from resumed context.

This PR makes the helper follow the compression chain tip first, while preserving the existing fallback for empty placeholder sessions that have child messages.

## Related Issue

Related: #10373

Related PRs:
- #13374 covers complementary TUI resume behavior in `tui_gateway/server.py`.
- #15418 merged the gateway `/resume` path through `SessionDB.resolve_resume_session_id()`.
- This PR keeps the fix at the shared helper layer in `hermes_state.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`
  - Update `SessionDB.resolve_resume_session_id()` to call `get_compression_tip()` before returning a session with existing message rows.
  - Preserve the legacy fallback for empty placeholder sessions by walking descendants until the first child with messages is found.
  - Keep the malformed-chain depth guard behavior.
- `tests/test_hermes_state.py`
  - Add regression coverage for compressed roots that already have pre-compression messages.
  - Add coverage that uncompressed sessions with messages still resolve to themselves.

## How to Test

1. Run the focused regression suite:
   ```bash
   python -m pytest \
     tests/test_hermes_state.py::TestCompressionChainProjection::test_resolve_resume_session_id_returns_compression_tip_even_when_parent_has_messages \
     tests/test_hermes_state.py::TestCompressionChainProjection::test_resolve_resume_session_id_returns_self_for_uncompressed_session_with_messages \
     tests/test_hermes_state.py::TestCompressionChainProjection::test_get_compression_tip_walks_full_chain \
     tests/test_hermes_state.py::TestCompressionChainProjection::test_list_surfaces_tip_for_compressed_root \
     -q -o addopts=''
   ```

2. Run the full `hermes_state` test module:
   ```bash
   python -m pytest tests/test_hermes_state.py -q -o addopts=''
   ```

3. Run syntax and whitespace checks:
   ```bash
   python -m compileall -q hermes_state.py tests/test_hermes_state.py
   git diff --check
   ```

## Validation Status

- Focused regression suite from fresh recheck: 4 passed.
- `python -m pytest tests/test_hermes_state.py -q -o addopts=''`: passed locally in the original PR validation.
- `python -m compileall -q hermes_state.py tests/test_hermes_state.py`: passed locally in the original PR validation.
- `git diff --check`: passed locally in the original PR validation.
- GitHub checks are not currently all green.
- Failed checks: `test`, `e2e`.
- Current merge state: mergeable but unstable.
- Full-suite checklist is not marked complete because this branch needs rebasing/refreshing after the base-CI stabilizer lands.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and noted related #13374 above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux local checkout

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A. This PR does not add a skill.

## Screenshots / Logs

Fresh helper-level repro from a previous PR comment against `origin/main`:

```text
get_compression_tip(root1)= tip1
resolve_resume_session_id(root1)= root1
```

Expected behavior after this PR:

```text
resolve_resume_session_id(root1)= tip1
```

Fresh focused validation from the previous PR comment:

```text
4 passed, 4 warnings in 0.23s
```
