### PR TITLE
fix(tools): dedup early-return bypasses loop detection in read_file (#15759)

### DIFF
--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -195,7 +195,7 @@ class TestDedupLoopDetection(unittest.TestCase):
     """Dedup hits must flow through the consecutive counter and trigger the hard block.
 
     Without this fix, the dedup path returned early and the loop-detection guard
-    at line 538 was never reached — the agent could loop forever on a dedup stub.
+    was never reached — the agent could loop forever on a dedup stub.
     """
 
     def setUp(self):
@@ -210,9 +210,9 @@ class TestDedupLoopDetection(unittest.TestCase):
         """2nd read (dedup hit) returns the stub but no warning yet."""
         read_file_tool("/tmp/test.py", task_id="td1")
         result = json.loads(read_file_tool("/tmp/test.py", task_id="td1"))
-        assert result.get("dedup") is True
-        assert "_warning" not in result
-        assert "error" not in result
+        self.assertTrue(result.get("dedup"))
+        self.assertNotIn("_warning", result)
+        self.assertNotIn("error", result)
 
     @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
@@ -221,9 +221,9 @@ class TestDedupLoopDetection(unittest.TestCase):
         for _ in range(2):
             read_file_tool("/tmp/test.py", task_id="td2")
         result = json.loads(read_file_tool("/tmp/test.py", task_id="td2"))
-        assert result.get("dedup") is True
-        assert "_warning" in result
-        assert "3 times" in result["_warning"]
+        self.assertTrue(result.get("dedup"))
+        self.assertIn("_warning", result)
+        self.assertIn("3 times", result["_warning"])
 
     @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
@@ -232,10 +232,10 @@ class TestDedupLoopDetection(unittest.TestCase):
         for _ in range(3):
             read_file_tool("/tmp/test.py", task_id="td3")
         result = json.loads(read_file_tool("/tmp/test.py", task_id="td3"))
-        assert "error" in result
-        assert "BLOCKED" in result["error"]
-        assert "4 times" in result["error"]
-        assert "content" not in result
+        self.assertIn("error", result)
+        self.assertIn("BLOCKED", result["error"])
+        self.assertIn("4 times", result["error"])
+        self.assertNotIn("content", result)
 
     @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
@@ -246,9 +246,9 @@ class TestDedupLoopDetection(unittest.TestCase):
         notify_other_tool_call("td4")
         result = json.loads(read_file_tool("/tmp/test.py", task_id="td4"))
         # After reset a dedup hit is fine — no block and no warning
-        assert result.get("dedup") is True
-        assert "_warning" not in result
-        assert "error" not in result
+        self.assertTrue(result.get("dedup"))
+        self.assertNotIn("_warning", result)
+        self.assertNotIn("error", result)
 
     @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
@@ -257,7 +257,30 @@ class TestDedupLoopDetection(unittest.TestCase):
         for _ in range(3):
             read_file_tool("/tmp/test.py", task_id="td5")
         result = json.loads(read_file_tool("/tmp/test.py", task_id="td6"))
-        assert "error" not in result
+        self.assertNotIn("error", result)
+
+    @patch(
+        "tools.file_tools._resolve_path_for_task",
+        return_value=__import__("pathlib").Path("/resolved/file.py"),
+    )
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_dedup_path_normalization_shares_counter(
+        self, _mock_ops, _mock_mtime, _mock_resolve
+    ):
+        """Different path strings that resolve to the same file share the loop counter.
+
+        The loop-detection key must use the resolved path so that alternating
+        between e.g. './foo.py' and '/abs/foo.py' cannot bypass the block.
+        """
+        # Both paths resolve to /resolved/file.py via the mock.
+        read_file_tool("/resolved/file.py", task_id="td7")
+        read_file_tool("/resolved/file.py", task_id="td7")
+        read_file_tool("./resolved/file.py", task_id="td7")   # different raw string
+        result = json.loads(read_file_tool("../resolved/file.py", task_id="td7"))
+        # 4th consecutive hit against the same resolved path → BLOCKED
+        self.assertIn("error", result)
+        self.assertIn("BLOCKED", result["error"])
 
 
 

--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -191,6 +191,73 @@ class TestNotifyOtherToolCall(unittest.TestCase):
         notify_other_tool_call("nonexistent_task")  # Should not raise
 
 
+class TestDedupLoopDetection(unittest.TestCase):
+    """Dedup hits must flow through the consecutive counter and trigger the hard block.
+
+    Without this fix, the dedup path returned early and the loop-detection guard
+    at line 538 was never reached — the agent could loop forever on a dedup stub.
+    """
+
+    def setUp(self):
+        _read_tracker.clear()
+
+    def tearDown(self):
+        _read_tracker.clear()
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_dedup_second_read_returns_stub_no_warning(self, _mock_ops, _mock_mtime):
+        """2nd read (dedup hit) returns the stub but no warning yet."""
+        read_file_tool("/tmp/test.py", task_id="td1")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="td1"))
+        assert result.get("dedup") is True
+        assert "_warning" not in result
+        assert "error" not in result
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_dedup_third_read_returns_stub_with_warning(self, _mock_ops, _mock_mtime):
+        """3rd consecutive dedup hit returns the stub plus a warning."""
+        for _ in range(2):
+            read_file_tool("/tmp/test.py", task_id="td2")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="td2"))
+        assert result.get("dedup") is True
+        assert "_warning" in result
+        assert "3 times" in result["_warning"]
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_dedup_fourth_read_is_hard_blocked(self, _mock_ops, _mock_mtime):
+        """4th consecutive dedup hit returns BLOCKED with no content."""
+        for _ in range(3):
+            read_file_tool("/tmp/test.py", task_id="td3")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="td3"))
+        assert "error" in result
+        assert "BLOCKED" in result["error"]
+        assert "4 times" in result["error"]
+        assert "content" not in result
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_dedup_notify_resets_counter(self, _mock_ops, _mock_mtime):
+        """notify_other_tool_call between dedup hits resets the consecutive counter."""
+        for _ in range(3):
+            read_file_tool("/tmp/test.py", task_id="td4")
+        notify_other_tool_call("td4")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="td4"))
+        # After reset a dedup hit is fine — no block and no warning
+        assert result.get("dedup") is True
+        assert "_warning" not in result
+        assert "error" not in result
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_dedup_different_task_isolated(self, _mock_ops, _mock_mtime):
+        """Dedup consecutive counts are scoped to the task_id."""
+        for _ in range(3):
+            read_file_tool("/tmp/test.py", task_id="td5")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="td6"))
+        assert "error" not in result
 
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -439,7 +439,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                     # Dedup hit: still update the consecutive counter so the
                     # loop-detection hard block fires for pathological re-reads
                     # of unchanged files (the full-read path below is skipped).
-                    read_key = ("read", path, offset, limit)
+                    read_key = ("read", resolved_str, offset, limit)
                     with _read_tracker_lock:
                         if task_data["last_key"] == read_key:
                             task_data["consecutive"] += 1
@@ -525,7 +525,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             ))
 
         # ── Track for consecutive-loop detection ──────────────────────
-        read_key = ("read", path, offset, limit)
+        read_key = ("read", resolved_str, offset, limit)
         with _read_tracker_lock:
             # Ensure "dedup" key exists (backward compat with old tracker state)
             if "dedup" not in task_data:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -436,7 +436,30 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
-                    return json.dumps({
+                    # Dedup hit: still update the consecutive counter so the
+                    # loop-detection hard block fires for pathological re-reads
+                    # of unchanged files (the full-read path below is skipped).
+                    read_key = ("read", path, offset, limit)
+                    with _read_tracker_lock:
+                        if task_data["last_key"] == read_key:
+                            task_data["consecutive"] += 1
+                        else:
+                            task_data["last_key"] = read_key
+                            task_data["consecutive"] = 1
+                        count = task_data["consecutive"]
+
+                    if count >= 4:
+                        return json.dumps({
+                            "error": (
+                                f"BLOCKED: You have read this exact file region {count} times in a row. "
+                                "The content has NOT changed. You already have this information. "
+                                "STOP re-reading and proceed with your task."
+                            ),
+                            "path": path,
+                            "already_read": count,
+                        }, ensure_ascii=False)
+
+                    stub: dict = {
                         "content": (
                             "File unchanged since last read. The content from "
                             "the earlier read_file result in this conversation is "
@@ -444,7 +467,15 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                         ),
                         "path": path,
                         "dedup": True,
-                    }, ensure_ascii=False)
+                    }
+                    if count >= 3:
+                        stub["_warning"] = (
+                            f"You have read this exact file region {count} times consecutively. "
+                            "The content has not changed since your last read. Use the information "
+                            "you already have. If you are stuck in a loop, stop reading and proceed "
+                            "with writing or responding."
+                        )
+                    return json.dumps(stub, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
 


### PR DESCRIPTION
## Summary
- The `read_file` dedup path at `tools/file_tools.py:435` returned immediately for unchanged-file hits without updating the consecutive re-read counter.
- The hard-block guard (`count >= 4`) and the warning guard (`count >= 3`) at line 538 were unreachable for dedup hits.
- Models that repeatedly call `read_file` on an unchanged file received an infinite stream of dedup stubs with no escalation.

## The bug

`_read_tracker[task_id]["consecutive"]` is only incremented in the full-read path (line 504).  The dedup path returned before that code ran:

```
read_file → content      (mtime cached, consecutive=1)
read_file → dedup stub   (returns early — consecutive stays at 1 forever)
read_file → dedup stub   ← infinite loop
```

Issue reported with Qwen3.6 local models that became stuck re-reading files mid-task after a `hermes update`.

## The fix

Before returning the dedup stub, acquire `_read_tracker_lock` and update `last_key` / `consecutive` using the same logic as the full-read path.  If `count >= 4`, return the `BLOCKED` error instead of the stub.  If `count >= 3`, annotate the stub with `_warning`.

`notify_other_tool_call()` already zeroes `consecutive`, so interleaved tool calls continue to work correctly.

## Test plan
- [x] **Before**: `test_dedup_fourth_read_is_hard_blocked` and `test_dedup_third_read_returns_stub_with_warning` fail (stub returned with no warning or block)
- [x] **After**: all 30 loop-detection tests pass including 5 new dedup-specific cases
- [x] **Regression guard**: reverted fix → observed dedup returning plain stub on 4th call; restored → 0 failures
- [x] **CI baseline**: 8 pre-existing failures (7 dingtalk + 1 matrix) on `origin/main` — unchanged

## Related
- Fixes #15759

🤖 Generated with [Claude Code](https://claude.com/claude-code)