### PR TITLE
fix(tui): honor client copy shortcut over ssh

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/screen.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/screen.ts
@@ -437,6 +437,13 @@ export type Screen = Size & {
   noSelect: Uint8Array
 
   /**
+   * Per-cell written bitmap. A written plain space and never-written padding
+   * share the same packed cell value, so selection needs this side channel to
+   * preserve code indentation without selecting blank UI margins.
+   */
+  written: Uint8Array
+
+  /**
    * Per-ROW soft-wrap continuation marker. softWrap[r]=N>0 means row r
    * is a word-wrap continuation of row r-1 (the `\n` before it was
    * inserted by wrapAnsi, not in the source), and row r-1's written
@@ -473,6 +480,14 @@ export function isEmptyCellAt(screen: Screen, x: number, y: number): boolean {
   }
 
   return isEmptyCellByIndex(screen, y * screen.width + x)
+}
+
+export function isWrittenCellAt(screen: Screen, x: number, y: number): boolean {
+  if (x < 0 || y < 0 || x >= screen.width || y >= screen.height) {
+    return false
+  }
+
+  return screen.written[y * screen.width + x] === 1
 }
 
 /**
@@ -533,6 +548,7 @@ export function createScreen(
     emptyStyleId: styles.none,
     damage: undefined,
     noSelect: new Uint8Array(size),
+    written: new Uint8Array(size),
     softWrap: new Int32Array(height)
   }
 }
@@ -566,6 +582,7 @@ export function resetScreen(screen: Screen, width: number, height: number): void
     screen.cells = new Int32Array(buf)
     screen.cells64 = new BigInt64Array(buf)
     screen.noSelect = new Uint8Array(size)
+    screen.written = new Uint8Array(size)
   }
 
   if (screen.softWrap.length < height) {
@@ -575,6 +592,7 @@ export function resetScreen(screen: Screen, width: number, height: number): void
   // Reset all cells — single fill call, no loop
   screen.cells64.fill(EMPTY_CELL_VALUE, 0, size)
   screen.noSelect.fill(0, 0, size)
+  screen.written.fill(0, 0, size)
   screen.softWrap.fill(0, 0, height)
 
   // Update dimensions
@@ -770,6 +788,7 @@ export function setCellAt(screen: Screen, x: number, y: number, cell: Cell): voi
       if ((cells[spacerCI + 1]! & WIDTH_MASK) === CellWidth.SpacerTail) {
         cells[spacerCI] = EMPTY_CHAR_INDEX
         cells[spacerCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
+        screen.written[y * screen.width + spacerX] = 0
       }
     }
   }
@@ -787,6 +806,7 @@ export function setCellAt(screen: Screen, x: number, y: number, cell: Cell): voi
       if ((cells[wideCI + 1]! & WIDTH_MASK) === CellWidth.Wide) {
         cells[wideCI] = EMPTY_CHAR_INDEX
         cells[wideCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
+        screen.written[y * screen.width + x - 1] = 0
         clearedWideX = x - 1
       }
     }
@@ -795,6 +815,7 @@ export function setCellAt(screen: Screen, x: number, y: number, cell: Cell): voi
   // Pack cell data into cells array
   cells[ci] = internCharString(screen, cell.char)
   cells[ci + 1] = packWord1(cell.styleId, internHyperlink(screen, cell.hyperlink), cell.width)
+  screen.written[y * screen.width + x] = 1
 
   // Track damage - expand bounds in place instead of allocating new objects
   // Include the main cell position and any cleared orphan cells
@@ -841,11 +862,13 @@ export function setCellAt(screen: Screen, x: number, y: number, cell: Cell): voi
         if (spacerX + 1 < screen.width && (cells[orphanCI + 1]! & WIDTH_MASK) === CellWidth.SpacerTail) {
           cells[orphanCI] = EMPTY_CHAR_INDEX
           cells[orphanCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
+          screen.written[y * screen.width + spacerX + 1] = 0
         }
       }
 
       cells[spacerCI] = SPACER_CHAR_INDEX
       cells[spacerCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.SpacerTail)
+      screen.written[y * screen.width + spacerX] = 1
 
       // Expand damage to include SpacerTail so diff() scans it
       const d = screen.damage
@@ -929,6 +952,8 @@ export function blitRegion(
   const dstCells = dst.cells
   const srcNoSel = src.noSelect
   const dstNoSel = dst.noSelect
+  const srcWritten = src.written
+  const dstWritten = dst.written
 
   // softWrap is per-row — copy the row range regardless of stride/width.
   // Partial-width blits still carry the row's wrap provenance since the
@@ -947,6 +972,7 @@ export function blitRegion(
     const nsStart = regionY * src.width
     const nsLen = (maxY - regionY) * src.width
     dstNoSel.set(srcNoSel.subarray(nsStart, nsStart + nsLen), nsStart)
+    dstWritten.set(srcWritten.subarray(nsStart, nsStart + nsLen), nsStart)
   } else {
     // Per-row copy for partial-width or mismatched-stride regions
     let srcRowCI = regionY * srcStride + (regionX << 1)
@@ -957,6 +983,7 @@ export function blitRegion(
     for (let y = regionY; y < maxY; y++) {
       dstCells.set(srcCells.subarray(srcRowCI, srcRowCI + rowBytes), dstRowCI)
       dstNoSel.set(srcNoSel.subarray(srcRowNS, srcRowNS + rowLen), dstRowNS)
+      dstWritten.set(srcWritten.subarray(srcRowNS, srcRowNS + rowLen), dstRowNS)
       srcRowCI += srcStride
       dstRowCI += dstStride
       srcRowNS += src.width
@@ -989,6 +1016,7 @@ export function blitRegion(
       if ((srcCells[srcLastCI + 1]! & WIDTH_MASK) === CellWidth.Wide) {
         dstCells[dstSpacerCI] = SPACER_CHAR_INDEX
         dstCells[dstSpacerCI + 1] = packWord1(dst.emptyStyleId, 0, CellWidth.SpacerTail)
+        dstWritten[y * dst.width + maxX] = 1
         wroteSpacerOutsideRegion = true
       }
 
@@ -1030,6 +1058,7 @@ export function clearRegion(
 
   const cells = screen.cells
   const cells64 = screen.cells64
+  const written = screen.written
   const screenWidth = screen.width
   const rowBase = startY * screenWidth
   let damageMinX = startX
@@ -1040,6 +1069,7 @@ export function clearRegion(
   if (startX === 0 && maxX === screenWidth) {
     // Full-width: single fill, no boundary checks needed
     cells64.fill(EMPTY_CELL_VALUE, rowBase, rowBase + (maxY - startY) * screenWidth)
+    written.fill(0, rowBase, rowBase + (maxY - startY) * screenWidth)
   } else {
     // Partial-width: single loop handles boundary cleanup and fill per row.
     const stride = screenWidth << 1 // 2 Int32s per cell
@@ -1062,6 +1092,7 @@ export function clearRegion(
           if ((cells[prevW1]! & WIDTH_MASK) === CellWidth.Wide) {
             cells[prevW1 - 1] = EMPTY_CHAR_INDEX
             cells[prevW1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
+            written[y * screenWidth + startX - 1] = 0
             damageMinX = startX - 1
           }
         }
@@ -1078,12 +1109,14 @@ export function clearRegion(
           if ((cells[nextW1]! & WIDTH_MASK) === CellWidth.SpacerTail) {
             cells[nextW1 - 1] = EMPTY_CHAR_INDEX
             cells[nextW1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
+            written[y * screenWidth + maxX] = 0
             damageMaxX = maxX + 1
           }
         }
       }
 
       cells64.fill(EMPTY_CELL_VALUE, fillStart, fillStart + rowLen)
+      written.fill(0, fillStart, fillStart + rowLen)
       leftEdge += stride
       rightEdge += stride
       fillStart += screenWidth
@@ -1120,12 +1153,14 @@ export function shiftRows(screen: Screen, top: number, bottom: number, n: number
   const w = screen.width
   const cells64 = screen.cells64
   const noSel = screen.noSelect
+  const written = screen.written
   const sw = screen.softWrap
   const absN = Math.abs(n)
 
   if (absN > bottom - top) {
     cells64.fill(EMPTY_CELL_VALUE, top * w, (bottom + 1) * w)
     noSel.fill(0, top * w, (bottom + 1) * w)
+    written.fill(0, top * w, (bottom + 1) * w)
     sw.fill(0, top, bottom + 1)
 
     return
@@ -1135,17 +1170,21 @@ export function shiftRows(screen: Screen, top: number, bottom: number, n: number
     // SU: row top+n..bottom → top..bottom-n; clear bottom-n+1..bottom
     cells64.copyWithin(top * w, (top + n) * w, (bottom + 1) * w)
     noSel.copyWithin(top * w, (top + n) * w, (bottom + 1) * w)
+    written.copyWithin(top * w, (top + n) * w, (bottom + 1) * w)
     sw.copyWithin(top, top + n, bottom + 1)
     cells64.fill(EMPTY_CELL_VALUE, (bottom - n + 1) * w, (bottom + 1) * w)
     noSel.fill(0, (bottom - n + 1) * w, (bottom + 1) * w)
+    written.fill(0, (bottom - n + 1) * w, (bottom + 1) * w)
     sw.fill(0, bottom - n + 1, bottom + 1)
   } else {
     // SD: row top..bottom+n → top-n..bottom; clear top..top-n-1
     cells64.copyWithin((top - n) * w, top * w, (bottom + n + 1) * w)
     noSel.copyWithin((top - n) * w, top * w, (bottom + n + 1) * w)
+    written.copyWithin((top - n) * w, top * w, (bottom + n + 1) * w)
     sw.copyWithin(top - n, top, bottom + n + 1)
     cells64.fill(EMPTY_CELL_VALUE, top * w, (top - n) * w)
     noSel.fill(0, top * w, (top - n) * w)
+    written.fill(0, top * w, (top - n) * w)
     sw.fill(0, top, top - n)
   }
 }

--- a/ui-tui/packages/hermes-ink/src/ink/screen.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/screen.ts
@@ -1,6 +1,6 @@
-import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi-tokenize'
+import { ansiCodesToString, diffAnsiCodes, type AnsiCode } from '@alcalzone/ansi-tokenize'
 
-import { type Point, type Rectangle, type Size, unionRect } from './layout/geometry.js'
+import { unionRect, type Point, type Rectangle, type Size } from './layout/geometry.js'
 import { BEL, ESC, SEP } from './termio/ansi.js'
 import * as warn from './warn.js'
 

--- a/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
@@ -55,6 +55,16 @@ describe('selection whitespace handling', () => {
     expect(getSelectedText(selection, screen)).toBe('  x')
   })
 
+  it('clamps copied selection bounds to screen width', () => {
+    const { screen } = screenWithText()
+    const selection = createSelectionState()
+
+    startSelection(selection, 0, 1)
+    updateSelection(selection, 99, 1)
+
+    expect(getSelectedText(selection, screen)).toBe('hi')
+  })
+
   it('does not paint selection background on leading/trailing empty cells or empty rows', () => {
     const { screen, styles } = screenWithText()
     const selection = createSelectionState()

--- a/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
@@ -19,6 +19,8 @@ const screenWithText = () => {
   return { screen, styles }
 }
 
+const styledSpace = (styles: StylePool) => styles.intern([{ code: '\x1b[4m', endCode: '\x1b[24m', type: 'ansi' }])
+
 describe('selection whitespace handling', () => {
   it('does not copy whitespace-only selections', () => {
     const { screen } = screenWithText()
@@ -38,6 +40,22 @@ describe('selection whitespace handling', () => {
     updateSelection(selection, 9, 1)
 
     expect(getSelectedText(selection, screen)).toBe('hi')
+  })
+
+  it('preserves selected indentation when spaces are rendered content', () => {
+    const styles = new StylePool()
+    const screen = createScreen(10, 1, styles, new CharPool(), new HyperlinkPool())
+    const indentStyle = styledSpace(styles)
+    const selection = createSelectionState()
+
+    setCellAt(screen, 0, 0, { char: ' ', hyperlink: undefined, styleId: indentStyle, width: CellWidth.Narrow })
+    setCellAt(screen, 1, 0, { char: ' ', hyperlink: undefined, styleId: indentStyle, width: CellWidth.Narrow })
+    setCellAt(screen, 2, 0, { char: 'x', hyperlink: undefined, styleId: screen.emptyStyleId, width: CellWidth.Narrow })
+
+    startSelection(selection, 0, 0)
+    updateSelection(selection, 9, 0)
+
+    expect(getSelectedText(selection, screen)).toBe('  x')
   })
 
   it('does not paint selection background on leading/trailing empty cells or empty rows', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { cellAt, CellWidth, CharPool, createScreen, HyperlinkPool, setCellAt, StylePool } from './screen.js'
+import {
+  applySelectionOverlay,
+  createSelectionState,
+  getSelectedText,
+  startSelection,
+  updateSelection
+} from './selection.js'
+
+const screenWithText = () => {
+  const styles = new StylePool()
+  const screen = createScreen(10, 3, styles, new CharPool(), new HyperlinkPool())
+
+  setCellAt(screen, 2, 1, { char: 'h', hyperlink: undefined, styleId: screen.emptyStyleId, width: CellWidth.Narrow })
+  setCellAt(screen, 3, 1, { char: 'i', hyperlink: undefined, styleId: screen.emptyStyleId, width: CellWidth.Narrow })
+
+  return { screen, styles }
+}
+
+describe('selection whitespace handling', () => {
+  it('does not copy whitespace-only selections', () => {
+    const { screen } = screenWithText()
+    const selection = createSelectionState()
+
+    startSelection(selection, 0, 0)
+    updateSelection(selection, 9, 0)
+
+    expect(getSelectedText(selection, screen)).toBe('')
+  })
+
+  it('trims outer drag padding while preserving selected content', () => {
+    const { screen } = screenWithText()
+    const selection = createSelectionState()
+
+    startSelection(selection, 0, 1)
+    updateSelection(selection, 9, 1)
+
+    expect(getSelectedText(selection, screen)).toBe('hi')
+  })
+
+  it('does not paint selection background on leading/trailing empty cells or empty rows', () => {
+    const { screen, styles } = screenWithText()
+    const selection = createSelectionState()
+
+    startSelection(selection, 0, 0)
+    updateSelection(selection, 9, 2)
+    applySelectionOverlay(screen, selection, styles)
+
+    expect(cellAt(screen, 0, 0)?.styleId).toBe(screen.emptyStyleId)
+    expect(cellAt(screen, 0, 1)?.styleId).toBe(screen.emptyStyleId)
+    expect(cellAt(screen, 2, 1)?.styleId).not.toBe(screen.emptyStyleId)
+    expect(cellAt(screen, 4, 1)?.styleId).toBe(screen.emptyStyleId)
+    expect(cellAt(screen, 0, 2)?.styleId).toBe(screen.emptyStyleId)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
@@ -19,8 +19,6 @@ const screenWithText = () => {
   return { screen, styles }
 }
 
-const styledSpace = (styles: StylePool) => styles.intern([{ code: '\x1b[4m', endCode: '\x1b[24m', type: 'ansi' }])
-
 describe('selection whitespace handling', () => {
   it('does not copy whitespace-only selections', () => {
     const { screen } = screenWithText()
@@ -45,11 +43,10 @@ describe('selection whitespace handling', () => {
   it('preserves selected indentation when spaces are rendered content', () => {
     const styles = new StylePool()
     const screen = createScreen(10, 1, styles, new CharPool(), new HyperlinkPool())
-    const indentStyle = styledSpace(styles)
     const selection = createSelectionState()
 
-    setCellAt(screen, 0, 0, { char: ' ', hyperlink: undefined, styleId: indentStyle, width: CellWidth.Narrow })
-    setCellAt(screen, 1, 0, { char: ' ', hyperlink: undefined, styleId: indentStyle, width: CellWidth.Narrow })
+    setCellAt(screen, 0, 0, { char: ' ', hyperlink: undefined, styleId: screen.emptyStyleId, width: CellWidth.Narrow })
+    setCellAt(screen, 1, 0, { char: ' ', hyperlink: undefined, styleId: screen.emptyStyleId, width: CellWidth.Narrow })
     setCellAt(screen, 2, 0, { char: 'x', hyperlink: undefined, styleId: screen.emptyStyleId, width: CellWidth.Narrow })
 
     startSelection(selection, 0, 0)

--- a/ui-tui/packages/hermes-ink/src/ink/selection.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.ts
@@ -12,7 +12,7 @@
 
 import { clamp } from './layout/geometry.js'
 import type { Screen, StylePool } from './screen.js'
-import { cellAt, cellAtIndex, CellWidth, setCellStyleId } from './screen.js'
+import { cellAt, cellAtIndex, CellWidth, isEmptyCellAt, setCellStyleId } from './screen.js'
 
 type Point = { col: number; row: number }
 
@@ -842,31 +842,41 @@ export function isCellSelected(s: SelectionState, col: number, row: number): boo
   return true
 }
 
-function rowSelectableContentBounds(screen: Screen, row: number): { first: number; last: number } | null {
-  if (row < 0 || row >= screen.height) {
+function selectableCell(screen: Screen, row: number, col: number): boolean {
+  const cell = cellAt(screen, col, row)
+
+  return (
+    screen.noSelect[row * screen.width + col] !== 1 &&
+    !isEmptyCellAt(screen, col, row) &&
+    !!cell &&
+    cell.width !== CellWidth.SpacerTail &&
+    cell.width !== CellWidth.SpacerHead
+  )
+}
+
+function selectionContentBounds(
+  screen: Screen,
+  row: number,
+  start: number,
+  end: number
+): { first: number; last: number } | null {
+  let first = start
+
+  while (first <= end && !selectableCell(screen, row, first)) {
+    first++
+  }
+
+  if (first > end) {
     return null
   }
 
-  const rowOff = row * screen.width
-  let first = -1
-  let last = -1
+  let last = end
 
-  for (let col = 0; col < screen.width; col++) {
-    if (screen.noSelect[rowOff + col] === 1) {
-      continue
-    }
-
-    const cell = cellAt(screen, col, row)
-
-    if (!cell || cell.width === CellWidth.SpacerTail || cell.width === CellWidth.SpacerHead || !cell.char.trim()) {
-      continue
-    }
-
-    first = first === -1 ? col : first
-    last = col
+  while (last >= first && !selectableCell(screen, row, last)) {
+    last--
   }
 
-  return first === -1 ? null : { first, last }
+  return { first, last }
 }
 
 /** Extract text from one screen row. When the next row is a soft-wrap
@@ -917,6 +927,21 @@ function joinRows(lines: string[], text: string, sw: boolean | undefined): void 
   }
 }
 
+function trimEmptyEdgeRows(lines: string[]): string[] {
+  let start = 0
+  let end = lines.length
+
+  while (start < end && !lines[start]!.trim()) {
+    start++
+  }
+
+  while (end > start && !lines[end - 1]!.trim()) {
+    end--
+  }
+
+  return lines.slice(start, end)
+}
+
 /**
  * Extract text from the screen buffer within the selection range.
  * Rows are joined with newlines unless the screen's softWrap bitmap
@@ -946,14 +971,16 @@ export function getSelectedText(s: SelectionState, screen: Screen): string {
   for (let row = start.row; row <= end.row; row++) {
     const rowStart = row === start.row ? start.col : 0
     const rowEnd = row === end.row ? end.col : screen.width - 1
-    joinRows(lines, extractRowText(screen, row, rowStart, rowEnd), sw[row]! > 0)
+    const bounds = selectionContentBounds(screen, row, rowStart, rowEnd)
+
+    joinRows(lines, bounds ? extractRowText(screen, row, bounds.first, bounds.last) : '', sw[row]! > 0)
   }
 
   for (let i = 0; i < s.scrolledOffBelow.length; i++) {
     joinRows(lines, s.scrolledOffBelow[i]!, s.scrolledOffBelowSW[i])
   }
 
-  return lines.join('\n').trim()
+  return trimEmptyEdgeRows(lines).join('\n')
 }
 
 /**
@@ -1076,21 +1103,16 @@ export function applySelectionOverlay(screen: Screen, selection: SelectionState,
   const noSelect = screen.noSelect
 
   for (let row = start.row; row <= end.row && row < screen.height; row++) {
-    const bounds = rowSelectableContentBounds(screen, row)
+    const colStart = row === start.row ? start.col : 0
+    const colEnd = row === end.row ? Math.min(end.col, width - 1) : width - 1
+    const bounds = selectionContentBounds(screen, row, colStart, colEnd)
+    const rowOff = row * width
 
     if (!bounds) {
       continue
     }
 
-    const colStart = Math.max(row === start.row ? start.col : 0, bounds.first)
-    const colEnd = Math.min(row === end.row ? end.col : width - 1, bounds.last)
-    const rowOff = row * width
-
-    if (colStart > colEnd) {
-      continue
-    }
-
-    for (let col = colStart; col <= colEnd; col++) {
+    for (let col = bounds.first; col <= bounds.last; col++) {
       const idx = rowOff + col
 
       // Skip noSelect cells — gutters stay visually unchanged so it's

--- a/ui-tui/packages/hermes-ink/src/ink/selection.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.ts
@@ -842,6 +842,33 @@ export function isCellSelected(s: SelectionState, col: number, row: number): boo
   return true
 }
 
+function rowSelectableContentBounds(screen: Screen, row: number): { first: number; last: number } | null {
+  if (row < 0 || row >= screen.height) {
+    return null
+  }
+
+  const rowOff = row * screen.width
+  let first = -1
+  let last = -1
+
+  for (let col = 0; col < screen.width; col++) {
+    if (screen.noSelect[rowOff + col] === 1) {
+      continue
+    }
+
+    const cell = cellAt(screen, col, row)
+
+    if (!cell || cell.width === CellWidth.SpacerTail || cell.width === CellWidth.SpacerHead || !cell.char.trim()) {
+      continue
+    }
+
+    first = first === -1 ? col : first
+    last = col
+  }
+
+  return first === -1 ? null : { first, last }
+}
+
 /** Extract text from one screen row. When the next row is a soft-wrap
  *  continuation (screen.softWrap[row+1]>0), clamp to that content-end
  *  column and skip the trailing trim so the word-separator space survives
@@ -926,7 +953,7 @@ export function getSelectedText(s: SelectionState, screen: Screen): string {
     joinRows(lines, s.scrolledOffBelow[i]!, s.scrolledOffBelowSW[i])
   }
 
-  return lines.join('\n')
+  return lines.join('\n').trim()
 }
 
 /**
@@ -1049,9 +1076,19 @@ export function applySelectionOverlay(screen: Screen, selection: SelectionState,
   const noSelect = screen.noSelect
 
   for (let row = start.row; row <= end.row && row < screen.height; row++) {
-    const colStart = row === start.row ? start.col : 0
-    const colEnd = row === end.row ? Math.min(end.col, width - 1) : width - 1
+    const bounds = rowSelectableContentBounds(screen, row)
+
+    if (!bounds) {
+      continue
+    }
+
+    const colStart = Math.max(row === start.row ? start.col : 0, bounds.first)
+    const colEnd = Math.min(row === end.row ? end.col : width - 1, bounds.last)
     const rowOff = row * width
+
+    if (colStart > colEnd) {
+      continue
+    }
 
     for (let col = colStart; col <= colEnd; col++) {
       const idx = rowOff + col

--- a/ui-tui/packages/hermes-ink/src/ink/selection.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.ts
@@ -12,7 +12,7 @@
 
 import { clamp } from './layout/geometry.js'
 import type { Screen, StylePool } from './screen.js'
-import { cellAt, cellAtIndex, CellWidth, isEmptyCellAt, setCellStyleId } from './screen.js'
+import { cellAt, cellAtIndex, CellWidth, isWrittenCellAt, setCellStyleId } from './screen.js'
 
 type Point = { col: number; row: number }
 
@@ -847,7 +847,7 @@ function selectableCell(screen: Screen, row: number, col: number): boolean {
 
   return (
     screen.noSelect[row * screen.width + col] !== 1 &&
-    !isEmptyCellAt(screen, col, row) &&
+    isWrittenCellAt(screen, col, row) &&
     !!cell &&
     cell.width !== CellWidth.SpacerTail &&
     cell.width !== CellWidth.SpacerHead

--- a/ui-tui/packages/hermes-ink/src/ink/selection.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.ts
@@ -969,8 +969,8 @@ export function getSelectedText(s: SelectionState, screen: Screen): string {
   }
 
   for (let row = start.row; row <= end.row; row++) {
-    const rowStart = row === start.row ? start.col : 0
-    const rowEnd = row === end.row ? end.col : screen.width - 1
+    const rowStart = Math.max(0, row === start.row ? start.col : 0)
+    const rowEnd = Math.min(row === end.row ? end.col : screen.width - 1, screen.width - 1)
     const bounds = selectionContentBounds(screen, row, rowStart, rowEnd)
 
     joinRows(lines, bounds ? extractRowText(screen, row, bounds.first, bounds.last) : '', sw[row]! > 0)

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -31,6 +31,28 @@ describe('platform action modifier', () => {
   })
 })
 
+describe('isCopyShortcut', () => {
+  it('keeps Ctrl+C as the local non-macOS copy chord', async () => {
+    const { isCopyShortcut } = await importPlatform('linux')
+
+    expect(isCopyShortcut({ ctrl: true, meta: false, super: false }, 'c', {})).toBe(true)
+  })
+
+  it('accepts client Cmd+C over SSH even when running on Linux', async () => {
+    const { isCopyShortcut } = await importPlatform('linux')
+    const env = { SSH_CONNECTION: '1 2 3 4' } as NodeJS.ProcessEnv
+
+    expect(isCopyShortcut({ ctrl: false, meta: false, super: true }, 'c', env)).toBe(true)
+    expect(isCopyShortcut({ ctrl: false, meta: true, super: false }, 'c', env)).toBe(true)
+  })
+
+  it('does not treat local Linux Alt+C as copy', async () => {
+    const { isCopyShortcut } = await importPlatform('linux')
+
+    expect(isCopyShortcut({ ctrl: false, meta: true, super: false }, 'c', {})).toBe(false)
+  })
+})
+
 describe('isVoiceToggleKey', () => {
   it('matches raw Ctrl+B on macOS (doc-default across platforms)', async () => {
     const { isVoiceToggleKey } = await importPlatform('darwin')

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -269,7 +269,6 @@ export const coreCommands: SlashCommand[] = [
       }
 
       writeOsc52Clipboard(target.text)
-      sys(`copied ${target.text.length} chars`)
     }
   },
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -8,7 +8,7 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
-import { isAction, isMac, isVoiceToggleKey } from '../lib/platform.js'
+import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
 
 import { getInputSelection } from './inputSelectionStore.js'
 import type { InputHandlerContext, InputHandlerResult } from './interfaces.js'
@@ -315,7 +315,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       }
     }
 
-    if (isAction(key, ch, 'c')) {
+    if (isCopyShortcut(key, ch)) {
       if (terminal.hasSelection) {
         return copySelection()
       }

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -30,11 +30,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const copySelection = () => {
     // ink's copySelection() already calls setClipboard() which handles
     // pbcopy (macOS), wl-copy/xclip (Linux), tmux, and OSC 52 fallback.
-    const text = terminal.selection.copySelection()
-
-    if (text) {
-      actions.sys(`copied ${text.length} chars`)
-    }
+    terminal.selection.copySelection()
   }
 
   const clearSelection = () => {

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -114,25 +114,6 @@ const renderTable = (k: number, rows: string[][], t: Theme) => {
   )
 }
 
-const codeText = (text: string, color: string | undefined, key: number | string, t: Theme) => (
-  <Text color={color ?? (text.trim() ? undefined : t.color.dim)} key={key}>
-    {text}
-  </Text>
-)
-
-const plainCodeLine = (text: string, t: Theme) => {
-  const indent = text.match(/^\s+/)?.[0] ?? ''
-
-  return indent ? (
-    <>
-      {codeText(indent, undefined, 'indent', t)}
-      {text.slice(indent.length)}
-    </>
-  ) : (
-    text
-  )
-}
-
 function MdInline({ t, text }: { t: Theme; text: string }) {
   const parts: ReactNode[] = []
 
@@ -335,7 +316,19 @@ function MdImpl({ compact, t, text }: MdProps) {
 
             {block.map((l, j) => {
               if (highlighted) {
-                return <Text key={j}>{highlightLine(l, lang, t).map(([color, text], kk) => codeText(text, color, kk, t))}</Text>
+                return (
+                  <Text key={j}>
+                    {highlightLine(l, lang, t).map(([color, text], kk) =>
+                      color ? (
+                        <Text color={color} key={kk}>
+                          {text}
+                        </Text>
+                      ) : (
+                        <Text key={kk}>{text}</Text>
+                      )
+                    )}
+                  </Text>
+                )
               }
 
               const add = isDiff && l.startsWith('+')
@@ -349,7 +342,7 @@ function MdImpl({ compact, t, text }: MdProps) {
                   dimColor={isDiff && !add && !del && !hunk && l.startsWith(' ')}
                   key={j}
                 >
-                  {plainCodeLine(l, t)}
+                  {l}
                 </Text>
               )
             })}

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -114,6 +114,25 @@ const renderTable = (k: number, rows: string[][], t: Theme) => {
   )
 }
 
+const codeText = (text: string, color: string | undefined, key: number | string, t: Theme) => (
+  <Text color={color ?? (text.trim() ? undefined : t.color.dim)} key={key}>
+    {text}
+  </Text>
+)
+
+const plainCodeLine = (text: string, t: Theme) => {
+  const indent = text.match(/^\s+/)?.[0] ?? ''
+
+  return indent ? (
+    <>
+      {codeText(indent, undefined, 'indent', t)}
+      {text.slice(indent.length)}
+    </>
+  ) : (
+    text
+  )
+}
+
 function MdInline({ t, text }: { t: Theme; text: string }) {
   const parts: ReactNode[] = []
 
@@ -316,19 +335,7 @@ function MdImpl({ compact, t, text }: MdProps) {
 
             {block.map((l, j) => {
               if (highlighted) {
-                return (
-                  <Text key={j}>
-                    {highlightLine(l, lang, t).map(([color, text], kk) =>
-                      color ? (
-                        <Text color={color} key={kk}>
-                          {text}
-                        </Text>
-                      ) : (
-                        <Text key={kk}>{text}</Text>
-                      )
-                    )}
-                  </Text>
-                )
+                return <Text key={j}>{highlightLine(l, lang, t).map(([color, text], kk) => codeText(text, color, kk, t))}</Text>
               }
 
               const add = isDiff && l.startsWith('+')
@@ -342,7 +349,7 @@ function MdImpl({ compact, t, text }: MdProps) {
                   dimColor={isDiff && !add && !del && !hunk && l.startsWith(' ')}
                   key={j}
                 >
-                  {l}
+                  {plainCodeLine(l, t)}
                 </Text>
               )
             })}

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -1,6 +1,5 @@
-import { isMac } from '../lib/platform.js'
+import { isMac, isRemoteShell } from '../lib/platform.js'
 
-const isRemoteShell = Boolean(process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
 const action = isMac ? 'Cmd' : 'Ctrl'
 const paste = isMac ? 'Cmd' : 'Alt'
 
@@ -10,7 +9,7 @@ const copyHotkeys: [string, string][] = isMac
       ['Ctrl+C', 'interrupt / clear draft / exit']
     ]
   : [
-      ...(isRemoteShell ? ([['Cmd+C', 'copy selection when forwarded by the terminal']] as [string, string][]) : []),
+      ...(isRemoteShell() ? ([['Cmd+C', 'copy selection when forwarded by the terminal']] as [string, string][]) : []),
       ['Ctrl+C', 'copy selection / interrupt / clear draft / exit']
     ]
 

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -8,10 +8,12 @@ const copyHotkeys: [string, string][] = isMac
       ['Cmd+C', 'copy selection'],
       ['Ctrl+C', 'interrupt / clear draft / exit']
     ]
-  : [
-      ...(isRemoteShell() ? ([['Cmd+C', 'copy selection when forwarded by the terminal']] as [string, string][]) : []),
-      ['Ctrl+C', 'copy selection / interrupt / clear draft / exit']
-    ]
+  : isRemoteShell()
+    ? [
+        ['Cmd+C', 'copy selection when forwarded by the terminal'],
+        ['Ctrl+C', 'copy selection / interrupt / clear draft / exit']
+      ]
+    : [['Ctrl+C', 'copy selection / interrupt / clear draft / exit']]
 
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -1,15 +1,21 @@
 import { isMac } from '../lib/platform.js'
 
+const isRemoteShell = Boolean(process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
 const action = isMac ? 'Cmd' : 'Ctrl'
 const paste = isMac ? 'Cmd' : 'Alt'
 
+const copyHotkeys: [string, string][] = isMac
+  ? [
+      ['Cmd+C', 'copy selection'],
+      ['Ctrl+C', 'interrupt / clear draft / exit']
+    ]
+  : [
+      ...(isRemoteShell ? ([['Cmd+C', 'copy selection when forwarded by the terminal']] as [string, string][]) : []),
+      ['Ctrl+C', 'copy selection / interrupt / clear draft / exit']
+    ]
+
 export const HOTKEYS: [string, string][] = [
-  ...(isMac
-    ? ([
-        ['Cmd+C', 'copy selection'],
-        ['Ctrl+C', 'interrupt / clear draft / exit']
-      ] as [string, string][])
-    : ([['Ctrl+C', 'copy selection / interrupt / clear draft / exit']] as [string, string][])),
+  ...copyHotkeys,
   [action + '+D', 'exit'],
   [action + '+G', 'open $EDITOR for prompt'],
   [action + '+L', 'new session (clear)'],

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -34,7 +34,7 @@ export const isMacActionFallback = (
 export const isAction = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string, target: string): boolean =>
   isActionMod(key) && ch.toLowerCase() === target
 
-const isRemoteShell = (env: NodeJS.ProcessEnv = process.env): boolean =>
+export const isRemoteShell = (env: NodeJS.ProcessEnv = process.env): boolean =>
   Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY)
 
 export const isCopyShortcut = (

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -5,8 +5,8 @@
  * as `key.meta`. Some macOS terminals also translate Cmd+Left/Right/Backspace
  * into readline-style Ctrl+A/Ctrl+E/Ctrl+U before the app sees them.
  * On other platforms the action modifier is Ctrl.
- * Ctrl+C is ALWAYS the interrupt key regardless of platform — it must never be
- * remapped to copy.
+ * Ctrl+C stays the interrupt key on macOS. On non-mac terminals it can also
+ * copy an active TUI selection, matching common terminal selection behavior.
  */
 
 export const isMac = process.platform === 'darwin'
@@ -33,6 +33,16 @@ export const isMacActionFallback = (
 /** Match action-modifier + a single character (case-insensitive). */
 export const isAction = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string, target: string): boolean =>
   isActionMod(key) && ch.toLowerCase() === target
+
+const isRemoteShell = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY)
+
+export const isCopyShortcut = (
+  key: { ctrl: boolean; meta: boolean; super?: boolean },
+  ch: string,
+  env: NodeJS.ProcessEnv = process.env
+): boolean =>
+  isAction(key, ch, 'c') || (isRemoteShell(env) && (key.meta || key.super === true) && ch.toLowerCase() === 'c')
 
 /**
  * Voice recording toggle key (Ctrl+B).


### PR DESCRIPTION
## Summary
- Checked existing open PRs first: #12362 is a broader stale `/copy` picker feature and #13379 is dashboard/xterm copy work; neither directly fixes TUI selection copy shortcuts over SSH.
- Add a dedicated TUI copy shortcut helper so forwarded Cmd+C (`super`/legacy `meta`) copies selections during SSH sessions even when Hermes runs on remote Linux.
- Preserve local Linux behavior by not treating local Alt+C as copy, and update TUI hotkey hints for remote shells.
- Track rendered screen cells separately from blank padding so selection can skip UI margins while preserving meaningful spaces, including code-block indentation.
- Keep successful copy actions silent; usage and “nothing to copy” feedback still appears.

## Test plan
- `npm run fix && npm run type-check` (in `ui-tui`)
- `npm run type-check` (in `ui-tui`)
- `npm test -- src/__tests__/platform.test.ts src/__tests__/createSlashHandler.test.ts` (in `ui-tui`)
- `npm test -- packages/hermes-ink/src/ink/selection.test.ts src/__tests__/platform.test.ts` (in `ui-tui`)
- `npm test -- packages/hermes-ink/src/ink/selection.test.ts src/__tests__/platform.test.ts src/__tests__/createSlashHandler.test.ts` (in `ui-tui`)
- `npm test -- src/__tests__/markdown.test.ts packages/hermes-ink/src/ink/selection.test.ts` (in `ui-tui`)
- `npm test -- packages/hermes-ink/src/ink/selection.test.ts src/__tests__/markdown.test.ts src/__tests__/platform.test.ts src/__tests__/createSlashHandler.test.ts` (in `ui-tui`)