### PR TITLE
fix(installer): prevent uv shell profile side effects

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -468,6 +468,35 @@ detect_os() {
 # Dependency checks
 # ============================================================================
 
+cleanup_broken_uv_shell_env_hooks() {
+    # Astral's installer may have added a shell startup hook such as
+    # `. "$HOME/.local/bin/env"`. Hermes manages PATH itself, and if that
+    # helper file is missing macOS bash prints this on every new Terminal:
+    #   -bash: /Users/.../.local/bin/env: No such file or directory
+    # Only remove the exact uv helper hook when the helper file is absent.
+    if [ -e "$HOME/.local/bin/env" ]; then
+        return 0
+    fi
+
+    local shell_configs=()
+    [ -f "$HOME/.bash_profile" ] && shell_configs+=("$HOME/.bash_profile")
+    [ -f "$HOME/.bashrc" ] && shell_configs+=("$HOME/.bashrc")
+    [ -f "$HOME/.profile" ] && shell_configs+=("$HOME/.profile")
+    [ -f "$HOME/.zprofile" ] && shell_configs+=("$HOME/.zprofile")
+    [ -f "$HOME/.zshrc" ] && shell_configs+=("$HOME/.zshrc")
+
+    local shell_config tmp_file
+    for shell_config in "${shell_configs[@]}"; do
+        if grep -qE '^[[:space:]]*(\.|source)[[:space:]]+"?\$HOME/\.local/bin/env"?[[:space:]]*$' "$shell_config" 2>/dev/null; then
+            tmp_file="$(mktemp)"
+            grep -vE '^[[:space:]]*(\.|source)[[:space:]]+"?\$HOME/\.local/bin/env"?[[:space:]]*$' "$shell_config" > "$tmp_file" || true
+            cat "$tmp_file" > "$shell_config"
+            rm -f "$tmp_file"
+            log_success "Removed broken uv PATH hook from $shell_config"
+        fi
+    done
+}
+
 install_uv() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Termux detected — using Python's stdlib venv + pip instead of uv"
@@ -507,7 +536,12 @@ install_uv() {
     fi
     # UV_UNMANAGED_INSTALL tells the astral installer to place the binary
     # directly into $HERMES_HOME/bin instead of ~/.local/bin.
-    if UV_UNMANAGED_INSTALL="$HERMES_HOME/bin" sh "$_uv_installer" >>"$_uv_install_log" 2>&1; then
+    #
+    # Hermes manages PATH itself in setup_path(), so also keep uv's installer
+    # from adding shell startup hooks like `. "$HOME/.local/bin/env"` via
+    # INSTALLER_NO_MODIFY_PATH=1.  Those hooks can break every new macOS bash
+    # login shell if the helper file is missing.
+    if INSTALLER_NO_MODIFY_PATH=1 UV_UNMANAGED_INSTALL="$HERMES_HOME/bin" sh "$_uv_installer" >>"$_uv_install_log" 2>&1; then
         rm -f "$_uv_installer"
         if [ -x "$_managed_uv" ]; then
             UV_CMD="$_managed_uv"
@@ -2494,6 +2528,7 @@ main() {
     detect_os
     resolve_install_layout
     install_uv
+    cleanup_broken_uv_shell_env_hooks
     check_python
     check_git
     check_node

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -314,6 +314,35 @@ detect_os() {
 # Dependency checks
 # ============================================================================
 
+cleanup_broken_uv_shell_env_hooks() {
+    # Astral's installer may have added a shell startup hook such as
+    # `. "$HOME/.local/bin/env"`. Hermes manages PATH itself, and if that
+    # helper file is missing macOS bash prints this on every new Terminal:
+    #   -bash: /Users/.../.local/bin/env: No such file or directory
+    # Only remove the exact uv helper hook when the helper file is absent.
+    if [ -e "$HOME/.local/bin/env" ]; then
+        return 0
+    fi
+
+    local shell_configs=()
+    [ -f "$HOME/.bash_profile" ] && shell_configs+=("$HOME/.bash_profile")
+    [ -f "$HOME/.bashrc" ] && shell_configs+=("$HOME/.bashrc")
+    [ -f "$HOME/.profile" ] && shell_configs+=("$HOME/.profile")
+    [ -f "$HOME/.zprofile" ] && shell_configs+=("$HOME/.zprofile")
+    [ -f "$HOME/.zshrc" ] && shell_configs+=("$HOME/.zshrc")
+
+    local shell_config tmp_file
+    for shell_config in "${shell_configs[@]}"; do
+        if grep -qE '^[[:space:]]*(\.|source)[[:space:]]+"?\$HOME/\.local/bin/env"?[[:space:]]*$' "$shell_config" 2>/dev/null; then
+            tmp_file="$(mktemp)"
+            grep -vE '^[[:space:]]*(\.|source)[[:space:]]+"?\$HOME/\.local/bin/env"?[[:space:]]*$' "$shell_config" > "$tmp_file" || true
+            cat "$tmp_file" > "$shell_config"
+            rm -f "$tmp_file"
+            log_success "Removed broken uv PATH hook from $shell_config"
+        fi
+    done
+}
+
 install_uv() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Termux detected — using Python's stdlib venv + pip instead of uv"
@@ -349,8 +378,11 @@ install_uv() {
 
     # Install uv
     log_info "Installing uv (fast Python package manager)..."
-    if curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null; then
-        # uv installs to ~/.local/bin by default
+    if curl -LsSf https://astral.sh/uv/install.sh | INSTALLER_NO_MODIFY_PATH=1 sh 2>/dev/null; then
+        # uv installs to ~/.local/bin by default. Hermes manages PATH itself in
+        # setup_path(), so keep uv's installer from adding shell startup hooks
+        # like `. "$HOME/.local/bin/env"`.  Those hooks can break every new
+        # macOS bash login shell if the helper file is missing.
         if [ -x "$HOME/.local/bin/uv" ]; then
             UV_CMD="$HOME/.local/bin/uv"
         elif [ -x "$HOME/.cargo/bin/uv" ]; then
@@ -1508,6 +1540,7 @@ main() {
     detect_os
     resolve_install_layout
     install_uv
+    cleanup_broken_uv_shell_env_hooks
     check_python
     check_git
     check_node

--- a/tests/scripts/test_install_sh.py
+++ b/tests/scripts/test_install_sh.py
@@ -1,0 +1,64 @@
+"""Regression tests for the shell installer."""
+
+import subprocess
+from pathlib import Path
+
+
+INSTALL_SH = Path(__file__).resolve().parents[2] / "scripts" / "install.sh"
+
+
+def test_uv_installer_does_not_modify_shell_profiles():
+    """Hermes owns PATH setup; uv must not add a ~/.local/bin/env source line.
+
+    Astral's uv installer modifies shell startup files by default and can add
+    lines such as `. "$HOME/.local/bin/env"`.  If that helper file is later
+    missing, every new macOS bash login shell prints:
+
+        -bash: /Users/.../.local/bin/env: No such file or directory
+
+    The Hermes installer already creates the hermes shim and manages PATH, so
+    it should disable uv's shell-profile mutation.
+    """
+    content = INSTALL_SH.read_text()
+
+    assert "INSTALLER_NO_MODIFY_PATH=1" in content
+    # The installer is invoked with the mutation guard set as an environment
+    # variable.  Other env vars (e.g. UV_UNMANAGED_INSTALL) may sit between the
+    # guard and `sh`, so assert it on the same line as the installer call.
+    installer_lines = [
+        line
+        for line in content.splitlines()
+        if 'sh "$_uv_installer"' in line
+    ]
+    assert installer_lines, "could not find the uv installer invocation"
+    assert all(
+        "INSTALLER_NO_MODIFY_PATH=1" in line for line in installer_lines
+    )
+
+
+def test_cleanup_removes_broken_uv_env_hook(tmp_path):
+    """Rerunning the installer repairs stale uv profile hooks when env is gone."""
+    bash_profile = tmp_path / ".bash_profile"
+    bash_profile.write_text(
+        "before\n"
+        '. "$HOME/.local/bin/env"\n'
+        'source "$HOME/.local/bin/env"\n'
+        "after\n"
+    )
+
+    script = f"""
+set -euo pipefail
+export HOME={tmp_path}
+source <(sed '/^if .*ENSURE_DEPS/,$d' {INSTALL_SH})
+cleanup_broken_uv_shell_env_hooks >/tmp/hermes-cleanup.log
+cat "$HOME/.bash_profile"
+"""
+
+    result = subprocess.run(
+        ["bash", "-lc", script],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.stdout == "before\nafter\n"

--- a/tests/scripts/test_install_sh.py
+++ b/tests/scripts/test_install_sh.py
@@ -1,0 +1,53 @@
+"""Regression tests for the shell installer."""
+
+import subprocess
+from pathlib import Path
+
+
+INSTALL_SH = Path(__file__).resolve().parents[2] / "scripts" / "install.sh"
+
+
+def test_uv_installer_does_not_modify_shell_profiles():
+    """Hermes owns PATH setup; uv must not add a ~/.local/bin/env source line.
+
+    Astral's uv installer modifies shell startup files by default and can add
+    lines such as `. "$HOME/.local/bin/env"`.  If that helper file is later
+    missing, every new macOS bash login shell prints:
+
+        -bash: /Users/.../.local/bin/env: No such file or directory
+
+    The Hermes installer already creates the hermes shim and manages PATH, so
+    it should disable uv's shell-profile mutation.
+    """
+    content = INSTALL_SH.read_text()
+
+    assert "INSTALLER_NO_MODIFY_PATH=1" in content
+    assert "INSTALLER_NO_MODIFY_PATH=1 sh" in content
+
+
+def test_cleanup_removes_broken_uv_env_hook(tmp_path):
+    """Rerunning the installer repairs stale uv profile hooks when env is gone."""
+    bash_profile = tmp_path / ".bash_profile"
+    bash_profile.write_text(
+        "before\n"
+        '. "$HOME/.local/bin/env"\n'
+        'source "$HOME/.local/bin/env"\n'
+        "after\n"
+    )
+
+    script = f"""
+set -euo pipefail
+export HOME={tmp_path}
+source <(sed '$d' {INSTALL_SH})
+cleanup_broken_uv_shell_env_hooks >/tmp/hermes-cleanup.log
+cat "$HOME/.bash_profile"
+"""
+
+    result = subprocess.run(
+        ["bash", "-lc", script],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.stdout == "before\nafter\n"


### PR DESCRIPTION
## Summary
- Run Astral's uv installer with INSTALLER_NO_MODIFY_PATH=1 so it does not mutate shell startup files
- Add a cleanup step for stale uv hooks like `. "$HOME/.local/bin/env"` when the helper file is missing
- Add regression tests for both preventing future shell-profile mutation and repairing existing broken hooks

## Root cause
Hermes installs uv via `curl -LsSf https://astral.sh/uv/install.sh | sh`. By default, Astral's installer may edit shell startup files and add a hook to source `~/.local/bin/env`. If that helper file is later absent, every new macOS bash login shell prints:

`-bash: /Users/.../.local/bin/env: No such file or directory`

Hermes already creates its own `~/.local/bin/hermes` shim and manages PATH in `setup_path()`, so uv's profile mutation is unnecessary and can cause this startup error.

## Test Plan
- scripts/run_tests.sh tests/scripts/test_install_sh.py -q
- scripts/run_tests.sh tests/scripts/ -q