### PR TITLE
Fix DeepSeek reasoning_content propagation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7024,10 +7024,19 @@ class AIAgent:
             "finish_reason": finish_reason,
         }
 
-        if hasattr(assistant_message, "reasoning_content"):
-            raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
-            if raw_reasoning_content is not None:
-                msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
+        _rc = getattr(assistant_message, "reasoning_content", None)
+        if _rc is None and hasattr(assistant_message, "model_extra"):
+            _rc = (assistant_message.model_extra or {}).get("reasoning_content")
+
+        deepseek_requires_reasoning = (
+            self.provider == "deepseek"
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+        if _rc is not None:
+            msg["reasoning_content"] = _sanitize_surrogates(_rc)
+        elif deepseek_requires_reasoning:
+            msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
@@ -7124,7 +7133,13 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
-        if kimi_requires_reasoning and source_msg.get("tool_calls"):
+        deepseek_requires_reasoning = (
+            self.provider == "deepseek"
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+        if deepseek_requires_reasoning or (
+            source_msg.get("tool_calls") and kimi_requires_reasoning
+        ):
             api_msg["reasoning_content"] = ""
 
     @staticmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -7122,11 +7122,6 @@ class AIAgent:
             api_msg["reasoning_content"] = explicit_reasoning
             return
 
-        normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
-            api_msg["reasoning_content"] = normalized_reasoning
-            return
-
         kimi_requires_reasoning = (
             self.provider in {"kimi-coding", "kimi-coding-cn"}
             or base_url_host_matches(self.base_url, "api.kimi.com")
@@ -7137,10 +7132,20 @@ class AIAgent:
             self.provider == "deepseek"
             or base_url_host_matches(self.base_url, "api.deepseek.com")
         )
+        
+        # DeepSeek and Kimi must inject an empty string if reasoning_content is missing
+        # Evaluate this BEFORE promoting `reasoning`, to prevent cross-provider 
+        # reasoning leakage (e.g. MiniMax reasoning causing a 400 on DeepSeek).
         if deepseek_requires_reasoning or (
             source_msg.get("tool_calls") and kimi_requires_reasoning
         ):
             api_msg["reasoning_content"] = ""
+            return
+
+        normalized_reasoning = source_msg.get("reasoning")
+        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            api_msg["reasoning_content"] = normalized_reasoning
+            return
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7031,6 +7031,7 @@ class AIAgent:
         deepseek_requires_reasoning = (
             self.provider == "deepseek"
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+            or "deepseek" in (self.model or "").lower()
         )
 
         if _rc is not None:
@@ -7131,6 +7132,7 @@ class AIAgent:
         deepseek_requires_reasoning = (
             self.provider == "deepseek"
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+            or "deepseek" in (self.model or "").lower()
         )
         
         # DeepSeek and Kimi must inject an empty string if reasoning_content is missing


### PR DESCRIPTION
This PR fixes two issues with DeepSeek reasoning_content. 1. Extracts reasoning_content from model_extra for ZenMux responses. 2. Adds empty string fallback for DeepSeek to non-tool-call messages.