### PR TITLE
feat(gateway/discord): sync thread names with session titles

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1299,6 +1299,21 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def rename_thread(self, thread_id: str, name: str) -> bool:
+        """Rename a Discord thread to match the session title."""
+        if not self._client:
+            return False
+        try:
+            thread = self._client.get_channel(int(thread_id))
+            if not thread:
+                thread = await self._client.fetch_channel(int(thread_id))
+            if thread and hasattr(thread, "edit"):
+                await thread.edit(name=name[:100])
+                return True
+        except Exception as e:
+            logger.debug("[%s] Failed to rename thread %s: %s", self.name, thread_id, e)
+        return False
+
     async def _send_file_attachment(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6107,6 +6107,29 @@ class GatewayRunner:
 
         await adapter.handle_message(event)
 
+    async def _sync_discord_thread_title(
+        self,
+        session_id: str,
+        thread_id: str,
+        max_wait: float = 15.0,
+    ) -> None:
+        """Poll for an auto-generated session title and sync it to the Discord thread name."""
+        if not self._session_db:
+            return
+        adapter = self.adapters.get(Platform.DISCORD)
+        if not adapter or not getattr(adapter, "rename_thread", None):
+            return
+        deadline = time.monotonic() + max_wait
+        while time.monotonic() < deadline:
+            try:
+                title = self._session_db.get_session_title(session_id)
+                if title:
+                    await adapter.rename_thread(thread_id, title)
+                    return
+            except Exception:
+                pass
+            await asyncio.sleep(1.0)
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -7052,6 +7075,13 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    # Sync Discord thread name if applicable
+                    if source.platform == Platform.DISCORD and source.thread_id:
+                        adapter = self.adapters.get(Platform.DISCORD)
+                        if adapter and getattr(adapter, "rename_thread", None):
+                            asyncio.create_task(
+                                adapter.rename_thread(source.thread_id, sanitized)
+                            )
                     return f"✏️ Session title set: **{sanitized}**"
                 else:
                     return "Session not found in database."
@@ -9014,6 +9044,7 @@ class GatewayRunner:
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        reply_to=event_message_id,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
@@ -9637,6 +9668,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id,
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:
@@ -10125,6 +10157,15 @@ class GatewayRunner:
                         final_response,
                         all_msgs,
                     )
+                    # Sync Discord thread name with the auto-generated title.
+                    # Title generation runs in a background thread; we poll
+                    # briefly and fire a non-blocking rename when it appears.
+                    if source.platform == Platform.DISCORD and source.thread_id:
+                        asyncio.create_task(
+                            self._sync_discord_thread_title(
+                                effective_session_id, source.thread_id
+                            )
+                        )
                 except Exception:
                     pass
 


### PR DESCRIPTION
Auto-generated session titles (after the first exchange) and user-set titles via `/title` now propagate to Discord thread names.

**Problem:** Session titles are generated and stored in the local SQLite database, visible in `/sessions list` and the web dashboard. Discord thread names, however, are set once at thread creation and never updated. This creates a disconnect between the two.

**Changes:**
- `DiscordAdapter.rename_thread()` - edits thread names via discord.py
- After `maybe_auto_title()`, fire a lightweight async task that polls the session DB for up to 15s and renames the thread when the title appears
- Also sync immediately when `/title` is used

This bridges the gap between Hermes session titles and Discord thread names.