### PR TITLE
fix(tui): include `webui` in resume-picker allow-list

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1578,6 +1578,7 @@ def _(rid, params: dict) -> dict:
             {
                 "cli",
                 "tui",
+                "webui",
                 "telegram",
                 "discord",
                 "slack",


### PR DESCRIPTION
## Summary

Closes #15745.

The `session.list` JSON-RPC handler in `tui_gateway/server.py` filters its picker output through an `allow` frozenset whose stated intent (per the inline comment) is to surface human conversation channels and exclude internal sources like `tool`/`acp`. `webui` was missing from the set, so conversations started in `hermes-webui` — which are written to `state.db` via `sync_to_insights` plus the shared `AIAgent` — were invisible to `hermes --tui`'s `/resume` modal.

This adds the one missing entry. No behaviour change for any other source.

## Diff

```diff
                 "cli",
                 "tui",
+                "webui",
                 "telegram",
```

## Test plan

- [x] Apply the patch on a host with WebUI sessions in `state.db` (in our case: 6 webui sessions, 554 webui messages).
- [x] `hermes --tui` → `/resume` — webui sessions now appear alongside cli/tui/telegram entries.
- [x] `/resume <session-id>` and `/resume "<title>"` continue to work for every source (path was already source-agnostic via `_resolve_session_by_name_or_id` — unaffected).
- [ ] Maintainer to re-run any TUI integration tests that cover `session.list`.

## Notes

`cron` is intentionally still excluded — those rows are background runs rather than user conversations and the existing intent of keeping the picker clean still applies.