### PR TITLE
feat: add review-specific delegation reasoning defaults

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -777,6 +777,8 @@ DEFAULT_CONFIG = {
                                        # raise if children time out before producing output.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "review_reasoning_effort": "",  # optional override for delegated review/code-review agents;
+                                        # same accepted values as reasoning_effort (empty = generic setting)
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Values are clamped to [1, 3] with a

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1537,6 +1537,7 @@ def provider_label(provider: Optional[str]) -> str:
 # See https://openai.com/api-priority-processing/ for the canonical list.
 # Only the bare model slug is stored (no vendor prefix).
 _PRIORITY_PROCESSING_MODELS: frozenset[str] = frozenset({
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.2",

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -116,7 +116,7 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
         # All models from OpenAI's Priority Processing pricing table
         supported = [
-            "gpt-5.4", "gpt-5.4-mini", "gpt-5.2",
+            "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2",
             "gpt-5.1", "gpt-5", "gpt-5-mini",
             "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
             "gpt-4o", "gpt-4o-mini",
@@ -128,6 +128,7 @@ class TestPriorityProcessingModels(unittest.TestCase):
     def test_vendor_prefix_stripped(self):
         from hermes_cli.models import model_supports_fast_mode
 
+        assert model_supports_fast_mode("openai/gpt-5.5") is True
         assert model_supports_fast_mode("openai/gpt-5.4") is True
         assert model_supports_fast_mode("openai/gpt-4.1") is True
         assert model_supports_fast_mode("openai/o3") is True
@@ -142,6 +143,9 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
     def test_resolve_overrides_returns_service_tier(self):
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        result = resolve_fast_mode_overrides("gpt-5.5")
+        assert result == {"service_tier": "priority"}
 
         result = resolve_fast_mode_overrides("gpt-5.4")
         assert result == {"service_tier": "priority"}
@@ -255,6 +259,9 @@ class TestAnthropicFastMode(unittest.TestCase):
     def test_resolve_overrides_returns_service_tier_for_openai(self):
         """OpenAI models should still get service_tier, not speed."""
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        result = resolve_fast_mode_overrides("gpt-5.5")
+        assert result == {"service_tier": "priority"}
 
         result = resolve_fast_mode_overrides("gpt-5.4")
         assert result == {"service_tier": "priority"}

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -32,6 +32,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _is_review_agent_task,
 )
 
 
@@ -1112,6 +1113,89 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         self.assertEqual(
             MockAgent.call_args[1]["enabled_toolsets"],
             ["web", "browser"],
+        )
+
+
+class TestDelegationReasoningDefaults(unittest.TestCase):
+    def test_review_agent_detection_matches_explicit_review_tasks(self):
+        self.assertTrue(
+            _is_review_agent_task(
+                "You are an independent code reviewer. Review the git diff."
+            )
+        )
+        self.assertTrue(
+            _is_review_agent_task(
+                "Check this work",
+                "Independent code review. Return only JSON verdict.",
+            )
+        )
+        self.assertTrue(_is_review_agent_task("Run a code-review agent on this diff"))
+        self.assertTrue(_is_review_agent_task("Use a code-reviewer subagent"))
+
+    def test_review_agent_detection_ignores_reviewer_comment_fix_tasks(self):
+        self.assertFalse(_is_review_agent_task("Fix reviewer comments in PR 42"))
+        self.assertFalse(_is_review_agent_task("Fix code review comments in PR 42"))
+        self.assertFalse(_is_review_agent_task("Fix PR review comments"))
+        self.assertFalse(_is_review_agent_task("Address pull request review feedback"))
+        self.assertFalse(_is_review_agent_task("Implement code review feedback"))
+        self.assertFalse(_is_review_agent_task("Address the review comments"))
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "reasoning_effort": "medium",
+            "review_reasoning_effort": "xhigh",
+        },
+    )
+    def test_review_agent_uses_review_reasoning_override(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="You are an independent code reviewer. Review the git diff.",
+                context="Independent code review. Return only JSON verdict.",
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["reasoning_config"],
+            {"enabled": True, "effort": "xhigh"},
+        )
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "reasoning_effort": "medium",
+            "review_reasoning_effort": "xhigh",
+        },
+    )
+    def test_non_review_agent_uses_generic_delegation_reasoning(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Implement the requested bugfix",
+                context="Implement code review feedback and update tests.",
+                toolsets=["terminal", "file"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["reasoning_config"],
+            {"enabled": True, "effort": "medium"},
         )
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -19,6 +19,7 @@ never the child's intermediate tool calls or reasoning.
 import enum
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 import os
@@ -47,6 +48,65 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
         "execute_code",  # children should reason step-by-step, not write scripts
     ]
 )
+
+
+_REVIEW_AGENT_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"\b(independent\s+)?code[-\s]+reviewer\b",
+        r"\bcode[-\s]+review(er)?\b",
+        r"\breview(er)?[-\s]+(sub)?agent\b",
+        r"\b(code|security|logic|pull\s+request|pr)[-\s]+review\b",
+        r"\breview\s+(the\s+)?(git\s+diff|diff|changes|code|pull\s+request|pr)\b",
+        r"\breview\s+this\s+pr\b",
+    )
+)
+
+_REVIEW_COMMENT_FIX_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"\b(address|fix|apply|resolve|respond\s+to)\s+(the\s+)?review(er)?\s+comments?\b",
+        r"\b(address|fix|apply|resolve|respond\s+to|implement|incorporate)\s+(the\s+)?(code[-\s]+review|pr[-\s]+review|pull[-\s]+request[-\s]+review)\s+(comments?|feedback)\b",
+        r"\breviewer\s+comments?\s+(fix|resolution|follow[-\s]?up)\b",
+    )
+)
+
+
+def _is_review_agent_task(goal: Optional[str], context: Optional[str] = None) -> bool:
+    """Return True when a delegated task is explicitly a review agent."""
+    text = f"{goal or ''}\n{context or ''}".strip().lower()
+    if not text:
+        return False
+    if any(pattern.search(text) for pattern in _REVIEW_COMMENT_FIX_PATTERNS):
+        return False
+    return any(pattern.search(text) for pattern in _REVIEW_AGENT_PATTERNS)
+
+
+def _parse_delegation_reasoning_effort(
+    value: Any,
+    *,
+    config_key: str,
+    fallback: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Parse a configured delegation reasoning effort with consistent logging."""
+    effort = str(value or "").strip()
+    if not effort:
+        return fallback
+    try:
+        from hermes_constants import parse_reasoning_effort
+
+        parsed = parse_reasoning_effort(effort)
+    except Exception as exc:
+        logger.debug("Could not parse %s: %s", config_key, exc)
+        return fallback
+    if parsed is not None:
+        return parsed
+    logger.warning(
+        "Unknown %s '%s', falling back to inherited/generic delegation reasoning",
+        config_key,
+        effort,
+    )
+    return fallback
 
 
 # ---------------------------------------------------------------------------
@@ -1000,24 +1060,20 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config:
+    # review_reasoning_effort (review tasks only) > reasoning_effort > parent inherit.
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
-    child_reasoning = parent_reasoning
-    try:
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
-        if delegation_effort:
-            from hermes_constants import parse_reasoning_effort
-
-            parsed = parse_reasoning_effort(delegation_effort)
-            if parsed is not None:
-                child_reasoning = parsed
-            else:
-                logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
-                )
-    except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+    child_reasoning = _parse_delegation_reasoning_effort(
+        delegation_cfg.get("reasoning_effort"),
+        config_key="delegation.reasoning_effort",
+        fallback=parent_reasoning,
+    )
+    if _is_review_agent_task(goal, context):
+        child_reasoning = _parse_delegation_reasoning_effort(
+            delegation_cfg.get("review_reasoning_effort"),
+            config_key="delegation.review_reasoning_effort",
+            fallback=child_reasoning,
+        )
 
     child = AIAgent(
         base_url=effective_base_url,


### PR DESCRIPTION
## Summary
- Add GPT-5.5 to OpenAI Priority Processing / fast-mode model support.
- Add `delegation.review_reasoning_effort` so review/code-review delegate tasks can use a different reasoning default from normal execution delegates.
- Preserve normal delegated execution behavior through `delegation.reasoning_effort` and avoid classifying reviewer-comment fix tasks as review agents.
- Add tests for GPT-5.5 fast-mode handling and review-specific delegation reasoning defaults.

## Test Plan
- `/home/hermes/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_delegate.py tests/cli/test_fast_command.py -q -o 'addopts='` → 148 passed
- `git diff --check --cached`
- `hermes config check`
- Independent pre-commit reviewer: passed; no security concerns or logic errors

## Notes
- Local config changes were applied on the VPS separately and are intentionally not included in this PR.
- `web/package-lock.json` has an unrelated pre-existing local modification and is intentionally not included.
