### PR TITLE
fix(deepseek): pad reasoning_content on plain assistant turns in thinking mode (#15741)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7639,11 +7639,11 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
-                # DeepSeek thinking mode requires reasoning_content on every
-                # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
+            elif self._needs_deepseek_tool_reasoning():
+                # DeepSeek thinking mode requires reasoning_content on EVERY
+                # assistant message (not just tool-call turns). Without it,
+                # replaying any persisted assistant turn causes HTTP 400.
+                # Include empty string as a defensive compatibility fallback.
                 msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
@@ -7764,14 +7764,14 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        # Providers that require an echoed reasoning_content on every
-        # assistant tool-call turn. Detection logic lives in the per-provider
-        # helpers so both the creation path (_build_assistant_message) and
-        # this replay path stay in sync.
-        if source_msg.get("tool_calls") and (
-            self._needs_kimi_tool_reasoning()
-            or self._needs_deepseek_tool_reasoning()
-        ):
+        # Kimi requires reasoning_content only on tool-call turns.
+        if source_msg.get("tool_calls") and self._needs_kimi_tool_reasoning():
+            api_msg["reasoning_content"] = ""
+            return
+        # DeepSeek thinking mode requires reasoning_content on EVERY assistant
+        # turn (not just tool-call turns). Plain assistant turns without it
+        # cause HTTP 400 on replay (#15741).
+        if self._needs_deepseek_tool_reasoning():
             api_msg["reasoning_content"] = ""
 
     @staticmethod

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -1,24 +1,23 @@
 """Regression test: DeepSeek V4 thinking mode reasoning_content echo.
 
 DeepSeek V4-flash / V4-pro thinking mode requires ``reasoning_content`` on
-every assistant message that carries ``tool_calls``. When a persisted
-session replays an assistant tool-call turn that was recorded without the
-field, DeepSeek rejects the next request with HTTP 400::
+EVERY assistant message (both tool-call and plain turns). When a persisted
+session replays any assistant turn without the field, DeepSeek rejects the
+next request with HTTP 400::
 
     The reasoning_content in the thinking mode must be passed back to the API.
 
 Fix covers three paths:
 
-1. ``_build_assistant_message`` — new tool-call messages without raw
-   reasoning_content get ``""`` pinned at creation time so nothing gets
-   persisted poisoned.
+1. ``_build_assistant_message`` — new messages without raw reasoning_content
+   get ``""`` pinned at creation time (tool-call AND plain turns).
 2. ``_copy_reasoning_content_for_api`` — already-poisoned history replays
-   with ``reasoning_content=""`` injected defensively.
+   with ``reasoning_content=""`` injected defensively for all turns.
 3. Detection covers three signals: ``provider == "deepseek"``,
-   ``"deepseek" in model``, and ``api.deepseek.com`` host match. The third
-   catches custom-provider setups pointing at DeepSeek.
+   ``"deepseek" in model``, and ``api.deepseek.com`` host match.
 
-Refs #15250 / #15353.
+Kimi still only requires the echo on tool-call turns (#15250 / #15353 /
+#15741).
 """
 
 from __future__ import annotations
@@ -88,9 +87,21 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg.get("reasoning_content") == ""
 
-    def test_deepseek_assistant_no_tool_call_left_alone(self) -> None:
-        """Plain assistant turns without tool_calls don't get padded."""
+    def test_deepseek_plain_assistant_also_padded(self) -> None:
+        """Plain assistant turns (no tool_calls) also get reasoning_content=''.
+
+        DeepSeek thinking mode requires the field on EVERY assistant turn,
+        not just tool-call turns. (#15741)
+        """
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        source = {"role": "assistant", "content": "hello"}
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == ""
+
+    def test_kimi_plain_assistant_not_padded(self) -> None:
+        """Kimi only requires reasoning_content on tool-call turns, not plain ones."""
+        agent = _make_agent(provider="kimi-coding", model="kimi-k2.5")
         source = {"role": "assistant", "content": "hello"}
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)


### PR DESCRIPTION
## Summary
- Extend the DeepSeek thinking-mode `reasoning_content` echo to cover **plain assistant messages** (no `tool_calls`), not just tool-call turns
- Kimi's narrower scope (tool-call turns only) is preserved
- 2 test changes: one renamed+corrected assertion, one new Kimi contrast test

## The bug

After `93a2d6b3` landed (fixing tool-call turns in #15250), interactive sessions with mixed plain + tool-call turns continued to fail with HTTP 400:

> The reasoning_content in the thinking mode must be passed back to the API.

DeepSeek V4 thinking mode requires `reasoning_content` on **every** assistant message in history. A plain assistant turn (e.g. \"Sure, let me check that for you.\") that is stored without the field poisons all subsequent replays of that session.

## The fix

**`_build_assistant_message`** — Remove the `tool_calls` guard from the DeepSeek empty-string fallback. When the API response carries `reasoning_content=None` (attribute present, value None), plain messages now also get `reasoning_content=""` pinned at creation time.

**`_copy_reasoning_content_for_api`** — Split the Kimi and DeepSeek paths:
- Kimi: still only pads tool-call turns (existing behavior, no regression)
- DeepSeek: now pads **all** assistant turns — injects `reasoning_content=""` whenever no real reasoning was stored

## Test plan
- [x] **Before** (stash fix, keep test changes): `test_deepseek_plain_assistant_also_padded` → `FAILED` (`AssertionError: 'reasoning_content' not in {}`)
- [x] **After** (restore fix): 22 passed in `test_deepseek_reasoning_content_echo.py`
- [x] Adjacent transport tests unchanged: 41 passed in `tests/agent/transports/test_chat_completions.py`
- [x] `test_kimi_plain_assistant_not_padded` confirms Kimi scope is unchanged

## Related
- Fixes #15741
- Follow-up to #15250 / #15353 (`93a2d6b3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)