### PR TITLE
feat(skills): add Langfuse tracing installer

### DIFF
--- a/optional-skills/observability/langfuse-tracing/SKILL.md
+++ b/optional-skills/observability/langfuse-tracing/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: langfuse-tracing
+description: Optional installer for persistent Langfuse tracing in Hermes. It installs and configures the external runtime plugin; traced sessions then auto-load the plugin through Hermes plugin discovery without adding skill text to prompt context.
+version: 1.0.0
+author: Nous Research
+license: MIT
+metadata:
+  hermes:
+    tags: [observability, tracing, langfuse, telemetry, hooks]
+    category: observability
+---
+
+# Langfuse Tracing for Hermes
+
+This is an optional skill, but it is not a runtime prompt skill.
+
+Its job is to install, configure, verify, and update the persistent Langfuse tracing plugin for the active Hermes profile. Once installed, tracing is handled by Hermes plugin discovery and plugin hooks at session startup. Normal traced sessions should not load this skill into model context.
+
+The intended lifecycle is:
+- install this optional skill when you want Langfuse tracing support
+- run the setup helper once to install and enable the plugin
+- the runtime tracing code stays in the external plugin repo
+- the helper installs the plugin into `$HERMES_HOME/plugins/langfuse_tracing/`
+- new Hermes sessions auto-load the plugin through Hermes plugin discovery/hooks
+- do not use `/skill langfuse-tracing` or `hermes -s langfuse-tracing` for normal traced sessions
+
+This keeps Hermes core clean, keeps observability instructions out of model context, and makes tracing a persistent opt-in plugin capability rather than per-session prompt content.
+
+## What this skill installs
+
+The helper script can:
+- install the `langfuse` Python package in the active Hermes environment if it is missing
+- fetch the plugin from an external Git repo
+- install the plugin into the active Hermes profile under `$HERMES_HOME/plugins/langfuse_tracing/`
+- add Langfuse env vars to `$HERMES_HOME/.env` without silently overwriting existing values
+- verify `hermes plugins list` discovers `langfuse_tracing`
+- optionally check the Langfuse health endpoint
+
+## Default external source
+
+By default the installer pulls from:
+- repo: `https://github.com/kshitijk4poor/hermes-langfuse-tracing.git`
+- branch: `main`
+
+The plugin repo can expose files in these layouts:
+- `__init__.py` + `plugin.yaml` at repo root  (preferred for `hermes plugins install`)
+- `langfuse_tracing/__init__.py` + `langfuse_tracing/plugin.yaml`  (older standalone layout)
+- `.hermes/plugins/langfuse_tracing/...`  (legacy branch layout)
+
+## Rules
+
+1. Never enable tracing without explicit user consent.
+2. Never overwrite existing Langfuse credentials silently.
+3. Install into the active Hermes profile via `get_hermes_home()`, not a hardcoded `~/.hermes` path.
+4. Keep the runtime tracing code in the external plugin repo, not inside Hermes core.
+
+## One-command setup
+
+```bash
+source .venv/bin/activate
+python optional-skills/observability/langfuse-tracing/scripts/setup_langfuse_env.py
+```
+
+Explicit values can be passed when they are not already present in the shell env or Hermes env file:
+
+```bash
+source .venv/bin/activate
+python optional-skills/observability/langfuse-tracing/scripts/setup_langfuse_env.py \
+  --public-key 'pk-lf-...' \
+  --secret-key 'sk-lf-...' \
+  --base-url 'http://localhost:3000' \
+  --environment 'local' \
+  --release 'local-skill'
+```
+
+If you want a different repo or branch:
+
+```bash
+source .venv/bin/activate
+python optional-skills/observability/langfuse-tracing/scripts/setup_langfuse_env.py \
+  --feature-repo 'https://github.com/kshitijk4poor/hermes-langfuse-tracing.git' \
+  --feature-branch 'main' \
+  --plugin-ref 'langfuse-plugin/main'
+```
+
+## Required credentials
+
+The plugin needs these values available either in `$HERMES_HOME/.env`, the current shell environment, or explicit script args:
+
+```bash
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=http://localhost:3000
+```
+
+Optional:
+
+```bash
+HERMES_LANGFUSE_ENV=local
+HERMES_LANGFUSE_RELEASE=local-skill
+HERMES_LANGFUSE_SAMPLE_RATE=1.0
+HERMES_LANGFUSE_MAX_CHARS=12000
+HERMES_LANGFUSE_DEBUG=true
+```
+
+## Verify
+
+1. Restart Hermes after installation
+2. Run `hermes plugins list`
+3. Confirm `langfuse_tracing` is listed/enabled
+4. Run a simple prompt in any new Hermes session
+5. Confirm Langfuse shows a Hermes turn trace with nested LLM/tool spans
+
+Do not load this skill for normal traced sessions. If the plugin is installed under `$HERMES_HOME/plugins/langfuse_tracing/` and `HERMES_LANGFUSE_ENABLED=true`, plugin discovery makes it active automatically on session start.
+
+## Troubleshooting
+
+### Plugin does not load
+
+Check:
+
+```bash
+test -f "$HERMES_HOME/plugins/langfuse_tracing/plugin.yaml" && echo plugin-present
+hermes plugins list
+```
+
+### Langfuse receives nothing
+
+Check the required env vars in `$HERMES_HOME/.env` and verify the server is reachable at `LANGFUSE_BASE_URL`.
+
+### Need to switch plugin source
+
+Re-run the installer with `--feature-repo`, `--feature-branch`, and optionally `--plugin-ref`.

--- a/optional-skills/observability/langfuse-tracing/scripts/setup_langfuse_env.py
+++ b/optional-skills/observability/langfuse-tracing/scripts/setup_langfuse_env.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Install the Langfuse tracing plugin from an external repo and persist env wiring."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.config import get_env_path, load_env, save_env_value
+from hermes_constants import get_hermes_home
+
+PLUGIN_NAME = "langfuse_tracing"
+DEFAULT_FEATURE_REPO = "https://github.com/kshitijk4poor/hermes-langfuse-tracing.git"
+DEFAULT_FEATURE_BRANCH = "main"
+DEFAULT_PLUGIN_REF = "langfuse-plugin/main"
+PLUGIN_FILES = ("__init__.py", "plugin.yaml")
+PLUGIN_PATH_CANDIDATES = {
+    "__init__.py": (
+        "__init__.py",
+        "langfuse_tracing/__init__.py",
+        ".hermes/plugins/langfuse_tracing/__init__.py",
+    ),
+    "plugin.yaml": (
+        "plugin.yaml",
+        "langfuse_tracing/plugin.yaml",
+        ".hermes/plugins/langfuse_tracing/plugin.yaml",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class EnvSetting:
+    name: str
+    aliases: tuple[str, ...]
+    required: bool = False
+
+
+_SETTINGS = (
+    EnvSetting("HERMES_LANGFUSE_ENABLED", ("HERMES_LANGFUSE_ENABLED", "TRACE_TO_LANGFUSE", "CC_LANGFUSE_ENABLED")),
+    EnvSetting("HERMES_LANGFUSE_PUBLIC_KEY", ("HERMES_LANGFUSE_PUBLIC_KEY", "CC_LANGFUSE_PUBLIC_KEY", "LANGFUSE_PUBLIC_KEY"), required=True),
+    EnvSetting("HERMES_LANGFUSE_SECRET_KEY", ("HERMES_LANGFUSE_SECRET_KEY", "CC_LANGFUSE_SECRET_KEY", "LANGFUSE_SECRET_KEY"), required=True),
+    EnvSetting("HERMES_LANGFUSE_BASE_URL", ("HERMES_LANGFUSE_BASE_URL", "CC_LANGFUSE_BASE_URL", "LANGFUSE_BASE_URL")),
+    EnvSetting("HERMES_LANGFUSE_ENV", ("HERMES_LANGFUSE_ENV", "LANGFUSE_ENV")),
+    EnvSetting("HERMES_LANGFUSE_RELEASE", ("HERMES_LANGFUSE_RELEASE", "LANGFUSE_RELEASE")),
+    EnvSetting("HERMES_LANGFUSE_SAMPLE_RATE", ("HERMES_LANGFUSE_SAMPLE_RATE",)),
+    EnvSetting("HERMES_LANGFUSE_MAX_CHARS", ("HERMES_LANGFUSE_MAX_CHARS",)),
+    EnvSetting("HERMES_LANGFUSE_DEBUG", ("HERMES_LANGFUSE_DEBUG", "CC_LANGFUSE_DEBUG")),
+)
+
+_ARG_TO_SETTING = {
+    "enable_tracing": "HERMES_LANGFUSE_ENABLED",
+    "public_key": "HERMES_LANGFUSE_PUBLIC_KEY",
+    "secret_key": "HERMES_LANGFUSE_SECRET_KEY",
+    "base_url": "HERMES_LANGFUSE_BASE_URL",
+    "environment": "HERMES_LANGFUSE_ENV",
+    "release": "HERMES_LANGFUSE_RELEASE",
+    "sample_rate": "HERMES_LANGFUSE_SAMPLE_RATE",
+    "max_chars": "HERMES_LANGFUSE_MAX_CHARS",
+    "debug": "HERMES_LANGFUSE_DEBUG",
+}
+
+_DEFAULTS = {
+    "HERMES_LANGFUSE_ENABLED": "true",
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _plugin_dir() -> Path:
+    return get_hermes_home() / "plugins" / PLUGIN_NAME
+
+
+def _nonempty(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _run(argv: list[str], *, cwd: Path | None = None, capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=str(cwd) if cwd else None,
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def _git_ref_exists(ref: str) -> bool:
+    try:
+        _run(["git", "rev-parse", "--verify", ref], cwd=_repo_root())
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _feature_repo(args: argparse.Namespace) -> str:
+    return _nonempty(getattr(args, "feature_repo", None)) or _nonempty(os.environ.get("HERMES_LANGFUSE_FEATURE_REPO")) or DEFAULT_FEATURE_REPO
+
+
+def _feature_branch(args: argparse.Namespace) -> str:
+    return _nonempty(getattr(args, "feature_branch", None)) or _nonempty(os.environ.get("HERMES_LANGFUSE_FEATURE_BRANCH")) or DEFAULT_FEATURE_BRANCH
+
+
+def _plugin_ref(args: argparse.Namespace) -> str:
+    return _nonempty(getattr(args, "plugin_ref", None)) or _nonempty(os.environ.get("HERMES_LANGFUSE_PLUGIN_REF")) or DEFAULT_PLUGIN_REF
+
+
+def _fetch_plugin_ref(feature_repo: str, feature_branch: str, plugin_ref: str) -> dict[str, Any]:
+    if _git_ref_exists(plugin_ref):
+        return {"plugin_ref": plugin_ref, "fetched": False, "feature_repo": feature_repo, "feature_branch": feature_branch}
+
+    fetch_ref = f"{feature_branch}:refs/remotes/{plugin_ref}"
+    _run(["git", "fetch", feature_repo, fetch_ref], cwd=_repo_root())
+    return {"plugin_ref": plugin_ref, "fetched": True, "feature_repo": feature_repo, "feature_branch": feature_branch}
+
+
+def _read_git_file(plugin_ref: str, candidates: tuple[str, ...]) -> str:
+    last_error: subprocess.CalledProcessError | None = None
+    for git_path in candidates:
+        try:
+            result = _run(["git", "show", f"{plugin_ref}:{git_path}"], cwd=_repo_root())
+            return result.stdout
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
+    raise RuntimeError(f"Could not locate plugin file in {plugin_ref}. Tried: {', '.join(candidates)}") from last_error
+
+
+def _write_git_file(plugin_ref: str, filename: str, destination: Path) -> str:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    content = _read_git_file(plugin_ref, PLUGIN_PATH_CANDIDATES[filename])
+    destination.write_text(content, encoding="utf-8")
+    return str(destination)
+
+
+def _ensure_langfuse_dependency() -> dict[str, Any]:
+    try:
+        import langfuse  # noqa: F401
+        return {"installed": True, "changed": False}
+    except Exception:
+        _run([sys.executable, "-m", "pip", "install", "langfuse"], cwd=_repo_root())
+        return {"installed": True, "changed": True}
+
+
+def ensure_langfuse_plugin(args: argparse.Namespace | None = None) -> dict[str, Any]:
+    args = args or argparse.Namespace()
+    feature_repo = _feature_repo(args)
+    feature_branch = _feature_branch(args)
+    plugin_ref = _plugin_ref(args)
+    fetch_result = _fetch_plugin_ref(feature_repo, feature_branch, plugin_ref)
+
+    plugin_dir = _plugin_dir()
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+
+    files = []
+    for filename in PLUGIN_FILES:
+        files.append(_write_git_file(plugin_ref, filename, plugin_dir / filename))
+
+    return {
+        "plugin_dir": str(plugin_dir),
+        "plugin_ref": plugin_ref,
+        "feature_repo": feature_repo,
+        "feature_branch": feature_branch,
+        "fetched": fetch_result["fetched"],
+        "files": files,
+    }
+
+
+def _existing_alias(setting: EnvSetting, dotenv: dict[str, str]) -> str | None:
+    for key in setting.aliases:
+        if key in dotenv:
+            return key
+    return None
+
+
+def _resolve_value(setting: EnvSetting, args: argparse.Namespace) -> str | None:
+    for arg_name, setting_name in _ARG_TO_SETTING.items():
+        if setting_name != setting.name:
+            continue
+        value = _nonempty(getattr(args, arg_name, None))
+        if value is not None:
+            return value
+
+    for key in setting.aliases:
+        value = _nonempty(os.environ.get(key))
+        if value is not None:
+            return value
+
+    return _DEFAULTS.get(setting.name)
+
+
+def ensure_langfuse_env(args: argparse.Namespace | None = None) -> dict[str, Any]:
+    args = args or argparse.Namespace()
+    dotenv = load_env()
+
+    added: dict[str, str] = {}
+    preserved: dict[str, str] = {}
+    missing: list[str] = []
+
+    for setting in _SETTINGS:
+        existing_key = _existing_alias(setting, dotenv)
+        if existing_key is not None:
+            preserved[setting.name] = existing_key
+            continue
+
+        value = _resolve_value(setting, args)
+        if value is None:
+            if setting.required:
+                missing.append(setting.name)
+            continue
+
+        save_env_value(setting.name, value)
+        dotenv[setting.name] = value
+        added[setting.name] = value
+
+    return {
+        "success": True,
+        "env_path": str(get_env_path()),
+        "added": sorted(added.keys()),
+        "preserved": preserved,
+        "missing": missing,
+    }
+
+
+def _hermes_executable() -> str | None:
+    hermes = shutil.which("hermes")
+    if hermes:
+        return hermes
+
+    candidate = _repo_root() / ".venv" / "bin" / "hermes"
+    if candidate.exists():
+        return str(candidate)
+    return None
+
+
+def verify_plugin_discovery() -> dict[str, Any]:
+    hermes = _hermes_executable()
+    if not hermes:
+        return {"success": False, "error": "hermes executable not found"}
+
+    result = _run([hermes, "plugins", "list"], cwd=_repo_root())
+    output = result.stdout.strip()
+    return {"success": PLUGIN_NAME in output, "hermes": hermes, "output": output}
+
+
+def verify_langfuse_health(base_url: str | None) -> dict[str, Any]:
+    resolved = _nonempty(base_url) or _nonempty(os.environ.get("HERMES_LANGFUSE_BASE_URL")) or _nonempty(os.environ.get("LANGFUSE_BASE_URL"))
+    if not resolved:
+        return {"success": False, "skipped": True, "error": "base_url missing"}
+
+    url = resolved.rstrip("/") + "/api/public/health"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            body = response.read().decode("utf-8", errors="replace")
+        return {"success": True, "url": url, "body": body[:500]}
+    except urllib.error.URLError as exc:
+        return {"success": False, "url": url, "error": str(exc)}
+
+
+def ensure_langfuse_setup(args: argparse.Namespace | None = None) -> dict[str, Any]:
+    args = args or argparse.Namespace()
+    dependency = _ensure_langfuse_dependency()
+    plugin = ensure_langfuse_plugin(args)
+    env = ensure_langfuse_env(args)
+    verification = {
+        "plugin_discovery": verify_plugin_discovery(),
+        "langfuse_health": verify_langfuse_health(_resolve_value(EnvSetting("HERMES_LANGFUSE_BASE_URL", ("HERMES_LANGFUSE_BASE_URL",)), args)),
+    }
+    success = not env["missing"] and verification["plugin_discovery"].get("success", False)
+    return {
+        "success": success,
+        "dependency": dependency,
+        "plugin": plugin,
+        "env": env,
+        "verification": verification,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--feature-repo")
+    parser.add_argument("--feature-branch")
+    parser.add_argument("--plugin-ref")
+    parser.add_argument("--public-key")
+    parser.add_argument("--secret-key")
+    parser.add_argument("--base-url")
+    parser.add_argument("--environment")
+    parser.add_argument("--release")
+    parser.add_argument("--sample-rate")
+    parser.add_argument("--max-chars")
+    parser.add_argument("--debug")
+    parser.add_argument("--enable-tracing")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = ensure_langfuse_setup(args)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_langfuse_tracing_skill.py
+++ b/tests/skills/test_langfuse_tracing_skill.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "observability"
+    / "langfuse-tracing"
+    / "scripts"
+    / "setup_langfuse_env.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("langfuse_tracing_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def clear_langfuse_env(monkeypatch):
+    for name in (
+        "HERMES_LANGFUSE_ENABLED",
+        "TRACE_TO_LANGFUSE",
+        "CC_LANGFUSE_ENABLED",
+        "HERMES_LANGFUSE_PUBLIC_KEY",
+        "CC_LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_PUBLIC_KEY",
+        "HERMES_LANGFUSE_SECRET_KEY",
+        "CC_LANGFUSE_SECRET_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "HERMES_LANGFUSE_BASE_URL",
+        "CC_LANGFUSE_BASE_URL",
+        "LANGFUSE_BASE_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_ensure_langfuse_env_copies_missing_values_from_shell(tmp_path: Path, monkeypatch):
+    clear_langfuse_env(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-from-shell")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-from-shell")
+    mod = load_module()
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+
+    result = mod.ensure_langfuse_env()
+    env_text = (tmp_path / ".hermes" / ".env").read_text(encoding="utf-8")
+
+    assert result["success"] is True
+    assert "HERMES_LANGFUSE_ENABLED=true" in env_text
+    assert "HERMES_LANGFUSE_PUBLIC_KEY=pk-from-shell" in env_text
+    assert "HERMES_LANGFUSE_SECRET_KEY=" in env_text
+    assert "HERMES_LANGFUSE_BASE_URL=http://localhost:3000" in env_text
+    assert result["missing"] == []
+
+
+def test_ensure_langfuse_env_preserves_existing_alias_values(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mod = load_module()
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / ".env").write_text(
+        "TRACE_TO_LANGFUSE=true\n"
+        "LANGFUSE_PUBLIC_KEY=pk-existing\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-new")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-new")
+
+    result = mod.ensure_langfuse_env()
+    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+
+    assert "TRACE_TO_LANGFUSE=true" in env_text
+    assert "LANGFUSE_PUBLIC_KEY=pk-existing" in env_text
+    assert "HERMES_LANGFUSE_SECRET_KEY=" in env_text
+    assert result["preserved"]["HERMES_LANGFUSE_ENABLED"] == "TRACE_TO_LANGFUSE"
+    assert result["preserved"]["HERMES_LANGFUSE_PUBLIC_KEY"] == "LANGFUSE_PUBLIC_KEY"
+
+
+def test_ensure_langfuse_plugin_fetches_and_installs_files(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    mod = load_module()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    monkeypatch.setattr(mod, "_repo_root", lambda: repo_root)
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv, *, cwd=None, capture_output=True):
+        calls.append(argv)
+        if argv[:3] == ["git", "rev-parse", "--verify"]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=argv)
+        if argv[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        if argv[:2] == ["git", "show"]:
+            git_path = argv[2].split(":", 1)[1]
+            if git_path in {"langfuse_tracing/__init__.py", "langfuse_tracing/plugin.yaml"}:
+                filename = git_path.rsplit("/", 1)[1]
+                return subprocess.CompletedProcess(argv, 0, stdout=f"contents for {filename}\n", stderr="")
+            raise subprocess.CalledProcessError(returncode=1, cmd=argv)
+        raise AssertionError(f"Unexpected command: {argv}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    result = mod.ensure_langfuse_plugin(
+        Namespace(
+            feature_repo="https://example.com/repo.git",
+            feature_branch="main",
+            plugin_ref="langfuse-plugin/main",
+        )
+    )
+
+    plugin_dir = tmp_path / ".hermes" / "plugins" / "langfuse_tracing"
+    assert (plugin_dir / "__init__.py").read_text(encoding="utf-8") == "contents for __init__.py\n"
+    assert (plugin_dir / "plugin.yaml").read_text(encoding="utf-8") == "contents for plugin.yaml\n"
+    assert result["fetched"] is True
+    assert result["plugin_ref"] == "langfuse-plugin/main"
+    assert ["git", "fetch", "https://example.com/repo.git", "main:refs/remotes/langfuse-plugin/main"] in calls
+
+
+def test_ensure_langfuse_setup_reports_combined_success(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    mod = load_module()
+
+    monkeypatch.setattr(mod, "_ensure_langfuse_dependency", lambda: {"installed": True, "changed": False})
+    monkeypatch.setattr(mod, "ensure_langfuse_plugin", lambda args=None: {"plugin_dir": str(tmp_path / ".hermes" / "plugins" / "langfuse_tracing")})
+    monkeypatch.setattr(
+        mod,
+        "ensure_langfuse_env",
+        lambda args=None: {
+            "success": True,
+            "env_path": str(tmp_path / ".hermes" / ".env"),
+            "added": ["HERMES_LANGFUSE_ENABLED"],
+            "preserved": {},
+            "missing": [],
+        },
+    )
+    monkeypatch.setattr(mod, "verify_plugin_discovery", lambda: {"success": True, "output": "langfuse_tracing"})
+    monkeypatch.setattr(mod, "verify_langfuse_health", lambda base_url: {"success": True, "url": "http://localhost:3000/api/public/health"})
+
+    result = mod.ensure_langfuse_setup(Namespace())
+
+    assert result["success"] is True
+    assert result["verification"]["plugin_discovery"]["success"] is True
+    assert result["verification"]["langfuse_health"]["success"] is True
+
+
+def test_main_reports_missing_required_keys(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    mod = load_module()
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("HERMES_LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("HERMES_LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.setattr(mod, "_ensure_langfuse_dependency", lambda: {"installed": True, "changed": False})
+    monkeypatch.setattr(mod, "ensure_langfuse_plugin", lambda args=None: {"plugin_dir": str(tmp_path / ".hermes" / "plugins" / "langfuse_tracing")})
+    monkeypatch.setattr(mod, "verify_plugin_discovery", lambda: {"success": True, "output": "langfuse_tracing"})
+    monkeypatch.setattr(mod, "verify_langfuse_health", lambda base_url: {"success": False, "skipped": True, "error": "base_url missing"})
+
+    assert mod.main([]) == 1
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["env"]["missing"] == [
+        "HERMES_LANGFUSE_PUBLIC_KEY",
+        "HERMES_LANGFUSE_SECRET_KEY",
+    ]

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -95,6 +95,12 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**openclaw-migration**](/docs/user-guide/skills/optional/migration/migration-openclaw-migration) | Migrate a user's OpenClaw customization footprint into Hermes Agent. Imports Hermes-compatible memories, SOUL.md, command allowlists, user skills, and selected workspace assets from ~/.openclaw, then reports exactly what could not be mig... |
 
+## observability
+
+| Skill | Description |
+|-------|-------------|
+| [**langfuse-tracing**](/docs/user-guide/skills/optional/observability/observability-langfuse-tracing) | Install and configure opt-in Langfuse tracing as a persistent Hermes plugin. The skill is only the setup/update surface; once installed, tracing auto-loads through plugin hooks for new sessions without prompt-context injection. |
+
 ## mlops
 
 | Skill | Description |


### PR DESCRIPTION
## Summary
- Add optional `langfuse-tracing` skill v1 under `optional-skills/observability/`
- Frame the skill as an installer/updater only: it installs/configures the external persistent runtime plugin for the active Hermes profile
- Document that traced sessions auto-load through Hermes plugin discovery/hooks after installation, without loading skill text into prompt context
- Add tests for plugin install layout handling, env preservation, missing credentials, and combined setup reporting

## Test Plan
- `scripts/run_tests.sh tests/skills/test_langfuse_tracing_skill.py -q`
- `python3 -m compileall optional-skills/observability/langfuse-tracing/scripts/setup_langfuse_env.py tests/skills/test_langfuse_tracing_skill.py`
