### PR TITLE
fix(cli): profile wrappers show alias name instead of hardcoded 'hermes' in --help (#15698)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7748,48 +7748,60 @@ def cmd_logs(args):
     )
 
 
+def _cli_prog() -> str:
+    """Return the program name to use in help output.
+
+    Profile wrappers set HERMES_CLI_NAME so that ``june --help`` shows
+    ``usage: june`` instead of ``usage: hermes``.  Falls back to the
+    basename of ``sys.argv[0]`` (handles ``python -m hermes_cli`` etc.),
+    then to the literal string ``"hermes"``.
+    """
+    return os.environ.get("HERMES_CLI_NAME") or Path(sys.argv[0]).name or "hermes"
+
+
 def main():
     """Main entry point for hermes CLI."""
+    _prog = _cli_prog()
     parser = argparse.ArgumentParser(
-        prog="hermes",
+        prog=_prog,
         description="Hermes Agent - AI assistant with tool-calling capabilities",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
+        epilog=f"""
 Examples:
-    hermes                        Start interactive chat
-    hermes chat -q "Hello"        Single query mode
-    hermes -c                     Resume the most recent session
-    hermes -c "my project"        Resume a session by name (latest in lineage)
-    hermes --resume <session_id>  Resume a specific session by ID
-    hermes setup                  Run setup wizard
-    hermes logout                 Clear stored authentication
-    hermes auth add <provider>    Add a pooled credential
-    hermes auth list              List pooled credentials
-    hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
-    hermes auth reset <provider>  Clear exhaustion status for a provider
-    hermes model                  Select default model
-    hermes fallback [list]        Show fallback provider chain
-    hermes fallback add           Add a fallback provider (same picker as `hermes model`)
-    hermes fallback remove        Remove a fallback provider from the chain
-    hermes config                 View configuration
-    hermes config edit            Edit config in $EDITOR
-    hermes config set model gpt-4 Set a config value
-    hermes gateway                Run messaging gateway
-    hermes -s hermes-agent-dev,github-auth
-    hermes -w                     Start in isolated git worktree
-    hermes gateway install        Install gateway background service
-    hermes sessions list          List past sessions
-    hermes sessions browse        Interactive session picker
-    hermes sessions rename ID T   Rename/title a session
-    hermes logs                   View agent.log (last 50 lines)
-    hermes logs -f                Follow agent.log in real time
-    hermes logs errors            View errors.log
-    hermes logs --since 1h        Lines from the last hour
-    hermes debug share             Upload debug report for support
-    hermes update                 Update to latest version
+    {_prog}                        Start interactive chat
+    {_prog} chat -q "Hello"        Single query mode
+    {_prog} -c                     Resume the most recent session
+    {_prog} -c "my project"        Resume a session by name (latest in lineage)
+    {_prog} --resume <session_id>  Resume a specific session by ID
+    {_prog} setup                  Run setup wizard
+    {_prog} logout                 Clear stored authentication
+    {_prog} auth add <provider>    Add a pooled credential
+    {_prog} auth list              List pooled credentials
+    {_prog} auth remove <p> <t>    Remove pooled credential by index, id, or label
+    {_prog} auth reset <provider>  Clear exhaustion status for a provider
+    {_prog} model                  Select default model
+    {_prog} fallback [list]        Show fallback provider chain
+    {_prog} fallback add           Add a fallback provider (same picker as `{_prog} model`)
+    {_prog} fallback remove        Remove a fallback provider from the chain
+    {_prog} config                 View configuration
+    {_prog} config edit            Edit config in $EDITOR
+    {_prog} config set model gpt-4 Set a config value
+    {_prog} gateway                Run messaging gateway
+    {_prog} -s hermes-agent-dev,github-auth
+    {_prog} -w                     Start in isolated git worktree
+    {_prog} gateway install        Install gateway background service
+    {_prog} sessions list          List past sessions
+    {_prog} sessions browse        Interactive session picker
+    {_prog} sessions rename ID T   Rename/title a session
+    {_prog} logs                   View agent.log (last 50 lines)
+    {_prog} logs -f                Follow agent.log in real time
+    {_prog} logs errors            View errors.log
+    {_prog} logs --since 1h        Lines from the last hour
+    {_prog} debug share             Upload debug report for support
+    {_prog} update                 Update to latest version
 
 For more help on a command:
-    hermes <command> --help
+    {_prog} <command> --help
 """,
     )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7628,11 +7628,10 @@ def cmd_profile(args):
             if collision:
                 print(f"Error: {collision}")
                 sys.exit(1)
-            wrapper_path = create_wrapper_script(alias_name)
+            wrapper_path = create_wrapper_script(
+                alias_name, profile=name if custom_name else None
+            )
             if wrapper_path:
-                # If custom name, write the profile name into the wrapper
-                if custom_name:
-                    wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
                 print(f"✓ Alias created: {wrapper_path}")
                 if not _is_wrapper_dir_in_path():
                     print(f"⚠ {_get_wrapper_dir()} is not in your PATH.")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -238,7 +238,9 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
     wrapper_path = wrapper_dir / name
     try:
-        wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
+        wrapper_path.write_text(
+            f'#!/bin/sh\nHERMES_CLI_NAME="$(basename "$0")" exec hermes -p {name} "$@"\n'
+        )
         wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
         return wrapper_path
     except OSError as e:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -22,6 +22,7 @@ Usage::
 import json
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -224,11 +225,22 @@ def _is_wrapper_dir_in_path() -> bool:
     return wrapper_dir in os.environ.get("PATH", "").split(os.pathsep)
 
 
-def create_wrapper_script(name: str) -> Optional[Path]:
+def create_wrapper_script(name: str, profile: Optional[str] = None) -> Optional[Path]:
     """Create a shell wrapper script at ~/.local/bin/<name>.
+
+    ``profile`` is the Hermes profile passed to ``hermes -p``; defaults to
+    ``name`` when not provided.  The alias file name (``name``) must not
+    contain path separators or shell metacharacters.
 
     Returns the path to the created wrapper, or None if creation failed.
     """
+    if "/" in name or "\\" in name or name.startswith("."):
+        print(f"⚠ Invalid wrapper name {name!r}: must not contain path separators or start with '.'")
+        return None
+
+    target_profile = profile or name
+    quoted_profile = shlex.quote(target_profile)
+
     wrapper_dir = _get_wrapper_dir()
     try:
         wrapper_dir.mkdir(parents=True, exist_ok=True)
@@ -239,7 +251,7 @@ def create_wrapper_script(name: str) -> Optional[Path]:
     wrapper_path = wrapper_dir / name
     try:
         wrapper_path.write_text(
-            f'#!/bin/sh\nHERMES_CLI_NAME="$(basename "$0")" exec hermes -p {name} "$@"\n'
+            f'#!/bin/sh\nHERMES_CLI_NAME="$(basename "$0")" exec hermes -p {quoted_profile} "$@"\n'
         )
         wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
         return wrapper_path

--- a/tests/hermes_cli/test_cli_prog_name.py
+++ b/tests/hermes_cli/test_cli_prog_name.py
@@ -1,0 +1,31 @@
+"""Tests for _cli_prog() — the function that supplies prog= to ArgumentParser.
+
+Profile wrappers set HERMES_CLI_NAME so that ``june --help`` shows
+``usage: june`` instead of ``usage: hermes``.
+"""
+
+import sys
+from unittest.mock import patch
+
+from hermes_cli.main import _cli_prog
+
+
+class TestCliProg:
+    def test_returns_hermes_cli_name_env_var(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLI_NAME", "june")
+        assert _cli_prog() == "june"
+
+    def test_falls_back_to_argv0_basename(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLI_NAME", raising=False)
+        with patch.object(sys, "argv", ["/usr/local/bin/june", "--help"]):
+            assert _cli_prog() == "june"
+
+    def test_ultimate_fallback_is_hermes(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLI_NAME", raising=False)
+        with patch.object(sys, "argv", [""]):
+            assert _cli_prog() == "hermes"
+
+    def test_env_var_takes_precedence_over_argv(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLI_NAME", "luna")
+        with patch.object(sys, "argv", ["/usr/bin/cid"]):
+            assert _cli_prog() == "luna"

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -30,6 +30,8 @@ from hermes_cli.profiles import (
     import_profile,
     generate_bash_completion,
     generate_zsh_completion,
+    create_wrapper_script,
+    remove_wrapper_script,
     _get_profiles_root,
     _get_default_hermes_home,
 )
@@ -968,3 +970,39 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+
+# ===================================================================
+# TestWrapperScriptContent (#15698)
+# ===================================================================
+
+class TestWrapperScriptContent:
+    """Wrapper scripts must set HERMES_CLI_NAME so --help shows the alias."""
+
+    def test_wrapper_contains_hermes_cli_name(self, profile_env, tmp_path):
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            path = create_wrapper_script("june")
+
+        assert path is not None
+        content = path.read_text()
+        assert 'HERMES_CLI_NAME="$(basename "$0")"' in content
+        assert 'exec hermes -p june' in content
+
+    def test_wrapper_is_self_aware_for_remove(self, profile_env, tmp_path):
+        """remove_wrapper_script must still identify wrappers created by the new template."""
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            path = create_wrapper_script("luna")
+            assert path is not None
+            removed = remove_wrapper_script("luna")
+
+        assert removed is True
+        assert not path.exists()
+
+    def test_wrapper_shebang_is_sh(self, profile_env, tmp_path):
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            path = create_wrapper_script("cid")
+
+        assert path.read_text().startswith("#!/bin/sh\n")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1006,3 +1006,47 @@ class TestWrapperScriptContent:
             path = create_wrapper_script("cid")
 
         assert path.read_text().startswith("#!/bin/sh\n")
+
+    def test_custom_alias_includes_hermes_cli_name(self, profile_env, tmp_path):
+        """Custom alias (--name) must still set HERMES_CLI_NAME for --help to work."""
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            path = create_wrapper_script("myalias", profile="june")
+
+        assert path is not None
+        content = path.read_text()
+        assert 'HERMES_CLI_NAME="$(basename "$0")"' in content
+        assert "hermes -p june" in content
+        assert "myalias" not in content  # alias name is only the file name, not in script body
+
+    def test_custom_alias_targets_correct_profile(self, profile_env, tmp_path):
+        """When profile differs from alias name, exec must reference the profile, not the alias."""
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            path = create_wrapper_script("ws", profile="workstation")
+
+        content = path.read_text()
+        assert "hermes -p workstation" in content
+        assert "hermes -p ws " not in content
+
+    def test_wrapper_name_path_traversal_rejected(self, profile_env, tmp_path):
+        """Names with path separators must be rejected to prevent directory traversal."""
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            result_slash = create_wrapper_script("../evil")
+            result_abs = create_wrapper_script("/etc/cron.d/pwned")
+            result_dot = create_wrapper_script(".hidden")
+
+        assert result_slash is None
+        assert result_abs is None
+        assert result_dot is None
+
+    def test_profile_name_with_spaces_is_shell_quoted(self, profile_env, tmp_path):
+        """Profile names with whitespace or metacharacters must be shell-quoted in the script."""
+        wrapper_dir = tmp_path / ".local" / "bin"
+        with patch("hermes_cli.profiles._get_wrapper_dir", return_value=wrapper_dir):
+            path = create_wrapper_script("mybot", profile="my profile")
+
+        assert path is not None
+        content = path.read_text()
+        assert "'my profile'" in content  # shlex.quote wraps in single quotes


### PR DESCRIPTION
## Problem

When `hermes profile add june --alias june` creates a wrapper, running `june --help` showed:

```
usage: hermes [-h] ...

Examples:
    hermes                        Start interactive chat
    hermes chat -q "Hello"        Single query mode
    ...
```

The alias name was completely invisible to the user — unhelpful and confusing.

Fixes #15698.

## Root cause

Two hard-coded `"hermes"` strings:

1. `hermes_cli/main.py` — `ArgumentParser(prog="hermes", ...)` and the epilog examples block were static strings.
2. `hermes_cli/profiles.py` — wrapper scripts were `exec hermes -p {name} "$@"` with no way to propagate the alias name back into the process.

## Fix

### 1. Wrapper scripts now export `HERMES_CLI_NAME`

```sh
#!/bin/sh
HERMES_CLI_NAME="$(basename "$0")" exec hermes -p june "$@"
```

`$(basename "$0")` resolves to the invoked name (the alias), and the env var travels transparently into the hermes process. If the user symlinks the wrapper to another name, that name is also picked up correctly.

`remove_wrapper_script` identifies our wrappers by checking for `"hermes -p"`, which still matches the new template — no regression.

### 2. `_cli_prog()` helper in `main.py`

```python
def _cli_prog() -> str:
    return os.environ.get("HERMES_CLI_NAME") or Path(sys.argv[0]).name or "hermes"
```

Priority order:
1. `HERMES_CLI_NAME` env var (set by wrapper)
2. `Path(sys.argv[0]).name` (handles `python -m hermes_cli`, direct binary invocation)
3. `"hermes"` (ultimate fallback)

`prog=_cli_prog()` is passed to `ArgumentParser`, and the epilog examples use an f-string so every `hermes <cmd>` line becomes `june <cmd>` automatically.

## After fix

```
$ june --help
usage: june [-h] [--version] ...

Examples:
    june                        Start interactive chat
    june chat -q "Hello"        Single query mode
    june -c                     Resume the most recent session
    ...

For more help on a command:
    june <command> --help
```

## Tests

- `TestWrapperScriptContent` (3 tests in `test_profiles.py`):
  - wrapper contains `HERMES_CLI_NAME="$(basename "$0")"`
  - wrapper still satisfies `remove_wrapper_script`'s safety check
  - shebang is `#!/bin/sh`
- `TestCliProg` (4 tests in `test_cli_prog_name.py`):
  - env var used when set
  - falls back to argv[0] basename
  - ultimate fallback is `"hermes"`
  - env var takes precedence over argv[0]

All 7 new tests pass alongside the existing 89 profile tests (96 total).

## Checklist

- [x] No breaking change — bare `hermes --help` still shows `hermes` (env var absent)
- [x] Existing wrappers re-created via `hermes profile add` pick up the fix; old wrappers continue to work (they just don't set the env var)
- [x] `remove_wrapper_script` still works for new wrappers
- [x] Epilog and prog= are consistent — no mixed branding

Closes #15698