### PR TITLE
feat(voice): allow reviewing transcripts before submit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2334,23 +2334,29 @@ class HermesCLI:
             return f"  {txt}  ({elapsed_str})"
         return f"  {txt}"
 
-    def _get_voice_status_fragments(self, width: Optional[int] = None):
+    def _get_voice_status_fragments(self, width: Optional[int] = None) -> list:
         """Return the voice status bar fragments for the interactive TUI."""
         width = width or self._get_tui_terminal_width()
         compact = self._use_minimal_tui_chrome(width=width)
+        try:
+            from hermes_cli.config import load_config
+            raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
+            key_display = str(raw_key).replace("ctrl+", "Ctrl+").replace("alt+", "Alt+")
+        except Exception:
+            key_display = "Ctrl+B"
         if self._voice_recording:
             if compact:
                 return [("class:voice-status-recording", " ● REC ")]
-            return [("class:voice-status-recording", " ● REC  Ctrl+B to stop ")]
+            return [("class:voice-status-recording", f" ● REC  {key_display} to stop ")]
         if self._voice_processing:
             if compact:
                 return [("class:voice-status", " ◉ STT ")]
             return [("class:voice-status", " ◉ Transcribing... ")]
         if compact:
-            return [("class:voice-status", " 🎤 Ctrl+B ")]
+            return [("class:voice-status", f" 🎤 {key_display} ")]
         tts = " | TTS on" if self._voice_tts else ""
         cont = " | Continuous" if self._voice_continuous else ""
-        return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  Ctrl+B to record ")]
+        return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {key_display} to record ")]
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
@@ -7574,8 +7580,41 @@ class HermesCLI:
                 time.sleep(0.15)
         threading.Thread(target=_refresh_level, daemon=True).start()
 
+    def _handle_voice_transcript(self, transcript: str) -> bool:
+        """Route a voice transcript to immediate submit or the editable prompt.
+
+        Returns True when the transcript was submitted as a request, False when
+        it was inserted into the current prompt draft for review/editing.
+        """
+        try:
+            from hermes_cli.config import load_config
+            voice_cfg = load_config().get("voice", {})
+            auto_submit = bool(voice_cfg.get("auto_submit", True))
+        except Exception:
+            auto_submit = True
+
+        if auto_submit:
+            self._pending_input.put(transcript)
+            return True
+
+        app = getattr(self, "_app", None)
+        buffer = getattr(app, "current_buffer", None) if app else None
+        if buffer is None:
+            # Non-interactive fallback: preserve old behavior when there is no
+            # editable prompt to receive the transcript.
+            self._pending_input.put(transcript)
+            return True
+
+        existing = getattr(buffer, "text", "") or ""
+        prefix = "" if not existing or existing.endswith((" ", "\n")) else " "
+        buffer.insert_text(prefix + transcript)
+        if app:
+            app.invalidate()
+        _cprint(f"{_DIM}Transcript inserted into draft. Edit if needed, then press Enter.{_RST}")
+        return False
+
     def _voice_stop_and_transcribe(self):
-        """Stop recording, transcribe via STT, and queue the transcript as input."""
+        """Stop recording, transcribe via STT, and route the transcript as input."""
         # Atomic guard: only one thread can enter stop-and-transcribe.
         # Set _voice_processing immediately so concurrent Ctrl+B presses
         # don't race into the START path while recorder.stop() holds its lock.
@@ -7627,8 +7666,7 @@ class HermesCLI:
                 self._attached_images.clear()
                 if hasattr(self, '_app') and self._app:
                     self._app.invalidate()
-                self._pending_input.put(transcript)
-                submitted = True
+                submitted = self._handle_voice_transcript(transcript)
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
             else:
@@ -10752,6 +10790,11 @@ class HermesCLI:
         # Run the application with patch_stdout for proper output handling
         try:
             with patch_stdout():
+                try:
+                    if bool((self.config.get("voice") or {}).get("start_enabled", False)):
+                        self._enable_voice_mode()
+                except Exception as e:
+                    _cprint(f"\n{_DIM}Could not enable voice mode at startup: {e}{_RST}")
                 # Set the custom handler on prompt_toolkit's event loop
                 try:
                     import asyncio as _aio

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -709,8 +709,10 @@ DEFAULT_CONFIG = {
     },
 
     "voice": {
+        "start_enabled": False,       # Start CLI sessions with /voice on already enabled
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
+        "auto_submit": True,          # Submit transcripts immediately; false inserts into editable prompt
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -147,6 +147,51 @@ class TestVoiceCommandParsing:
             assert subcommand == expected, f"Failed for {command!r}: got {subcommand!r}"
 
 
+
+
+class TestVoiceTranscriptDraftMode:
+    def test_auto_submit_false_inserts_transcript_into_editable_prompt(self):
+        cli = _make_voice_cli()
+        buffer = MagicMock()
+        app = SimpleNamespace(current_buffer=buffer, invalidate=MagicMock())
+        cli._app = app
+
+        with patch("hermes_cli.config.load_config", return_value={"voice": {"auto_submit": False}}):
+            submitted = cli._handle_voice_transcript("first batch")
+
+        assert submitted is False
+        assert cli._pending_input.empty()
+        buffer.insert_text.assert_called_once_with("first batch")
+        app.invalidate.assert_called_once()
+
+    def test_auto_submit_true_queues_transcript_for_immediate_request(self):
+        cli = _make_voice_cli()
+
+        with patch("hermes_cli.config.load_config", return_value={"voice": {"auto_submit": True}}):
+            submitted = cli._handle_voice_transcript("send now")
+
+        assert submitted is True
+        assert cli._pending_input.get_nowait() == "send now"
+
+    def test_draft_mode_separates_batches_with_space_when_prompt_has_text(self):
+        cli = _make_voice_cli()
+        class FakeBuffer:
+            text = "first batch"
+            def __init__(self):
+                self.inserted = []
+            def insert_text(self, text):
+                self.inserted.append(text)
+                self.text += text
+        buffer = FakeBuffer()
+        cli._app = SimpleNamespace(current_buffer=buffer, invalidate=MagicMock())
+
+        with patch("hermes_cli.config.load_config", return_value={"voice": {"auto_submit": False}}):
+            submitted = cli._handle_voice_transcript("second batch")
+
+        assert submitted is False
+        assert buffer.inserted == [" second batch"]
+
+
 # ============================================================================
 # Voice state thread safety
 # ============================================================================


### PR DESCRIPTION
## Summary
- Adds `voice.auto_submit` config to let CLI voice transcripts insert into the editable prompt instead of submitting immediately
- Preserves existing auto-submit behavior by default
- Shows the configured voice hotkey in the status bar and supports enabling voice mode at startup with `voice.start_enabled`
- Adds tests for immediate submit and draft insertion/multi-batch dictation behavior

## Test Plan
- `scripts/run_tests.sh tests/tools/test_voice_cli_integration.py`
