### PR TITLE
fix(cli): prevent orphaned worktree in docker container

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10921,6 +10921,16 @@ def main(
                 _active_worktree = wt_info
                 os.environ["TERMINAL_CWD"] = wt_info["path"]
                 atexit.register(_cleanup_worktree, wt_info)
+                if "docker" in os.environ["TERMINAL_ENV"].lower():
+                    # Prevent orphaned worktree inside docker container
+                    import json
+                    from tools.terminal_tool import _parse_env_var
+                    repo_mnt = f"{wt_info['repo_root']}:{wt_info['repo_root']}"
+                    volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
+                    if repo_mnt not in volumes:
+                        volumes.append(repo_mnt)
+                    os.environ["TERMINAL_DOCKER_VOLUMES"] = json.dumps(volumes)
+                    os.environ["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] = 'true'
             else:
                 # Worktree was explicitly requested but setup failed —
                 # don't silently run without isolation.

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -5,6 +5,7 @@ Verifies worktree creation, cleanup, .worktreeinclude handling,
 """
 
 import os
+import json
 import shutil
 import subprocess
 import pytest
@@ -689,6 +690,51 @@ class TestTerminalCWDIntegration:
             capture_output=True, text=True, cwd=info["path"],
         )
         assert result.stdout.strip() == "true"
+
+
+class TestDockerBackendIntegration:
+    """Test that docker adds root_repo and CWD mounts to /workspace."""
+
+    def test_docker_volume_set(self, git_repo):
+        """After worktree setup, TERMINAL_DOCKER_VOLUMES contain root_repo."""
+        info = _setup_worktree(str(git_repo))
+        assert info is not None
+
+        # This is what main() does:
+        repo_mnt = f"{info['repo_root']}:{info['repo_root']}"
+        user_spec = "/a:/b" # user spec defined in config.yaml
+        volumes = [user_spec]
+        if repo_mnt not in volumes:
+            volumes.append(repo_mnt)
+        assert len(volumes) == 2
+        os.environ["TERMINAL_DOCKER_VOLUMES"] = json.dumps(volumes)
+        assert os.environ["TERMINAL_DOCKER_VOLUMES"] == json.dumps(volumes)
+        assert repo_mnt in os.environ["TERMINAL_DOCKER_VOLUMES"]
+        assert user_spec in os.environ["TERMINAL_DOCKER_VOLUMES"]
+
+        volumes = [repo_mnt] # repo_root already requested in volumes
+        if repo_mnt not in volumes:
+            volumes.append(repo_mnt)
+        assert len(volumes) == 1
+        os.environ["TERMINAL_DOCKER_VOLUMES"] = json.dumps(volumes)
+        assert os.environ["TERMINAL_DOCKER_VOLUMES"] == json.dumps(volumes)
+        assert repo_mnt in os.environ["TERMINAL_DOCKER_VOLUMES"]
+        assert user_spec not in os.environ["TERMINAL_DOCKER_VOLUMES"]
+
+        # Clean up env
+        del os.environ["TERMINAL_DOCKER_VOLUMES"]
+
+    def test_docker_mnt_cwd_to_workspace(self, git_repo):
+        """The TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE should be set for worktree isolation."""
+        info = _setup_worktree(str(git_repo))
+        assert info is not None
+
+        # This is what main() does:
+        os.environ["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] = 'true'
+        assert os.environ["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] == 'true'
+
+        # Clean up env
+        del os.environ["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"]
 
 
 class TestOrphanedBranchPruning:

--- a/website/docs/user-guide/git-worktrees.md
+++ b/website/docs/user-guide/git-worktrees.md
@@ -158,7 +158,12 @@ This is the easiest way to get worktree isolation. You can also combine it with 
 hermes -w -q "Fix issue #123"
 ```
 
-For parallel agents, open multiple terminals and run `hermes -w` in each — every invocation gets its own worktree and branch automatically.
+For parallel agents, open multiple terminals and run `hermes -w` in each — every
+invocation gets its own worktree and branch automatically.  If
+`terminal.backend` is set to `docker`, the host git repository corresponding to
+the worktree will be automatically mounted inside the container using the same
+path as on the host.  This prevents a dangling worktree inside the docker
+container.  The worktree itself is mounted at `/workspace` inside the container.
 
 ## Putting It All Together
 


### PR DESCRIPTION
## What does this PR do?

- If `terminal.backend` is `docker` and `-w` option is passed, append path of git repository to `TERMINAL_DOCKER_VOLUMES` to prevent worktree decoupling from owning repository inside the container.
- Enforce `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` in this situation.
- Extend documentation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: Add `if "docker" in os.environ["TERMINAL_ENV"].lower()` that appends `wt_info['repo_root']` to `TERMINAL_DOCKER_VOLUMES` (takes into account possibly existing volumes) and enforce `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` if the `-w`/`--worktree` argument is passed as this is the expected behavior if `terminal.backend` is set to `local`.

## How to Test

1. `pytest tests/cli/test_worktree.py -v`
2. Tested on Arch Linux using `podman`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


