### PR TITLE
fix(doctor): honor providers.py ALIASES for local-server provider names

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -316,11 +316,18 @@ def run_doctor(args):
                 from hermes_cli.providers import (
                     normalize_provider as _normalize_catalog_provider,
                     resolve_provider_full as _resolve_provider_full,
+                    ALIASES as _PROVIDER_ALIASES,
                 )
+                # ALIASES values include virtual canonicals like "local" and
+                # "lmstudio" that aren't in PROVIDER_REGISTRY but are valid
+                # configuration values (the config docstring documents
+                # `provider: "lmstudio"` as the LM Studio example).
+                known_providers |= set(_PROVIDER_ALIASES.values())
             except Exception:
                 _compatible_custom_providers = None
                 _normalize_catalog_provider = None
                 _resolve_provider_full = None
+                _PROVIDER_ALIASES = None
 
             custom_providers = []
             if _compatible_custom_providers is not None:
@@ -367,7 +374,16 @@ def run_doctor(args):
                 and provider not in ("auto", "custom")
             ):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
-                catalog_provider = provider_def.id if provider_def is not None else None
+                if provider_def is not None:
+                    catalog_provider = provider_def.id
+                elif _normalize_catalog_provider is not None:
+                    # Honor providers.py ALIASES even when resolve_provider_full
+                    # returns None for virtual canonicals (e.g. "ollama" →
+                    # "custom", "vllm" → "local"). Without this fallback, the
+                    # ALIASES table is shadowed by doctor's stricter check.
+                    catalog_provider = _normalize_catalog_provider(provider)
+                else:
+                    catalog_provider = None
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -289,6 +289,55 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "docker not found (optional)" not in out
 
 
+@pytest.mark.parametrize("alias,canonical", [
+    ("ollama", "custom"),
+    ("lmstudio", "lmstudio"),
+    ("vllm", "local"),
+    ("llamacpp", "local"),
+])
+def test_run_doctor_accepts_local_provider_aliases(monkeypatch, tmp_path, alias, canonical):
+    """providers.py ALIASES maps bare local-server names to virtual canonicals
+    ("ollama" → "custom", etc.). The config docstring documents these aliases as
+    user-facing (`provider: "lmstudio"` is shown as the LM Studio example).
+    Doctor must accept them — `_resolve_provider_full` returns None for virtual
+    canonicals like "custom"/"local", so the fallback uses `normalize_provider`.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+
+    import yaml
+
+    (home / "config.yaml").write_text(
+        yaml.dump({"model": {"provider": alias, "base_url": "http://localhost:11434/v1"}})
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert f"model.provider '{alias}' is not a recognised provider" not in out
+    assert f"model.provider '{alias}' is unknown" not in out
+
+
 def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

`hermes doctor` rejects `model.provider: "ollama"` (and `"lmstudio"`, `"vllm"`, `"llamacpp"`) with *"is unknown"* even though `hermes_cli/providers.py` ALIASES maps these to virtual canonicals (`"custom"`, `"local"`) and the config template documents them as user-facing values:

```yaml
# scripts/install/.../cli-config.yaml (excerpt)
#   "custom"       - Any OpenAI-compatible endpoint. Set base_url below.
#   Aliases: "lmstudio", "ollama", "vllm", "llamacpp" all map to "custom".
#   Example for LM Studio:
#     provider: "lmstudio"
```

So `provider: "ollama"` is the documented surface for "local Ollama via OpenAI-compatible endpoint" — but doctor surfaces it as a configuration error.

## Repro

```yaml
# ~/.hermes/config.yaml
model:
  provider: "ollama"
  base_url: "http://localhost:11434/v1"
  default: "qwen3.6:27b-coding-nvfp4"
```

```
$ hermes doctor
...
Found 2 issue(s) to address:

  1. model.provider 'ollama' is unknown. Valid providers: ai-gateway, alibaba, ...
     Fix: run 'hermes config set model.provider <valid_provider>'
```

(End user — me — hit this trying to point Hermes at a local Ollama for `qwen3.6:27b-coding-nvfp4`. The agent ran fine; only doctor complained.)

## Root cause

Two separate gaps in `hermes_cli/doctor.py`:

1. **`_resolve_provider_full("ollama")` returns `None`.** `normalize_provider("ollama")` returns `"custom"` per ALIASES, but `get_provider("custom")` is `None` because "custom" is a sentinel for "use whatever base_url is set" — not a real entry in models.dev / built-in registry. So `provider_def is None` → `canonical_provider = None` → the membership check fails.

2. **`known_providers` is missing virtual canonicals like `"local"` and `"lmstudio"`.** Built from `PROVIDER_REGISTRY.keys() | {"openrouter", "custom", "auto"}`, it excludes alias *targets* that aren't in the registry — so even if step 1 is fixed, `vllm` → `local` and bare `lmstudio` would still fail.

## Fix

Two-part, both in `hermes_cli/doctor.py`:

1. When `_resolve_provider_full` returns `None`, fall back to `normalize_provider` so the ALIASES table's canonical value is honored.
2. Extend `known_providers |= set(ALIASES.values())` so virtual canonicals are accepted.

Net effect: `ollama` → `custom` ✓, `lmstudio` → `lmstudio` ✓, `vllm` → `local` ✓, `llamacpp` → `local` ✓. Real typos (`ollam`, `gpt`, etc.) still fail because `normalize_provider` is the identity for unknown keys, and unknown keys aren't in `known_providers`.

## Test

New parametrized test `test_run_doctor_accepts_local_provider_aliases` covering all four aliases. Modeled on existing `test_run_doctor_accepts_named_provider_from_providers_section` (added in `ccc8fccf`).

Full `tests/hermes_cli/test_doctor.py` — 26 tests, 0 failures, 14 prior `audioop` deprecation warnings (unrelated).

## Test plan

- [x] Run `tests/hermes_cli/test_doctor.py` — all pass (26 tests, 4 new)
- [x] Confirmed `provider: "ollama"` config now passes `hermes doctor` on local install
- [ ] Maintainer: run full CI suite

## Notes

- No behavioral change for the agent path — `provider: "ollama"` already worked at runtime (ALIASES is consulted at every other call site). This only fixes the doctor's report.
- No new public API. `ALIASES` is already exported as a module-level dict.
- I'm a downstream user, not a regular contributor — happy to adjust the fix shape if a different layering is preferred (e.g., move the alias-known-providers union into `providers.py` as a new helper).