### PR TITLE
feat(cli): add configurable worktree directories

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -128,8 +128,13 @@ model:
 # When enabled, each CLI session creates an isolated git worktree so multiple
 # agents can work on the same repo concurrently without file collisions.
 # Equivalent to always passing --worktree / -w on the command line.
+# Relative dirs resolve from the git repo root; absolute dirs are allowed.
 #
-# worktree: true    # Always create a worktree when in a git repo
+# worktree:
+#   enabled: true
+#   dir: ".worktrees"
+#
+# Legacy boolean form is still supported:
 # worktree: false   # Default — only create when -w flag is passed
 
 # =============================================================================

--- a/cli.py
+++ b/cli.py
@@ -30,7 +30,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -416,6 +416,10 @@ def load_cli_config() -> Dict[str, Any]:
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         },
+        "worktree": {
+            "enabled": False,
+            "dir": ".worktrees",
+        },
     }
     
     # Track whether the config file explicitly set terminal config.
@@ -791,7 +795,59 @@ def _path_is_within_root(path: Path, root: Path) -> bool:
         return False
 
 
-def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
+def _normalize_worktree_config(
+    config_value: Any,
+    cli_value: Union[bool, str] = False,
+    shorthand_value: Union[bool, str] = False,
+) -> Dict[str, Any]:
+    """Return normalized worktree activation and directory settings."""
+    enabled = False
+    directory = ".worktrees"
+
+    if isinstance(config_value, dict):
+        enabled = bool(config_value.get("enabled", False))
+        configured_dir = config_value.get("dir")
+        if configured_dir:
+            directory = str(configured_dir)
+    elif isinstance(config_value, bool):
+        enabled = config_value
+    elif config_value:
+        enabled = True
+
+    for override in (cli_value, shorthand_value):
+        if isinstance(override, str):
+            value = override.strip()
+            if value:
+                return {"enabled": True, "dir": value}
+        elif override:
+            enabled = True
+
+    return {"enabled": enabled, "dir": directory}
+
+
+def _resolve_worktrees_dir(repo_root: str, directory: str = ".worktrees") -> Path:
+    """Resolve the configured worktree base directory for a repository."""
+    raw = directory or ".worktrees"
+    path = Path(str(raw)).expanduser()
+    if path.is_absolute():
+        return path.resolve()
+    return (Path(repo_root) / path).resolve()
+
+
+def _gitignore_entry_for_worktrees_dir(repo_root: str, worktrees_dir: Path) -> Optional[str]:
+    """Return a repo-relative gitignore entry when the worktree dir is in-repo."""
+    try:
+        relative = worktrees_dir.resolve().relative_to(Path(repo_root).resolve())
+    except ValueError:
+        return None
+    entry = relative.as_posix().rstrip("/")
+    return f"{entry}/" if entry else None
+
+
+def _setup_worktree(
+    repo_root: str = None,
+    worktree_dir: str = ".worktrees",
+) -> Optional[Dict[str, str]]:
     """Create an isolated git worktree for this CLI session.
 
     Returns a dict with worktree metadata on success, None on failure.
@@ -809,21 +865,22 @@ def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
     wt_name = f"hermes-{short_id}"
     branch_name = f"hermes/{wt_name}"
 
-    worktrees_dir = Path(repo_root) / ".worktrees"
+    worktrees_dir = _resolve_worktrees_dir(repo_root, worktree_dir)
     worktrees_dir.mkdir(parents=True, exist_ok=True)
 
     wt_path = worktrees_dir / wt_name
 
-    # Ensure .worktrees/ is in .gitignore
+    # Ensure in-repo worktree directories are ignored.
     gitignore = Path(repo_root) / ".gitignore"
-    _ignore_entry = ".worktrees/"
+    _ignore_entry = _gitignore_entry_for_worktrees_dir(repo_root, worktrees_dir)
     try:
-        existing = gitignore.read_text() if gitignore.exists() else ""
-        if _ignore_entry not in existing.splitlines():
-            with open(gitignore, "a") as f:
-                if existing and not existing.endswith("\n"):
-                    f.write("\n")
-                f.write(f"{_ignore_entry}\n")
+        if _ignore_entry:
+            existing = gitignore.read_text() if gitignore.exists() else ""
+            if _ignore_entry not in existing.splitlines():
+                with open(gitignore, "a") as f:
+                    if existing and not existing.endswith("\n"):
+                        f.write("\n")
+                    f.write(f"{_ignore_entry}\n")
     except Exception as e:
         logger.debug("Could not update .gitignore: %s", e)
 
@@ -980,7 +1037,11 @@ def _run_state_db_auto_maintenance(session_db) -> None:
         logger.debug("state.db auto-maintenance skipped: %s", exc)
 
 
-def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
+def _prune_stale_worktrees(
+    repo_root: str,
+    max_age_hours: int = 24,
+    worktree_dir: str = ".worktrees",
+) -> None:
     """Remove stale worktrees and orphaned branches on startup.
 
     Age-based tiers:
@@ -994,7 +1055,7 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
     import subprocess
     import time
 
-    worktrees_dir = Path(repo_root) / ".worktrees"
+    worktrees_dir = _resolve_worktrees_dir(repo_root, worktree_dir)
     if not worktrees_dir.exists():
         _prune_orphaned_branches(repo_root)
         return
@@ -10850,8 +10911,8 @@ def main(
     list_toolsets: bool = False,
     gateway: bool = False,
     resume: str = None,
-    worktree: bool = False,
-    w: bool = False,
+    worktree: Union[bool, str] = False,
+    w: Union[bool, str] = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
@@ -10876,8 +10937,8 @@ def main(
         list_tools: List available tools and exit
         list_toolsets: List available toolsets and exit
         resume: Resume a previous session by its ID (e.g., 20260225_143052_a1b2c3)
-        worktree: Run in an isolated git worktree (for parallel agents). Alias: -w
-        w: Shorthand for --worktree
+        worktree: Run in an isolated git worktree, optionally under this base dir. Alias: -w
+        w: Shorthand for --worktree, optionally with a base dir
     
     Examples:
         python cli.py                            # Start interactive mode
@@ -10888,6 +10949,7 @@ def main(
         python cli.py --list-tools               # List tools and exit
         python cli.py --resume 20260225_143052_a1b2c3  # Resume session
         python cli.py -w                         # Start in isolated git worktree
+        python cli.py -w .agent-worktrees        # Use custom worktree directory
         python cli.py -w -q "Fix issue #123"     # Single query in worktree
     """
     global _active_worktree
@@ -10909,14 +10971,19 @@ def main(
         # ── Git worktree isolation (#652) ──
         # Create an isolated worktree so this agent instance doesn't collide
         # with other agents working on the same repo.
-        use_worktree = worktree or w or CLI_CONFIG.get("worktree", False)
+        worktree_settings = _normalize_worktree_config(
+            CLI_CONFIG.get("worktree", False),
+            worktree,
+            w,
+        )
+        use_worktree = worktree_settings["enabled"]
         wt_info = None
         if use_worktree:
             # Prune stale worktrees from crashed/killed sessions
             _repo = _git_repo_root()
             if _repo:
-                _prune_stale_worktrees(_repo)
-            wt_info = _setup_worktree()
+                _prune_stale_worktrees(_repo, worktree_dir=worktree_settings["dir"])
+            wt_info = _setup_worktree(worktree_dir=worktree_settings["dir"])
             if wt_info:
                 _active_worktree = wt_info
                 os.environ["TERMINAL_CWD"] = wt_info["path"]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -349,6 +349,10 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "worktree": {
+        "enabled": False,
+        "dir": ".worktrees",
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).
@@ -2226,6 +2230,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
+    "worktree",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6884,6 +6884,7 @@ Examples:
     hermes gateway                Run messaging gateway
     hermes -s hermes-agent-dev,github-auth
     hermes -w                     Start in isolated git worktree
+    hermes -w .agent-worktrees    Use a custom worktree directory
     hermes gateway install        Install gateway background service
     hermes sessions list          List past sessions
     hermes sessions browse        Interactive session picker
@@ -6957,9 +6958,11 @@ For more help on a command:
     parser.add_argument(
         "--worktree",
         "-w",
-        action="store_true",
+        nargs="?",
+        const=True,
         default=False,
-        help="Run in an isolated git worktree (for parallel agents)",
+        metavar="DIR",
+        help="Run in an isolated git worktree, optionally under DIR",
     )
     parser.add_argument(
         "--accept-hooks",
@@ -7103,9 +7106,11 @@ For more help on a command:
     chat_parser.add_argument(
         "--worktree",
         "-w",
-        action="store_true",
+        nargs="?",
+        const=True,
         default=argparse.SUPPRESS,
-        help="Run in an isolated git worktree (for parallel agents on the same repo)",
+        metavar="DIR",
+        help="Run in an isolated git worktree, optionally under DIR",
     )
     chat_parser.add_argument(
         "--accept-hooks",
@@ -9150,6 +9155,18 @@ Examples:
     _known_cmds = (
         set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
     )
+    _WORKTREE_FLAG_SENTINEL = "__HERMES_WORKTREE_FLAG__"
+    _rewritten_argv = []
+    _i = 0
+    while _i < len(_processed_argv):
+        token = _processed_argv[_i]
+        next_token = _processed_argv[_i + 1] if _i + 1 < len(_processed_argv) else None
+        if token in ("-w", "--worktree") and next_token in _known_cmds:
+            _rewritten_argv.append(f"{token}={_WORKTREE_FLAG_SENTINEL}")
+        else:
+            _rewritten_argv.append(token)
+        _i += 1
+    _processed_argv = _rewritten_argv
     _has_cmd_token = any(
         t in _known_cmds for t in _processed_argv if not t.startswith("-")
     )
@@ -9175,6 +9192,9 @@ Examples:
     else:
         subparsers.required = False
         args = parser.parse_args(_processed_argv)
+
+    if getattr(args, "worktree", None) == _WORKTREE_FLAG_SENTINEL:
+        args.worktree = True
 
     # Handle --version flag
     if args.version:

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -368,6 +368,94 @@ class TestGitignoreManagement:
         assert ".worktrees/" in existing.splitlines()
 
 
+class TestConfigurableWorktreeDirectory:
+    """Test the real configurable worktree directory helpers."""
+
+    def test_normalizes_legacy_boolean_config(self):
+        import cli as cli_mod
+
+        assert cli_mod._normalize_worktree_config(True) == {
+            "enabled": True,
+            "dir": ".worktrees",
+        }
+        assert cli_mod._normalize_worktree_config(False) == {
+            "enabled": False,
+            "dir": ".worktrees",
+        }
+
+    def test_normalizes_nested_config_and_cli_override(self):
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(
+            {"enabled": True, "dir": ".configured-worktrees"},
+            ".cli-worktrees",
+        )
+        assert settings == {"enabled": True, "dir": ".cli-worktrees"}
+
+    def test_w_flag_enables_configured_dir_without_overriding_it(self):
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(
+            {"enabled": False, "dir": ".configured-worktrees"},
+            True,
+        )
+        assert settings == {"enabled": True, "dir": ".configured-worktrees"}
+
+    def test_resolves_relative_dir_under_repo_root(self, git_repo):
+        import cli as cli_mod
+
+        resolved = cli_mod._resolve_worktrees_dir(str(git_repo), ".agent-worktrees")
+        assert resolved == (git_repo / ".agent-worktrees").resolve()
+
+    def test_resolves_absolute_dir_as_is(self, git_repo, tmp_path):
+        import cli as cli_mod
+
+        external = tmp_path / "external-worktrees"
+        resolved = cli_mod._resolve_worktrees_dir(str(git_repo), str(external))
+        assert resolved == external.resolve()
+
+    def test_setup_uses_custom_relative_dir_and_gitignore_entry(self, git_repo):
+        import cli as cli_mod
+
+        info = cli_mod._setup_worktree(str(git_repo), worktree_dir=".agent-worktrees")
+        try:
+            assert info is not None
+            assert Path(info["path"]).parent == (git_repo / ".agent-worktrees").resolve()
+            assert ".agent-worktrees/" in (git_repo / ".gitignore").read_text().splitlines()
+        finally:
+            cli_mod._cleanup_worktree(info)
+
+    def test_setup_uses_absolute_dir_without_gitignore_entry(self, git_repo, tmp_path):
+        import cli as cli_mod
+
+        external = tmp_path / "external-worktrees"
+        info = cli_mod._setup_worktree(str(git_repo), worktree_dir=str(external))
+        try:
+            assert info is not None
+            assert Path(info["path"]).parent == external.resolve()
+            gitignore = git_repo / ".gitignore"
+            assert not gitignore.exists() or str(external) not in gitignore.read_text()
+        finally:
+            cli_mod._cleanup_worktree(info)
+
+    def test_prune_scans_custom_worktree_dir(self, git_repo):
+        import cli as cli_mod
+        import time
+
+        info = cli_mod._setup_worktree(str(git_repo), worktree_dir=".agent-worktrees")
+        assert info is not None
+
+        old_time = time.time() - (25 * 3600)
+        os.utime(info["path"], (old_time, old_time))
+
+        cli_mod._prune_stale_worktrees(
+            str(git_repo),
+            worktree_dir=".agent-worktrees",
+        )
+
+        assert not Path(info["path"]).exists()
+
+
 class TestMultipleWorktrees:
     """Test running multiple worktrees concurrently (the core use case)."""
 
@@ -632,35 +720,42 @@ class TestCLIFlagLogic:
 
     def test_worktree_flag_triggers(self):
         """--worktree flag should trigger worktree creation."""
-        worktree = True
-        w = False
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
-        assert use_worktree
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(False, True, False)
+        assert settings["enabled"] is True
 
     def test_w_flag_triggers(self):
         """-w flag should trigger worktree creation."""
-        worktree = False
-        w = True
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
-        assert use_worktree
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(False, False, True)
+        assert settings["enabled"] is True
 
     def test_config_triggers(self):
         """worktree: true in config should trigger worktree creation."""
-        worktree = False
-        w = False
-        config_worktree = True
-        use_worktree = worktree or w or config_worktree
-        assert use_worktree
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(True, False, False)
+        assert settings["enabled"] is True
+
+    def test_nested_config_triggers(self):
+        """worktree.enabled: true in config should trigger worktree creation."""
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(
+            {"enabled": True, "dir": ".agent-worktrees"},
+            False,
+            False,
+        )
+        assert settings == {"enabled": True, "dir": ".agent-worktrees"}
 
     def test_none_set_no_trigger(self):
         """No flags and no config should not trigger."""
-        worktree = False
-        w = False
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
-        assert not use_worktree
+        import cli as cli_mod
+
+        settings = cli_mod._normalize_worktree_config(False, False, False)
+        assert settings["enabled"] is False
 
 
 class TestTerminalCWDIntegration:

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -32,7 +32,7 @@ def _build_parser():
         "--continue", "-c", dest="continue_last", nargs="?",
         const=True, default=None, metavar="SESSION_NAME",
     )
-    parser.add_argument("--worktree", "-w", action="store_true", default=False)
+    parser.add_argument("--worktree", "-w", nargs="?", const=True, default=False)
     parser.add_argument("--skills", "-s", action="append", default=None)
     parser.add_argument("--yolo", action="store_true", default=False)
     parser.add_argument("--pass-session-id", action="store_true", default=False)
@@ -42,7 +42,7 @@ def _build_parser():
     # These MUST use argparse.SUPPRESS to avoid overwriting parent values
     chat.add_argument("--yolo", action="store_true",
                       default=argparse.SUPPRESS)
-    chat.add_argument("--worktree", "-w", action="store_true",
+    chat.add_argument("--worktree", "-w", nargs="?", const=True,
                       default=argparse.SUPPRESS)
     chat.add_argument("--skills", "-s", action="append",
                       default=argparse.SUPPRESS)
@@ -55,6 +55,23 @@ def _build_parser():
         const=True, default=argparse.SUPPRESS, metavar="SESSION_NAME",
     )
     return parser
+
+
+def _parse_with_worktree_rewrite(parser, argv):
+    """Mirror main.py's rewrite so `-w chat` remains flag-before-subcommand."""
+    known = {"chat"}
+    sentinel = "__HERMES_WORKTREE_FLAG__"
+    rewritten = []
+    for index, token in enumerate(argv):
+        next_token = argv[index + 1] if index + 1 < len(argv) else None
+        if token in ("-w", "--worktree") and next_token in known:
+            rewritten.append(f"{token}={sentinel}")
+        else:
+            rewritten.append(token)
+    args = parser.parse_args(rewritten)
+    if getattr(args, "worktree", None) == sentinel:
+        args.worktree = True
+    return args
 
 
 class TestYoloEnvVar:
@@ -91,6 +108,36 @@ class TestYoloEnvVar:
         args = parser.parse_args(["chat"])
         self._simulate_cmd_chat_yolo_check(args)
         assert os.environ.get("HERMES_YOLO_MODE") is None
+
+
+class TestWorktreeOptionalPath:
+    """Verify -w remains a flag and can optionally carry a directory."""
+
+    def test_top_level_worktree_without_path_is_true(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-w"])
+        assert args.worktree is True
+
+    def test_parent_worktree_before_chat_is_true(self):
+        parser = _build_parser()
+        args = _parse_with_worktree_rewrite(parser, ["-w", "chat"])
+        assert args.worktree is True
+        assert args.command == "chat"
+
+    def test_parent_worktree_with_path(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-w", ".agent-worktrees"])
+        assert args.worktree == ".agent-worktrees"
+
+    def test_chat_worktree_without_path_is_true(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "-w"])
+        assert args.worktree is True
+
+    def test_chat_worktree_with_path(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "--worktree", "/tmp/hermes-worktrees"])
+        assert args.worktree == "/tmp/hermes-worktrees"
 
 
 class TestAcceptHooksOnAgentSubparsers:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -640,3 +640,24 @@ class TestUserMessagePreviewConfig:
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]
         assert preview["first_lines"] == 2
         assert preview["last_lines"] == 2
+
+
+class TestWorktreeConfig:
+    def test_default_config_includes_worktree_section(self):
+        assert DEFAULT_CONFIG["worktree"] == {
+            "enabled": False,
+            "dir": ".worktrees",
+        }
+
+    def test_load_config_merges_partial_worktree_section(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({"worktree": {"dir": ".agent-worktrees"}}),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["worktree"]["enabled"] is False
+        assert config["worktree"]["dir"] == ".agent-worktrees"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -24,7 +24,7 @@ hermes [global-options] <command> [subcommand/options]
 | `--profile <name>`, `-p <name>` | Select which Hermes profile to use for this invocation. Overrides the sticky default set by `hermes profile use`. |
 | `--resume <session>`, `-r <session>` | Resume a previous session by ID or title. |
 | `--continue [name]`, `-c [name]` | Resume the most recent session, or the most recent session matching a title. |
-| `--worktree`, `-w` | Start in an isolated git worktree for parallel-agent workflows. |
+| `--worktree [dir]`, `-w [dir]` | Start in an isolated git worktree, optionally under `dir`. |
 | `--yolo` | Bypass dangerous-command approval prompts. |
 | `--pass-session-id` | Include the session ID in the agent's system prompt. |
 | `--ignore-user-config` | Ignore `~/.hermes/config.yaml` and fall back to built-in defaults. Credentials in `.env` are still loaded. |
@@ -90,7 +90,7 @@ Common options:
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |
 | `--image <path>` | Attach a local image to a single query. |
 | `--resume <session>` / `--continue [name]` | Resume a session directly from `chat`. |
-| `--worktree` | Create an isolated git worktree for this run. |
+| `--worktree [dir]`, `-w [dir]` | Create an isolated git worktree for this run, optionally under `dir`. |
 | `--checkpoints` | Enable filesystem checkpoints before destructive file changes. |
 | `--yolo` | Skip approval prompts. |
 | `--pass-session-id` | Pass the session ID into the system prompt. |
@@ -108,6 +108,7 @@ hermes chat --provider openrouter --model anthropic/claude-sonnet-4.6
 hermes chat --toolsets web,terminal,skills
 hermes chat --quiet -q "Return only JSON"
 hermes chat --worktree -q "Review this repo and open a PR"
+hermes chat --worktree .agent-worktrees -q "Review this repo and open a PR"
 hermes chat --ignore-user-config --ignore-rules -q "Repro without my personal setup"
 ```
 

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -44,6 +44,7 @@ hermes chat --verbose
 
 # Isolated git worktree (for running multiple agents in parallel)
 hermes -w                         # Interactive mode in worktree
+hermes -w .agent-worktrees        # Use a custom worktree directory
 hermes -w -q "Fix issue #123"     # Single query in worktree
 ```
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -465,11 +465,22 @@ tool_output:
 Enable isolated git worktrees for running multiple agents in parallel on the same repo:
 
 ```yaml
-worktree: true    # Always create a worktree (same as hermes -w)
-# worktree: false # Default — only when -w flag is passed
+worktree:
+  enabled: true
+  dir: ".worktrees"
 ```
 
-When enabled, each CLI session creates a fresh worktree under `.worktrees/` with its own branch. Agents can edit files, commit, push, and create PRs without interfering with each other. Clean worktrees are removed on exit; dirty ones are kept for manual recovery.
+When enabled, each CLI session creates a fresh worktree under the configured directory with its own branch. Relative paths resolve from the git repo root, and absolute paths are allowed. The legacy boolean form (`worktree: true` / `worktree: false`) is still supported.
+
+You can also override the directory for a single run:
+
+```bash
+hermes -w
+hermes -w .agent-worktrees
+hermes --worktree /tmp/hermes-worktrees
+```
+
+Agents can edit files, commit, push, and create PRs without interfering with each other. Worktrees without unpushed commits are removed on exit; worktrees with unpushed commits are kept for manual recovery.
 
 You can also list gitignored files to copy into worktrees via `.worktreeinclude` in your repo root:
 

--- a/website/docs/user-guide/git-worktrees.md
+++ b/website/docs/user-guide/git-worktrees.md
@@ -152,7 +152,14 @@ Hermes will:
 - Check out an isolated branch (e.g. `hermes/hermes-<hash>`).
 - Run the full CLI session inside that worktree.
 
-This is the easiest way to get worktree isolation. You can also combine it with a single query:
+This is the easiest way to get worktree isolation. You can also provide a custom worktree directory for one run:
+
+```bash
+hermes -w .agent-worktrees
+hermes --worktree /tmp/hermes-worktrees
+```
+
+Relative paths resolve from the git repo root; absolute paths are used as-is. You can also combine worktree isolation with a single query:
 
 ```bash
 hermes -w -q "Fix issue #123"
@@ -171,4 +178,3 @@ This combination gives you:
 - Strong guarantees that different agents and experiments do not step on each other.
 - Fast iteration cycles with easy recovery from bad edits.
 - Clean, reviewable pull requests.
-


### PR DESCRIPTION
## What does this PR do?

Adds support for configuring where Hermes creates disposable git worktrees.

Previously, `hermes -w` always created worktrees under a hardcoded `.worktrees/` directory inside the repository. This PR introduces a canonical `config.yaml` setting for the worktree base directory while preserving the existing boolean config behavior.

The new canonical config shape is:

```yaml
worktree:
  enabled: false
  dir: ".worktrees"
```

Relative paths resolve from the git repository root, and absolute paths are supported for users who want worktrees on another volume or scratch directory. The CLI also supports a per-run override, for example `hermes -w .agent-worktrees` or `hermes --worktree /tmp/hermes-worktrees`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `worktree.enabled` and `worktree.dir` defaults in `hermes_cli/config.py` and `cli.py`.
- Added worktree config normalization in `cli.py`, including compatibility with legacy `worktree: true` / `worktree: false`.
- Updated worktree setup and stale pruning to use the configured or CLI-overridden worktree directory.
- Updated `.gitignore` handling so only repo-contained worktree directories are added.
- Changed `-w` / `--worktree` argument parsing in `hermes_cli/main.py` to accept an optional directory.
- Updated docs and examples in `cli-config.yaml.example`, `website/docs/user-guide/configuration.md`, `website/docs/user-guide/git-worktrees.md`, `website/docs/user-guide/cli.md`, and `website/docs/reference/cli-commands.md`.
- Added tests for config normalization, custom relative and absolute worktree dirs, pruning, and optional `-w <dir>` parsing.

## How to Test

1. Configure automatic worktrees:
   ```yaml
   worktree:
     enabled: true
     dir: ".agent-worktrees"
   ```
   Then run `hermes` inside a git repo and confirm it creates a worktree under `.agent-worktrees/`.

2. Test per-run override:
   ```bash
   hermes -w .agent-worktrees
   hermes --worktree /tmp/hermes-worktrees
   ```

3. Run targeted validation:
   ```bash
   scripts/run_tests.sh tests/cli/test_worktree.py tests/cli/test_worktree_security.py tests/hermes_cli/test_argparse_flag_propagation.py tests/hermes_cli/test_config.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed:

```bash
scripts/run_tests.sh tests/cli/test_worktree.py tests/cli/test_worktree_security.py tests/hermes_cli/test_argparse_flag_propagation.py tests/hermes_cli/test_config.py -q
```

```text
122 passed in 5.89s
```