### PR TITLE
fix: keep status API keys redacted and harden compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -810,7 +810,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
+            message = response.choices[0].message
+            if isinstance(message, dict):
+                content = message.get("content")
+            else:
+                content = getattr(message, "content", message)
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -84,7 +84,6 @@ from hermes_constants import is_termux as _is_termux
 
 def show_status(args):
     """Show status of all Hermes Agent components."""
-    show_all = getattr(args, 'all', False)
     deep = getattr(args, 'deep', False)
     
     print()
@@ -139,12 +138,12 @@ def show_status(args):
     for name, env_var in keys.items():
         value = get_env_value(env_var) or ""
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -172,6 +172,24 @@ class TestNonStringContent:
         assert summary is not None
         assert summary == SUMMARY_PREFIX
 
+    def test_string_message_coerced_to_summary_content(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = "plain summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary(messages)
+
+        assert summary == f"{SUMMARY_PREFIX}\nplain summary text"
+
     def test_summary_call_does_not_force_temperature(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,15 +3,16 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
-def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
+def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    sentinel = "NONSECRET_SENTINEL_VALUE_DO_NOT_PRINT_123456"
+    monkeypatch.setenv("TAVILY_API_KEY", sentinel)
 
-    show_status(SimpleNamespace(all=False, deep=False))
+    show_status(SimpleNamespace(all=True, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
-    assert "tvly...cdef" in output
+    assert sentinel not in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- Always redact API keys in `hermes status --all` instead of printing raw values.
- Handle dict/string-shaped context compression messages without crashing.
- Add regression coverage for both safety fixes.

## Test plan
- `./venv/bin/python -m pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_status_model_provider.py tests/agent/test_context_compressor.py -q`
- Secret-shape scan of PR diff/history and changed files: 0 high-confidence hits.
- `hermes status --all`, `hermes doctor`, and `hermes config check`: exit 0, secret-shape scan 0 hits.

## Safety notes
- No raw API keys/tokens/secrets are intentionally included in this PR.
- The status change is intentionally conservative: `--all` no longer bypasses API key redaction.
