### PR TITLE
fix: allow category-qualified local skill lookup

### DIFF
--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -224,6 +224,22 @@ class TestSkillViewQualifiedName:
         assert result["success"] is True
         assert result["name"] == "my-local"
 
+    def test_local_category_alias_resolves_flat_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        skills_dir = tmp_path / "local-skills"
+        skill_dir = skills_dir / "autonomous-ai-agents" / "hermes-agent"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: local\n---\nLocal category body.\n"
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+
+        result = json.loads(skill_view("autonomous-ai-agents:hermes-agent"))
+        assert result["success"] is True
+        assert result["name"] == "hermes-agent"
+        assert "Local category body." in result["content"]
+
     def test_plugin_exists_but_skill_missing(self, tmp_path):
         from tools.skills_tool import skill_view
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -947,17 +947,29 @@ def skill_view(
 
         skill_dir = None
         skill_md = None
+        search_names = [name]
+
+        # When a qualified name doesn't resolve to a plugin skill, allow a
+        # category alias fallback such as "autonomous-ai-agents:hermes-agent"
+        # -> "autonomous-ai-agents/hermes-agent" for local/external skills.
+        if ":" in name:
+            category_alias = name.replace(":", "/", 1)
+            if category_alias not in search_names:
+                search_names.append(category_alias)
 
         # Search all dirs: local first, then external (first match wins)
         for search_dir in all_dirs:
             # Try direct path first (e.g., "mlops/axolotl")
-            direct_path = search_dir / name
-            if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
-                skill_dir = direct_path
-                skill_md = direct_path / "SKILL.md"
-                break
-            elif direct_path.with_suffix(".md").exists():
-                skill_md = direct_path.with_suffix(".md")
+            for candidate_name in search_names:
+                direct_path = search_dir / candidate_name
+                if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
+                    skill_dir = direct_path
+                    skill_md = direct_path / "SKILL.md"
+                    break
+                elif direct_path.with_suffix(".md").exists():
+                    skill_md = direct_path.with_suffix(".md")
+                    break
+            if skill_md:
                 break
 
         # Search by directory name across all dirs


### PR DESCRIPTION
## Summary
- allow skill_view to fall back from category-qualified names like `autonomous-ai-agents:hermes-agent` to local/external skill paths such as `autonomous-ai-agents/hermes-agent`
- preserve plugin-qualified lookup behavior
- add a regression test covering category-qualified local skill resolution

## Testing
- /Users/bank/.hermes/hermes-agent/venv/bin/python -m pytest /Users/bank/.hermes/hermes-agent/tests/test_plugin_skills.py -q