### PR TITLE
fix(fallback): resolve base_url from custom_providers when fallback entry has none (#15743)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7447,6 +7447,28 @@ class AIAgent:
                 fb_key_env = (fb.get("key_env") or "").strip()
                 if fb_key_env:
                     fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
+            # When base_url and api_key are absent from the fallback entry itself,
+            # look them up explicitly from custom_providers / providers config.
+            # Without this, a fallback_model that references a custom_providers entry
+            # by name (e.g. provider: aliyun-singapore) sends the request to the
+            # primary provider's endpoint instead of the custom provider's own
+            # base_url, because the named-provider lookup inside resolve_provider_client
+            # can miss for custom entries (refs #15743).
+            if not fb_base_url_hint and not fb_api_key_hint:
+                try:
+                    from hermes_cli.runtime_provider import _get_named_custom_provider
+                    _cp = _get_named_custom_provider(fb_provider)
+                    if _cp:
+                        fb_base_url_hint = (_cp.get("base_url") or "").strip() or None
+                        _cp_key = (_cp.get("api_key") or "").strip()
+                        _cp_key_env = (_cp.get("key_env") or "").strip()
+                        if not fb_api_key_hint:
+                            if _cp_key:
+                                fb_api_key_hint = _cp_key or None
+                            elif _cp_key_env:
+                                fb_api_key_hint = os.getenv(_cp_key_env, "").strip() or None
+                except Exception:
+                    pass
             # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
             # when no explicit key is in the fallback config. Host match
             # (not substring) — see GHSA-76xc-57q6-vm5m.

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -194,6 +194,98 @@ def _pool(n_entries: int, has_available: bool = True):
     return pool
 
 
+# ── Custom-providers fallback base_url lookup (#15743) ───────────────────
+
+
+class TestCustomProviderFallbackBaseUrl:
+    """Fallback entries that reference a custom_providers name (no inline base_url)
+    must resolve the base_url from the custom_providers config, not from the
+    primary provider."""
+
+    def test_custom_provider_base_url_used_when_not_in_fallback_entry(self):
+        """When fallback_model has no base_url but names a custom_providers entry,
+        the custom provider's base_url must be passed to resolve_provider_client
+        and end up as agent.base_url after activation."""
+        fbs = [{"provider": "aliyun-singapore", "model": "qwen3.6-plus"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent.base_url = "https://inference-api.nousresearch.com/v1"  # primary
+
+        aliyun_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        aliyun_client = _mock_client(base_url=aliyun_url, api_key="aliyun-key")
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider._get_named_custom_provider",
+                return_value={
+                    "name": "aliyun-singapore",
+                    "base_url": aliyun_url,
+                    "api_key": "aliyun-key",
+                },
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(aliyun_client, "qwen3.6-plus"),
+            ) as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is True
+            # The aliyun URL must be passed explicitly so the agent doesn't
+            # send the request to the primary (nous) endpoint.
+            assert mock_rpc.call_args.kwargs["explicit_base_url"] == aliyun_url
+            assert agent.base_url.rstrip("/") == aliyun_url.rstrip("/")
+            assert agent.model == "qwen3.6-plus"
+            assert agent.provider == "aliyun-singapore"
+
+    def test_inline_base_url_takes_precedence_over_custom_providers_lookup(self):
+        """When the fallback entry has its own base_url, it is used directly
+        and the custom_providers lookup is not performed."""
+        fbs = [
+            {
+                "provider": "my-provider",
+                "model": "my-model",
+                "base_url": "https://direct.example.com/v1",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+
+        direct_client = _mock_client(base_url="https://direct.example.com/v1", api_key="direct-key")
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider._get_named_custom_provider"
+            ) as mock_lookup,
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(direct_client, "my-model"),
+            ) as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is True
+            # The custom_providers lookup must NOT be called when base_url
+            # is already present in the fallback entry.
+            mock_lookup.assert_not_called()
+            assert mock_rpc.call_args.kwargs["explicit_base_url"] == "https://direct.example.com/v1"
+
+    def test_custom_provider_lookup_failure_does_not_crash_fallback(self):
+        """If the custom_providers lookup raises, fallback still works via
+        the named-provider path inside resolve_provider_client."""
+        fbs = [{"provider": "my-provider", "model": "my-model"}]
+        agent = _make_agent(fallback_model=fbs)
+        fallback_client = _mock_client(base_url="https://resolved-by-aux.example/v1")
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider._get_named_custom_provider",
+                side_effect=RuntimeError("config load failed"),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "my-model"),
+            ),
+        ):
+            # Should NOT raise — the except swallows the lookup error
+            assert agent._try_activate_fallback() is True
+            assert agent.model == "my-model"
+
+
 class TestPoolRotationRoom:
     def test_none_pool_returns_false(self):
         assert _pool_may_recover_from_rate_limit(None) is False


### PR DESCRIPTION
## Problem

When `fallback_providers` references a provider defined in `custom_providers` but does **not** supply an inline `base_url`, `_try_activate_fallback()` passed `explicit_base_url=None` to `resolve_provider_client()`. The resolution then fell through to the *primary* provider's endpoint, silently misdirecting the fallback request.

Reported in #15743.

## Root cause

`_try_activate_fallback()` only sourced `fb_base_url_hint` from the fallback entry's own `base_url` field and from `KNOWN_PROVIDERS`. Named `custom_providers` entries were never consulted, so any provider whose connectivity lives entirely in `custom_providers` (no built-in entry) produced a `None` hint.

## Fix

Before calling `resolve_provider_client()`, when neither `fb_base_url_hint` nor `fb_api_key_hint` is set, attempt a lookup via `_get_named_custom_provider(fb_provider)` and propagate `base_url`, `api_key`, and `key_env` as explicit hints:

```python
if not fb_base_url_hint and not fb_api_key_hint:
    try:
        from hermes_cli.runtime_provider import _get_named_custom_provider
        _cp = _get_named_custom_provider(fb_provider)
        if _cp:
            fb_base_url_hint = (_cp.get("base_url") or "").strip() or None
            _cp_key = (_cp.get("api_key") or "").strip()
            _cp_key_env = (_cp.get("key_env") or "").strip()
            if not fb_api_key_hint:
                if _cp_key:
                    fb_api_key_hint = _cp_key or None
                elif _cp_key_env:
                    fb_api_key_hint = os.getenv(_cp_key_env, "").strip() or None
    except Exception:
        pass
```

The entire block is wrapped in `except Exception: pass` so a config-load failure degrades gracefully — `resolve_provider_client()` still runs with whatever it can derive from the provider name alone, exactly as before.

**Precedence is preserved:** the lookup only runs when both hints are empty. An inline `base_url` in the fallback entry always takes priority.

## Tests

Three new tests in `TestCustomProviderFallbackBaseUrl` (appended to `tests/run_agent/test_provider_fallback.py`):

| Test | Assertion |
|------|-----------|
| `test_custom_provider_base_url_used_when_not_in_fallback_entry` | `explicit_base_url` is the custom provider's URL; `agent.base_url` is updated; `agent.provider` matches |
| `test_inline_base_url_takes_precedence_over_custom_providers_lookup` | `_get_named_custom_provider` is **not called** when inline `base_url` is present |
| `test_custom_provider_lookup_failure_does_not_crash_fallback` | A `RuntimeError` from the lookup does not abort fallback activation |

All 22 tests in the file pass (`22 passed`).

## Checklist

- [x] Fixes the reported symptom end-to-end (wrong endpoint → correct endpoint)
- [x] Inline `base_url` continues to take precedence (no behaviour change for existing configs)
- [x] Lookup failure is silently swallowed — no regression for providers that aren't in `custom_providers`
- [x] Three targeted tests cover the happy path, the no-op path, and the error path
- [x] No new dependencies introduced

Closes #15743