### PR TITLE
fix(gateway): allow free_response_channels to override DISCORD_IGNORE_NO_MENTION

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -704,11 +704,22 @@ class DiscordAdapter(BasePlatformAdapter):
                         return
                     # If humans are mentioned but we're not → not for us
                     # (preserves old DISCORD_IGNORE_NO_MENTION=true behavior)
+                    # EXCEPT in free-response channels where the bot should
+                    # answer regardless of who is mentioned.
                     _ignore_no_mention = os.getenv(
                         "DISCORD_IGNORE_NO_MENTION", "true"
                     ).lower() in ("true", "1", "yes")
                     if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        return
+                        _channel_id = str(message.channel.id)
+                        _parent_id = None
+                        if hasattr(message.channel, "parent_id") and message.channel.parent_id:
+                            _parent_id = str(message.channel.parent_id)
+                        _free_channels = adapter_self._discord_free_response_channels()
+                        _channel_ids = {_channel_id}
+                        if _parent_id:
+                            _channel_ids.add(_parent_id)
+                        if "*" not in _free_channels and not (_channel_ids & _free_channels):
+                            return
 
                 await self._handle_message(message)
 
@@ -3255,7 +3266,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:


### PR DESCRIPTION
## Problem

When `DISCORD_IGNORE_NO_MENTION=true` (the default), the bot drops every message that does not @-mention it. This happens *before* the `free_response_channels` check, so a channel configured as a free-response channel (where the bot should answer without being pinged) is effectively ignored unless someone explicitly mentions the bot.

## Changes

1. **In `on_message`**: After the `DISCORD_IGNORE_NO_MENTION` guard fires, add a carve-out that checks whether the message arrived in a `free_response_channel` (or its parent category). If so, the message is allowed through.

2. **In `_handle_message`**: Remove the unconditional `skip_thread` for free response channels (`or is_free_channel`). This means `auto_thread` can still create threads in free response channels unless the channel is explicitly listed in `DISCORD_NO_THREAD_CHANNELS`.

## Steps to reproduce the bug

1. Set `DISCORD_FREE_RESPONSE_CHANNELS=<channel-id>`
2. Set `DISCORD_IGNORE_NO_MENTION=true` (or leave default)
3. Send a plain message (no @mention) in that channel
4. Bot ignores the message

With this patch the bot replies as expected.

---
*Note: this PR salvages the useful behavior described in local deployments where free_response_channels and ignore-no-mention are used together.*