### PR TITLE
fix(mcp-oauth): preserve server URL path when constructing OAuthClientProvider

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -126,6 +126,7 @@ AUTHOR_MAP = {
     "ben.burtenshaw@gmail.com": "burtenshaw",
     "roopaknijhara@gmail.com": "rnijhara",
     "josephzcan@gmail.com": "j0sephz",
+    "me@freeformz.me": "freeformz",
     # contributors (manual mapping from git names)
     "ahmedsherif95@gmail.com": "asheriif",
     "dyxushuai@gmail.com": "dyxushuai",

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -491,11 +491,22 @@ def test_configure_callback_port_uses_explicit_port():
     assert cfg["_resolved_port"] == 54321
 
 
-def test_parse_base_url_strips_path():
-    """_parse_base_url drops path components for OAuth discovery."""
-    from tools.mcp_oauth import _parse_base_url
+def test_build_oauth_auth_preserves_server_url_path():
+    """build_oauth_auth must pass the full server URL (including path) to
+    OAuthClientProvider. Stripping the path causes RFC 8707 PRM resource
+    matching to fail against servers (e.g. Fastmail) whose PRM advertises
+    the full endpoint URL as the resource."""
+    from tools.mcp_oauth import _OAUTH_AVAILABLE, build_oauth_auth
 
-    assert _parse_base_url("https://example.com/mcp/v1") == "https://example.com"
-    assert _parse_base_url("https://example.com") == "https://example.com"
-    assert _parse_base_url("https://host.example.com:8080/api") == "https://host.example.com:8080"
+    if not _OAUTH_AVAILABLE:
+        return  # SDK not available — nothing to test
+
+    provider = build_oauth_auth("test_server", "https://api.example.com/mcp")
+    if provider is None:
+        return  # SDK lacks OAuth support
+
+    # The provider stores the URL in its OAuthContext. Per RFC 8707 the path
+    # must be preserved so that PRM resource matching succeeds when a server
+    # advertises e.g. resource="https://api.example.com/mcp".
+    assert str(provider.context.server_url) == "https://api.example.com/mcp"
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -519,12 +519,6 @@ def _maybe_preregister_client(
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 
-def _parse_base_url(server_url: str) -> str:
-    """Strip path component from server URL, returning the base origin."""
-    parsed = urlparse(server_url)
-    return f"{parsed.scheme}://{parsed.netloc}"
-
-
 def build_oauth_auth(
     server_name: str,
     server_url: str,
@@ -570,7 +564,7 @@ def build_oauth_auth(
     _maybe_preregister_client(storage, cfg, client_metadata)
 
     return OAuthClientProvider(
-        server_url=_parse_base_url(server_url),
+        server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -362,7 +362,6 @@ class MCPOAuthManager:
             _configure_callback_port,
             _is_interactive,
             _maybe_preregister_client,
-            _parse_base_url,
             _redirect_handler,
             _wait_for_callback,
         )
@@ -387,7 +386,7 @@ class MCPOAuthManager:
 
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
-            server_url=_parse_base_url(entry.server_url),
+            server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
             redirect_handler=_redirect_handler,


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP OAuth flow against servers whose Protected Resource Metadata (PRM, [RFC 9728](https://datatracker.ietf.org/doc/rfc9728/)) document advertises a path-suffixed canonical resource. Today, attempting OAuth against any such server fails with:

```
Protected resource https://api.fastmail.com/mcp does not match expected https://api.fastmail.com
```

Fastmail is a concrete real-world example — its PRM legitimately advertises `https://api.fastmail.com/mcp` as the canonical resource — but the same failure mode hits any spec-compliant server that mounts MCP under a path.

**Root cause:** `build_oauth_auth()` (and the manager equivalent) ran the configured server URL through `_parse_base_url()`, which strips the path and keeps only `scheme://netloc`, before handing it to the SDK's `OAuthClientProvider`. So the provider was instantiated with `https://api.fastmail.com` while the server's PRM honestly advertises:

```json
{
  "resource": "https://api.fastmail.com/mcp",
  "authorization_servers": ["https://api.fastmail.com"],
  "scopes_supported": ["https://www.fastmail.com/dev/mcp", "offline_access"],
  "bearer_methods_supported": ["header"]
}
```

The SDK's `_validate_resource_match()` then runs `check_resource_allowed("https://api.fastmail.com/", "https://api.fastmail.com/mcp")`, which (correctly, per [RFC 8707](https://datatracker.ietf.org/doc/rfc8707/)) refuses the hierarchical mismatch and raises `OAuthFlowError`.

**Why this approach is right:** Current `mcp` (≥1.26 — already what `build_oauth_auth` warns about as the minimum) handles AS discovery correctly when given the full endpoint URL: it probes both `/.well-known/oauth-protected-resource` and `/.well-known/oauth-protected-resource/<path>`, and `check_resource_allowed()` does hierarchical matching that accepts the broader path. So passing the full URL through is safe for spec-compliant servers and required for ones that take RFC 9728 seriously. The path-stripping was likely defensive code from an earlier era of the SDK.

## Related Issue

No tracking issue. Reproduces against any user with `fastmail` configured as an `auth: oauth` MCP server in `~/.hermes/config.yaml`.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth.py`: drop `_parse_base_url()` (dead code now) and pass `server_url` through unchanged to `OAuthClientProvider`.
- `tools/mcp_oauth_manager.py`: same fix in the manager path; remove the now-unused `_parse_base_url` import.
- `tests/tools/test_mcp_oauth.py`: replace the stale `test_parse_base_url_strips_path` with `test_build_oauth_auth_preserves_server_url_path`, which verifies the provider is constructed with the full endpoint URL (the actual contract that matters).
- `scripts/release.py`: add `me@freeformz.me` → `freeformz` to `AUTHOR_MAP` for the contributor-check workflow.

## How to Test

1. Add a Fastmail MCP entry to `~/.hermes/config.yaml`:
   ```yaml
   mcp_servers:
     fastmail:
       url: https://api.fastmail.com/mcp
       auth: oauth
   ```
2. Run `hermes mcp login fastmail`.
   - **Before this PR:** fails immediately with `Protected resource https://api.fastmail.com/mcp does not match expected https://api.fastmail.com`.
   - **After this PR:** opens browser for OAuth, completes the flow, prints `Authenticated — 18 tool(s) available`.
3. Run the regression test: `pytest tests/tools/test_mcp_oauth.py -v` — 37 passed (1.27s on macOS 15 / Python 3.11).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(mcp-oauth): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_mcp_oauth.py -q` and all tests pass
- [x] I've added a regression test (required for bug fixes)
- [x] I've tested on my platform: macOS 15 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no behavior visible to users via README/docs/docstrings; the fix is purely an internal URL-handling correction)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure URL string handling, no OS-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before:
```
$ hermes mcp login fastmail
Starting OAuth flow for 'fastmail'...
  ✗ Authentication failed: Protected resource https://api.fastmail.com/mcp does not match expected https://api.fastmail.com
```

After:
```
$ hermes mcp login fastmail
  MCP OAuth: authorization required.
  Open this URL in your browser:

    https://api.fastmail.com/oauth/authorize?...&resource=https%3A%2F%2Fapi.fastmail.com%2Fmcp&scope=https%3A%2F%2Fwww.fastmail.com%2Fdev%2Fmcp+offline_access

  (Browser opened automatically.)

  Starting OAuth flow for 'fastmail'...
  ✓ Authenticated — 18 tool(s) available
```
