### PR TITLE
[codex] Async profile-aware delegation jobs

### DIFF
--- a/agent/sandbox_provider.py
+++ b/agent/sandbox_provider.py
@@ -1,0 +1,69 @@
+"""Provider-neutral sandbox runtime contract for Hermes execution backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Inputs needed by a sandbox provider to create a Hermes environment."""
+
+    provider: str
+    mode: str
+    task_id: str
+    scope: str
+    cwd: str
+    host_cwd: str
+    timeout: int
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SandboxRuntimeInfo:
+    """Lightweight status returned by sandbox providers for CLI/UI display."""
+
+    provider: str
+    runtime_id: str
+    running: bool
+    mode: str = ""
+    source: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class SandboxProvider(ABC):
+    """Base class for sandbox provider plugins.
+
+    Providers return objects compatible with ``tools.environments.base.BaseEnvironment``.
+    The concrete return type is intentionally not enforced here to keep the
+    plugin contract decoupled from one implementation module.
+    """
+
+    name: str = ""
+    description: str = ""
+
+    def is_available(self) -> bool:
+        """Return whether the provider can run in the current process."""
+
+        return True
+
+    @abstractmethod
+    def create_environment(self, spec: SandboxSpec):
+        """Create an execution environment for *spec*."""
+
+    def describe_runtime(self, scope: str, config: Optional[dict[str, Any]] = None) -> SandboxRuntimeInfo:
+        """Return best-effort runtime status for a scope."""
+
+        return SandboxRuntimeInfo(
+            provider=self.name,
+            runtime_id=scope,
+            running=False,
+            details={"message": "status not implemented"},
+        )
+
+    def delete_runtime(self, scope: str, config: Optional[dict[str, Any]] = None) -> None:
+        """Delete the runtime for *scope* if the provider supports it."""
+
+        raise NotImplementedError(f"{self.name} does not support runtime deletion")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -789,6 +789,11 @@ code_execution:
 # The delegate_task tool spawns child agents with isolated context.
 # Supports single tasks and batch mode (default 3 parallel, configurable).
 delegation:
+  async_default: true                         # delegate_task returns job ids by default; set false for legacy blocking behavior
+  default_profile: ""                         # Profile for child jobs (empty = inherit active profile)
+  allowed_profiles: []                        # Profiles allowed for delegation (empty = all profiles)
+  job_retention_hours: 24                     # How long completed job metadata is retained
+  approval_mode: deny                         # Subprocess child command policy: deny, approve, or inherit
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
   # max_concurrent_children: 3                # Max parallel child agents per batch (default: 3, floor: 1, no ceiling).
                                               # WARNING: values above 10 multiply API cost linearly.

--- a/cli.py
+++ b/cli.py
@@ -346,6 +346,29 @@ def load_cli_config() -> Dict[str, Any]:
             "docker_volumes": [],  # host:container volume mounts for Docker backend
             "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
         },
+        "sandbox": {
+            "enabled": False,
+            "provider": "host",
+            "mode": "mirror",
+            "delegation_default": "inherit",
+            "openshell": {
+                "command": "openshell",
+                "from": "",
+                "policy": "",
+                "providers": [],
+                "auto_providers": True,
+                "gpu": False,
+                "gateway": "hermes-openshell",
+                "gateway_endpoint": "",
+                "gateway_port": 18080,
+                "gateway_host": "",
+                "remote_workspace_dir": "/sandbox",
+                "remote_agent_workspace_dir": "/agent",
+                "timeout_seconds": 120,
+                "mirror_excludes": [".git", ".hermes", "node_modules", ".venv", "dist", "build", "target"],
+                "extra_syncs": [],
+            },
+        },
         "browser": {
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
             "record_sessions": False,  # Auto-record browser sessions as WebM videos
@@ -574,6 +597,43 @@ def load_cli_config() -> Dict[str, Any]:
                     os.environ[env_var] = json.dumps(val)
                 else:
                     os.environ[env_var] = str(val)
+
+    sandbox_config = defaults.get("sandbox", {})
+    if isinstance(sandbox_config, dict):
+        sandbox_env_mappings = {
+            "enabled": "HERMES_SANDBOX_ENABLED",
+            "provider": "HERMES_SANDBOX_PROVIDER",
+            "mode": "HERMES_SANDBOX_MODE",
+            "delegation_default": "HERMES_SANDBOX_DELEGATION_DEFAULT",
+        }
+        for config_key, env_var in sandbox_env_mappings.items():
+            if config_key in sandbox_config and env_var not in os.environ:
+                os.environ[env_var] = str(sandbox_config[config_key])
+
+        openshell_config = sandbox_config.get("openshell", {})
+        if isinstance(openshell_config, dict):
+            openshell_env_mappings = {
+                "command": "HERMES_OPENSHELL_COMMAND",
+                "from": "HERMES_SANDBOX_SOURCE",
+                "source": "HERMES_SANDBOX_SOURCE",
+                "policy": "HERMES_OPENSHELL_POLICY",
+                "providers": "HERMES_OPENSHELL_PROVIDERS",
+                "auto_providers": "HERMES_OPENSHELL_AUTO_PROVIDERS",
+                "gpu": "HERMES_OPENSHELL_GPU",
+                "gateway": "HERMES_OPENSHELL_GATEWAY",
+                "gateway_endpoint": "HERMES_OPENSHELL_GATEWAY_ENDPOINT",
+                "gateway_port": "HERMES_OPENSHELL_GATEWAY_PORT",
+                "gateway_host": "HERMES_OPENSHELL_GATEWAY_HOST",
+                "remote_workspace_dir": "HERMES_SANDBOX_REMOTE_WORKSPACE_DIR",
+                "remote_agent_workspace_dir": "HERMES_SANDBOX_REMOTE_AGENT_WORKSPACE_DIR",
+                "timeout_seconds": "HERMES_SANDBOX_TIMEOUT_SECONDS",
+                "mirror_excludes": "HERMES_SANDBOX_MIRROR_EXCLUDES",
+                "extra_syncs": "HERMES_SANDBOX_EXTRA_SYNCS",
+            }
+            for config_key, env_var in openshell_env_mappings.items():
+                if config_key in openshell_config and env_var not in os.environ:
+                    val = openshell_config[config_key]
+                    os.environ[env_var] = json.dumps(val) if isinstance(val, list) else str(val)
     
     # Apply browser config to environment variables
     browser_config = defaults.get("browser", {})

--- a/cli.py
+++ b/cli.py
@@ -433,11 +433,19 @@ def load_cli_config() -> Dict[str, Any]:
             },
         },
         "delegation": {
+            "async_default": True,
+            "default_profile": "",
+            "allowed_profiles": [],
+            "job_retention_hours": 24,
+            "approval_mode": "deny",
             "max_iterations": 45,  # Max tool-calling turns per child agent
             "model": "",       # Subagent model override (empty = inherit parent model)
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "max_concurrent_children": 3,
+            "max_spawn_depth": 1,
+            "orchestrator_enabled": True,
         },
     }
     
@@ -1604,6 +1612,55 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
         seen.add(key)
         deduped.append(img)
     return message, deduped
+
+
+def _load_delegate_request(path: str | None) -> Dict[str, Any]:
+    if not path:
+        return {}
+    request_path = Path(path).expanduser()
+    try:
+        data = json.loads(request_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Could not read delegation request {request_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Delegation request {request_path} must contain a JSON object")
+    return data
+
+
+def _format_delegate_query(payload: Dict[str, Any]) -> str:
+    goal = str(payload.get("goal") or "").strip()
+    context = str(payload.get("context") or "").strip()
+    parts = [
+        "Complete the delegated task below and return a concise final summary.",
+        "",
+        f"TASK:\n{goal}",
+    ]
+    if context:
+        parts.extend(["", f"CONTEXT:\n{context}"])
+    return "\n".join(parts)
+
+
+def _write_delegate_output(path: str | None, payload: Dict[str, Any], result: Dict[str, Any] | None, error: str = "") -> None:
+    if not path:
+        return
+    output_path = Path(path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    result = result if isinstance(result, dict) else {}
+    data = {
+        "job_id": payload.get("job_id") or os.getenv("HERMES_DELEGATE_JOB_ID", ""),
+        "status": "failed" if error or result.get("failed") else "completed",
+        "final_response": result.get("final_response") or "",
+        "session_id": result.get("session_id") or "",
+        "completed": bool(result.get("completed", not error)),
+        "failed": bool(error or result.get("failed")),
+        "error": error or result.get("error", ""),
+        "api_calls": result.get("api_calls", 0),
+        "exit_reason": result.get("exit_reason", ""),
+        "updated_at": time.time(),
+    }
+    tmp = output_path.with_suffix(output_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, output_path)
 
 
 class ChatConsole:
@@ -10916,6 +10973,8 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    delegate_request: str = None,
+    delegate_output: str = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -10990,6 +11049,46 @@ def main(
     
     # Handle query shorthand
     query = query or q
+
+    delegate_payload: Dict[str, Any] = {}
+    if delegate_request:
+        delegate_payload = _load_delegate_request(delegate_request)
+        query = _format_delegate_query(delegate_payload)
+        if delegate_payload.get("toolsets"):
+            toolsets = ",".join(str(t) for t in delegate_payload.get("toolsets") or [])
+        if delegate_payload.get("model") and not model:
+            model = str(delegate_payload.get("model"))
+        if delegate_payload.get("provider") and not provider:
+            provider = str(delegate_payload.get("provider"))
+        if delegate_payload.get("skills") and not skills:
+            skills = delegate_payload.get("skills")
+        if delegate_payload.get("resume") and not resume:
+            resume = str(delegate_payload.get("resume"))
+        if "pass_session_id" in delegate_payload and not pass_session_id:
+            raw_pass_session_id = delegate_payload.get("pass_session_id")
+            pass_session_id = (
+                raw_pass_session_id
+                if isinstance(raw_pass_session_id, bool)
+                else str(raw_pass_session_id).strip().lower() in {"1", "true", "yes", "on"}
+            )
+        if delegate_payload.get("max_iterations") and not max_turns:
+            try:
+                max_turns = int(delegate_payload.get("max_iterations"))
+            except (TypeError, ValueError):
+                pass
+        ignore_rules = True
+        os.environ["HERMES_IGNORE_RULES"] = "1"
+        sandbox_config = delegate_payload.get("sandbox_config")
+        if isinstance(sandbox_config, dict) and sandbox_config:
+            provider_name = sandbox_config.get("provider")
+            if provider_name:
+                os.environ["HERMES_SANDBOX"] = str(provider_name)
+            if sandbox_config.get("mode"):
+                os.environ["HERMES_SANDBOX_MODE"] = str(sandbox_config["mode"])
+            if sandbox_config.get("scope"):
+                os.environ["HERMES_SANDBOX_SCOPE"] = str(sandbox_config["scope"])
+            if sandbox_config.get("source"):
+                os.environ["HERMES_SANDBOX_SOURCE"] = str(sandbox_config["source"])
     
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools
@@ -11041,6 +11140,9 @@ def main(
                 part for part in (cli.system_prompt, skills_prompt) if part
             ).strip()
             cli.preloaded_skills = loaded_skills
+
+    if delegate_payload:
+        cli.system_prompt = str(delegate_payload.get("system_prompt") or cli.system_prompt or "")
 
     # Inject worktree context into agent's system prompt
     if wt_info:
@@ -11130,15 +11232,28 @@ def main(
                 ):
                     cli.agent.quiet_mode = True
                     cli.agent.suppress_status_output = True
+                    if delegate_payload:
+                        try:
+                            cli.agent._delegate_depth = int(delegate_payload.get("child_depth") or 1)
+                            cli.agent._delegate_role = delegate_payload.get("role") or "leaf"
+                            cli.agent._subagent_id = delegate_payload.get("job_id") or ""
+                            cli.agent._parent_subagent_id = delegate_payload.get("parent_subagent_id") or None
+                            cli.agent._subagent_goal = delegate_payload.get("goal") or ""
+                        except Exception:
+                            pass
                     # Suppress streaming display callbacks so stdout stays
                     # machine-readable (no styled "Hermes" box, no tool-gen
                     # status lines).  The response is printed once below.
                     cli.agent.stream_delta_callback = None
                     cli.agent.tool_gen_callback = None
-                    result = cli.agent.run_conversation(
-                        user_message=effective_query,
-                        conversation_history=cli.conversation_history,
-                    )
+                    try:
+                        result = cli.agent.run_conversation(
+                            user_message=effective_query,
+                            conversation_history=cli.conversation_history,
+                        )
+                    except Exception as exc:
+                        _write_delegate_output(delegate_output, delegate_payload, None, error=str(exc))
+                        raise
                     # Sync session_id if mid-run compression created a
                     # continuation session. The exit line below reports
                     # session_id to stderr for automation wrappers; without
@@ -11149,6 +11264,9 @@ def main(
                     ):
                         cli.session_id = cli.agent.session_id
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                    if isinstance(result, dict):
+                        result["session_id"] = cli.session_id
+                    _write_delegate_output(delegate_output, delegate_payload, result if isinstance(result, dict) else {}, error="")
                     if response:
                         print(response)
                     # Session ID goes to stderr so piped stdout is clean.
@@ -11158,6 +11276,12 @@ def main(
                     sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
             
             # Exit with error code if credentials or agent init fails
+            _write_delegate_output(
+                delegate_output,
+                delegate_payload,
+                None,
+                error="Runtime credentials or agent initialization failed.",
+            )
             sys.exit(1)
         else:
             cli.show_banner()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -799,6 +799,11 @@ DEFAULT_CONFIG = {
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
     "delegation": {
+        "async_default": True,  # delegate_task returns job ids by default; pass async=false for legacy blocking
+        "default_profile": "",  # empty = inherit active profile
+        "allowed_profiles": [],  # empty = all existing profiles allowed
+        "job_retention_hours": 24,
+        "approval_mode": "deny",  # subprocess children: deny flagged commands without prompting
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -53,6 +53,16 @@ _EXTRA_ENV_KEYS = frozenset({
     "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
     "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "HERMES_SANDBOX", "HERMES_SANDBOX_ENABLED", "HERMES_SANDBOX_PROVIDER",
+    "HERMES_SANDBOX_MODE", "HERMES_SANDBOX_SCOPE", "HERMES_SANDBOX_SOURCE",
+    "HERMES_SANDBOX_REMOTE_WORKSPACE_DIR", "HERMES_SANDBOX_REMOTE_AGENT_WORKSPACE_DIR",
+    "HERMES_SANDBOX_TIMEOUT_SECONDS", "HERMES_SANDBOX_MIRROR_EXCLUDES",
+    "HERMES_SANDBOX_EXTRA_SYNCS",
+    "HERMES_SANDBOX_DELEGATION_DEFAULT", "HERMES_OPENSHELL_COMMAND",
+    "HERMES_OPENSHELL_POLICY", "HERMES_OPENSHELL_PROVIDERS",
+    "HERMES_OPENSHELL_AUTO_PROVIDERS", "HERMES_OPENSHELL_GPU",
+    "HERMES_OPENSHELL_GATEWAY", "HERMES_OPENSHELL_GATEWAY_ENDPOINT",
+    "HERMES_OPENSHELL_GATEWAY_PORT", "HERMES_OPENSHELL_GATEWAY_HOST",
     "WHATSAPP_MODE", "WHATSAPP_ENABLED",
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
@@ -458,6 +468,44 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+    },
+
+    "sandbox": {
+        "enabled": False,
+        "provider": "host",
+        "mode": "mirror",
+        "delegation_default": "inherit",
+        "openshell": {
+            "command": "openshell",
+            "from": "bundled-hermes-source",
+            "policy": "",
+            "providers": [],
+            "auto_providers": True,
+            "gpu": False,
+            "gateway": "hermes-openshell",
+            "gateway_endpoint": "",
+            "gateway_port": 18080,
+            "gateway_host": "",
+            "remote_workspace_dir": "/sandbox",
+            "remote_agent_workspace_dir": "/agent",
+            "timeout_seconds": 120,
+            "sync_hermes_files": False,
+            "mirror_excludes": [
+                ".git",
+                ".hermes",
+                "node_modules",
+                ".venv",
+                "venv",
+                "__pycache__",
+                ".pytest_cache",
+                ".mypy_cache",
+                ".ruff_cache",
+                "dist",
+                "build",
+                "target",
+            ],
+            "extra_syncs": [],
+        },
     },
     
     "browser": {
@@ -2226,7 +2274,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "agent", "terminal", "sandbox", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",
 }
@@ -3902,9 +3950,32 @@ def set_config_value(key: str, value: str):
         "terminal.container_memory": "TERMINAL_CONTAINER_MEMORY",
         "terminal.container_disk": "TERMINAL_CONTAINER_DISK",
         "terminal.container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+        "sandbox.enabled": "HERMES_SANDBOX_ENABLED",
+        "sandbox.provider": "HERMES_SANDBOX_PROVIDER",
+        "sandbox.mode": "HERMES_SANDBOX_MODE",
+        "sandbox.openshell.command": "HERMES_OPENSHELL_COMMAND",
+        "sandbox.openshell.from": "HERMES_SANDBOX_SOURCE",
+        "sandbox.openshell.policy": "HERMES_OPENSHELL_POLICY",
+        "sandbox.openshell.providers": "HERMES_OPENSHELL_PROVIDERS",
+        "sandbox.openshell.auto_providers": "HERMES_OPENSHELL_AUTO_PROVIDERS",
+        "sandbox.openshell.gpu": "HERMES_OPENSHELL_GPU",
+        "sandbox.openshell.gateway": "HERMES_OPENSHELL_GATEWAY",
+        "sandbox.openshell.gateway_endpoint": "HERMES_OPENSHELL_GATEWAY_ENDPOINT",
+        "sandbox.openshell.gateway_port": "HERMES_OPENSHELL_GATEWAY_PORT",
+        "sandbox.openshell.gateway_host": "HERMES_OPENSHELL_GATEWAY_HOST",
+        "sandbox.openshell.remote_workspace_dir": "HERMES_SANDBOX_REMOTE_WORKSPACE_DIR",
+        "sandbox.openshell.remote_agent_workspace_dir": "HERMES_SANDBOX_REMOTE_AGENT_WORKSPACE_DIR",
+        "sandbox.openshell.timeout_seconds": "HERMES_SANDBOX_TIMEOUT_SECONDS",
+        "sandbox.openshell.mirror_excludes": "HERMES_SANDBOX_MIRROR_EXCLUDES",
+        "sandbox.openshell.extra_syncs": "HERMES_SANDBOX_EXTRA_SYNCS",
     }
     if key in _config_to_env_sync:
-        save_env_value(_config_to_env_sync[key], str(value))
+        if isinstance(value, list):
+            import json
+
+            save_env_value(_config_to_env_sync[key], json.dumps(value))
+        else:
+            save_env_value(_config_to_env_sync[key], str(value))
 
     print(f"✓ Set {key} = {value} in {config_path}")
 

--- a/hermes_cli/delegate_cmd.py
+++ b/hermes_cli/delegate_cmd.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Operator CLI for async delegation jobs."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict
+
+
+def _fmt_time(ts: Any) -> str:
+    try:
+        val = float(ts)
+    except (TypeError, ValueError):
+        return "-"
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(val))
+
+
+def _print_json(data: Dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
+
+
+def delegate_command(args) -> None:
+    from tools import delegation_jobs
+
+    action = getattr(args, "delegate_action", None) or "list"
+    if action in ("list", "ls"):
+        jobs = delegation_jobs.list_jobs(
+            status=getattr(args, "status", None),
+            profile=getattr(args, "profile", None),
+            parent_session_id=getattr(args, "parent_session_id", None),
+            limit=getattr(args, "limit", 50),
+        )
+        if getattr(args, "json", False):
+            _print_json({"jobs": jobs})
+            return
+        if not jobs:
+            print("No delegation jobs found.")
+            return
+        print(f"{'JOB ID':<28} {'STATUS':<11} {'PROFILE':<12} {'STARTED':<19} GOAL")
+        for job in jobs:
+            goal = (job.get("goal") or "").replace("\n", " ")
+            if len(goal) > 60:
+                goal = goal[:57] + "..."
+            print(
+                f"{job.get('job_id',''):<28} {job.get('status',''):<11} "
+                f"{job.get('profile',''):<12} {_fmt_time(job.get('started_at')):<19} {goal}"
+            )
+        return
+
+    if action == "status":
+        job = delegation_jobs.get_job(args.job_id)
+        if not job:
+            print(f"Job not found: {args.job_id}")
+            return
+        _print_json(job)
+        return
+
+    if action == "wait":
+        result = delegation_jobs.wait_jobs([args.job_id], timeout=getattr(args, "timeout", 0))
+        _print_json(result)
+        return
+
+    if action == "cancel":
+        _print_json(delegation_jobs.cancel_jobs([args.job_id]))
+        return
+
+    if action == "logs":
+        result = delegation_jobs.get_result(args.job_id, tail_chars=getattr(args, "tail_chars", 12000))
+        if getattr(args, "json", False):
+            _print_json(result)
+            return
+        stdout = result.get("stdout_tail") or ""
+        stderr = result.get("stderr_tail") or ""
+        if stdout:
+            print("== stdout ==")
+            print(stdout.rstrip())
+        if stderr:
+            print("== stderr ==")
+            print(stderr.rstrip())
+        if not stdout and not stderr:
+            print("No logs yet.")
+        return
+
+    raise SystemExit(f"Unknown delegate action: {action}")
+

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1183,6 +1183,17 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    if getattr(args, "no_sandbox", False):
+        os.environ["HERMES_SANDBOX"] = "host"
+    elif getattr(args, "sandbox", None) is not None:
+        os.environ["HERMES_SANDBOX"] = args.sandbox or "openshell"
+    if getattr(args, "sandbox_mode", None):
+        os.environ["HERMES_SANDBOX_MODE"] = args.sandbox_mode
+    if getattr(args, "sandbox_scope", None):
+        os.environ["HERMES_SANDBOX_SCOPE"] = args.sandbox_scope
+    if getattr(args, "sandbox_source", None):
+        os.environ["HERMES_SANDBOX_SOURCE"] = args.sandbox_source
+
     if use_tui:
         _launch_tui(
             getattr(args, "resume", None),
@@ -6882,6 +6893,11 @@ Examples:
     hermes config edit            Edit config in $EDITOR
     hermes config set model gpt-4 Set a config value
     hermes gateway                Run messaging gateway
+    hermes openshell --help       Show OpenShell sandbox management commands
+    hermes openshell status       Show OpenShell provider/gateway status
+    hermes openshell enable       Configure OpenShell sandboxing
+    hermes openshell disable      Return tool execution defaults to host/local
+    hermes chat --sandbox=openshell -q "pwd"  Run tools in an OpenShell sandbox
     hermes -s hermes-agent-dev,github-auth
     hermes -w                     Start in isolated git worktree
     hermes gateway install        Install gateway background service
@@ -7158,6 +7174,36 @@ For more help on a command:
         "--source",
         default=None,
         help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",
+    )
+    chat_parser.add_argument(
+        "--sandbox",
+        nargs="?",
+        const="openshell",
+        default=None,
+        metavar="PROVIDER",
+        help="Run Hermes tool execution in a sandbox provider (default provider: openshell)",
+    )
+    chat_parser.add_argument(
+        "--no-sandbox",
+        action="store_true",
+        default=False,
+        help="Force host/local tool execution even when sandboxing is configured",
+    )
+    chat_parser.add_argument(
+        "--sandbox-mode",
+        choices=["mirror", "remote"],
+        default=None,
+        help="Sandbox workspace mode for providers that support it",
+    )
+    chat_parser.add_argument(
+        "--sandbox-scope",
+        default=None,
+        help="Stable sandbox scope/name seed for reusing provider runtimes",
+    )
+    chat_parser.add_argument(
+        "--sandbox-source",
+        default=None,
+        help="Provider source override, e.g. OpenShell --from source",
     )
     chat_parser.add_argument(
         "--tui",
@@ -8245,7 +8291,21 @@ Examples:
             )
             cmd_info["setup_fn"](plugin_parser)
     except Exception as _exc:
-        logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
+        logging.getLogger(__name__).debug("Memory plugin CLI discovery failed: %s", _exc)
+
+    try:
+        from plugins.sandbox import discover_plugin_cli_commands as discover_sandbox_cli_commands
+
+        for cmd_info in discover_sandbox_cli_commands():
+            plugin_parser = subparsers.add_parser(
+                cmd_info["name"],
+                help=cmd_info["help"],
+                description=cmd_info.get("description", ""),
+                formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
+            )
+            cmd_info["setup_fn"](plugin_parser)
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("Sandbox plugin CLI discovery failed: %s", _exc)
 
     # =========================================================================
     # memory command

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1222,6 +1222,8 @@ def cmd_chat(args):
         "max_turns": getattr(args, "max_turns", None),
         "ignore_rules": getattr(args, "ignore_rules", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False),
+        "delegate_request": getattr(args, "delegate_request", None),
+        "delegate_output": getattr(args, "delegate_output", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -6898,6 +6900,8 @@ Examples:
     hermes openshell enable       Configure OpenShell sandboxing
     hermes openshell disable      Return tool execution defaults to host/local
     hermes chat --sandbox=openshell -q "pwd"  Run tools in an OpenShell sandbox
+    hermes delegate list          List async delegation jobs
+    hermes delegate status JOB    Show async delegation job metadata
     hermes -s hermes-agent-dev,github-auth
     hermes -w                     Start in isolated git worktree
     hermes gateway install        Install gateway background service
@@ -7205,6 +7209,8 @@ For more help on a command:
         default=None,
         help="Provider source override, e.g. OpenShell --from source",
     )
+    chat_parser.add_argument("--delegate-request", default=None, help=argparse.SUPPRESS)
+    chat_parser.add_argument("--delegate-output", default=None, help=argparse.SUPPRESS)
     chat_parser.add_argument(
         "--tui",
         action="store_true",
@@ -8306,6 +8312,44 @@ Examples:
             cmd_info["setup_fn"](plugin_parser)
     except Exception as _exc:
         logging.getLogger(__name__).debug("Sandbox plugin CLI discovery failed: %s", _exc)
+
+    # =========================================================================
+    # delegate command
+    # =========================================================================
+    delegate_parser = subparsers.add_parser(
+        "delegate",
+        help="Inspect and control async delegation jobs",
+        description="List, inspect, wait for, cancel, and tail async delegation jobs.",
+    )
+    delegate_sub = delegate_parser.add_subparsers(dest="delegate_action")
+    delegate_list = delegate_sub.add_parser("list", aliases=["ls"], help="List delegation jobs")
+    delegate_list.add_argument("--status", help="Filter by status")
+    delegate_list.add_argument("--profile", help="Filter by Hermes profile")
+    delegate_list.add_argument("--parent-session-id", help="Filter by parent session id")
+    delegate_list.add_argument("--limit", type=int, default=50, help="Maximum jobs to show")
+    delegate_list.add_argument("--json", action="store_true", help="Print JSON")
+
+    delegate_status = delegate_sub.add_parser("status", help="Show job metadata")
+    delegate_status.add_argument("job_id")
+
+    delegate_wait_p = delegate_sub.add_parser("wait", help="Wait for a job to complete")
+    delegate_wait_p.add_argument("job_id")
+    delegate_wait_p.add_argument("--timeout", type=float, default=0, help="Seconds to wait; 0 polls once")
+
+    delegate_cancel_p = delegate_sub.add_parser("cancel", help="Cancel a job")
+    delegate_cancel_p.add_argument("job_id")
+
+    delegate_logs = delegate_sub.add_parser("logs", help="Show job stdout/stderr tails")
+    delegate_logs.add_argument("job_id")
+    delegate_logs.add_argument("--tail-chars", type=int, default=12000)
+    delegate_logs.add_argument("--json", action="store_true", help="Print JSON")
+
+    def cmd_delegate(args):
+        from hermes_cli.delegate_cmd import delegate_command
+
+        delegate_command(args)
+
+    delegate_parser.set_defaults(func=cmd_delegate)
 
     # =========================================================================
     # memory command

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -430,6 +430,32 @@ class PluginContext:
             self.manifest.name, provider.name,
         )
 
+    # -- sandbox provider registration ---------------------------------------
+
+    def register_sandbox_provider(self, provider) -> None:
+        """Register a sandbox execution provider.
+
+        Category loaders such as ``plugins.sandbox`` usually capture providers
+        through a lightweight collector. This method exists for the full plugin
+        context so sandbox providers have the same registration surface as
+        memory, context, and image generation providers.
+        """
+        from agent.sandbox_provider import SandboxProvider
+
+        if not isinstance(provider, SandboxProvider):
+            logger.warning(
+                "Plugin '%s' tried to register a sandbox provider that does not "
+                "inherit from SandboxProvider. Ignoring.",
+                self.manifest.name,
+            )
+            return
+        self._manager._sandbox_providers[provider.name] = provider
+        logger.info(
+            "Plugin '%s' registered sandbox provider: %s",
+            self.manifest.name,
+            provider.name,
+        )
+
     # -- hook registration --------------------------------------------------
 
     def register_hook(self, hook_name: str, callback: Callable) -> None:
@@ -515,6 +541,7 @@ class PluginManager:
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
         self._plugin_skills: Dict[str, Dict[str, Any]] = {}
+        self._sandbox_providers: Dict[str, Any] = {}
 
     # -----------------------------------------------------------------------
     # Public
@@ -537,6 +564,7 @@ class PluginManager:
             self._plugin_commands.clear()
             self._plugin_skills.clear()
             self._context_engine = None
+            self._sandbox_providers.clear()
         self._discovered = True
 
         manifests: List[PluginManifest] = []

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -758,6 +758,16 @@ def _discover_context_engines() -> list[tuple[str, str]]:
         return []
 
 
+def _discover_sandbox_providers() -> list[tuple[str, str]]:
+    """Return [(name, description), ...] for available sandbox providers."""
+    try:
+        from plugins.sandbox import discover_sandbox_providers
+
+        return [(name, desc) for name, desc, _avail in discover_sandbox_providers()]
+    except Exception:
+        return []
+
+
 def _get_current_memory_provider() -> str:
     """Return the current memory.provider from config (empty = built-in)."""
     try:
@@ -778,6 +788,20 @@ def _get_current_context_engine() -> str:
         return "compressor"
 
 
+def _get_current_sandbox_provider() -> str:
+    """Return the current sandbox.provider from config."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        sandbox = config.get("sandbox", {}) if isinstance(config.get("sandbox"), dict) else {}
+        if not sandbox.get("enabled", False):
+            return "host"
+        return sandbox.get("provider", "host") or "host"
+    except Exception:
+        return "host"
+
+
 def _save_memory_provider(name: str) -> None:
     """Persist memory.provider to config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -795,6 +819,21 @@ def _save_context_engine(name: str) -> None:
     if "context" not in config:
         config["context"] = {}
     config["context"]["engine"] = name
+    save_config(config)
+
+
+def _save_sandbox_provider(name: str) -> None:
+    """Persist sandbox.provider to config.yaml."""
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    if "sandbox" not in config or not isinstance(config.get("sandbox"), dict):
+        config["sandbox"] = {}
+    config["sandbox"]["provider"] = "host" if name == "host" else name
+    config["sandbox"]["enabled"] = name != "host"
+    if name != "host":
+        config["terminal"] = config.get("terminal", {}) if isinstance(config.get("terminal"), dict) else {}
+        config["terminal"]["backend"] = name
     save_config(config)
 
 
@@ -874,6 +913,48 @@ def _configure_context_engine() -> bool:
     return False
 
 
+def _configure_sandbox_provider() -> bool:
+    """Launch a radio picker for sandbox providers. Returns True if changed."""
+    from hermes_cli.curses_ui import curses_radiolist
+
+    current = _get_current_sandbox_provider()
+    providers = _discover_sandbox_providers()
+    items = ["host (default)"]
+    names = ["host"]
+    selected = 0
+
+    for name, desc in providers:
+        names.append(name)
+        label = f"{name} \u2014 {desc}" if desc else name
+        items.append(label)
+        if name == current:
+            selected = len(items) - 1
+
+    if current != "host" and current not in names:
+        names.append(current)
+        items.append(f"{current} (not found)")
+        selected = len(items) - 1
+
+    choice = curses_radiolist(
+        title="Sandbox Provider (select one)",
+        items=items,
+        selected=selected,
+    )
+    new_provider = names[choice]
+    if new_provider != current:
+        _save_sandbox_provider(new_provider)
+        return True
+    return False
+
+
+def _current_provider_value(index: int) -> str:
+    if index == 0:
+        return _get_current_memory_provider() or "built-in"
+    if index == 1:
+        return _get_current_context_engine()
+    return _get_current_sandbox_provider()
+
+
 # ---------------------------------------------------------------------------
 # Composite plugins UI
 # ---------------------------------------------------------------------------
@@ -907,9 +988,11 @@ def cmd_toggle() -> None:
     # -- Provider categories --
     current_memory = _get_current_memory_provider() or "built-in"
     current_context = _get_current_context_engine()
+    current_sandbox = _get_current_sandbox_provider()
     categories = [
         ("Memory Provider", current_memory, _configure_memory_provider),
         ("Context Engine", current_context, _configure_context_engine),
+        ("Sandbox Provider", current_sandbox, _configure_sandbox_provider),
     ]
 
     has_plugins = bool(plugin_names)
@@ -1088,8 +1171,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
                             # Refresh current values
                             categories[ci] = (
                                 _cat_name,
-                                _get_current_memory_provider() or "built-in" if ci == 0
-                                else _get_current_context_engine(),
+                                _current_provider_value(ci),
                                 cat_fn,
                             )
                         # Re-enter curses
@@ -1121,8 +1203,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
                             result_holder["providers_changed"] = True
                             categories[ci] = (
                                 _cat_name,
-                                _get_current_memory_provider() or "built-in" if ci == 0
-                                else _get_current_context_engine(),
+                                _current_provider_value(ci),
                                 cat_fn,
                             )
                         stdscr = curses.initscr()
@@ -1175,9 +1256,11 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
     if result_holder["providers_changed"]:
         new_memory = _get_current_memory_provider() or "built-in"
         new_context = _get_current_context_engine()
+        new_sandbox = _get_current_sandbox_provider()
         console.print(
             f"[green]\u2713[/green] Memory provider: [bold]{new_memory}[/bold]  "
-            f"Context engine: [bold]{new_context}[/bold]"
+            f"Context engine: [bold]{new_context}[/bold]  "
+            f"Sandbox provider: [bold]{new_sandbox}[/bold]"
         )
 
     if n_plugins > 0 or result_holder["providers_changed"]:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -129,6 +129,15 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
+def _model_config_for_target(target_model: Optional[str] = None) -> Dict[str, Any]:
+    model_cfg = _get_model_config()
+    target = str(target_model or "").strip()
+    if target:
+        model_cfg = dict(model_cfg)
+        model_cfg["default"] = target
+    return model_cfg
+
+
 def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
     """Check whether a persisted api_mode should be honored for a given provider.
 
@@ -489,8 +498,9 @@ def _resolve_openrouter_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    model_cfg: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    model_cfg = _get_model_config()
+    model_cfg = model_cfg or _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
     cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
     cfg_api_key = ""
@@ -736,13 +746,9 @@ def resolve_runtime_provider(
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution.
 
-    target_model: Optional override for model_cfg.get("default") when
-    computing provider-specific api_mode (e.g. OpenCode Zen/Go where different
-    models route through different API surfaces). Callers performing an
-    explicit mid-session model switch should pass the new model here so
-    api_mode is derived from the model they are switching TO, not the stale
-    persisted default. Other callers can leave it None to preserve existing
-    behavior (api_mode derived from config).
+    ``target_model`` lets callers that are about to launch a non-default model
+    ask provider-specific routing logic to evaluate that model instead of the
+    process-wide configured default.
     """
     requested_provider = resolve_requested_provider(requested)
 
@@ -760,7 +766,7 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
-    model_cfg = _get_model_config()
+    model_cfg = _model_config_for_target(target_model)
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,
         requested_provider=requested_provider,
@@ -1072,6 +1078,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        model_cfg=model_cfg,
     )
     runtime["requested_provider"] = requested_provider
     return runtime

--- a/model_tools.py
+++ b/model_tools.py
@@ -370,7 +370,18 @@ def get_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {
+    "todo",
+    "memory",
+    "session_search",
+    "delegate_task",
+    "delegate_start",
+    "delegate_status",
+    "delegate_wait",
+    "delegate_result",
+    "delegate_cancel",
+    "delegate_message",
+}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/plugins/sandbox/__init__.py
+++ b/plugins/sandbox/__init__.py
@@ -1,0 +1,298 @@
+"""Sandbox provider plugin discovery.
+
+Sandbox providers are single-select execution backends selected via
+``sandbox.provider`` or the legacy ``terminal.backend``/``TERMINAL_ENV`` bridge.
+They are discovered under bundled ``plugins/sandbox/<name>/`` and user
+``$HERMES_HOME/plugins/sandbox/<name>/`` directories.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_SANDBOX_PLUGINS_DIR = Path(__file__).parent
+
+
+def _get_user_sandbox_plugins_dir() -> Optional[Path]:
+    try:
+        from hermes_constants import get_hermes_home
+
+        d = get_hermes_home() / "plugins" / "sandbox"
+        return d if d.is_dir() else None
+    except Exception:
+        return None
+
+
+def _is_sandbox_provider_dir(path: Path) -> bool:
+    init_file = path / "__init__.py"
+    if not init_file.exists():
+        return False
+    try:
+        source = init_file.read_text(errors="replace")[:8192]
+        return "register_sandbox_provider" in source or "SandboxProvider" in source
+    except Exception:
+        return False
+
+
+def _iter_provider_dirs() -> List[Tuple[str, Path]]:
+    seen: set[str] = set()
+    dirs: List[Tuple[str, Path]] = []
+
+    if _SANDBOX_PLUGINS_DIR.is_dir():
+        for child in sorted(_SANDBOX_PLUGINS_DIR.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if not (child / "__init__.py").exists():
+                continue
+            seen.add(child.name)
+            dirs.append((child.name, child))
+
+    user_dir = _get_user_sandbox_plugins_dir()
+    if user_dir:
+        for child in sorted(user_dir.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if child.name in seen or not _is_sandbox_provider_dir(child):
+                continue
+            dirs.append((child.name, child))
+
+    return dirs
+
+
+def find_provider_dir(name: str) -> Optional[Path]:
+    bundled = _SANDBOX_PLUGINS_DIR / name
+    if bundled.is_dir() and (bundled / "__init__.py").exists():
+        return bundled
+
+    user_dir = _get_user_sandbox_plugins_dir()
+    if user_dir:
+        user = user_dir / name
+        if user.is_dir() and _is_sandbox_provider_dir(user):
+            return user
+    return None
+
+
+def discover_sandbox_providers() -> List[Tuple[str, str, bool]]:
+    """Return ``[(name, description, available), ...]``."""
+
+    results: List[Tuple[str, str, bool]] = []
+    for name, child in _iter_provider_dirs():
+        desc = ""
+        yaml_file = child / "plugin.yaml"
+        if yaml_file.exists():
+            try:
+                import yaml
+
+                with open(yaml_file, encoding="utf-8") as f:
+                    meta = yaml.safe_load(f) or {}
+                desc = meta.get("description", "") or ""
+            except Exception:
+                pass
+
+        try:
+            provider = _load_provider_from_dir(child)
+            available = bool(provider and provider.is_available())
+        except Exception:
+            available = False
+        results.append((name, desc, available))
+    return results
+
+
+def load_sandbox_provider(name: str) -> Optional["SandboxProvider"]:
+    provider_dir = find_provider_dir(name)
+    if not provider_dir:
+        logger.debug("Sandbox provider '%s' not found", name)
+        return None
+
+    try:
+        return _load_provider_from_dir(provider_dir)
+    except Exception as exc:
+        logger.warning("Failed to load sandbox provider '%s': %s", name, exc)
+        return None
+
+
+def _load_provider_from_dir(provider_dir: Path) -> Optional["SandboxProvider"]:
+    name = provider_dir.name
+    is_bundled = (
+        _SANDBOX_PLUGINS_DIR in provider_dir.parents
+        or provider_dir.parent == _SANDBOX_PLUGINS_DIR
+    )
+    module_name = f"plugins.sandbox.{name}" if is_bundled else f"_hermes_user_sandbox.{name}"
+    init_file = provider_dir / "__init__.py"
+    if not init_file.exists():
+        return None
+
+    if module_name in sys.modules:
+        mod = sys.modules[module_name]
+    else:
+        for parent in ("plugins", "plugins.sandbox"):
+            if parent in sys.modules:
+                continue
+            parent_path = Path(__file__).parent
+            if parent == "plugins":
+                parent_path = parent_path.parent
+            parent_init = parent_path / "__init__.py"
+            if not parent_init.exists():
+                continue
+            spec = importlib.util.spec_from_file_location(
+                parent,
+                str(parent_init),
+                submodule_search_locations=[str(parent_path)],
+            )
+            if spec and spec.loader:
+                parent_mod = importlib.util.module_from_spec(spec)
+                sys.modules[parent] = parent_mod
+                try:
+                    spec.loader.exec_module(parent_mod)
+                except Exception:
+                    pass
+
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            str(init_file),
+            submodule_search_locations=[str(provider_dir)],
+        )
+        if not spec or not spec.loader:
+            return None
+
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = mod
+
+        for sub_file in provider_dir.glob("*.py"):
+            if sub_file.name == "__init__.py":
+                continue
+            full_sub_name = f"{module_name}.{sub_file.stem}"
+            if full_sub_name in sys.modules:
+                continue
+            sub_spec = importlib.util.spec_from_file_location(full_sub_name, str(sub_file))
+            if sub_spec and sub_spec.loader:
+                sub_mod = importlib.util.module_from_spec(sub_spec)
+                sys.modules[full_sub_name] = sub_mod
+                try:
+                    sub_spec.loader.exec_module(sub_mod)
+                except Exception as exc:
+                    logger.debug("Failed to load sandbox submodule %s: %s", full_sub_name, exc)
+
+        try:
+            spec.loader.exec_module(mod)
+        except Exception as exc:
+            logger.debug("Failed to exec sandbox module %s: %s", module_name, exc)
+            sys.modules.pop(module_name, None)
+            return None
+
+    if hasattr(mod, "register"):
+        collector = _ProviderCollector()
+        try:
+            mod.register(collector)
+            if collector.provider:
+                return collector.provider
+        except Exception as exc:
+            logger.debug("register() failed for sandbox provider %s: %s", name, exc)
+
+    from agent.sandbox_provider import SandboxProvider
+
+    for attr_name in dir(mod):
+        attr = getattr(mod, attr_name, None)
+        if isinstance(attr, type) and issubclass(attr, SandboxProvider) and attr is not SandboxProvider:
+            try:
+                return attr()
+            except Exception:
+                pass
+    return None
+
+
+class _ProviderCollector:
+    def __init__(self):
+        self.provider = None
+
+    def register_sandbox_provider(self, provider):
+        self.provider = provider
+
+    def register_tool(self, *args, **kwargs):
+        pass
+
+    def register_hook(self, *args, **kwargs):
+        pass
+
+    def register_cli_command(self, *args, **kwargs):
+        pass
+
+    def register_memory_provider(self, *args, **kwargs):
+        pass
+
+    def register_context_engine(self, *args, **kwargs):
+        pass
+
+
+def discover_plugin_cli_commands() -> List[dict]:
+    """Return CLI commands exposed by sandbox provider plugins.
+
+    Unlike memory providers, sandbox setup commands must be visible before a
+    provider is active, so this scans every discovered provider for ``cli.py``.
+    """
+
+    results: List[dict] = []
+    for name, plugin_dir in _iter_provider_dirs():
+        cli_file = plugin_dir / "cli.py"
+        if not cli_file.exists():
+            continue
+
+        is_bundled = (
+            _SANDBOX_PLUGINS_DIR in plugin_dir.parents
+            or plugin_dir.parent == _SANDBOX_PLUGINS_DIR
+        )
+        module_name = (
+            f"plugins.sandbox.{name}.cli"
+            if is_bundled
+            else f"_hermes_user_sandbox.{name}.cli"
+        )
+        try:
+            if module_name in sys.modules:
+                cli_mod = sys.modules[module_name]
+            else:
+                spec = importlib.util.spec_from_file_location(module_name, str(cli_file))
+                if not spec or not spec.loader:
+                    continue
+                cli_mod = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = cli_mod
+                spec.loader.exec_module(cli_mod)
+
+            register_cli = getattr(cli_mod, "register_cli", None)
+            if not callable(register_cli):
+                continue
+
+            help_text = f"Manage {name} sandbox provider"
+            description = ""
+            yaml_file = plugin_dir / "plugin.yaml"
+            if yaml_file.exists():
+                try:
+                    import yaml
+
+                    with open(yaml_file, encoding="utf-8") as f:
+                        meta = yaml.safe_load(f) or {}
+                    desc = meta.get("description", "") or ""
+                    if desc:
+                        help_text = desc
+                        description = desc
+                except Exception:
+                    pass
+
+            results.append(
+                {
+                    "name": name,
+                    "help": help_text,
+                    "description": description,
+                    "setup_fn": register_cli,
+                    "handler_fn": getattr(cli_mod, f"{name}_command", None),
+                    "plugin": name,
+                }
+            )
+        except Exception as exc:
+            logger.debug("Failed to scan CLI for sandbox plugin '%s': %s", name, exc)
+    return results

--- a/plugins/sandbox/openshell/__init__.py
+++ b/plugins/sandbox/openshell/__init__.py
@@ -1,0 +1,7 @@
+"""OpenShell sandbox provider plugin."""
+
+from .environment import OpenShellSandboxProvider
+
+
+def register(ctx):
+    ctx.register_sandbox_provider(OpenShellSandboxProvider())

--- a/plugins/sandbox/openshell/cli.py
+++ b/plugins/sandbox/openshell/cli.py
@@ -1,0 +1,553 @@
+"""CLI for the OpenShell sandbox provider."""
+
+from __future__ import annotations
+
+import json
+import os
+import argparse
+import shutil
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from plugins.sandbox.openshell.environment import (
+    DEFAULT_MIRROR_EXCLUDES,
+    DEFAULT_GATEWAY_NAME,
+    DEFAULT_GATEWAY_PORT,
+    build_sandbox_name,
+    bundled_source_dir,
+    ensure_openshell_gateway,
+    normalize_openshell_config,
+    prepare_openshell_source,
+    run_openshell_cli,
+)
+
+
+def register_cli(parser):
+    sub = parser.add_subparsers(dest="openshell_command")
+
+    enable = sub.add_parser("enable", help="Configure Hermes OpenShell sandboxing")
+    enable.add_argument("--default", action="store_true", help="Make OpenShell the default Hermes sandbox backend")
+    enable.add_argument("--install", action="store_true", help="Install or update OpenShell with uv tool install -U openshell")
+    enable.add_argument("--mode", choices=["mirror", "remote"], default="mirror")
+    enable.add_argument("--from", dest="source", default="", help="OpenShell source name, image, or local source directory")
+    enable.add_argument("--policy", default="", help="Optional OpenShell policy YAML path")
+    enable.add_argument("--provider", action="append", default=[], help="OpenShell provider to attach at sandbox creation")
+    enable.add_argument("--gpu", action="store_true", help="Request OpenShell GPU passthrough")
+    enable.add_argument("--no-auto-providers", action="store_true", help="Disable OpenShell auto provider creation")
+    enable.add_argument("--gateway-name", default=DEFAULT_GATEWAY_NAME, help="OpenShell gateway name for Hermes sandboxes")
+    enable.add_argument("--gateway-port", type=int, default=DEFAULT_GATEWAY_PORT, help="Local OpenShell gateway port")
+    enable.add_argument("--gateway-host", default="", help="Gateway host advertised in OpenShell metadata")
+    enable.add_argument("--gateway-endpoint", default="", help="Use an existing gateway endpoint instead of starting a local gateway")
+    enable.add_argument("--extra-sync", action="append", default=[], help="Additional host path sync as LOCAL[:REMOTE]")
+    enable.add_argument("--scope", default="smoke", help="Smoke-test scope name")
+    enable.add_argument("--smoke", action="store_true", help="Run smoke validation even if OpenShell is already configured")
+    enable.add_argument("--no-smoke", action="store_true", help="Skip create/validate smoke sandbox")
+
+    sub.add_parser("disable", help="Disable OpenShell as the default sandbox backend")
+    status = sub.add_parser("status", help="Show OpenShell/Hermes sandbox status")
+    _add_config_override_args(status)
+    list_p = sub.add_parser("list", help="List OpenShell sandboxes")
+    _add_config_override_args(list_p)
+
+    create = sub.add_parser("create", help="Create or validate a Hermes OpenShell sandbox")
+    _add_scope_name_args(create)
+    _add_config_override_args(create)
+
+    delete = sub.add_parser("delete", help="Delete a Hermes OpenShell sandbox")
+    _add_scope_name_args(delete)
+    _add_config_override_args(delete)
+
+    shell = sub.add_parser("shell", help="Open an interactive shell in a sandbox")
+    _add_scope_name_args(shell)
+    _add_config_override_args(shell)
+
+    exec_p = sub.add_parser("exec", help="Run a command in a sandbox")
+    _add_scope_name_args(exec_p)
+    _add_config_override_args(exec_p)
+    exec_p.add_argument("exec_command", nargs=argparse.REMAINDER)
+
+    push = sub.add_parser("push", help="Upload a host path into a sandbox")
+    _add_scope_name_args(push)
+    _add_config_override_args(push)
+    push.add_argument("local_path")
+    push.add_argument("remote_path")
+
+    pull = sub.add_parser("pull", help="Download a sandbox path to the host")
+    _add_scope_name_args(pull)
+    _add_config_override_args(pull)
+    pull.add_argument("remote_path")
+    pull.add_argument("local_path")
+
+    parser.set_defaults(func=openshell_command)
+
+def _add_scope_name_args(parser):
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--scope", default="", help="Hermes scope used to derive the sandbox name")
+    group.add_argument("--name", default="", help="Raw OpenShell sandbox name")
+
+
+def _add_config_override_args(parser):
+    parser.add_argument("--gateway-name", default="", help="OpenShell gateway name")
+    parser.add_argument("--gateway-port", type=int, default=None, help="Local OpenShell gateway port")
+    parser.add_argument("--gateway-host", default="", help="Gateway host advertised in OpenShell metadata")
+    parser.add_argument("--gateway-endpoint", default="", help="Existing gateway endpoint")
+    parser.add_argument("--source", default="", help="OpenShell source name, image, or local source directory")
+    parser.add_argument("--timeout-seconds", type=int, default=None, help="OpenShell operation timeout")
+
+
+def openshell_command(args):
+    cmd = getattr(args, "openshell_command", None)
+    if cmd == "enable":
+        return _cmd_enable(args)
+    if cmd == "disable":
+        return _cmd_disable(args)
+    if cmd == "status":
+        return _cmd_status(args)
+    if cmd == "list":
+        return _run_passthrough(["sandbox", "list"], args)
+    if cmd == "create":
+        return _cmd_create(args)
+    if cmd == "delete":
+        return _run_for_sandbox(args, lambda cfg, name: run_openshell_cli(cfg, ["sandbox", "delete", name], timeout=120))
+    if cmd == "shell":
+        return _cmd_shell(args)
+    if cmd == "exec":
+        return _cmd_exec(args)
+    if cmd == "push":
+        return _run_for_sandbox(
+            args,
+            lambda cfg, name: run_openshell_cli(
+                cfg,
+                ["sandbox", "upload", name, args.local_path, args.remote_path],
+                timeout=max(cfg["timeout_seconds"], 300),
+            ),
+        )
+    if cmd == "pull":
+        return _run_for_sandbox(
+            args,
+            lambda cfg, name: run_openshell_cli(
+                cfg,
+                ["sandbox", "download", name, args.remote_path, args.local_path],
+                timeout=max(cfg["timeout_seconds"], 300),
+            ),
+        )
+
+    print("Usage: hermes openshell {enable|disable|status|list|create|delete|shell|exec|push|pull}")
+    return None
+
+
+def _get_dotted(config: dict[str, Any], dotted: str) -> Any:
+    current: Any = config
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _values_equal(current: Any, desired: Any) -> bool:
+    if isinstance(desired, bool):
+        return bool(current) is desired
+    if isinstance(desired, int):
+        try:
+            return int(current) == desired
+        except (TypeError, ValueError):
+            return False
+    if isinstance(desired, list):
+        return list(current or []) == desired
+    return str(current or "") == str(desired or "")
+
+
+def _is_already_configured(config: dict[str, Any], updates: dict[str, Any]) -> bool:
+    """Return whether OpenShell provider settings already match.
+
+    Default-on/off state is intentionally ignored: `hermes openshell enable
+    --default` may flip the default while reusing an already validated provider
+    setup.
+    """
+
+    keys = [
+        key
+        for key in updates
+        if key.startswith("sandbox.openshell.") or key in {"sandbox.provider", "sandbox.mode"}
+    ]
+    if not keys:
+        return False
+    return all(_values_equal(_get_dotted(config, key), updates[key]) for key in keys)
+
+
+def _cmd_enable(args):
+    previous_config = _load_raw_config()
+    if args.install:
+        uv = shutil.which("uv")
+        if not uv:
+            print("uv is required for --install; install uv or install OpenShell manually.", file=sys.stderr)
+            sys.exit(1)
+        result = subprocess.run([uv, "tool", "install", "-U", "openshell"], text=True)
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+
+    if not shutil.which("openshell"):
+        print("OpenShell CLI not found. Re-run with --install or install it from NVIDIA OpenShell docs.", file=sys.stderr)
+        sys.exit(1)
+
+    source = args.source or str(bundled_source_dir())
+    updates = {
+        "sandbox.enabled": bool(args.default),
+        "sandbox.provider": "openshell",
+        "sandbox.mode": args.mode,
+        "sandbox.openshell.command": "openshell",
+        "sandbox.openshell.from": source,
+        "sandbox.openshell.policy": args.policy or "",
+        "sandbox.openshell.providers": args.provider or [],
+        "sandbox.openshell.auto_providers": not args.no_auto_providers,
+        "sandbox.openshell.gpu": bool(args.gpu),
+        "sandbox.openshell.gateway": args.gateway_name or DEFAULT_GATEWAY_NAME,
+        "sandbox.openshell.gateway_endpoint": args.gateway_endpoint or "",
+        "sandbox.openshell.gateway_port": int(args.gateway_port or 0),
+        "sandbox.openshell.gateway_host": args.gateway_host or "",
+        "sandbox.openshell.remote_workspace_dir": "/sandbox",
+        "sandbox.openshell.remote_agent_workspace_dir": "/agent",
+        "sandbox.openshell.sync_hermes_files": False,
+        "sandbox.openshell.extra_syncs": args.extra_sync or [],
+    }
+    if args.default:
+        updates["terminal.backend"] = "openshell"
+    already_configured = _is_already_configured(previous_config, updates)
+    _update_config(updates)
+
+    if already_configured:
+        print("OpenShell sandbox provider was already configured with these settings.")
+    else:
+        print("OpenShell sandbox provider configured.")
+    if args.default:
+        print("OpenShell is now the default Hermes tool execution backend.")
+    else:
+        print("Host execution remains the default. Use `hermes chat --sandbox=openshell` to opt in.")
+    print("Disable it with `hermes openshell disable`.")
+
+    should_smoke = not args.no_smoke and (args.smoke or args.install or not already_configured)
+    if not should_smoke:
+        print("Skipping smoke validation because this OpenShell setup is already configured.")
+        print("Use `hermes openshell enable --smoke` to validate the smoke sandbox now.")
+        return
+
+    if not args.no_smoke:
+        cfg = _load_openshell_config()
+        cfg["source"] = source
+        cfg["mode"] = args.mode
+        cfg["providers"] = args.provider or []
+        cfg["policy"] = args.policy or ""
+        cfg["auto_providers"] = not args.no_auto_providers
+        cfg["gpu"] = bool(args.gpu)
+        cfg["gateway"] = args.gateway_name or DEFAULT_GATEWAY_NAME
+        cfg["gateway_endpoint"] = args.gateway_endpoint or ""
+        cfg["gateway_port"] = int(args.gateway_port or 0)
+        cfg["gateway_host"] = args.gateway_host or ""
+        cfg["extra_syncs"] = args.extra_sync or []
+        cfg = normalize_openshell_config(cfg)
+        name = build_sandbox_name(args.scope)
+        print(
+            f"Validating smoke sandbox {name!r} on gateway {cfg['gateway']!r} "
+            f"(port {cfg['gateway_port'] or 'external'})."
+        )
+        print("First run can take several minutes while OpenShell starts Docker/K3s and builds the image.")
+        result = _ensure_sandbox(cfg, name, stream=True)
+        if result.returncode != 0:
+            print(result.stderr or result.stdout, file=sys.stderr)
+            sys.exit(result.returncode)
+        print(f"Smoke sandbox ready: {name}")
+
+
+def _cmd_disable(args):
+    _update_config(
+        {
+            "sandbox.enabled": False,
+            "sandbox.provider": "host",
+            "terminal.backend": "local",
+        }
+    )
+    print("OpenShell sandboxing disabled; Hermes tool execution defaults to host/local.")
+    print("Existing OpenShell sandboxes were not deleted. Use `hermes openshell list` and `hermes openshell delete` to manage them.")
+
+
+def _cmd_status(args):
+    cfg = _load_openshell_config(args)
+    print("Hermes OpenShell sandbox provider")
+    print(f"  openshell: {shutil.which(cfg['command']) or 'not found'}")
+    print(f"  source:    {cfg['source']}")
+    print(f"  mode:      {cfg['mode']}")
+    print(f"  gateway:   {cfg['gateway']}")
+    print(f"  port:      {cfg['gateway_port'] or 'external'}")
+    print(f"  workspace: {cfg['remote_workspace_dir']}")
+    result = run_openshell_cli(cfg, ["status"], timeout=30)
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+
+
+def _cmd_create(args):
+    return _run_for_sandbox(args, lambda cfg, name: _ensure_sandbox(cfg, name))
+
+
+def _cmd_shell(args):
+    cfg = _load_openshell_config(args)
+    name = _resolve_sandbox_name(args)
+    argv = [*_base_cli(cfg), "sandbox", "connect", name]
+    os.execvp(argv[0], argv)
+
+
+def _cmd_exec(args):
+    command = list(getattr(args, "exec_command", []) or [])
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        print("Missing command for `hermes openshell exec`.", file=sys.stderr)
+        sys.exit(2)
+    return _run_for_sandbox(
+        args,
+        lambda cfg, name: _exec_via_ssh_config(cfg, name, command),
+    )
+
+
+def _run_passthrough(openshell_args: list[str], args=None):
+    cfg = _load_openshell_config(args)
+    result = run_openshell_cli(cfg, openshell_args, timeout=120)
+    _print_result(result)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def _run_for_sandbox(args, fn):
+    cfg = _load_openshell_config(args)
+    name = _resolve_sandbox_name(args)
+    result = fn(cfg, name)
+    _print_result(result)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def _ensure_sandbox(cfg: dict[str, Any], name: str, *, stream: bool = False):
+    if stream and cfg.get("gateway_port") and not cfg.get("gateway_endpoint"):
+        print(f"Starting or validating OpenShell gateway {cfg['gateway']!r}...")
+    gateway = ensure_openshell_gateway(cfg, capture_output=not stream)
+    if gateway is not None and gateway.returncode != 0:
+        return gateway
+
+    get_result = run_openshell_cli(cfg, ["sandbox", "get", name], timeout=30)
+    if get_result.returncode == 0:
+        if stream:
+            print(f"Smoke sandbox already exists: {name}")
+        return get_result
+    source = prepare_openshell_source(cfg, cwd=os.getcwd(), stream=stream)
+    create_args = ["sandbox", "create", "--name", name, "--from", source]
+    if cfg.get("policy"):
+        create_args.extend(["--policy", cfg["policy"]])
+    if cfg.get("gpu"):
+        create_args.append("--gpu")
+    create_args.append("--auto-providers" if cfg.get("auto_providers", True) else "--no-auto-providers")
+    for provider in cfg.get("providers", []):
+        create_args.extend(["--provider", provider])
+    create_args.extend(["--", "true"])
+    if stream:
+        print(f"Creating OpenShell sandbox {name!r}...")
+        return _run_openshell_cli_stream(cfg, create_args, timeout=max(cfg["timeout_seconds"], 300))
+    return run_openshell_cli(cfg, create_args, timeout=max(cfg["timeout_seconds"], 300))
+
+
+def _run_openshell_cli_stream(cfg: dict[str, Any], args: list[str], *, timeout: int) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*_base_cli(cfg), *args],
+        cwd=os.getcwd(),
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _exec_via_ssh_config(cfg: dict[str, Any], name: str, command: list[str]) -> subprocess.CompletedProcess:
+    ssh_config = run_openshell_cli(cfg, ["sandbox", "ssh-config", name], timeout=60)
+    if ssh_config.returncode != 0:
+        return ssh_config
+
+    with tempfile.TemporaryDirectory(prefix="hermes-openshell-cli-") as tmp:
+        config_path = Path(tmp) / "ssh_config"
+        config_path.write_text(ssh_config.stdout, encoding="utf-8")
+        host = name
+        for line in ssh_config.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.lower().startswith("host "):
+                parts = stripped.split()
+                if len(parts) >= 2 and "*" not in parts[1]:
+                    host = parts[1]
+                    break
+        remote_command = " ".join(shlex.quote(part) for part in command)
+        return subprocess.run(
+            ["ssh", "-F", str(config_path), "-T", host, remote_command],
+            capture_output=True,
+            text=True,
+            timeout=cfg["timeout_seconds"],
+        )
+
+
+def _resolve_sandbox_name(args) -> str:
+    if getattr(args, "name", ""):
+        return args.name
+    return build_sandbox_name(getattr(args, "scope", "") or "default")
+
+
+def _base_cli(cfg: dict[str, Any]) -> list[str]:
+    argv = [cfg["command"]]
+    if cfg.get("gateway_endpoint"):
+        argv.extend(["--gateway-endpoint", cfg["gateway_endpoint"]])
+    elif cfg.get("gateway"):
+        argv.extend(["--gateway", cfg["gateway"]])
+    return argv
+
+
+def _print_result(result: subprocess.CompletedProcess):
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+
+
+def _load_raw_config() -> dict:
+    from hermes_cli.config import get_config_path
+
+    path = get_config_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _update_config(updates: dict[str, Any]) -> None:
+    from hermes_cli.config import ensure_hermes_home, get_config_path, save_env_value
+    from utils import atomic_yaml_write
+
+    config = _load_raw_config()
+    for key, value in updates.items():
+        current = config
+        parts = key.split(".")
+        for part in parts[:-1]:
+            if not isinstance(current.get(part), dict):
+                current[part] = {}
+            current = current[part]
+        current[parts[-1]] = value
+
+    ensure_hermes_home()
+    atomic_yaml_write(get_config_path(), config, sort_keys=False)
+
+    env_sync = {
+        "terminal.backend": "TERMINAL_ENV",
+        "sandbox.enabled": "HERMES_SANDBOX_ENABLED",
+        "sandbox.provider": "HERMES_SANDBOX_PROVIDER",
+        "sandbox.mode": "HERMES_SANDBOX_MODE",
+        "sandbox.openshell.command": "HERMES_OPENSHELL_COMMAND",
+        "sandbox.openshell.from": "HERMES_SANDBOX_SOURCE",
+        "sandbox.openshell.policy": "HERMES_OPENSHELL_POLICY",
+        "sandbox.openshell.providers": "HERMES_OPENSHELL_PROVIDERS",
+        "sandbox.openshell.auto_providers": "HERMES_OPENSHELL_AUTO_PROVIDERS",
+        "sandbox.openshell.gpu": "HERMES_OPENSHELL_GPU",
+        "sandbox.openshell.gateway": "HERMES_OPENSHELL_GATEWAY",
+        "sandbox.openshell.gateway_endpoint": "HERMES_OPENSHELL_GATEWAY_ENDPOINT",
+        "sandbox.openshell.gateway_port": "HERMES_OPENSHELL_GATEWAY_PORT",
+        "sandbox.openshell.gateway_host": "HERMES_OPENSHELL_GATEWAY_HOST",
+        "sandbox.openshell.sync_hermes_files": "HERMES_OPENSHELL_SYNC_HERMES_FILES",
+        "sandbox.openshell.extra_syncs": "HERMES_SANDBOX_EXTRA_SYNCS",
+    }
+    for key, env_var in env_sync.items():
+        if key in updates:
+            value = updates[key]
+            save_env_value(env_var, json.dumps(value) if isinstance(value, list) else str(value))
+
+
+def _env_truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_list(value: str) -> list[str]:
+    stripped = value.strip()
+    if not stripped:
+        return []
+    if stripped.startswith("["):
+        try:
+            loaded = json.loads(stripped)
+            if isinstance(loaded, list):
+                return [str(item) for item in loaded]
+        except json.JSONDecodeError:
+            pass
+    return [part.strip() for part in stripped.split(",") if part.strip()]
+
+
+def _load_openshell_config(args=None) -> dict[str, Any]:
+    raw = _load_raw_config()
+    sandbox = raw.get("sandbox") if isinstance(raw.get("sandbox"), dict) else {}
+    openshell = sandbox.get("openshell") if isinstance(sandbox.get("openshell"), dict) else {}
+    cfg = {
+        "mode": sandbox.get("mode", "mirror"),
+        "source": openshell.get("from") or openshell.get("source") or str(bundled_source_dir()),
+        "command": openshell.get("command", "openshell"),
+        "policy": openshell.get("policy", ""),
+        "providers": openshell.get("providers", []),
+        "auto_providers": openshell.get("auto_providers", True),
+        "gpu": openshell.get("gpu", False),
+        "gateway": openshell.get("gateway", ""),
+        "gateway_endpoint": openshell.get("gateway_endpoint", ""),
+        "gateway_port": openshell.get("gateway_port", DEFAULT_GATEWAY_PORT),
+        "gateway_host": openshell.get("gateway_host", ""),
+        "remote_workspace_dir": openshell.get("remote_workspace_dir", "/sandbox"),
+        "remote_agent_workspace_dir": openshell.get("remote_agent_workspace_dir", "/agent"),
+        "timeout_seconds": openshell.get("timeout_seconds", 120),
+        "mirror_excludes": openshell.get("mirror_excludes", DEFAULT_MIRROR_EXCLUDES),
+        "extra_syncs": openshell.get("extra_syncs", []),
+        "sync_hermes_files": openshell.get("sync_hermes_files", False),
+    }
+    env_map = {
+        "HERMES_OPENSHELL_COMMAND": "command",
+        "HERMES_SANDBOX_SOURCE": "source",
+        "HERMES_OPENSHELL_SOURCE": "source",
+        "HERMES_OPENSHELL_POLICY": "policy",
+        "HERMES_OPENSHELL_GATEWAY": "gateway",
+        "HERMES_OPENSHELL_GATEWAY_ENDPOINT": "gateway_endpoint",
+        "HERMES_OPENSHELL_GATEWAY_PORT": "gateway_port",
+        "HERMES_OPENSHELL_GATEWAY_HOST": "gateway_host",
+        "HERMES_SANDBOX_MODE": "mode",
+        "HERMES_SANDBOX_TIMEOUT_SECONDS": "timeout_seconds",
+        "HERMES_SANDBOX_EXTRA_SYNCS": "extra_syncs",
+    }
+    for env_var, key in env_map.items():
+        value = os.getenv(env_var)
+        if value not in (None, ""):
+            cfg[key] = value
+    if os.getenv("HERMES_OPENSHELL_PROVIDERS"):
+        cfg["providers"] = _env_list(os.environ["HERMES_OPENSHELL_PROVIDERS"])
+    if os.getenv("HERMES_OPENSHELL_AUTO_PROVIDERS"):
+        cfg["auto_providers"] = _env_truthy(os.environ["HERMES_OPENSHELL_AUTO_PROVIDERS"])
+    if os.getenv("HERMES_OPENSHELL_GPU"):
+        cfg["gpu"] = _env_truthy(os.environ["HERMES_OPENSHELL_GPU"])
+    if os.getenv("HERMES_OPENSHELL_SYNC_HERMES_FILES"):
+        cfg["sync_hermes_files"] = _env_truthy(os.environ["HERMES_OPENSHELL_SYNC_HERMES_FILES"])
+    if args is not None:
+        cli_overrides = {
+            "source": getattr(args, "source", ""),
+            "gateway": getattr(args, "gateway_name", ""),
+            "gateway_endpoint": getattr(args, "gateway_endpoint", ""),
+            "gateway_port": getattr(args, "gateway_port", None),
+            "gateway_host": getattr(args, "gateway_host", ""),
+            "timeout_seconds": getattr(args, "timeout_seconds", None),
+        }
+        for key, value in cli_overrides.items():
+            if value not in (None, ""):
+                cfg[key] = value
+    return normalize_openshell_config(cfg)

--- a/plugins/sandbox/openshell/environment.py
+++ b/plugins/sandbox/openshell/environment.py
@@ -1,0 +1,833 @@
+"""OpenShell-backed Hermes execution environment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from agent.sandbox_provider import SandboxProvider, SandboxRuntimeInfo, SandboxSpec
+from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.file_sync import FileSyncManager, iter_sync_files
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MIRROR_EXCLUDES = [
+    ".git",
+    ".hermes",
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    "target",
+]
+DEFAULT_GATEWAY_NAME = "hermes-openshell"
+DEFAULT_GATEWAY_PORT = 18080
+
+
+def bundled_source_dir() -> Path:
+    return Path(__file__).resolve().parent / "source"
+
+
+def normalize_openshell_config(raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    cfg = dict(raw or {})
+    source = str(cfg.get("source") or cfg.get("from") or "").strip()
+    if not source or source == "bundled-hermes-source":
+        source = str(bundled_source_dir())
+    mode = str(cfg.get("mode") or "mirror").strip().lower()
+    if mode not in ("mirror", "remote"):
+        mode = "mirror"
+    providers = cfg.get("providers") or []
+    if isinstance(providers, str):
+        providers = [part.strip() for part in providers.split(",") if part.strip()]
+    gateway_port = cfg.get("gateway_port", cfg.get("port", DEFAULT_GATEWAY_PORT))
+    try:
+        gateway_port = int(gateway_port)
+    except (TypeError, ValueError):
+        gateway_port = DEFAULT_GATEWAY_PORT
+    return {
+        "command": str(cfg.get("command") or "openshell").strip() or "openshell",
+        "mode": mode,
+        "source": source,
+        "policy": str(cfg.get("policy") or "").strip(),
+        "providers": [str(p) for p in providers if str(p).strip()],
+        "auto_providers": bool(cfg.get("auto_providers", True)),
+        "gpu": bool(cfg.get("gpu", False)),
+        "gateway": str(cfg.get("gateway") or DEFAULT_GATEWAY_NAME).strip() or DEFAULT_GATEWAY_NAME,
+        "gateway_endpoint": str(cfg.get("gateway_endpoint") or "").strip(),
+        "gateway_port": gateway_port if gateway_port > 0 else 0,
+        "gateway_host": str(cfg.get("gateway_host") or "").strip(),
+        "remote_workspace_dir": str(cfg.get("remote_workspace_dir") or "/sandbox").rstrip("/") or "/sandbox",
+        "remote_agent_workspace_dir": str(cfg.get("remote_agent_workspace_dir") or "/agent").rstrip("/") or "/agent",
+        "timeout_seconds": int(cfg.get("timeout_seconds") or 120),
+        "mirror_excludes": _normalize_mirror_excludes(cfg.get("mirror_excludes")),
+        "extra_syncs": _normalize_extra_syncs(cfg.get("extra_syncs") or cfg.get("extra_dirs") or []),
+        "sync_hermes_files": bool(cfg.get("sync_hermes_files", False)),
+    }
+
+
+def build_sandbox_name(scope: str) -> str:
+    trimmed = (scope or "session").strip() or "session"
+    digest = hashlib.sha256(trimmed.encode("utf-8")).hexdigest()[:8]
+    max_slug_len = 63 - len("hermes") - 1 - len(digest) - 1
+    safe = re.sub(r"[^a-z0-9]+", "-", trimmed.lower())
+    safe = re.sub(r"-+", "-", safe).strip("-")[:max_slug_len].strip("-") or "session"
+    return f"hermes-{safe}-{digest}"
+
+
+def prepare_openshell_source(
+    cfg: dict[str, Any],
+    *,
+    cwd: str | None = None,
+    stream: bool = False,
+) -> str:
+    """Return a source suitable for OpenShell, importing local builds when possible."""
+
+    source = str(cfg.get("source") or "").strip()
+    source_path = _resolve_local_source_path(source, cwd=cwd)
+    if source_path is None:
+        return source
+
+    docker = shutil.which("docker")
+    if not docker or cfg.get("gateway_endpoint"):
+        return source
+
+    context_dir, dockerfile = _source_build_paths(source_path)
+    if dockerfile is None:
+        return source
+
+    container = _resolve_gateway_container(docker, str(cfg.get("gateway") or DEFAULT_GATEWAY_NAME))
+    if not container:
+        return source
+
+    digest = _hash_local_source(context_dir)
+    tag = f"openshell/sandbox-from:hermes-{digest[:16]}"
+    if not _host_docker_has_image(docker, tag):
+        if stream:
+            print(f"Preparing OpenShell source image {tag}...")
+        build = subprocess.run(
+            [docker, "build", "-t", tag, "-f", str(dockerfile), str(context_dir)],
+            capture_output=not stream,
+            text=True,
+            timeout=max(int(cfg.get("timeout_seconds") or 120), 300),
+        )
+        if build.returncode != 0:
+            return source
+
+    if _gateway_container_has_image(docker, container, tag):
+        return tag
+    if _import_image_into_gateway(docker, container, tag, timeout=max(int(cfg.get("timeout_seconds") or 120), 300)):
+        return tag
+    return source
+
+
+def _resolve_local_source_path(source: str, *, cwd: str | None = None) -> Path | None:
+    if not source or "://" in source:
+        return None
+    raw = Path(source).expanduser()
+    candidates = [raw]
+    if not raw.is_absolute() and cwd:
+        candidates.insert(0, Path(cwd).expanduser() / raw)
+    for candidate in candidates:
+        if candidate.exists() and (candidate.is_dir() or candidate.is_file()):
+            return candidate.resolve()
+    return None
+
+
+def _source_build_paths(source_path: Path) -> tuple[Path, Path | None]:
+    if source_path.is_file():
+        return source_path.parent, source_path
+    dockerfile = source_path / "Dockerfile"
+    if dockerfile.is_file():
+        return source_path, dockerfile
+    return source_path, None
+
+
+def _hash_local_source(context_dir: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"hermes-openshell-source-v1\0")
+    skip_dirs = {".git", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"}
+    for path in sorted(context_dir.rglob("*")):
+        rel = path.relative_to(context_dir).as_posix()
+        if any(part in skip_dirs for part in path.relative_to(context_dir).parts):
+            continue
+        if path.is_dir():
+            continue
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        if path.is_symlink():
+            digest.update(b"symlink\0")
+            digest.update(os.readlink(path).encode("utf-8"))
+            digest.update(b"\0")
+        elif path.is_file():
+            digest.update(b"file\0")
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _host_docker_has_image(docker: str, tag: str) -> bool:
+    result = subprocess.run(
+        [docker, "image", "inspect", tag],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return result.returncode == 0
+
+
+def _resolve_gateway_container(docker: str, gateway: str) -> str | None:
+    candidates = [f"openshell-cluster-{gateway}", f"openshell-{gateway}", gateway]
+    for candidate in candidates:
+        result = subprocess.run(
+            [docker, "container", "inspect", candidate],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return candidate
+    result = subprocess.run(
+        [docker, "ps", "--format", "{{.Names}}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return None
+    suffix = f"-{gateway}"
+    for name in result.stdout.splitlines():
+        if name == gateway or name.endswith(suffix):
+            return name
+    return None
+
+
+def _gateway_container_has_image(docker: str, container: str, tag: str) -> bool:
+    result = subprocess.run(
+        [docker, "exec", container, "ctr", "-n", "k8s.io", "images", "list", "-q"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        return False
+    image_names = set(result.stdout.splitlines())
+    return tag in image_names or f"docker.io/{tag}" in image_names
+
+
+def _import_image_into_gateway(docker: str, container: str, tag: str, *, timeout: int) -> bool:
+    safe_tag = re.sub(r"[^a-zA-Z0-9_.-]+", "-", tag)
+    remote_tar = f"/tmp/hermes-openshell-{safe_tag}.tar"
+    with tempfile.NamedTemporaryFile(prefix="hermes-openshell-image-", suffix=".tar") as tmp:
+        save = subprocess.run(
+            [docker, "image", "save", "-o", tmp.name, tag],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if save.returncode != 0:
+            return False
+        copied = subprocess.run(
+            [docker, "cp", tmp.name, f"{container}:{remote_tar}"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if copied.returncode != 0:
+            return False
+        try:
+            imported = subprocess.run(
+                [docker, "exec", container, "ctr", "-n", "k8s.io", "images", "import", remote_tar],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return imported.returncode == 0
+        finally:
+            subprocess.run(
+                [docker, "exec", container, "rm", "-f", remote_tar],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+
+def _openshell_base_argv(cfg: dict[str, Any]) -> list[str]:
+    argv = [cfg["command"]]
+    if cfg.get("gateway_endpoint"):
+        argv.extend(["--gateway-endpoint", cfg["gateway_endpoint"]])
+    elif cfg.get("gateway"):
+        argv.extend(["--gateway", cfg["gateway"]])
+    return argv
+
+
+def _normalize_mirror_excludes(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        raw = [part.strip() for part in raw.split(",") if part.strip()]
+    elif not isinstance(raw, list):
+        raw = []
+    merged: list[str] = []
+    for item in [*DEFAULT_MIRROR_EXCLUDES, *raw]:
+        value = str(item).strip()
+        if value and value not in merged:
+            merged.append(value)
+    return merged
+
+
+def _normalize_extra_syncs(raw: Any) -> list[dict[str, Any]]:
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return []
+        if stripped.startswith("["):
+            try:
+                raw = json.loads(stripped)
+            except json.JSONDecodeError:
+                raw = [stripped]
+        else:
+            raw = [part.strip() for part in stripped.split(";") if part.strip()]
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+
+    syncs: list[dict[str, Any]] = []
+    for entry in raw:
+        host_path = ""
+        remote_path = ""
+        mode = "inherit"
+        excludes = DEFAULT_MIRROR_EXCLUDES
+        if isinstance(entry, str):
+            local, sep, remote = entry.partition(":")
+            host_path = local.strip()
+            remote_path = remote.strip() if sep else ""
+        elif isinstance(entry, dict):
+            host_path = str(
+                entry.get("host")
+                or entry.get("local")
+                or entry.get("path")
+                or entry.get("source")
+                or ""
+            ).strip()
+            remote_path = str(
+                entry.get("remote")
+                or entry.get("target")
+                or entry.get("sandbox_path")
+                or ""
+            ).strip()
+            mode = str(entry.get("mode") or "inherit").strip().lower()
+            excludes = entry.get("excludes") or DEFAULT_MIRROR_EXCLUDES
+        if not host_path:
+            continue
+        host_path = os.path.abspath(os.path.expanduser(host_path))
+        if not remote_path:
+            remote_path = f"/sandbox/{Path(host_path).name}"
+        elif not remote_path.startswith("/"):
+            remote_path = f"/sandbox/{remote_path}"
+        remote_path = remote_path.rstrip("/") or "/sandbox"
+        if mode not in ("inherit", "mirror", "remote", "seed"):
+            mode = "inherit"
+        if isinstance(excludes, str):
+            excludes = [part.strip() for part in excludes.split(",") if part.strip()]
+        syncs.append(
+            {
+                "host": host_path,
+                "remote": remote_path,
+                "mode": mode,
+                "excludes": list(excludes or DEFAULT_MIRROR_EXCLUDES),
+            }
+        )
+    return syncs
+
+
+def ensure_openshell_gateway(cfg: dict[str, Any], *, capture_output: bool = True) -> subprocess.CompletedProcess | None:
+    """Start the configured local gateway before sandbox operations.
+
+    OpenShell's sandbox auto-bootstrap uses port 8080. Hermes uses a named
+    gateway on a separate default port so unrelated local services do not
+    collide with sandbox startup. Set gateway_port to 0 or gateway_endpoint
+    to skip local gateway management.
+    """
+
+    if cfg.get("gateway_endpoint") or not cfg.get("gateway_port"):
+        return None
+    args = [
+        cfg["command"],
+        "gateway",
+        "start",
+        "--name",
+        cfg["gateway"],
+        "--port",
+        str(cfg["gateway_port"]),
+    ]
+    if cfg.get("gateway_host"):
+        args.extend(["--gateway-host", cfg["gateway_host"]])
+    if cfg.get("gpu"):
+        args.append("--gpu")
+    kwargs: dict[str, Any] = {
+        "text": True,
+        "timeout": max(cfg.get("timeout_seconds") or 120, 300),
+    }
+    if capture_output:
+        kwargs["capture_output"] = True
+    return subprocess.run(args, **kwargs)
+
+
+def run_openshell_cli(
+    cfg: dict[str, Any],
+    args: list[str],
+    *,
+    cwd: str | None = None,
+    timeout: int | None = None,
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*_openshell_base_argv(cfg), *args],
+        cwd=cwd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=timeout or cfg.get("timeout_seconds") or 120,
+    )
+
+
+class OpenShellSandboxProvider(SandboxProvider):
+    name = "openshell"
+    description = "OpenShell sandbox provider for Hermes tool execution"
+
+    def is_available(self) -> bool:
+        command = os.getenv("HERMES_OPENSHELL_COMMAND", "openshell")
+        return shutil.which(command) is not None
+
+    def create_environment(self, spec: SandboxSpec):
+        return OpenShellEnvironment(spec)
+
+    def describe_runtime(self, scope: str, config: dict[str, Any] | None = None) -> SandboxRuntimeInfo:
+        cfg = normalize_openshell_config(config)
+        name = build_sandbox_name(scope)
+        result = run_openshell_cli(cfg, ["sandbox", "get", name], timeout=30)
+        return SandboxRuntimeInfo(
+            provider=self.name,
+            runtime_id=name,
+            running=result.returncode == 0,
+            mode=cfg["mode"],
+            source=cfg["source"],
+            details={"stdout": result.stdout, "stderr": result.stderr},
+        )
+
+    def delete_runtime(self, scope: str, config: dict[str, Any] | None = None) -> None:
+        cfg = normalize_openshell_config(config)
+        name = build_sandbox_name(scope)
+        result = run_openshell_cli(cfg, ["sandbox", "delete", name], timeout=120)
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "openshell sandbox delete failed")
+
+
+class OpenShellEnvironment(BaseEnvironment):
+    """Run Hermes tools inside an OpenShell sandbox over SSH."""
+
+    def __init__(self, spec: SandboxSpec):
+        self.spec = spec
+        self.cfg = normalize_openshell_config(spec.config)
+        self.sandbox_name = build_sandbox_name(spec.scope or spec.task_id)
+        self.host_workspace = Path(spec.host_cwd or os.getcwd()).resolve()
+        self.remote_workspace = self.cfg["remote_workspace_dir"]
+        self.remote_agent_workspace = self.cfg["remote_agent_workspace_dir"]
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="hermes-openshell-"))
+        self._ssh_config_path = self._tmpdir / "ssh_config"
+        self._ssh_host = self.sandbox_name
+        self._remote_home = "/root"
+        self._workspace_seeded = False
+        self._sync_manager: FileSyncManager | None = None
+        self._closed = False
+
+        super().__init__(
+            cwd=spec.cwd or self.remote_workspace,
+            timeout=spec.timeout or self.cfg["timeout_seconds"],
+        )
+        self._ensure_sandbox_exists()
+        self._refresh_ssh_config()
+        self._remote_home = self._detect_remote_home()
+        self._ensure_remote_dirs()
+        if self.cfg.get("sync_hermes_files"):
+            self._sync_manager = FileSyncManager(
+                get_files_fn=lambda: iter_sync_files(f"{self._remote_home}/.hermes"),
+                upload_fn=self._upload_file,
+                delete_fn=self._delete_remote_paths,
+                bulk_upload_fn=self._bulk_upload_files,
+            )
+        self._seed_workspace()
+        self.init_session()
+
+    def _run_openshell(self, args: list[str], *, timeout: int | None = None) -> subprocess.CompletedProcess:
+        return run_openshell_cli(
+            self.cfg,
+            args,
+            cwd=str(self.host_workspace) if self.host_workspace.is_dir() else None,
+            timeout=timeout,
+        )
+
+    def _ensure_sandbox_exists(self) -> None:
+        gateway = ensure_openshell_gateway(self.cfg)
+        if gateway is not None and gateway.returncode != 0:
+            raise RuntimeError(gateway.stderr.strip() or gateway.stdout.strip() or "openshell gateway start failed")
+
+        result = self._run_openshell(["sandbox", "get", self.sandbox_name], timeout=30)
+        if result.returncode == 0:
+            return
+
+        source = prepare_openshell_source(self.cfg, cwd=str(self.host_workspace))
+        args = [
+            "sandbox",
+            "create",
+            "--name",
+            self.sandbox_name,
+            "--from",
+            source,
+        ]
+        if self.cfg.get("policy"):
+            args.extend(["--policy", self.cfg["policy"]])
+        if self.cfg.get("gpu"):
+            args.append("--gpu")
+        args.append("--auto-providers" if self.cfg.get("auto_providers", True) else "--no-auto-providers")
+        for provider in self.cfg.get("providers", []):
+            args.extend(["--provider", provider])
+        args.extend(["--", "true"])
+
+        create = self._run_openshell(args, timeout=max(self.cfg["timeout_seconds"], 300))
+        if create.returncode != 0:
+            raise RuntimeError(create.stderr.strip() or create.stdout.strip() or "openshell sandbox create failed")
+
+    def _refresh_ssh_config(self) -> None:
+        result = self._run_openshell(["sandbox", "ssh-config", self.sandbox_name], timeout=60)
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "openshell sandbox ssh-config failed")
+        config_text = result.stdout
+        self._ssh_config_path.write_text(config_text, encoding="utf-8")
+        for line in config_text.splitlines():
+            stripped = line.strip()
+            if stripped.lower().startswith("host "):
+                parts = stripped.split()
+                if len(parts) >= 2 and "*" not in parts[1]:
+                    self._ssh_host = parts[1]
+                    break
+
+    def _ssh_argv(self, remote_command: str) -> list[str]:
+        return ["ssh", "-F", str(self._ssh_config_path), "-T", self._ssh_host, remote_command]
+
+    def _run_ssh_command(self, remote_command: str, *, timeout: int = 30) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            self._ssh_argv(remote_command),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def _detect_remote_home(self) -> str:
+        result = self._run_ssh_command("printf '%s\\n' \"$HOME\"", timeout=30)
+        home = result.stdout.strip()
+        return home or "/root"
+
+    def _ensure_remote_dirs(self) -> None:
+        dirs = [
+            f"{self._remote_home}/.hermes",
+            f"{self._remote_home}/.hermes/skills",
+            f"{self._remote_home}/.hermes/credentials",
+            f"{self._remote_home}/.hermes/cache",
+            self.remote_workspace,
+        ]
+        quoted_dirs = " ".join(shlex.quote(path) for path in dirs)
+        result = self._run_ssh_command(
+            "for d in "
+            + quoted_dirs
+            + '; do if [ -e "$d" ] && [ ! -d "$d" ]; then rm -f -- "$d"; fi; mkdir -p -- "$d"; done',
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or "failed to create OpenShell remote directories")
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> subprocess.Popen:
+        if login:
+            remote_command = f"bash -l -c {shlex.quote(cmd_string)}"
+        else:
+            remote_command = f"bash -c {shlex.quote(cmd_string)}"
+        return _popen_bash(self._ssh_argv(remote_command), stdin_data)
+
+    def _before_execute(self) -> None:
+        if self._sync_manager:
+            self._sync_manager.sync()
+        if self.cfg["mode"] == "mirror":
+            self._sync_workspace_to_remote()
+            self._sync_extra_paths_to_remote()
+        elif not self._workspace_seeded:
+            self._seed_workspace()
+
+    def execute(self, *args, **kwargs) -> dict:
+        try:
+            return super().execute(*args, **kwargs)
+        finally:
+            if self.cfg["mode"] == "mirror":
+                self._sync_workspace_from_remote()
+                self._sync_extra_paths_from_remote()
+
+    def _seed_workspace(self) -> None:
+        if self._workspace_seeded:
+            return
+        self._sync_workspace_to_remote()
+        self._sync_extra_paths_to_remote()
+        self._workspace_seeded = True
+
+    def _sync_workspace_to_remote(self) -> None:
+        self._sync_path_to_remote(
+            self.host_workspace,
+            self.remote_workspace,
+            set(self.cfg.get("mirror_excludes") or DEFAULT_MIRROR_EXCLUDES),
+        )
+
+    def _sync_path_to_remote(self, host_path: Path, remote_path: str, exclude_dirs: set[str]) -> None:
+        if not host_path.exists():
+            logger.warning("OpenShell extra sync path does not exist: %s", host_path)
+            return
+        if not self.host_workspace.is_dir():
+            return
+        if self._rsync_path_to_remote(host_path, remote_path, exclude_dirs):
+            return
+        self._run_ssh_command(
+            f"mkdir -p {shlex.quote(remote_path)} && "
+            f"find {shlex.quote(remote_path)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {{}} +",
+            timeout=60,
+        )
+        with tempfile.TemporaryDirectory(prefix="hermes-openshell-upload-") as tmp:
+            staged = Path(tmp) / "workspace"
+            _copy_tree_without_symlinks(
+                host_path,
+                staged,
+                exclude_dirs,
+            )
+            result = self._run_openshell(
+                [
+                    "sandbox",
+                    "upload",
+                    "--no-git-ignore",
+                    self.sandbox_name,
+                    str(staged),
+                    remote_path,
+                ],
+                timeout=max(self.cfg["timeout_seconds"], 300),
+            )
+            if result.returncode != 0:
+                raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "openshell sandbox upload failed")
+
+    def _sync_workspace_from_remote(self) -> None:
+        if not self.host_workspace.is_dir():
+            return
+        self._sync_path_from_remote(
+            self.remote_workspace,
+            self.host_workspace,
+            set(self.cfg.get("mirror_excludes") or DEFAULT_MIRROR_EXCLUDES),
+        )
+
+    def _sync_path_from_remote(self, remote_path: str, host_path: Path, exclude_dirs: set[str]) -> None:
+        if not host_path.is_dir():
+            return
+        if self._rsync_path_from_remote(remote_path, host_path, exclude_dirs):
+            return
+        with tempfile.TemporaryDirectory(prefix="hermes-openshell-download-") as tmp:
+            result = self._run_openshell(
+                ["sandbox", "download", self.sandbox_name, remote_path, tmp],
+                timeout=max(self.cfg["timeout_seconds"], 300),
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "OpenShell workspace download failed: %s",
+                    result.stderr.strip() or result.stdout.strip(),
+                )
+                return
+            source = Path(tmp)
+            maybe_nested = source / Path(remote_path).name
+            if maybe_nested.is_dir() and len(list(source.iterdir())) == 1:
+                source = maybe_nested
+            _replace_directory_contents(
+                source,
+                host_path,
+                exclude_dirs,
+            )
+
+    def _rsync_path_to_remote(self, host_path: Path, remote_path: str, exclude_dirs: set[str]) -> bool:
+        if not shutil.which("rsync"):
+            return False
+        mkdir = self._run_ssh_command(f"mkdir -p {shlex.quote(remote_path)}", timeout=30)
+        if mkdir.returncode != 0:
+            raise RuntimeError(mkdir.stderr.strip() or "failed to create OpenShell remote sync directory")
+        result = subprocess.run(
+            [
+                "rsync",
+                "-rt",
+                "--delete",
+                *self._rsync_exclude_args(exclude_dirs),
+                "-e",
+                f"ssh -F {self._ssh_config_path} -T",
+                f"{str(host_path).rstrip('/')}/",
+                f"{self._ssh_host}:{remote_path.rstrip('/')}/",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=max(self.cfg["timeout_seconds"], 300),
+        )
+        if result.returncode == 0:
+            return True
+        if result.returncode in {12, 127} or "rsync: command not found" in result.stderr:
+            logger.warning("OpenShell rsync upload unavailable, falling back to sandbox upload: %s", result.stderr.strip())
+            return False
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "OpenShell rsync upload failed")
+
+    def _rsync_path_from_remote(self, remote_path: str, host_path: Path, exclude_dirs: set[str]) -> bool:
+        if not shutil.which("rsync"):
+            return False
+        result = subprocess.run(
+            [
+                "rsync",
+                "-rt",
+                "--delete",
+                *self._rsync_exclude_args(exclude_dirs),
+                "-e",
+                f"ssh -F {self._ssh_config_path} -T",
+                f"{self._ssh_host}:{remote_path.rstrip('/')}/",
+                f"{str(host_path).rstrip('/')}/",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=max(self.cfg["timeout_seconds"], 300),
+        )
+        if result.returncode == 0:
+            return True
+        if result.returncode in {12, 127} or "rsync: command not found" in result.stderr:
+            logger.warning("OpenShell rsync download unavailable, falling back to sandbox download: %s", result.stderr.strip())
+            return False
+        logger.warning("OpenShell rsync download failed: %s", result.stderr.strip() or result.stdout.strip())
+        return True
+
+    def _rsync_exclude_args(self, exclude_dirs: set[str]) -> list[str]:
+        args: list[str] = []
+        for item in sorted({str(entry).strip() for entry in exclude_dirs if str(entry).strip()}):
+            args.extend(["--exclude", item])
+        return args
+
+    def _sync_extra_paths_to_remote(self) -> None:
+        for sync in self.cfg.get("extra_syncs") or []:
+            self._sync_path_to_remote(
+                Path(sync["host"]),
+                sync["remote"],
+                set(sync.get("excludes") or DEFAULT_MIRROR_EXCLUDES),
+            )
+
+    def _sync_extra_paths_from_remote(self) -> None:
+        for sync in self.cfg.get("extra_syncs") or []:
+            mode = str(sync.get("mode") or "inherit").lower()
+            should_pull = mode == "mirror" or (mode == "inherit" and self.cfg["mode"] == "mirror")
+            if should_pull:
+                self._sync_path_from_remote(
+                    sync["remote"],
+                    Path(sync["host"]),
+                    set(sync.get("excludes") or DEFAULT_MIRROR_EXCLUDES),
+                )
+
+    def _upload_file(self, host_path: str, remote_path: str) -> None:
+        parent = str(Path(remote_path).parent)
+        quoted_parent = shlex.quote(parent)
+        mkdir = self._run_ssh_command(
+            f'if [ -e {quoted_parent} ] && [ ! -d {quoted_parent} ]; then rm -f -- {quoted_parent}; fi; '
+            f"mkdir -p -- {quoted_parent}",
+            timeout=30,
+        )
+        if mkdir.returncode != 0:
+            raise RuntimeError(mkdir.stderr.strip() or "failed to create remote OpenShell upload directory")
+        result = self._run_openshell(
+            ["sandbox", "upload", "--no-git-ignore", self.sandbox_name, host_path, remote_path],
+            timeout=max(self.cfg["timeout_seconds"], 120),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "openshell sandbox upload failed")
+
+    def _bulk_upload_files(self, files: list[tuple[str, str]]) -> None:
+        for host_path, remote_path in files:
+            self._upload_file(host_path, remote_path)
+
+    def _delete_remote_paths(self, remote_paths: list[str]) -> None:
+        if not remote_paths:
+            return
+        quoted = " ".join(shlex.quote(path) for path in remote_paths)
+        result = self._run_ssh_command(f"rm -f {quoted}", timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or "failed to delete remote OpenShell paths")
+
+    def cleanup(self):
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self.cfg["mode"] == "mirror":
+                self._sync_workspace_from_remote()
+        finally:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+
+def _copy_tree_without_symlinks(source: Path, target: Path, exclude_dirs: set[str]) -> None:
+    if source.name.lower() in {item.lower() for item in exclude_dirs}:
+        return
+    try:
+        stats = source.lstat()
+    except OSError:
+        return
+    if stats.st_mode and source.is_symlink():
+        return
+    if source.is_dir():
+        target.mkdir(parents=True, exist_ok=True)
+        for child in source.iterdir():
+            if child.name.lower() in {item.lower() for item in exclude_dirs}:
+                continue
+            _copy_tree_without_symlinks(child, target / child.name, exclude_dirs)
+    elif source.is_file():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def _replace_directory_contents(source: Path, target: Path, exclude_dirs: set[str]) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    excluded = {item.lower() for item in exclude_dirs}
+    for child in list(target.iterdir()):
+        if child.name.lower() in excluded:
+            continue
+        if child.is_symlink() or child.is_file():
+            child.unlink(missing_ok=True)
+        elif child.is_dir():
+            shutil.rmtree(child)
+    for child in source.iterdir():
+        if child.name.lower() in excluded:
+            continue
+        _copy_tree_without_symlinks(child, target / child.name, exclude_dirs)

--- a/plugins/sandbox/openshell/plugin.yaml
+++ b/plugins/sandbox/openshell/plugin.yaml
@@ -1,0 +1,5 @@
+name: openshell
+version: "0.1.0"
+kind: exclusive
+description: "OpenShell sandbox provider for Hermes tool execution"
+author: "Hermes"

--- a/plugins/sandbox/openshell/source/Dockerfile
+++ b/plugins/sandbox/openshell/source/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    dnsutils \
+    git \
+    iproute2 \
+    iptables \
+    iputils-ping \
+    jq \
+    nano \
+    net-tools \
+    netcat-openbsd \
+    nodejs \
+    npm \
+    openssh-client \
+    openssh-sftp-server \
+    procps \
+    python3 \
+    python3-pip \
+    python3-venv \
+    ripgrep \
+    rsync \
+    sudo \
+    traceroute \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+
+# OpenShell's default static process policy runs as sandbox:sandbox.
+RUN groupadd -r supervisor \
+  && useradd -r -g supervisor -s /usr/sbin/nologin supervisor \
+  && groupadd -r sandbox \
+  && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
+  && mkdir -p /sandbox /agent/.hermes/skills /agent/.hermes/credentials /agent/.hermes/cache \
+  && chown -R sandbox:sandbox /sandbox /agent
+WORKDIR /sandbox
+
+COPY start.sh /usr/local/bin/hermes-openshell-start
+RUN chmod +x /usr/local/bin/hermes-openshell-start
+
+USER sandbox
+ENTRYPOINT ["/bin/bash"]

--- a/plugins/sandbox/openshell/source/README.md
+++ b/plugins/sandbox/openshell/source/README.md
@@ -1,0 +1,8 @@
+# Hermes OpenShell Source
+
+This local OpenShell source is intentionally small. It provides a generic
+Hermes tool-execution workspace at `/sandbox` plus an optional agent workspace
+at `/agent`.
+
+Use `hermes openshell enable --from openclaw` if you want to test against the
+OpenShell Community OpenClaw image instead.

--- a/plugins/sandbox/openshell/source/start.sh
+++ b/plugins/sandbox/openshell/source/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p /sandbox /agent/.hermes/skills /agent/.hermes/credentials /agent/.hermes/cache
+cd /sandbox
+if [ "$#" -eq 0 ]; then
+  exec bash
+fi
+exec "$@"

--- a/run_agent.py
+++ b/run_agent.py
@@ -4610,30 +4610,31 @@ class AIAgent:
 
     @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:
-        """Truncate excess delegate_task calls to max_concurrent_children.
+        """Truncate excess delegation spawn calls to max_concurrent_children.
 
         The delegate_tool caps the task list inside a single call, but the
-        model can emit multiple separate delegate_task tool_calls in one
+        model can emit multiple separate delegate_task/delegate_start tool_calls in one
         turn.  This truncates the excess, preserving all non-delegate calls.
 
         Returns the original list if no truncation was needed.
         """
         from tools.delegate_tool import _get_max_concurrent_children
         max_children = _get_max_concurrent_children()
-        delegate_count = sum(1 for tc in tool_calls if tc.function.name == "delegate_task")
+        spawn_tools = {"delegate_task", "delegate_start"}
+        delegate_count = sum(1 for tc in tool_calls if tc.function.name in spawn_tools)
         if delegate_count <= max_children:
             return tool_calls
         kept_delegates = 0
         truncated = []
         for tc in tool_calls:
-            if tc.function.name == "delegate_task":
+            if tc.function.name in spawn_tools:
                 if kept_delegates < max_children:
                     truncated.append(tc)
                     kept_delegates += 1
             else:
                 truncated.append(tc)
         logger.warning(
-            "Truncated %d excess delegate_task call(s) to enforce "
+            "Truncated %d excess delegation spawn call(s) to enforce "
             "max_concurrent_children=%d limit",
             delegate_count - max_children, max_children,
         )
@@ -8074,6 +8075,13 @@ class AIAgent:
             toolsets=function_args.get("toolsets"),
             tasks=function_args.get("tasks"),
             max_iterations=function_args.get("max_iterations"),
+            async_mode=function_args.get("async"),
+            profile=function_args.get("profile"),
+            model=function_args.get("model"),
+            provider=function_args.get("provider"),
+            skills=function_args.get("skills"),
+            resume=function_args.get("resume"),
+            pass_session_id=function_args.get("pass_session_id"),
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
@@ -8083,6 +8091,57 @@ class AIAgent:
             sandbox_source=function_args.get("sandbox_source"),
             parent_agent=self,
         )
+
+    def _dispatch_delegate_job_tool(self, function_name: str, function_args: dict) -> str:
+        """Dispatch async delegation job-control tools with agent context."""
+        from tools import delegate_tool as _delegate_tool
+
+        if function_name == "delegate_start":
+            return _delegate_tool.delegate_start(
+                goal=function_args.get("goal"),
+                context=function_args.get("context"),
+                toolsets=function_args.get("toolsets"),
+                tasks=function_args.get("tasks"),
+                role=function_args.get("role"),
+                profile=function_args.get("profile"),
+                model=function_args.get("model"),
+                provider=function_args.get("provider"),
+                skills=function_args.get("skills"),
+                resume=function_args.get("resume"),
+                pass_session_id=function_args.get("pass_session_id"),
+                sandbox=function_args.get("sandbox"),
+                sandbox_mode=function_args.get("sandbox_mode"),
+                sandbox_scope=function_args.get("sandbox_scope"),
+                sandbox_source=function_args.get("sandbox_source"),
+                parent_agent=self,
+            )
+        if function_name == "delegate_status":
+            return _delegate_tool.delegate_status(
+                status=function_args.get("status"),
+                profile=function_args.get("profile"),
+                parent_session_id=function_args.get("parent_session_id"),
+                limit=function_args.get("limit", 50),
+            )
+        if function_name == "delegate_wait":
+            return _delegate_tool.delegate_wait(
+                job_ids=function_args.get("job_ids") or [],
+                timeout=function_args.get("timeout", function_args.get("timeout_seconds", 0)),
+            )
+        if function_name == "delegate_result":
+            return _delegate_tool.delegate_result(
+                job_id=function_args.get("job_id", ""),
+                tail_chars=function_args.get("tail_chars", 12000),
+            )
+        if function_name == "delegate_cancel":
+            return _delegate_tool.delegate_cancel(
+                job_ids=function_args.get("job_ids") or function_args.get("job_id") or [],
+            )
+        if function_name == "delegate_message":
+            return _delegate_tool.delegate_message(
+                job_id=function_args.get("job_id", ""),
+                message=function_args.get("message", ""),
+            )
+        return json.dumps({"error": f"Unknown delegation tool: {function_name}"})
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
                      tool_call_id: Optional[str] = None, messages: list = None) -> str:
@@ -8158,6 +8217,8 @@ class AIAgent:
             )
         elif function_name == "delegate_task":
             return self._dispatch_delegate_task(function_args)
+        elif function_name.startswith("delegate_"):
+            return self._dispatch_delegate_job_tool(function_name, function_args)
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -8699,6 +8760,13 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+            elif function_name.startswith("delegate_"):
+                function_result = self._dispatch_delegate_job_tool(function_name, function_args)
+                tool_duration = time.time() - tool_start_time
+                if self._should_emit_quiet_tool_messages():
+                    self._vprint(
+                        f"  {_get_cute_tool_message_impl(function_name, function_args, tool_duration, result=function_result)}"
+                    )
             elif self._context_engine_tool_names and function_name in self._context_engine_tool_names:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -8077,6 +8077,10 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            sandbox=function_args.get("sandbox"),
+            sandbox_mode=function_args.get("sandbox_mode"),
+            sandbox_scope=function_args.get("sandbox_scope"),
+            sandbox_source=function_args.get("sandbox_source"),
             parent_agent=self,
         )
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1168,6 +1168,22 @@ def test_opencode_go_glm_defaults_to_chat_completions(monkeypatch):
     assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
 
 
+def test_target_model_controls_opencode_api_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "glm-5"})
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go",
+        target_model="minimax-m2.5",
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go"
+
+
 def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -26,6 +26,29 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
 
 
+def test_platform_defaults_include_complete_delegation_toolset():
+    """Composite defaults must stay in sync with configurable toolsets.
+
+    _get_platform_tools() reverse-maps platform defaults like hermes-cli back
+    to configurable toolsets by checking whether every tool in the configurable
+    toolset is present in the composite default. If delegation grows a new tool
+    but hermes-cli is not updated, the whole delegation toolset disappears.
+    """
+    from toolsets import resolve_toolset
+
+    delegation_tools = set(resolve_toolset("delegation"))
+
+    for default_toolset in ("hermes-cli", "hermes-acp", "hermes-api-server"):
+        assert delegation_tools.issubset(resolve_toolset(default_toolset))
+
+    enabled = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["hermes-cli"]}},
+        "cli",
+        include_default_mcp_servers=False,
+    )
+    assert "delegation" in enabled
+
+
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 

--- a/tests/integration/test_openshell_sandbox.py
+++ b/tests/integration/test_openshell_sandbox.py
@@ -1,0 +1,114 @@
+"""Integration tests for the OpenShell sandbox provider.
+
+Run manually with:
+    HERMES_TEST_OPENSHELL=1 pytest -o addopts='' tests/integration/test_openshell_sandbox.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+if os.getenv("HERMES_TEST_OPENSHELL") != "1":
+    pytest.skip("HERMES_TEST_OPENSHELL=1 not set", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def _allow_slow_openshell_startup():
+    """OpenShell image builds/gateway startup can exceed the repo's 30s unit-test alarm."""
+
+    if sys.platform != "win32":
+        signal.alarm(0)
+    yield
+    if sys.platform != "win32":
+        signal.alarm(0)
+
+
+@pytest.fixture()
+def openshell_task(monkeypatch, tmp_path):
+    from plugins.sandbox.openshell.environment import (
+        build_sandbox_name,
+        bundled_source_dir,
+        ensure_openshell_gateway,
+        normalize_openshell_config,
+        run_openshell_cli,
+    )
+    from tools.terminal_tool import cleanup_vm
+
+    scope = f"it-{uuid.uuid4().hex[:10]}"
+    task_id = f"openshell_{scope}"
+    source = str(bundled_source_dir())
+    gateway = "hermes-openshell-test"
+    gateway_port = int(os.getenv("HERMES_TEST_OPENSHELL_GATEWAY_PORT", "18080"))
+
+    monkeypatch.setenv("HERMES_SANDBOX", "openshell")
+    monkeypatch.setenv("HERMES_SANDBOX_MODE", "mirror")
+    monkeypatch.setenv("HERMES_SANDBOX_SCOPE", scope)
+    monkeypatch.setenv("HERMES_SANDBOX_SOURCE", source)
+    monkeypatch.setenv("HERMES_OPENSHELL_GATEWAY", gateway)
+    monkeypatch.setenv("HERMES_OPENSHELL_GATEWAY_PORT", str(gateway_port))
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    cfg = normalize_openshell_config(
+        {
+            "source": source,
+            "gateway": gateway,
+            "gateway_port": gateway_port,
+        }
+    )
+    started = ensure_openshell_gateway(cfg)
+    if started is not None and started.returncode != 0:
+        detail = (started.stderr or started.stdout or "").strip()
+        pytest.skip(f"OpenShell gateway unavailable: {detail[:500]}")
+
+    yield task_id, scope, tmp_path
+
+    cleanup_vm(task_id)
+    run_openshell_cli(cfg, ["sandbox", "delete", build_sandbox_name(scope)], timeout=120)
+
+
+def _run_terminal(command: str, task_id: str) -> dict:
+    from tools.terminal_tool import terminal_tool
+
+    return json.loads(terminal_tool(command, task_id=task_id, timeout=120))
+
+
+def test_openshell_terminal_runs_in_sandbox(openshell_task):
+    task_id, _scope, _tmp_path = openshell_task
+
+    result = _run_terminal("pwd", task_id)
+
+    assert result["exit_code"] == 0
+    assert "/sandbox" in result["output"]
+
+
+def test_openshell_file_tools_mirror_back_to_host(openshell_task):
+    from tools.file_tools import read_file_tool, write_file_tool
+
+    task_id, _scope, tmp_path = openshell_task
+
+    write_result = json.loads(write_file_tool("/sandbox/openshell-file.txt", "hello from openshell\n", task_id=task_id))
+    assert "error" not in write_result
+
+    read_result = json.loads(read_file_tool("/sandbox/openshell-file.txt", task_id=task_id))
+    assert "hello from openshell" in read_result.get("content", "")
+    assert (tmp_path / "openshell-file.txt").read_text() == "hello from openshell\n"
+
+
+def test_no_sandbox_forces_host_execution(monkeypatch, tmp_path):
+    task_id = f"host_{uuid.uuid4().hex[:10]}"
+    monkeypatch.setenv("HERMES_SANDBOX", "host")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = _run_terminal("pwd", task_id)
+
+    assert result["exit_code"] == 0
+    assert str(tmp_path) in result["output"]

--- a/tests/plugins/sandbox/test_sandbox_provider.py
+++ b/tests/plugins/sandbox/test_sandbox_provider.py
@@ -1,0 +1,398 @@
+import argparse
+import re
+import subprocess
+
+
+def test_discover_and_load_bundled_openshell_provider():
+    from plugins.sandbox import discover_plugin_cli_commands, discover_sandbox_providers, load_sandbox_provider
+
+    providers = {name: desc for name, desc, _available in discover_sandbox_providers()}
+    assert "openshell" in providers
+
+    provider = load_sandbox_provider("openshell")
+    assert provider is not None
+    assert provider.name == "openshell"
+
+    commands = {entry["name"]: entry for entry in discover_plugin_cli_commands()}
+    assert "openshell" in commands
+    assert callable(commands["openshell"]["setup_fn"])
+
+
+def test_openshell_cli_registers_expected_subcommands():
+    from plugins.sandbox.openshell.cli import register_cli
+
+    parser = argparse.ArgumentParser()
+    register_cli(parser)
+
+    args = parser.parse_args(["enable", "--default", "--mode", "remote", "--no-smoke"])
+    assert args.openshell_command == "enable"
+    assert args.default is True
+    assert args.mode == "remote"
+    assert args.no_smoke is True
+
+    args = parser.parse_args(["exec", "--scope", "abc", "--gateway-name", "gw", "--gateway-port", "18081", "--", "pwd"])
+    assert args.openshell_command == "exec"
+    assert args.scope == "abc"
+    assert args.gateway_name == "gw"
+    assert args.gateway_port == 18081
+    assert args.exec_command == ["--", "pwd"]
+
+
+def test_build_sandbox_name_is_kubernetes_safe():
+    from plugins.sandbox.openshell.environment import build_sandbox_name
+
+    name = build_sandbox_name("20260425_130221_bab5f1.a95cd9c1")
+
+    assert name.startswith("hermes-20260425-130221-bab5f1-a95cd9c1-")
+    assert len(name) <= 63
+    assert re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
+    assert "_" not in name
+    assert "." not in name
+
+
+def test_build_sandbox_name_trims_long_scope_to_kubernetes_limit():
+    from plugins.sandbox.openshell.environment import build_sandbox_name
+
+    name = build_sandbox_name("...A" * 80)
+
+    assert len(name) <= 63
+    assert re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
+    assert name.startswith("hermes-a-a")
+
+
+def test_prepare_openshell_source_imports_stable_image_for_local_gateway(tmp_path, monkeypatch):
+    from plugins.sandbox.openshell import environment as openshell_env
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Dockerfile").write_text("FROM alpine:3.20\nCOPY start.sh /start.sh\n", encoding="utf-8")
+    (source / "start.sh").write_text("#!/bin/sh\ntrue\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(openshell_env.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+    monkeypatch.setattr(openshell_env, "_resolve_gateway_container", lambda docker, gateway: "openshell-cluster-test")
+    monkeypatch.setattr(openshell_env, "_gateway_container_has_image", lambda docker, container, tag: False)
+    monkeypatch.setattr(openshell_env, "_import_image_into_gateway", lambda docker, container, tag, timeout: calls.append(("import", tag)) or True)
+
+    def fake_run(argv, **kwargs):
+        calls.append(tuple(argv))
+        if argv[:3] == ["/usr/bin/docker", "image", "inspect"]:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(openshell_env.subprocess, "run", fake_run)
+
+    tag = openshell_env.prepare_openshell_source(
+        {"source": str(source), "gateway": "test", "timeout_seconds": 120}
+    )
+
+    assert tag.startswith("openshell/sandbox-from:hermes-")
+    assert calls[0] == ("/usr/bin/docker", "image", "inspect", tag)
+    assert calls[1] == (
+        "/usr/bin/docker",
+        "build",
+        "-t",
+        tag,
+        "-f",
+        str(source / "Dockerfile"),
+        str(source),
+    )
+    assert calls[2] == ("import", tag)
+
+
+def test_prepare_openshell_source_reuses_gateway_imported_image(tmp_path, monkeypatch):
+    from plugins.sandbox.openshell import environment as openshell_env
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Dockerfile").write_text("FROM alpine:3.20\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(openshell_env.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+    monkeypatch.setattr(openshell_env, "_resolve_gateway_container", lambda docker, gateway: "openshell-cluster-test")
+    monkeypatch.setattr(openshell_env, "_gateway_container_has_image", lambda docker, container, tag: True)
+    monkeypatch.setattr(openshell_env, "_import_image_into_gateway", lambda *args, **kwargs: calls.append("import") or True)
+
+    def fake_run(argv, **kwargs):
+        calls.append(tuple(argv))
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(openshell_env.subprocess, "run", fake_run)
+
+    tag = openshell_env.prepare_openshell_source(
+        {"source": str(source), "gateway": "test", "timeout_seconds": 120}
+    )
+
+    assert tag.startswith("openshell/sandbox-from:hermes-")
+    assert calls == [("/usr/bin/docker", "image", "inspect", tag)]
+
+
+def test_prepare_openshell_source_falls_back_for_remote_gateway(tmp_path, monkeypatch):
+    from plugins.sandbox.openshell import environment as openshell_env
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Dockerfile").write_text("FROM alpine:3.20\n", encoding="utf-8")
+    monkeypatch.setattr(openshell_env.shutil, "which", lambda name: "/usr/bin/docker")
+
+    assert (
+        openshell_env.prepare_openshell_source(
+            {"source": str(source), "gateway_endpoint": "https://gateway.example", "timeout_seconds": 120}
+        )
+        == str(source)
+    )
+
+
+def test_run_openshell_cli_builds_gateway_argv(monkeypatch):
+    from plugins.sandbox.openshell.environment import normalize_openshell_config, run_openshell_cli
+
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cfg = normalize_openshell_config(
+        {
+            "command": "openshell",
+            "gateway": "local-gw",
+            "gateway_endpoint": "http://127.0.0.1:8080",
+        }
+    )
+    run_openshell_cli(cfg, ["sandbox", "get", "demo"], cwd="/tmp", timeout=9)
+
+    assert seen["argv"] == [
+        "openshell",
+        "--gateway-endpoint",
+        "http://127.0.0.1:8080",
+        "sandbox",
+        "get",
+        "demo",
+    ]
+    assert seen["kwargs"]["cwd"] == "/tmp"
+    assert seen["kwargs"]["timeout"] == 9
+
+
+def test_openshell_create_argv_uses_default_keep(monkeypatch):
+    from plugins.sandbox.openshell import cli as openshell_cli
+
+    seen = []
+
+    def fake_run(cfg, args, **kwargs):
+        seen.append(args)
+        if args[:2] == ["sandbox", "get"]:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(openshell_cli, "run_openshell_cli", fake_run)
+    monkeypatch.setattr(openshell_cli, "ensure_openshell_gateway", lambda cfg, **kwargs: None)
+
+    cfg = {
+        "source": "/tmp/source",
+        "policy": "",
+        "gpu": False,
+        "auto_providers": False,
+        "providers": ["anthropic"],
+        "timeout_seconds": 120,
+    }
+    result = openshell_cli._ensure_sandbox(cfg, "hermes-test")
+
+    assert result.returncode == 0
+    assert seen[1] == [
+        "sandbox",
+        "create",
+        "--name",
+        "hermes-test",
+        "--from",
+        "/tmp/source",
+        "--no-auto-providers",
+        "--provider",
+        "anthropic",
+        "--",
+        "true",
+    ]
+
+
+def test_openshell_enable_detects_existing_provider_config():
+    from plugins.sandbox.openshell import cli as openshell_cli
+
+    updates = {
+        "sandbox.enabled": False,
+        "sandbox.provider": "openshell",
+        "sandbox.mode": "mirror",
+        "sandbox.openshell.command": "openshell",
+        "sandbox.openshell.from": "/tmp/source",
+        "sandbox.openshell.policy": "",
+        "sandbox.openshell.providers": [],
+        "sandbox.openshell.auto_providers": True,
+        "sandbox.openshell.gpu": False,
+        "sandbox.openshell.gateway": "hermes-openshell",
+        "sandbox.openshell.gateway_endpoint": "",
+        "sandbox.openshell.gateway_port": 18080,
+        "sandbox.openshell.gateway_host": "",
+        "sandbox.openshell.remote_workspace_dir": "/sandbox",
+        "sandbox.openshell.remote_agent_workspace_dir": "/agent",
+        "sandbox.openshell.sync_hermes_files": False,
+        "sandbox.openshell.extra_syncs": [],
+    }
+    current = {
+        "sandbox": {
+            "enabled": False,
+            "provider": "openshell",
+            "mode": "mirror",
+            "openshell": {
+                "command": "openshell",
+                "from": "/tmp/source",
+                "policy": "",
+                "providers": [],
+                "auto_providers": True,
+                "gpu": False,
+                "gateway": "hermes-openshell",
+                "gateway_endpoint": "",
+                "gateway_port": 18080,
+                "gateway_host": "",
+                "remote_workspace_dir": "/sandbox",
+                "remote_agent_workspace_dir": "/agent",
+                "sync_hermes_files": False,
+                "extra_syncs": [],
+            },
+        }
+    }
+
+    assert openshell_cli._is_already_configured(current, updates)
+    updates["sandbox.enabled"] = True
+    assert openshell_cli._is_already_configured(current, updates)
+    updates["sandbox.openshell.gateway_port"] = 18081
+    assert not openshell_cli._is_already_configured(current, updates)
+
+
+def test_ensure_gateway_uses_configured_port(monkeypatch):
+    from plugins.sandbox.openshell.environment import ensure_openshell_gateway, normalize_openshell_config
+
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cfg = normalize_openshell_config(
+        {
+            "command": "openshell",
+            "gateway": "hermes-test",
+            "gateway_port": 18081,
+            "gateway_host": "host.docker.internal",
+        }
+    )
+    result = ensure_openshell_gateway(cfg)
+
+    assert result.returncode == 0
+    assert seen["argv"] == [
+        "openshell",
+        "gateway",
+        "start",
+        "--name",
+        "hermes-test",
+        "--port",
+        "18081",
+        "--gateway-host",
+        "host.docker.internal",
+    ]
+
+
+def test_openshell_cli_config_honors_env_and_args(monkeypatch):
+    from plugins.sandbox.openshell import cli as openshell_cli
+
+    monkeypatch.setattr(
+        openshell_cli,
+        "_load_raw_config",
+        lambda: {
+            "sandbox": {
+                "mode": "mirror",
+                "openshell": {
+                    "gateway": "saved-gw",
+                    "gateway_port": 18080,
+                    "from": "saved-source",
+                },
+            }
+        },
+    )
+    monkeypatch.setenv("HERMES_OPENSHELL_GATEWAY", "env-gw")
+    monkeypatch.setenv("HERMES_OPENSHELL_GATEWAY_PORT", "18082")
+    args = argparse.Namespace(
+        source="cli-source",
+        gateway_name="cli-gw",
+        gateway_port=18083,
+        gateway_endpoint="",
+        gateway_host="",
+        timeout_seconds=None,
+    )
+
+    cfg = openshell_cli._load_openshell_config(args)
+
+    assert cfg["source"] == "cli-source"
+    assert cfg["gateway"] == "cli-gw"
+    assert cfg["gateway_port"] == 18083
+
+
+def test_normalize_openshell_config_parses_extra_syncs(tmp_path):
+    from plugins.sandbox.openshell.environment import normalize_openshell_config
+
+    extra = tmp_path / "worktree-a"
+    extra.mkdir()
+
+    cfg = normalize_openshell_config(
+        {
+            "extra_syncs": [
+                {"host": str(extra), "remote": "/worktrees/a", "mode": "mirror"},
+                f"{extra}:/worktrees/b",
+            ]
+        }
+    )
+
+    assert cfg["extra_syncs"][0]["host"] == str(extra)
+    assert cfg["extra_syncs"][0]["remote"] == "/worktrees/a"
+    assert cfg["extra_syncs"][0]["mode"] == "mirror"
+    assert cfg["extra_syncs"][1]["remote"] == "/worktrees/b"
+
+
+def test_openshell_exec_uses_ssh_config(monkeypatch):
+    from plugins.sandbox.openshell import cli as openshell_cli
+
+    seen = {"openshell": [], "subprocess": []}
+
+    def fake_load():
+        return {"timeout_seconds": 120}
+
+    def fake_run_for_sandbox(args, fn):
+        result = fn(fake_load(), "hermes-test")
+        seen["result"] = result
+
+    def fake_run(cfg, args, **kwargs):
+        seen["openshell"].append(args)
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout="Host hermes-test\n  HostName 127.0.0.1\n",
+            stderr="",
+        )
+
+    def fake_subprocess_run(argv, **kwargs):
+        seen["subprocess"].append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(openshell_cli, "_run_for_sandbox", fake_run_for_sandbox)
+    monkeypatch.setattr(openshell_cli, "run_openshell_cli", fake_run)
+    monkeypatch.setattr(subprocess, "run", fake_subprocess_run)
+
+    args = argparse.Namespace(exec_command=["--", "pwd"])
+    openshell_cli._cmd_exec(args)
+
+    assert seen["openshell"][0] == ["sandbox", "ssh-config", "hermes-test"]
+    assert seen["subprocess"][0][:4] == ["ssh", "-F", seen["subprocess"][0][2], "-T"]
+    assert seen["subprocess"][0][-2:] == ["hermes-test", "pwd"]

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -39,7 +39,13 @@ def _clean_state():
     approval_module._pending.clear()
     approval_module._permanent_approved.clear()
     saved = {}
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "HERMES_DELEGATE_APPROVAL_MODE",
+    ):
         if k in os.environ:
             saved[k] = os.environ.pop(k)
     yield
@@ -48,7 +54,13 @@ def _clean_state():
     approval_module._permanent_approved.clear()
     for k, v in saved.items():
         os.environ[k] = v
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "HERMES_DELEGATE_APPROVAL_MODE",
+    ):
         os.environ.pop(k, None)
 
 
@@ -72,6 +84,34 @@ class TestContainerSkip:
     def test_daytona_skips_both(self):
         result = check_all_command_guards("rm -rf /", "daytona")
         assert result["approved"] is True
+
+
+class TestDelegationApprovalPolicy:
+    def test_delegate_deny_blocks_without_prompt(self):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["HERMES_DELEGATE_APPROVAL_MODE"] = "deny"
+
+        result = check_all_command_guards(
+            "python3 <<'PY'\nprint('hello')\nPY",
+            "local",
+            approval_callback=lambda *_args, **_kwargs: pytest.fail("should not prompt"),
+        )
+
+        assert result["approved"] is False
+        assert "subprocess delegation is non-interactive" in result["message"]
+
+    def test_delegate_approve_allows_without_prompt(self):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["HERMES_DELEGATE_APPROVAL_MODE"] = "approve"
+
+        result = check_all_command_guards(
+            "python3 <<'PY'\nprint('hello')\nPY",
+            "local",
+            approval_callback=lambda *_args, **_kwargs: pytest.fail("should not prompt"),
+        )
+
+        assert result["approved"] is True
+        assert result["delegate_approved"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -17,6 +17,8 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -56,6 +58,28 @@ def _make_mock_parent(depth=0):
     parent.tool_progress_callback = None
     parent.thinking_callback = None
     return parent
+
+
+@pytest.fixture(autouse=True)
+def _legacy_sync_delegation_default(monkeypatch):
+    """Keep legacy delegate_task tests on the blocking path by default.
+
+    Async behavior is covered in tests/tools/test_delegation_jobs.py.
+    """
+    import tools.delegate_tool as delegate_tool
+
+    monkeypatch.setattr(
+        delegate_tool,
+        "_load_config",
+        lambda: {
+            "async_default": False,
+            "max_iterations": 50,
+            "max_concurrent_children": 3,
+            "max_spawn_depth": 1,
+            "orchestrator_enabled": True,
+            "inherit_mcp_toolsets": True,
+        },
+    )
 
 
 class TestDelegateRequirements(unittest.TestCase):
@@ -1504,6 +1528,89 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
+
+    def test_run_agent_dispatch_delegate_task_matches_delegate_signature(self):
+        """Fresh child processes dispatch through run_agent._dispatch_delegate_task."""
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        seen = {}
+
+        def fake_delegate_task(**kwargs):
+            seen.update(kwargs)
+            return '{"ok": true}'
+
+        args = {
+            "goal": "nested work",
+            "async": True,
+            "profile": "coder",
+            "model": "test-model",
+            "provider": "test-provider",
+            "skills": ["python"],
+            "resume": "sess-child",
+            "pass_session_id": True,
+            "role": "orchestrator",
+            "sandbox": "host",
+        }
+        with patch("tools.delegate_tool.delegate_task", side_effect=fake_delegate_task):
+            result = agent._dispatch_delegate_task(args)
+
+        self.assertEqual(result, '{"ok": true}')
+        self.assertEqual(seen["async_mode"], True)
+        self.assertEqual(seen["profile"], "coder")
+        self.assertEqual(seen["model"], "test-model")
+        self.assertEqual(seen["provider"], "test-provider")
+        self.assertEqual(seen["skills"], ["python"])
+        self.assertEqual(seen["resume"], "sess-child")
+        self.assertIs(seen["pass_session_id"], True)
+        self.assertEqual(seen["role"], "orchestrator")
+        self.assertIs(seen["parent_agent"], agent)
+
+    def test_run_agent_dispatch_delegate_job_tools_match_signatures(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        calls = {}
+        with (
+            patch("tools.delegate_tool.delegate_status", side_effect=lambda **kw: calls.setdefault("status", kw) or "{}"),
+            patch("tools.delegate_tool.delegate_wait", side_effect=lambda **kw: calls.setdefault("wait", kw) or "{}"),
+            patch("tools.delegate_tool.delegate_result", side_effect=lambda **kw: calls.setdefault("result", kw) or "{}"),
+            patch("tools.delegate_tool.delegate_cancel", side_effect=lambda **kw: calls.setdefault("cancel", kw) or "{}"),
+            patch("tools.delegate_tool.delegate_message", side_effect=lambda **kw: calls.setdefault("message", kw) or "{}"),
+        ):
+            agent._dispatch_delegate_job_tool("delegate_status", {"status": "running", "limit": 2})
+            agent._dispatch_delegate_job_tool("delegate_wait", {"job_ids": ["job-1"], "timeout": 1})
+            agent._dispatch_delegate_job_tool("delegate_result", {"job_id": "job-1"})
+            agent._dispatch_delegate_job_tool("delegate_cancel", {"job_id": "job-1"})
+            agent._dispatch_delegate_job_tool("delegate_message", {"job_id": "job-1", "message": "go"})
+
+        self.assertEqual(calls["status"], {"status": "running", "profile": None, "parent_session_id": None, "limit": 2})
+        self.assertEqual(calls["wait"], {"job_ids": ["job-1"], "timeout": 1})
+        self.assertEqual(calls["result"], {"job_id": "job-1", "tail_chars": 12000})
+        self.assertEqual(calls["cancel"], {"job_ids": "job-1"})
+        self.assertEqual(calls["message"], {"job_id": "job-1", "message": "go"})
+
+    def test_delegate_job_control_tools_accept_dispatch_compat_kwargs(self):
+        """Older dispatch paths may still pass parent_agent/timeout_seconds."""
+        import tools.delegate_tool as delegate_tool
+
+        with (
+            patch("tools.delegation_jobs.list_jobs", return_value=[]) as list_jobs,
+            patch("tools.delegation_jobs.wait_jobs", return_value={"completed": [], "running": []}) as wait_jobs,
+            patch("tools.delegation_jobs.get_result", return_value={"status": "missing"}) as get_result,
+            patch("tools.delegation_jobs.cancel_jobs", return_value={"cancelled": ["job-1"]}) as cancel_jobs,
+        ):
+            delegate_tool.delegate_status(parent_agent=object())
+            delegate_tool.delegate_wait(["job-1"], timeout_seconds=2, parent_agent=object())
+            delegate_tool.delegate_result("job-1", parent_agent=object())
+            delegate_tool.delegate_cancel(job_id="job-1", parent_agent=object())
+            msg = json.loads(delegate_tool.delegate_message("job-1", "go", parent_agent=object()))
+
+        list_jobs.assert_called_once()
+        wait_jobs.assert_called_once_with(["job-1"], timeout=2.0)
+        get_result.assert_called_once()
+        cancel_jobs.assert_called_once_with(["job-1"])
+        self.assertFalse(msg["supported"])
 
     @patch("tools.delegate_tool._load_config", return_value={})
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tests/tools/test_delegation_jobs.py
+++ b/tests/tools/test_delegation_jobs.py
@@ -1,0 +1,245 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+class _FakeParent:
+    session_id = "parent-session"
+    _delegate_depth = 0
+    _subagent_id = None
+    tool_progress_callback = None
+    enabled_toolsets = ["terminal", "file", "web", "delegation"]
+    valid_tool_names = []
+
+
+class _FakePopen:
+    calls = []
+    _next_pid = 41000
+
+    def __init__(self, argv, **kwargs):
+        type(self)._next_pid += 1
+        self.pid = type(self)._next_pid
+        self.returncode = 0
+        self.argv = argv
+        self.kwargs = kwargs
+        type(self).calls.append((argv, kwargs, self))
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = -15
+
+    def kill(self):
+        self.returncode = -9
+
+
+@pytest.fixture(autouse=True)
+def _clean_fake_popen():
+    _FakePopen.calls.clear()
+    yield
+    _FakePopen.calls.clear()
+
+
+def test_start_jobs_builds_profile_subprocess_request(monkeypatch, tmp_path):
+    from tools import delegation_jobs
+
+    hermes_home = tmp_path / "hermes"
+    (hermes_home / "profiles" / "coder").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_DELEGATE_COMMAND", "/bin/hermes-test")
+    monkeypatch.setattr(delegation_jobs.subprocess, "Popen", _FakePopen)
+
+    result = delegation_jobs.start_jobs(
+        [
+            {
+                "goal": "check profile routing",
+                "context": "ctx",
+                "toolsets": ["terminal"],
+                "profile": "coder",
+                "role": "leaf",
+                "model": "test-model",
+                "provider": "test-provider",
+                "skills": ["cluster-topology"],
+                "resume": "sess-previous",
+                "pass_session_id": True,
+                "system_prompt": "child prompt",
+                "max_iterations": 7,
+            }
+        ],
+        parent_agent=_FakeParent(),
+        cfg={"allowed_profiles": ["coder"], "default_profile": "", "job_retention_hours": 24},
+    )
+
+    assert result["status"] == "running"
+    job_id = result["job_ids"][0]
+    argv, kwargs, proc = _FakePopen.calls[0]
+    assert argv[:4] == ["/bin/hermes-test", "--profile", "coder", "chat"]
+    assert "--delegate-request" in argv
+    assert "--delegate-output" in argv
+    assert kwargs["env"]["HERMES_HOME"] == str(hermes_home / "profiles" / "coder")
+    assert kwargs["env"]["HERMES_DELEGATE_JOB_ID"] == job_id
+    assert kwargs["env"]["HERMES_DELEGATE_APPROVAL_MODE"] == "deny"
+
+    request_path = Path(argv[argv.index("--delegate-request") + 1])
+    request = json.loads(request_path.read_text())
+    assert request["job_id"] == job_id
+    assert request["profile"] == "coder"
+    assert request["goal"] == "check profile routing"
+    assert request["toolsets"] == ["terminal"]
+    assert request["skills"] == ["cluster-topology"]
+    assert request["resume"] == "sess-previous"
+    assert request["pass_session_id"] is True
+
+
+def test_start_jobs_bridges_managed_tool_gateway_auth(monkeypatch, tmp_path):
+    from tools import delegation_jobs
+
+    hermes_home = tmp_path / "hermes"
+    (hermes_home / "profiles" / "coder").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_DELEGATE_COMMAND", "/bin/hermes-test")
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED_TOOLS_ENABLED", raising=False)
+    monkeypatch.setattr(delegation_jobs.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)
+    monkeypatch.setattr("tools.managed_tool_gateway.read_nous_access_token", lambda: "nous-token")
+
+    delegation_jobs.start_jobs(
+        [{"goal": "web research", "profile": "coder", "toolsets": ["web"]}],
+        parent_agent=_FakeParent(),
+        cfg={"allowed_profiles": ["coder"], "default_profile": "", "job_retention_hours": 24},
+    )
+
+    env = _FakePopen.calls[0][1]["env"]
+    assert env["TOOL_GATEWAY_USER_TOKEN"] == "nous-token"
+    assert env["HERMES_MANAGED_TOOLS_ENABLED"] == "1"
+
+
+def test_status_prefers_failed_when_process_crashes_after_completed_output():
+    from tools import delegation_jobs
+
+    assert delegation_jobs._normalize_status_from_output({"status": "completed"}, -6) == "failed"
+
+
+def test_start_jobs_rejects_disallowed_profile(monkeypatch, tmp_path):
+    from tools import delegation_jobs
+
+    hermes_home = tmp_path / "hermes"
+    (hermes_home / "profiles" / "coder").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="not allowed"):
+        delegation_jobs.start_jobs(
+            [{"goal": "x", "profile": "coder"}],
+            parent_agent=_FakeParent(),
+            cfg={"allowed_profiles": ["other"]},
+        )
+
+
+def test_delegate_task_async_default_returns_job_handles(monkeypatch):
+    import tools.delegate_tool as delegate_tool
+
+    monkeypatch.setattr(
+        delegate_tool,
+        "_load_config",
+        lambda: {
+            "async_default": True,
+            "max_iterations": 5,
+            "max_concurrent_children": 3,
+            "max_spawn_depth": 1,
+            "orchestrator_enabled": True,
+        },
+    )
+    monkeypatch.setattr(
+        "tools.delegation_jobs.start_jobs",
+        lambda tasks, **kwargs: {"status": "running", "job_ids": ["job-test"], "jobs": []},
+    )
+
+    raw = delegate_tool.delegate_task(goal="async please", parent_agent=_FakeParent())
+    result = json.loads(raw)
+    assert result["status"] == "running"
+    assert result["job_ids"] == ["job-test"]
+
+
+def test_delegate_task_profile_override_forces_async(monkeypatch):
+    import tools.delegate_tool as delegate_tool
+
+    monkeypatch.setattr(
+        delegate_tool,
+        "_load_config",
+        lambda: {
+            "async_default": False,
+            "max_iterations": 5,
+            "max_concurrent_children": 3,
+            "max_spawn_depth": 1,
+            "orchestrator_enabled": True,
+        },
+    )
+    seen = {}
+
+    def _start_jobs(tasks, **kwargs):
+        seen["tasks"] = tasks
+        seen["kwargs"] = kwargs
+        return {"status": "running", "job_ids": ["job-profile"], "jobs": []}
+
+    monkeypatch.setattr("tools.delegation_jobs.start_jobs", _start_jobs)
+
+    raw = delegate_tool.delegate_task(
+        goal="profile child",
+        profile="coder",
+        parent_agent=_FakeParent(),
+    )
+    result = json.loads(raw)
+    assert result["job_ids"] == ["job-profile"]
+    assert seen["kwargs"]["top_profile"] == "coder"
+
+
+def test_delegate_task_async_passes_session_controls_to_job_request(monkeypatch):
+    import tools.delegate_tool as delegate_tool
+
+    monkeypatch.setattr(
+        delegate_tool,
+        "_load_config",
+        lambda: {
+            "async_default": True,
+            "max_iterations": 5,
+            "max_concurrent_children": 3,
+            "max_spawn_depth": 1,
+            "orchestrator_enabled": True,
+        },
+    )
+    seen = {}
+
+    def _start_jobs(tasks, **kwargs):
+        seen["tasks"] = tasks
+        return {"status": "running", "job_ids": ["job-controls"], "jobs": []}
+
+    monkeypatch.setattr("tools.delegation_jobs.start_jobs", _start_jobs)
+
+    raw = delegate_tool.delegate_task(
+        goal="use session controls",
+        skills="cluster-topology,python-dev",
+        resume="sess-previous",
+        pass_session_id=True,
+        parent_agent=_FakeParent(),
+    )
+
+    result = json.loads(raw)
+    assert result["job_ids"] == ["job-controls"]
+    assert seen["tasks"][0]["skills"] == ["cluster-topology", "python-dev"]
+    assert seen["tasks"][0]["resume"] == "sess-previous"
+    assert seen["tasks"][0]["pass_session_id"] is True
+
+
+def test_delegate_result_missing_job(monkeypatch, tmp_path):
+    from tools import delegation_jobs
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    result = delegation_jobs.get_result("job-missing")
+    assert result["status"] == "missing"

--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -78,6 +78,15 @@ def test_resolve_managed_tool_gateway_is_disabled_without_subscription():
     assert result is None
 
 
+def test_managed_tools_enabled_accepts_delegated_token_env(monkeypatch):
+    from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+    monkeypatch.setenv("HERMES_MANAGED_TOOLS_ENABLED", "1")
+    monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+
+    assert managed_nous_tools_enabled() is True
+
+
 def test_read_nous_access_token_refreshes_expiring_cached_token(tmp_path, monkeypatch):
     monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/tools/test_sandbox_env_routing.py
+++ b/tests/tools/test_sandbox_env_routing.py
@@ -1,0 +1,115 @@
+import os
+
+
+def test_env_config_routes_explicit_sandbox_to_provider(monkeypatch, tmp_path):
+    from tools import terminal_tool as tt
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setenv("HERMES_SANDBOX", "openshell")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    cfg = tt._get_env_config()
+
+    assert cfg["env_type"] == "openshell"
+    assert cfg["cwd"] == "/sandbox"
+    assert cfg["host_cwd"] == str(tmp_path)
+    assert cfg["sandbox_config"]["provider"] == "openshell"
+
+
+def test_env_config_no_sandbox_forces_local(monkeypatch):
+    from tools import terminal_tool as tt
+
+    monkeypatch.setenv("TERMINAL_ENV", "openshell")
+    monkeypatch.setenv("HERMES_SANDBOX", "host")
+
+    cfg = tt._get_env_config()
+
+    assert cfg["env_type"] == "local"
+
+
+def test_create_environment_delegates_unknown_backend_to_sandbox_provider(monkeypatch, tmp_path):
+    from tools import terminal_tool as tt
+
+    seen = {}
+    sentinel = object()
+
+    class Provider:
+        def create_environment(self, spec):
+            seen["spec"] = spec
+            return sentinel
+
+    import plugins.sandbox as sandbox_plugins
+
+    monkeypatch.setattr(sandbox_plugins, "load_sandbox_provider", lambda name: Provider())
+
+    result = tt._create_environment(
+        env_type="openshell",
+        image="",
+        cwd="/sandbox",
+        timeout=11,
+        task_id="task-1",
+        host_cwd=str(tmp_path),
+        container_config={
+            "sandbox_config": {
+                "mode": "remote",
+                "scope": "scope-1",
+                "provider": "openshell",
+            }
+        },
+    )
+
+    assert result is sentinel
+    assert seen["spec"].provider == "openshell"
+    assert seen["spec"].mode == "remote"
+    assert seen["spec"].scope == "scope-1"
+    assert seen["spec"].host_cwd == str(tmp_path)
+
+
+def test_delegate_task_sandbox_override_resolves_host_and_openshell(monkeypatch):
+    import tools.delegate_tool as dt
+
+    monkeypatch.setattr(
+        dt,
+        "_load_full_config",
+        lambda: {
+            "sandbox": {
+                "provider": "openshell",
+                "mode": "mirror",
+                "openshell": {
+                    "from": "openclaw",
+                    "remote_workspace_dir": "/sandbox",
+                    "remote_agent_workspace_dir": "/agent",
+                },
+            }
+        },
+    )
+
+    host_override = dt._resolve_child_sandbox_override(
+        {"sandbox": "host"}, None, None, None, None
+    )
+    assert host_override["env_type"] == "local"
+
+    sandbox_override = dt._resolve_child_sandbox_override(
+        {"sandbox": "openshell", "sandbox_mode": "remote", "sandbox_scope": "child-a"},
+        None,
+        None,
+        None,
+        None,
+    )
+    assert sandbox_override["env_type"] == "openshell"
+    assert sandbox_override["cwd"] == "/sandbox"
+    assert sandbox_override["sandbox_config"]["mode"] == "remote"
+    assert sandbox_override["sandbox_config"]["scope"] == "child-a"
+    assert sandbox_override["sandbox_config"]["source"] == "openclaw"
+
+    monkeypatch.setenv("HERMES_OPENSHELL_GATEWAY", "env-gw")
+    monkeypatch.setenv("HERMES_OPENSHELL_GATEWAY_PORT", "18091")
+    sandbox_override = dt._resolve_child_sandbox_override(
+        {"sandbox": "openshell"},
+        None,
+        None,
+        None,
+        None,
+    )
+    assert sandbox_override["sandbox_config"]["gateway"] == "env-gw"
+    assert sandbox_override["sandbox_config"]["gateway_port"] == 18091

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -525,6 +525,18 @@ def _get_approval_config() -> dict:
         return {}
 
 
+def _get_delegate_approval_mode() -> str:
+    """Return subprocess-delegation approval policy, if one is active."""
+    mode = os.getenv("HERMES_DELEGATE_APPROVAL_MODE", "").strip().lower()
+    if mode in {"approve", "allow", "allowed", "approved"}:
+        return "approve"
+    if mode in {"deny", "block", "blocked", "denied"}:
+        return "deny"
+    if mode in {"inherit", "parent", "manual"}:
+        return "inherit"
+    return ""
+
+
 def _get_approval_mode() -> str:
     """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
     mode = _get_approval_config().get("mode", "manual")
@@ -629,6 +641,26 @@ def check_dangerous_command(command: str, env_type: str,
     session_key = get_current_session_key()
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
+
+    delegate_approval_mode = _get_delegate_approval_mode()
+    if delegate_approval_mode == "approve":
+        return {
+            "approved": True,
+            "message": None,
+            "delegate_approved": True,
+            "description": description,
+        }
+    if delegate_approval_mode == "deny":
+        return {
+            "approved": False,
+            "message": (
+                f"BLOCKED: Command flagged as dangerous ({description}) "
+                "and subprocess delegation is non-interactive. "
+                "Find an alternative approach that avoids this command."
+            ),
+            "pattern_key": pattern_key,
+            "description": description,
+        }
 
     is_cli = os.getenv("HERMES_INTERACTIVE")
     is_gateway = os.getenv("HERMES_GATEWAY_SESSION")
@@ -803,6 +835,27 @@ def check_all_command_guards(command: str, env_type: str,
     # Nothing to warn about
     if not warnings:
         return {"approved": True, "message": None}
+
+    delegate_approval_mode = _get_delegate_approval_mode()
+    if delegate_approval_mode == "approve":
+        return {
+            "approved": True,
+            "message": None,
+            "delegate_approved": True,
+            "description": "; ".join(desc for _, desc, _ in warnings),
+        }
+    if delegate_approval_mode == "deny":
+        return {
+            "approved": False,
+            "message": (
+                "BLOCKED: Command requires approval "
+                f"({'; '.join(desc for _, desc, _ in warnings)}) "
+                "but subprocess delegation is non-interactive. "
+                "Find an alternative approach that avoids this command."
+            ),
+            "pattern_key": warnings[0][0],
+            "description": "; ".join(desc for _, desc, _ in warnings),
+        }
 
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
     # When approvals.mode=smart, ask the aux LLM before prompting the user.

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -465,6 +465,7 @@ def _get_or_create_env(task_id: str):
         config = _get_env_config()
         env_type = config["env_type"]
         overrides = _task_env_overrides.get(effective_task_id, {})
+        env_type = overrides.get("env_type") or env_type
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -480,13 +481,16 @@ def _get_or_create_env(task_id: str):
         cwd = overrides.get("cwd") or config["cwd"]
 
         container_config = None
-        if env_type in ("docker", "singularity", "modal", "daytona"):
+        from tools.terminal_tool import _BUILTIN_ENV_TYPES, _task_sandbox_config
+
+        if env_type in ("docker", "singularity", "modal", "daytona") or env_type not in _BUILTIN_ENV_TYPES:
             container_config = {
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),
                 "container_disk": config.get("container_disk", 51200),
                 "container_persistent": config.get("container_persistent", True),
                 "docker_volumes": config.get("docker_volumes", []),
+                "sandbox_config": _task_sandbox_config(config, overrides),
             }
 
         ssh_config = None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -636,6 +636,57 @@ def _preserve_parent_mcp_toolsets(
     return preserved
 
 
+def _resolve_child_toolsets_and_role(
+    parent_agent,
+    requested_toolsets: Optional[List[str]],
+    *,
+    role: str = "leaf",
+) -> tuple[List[str], str, int, int]:
+    """Resolve a child's effective toolsets/role without constructing it.
+
+    This mirrors the legacy in-process child construction rules so async
+    subprocess jobs and synchronous children expose the same bounded tool
+    surface.
+    """
+    child_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
+    max_spawn = _get_max_spawn_depth()
+    orchestrator_ok = _get_orchestrator_enabled() and child_depth < max_spawn
+    effective_role = role if (role == "orchestrator" and orchestrator_ok) else "leaf"
+
+    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+    if parent_enabled is not None:
+        parent_toolsets = set(parent_enabled)
+    elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
+        import model_tools
+
+        parent_toolsets = {
+            ts
+            for name in parent_agent.valid_tool_names
+            if (ts := model_tools.get_toolset_for_tool(name)) is not None
+        }
+    else:
+        parent_toolsets = set(DEFAULT_TOOLSETS)
+
+    if requested_toolsets:
+        child_toolsets = [t for t in requested_toolsets if t in parent_toolsets]
+        if _get_inherit_mcp_toolsets():
+            child_toolsets = _preserve_parent_mcp_toolsets(
+                child_toolsets, parent_toolsets
+            )
+        child_toolsets = _strip_blocked_tools(child_toolsets)
+    elif parent_agent and parent_enabled is not None:
+        child_toolsets = _strip_blocked_tools(parent_enabled)
+    elif parent_toolsets:
+        child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
+    else:
+        child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+
+    if effective_role == "orchestrator" and "delegation" not in child_toolsets:
+        child_toolsets.append("delegation")
+
+    return child_toolsets, effective_role, child_depth, max_spawn
+
+
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_CHILD_TIMEOUT = 600  # seconds before a child agent is considered stuck
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
@@ -1028,16 +1079,12 @@ def _build_child_agent(
     from run_agent import AIAgent
     import uuid as _uuid
 
-    # ── Role resolution ─────────────────────────────────────────────────
-    # Honor the caller's role only when BOTH the kill switch and the
-    # child's depth allow it.  This is the single point where role
-    # degrades to 'leaf' — keeps the rule predictable.  Callers pass
-    # the normalised role (_normalize_role ran in delegate_task) so
-    # we only deal with 'leaf' or 'orchestrator' here.
-    child_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
-    max_spawn = _get_max_spawn_depth()
-    orchestrator_ok = _get_orchestrator_enabled() and child_depth < max_spawn
-    effective_role = role if (role == "orchestrator" and orchestrator_ok) else "leaf"
+    # ── Role/toolset resolution ─────────────────────────────────────────
+    child_toolsets, effective_role, child_depth, max_spawn = _resolve_child_toolsets_and_role(
+        parent_agent,
+        toolsets,
+        role=role,
+    )
 
     # ── Subagent identity (stable across events, 0-indexed for TUI) ─────
     # subagent_id is generated here so the progress callback, the
@@ -1049,47 +1096,6 @@ def _build_child_agent(
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
     delegation_cfg = _load_config()
-
-    # When no explicit toolsets given, inherit from parent's enabled toolsets
-    # so disabled tools (e.g. web) don't leak to subagents.
-    # Note: enabled_toolsets=None means "all tools enabled" (the default),
-    # so we must derive effective toolsets from the parent's loaded tools.
-    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
-    if parent_enabled is not None:
-        parent_toolsets = set(parent_enabled)
-    elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
-        # enabled_toolsets is None (all tools) — derive from loaded tool names
-        import model_tools
-
-        parent_toolsets = {
-            ts
-            for name in parent_agent.valid_tool_names
-            if (ts := model_tools.get_toolset_for_tool(name)) is not None
-        }
-    else:
-        parent_toolsets = set(DEFAULT_TOOLSETS)
-
-    if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks
-        child_toolsets = [t for t in toolsets if t in parent_toolsets]
-        if _get_inherit_mcp_toolsets():
-            child_toolsets = _preserve_parent_mcp_toolsets(
-                child_toolsets, parent_toolsets
-            )
-        child_toolsets = _strip_blocked_tools(child_toolsets)
-    elif parent_agent and parent_enabled is not None:
-        child_toolsets = _strip_blocked_tools(parent_enabled)
-    elif parent_toolsets:
-        child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
-    else:
-        child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
-
-    # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
-    # removed.  The re-add is unconditional on parent-toolset membership because
-    # orchestrator capability is granted by role, not inherited — see the
-    # test_intersection_preserves_delegation_bound test for the design rationale.
-    if effective_role == "orchestrator" and "delegation" not in child_toolsets:
-        child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(
@@ -1979,6 +1985,13 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    async_mode: Optional[bool] = None,
+    profile: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    skills: Any = None,
+    resume: Optional[str] = None,
+    pass_session_id: Optional[bool] = None,
     sandbox: Optional[str] = None,
     sandbox_mode: Optional[str] = None,
     sandbox_scope: Optional[str] = None,
@@ -2045,6 +2058,34 @@ def delegate_task(
             max_iterations, default_max_iter,
         )
     effective_max_iter = default_max_iter
+
+    force_async = any(
+        value not in (None, "", [], {})
+        for value in (profile, model, provider, skills, resume)
+    ) or pass_session_id is not None
+    use_async = (
+        _coerce_bool(async_mode, default=_coerce_bool(cfg.get("async_default"), default=False))
+        or force_async
+    )
+    if use_async:
+        return delegate_start(
+            goal=goal,
+            context=context,
+            toolsets=toolsets,
+            tasks=tasks,
+            role=role,
+            profile=profile,
+            model=model,
+            provider=provider,
+            skills=skills,
+            resume=resume,
+            pass_session_id=pass_session_id,
+            sandbox=sandbox,
+            sandbox_mode=sandbox_mode,
+            sandbox_scope=sandbox_scope,
+            sandbox_source=sandbox_source,
+            parent_agent=parent_agent,
+        )
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -2482,6 +2523,290 @@ def _load_config() -> dict:
         return {}
 
 
+def _normalize_string_list(value: Any) -> List[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _coerce_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _normalize_task_list(
+    *,
+    goal: Optional[str],
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+    tasks: Optional[List[Dict[str, Any]]],
+    top_role: str,
+) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    max_children = _get_max_concurrent_children()
+    if tasks and isinstance(tasks, list):
+        if len(tasks) > max_children:
+            return None, (
+                f"Too many tasks: {len(tasks)} provided, but "
+                f"max_concurrent_children is {max_children}. "
+                f"Either reduce the task count, split into multiple "
+                f"delegate_task calls, or increase "
+                f"delegation.max_concurrent_children in config.yaml."
+            )
+        task_list = [dict(t) for t in tasks]
+    elif goal and isinstance(goal, str) and goal.strip():
+        task_list = [
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+        ]
+    else:
+        return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
+
+    if not task_list:
+        return None, "No tasks provided."
+    for i, task in enumerate(task_list):
+        if not str(task.get("goal", "")).strip():
+            return None, f"Task {i} is missing a 'goal'."
+    return task_list, None
+
+
+def _build_async_job_tasks(
+    task_list: List[Dict[str, Any]],
+    *,
+    parent_agent,
+    top_toolsets: Optional[List[str]],
+    top_role: str,
+    top_model: Optional[str],
+    top_provider: Optional[str],
+    top_skills: Any,
+    top_resume: Optional[str],
+    top_pass_session_id: Optional[bool],
+    top_sandbox: Optional[str],
+    top_sandbox_mode: Optional[str],
+    top_sandbox_scope: Optional[str],
+    top_sandbox_source: Optional[str],
+    max_iterations: int,
+) -> List[Dict[str, Any]]:
+    job_tasks: List[Dict[str, Any]] = []
+    workspace_hint = _resolve_workspace_hint(parent_agent)
+    for i, task in enumerate(task_list):
+        effective_role = _normalize_role(task.get("role") or top_role)
+        requested_toolsets = task.get("toolsets") or top_toolsets
+        child_toolsets, child_role, child_depth, max_spawn = _resolve_child_toolsets_and_role(
+            parent_agent,
+            requested_toolsets,
+            role=effective_role,
+        )
+        system_prompt = _build_child_system_prompt(
+            str(task["goal"]),
+            task.get("context"),
+            workspace_path=workspace_hint,
+            role=child_role,
+            max_spawn_depth=max_spawn,
+            child_depth=child_depth,
+        )
+        sandbox_override = _resolve_child_sandbox_override(
+            task,
+            top_sandbox,
+            top_sandbox_mode,
+            top_sandbox_scope,
+            top_sandbox_source,
+        )
+        sandbox_config = (
+            sandbox_override.get("sandbox_config", {})
+            if isinstance(sandbox_override, dict)
+            else {}
+        )
+        job_tasks.append(
+            {
+                "task_index": i,
+                "goal": str(task["goal"]),
+                "context": task.get("context") or "",
+                "toolsets": child_toolsets,
+                "role": child_role,
+                "child_depth": child_depth,
+                "max_spawn_depth": max_spawn,
+                "system_prompt": system_prompt,
+                "model": task.get("model") or top_model or "",
+                "provider": task.get("provider") or top_provider or "",
+                "profile": task.get("profile") or "",
+                "skills": _normalize_string_list(
+                    task.get("skills") if "skills" in task else top_skills
+                ),
+                "resume": task.get("resume") or top_resume or "",
+                "pass_session_id": (
+                    bool(task.get("pass_session_id"))
+                    if "pass_session_id" in task
+                    else bool(top_pass_session_id)
+                ),
+                "max_iterations": int(max_iterations),
+                "sandbox": task.get("sandbox") if "sandbox" in task else top_sandbox,
+                "sandbox_mode": task.get("sandbox_mode") or top_sandbox_mode or "",
+                "sandbox_scope": task.get("sandbox_scope") or top_sandbox_scope or "",
+                "sandbox_source": task.get("sandbox_source") or top_sandbox_source or "",
+                "sandbox_config": sandbox_config,
+            }
+        )
+    return job_tasks
+
+
+def delegate_start(
+    goal: Optional[str] = None,
+    context: Optional[str] = None,
+    toolsets: Optional[List[str]] = None,
+    tasks: Optional[List[Dict[str, Any]]] = None,
+    role: Optional[str] = None,
+    profile: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    skills: Any = None,
+    resume: Optional[str] = None,
+    pass_session_id: Optional[bool] = None,
+    sandbox: Optional[str] = None,
+    sandbox_mode: Optional[str] = None,
+    sandbox_scope: Optional[str] = None,
+    sandbox_source: Optional[str] = None,
+    parent_agent=None,
+) -> str:
+    """Start one or more async delegation jobs and return job handles."""
+    if parent_agent is None:
+        return tool_error("delegate_start requires a parent agent context.")
+    if is_spawn_paused():
+        return tool_error(
+            "Delegation spawning is paused. Clear the pause via the TUI "
+            "(`p` in /agents) or the `delegation.pause` RPC before retrying."
+        )
+
+    depth = getattr(parent_agent, "_delegate_depth", 0)
+    max_spawn = _get_max_spawn_depth()
+    if depth >= max_spawn:
+        return json.dumps(
+            {
+                "error": (
+                    f"Delegation depth limit reached (depth={depth}, "
+                    f"max_spawn_depth={max_spawn})."
+                )
+            }
+        )
+
+    cfg = _load_config()
+    top_role = _normalize_role(role)
+    task_list, error = _normalize_task_list(
+        goal=goal,
+        context=context,
+        toolsets=toolsets,
+        tasks=tasks,
+        top_role=top_role,
+    )
+    if error:
+        return tool_error(error)
+
+    try:
+        effective_max_iter = int(cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS))
+    except (TypeError, ValueError):
+        effective_max_iter = DEFAULT_MAX_ITERATIONS
+
+    job_tasks = _build_async_job_tasks(
+        task_list or [],
+        parent_agent=parent_agent,
+        top_toolsets=toolsets,
+        top_role=top_role,
+        top_model=model or str(cfg.get("model") or "").strip() or None,
+        top_provider=provider or str(cfg.get("provider") or "").strip() or None,
+        top_skills=skills,
+        top_resume=resume,
+        top_pass_session_id=pass_session_id,
+        top_sandbox=sandbox,
+        top_sandbox_mode=sandbox_mode,
+        top_sandbox_scope=sandbox_scope,
+        top_sandbox_source=sandbox_source,
+        max_iterations=effective_max_iter,
+    )
+    try:
+        from tools.delegation_jobs import start_jobs
+
+        return json.dumps(
+            start_jobs(
+                job_tasks,
+                parent_agent=parent_agent,
+                top_profile=profile,
+                cfg=cfg,
+            ),
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.exception("delegate_start failed")
+        return tool_error(f"delegate_start failed: {exc}")
+
+
+def delegate_status(
+    status: Optional[str] = None,
+    profile: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+    limit: int = 50,
+    parent_agent=None,
+) -> str:
+    from tools.delegation_jobs import list_jobs
+
+    jobs = list_jobs(
+        status=status,
+        profile=profile,
+        parent_session_id=parent_session_id,
+        limit=int(limit or 50),
+    )
+    return json.dumps({"jobs": jobs, "count": len(jobs)}, ensure_ascii=False)
+
+
+def delegate_wait(
+    job_ids: Any,
+    timeout: float = 0,
+    timeout_seconds: Optional[float] = None,
+    parent_agent=None,
+) -> str:
+    from tools.delegation_jobs import wait_jobs
+
+    ids = _normalize_string_list(job_ids)
+    effective_timeout = timeout_seconds if timeout_seconds is not None else timeout
+    return json.dumps(wait_jobs(ids, timeout=float(effective_timeout or 0)), ensure_ascii=False)
+
+
+def delegate_result(job_id: str, tail_chars: int = 12000, parent_agent=None) -> str:
+    from tools.delegation_jobs import get_result
+
+    return json.dumps(
+        get_result(str(job_id), tail_chars=int(tail_chars or 12000)),
+        ensure_ascii=False,
+    )
+
+
+def delegate_cancel(job_ids: Any = None, job_id: Optional[str] = None, parent_agent=None) -> str:
+    from tools.delegation_jobs import cancel_jobs
+
+    target_ids = job_ids if job_ids not in (None, "", []) else job_id
+    return json.dumps(cancel_jobs(_normalize_string_list(target_ids)), ensure_ascii=False)
+
+
+def delegate_message(job_id: str, message: str, parent_agent=None) -> str:
+    return json.dumps(
+        {
+            "job_id": job_id,
+            "supported": False,
+            "error": "delegate_message is not supported for subprocess delegation jobs yet.",
+        },
+        ensure_ascii=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -2579,6 +2904,31 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": "Hermes profile for this child. Profile-routed children run as subprocess jobs.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Per-task model override.",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Per-task provider override.",
+                        },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Skills to preload for this child.",
+                        },
+                        "resume": {
+                            "type": "string",
+                            "description": "Child session id to resume.",
+                        },
+                        "pass_session_id": {
+                            "type": "boolean",
+                            "description": "Pass the parent session id through to the child runtime when supported.",
+                        },
                         "sandbox": {
                             "type": "string",
                             "description": "Per-task sandbox override: 'inherit', 'host', or a provider name such as 'openshell'.",
@@ -2620,6 +2970,35 @@ DELEGATE_TASK_SCHEMA = {
                     "max_spawn_depth or when "
                     "delegation.orchestrator_enabled=false."
                 ),
+            },
+            "async": {
+                "type": "boolean",
+                "description": "When true, start subprocess-backed delegation jobs and return job ids immediately. When false, use legacy blocking in-process delegation unless a profile override requires a subprocess.",
+            },
+            "profile": {
+                "type": "string",
+                "description": "Hermes profile for child jobs. Profile-routed children always use subprocess jobs.",
+            },
+            "model": {
+                "type": "string",
+                "description": "Model override for async child jobs.",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Provider override for async child jobs.",
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Skills to preload for async child jobs.",
+            },
+            "resume": {
+                "type": "string",
+                "description": "Child session id to resume.",
+            },
+            "pass_session_id": {
+                "type": "boolean",
+                "description": "Pass the parent session id through to the child runtime when supported.",
             },
             "acp_command": {
                 "type": "string",
@@ -2664,6 +3043,103 @@ DELEGATE_TASK_SCHEMA = {
 }
 
 
+DELEGATE_START_SCHEMA = {
+    "name": "delegate_start",
+    "description": (
+        "Start one or more async delegation jobs and return job ids immediately. "
+        "Supports the same goal/tasks/profile/model/provider/toolsets/sandbox fields as delegate_task."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            key: value
+            for key, value in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()
+            if key not in {"async", "acp_command", "acp_args"}
+        },
+        "required": [],
+    },
+}
+
+DELEGATE_STATUS_SCHEMA = {
+    "name": "delegate_status",
+    "description": "List active or recent async delegation jobs.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "status": {"type": "string", "description": "Optional status filter."},
+            "profile": {"type": "string", "description": "Optional profile filter."},
+            "parent_session_id": {"type": "string", "description": "Optional parent session filter."},
+            "limit": {"type": "integer", "description": "Maximum jobs to return.", "default": 50},
+        },
+        "required": [],
+    },
+}
+
+DELEGATE_WAIT_SCHEMA = {
+    "name": "delegate_wait",
+    "description": "Wait for one or more async delegation jobs to complete.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "job_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Job ids to wait for.",
+            },
+            "timeout": {"type": "number", "description": "Seconds to wait.", "default": 0},
+            "timeout_seconds": {
+                "type": "number",
+                "description": "Alias for timeout, accepted for compatibility.",
+                "default": 0,
+            },
+        },
+        "required": ["job_ids"],
+    },
+}
+
+DELEGATE_RESULT_SCHEMA = {
+    "name": "delegate_result",
+    "description": "Fetch a delegation job result, progress metadata, and stdout/stderr tails.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "job_id": {"type": "string", "description": "Job id."},
+            "tail_chars": {"type": "integer", "description": "Maximum log tail characters.", "default": 12000},
+        },
+        "required": ["job_id"],
+    },
+}
+
+DELEGATE_CANCEL_SCHEMA = {
+    "name": "delegate_cancel",
+    "description": "Cancel one or more async delegation jobs.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "job_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Job ids to cancel.",
+            }
+        },
+        "required": ["job_ids"],
+    },
+}
+
+DELEGATE_MESSAGE_SCHEMA = {
+    "name": "delegate_message",
+    "description": "Send a steer/message to a running delegation job when supported.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "job_id": {"type": "string", "description": "Job id."},
+            "message": {"type": "string", "description": "Message to send."},
+        },
+        "required": ["job_id", "message"],
+    },
+}
+
+
 # --- Registry ---
 from tools.registry import registry, tool_error
 
@@ -2680,6 +3156,13 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        async_mode=args.get("async"),
+        profile=args.get("profile"),
+        model=args.get("model"),
+        provider=args.get("provider"),
+        skills=args.get("skills"),
+        resume=args.get("resume"),
+        pass_session_id=args.get("pass_session_id"),
         sandbox=args.get("sandbox"),
         sandbox_mode=args.get("sandbox_mode"),
         sandbox_scope=args.get("sandbox_scope"),
@@ -2688,4 +3171,98 @@ registry.register(
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",
+)
+
+registry.register(
+    name="delegate_start",
+    toolset="delegation",
+    schema=DELEGATE_START_SCHEMA,
+    handler=lambda args, **kw: delegate_start(
+        goal=args.get("goal"),
+        context=args.get("context"),
+        toolsets=args.get("toolsets"),
+        tasks=args.get("tasks"),
+        role=args.get("role"),
+        profile=args.get("profile"),
+        model=args.get("model"),
+        provider=args.get("provider"),
+        skills=args.get("skills"),
+        resume=args.get("resume"),
+        pass_session_id=args.get("pass_session_id"),
+        sandbox=args.get("sandbox"),
+        sandbox_mode=args.get("sandbox_mode"),
+        sandbox_scope=args.get("sandbox_scope"),
+        sandbox_source=args.get("sandbox_source"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_requirements,
+    emoji="⚡",
+)
+
+registry.register(
+    name="delegate_status",
+    toolset="delegation",
+    schema=DELEGATE_STATUS_SCHEMA,
+    handler=lambda args, **kw: delegate_status(
+        status=args.get("status"),
+        profile=args.get("profile"),
+        parent_session_id=args.get("parent_session_id"),
+        limit=args.get("limit") or 50,
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_requirements,
+    emoji="⚡",
+)
+
+registry.register(
+    name="delegate_wait",
+    toolset="delegation",
+    schema=DELEGATE_WAIT_SCHEMA,
+    handler=lambda args, **kw: delegate_wait(
+        job_ids=args.get("job_ids") or [],
+        timeout=args.get("timeout") or 0,
+        timeout_seconds=args.get("timeout_seconds"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_requirements,
+    emoji="⚡",
+)
+
+registry.register(
+    name="delegate_result",
+    toolset="delegation",
+    schema=DELEGATE_RESULT_SCHEMA,
+    handler=lambda args, **kw: delegate_result(
+        job_id=args.get("job_id") or "",
+        tail_chars=args.get("tail_chars") or 12000,
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_requirements,
+    emoji="⚡",
+)
+
+registry.register(
+    name="delegate_cancel",
+    toolset="delegation",
+    schema=DELEGATE_CANCEL_SCHEMA,
+    handler=lambda args, **kw: delegate_cancel(
+        job_ids=args.get("job_ids"),
+        job_id=args.get("job_id"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_requirements,
+    emoji="⚡",
+)
+
+registry.register(
+    name="delegate_message",
+    toolset="delegation",
+    schema=DELEGATE_MESSAGE_SCHEMA,
+    handler=lambda args, **kw: delegate_message(
+        job_id=args.get("job_id") or "",
+        message=args.get("message") or "",
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_requirements,
+    emoji="⚡",
 )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -322,6 +322,168 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _normalize_sandbox_request(value: Optional[str]) -> Optional[str]:
+    if value is None or value == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in ("inherit", "default", "auto"):
+        return None
+    if normalized in ("0", "false", "no", "off", "host", "local", "none"):
+        return "host"
+    if normalized in ("1", "true", "yes", "on", "sandbox"):
+        return "openshell"
+    return str(value).strip()
+
+
+def _load_full_config() -> dict:
+    try:
+        from cli import CLI_CONFIG
+
+        if isinstance(CLI_CONFIG, dict) and CLI_CONFIG:
+            return CLI_CONFIG
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config()
+    except Exception:
+        return {}
+
+
+def _env_or_config(env_var: str, cfg: Dict[str, Any], key: str, default: Any = "") -> Any:
+    value = os.getenv(env_var)
+    if value not in (None, ""):
+        return value
+    return cfg.get(key, default)
+
+
+def _env_list_or_config(env_var: str, cfg: Dict[str, Any], key: str, default: Any = None) -> Any:
+    value = os.getenv(env_var)
+    if value in (None, ""):
+        return cfg.get(key, default if default is not None else [])
+    stripped = value.strip()
+    if stripped.startswith("["):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    return [part.strip() for part in stripped.split(",") if part.strip()]
+
+
+def _env_int_or_config(env_var: str, cfg: Dict[str, Any], key: str, default: int) -> int:
+    value = os.getenv(env_var)
+    if value not in (None, ""):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    try:
+        return int(cfg.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_child_sandbox_override(
+    task: Dict[str, Any],
+    top_sandbox: Optional[str],
+    top_sandbox_mode: Optional[str],
+    top_sandbox_scope: Optional[str],
+    top_sandbox_source: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Resolve delegate_task sandbox override into task env overrides.
+
+    ``None`` means inherit the process/global terminal configuration.
+    """
+
+    requested = task.get("sandbox") if "sandbox" in task else top_sandbox
+    provider = _normalize_sandbox_request(requested)
+
+    full_cfg = _load_full_config()
+    sandbox_cfg = full_cfg.get("sandbox", {}) if isinstance(full_cfg, dict) else {}
+    if not provider:
+        default = os.getenv(
+            "HERMES_SANDBOX_DELEGATION_DEFAULT",
+            str(sandbox_cfg.get("delegation_default", "inherit")) if isinstance(sandbox_cfg, dict) else "inherit",
+        ).strip().lower()
+        if default in ("inherit", "", "default"):
+            return None
+        if default == "host":
+            provider = "host"
+        elif default == "sandbox":
+            provider = str(sandbox_cfg.get("provider") or os.getenv("HERMES_SANDBOX_PROVIDER") or "openshell")
+        else:
+            provider = default
+
+    if provider == "host":
+        return {
+            "env_type": "local",
+            "sandbox_config": {"enabled": False, "provider": "host"},
+        }
+
+    mode = (
+        task.get("sandbox_mode")
+        or top_sandbox_mode
+        or os.getenv("HERMES_SANDBOX_MODE")
+        or (sandbox_cfg.get("mode") if isinstance(sandbox_cfg, dict) else None)
+        or "mirror"
+    )
+    scope = task.get("sandbox_scope") or top_sandbox_scope or ""
+    source = (
+        task.get("sandbox_source")
+        or top_sandbox_source
+        or os.getenv("HERMES_SANDBOX_SOURCE")
+        or os.getenv("HERMES_OPENSHELL_SOURCE")
+        or ""
+    )
+    openshell_cfg = {}
+    if isinstance(sandbox_cfg, dict) and isinstance(sandbox_cfg.get("openshell"), dict):
+        openshell_cfg = dict(sandbox_cfg.get("openshell") or {})
+    config = {
+        "enabled": True,
+        "provider": provider,
+        "mode": mode,
+        "scope": scope,
+        "source": source or openshell_cfg.get("from") or openshell_cfg.get("source") or "",
+        "command": _env_or_config("HERMES_OPENSHELL_COMMAND", openshell_cfg, "command", "openshell"),
+        "policy": _env_or_config("HERMES_OPENSHELL_POLICY", openshell_cfg, "policy", ""),
+        "providers": _env_list_or_config("HERMES_OPENSHELL_PROVIDERS", openshell_cfg, "providers", []),
+        "auto_providers": is_truthy_value(
+            os.getenv("HERMES_OPENSHELL_AUTO_PROVIDERS"),
+            default=bool(openshell_cfg.get("auto_providers", True)),
+        ),
+        "gpu": is_truthy_value(
+            os.getenv("HERMES_OPENSHELL_GPU"),
+            default=bool(openshell_cfg.get("gpu", False)),
+        ),
+        "gateway": _env_or_config("HERMES_OPENSHELL_GATEWAY", openshell_cfg, "gateway", "hermes-openshell"),
+        "gateway_endpoint": _env_or_config("HERMES_OPENSHELL_GATEWAY_ENDPOINT", openshell_cfg, "gateway_endpoint", ""),
+        "gateway_port": _env_int_or_config("HERMES_OPENSHELL_GATEWAY_PORT", openshell_cfg, "gateway_port", 18080),
+        "gateway_host": _env_or_config("HERMES_OPENSHELL_GATEWAY_HOST", openshell_cfg, "gateway_host", ""),
+        "remote_workspace_dir": _env_or_config(
+            "HERMES_SANDBOX_REMOTE_WORKSPACE_DIR", openshell_cfg, "remote_workspace_dir", "/sandbox"
+        ),
+        "remote_agent_workspace_dir": _env_or_config(
+            "HERMES_SANDBOX_REMOTE_AGENT_WORKSPACE_DIR", openshell_cfg, "remote_agent_workspace_dir", "/agent"
+        ),
+        "timeout_seconds": _env_int_or_config("HERMES_SANDBOX_TIMEOUT_SECONDS", openshell_cfg, "timeout_seconds", 120),
+        "mirror_excludes": _env_list_or_config(
+            "HERMES_SANDBOX_MIRROR_EXCLUDES",
+            openshell_cfg,
+            "mirror_excludes",
+            [".git", ".hermes", "node_modules", ".venv", "dist", "build", "target"],
+        ),
+        "extra_syncs": _env_or_config("HERMES_SANDBOX_EXTRA_SYNCS", openshell_cfg, "extra_syncs", []),
+    }
+    return {
+        "env_type": provider,
+        "cwd": str(config["remote_workspace_dir"]),
+        "sandbox_config": config,
+    }
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -1380,6 +1542,8 @@ def _run_single_child(
             }
         )
 
+    child_task_id = None
+    _registered_env_override = False
     try:
         if child_progress_cb:
             try:
@@ -1394,6 +1558,15 @@ def _run_single_child(
         import uuid as _uuid
 
         child_task_id = _subagent_id or f"subagent-{task_index}-{_uuid.uuid4().hex[:8]}"
+        sandbox_override = getattr(child, "_delegate_sandbox_override", None)
+        if isinstance(sandbox_override, dict) and sandbox_override:
+            try:
+                from tools.terminal_tool import register_task_env_overrides
+
+                register_task_env_overrides(child_task_id, sandbox_override)
+                _registered_env_override = True
+            except Exception as exc:
+                logger.debug("Failed to register subagent sandbox override: %s", exc)
         parent_task_id = getattr(parent_agent, "_current_task_id", None)
         wall_start = time.time()
         parent_reads_snapshot = (
@@ -1788,6 +1961,14 @@ def _run_single_child(
         except Exception:
             logger.debug("Failed to close child agent after delegation")
 
+        if _registered_env_override and child_task_id:
+            try:
+                from tools.terminal_tool import clear_task_env_overrides
+
+                clear_task_env_overrides(child_task_id)
+            except Exception:
+                pass
+
 
 def delegate_task(
     goal: Optional[str] = None,
@@ -1798,6 +1979,10 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    sandbox: Optional[str] = None,
+    sandbox_mode: Optional[str] = None,
+    sandbox_scope: Optional[str] = None,
+    sandbox_source: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1944,6 +2129,13 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+            )
+            child._delegate_sandbox_override = _resolve_child_sandbox_override(
+                t,
+                sandbox,
+                sandbox_mode,
+                sandbox_scope,
+                sandbox_source,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2387,6 +2579,23 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "sandbox": {
+                            "type": "string",
+                            "description": "Per-task sandbox override: 'inherit', 'host', or a provider name such as 'openshell'.",
+                        },
+                        "sandbox_mode": {
+                            "type": "string",
+                            "enum": ["mirror", "remote"],
+                            "description": "Per-task sandbox workspace mode when the provider supports it.",
+                        },
+                        "sandbox_scope": {
+                            "type": "string",
+                            "description": "Stable per-task sandbox scope/name seed for provider runtime reuse.",
+                        },
+                        "sandbox_source": {
+                            "type": "string",
+                            "description": "Per-task provider source override, e.g. OpenShell --from source.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2429,6 +2638,26 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
                 ),
             },
+            "sandbox": {
+                "type": "string",
+                "description": (
+                    "Sandbox override for spawned subagents: 'inherit' (default), "
+                    "'host'/'local' for host execution, or a provider name such as 'openshell'."
+                ),
+            },
+            "sandbox_mode": {
+                "type": "string",
+                "enum": ["mirror", "remote"],
+                "description": "Sandbox workspace mode for spawned subagents when the provider supports it.",
+            },
+            "sandbox_scope": {
+                "type": "string",
+                "description": "Stable sandbox scope/name seed for spawned subagents.",
+            },
+            "sandbox_source": {
+                "type": "string",
+                "description": "Provider source override, e.g. OpenShell --from source.",
+            },
         },
         "required": [],
     },
@@ -2451,6 +2680,10 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        sandbox=args.get("sandbox"),
+        sandbox_mode=args.get("sandbox_mode"),
+        sandbox_scope=args.get("sandbox_scope"),
+        sandbox_source=args.get("sandbox_source"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegation_jobs.py
+++ b/tools/delegation_jobs.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""Async delegation job manager.
+
+The manager is intentionally file-backed so operator commands can inspect jobs
+outside the parent agent turn.  Running processes are tracked in-memory when
+this process started them; persisted metadata carries enough pid/path state for
+CLI inspection and best-effort cancellation from a later process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+_ACTIVE_LOCK = threading.Lock()
+_ACTIVE_JOBS: Dict[str, Dict[str, Any]] = {}
+_RESULT_STATUSES = {"completed", "failed", "error", "timeout", "cancelled", "interrupted"}
+_DEFAULT_TAIL_CHARS = 12000
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _utc_id() -> str:
+    return time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+
+
+def jobs_root() -> Path:
+    from hermes_constants import get_hermes_home
+
+    root = get_hermes_home() / "delegation" / "jobs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def job_dir(job_id: str) -> Path:
+    return jobs_root() / job_id
+
+
+def _json_path(job_id: str) -> Path:
+    return job_dir(job_id) / "job.json"
+
+
+def _read_json(path: Path, default: Any = None) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def _write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    os.replace(tmp, path)
+
+
+def _update_job(job_id: str, **updates: Any) -> Dict[str, Any]:
+    path = _json_path(job_id)
+    data = _read_json(path, {}) or {}
+    data.update(updates)
+    data["updated_at"] = _now()
+    _write_json(path, data)
+    return data
+
+
+def _tail_file(path: Path, max_chars: int = _DEFAULT_TAIL_CHARS) -> str:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _is_pid_alive(pid: Optional[int]) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except Exception:
+        return False
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from cli import CLI_CONFIG
+
+        cfg = CLI_CONFIG.get("delegation", {})
+        if isinstance(cfg, dict) and cfg:
+            return cfg
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import load_config
+
+        full = load_config()
+        cfg = full.get("delegation", {})
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name()
+    except Exception:
+        return "default"
+
+
+def _resolve_profile(task: Dict[str, Any], cfg: Dict[str, Any], top_profile: Optional[str]) -> tuple[str, bool, str]:
+    """Return (profile_name, explicit, hermes_home)."""
+    requested = (
+        task.get("profile")
+        if task.get("profile") not in (None, "")
+        else top_profile if top_profile not in (None, "") else cfg.get("default_profile", "")
+    )
+    explicit = bool(str(requested or "").strip())
+    profile = str(requested).strip() if explicit else _active_profile_name()
+    if profile in ("inherit", "current"):
+        profile = _active_profile_name()
+        explicit = False
+
+    if profile == "custom" and not explicit:
+        hermes_home = os.environ.get("HERMES_HOME", "").strip()
+        if not hermes_home:
+            raise ValueError("Active Hermes profile is custom but HERMES_HOME is not set.")
+        return profile, False, hermes_home
+
+    try:
+        from hermes_cli.profiles import profile_exists, resolve_profile_env, validate_profile_name
+
+        validate_profile_name(profile)
+        if not profile_exists(profile):
+            raise ValueError(
+                f"Profile '{profile}' does not exist. Create it with: hermes profile create {profile}"
+            )
+        allowed = cfg.get("allowed_profiles") or []
+        if isinstance(allowed, str):
+            allowed = [p.strip() for p in allowed.split(",") if p.strip()]
+        if allowed and profile not in set(str(p) for p in allowed):
+            raise ValueError(
+                f"Profile '{profile}' is not allowed for delegation. "
+                "Update delegation.allowed_profiles in config.yaml."
+            )
+        hermes_home = resolve_profile_env(profile)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"Cannot resolve delegation profile '{profile}': {exc}") from exc
+    return profile, explicit, hermes_home
+
+
+def _hermes_command() -> List[str]:
+    raw = os.getenv("HERMES_DELEGATE_COMMAND", "").strip()
+    if raw:
+        import shlex
+
+        return shlex.split(raw)
+    hermes = shutil.which("hermes")
+    if hermes:
+        return [hermes]
+    project_root = Path(__file__).resolve().parents[1]
+    return [sys.executable, str(project_root / "hermes_cli" / "main.py")]
+
+
+def _normalize_approval_mode(value: Any) -> str:
+    mode = str(value or "").strip().lower()
+    if mode in {"allow", "allowed", "approve", "approved"}:
+        return "approve"
+    if mode in {"deny", "denied", "block", "blocked"}:
+        return "deny"
+    if mode in {"inherit", "parent", "manual", ""}:
+        return "inherit" if mode else "deny"
+    return "deny"
+
+
+def _resolve_approval_mode(task: Dict[str, Any], cfg: Dict[str, Any]) -> str:
+    if task.get("approval_mode") not in (None, ""):
+        return _normalize_approval_mode(task.get("approval_mode"))
+    return _normalize_approval_mode(cfg.get("approval_mode", "deny"))
+
+
+def _bridge_managed_tool_gateway_env(env: Dict[str, str]) -> None:
+    """Pass managed-tool gateway auth explicitly to subprocess children.
+
+    Children may run under a different profile/HERMES_HOME, so relying on them
+    to rediscover the parent's Nous auth store is brittle.  We only bridge when
+    the parent process can already prove managed tools are available.
+    """
+    if env.get("TOOL_GATEWAY_USER_TOKEN", "").strip():
+        env["HERMES_MANAGED_TOOLS_ENABLED"] = "1"
+        return
+
+    try:
+        from tools.managed_tool_gateway import read_nous_access_token
+        from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+        if not managed_nous_tools_enabled():
+            return
+        token = read_nous_access_token()
+    except Exception:
+        return
+
+    if token:
+        env["TOOL_GATEWAY_USER_TOKEN"] = str(token)
+        env["HERMES_MANAGED_TOOLS_ENABLED"] = "1"
+
+
+def _build_subprocess_argv(
+    *,
+    profile: str,
+    explicit_profile: bool,
+    request_path: Path,
+    output_path: Path,
+) -> List[str]:
+    argv = _hermes_command()
+    # If a profile was explicitly requested, keep it explicit in argv.  For
+    # inherited/default profile jobs, HERMES_HOME in the env is enough and avoids
+    # surprising the sticky-profile pre-parser.
+    if explicit_profile or profile != _active_profile_name():
+        argv.extend(["--profile", profile])
+    argv.extend(
+        [
+            "chat",
+            "-Q",
+            "--source",
+            "tool",
+            "--delegate-request",
+            str(request_path),
+            "--delegate-output",
+            str(output_path),
+        ]
+    )
+    return argv
+
+
+def _normalize_status_from_output(output: Dict[str, Any], returncode: int) -> str:
+    raw_status = str(output.get("status") or "")
+    if returncode != 0:
+        if raw_status in {"cancelled", "interrupted", "timeout"}:
+            return raw_status
+        return "failed"
+    if raw_status in _RESULT_STATUSES:
+        return raw_status
+    if output.get("failed") or output.get("error"):
+        return "failed"
+    return "completed"
+
+
+def _watch_subprocess(
+    job_id: str,
+    process: subprocess.Popen,
+    *,
+    stdout_file,
+    stderr_file,
+    output_path: Path,
+    parent_agent=None,
+    task_goal: str = "",
+) -> None:
+    try:
+        returncode = process.wait()
+    finally:
+        try:
+            stdout_file.close()
+        except Exception:
+            pass
+        try:
+            stderr_file.close()
+        except Exception:
+            pass
+
+    output = _read_json(output_path, {}) or {}
+    stdout_tail = _tail_file(job_dir(job_id) / "stdout.log")
+    stderr_tail = _tail_file(job_dir(job_id) / "stderr.log")
+    status = _normalize_status_from_output(output, returncode)
+    finished = _now()
+
+    result = {
+        "job_id": job_id,
+        "status": status,
+        "returncode": returncode,
+        "final_response": output.get("final_response") or stdout_tail.strip(),
+        "child_session_id": output.get("session_id") or "",
+        "error": output.get("error") or (stderr_tail.strip() if returncode else ""),
+        "stdout_tail": stdout_tail,
+        "stderr_tail": stderr_tail,
+        "finished_at": finished,
+    }
+    _write_json(job_dir(job_id) / "result.json", result)
+    meta = _update_job(
+        job_id,
+        status=status,
+        returncode=returncode,
+        finished_at=finished,
+        child_session_id=result["child_session_id"],
+        result_path=str(job_dir(job_id) / "result.json"),
+    )
+
+    with _ACTIVE_LOCK:
+        _ACTIVE_JOBS.pop(job_id, None)
+
+    parent_cb = getattr(parent_agent, "tool_progress_callback", None)
+    if parent_cb:
+        try:
+            parent_cb(
+                "subagent.complete",
+                preview=(result.get("final_response") or result.get("error") or "")[:160],
+                status=status,
+                duration_seconds=round(finished - float(meta.get("started_at") or finished), 2),
+                summary=(result.get("final_response") or result.get("error") or "")[:500],
+                subagent_id=job_id,
+                job_id=job_id,
+                profile=meta.get("profile"),
+                child_session_id=result["child_session_id"],
+            )
+        except Exception:
+            pass
+
+    try:
+        memory = getattr(parent_agent, "_memory_manager", None)
+        if memory:
+            memory.on_delegation(
+                task=task_goal,
+                result=result.get("final_response") or "",
+                child_session_id=result.get("child_session_id") or "",
+            )
+    except Exception:
+        pass
+
+
+def start_jobs(
+    tasks: List[Dict[str, Any]],
+    *,
+    parent_agent=None,
+    top_profile: Optional[str] = None,
+    cwd: Optional[str] = None,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Start async delegation jobs and return a model-facing summary."""
+    cfg = dict(cfg or _load_config())
+    parent_session_id = str(getattr(parent_agent, "session_id", "") or "")
+    parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
+    cwd = cwd or os.getenv("TERMINAL_CWD") or os.getcwd()
+    job_ids: List[str] = []
+
+    for index, task in enumerate(tasks):
+        job_id = f"job-{_utc_id()}-{uuid.uuid4().hex[:8]}"
+        jdir = job_dir(job_id)
+        jdir.mkdir(parents=True, exist_ok=True)
+
+        profile, explicit_profile, hermes_home = _resolve_profile(task, cfg, top_profile)
+        approval_mode = _resolve_approval_mode(task, cfg)
+        request_path = jdir / "request.json"
+        output_path = jdir / "output.json"
+        stdout_path = jdir / "stdout.log"
+        stderr_path = jdir / "stderr.log"
+
+        request = dict(task)
+        request.update(
+            {
+                "job_id": job_id,
+                "task_index": index,
+                "parent_session_id": parent_session_id,
+                "parent_subagent_id": parent_subagent_id,
+                "profile": profile,
+                "cwd": cwd,
+            }
+        )
+        _write_json(request_path, request)
+
+        argv = _build_subprocess_argv(
+            profile=profile,
+            explicit_profile=explicit_profile,
+            request_path=request_path,
+            output_path=output_path,
+        )
+        started = _now()
+        meta = {
+            "job_id": job_id,
+            "status": "starting",
+            "runner": "subprocess",
+            "created_at": started,
+            "started_at": started,
+            "updated_at": started,
+            "parent_session_id": parent_session_id,
+            "parent_subagent_id": parent_subagent_id,
+            "child_session_id": "",
+            "profile": profile,
+            "explicit_profile": explicit_profile,
+            "goal": str(task.get("goal") or ""),
+            "role": str(task.get("role") or "leaf"),
+            "model": task.get("model") or "",
+            "provider": task.get("provider") or "",
+            "sandbox": task.get("sandbox") or "",
+            "sandbox_mode": task.get("sandbox_mode") or "",
+            "sandbox_scope": task.get("sandbox_scope") or "",
+            "approval_mode": approval_mode,
+            "cwd": cwd,
+            "request_path": str(request_path),
+            "output_path": str(output_path),
+            "stdout_path": str(stdout_path),
+            "stderr_path": str(stderr_path),
+            "argv": argv,
+        }
+        _write_json(_json_path(job_id), meta)
+
+        env = os.environ.copy()
+        env["HERMES_HOME"] = hermes_home
+        env["HERMES_DELEGATE_JOB_ID"] = job_id
+        if approval_mode != "inherit":
+            env["HERMES_DELEGATE_APPROVAL_MODE"] = approval_mode
+            if approval_mode == "deny":
+                env.pop("HERMES_YOLO_MODE", None)
+            elif approval_mode == "approve":
+                env["HERMES_YOLO_MODE"] = "1"
+        else:
+            env.pop("HERMES_DELEGATE_APPROVAL_MODE", None)
+        _bridge_managed_tool_gateway_env(env)
+        if parent_session_id:
+            env["HERMES_DELEGATE_PARENT_SESSION_ID"] = parent_session_id
+
+        stdout_file = stdout_path.open("w", encoding="utf-8")
+        stderr_file = stderr_path.open("w", encoding="utf-8")
+        try:
+            process = subprocess.Popen(
+                argv,
+                cwd=cwd,
+                env=env,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                text=True,
+                start_new_session=True,
+            )
+        except Exception as exc:
+            try:
+                stdout_file.close()
+                stderr_file.close()
+            except Exception:
+                pass
+            failed = _update_job(job_id, status="failed", error=str(exc), finished_at=_now())
+            _write_json(
+                jdir / "result.json",
+                {
+                    "job_id": job_id,
+                    "status": "failed",
+                    "error": str(exc),
+                    "final_response": "",
+                    "child_session_id": "",
+                },
+            )
+            job_ids.append(job_id)
+            continue
+
+        _update_job(job_id, status="running", pid=process.pid)
+        with _ACTIVE_LOCK:
+            _ACTIVE_JOBS[job_id] = {
+                "job_id": job_id,
+                "process": process,
+                "parent_agent": parent_agent,
+                "started_at": started,
+            }
+
+        parent_cb = getattr(parent_agent, "tool_progress_callback", None)
+        if parent_cb:
+            try:
+                parent_cb(
+                    "subagent.start",
+                    preview=str(task.get("goal") or ""),
+                    subagent_id=job_id,
+                    job_id=job_id,
+                    parent_id=parent_subagent_id,
+                    depth=max(0, int(task.get("child_depth") or 1) - 1),
+                    profile=profile,
+                    status="running",
+                    model=task.get("model") or "",
+                    toolsets=list(task.get("toolsets") or []),
+                    role=task.get("role") or "leaf",
+                )
+            except Exception:
+                pass
+
+        watcher = threading.Thread(
+            target=_watch_subprocess,
+            args=(job_id, process),
+            kwargs={
+                "stdout_file": stdout_file,
+                "stderr_file": stderr_file,
+                "output_path": output_path,
+                "parent_agent": parent_agent,
+                "task_goal": str(task.get("goal") or ""),
+            },
+            daemon=True,
+            name=f"delegate-watch-{job_id}",
+        )
+        watcher.start()
+        with _ACTIVE_LOCK:
+            _ACTIVE_JOBS[job_id]["watcher"] = watcher
+        job_ids.append(job_id)
+
+    return {
+        "status": "running",
+        "job_ids": job_ids,
+        "jobs": [get_job(jid) for jid in job_ids],
+    }
+
+
+def _refresh_meta(meta: Dict[str, Any]) -> Dict[str, Any]:
+    status = str(meta.get("status") or "")
+    if status in _RESULT_STATUSES:
+        return meta
+    job_id = str(meta.get("job_id") or "")
+    result_path = Path(str(meta.get("result_path") or job_dir(job_id) / "result.json"))
+    if result_path.exists():
+        result = _read_json(result_path, {}) or {}
+        if result.get("status"):
+            meta["status"] = result.get("status")
+            meta["child_session_id"] = result.get("child_session_id") or meta.get("child_session_id", "")
+            _write_json(_json_path(job_id), meta)
+            return meta
+    pid = meta.get("pid")
+    if status in {"running", "starting", "cancelling"} and pid and not _is_pid_alive(int(pid)):
+        meta["status"] = "failed" if status != "cancelling" else "cancelled"
+        meta["finished_at"] = meta.get("finished_at") or _now()
+        meta["error"] = meta.get("error") or "Subprocess exited before writing a result."
+        _write_json(_json_path(job_id), meta)
+    return meta
+
+
+def get_job(job_id: str) -> Dict[str, Any]:
+    meta = _read_json(_json_path(job_id), {}) or {}
+    if meta:
+        meta = _refresh_meta(meta)
+    return meta
+
+
+def list_jobs(
+    *,
+    status: Optional[str] = None,
+    profile: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    metas: List[Dict[str, Any]] = []
+    root = jobs_root()
+    for path in sorted(root.glob("job-*/job.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        meta = _read_json(path, {}) or {}
+        if not meta:
+            continue
+        meta = _refresh_meta(meta)
+        if status and meta.get("status") != status:
+            continue
+        if profile and meta.get("profile") != profile:
+            continue
+        if parent_session_id and meta.get("parent_session_id") != parent_session_id:
+            continue
+        metas.append(meta)
+        if len(metas) >= limit:
+            break
+    return metas
+
+
+def wait_jobs(job_ids: Iterable[str], timeout: float = 0) -> Dict[str, Any]:
+    deadline = time.monotonic() + max(0.0, float(timeout or 0))
+    wanted = [str(j) for j in job_ids if str(j).strip()]
+    completed: List[Dict[str, Any]] = []
+    running: List[str] = []
+
+    while True:
+        completed.clear()
+        running.clear()
+        for jid in wanted:
+            meta = get_job(jid)
+            if not meta:
+                completed.append({"job_id": jid, "status": "missing", "error": "Job not found"})
+            elif meta.get("status") in _RESULT_STATUSES:
+                completed.append(get_result(jid))
+            else:
+                running.append(jid)
+        if not running or timeout == 0 or time.monotonic() >= deadline:
+            break
+        time.sleep(0.25)
+
+    return {"completed": completed, "running": running}
+
+
+def get_result(job_id: str, tail_chars: int = _DEFAULT_TAIL_CHARS) -> Dict[str, Any]:
+    meta = get_job(job_id)
+    if not meta:
+        return {"job_id": job_id, "status": "missing", "error": "Job not found"}
+    result = _read_json(job_dir(job_id) / "result.json", {}) or {}
+    stdout_path = Path(str(meta.get("stdout_path") or job_dir(job_id) / "stdout.log"))
+    stderr_path = Path(str(meta.get("stderr_path") or job_dir(job_id) / "stderr.log"))
+    return {
+        "job": meta,
+        "result": result,
+        "stdout_tail": _tail_file(stdout_path, tail_chars),
+        "stderr_tail": _tail_file(stderr_path, tail_chars),
+    }
+
+
+def cancel_jobs(job_ids: Iterable[str], grace_seconds: float = 2.0) -> Dict[str, Any]:
+    cancelled: List[str] = []
+    missing: List[str] = []
+    errors: Dict[str, str] = {}
+    for jid in [str(j) for j in job_ids if str(j).strip()]:
+        meta = get_job(jid)
+        if not meta:
+            missing.append(jid)
+            continue
+        with _ACTIVE_LOCK:
+            runtime = _ACTIVE_JOBS.get(jid)
+        proc = runtime.get("process") if runtime else None
+        pid = int(meta.get("pid") or 0)
+        _update_job(jid, status="cancelling")
+        try:
+            if proc is not None and proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=grace_seconds)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            elif pid:
+                try:
+                    os.killpg(pid, signal.SIGTERM)
+                except Exception:
+                    os.kill(pid, signal.SIGTERM)
+            _update_job(jid, status="cancelled", finished_at=_now())
+            _write_json(
+                job_dir(jid) / "result.json",
+                {
+                    "job_id": jid,
+                    "status": "cancelled",
+                    "error": "Delegation job cancelled.",
+                    "final_response": "",
+                    "child_session_id": meta.get("child_session_id") or "",
+                },
+            )
+            cancelled.append(jid)
+        except Exception as exc:
+            errors[jid] = str(exc)
+            _update_job(jid, status="failed", error=str(exc), finished_at=_now())
+    return {"cancelled": cancelled, "missing": missing, "errors": errors}
+
+
+def list_active_jobs_as_subagents() -> List[Dict[str, Any]]:
+    active: List[Dict[str, Any]] = []
+    with _ACTIVE_LOCK:
+        ids = list(_ACTIVE_JOBS.keys())
+    for jid in ids:
+        meta = get_job(jid)
+        if not meta or meta.get("status") not in {"starting", "running", "cancelling"}:
+            continue
+        active.append(
+            {
+                "subagent_id": jid,
+                "job_id": jid,
+                "parent_id": meta.get("parent_subagent_id"),
+                "depth": max(0, int(meta.get("child_depth") or 1) - 1),
+                "goal": meta.get("goal") or "",
+                "model": meta.get("model") or None,
+                "profile": meta.get("profile") or None,
+                "started_at": meta.get("started_at"),
+                "status": meta.get("status"),
+                "tool_count": 0,
+                "runner": "subprocess",
+            }
+        )
+    return active
+
+
+def interrupt_job(job_id: str) -> bool:
+    result = cancel_jobs([job_id])
+    return job_id in result.get("cancelled", [])
+
+
+def prune_old_jobs(retention_hours: Optional[float] = None) -> int:
+    cfg = _load_config()
+    if retention_hours is None:
+        try:
+            retention_hours = float(cfg.get("job_retention_hours", 24))
+        except (TypeError, ValueError):
+            retention_hours = 24.0
+    cutoff = _now() - max(0.0, retention_hours) * 3600
+    count = 0
+    for meta in list_jobs(limit=10000):
+        if meta.get("status") not in _RESULT_STATUSES:
+            continue
+        finished = float(meta.get("finished_at") or meta.get("updated_at") or 0)
+        if finished and finished < cutoff:
+            shutil.rmtree(job_dir(meta["job_id"]), ignore_errors=True)
+            count += 1
+    return count

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -306,6 +306,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             config = _get_env_config()
             env_type = config["env_type"]
             overrides = _task_env_overrides.get(task_id, {})
+            env_type = overrides.get("env_type") or env_type
 
             if env_type == "docker":
                 image = overrides.get("docker_image") or config["docker_image"]
@@ -322,7 +323,9 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None
-            if env_type in ("docker", "singularity", "modal", "daytona"):
+            from tools.terminal_tool import _BUILTIN_ENV_TYPES, _task_sandbox_config
+
+            if env_type in ("docker", "singularity", "modal", "daytona") or env_type not in _BUILTIN_ENV_TYPES:
                 container_config = {
                     "container_cpu": config.get("container_cpu", 1),
                     "container_memory": config.get("container_memory", 5120),
@@ -331,6 +334,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "sandbox_config": _task_sandbox_config(config, overrides),
                 }
 
             ssh_config = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -775,6 +775,8 @@ _cleanup_running = False
 # Thread-safe because each task_id is unique per rollout.
 _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 
+_BUILTIN_ENV_TYPES = {"local", "docker", "singularity", "modal", "daytona", "ssh"}
+
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     """
@@ -821,11 +823,114 @@ def _parse_env_var(name: str, default: str, converter=int, type_label: str = "in
         )
 
 
+def _env_truthy(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_list(name: str) -> list[str]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed if str(item).strip()]
+        except json.JSONDecodeError:
+            pass
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _env_json_or_list(name: str) -> Any:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return _env_list(name)
+
+
+def _resolve_sandbox_request(raw_env_type: str) -> tuple[str, dict[str, Any]]:
+    """Resolve sandbox env aliases into an effective terminal backend."""
+
+    provider = os.getenv("HERMES_SANDBOX_PROVIDER", "host").strip() or "host"
+    request = os.getenv("HERMES_SANDBOX", "").strip()
+    enabled = _env_truthy("HERMES_SANDBOX_ENABLED", "false")
+    forced_host = False
+
+    if request:
+        normalized = request.lower()
+        if normalized in ("0", "false", "no", "off", "host", "local", "none"):
+            provider = "host"
+            enabled = False
+            forced_host = True
+        elif normalized in ("1", "true", "yes", "on", "sandbox"):
+            enabled = True
+            if provider.lower() in ("", "host", "local", "none"):
+                provider = "openshell"
+        else:
+            provider = request
+            enabled = True
+
+    if forced_host:
+        env_type = "local"
+    elif enabled and provider.lower() not in ("host", "local", "none"):
+        env_type = provider
+    else:
+        env_type = raw_env_type
+
+    remote_workspace = os.getenv("HERMES_SANDBOX_REMOTE_WORKSPACE_DIR", "/sandbox").strip() or "/sandbox"
+    remote_agent_workspace = (
+        os.getenv("HERMES_SANDBOX_REMOTE_AGENT_WORKSPACE_DIR", "/agent").strip()
+        or "/agent"
+    )
+    mode = os.getenv("HERMES_SANDBOX_MODE", "mirror").strip().lower() or "mirror"
+    if mode not in ("mirror", "remote"):
+        mode = "mirror"
+
+    source = (
+        os.getenv("HERMES_SANDBOX_SOURCE")
+        or os.getenv("HERMES_OPENSHELL_SOURCE")
+        or os.getenv("HERMES_OPENSHELL_FROM")
+        or ""
+    ).strip()
+
+    sandbox_config = {
+        "enabled": enabled,
+        "provider": provider,
+        "mode": mode,
+        "scope": os.getenv("HERMES_SANDBOX_SCOPE", "").strip(),
+        "source": source,
+        "command": os.getenv("HERMES_OPENSHELL_COMMAND", "openshell").strip() or "openshell",
+        "policy": os.getenv("HERMES_OPENSHELL_POLICY", "").strip(),
+        "providers": _env_list("HERMES_OPENSHELL_PROVIDERS"),
+        "auto_providers": _env_truthy("HERMES_OPENSHELL_AUTO_PROVIDERS", "true"),
+        "gpu": _env_truthy("HERMES_OPENSHELL_GPU", "false"),
+        "gateway": os.getenv("HERMES_OPENSHELL_GATEWAY", "hermes-openshell").strip(),
+        "gateway_endpoint": os.getenv("HERMES_OPENSHELL_GATEWAY_ENDPOINT", "").strip(),
+        "gateway_port": _parse_env_var(
+            "HERMES_OPENSHELL_GATEWAY_PORT", "18080", int, "integer"
+        ),
+        "gateway_host": os.getenv("HERMES_OPENSHELL_GATEWAY_HOST", "").strip(),
+        "remote_workspace_dir": remote_workspace,
+        "remote_agent_workspace_dir": remote_agent_workspace,
+        "timeout_seconds": _parse_env_var(
+            "HERMES_SANDBOX_TIMEOUT_SECONDS", "120", int, "integer"
+        ),
+        "mirror_excludes": _env_list("HERMES_SANDBOX_MIRROR_EXCLUDES")
+        or [".git", ".hermes", "node_modules", ".venv", "dist", "build", "target"],
+        "extra_syncs": _env_json_or_list("HERMES_SANDBOX_EXTRA_SYNCS"),
+    }
+    return env_type, sandbox_config
+
+
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    raw_env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type, sandbox_config = _resolve_sandbox_request(raw_env_type)
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in ("true", "1", "yes")
 
@@ -836,6 +941,8 @@ def _get_env_config() -> Dict[str, Any]:
         default_cwd = os.getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
+    elif env_type not in _BUILTIN_ENV_TYPES:
+        default_cwd = sandbox_config["remote_workspace_dir"]
     else:
         default_cwd = "/root"
 
@@ -846,7 +953,15 @@ def _get_env_config() -> Dict[str, Any]:
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
-    if env_type == "docker" and mount_docker_cwd:
+    if env_type not in _BUILTIN_ENV_TYPES:
+        host_candidate = os.path.abspath(os.path.expanduser(os.getenv("TERMINAL_CWD") or os.getcwd()))
+        if os.path.isdir(host_candidate):
+            host_cwd = host_candidate
+        if sandbox_config["mode"] == "mirror":
+            cwd = sandbox_config["remote_workspace_dir"]
+        elif not cwd.startswith(sandbox_config["remote_workspace_dir"]):
+            cwd = sandbox_config["remote_workspace_dir"]
+    elif env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
@@ -897,7 +1012,16 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "sandbox_config": sandbox_config,
     }
+
+
+def _task_sandbox_config(config: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+    sandbox_config = dict(config.get("sandbox_config") or {})
+    override_config = overrides.get("sandbox_config")
+    if isinstance(override_config, dict):
+        sandbox_config.update(override_config)
+    return sandbox_config
 
 
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
@@ -1035,7 +1159,31 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         )
 
     else:
-        raise ValueError(f"Unknown environment type: {env_type}. Use 'local', 'docker', 'singularity', 'modal', 'daytona', or 'ssh'")
+        from agent.sandbox_provider import SandboxSpec
+        from plugins.sandbox import load_sandbox_provider
+
+        provider = load_sandbox_provider(env_type)
+        if provider is None:
+            raise ValueError(
+                f"Unknown environment type: {env_type}. Use 'local', 'docker', "
+                "'singularity', 'modal', 'daytona', 'ssh', or install a sandbox provider."
+            )
+        sandbox_config = cc.get("sandbox_config")
+        if not isinstance(sandbox_config, dict):
+            sandbox_config = _get_env_config().get("sandbox_config", {})
+        mode = str(sandbox_config.get("mode") or "mirror")
+        scope = str(sandbox_config.get("scope") or task_id or "default")
+        spec = SandboxSpec(
+            provider=env_type,
+            mode=mode,
+            task_id=task_id,
+            scope=scope,
+            cwd=cwd,
+            host_cwd=host_cwd or os.getcwd(),
+            timeout=timeout,
+            config=sandbox_config,
+        )
+        return provider.create_environment(spec)
 
 
 def _cleanup_inactive_envs(lifetime_seconds: int = 300):
@@ -1479,6 +1627,8 @@ def terminal_tool(
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config
         overrides = _task_env_overrides.get(effective_task_id, {})
+        env_type = overrides.get("env_type") or env_type
+        sandbox_config = _task_sandbox_config(config, overrides)
         
         # Select image based on env type, with per-task override support
         if env_type == "docker":
@@ -1565,7 +1715,7 @@ def terminal_tool(
                             }
 
                         container_config = None
-                        if env_type in ("docker", "singularity", "modal", "daytona"):
+                        if env_type in ("docker", "singularity", "modal", "daytona") or env_type not in _BUILTIN_ENV_TYPES:
                             container_config = {
                                 "container_cpu": config.get("container_cpu", 1),
                                 "container_memory": config.get("container_memory", 5120),
@@ -1576,6 +1726,7 @@ def terminal_tool(
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                                 "docker_forward_env": config.get("docker_forward_env", []),
                                 "docker_env": config.get("docker_env", {}),
+                                "sandbox_config": sandbox_config,
                             }
 
                         local_config = None
@@ -1992,12 +2143,17 @@ def check_terminal_requirements() -> bool:
             return os.getenv("DAYTONA_API_KEY") is not None
 
         else:
-            logger.error(
-                "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, ssh.",
-                env_type,
-            )
-            return False
+            from plugins.sandbox import load_sandbox_provider
+
+            provider = load_sandbox_provider(env_type)
+            if provider is None:
+                logger.error(
+                    "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
+                    "modal, daytona, ssh, or install a sandbox provider.",
+                    env_type,
+                )
+                return False
+            return provider.is_available()
     except Exception as e:
         logger.error("Terminal requirements check failed: %s", e, exc_info=True)
         return False

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -19,6 +19,13 @@ def managed_nous_tools_enabled() -> bool:
     the free tier.  We intentionally catch all exceptions and return
     False — never block the agent startup path.
     """
+    if (
+        os.getenv("HERMES_MANAGED_TOOLS_ENABLED", "").strip().lower()
+        in {"1", "true", "yes", "on"}
+        and os.getenv("TOOL_GATEWAY_USER_TOKEN", "").strip()
+    ):
+        return True
+
     try:
         from hermes_cli.auth import get_nous_auth_status
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -26,11 +26,21 @@ Usage:
 from typing import List, Dict, Any, Set, Optional
 
 
+_DELEGATION_TOOLS = [
+    "delegate_task",
+    "delegate_start",
+    "delegate_status",
+    "delegate_wait",
+    "delegate_result",
+    "delegate_cancel",
+]
+
+
 # Shared tool list for CLI and all messaging platform toolsets.
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "web_crawl", "crawl_status",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -53,7 +63,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", *_DELEGATION_TOOLS,
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -188,8 +198,8 @@ TOOLSETS = {
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Spawn and manage subagents with isolated context for complex subtasks",
+        "tools": _DELEGATION_TOOLS,
         "includes": []
     },
 
@@ -274,7 +284,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", *_DELEGATION_TOOLS,
         ],
         "includes": []
     },
@@ -302,7 +312,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", *_DELEGATION_TOOLS,
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1367,6 +1367,11 @@ Configure subagent behavior for the delegate tool:
 
 ```yaml
 delegation:
+  async_default: true                         # delegate_task returns job ids by default. Set false for legacy blocking behavior.
+  default_profile: ""                         # Child profile override (empty = inherit active profile)
+  allowed_profiles: []                        # Profiles allowed for delegation (empty = all profiles)
+  job_retention_hours: 24                     # Retain completed job metadata under ~/.hermes/delegation/jobs/
+  approval_mode: deny                         # Subprocess child command policy: deny, approve, or inherit
   # model: "google/gemini-3-flash-preview"  # Override model (empty = inherit parent)
   # provider: "openrouter"                  # Override provider (empty = inherit parent)
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
@@ -1377,6 +1382,8 @@ delegation:
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Async jobs and profiles:** By default, `delegate_task` starts file-backed delegation jobs and returns job ids immediately. Use `delegate_start`, `delegate_status`, `delegate_wait`, `delegate_result`, and `delegate_cancel` for explicit job control. Profile-selected children run in separate Hermes subprocesses with the requested profile via `--profile`, so profile-specific config, skills, memory, sandbox settings, and model/provider overrides stay isolated from the parent process.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -6,7 +6,7 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 # Subagent Delegation
 
-The `delegate_task` tool spawns child AIAgent instances with isolated context, restricted toolsets, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
+The `delegate_task` tool spawns child AIAgent instances with isolated context, restricted toolsets, and their own terminal sessions. Each child gets a fresh conversation and works independently. By default, delegation is file-backed and async: the parent receives job ids immediately, then uses `delegate_wait` or `delegate_result` to collect the final summaries.
 
 ## Single Task
 
@@ -29,6 +29,30 @@ delegate_task(tasks=[
     {"goal": "Fix the build", "toolsets": ["terminal", "file"]}
 ])
 ```
+
+## Async Job Control
+
+Async delegation persists job metadata under `~/.hermes/delegation/jobs/` so jobs can be inspected from the parent agent, the TUI, or the CLI.
+
+Model-callable job tools:
+
+- `delegate_start` — explicitly start one or more async jobs
+- `delegate_status` — list active or recent jobs
+- `delegate_wait` — wait for jobs to complete
+- `delegate_result` — fetch a final result and stdout/stderr tails
+- `delegate_cancel` — terminate running jobs
+
+Operator CLI:
+
+```bash
+hermes delegate list
+hermes delegate status JOB_ID
+hermes delegate wait JOB_ID
+hermes delegate cancel JOB_ID
+hermes delegate logs JOB_ID
+```
+
+Set `delegation.async_default: false` to restore legacy blocking `delegate_task` behavior for same-profile in-process children. Profile-selected children always run as subprocess jobs.
 
 ## How Subagent Context Works
 
@@ -119,15 +143,15 @@ delegate_task(
 
 ## Batch Mode Details
 
-When you provide a `tasks` array, subagents run in **parallel** using a thread pool:
+When you provide a `tasks` array, subagents run in **parallel** up to the configured concurrency cap:
 
 - **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
-- **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
-- **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback
+- **Runner:** Async/profile-routed delegation starts Hermes subprocess jobs. Legacy blocking same-profile delegation uses an in-process thread pool.
+- **Progress display:** CLI/TUI and gateway surfaces receive subagent/job progress events with job ids, profile, role, status, and child session ids when available.
 - **Result ordering:** Results are sorted by task index to match input order regardless of completion order
 - **Interrupt propagation:** Interrupting the parent (e.g., sending a new message) interrupts all active children
 
-Single-task delegation runs directly without thread pool overhead.
+Single-task async delegation still returns a job id; single-task legacy blocking delegation runs directly without thread pool overhead.
 
 ## Model Override
 
@@ -221,6 +245,11 @@ delegate_task(
 ```yaml
 # In ~/.hermes/config.yaml
 delegation:
+  async_default: true                       # delegate_task returns job ids immediately
+  default_profile: ""                       # Child profile override (empty = inherit active profile)
+  allowed_profiles: []                      # Profiles allowed for delegation (empty = all profiles)
+  job_retention_hours: 24                   # Retain completed job metadata
+  approval_mode: deny                       # Non-interactive child command policy: deny, approve, or inherit
   max_iterations: 50                        # Max turns per child (default: 50)
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # max_spawn_depth: 1                      # Tree depth (1-3, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3 for three levels.


### PR DESCRIPTION
## What does this PR do?

Adds a file-backed async delegation job layer so Hermes can start, inspect, wait for, cancel, and retrieve child-agent jobs without blocking the parent turn. Profile-selected children run as separate Hermes subprocesses with explicit request/output JSON files, preserving profile-level isolation while still supporting per-task model/provider/toolset/sandbox overrides.

The existing `delegate_task` surface stays compatible, but now routes to async jobs by default via config. Legacy blocking in-process delegation remains available with `async=false` / `delegation.async_default: false` for same-profile children.

## Related Issue

Fixes #9459

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tools/delegation_jobs.py`, a file-backed async job manager with persisted job/result/stdout/stderr metadata under `~/.hermes/delegation/jobs/`.
- Added `delegate_start`, `delegate_status`, `delegate_wait`, `delegate_result`, and `delegate_cancel` model-callable tools, plus `hermes delegate list/status/wait/cancel/logs` operator commands.
- Extended `delegate_task` with async/profile/model/provider/skills/resume/session/sandbox controls while preserving the existing synchronous path when async is disabled.
- Added subprocess child launch via JSON request/output files and `--profile` isolation instead of mutating parent process profile state.
- Added non-interactive subprocess approval policy propagation to avoid blocking child agents on terminal confirmation prompts.
- Propagated managed tool gateway auth to subprocess children when the parent already has valid managed-tool access.
- Updated default toolsets so platform presets expose the complete delegation tool surface without exposing unsupported `delegate_message` by default.
- Updated config examples and delegation docs for async jobs, profile routing, CLI job commands, and new delegation config keys.

## How to Test

1. `uv run --frozen python -m pytest -o addopts='' tests/tools/test_delegation_jobs.py tests/tools/test_delegate.py tests/tools/test_command_guards.py tests/tools/test_approval.py tests/tools/test_yolo_mode.py tests/tools/test_managed_tool_gateway.py tests/tools/test_web_tools_config.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_runtime_provider_resolution.py -q`
2. Start a parent Hermes session with `delegation.max_spawn_depth: 3` and call `delegate_task(role="orchestrator", ...)`; verify the orchestrator child can spawn leaf worker jobs and collect them with `delegate_wait`.
3. Run `hermes delegate list` and `hermes delegate status <job_id>` to inspect persisted job metadata.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python via `uv`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation on the rebased branch:

```text
464 passed, 2 warnings in 9.61s
```

Dogfood coverage confirmed nested orchestration through:

```text
parent -> orchestrator child -> parallel leaf grandchildren
parent -> orchestrator child -> orchestrator grandchildren -> leaf great-grandchildren
```

Known follow-ups intentionally left out of this PR:

- Shared/global auth fallback across profiles for web and managed tools.
- Live steering via `delegate_message`; the tool is registered but not exposed in the default delegation toolset.
- Early running-phase `child_session_id` population.
