### PR TITLE
fix: pad reasoning_content on all DeepSeek assistant messages, not just tool-call ones

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7765,12 +7765,17 @@ class AIAgent:
             return
 
         # Providers that require an echoed reasoning_content on every
-        # assistant tool-call turn. Detection logic lives in the per-provider
+        # assistant turn. Detection logic lives in the per-provider
         # helpers so both the creation path (_build_assistant_message) and
         # this replay path stay in sync.
-        if source_msg.get("tool_calls") and (
-            self._needs_kimi_tool_reasoning()
-            or self._needs_deepseek_tool_reasoning()
+        #
+        # DeepSeek V4 thinking mode: ALL assistant messages need
+        # reasoning_content — not just tool-call ones. Without it, the
+        # API rejects the replay with HTTP 400 (refs #15250, #16658).
+        # Kimi/Moonshot: only tool-call messages need it.
+        if self._needs_deepseek_tool_reasoning() or (
+            source_msg.get("tool_calls")
+            and self._needs_kimi_tool_reasoning()
         ):
             api_msg["reasoning_content"] = ""
 

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -1,9 +1,9 @@
 """Regression test: DeepSeek V4 thinking mode reasoning_content echo.
 
 DeepSeek V4-flash / V4-pro thinking mode requires ``reasoning_content`` on
-every assistant message that carries ``tool_calls``. When a persisted
-session replays an assistant tool-call turn that was recorded without the
-field, DeepSeek rejects the next request with HTTP 400::
+**every** assistant message (not just tool-call ones). When a persisted
+session replays an assistant turn that was recorded without the field,
+DeepSeek rejects the next request with HTTP 400::
 
     The reasoning_content in the thinking mode must be passed back to the API.
 
@@ -12,13 +12,14 @@ Fix covers three paths:
 1. ``_build_assistant_message`` — new tool-call messages without raw
    reasoning_content get ``""`` pinned at creation time so nothing gets
    persisted poisoned.
-2. ``_copy_reasoning_content_for_api`` — already-poisoned history replays
-   with ``reasoning_content=""`` injected defensively.
+2. ``_copy_reasoning_content_for_api`` — replays pad ``reasoning_content=""``
+   on all DeepSeek assistant messages (tool-call and plain) that lack it.
+   Kimi/Moonshot only pads tool-call messages.
 3. Detection covers three signals: ``provider == "deepseek"``,
    ``"deepseek" in model``, and ``api.deepseek.com`` host match. The third
    catches custom-provider setups pointing at DeepSeek.
 
-Refs #15250 / #15353.
+Refs #15250 / #15353 / #16658.
 """
 
 from __future__ import annotations
@@ -88,13 +89,14 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg.get("reasoning_content") == ""
 
-    def test_deepseek_assistant_no_tool_call_left_alone(self) -> None:
-        """Plain assistant turns without tool_calls don't get padded."""
+    def test_deepseek_assistant_no_tool_call_gets_padded(self) -> None:
+        """DeepSeek V4 thinking mode requires reasoning_content on ALL
+        assistant messages, not just tool-call ones (refs #16658)."""
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
         source = {"role": "assistant", "content": "hello"}
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
-        assert "reasoning_content" not in api_msg
+        assert api_msg.get("reasoning_content") == ""
 
     def test_deepseek_explicit_reasoning_content_preserved(self) -> None:
         """When reasoning_content is already set, it's copied verbatim."""


### PR DESCRIPTION
## Summary

DeepSeek V4 thinking mode (deepseek-v4-flash, deepseek-v4-pro) requires `reasoning_content` on **every** assistant message when the conversation history is replayed — not just tool-call ones. The existing code at `_copy_reasoning_content_for_api()` only set the defensive fallback for assistant messages with `tool_calls`, causing HTTP 400 on plain assistant messages (e.g. final summaries).

## Changes

- `run_agent.py` — Removed `source_msg.get('tool_calls')` gate for DeepSeek so all assistant messages get `reasoning_content=""` as fallback. Kimi/Moonshot behavior unchanged (still tool-call only).
- `tests/run_agent/test_deepseek_reasoning_content_echo.py` — Updated regression test to expect padding on all DeepSeek assistant messages, not just tool-call ones. Updated docstring.

## Validation

All 320 tests in `tests/run_agent/` pass (102 reasoning-related tests + full `test_run_agent.py`).

Closes #16658