### PR TITLE
fix(tui): bound live render memory pressure

### DIFF
--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  boundedLiveRenderText,
   edgePreview,
   estimateRows,
   estimateTokensRough,
@@ -104,5 +105,27 @@ describe('estimateRows', () => {
     const plain = 'look at test case with underscores now'
 
     expect(estimateRows(snake, w)).toBe(estimateRows(plain, w))
+  })
+})
+
+describe('boundedLiveRenderText', () => {
+  it('keeps short text unchanged', () => {
+    expect(boundedLiveRenderText('alpha\nbeta', { maxChars: 50, maxLines: 5 })).toBe('alpha\nbeta')
+  })
+
+  it('keeps the tail of long live text', () => {
+    const text = Array.from({ length: 6 }, (_, i) => `line-${i + 1}`).join('\n')
+    const out = boundedLiveRenderText(text, { maxChars: 100, maxLines: 3 })
+
+    expect(out).toContain('omitted 3 lines')
+    expect(out.endsWith('line-4\nline-5\nline-6')).toBe(true)
+    expect(out).not.toContain('line-1')
+  })
+
+  it('bounds very long single-line text by chars', () => {
+    const out = boundedLiveRenderText('a'.repeat(60), { maxChars: 12, maxLines: 5 })
+
+    expect(out).toContain('omitted 48 chars')
+    expect(out.endsWith('a'.repeat(12))).toBe(true)
   })
 })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -2,6 +2,7 @@ import { REASONING_PULSE_MS, STREAM_BATCH_MS } from '../config/timing.js'
 import type { SessionInterruptResponse, SubagentEventPayload } from '../gatewayTypes.js'
 import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
 import {
+  boundedLiveRenderText,
   buildToolTrailLine,
   estimateTokensRough,
   isTransientTrailLine,
@@ -492,7 +493,7 @@ class TurnController {
       this.streamTimer = null
       const raw = this.bufRef.trimStart()
       const visible = hasReasoningTag(raw) ? splitReasoning(raw).text : raw
-      patchTurnState({ streaming: visible })
+      patchTurnState({ streaming: boundedLiveRenderText(visible) })
     }, STREAM_BATCH_MS)
   }
 

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -5,7 +5,7 @@ import { LONG_MSG } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
-import { compactPreview, hasAnsi, isPasteBackedText, stripAnsi } from '../lib/text.js'
+import { boundedLiveRenderText, compactPreview, hasAnsi, isPasteBackedText, stripAnsi } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { DetailsMode, Msg, SectionVisibility } from '../types.js'
 
@@ -84,7 +84,11 @@ export const MessageLine = memo(function MessageLine({
     }
 
     if (msg.role === 'assistant') {
-      return isStreaming ? <Text color={body}>{msg.text}</Text> : <Md compact={compact} t={t} text={msg.text} />
+      return isStreaming ? (
+        <Text color={body}>{boundedLiveRenderText(msg.text)}</Text>
+      ) : (
+        <Md compact={compact} t={t} text={msg.text} />
+      )
     }
 
     if (msg.role === 'user' && msg.text.length > LONG_MSG && isPasteBackedText(msg.text)) {

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -16,6 +16,7 @@ import {
   widthByDepth
 } from '../lib/subagentTree.js'
 import {
+  boundedLiveRenderText,
   compactPreview,
   estimateTokensRough,
   fmtK,
@@ -633,7 +634,12 @@ export const Thinking = memo(function Thinking({
   streaming?: boolean
   t: Theme
 }) {
-  const preview = useMemo(() => thinkingPreview(reasoning, mode, THINKING_COT_MAX), [mode, reasoning])
+  const preview = useMemo(() => {
+    const raw = thinkingPreview(reasoning, mode, THINKING_COT_MAX)
+
+    return mode === 'full' ? boundedLiveRenderText(raw) : raw
+  }, [mode, reasoning])
+
   const lines = useMemo(() => preview.split('\n').map(line => line.replace(/\t/g, '  ')), [preview])
 
   if (!preview && !active) {
@@ -868,8 +874,8 @@ export const ToolTrail = memo(function ToolTrail({
   const hasTools = groups.length > 0
   const hasSubagents = subagents.length > 0
   const hasMeta = meta.length > 0
-  const hasThinking = !!cot || reasoningActive || busy
   const thinkingLive = reasoningActive || reasoningStreaming
+  const hasThinking = !!cot || thinkingLive
 
   const tokenCount =
     reasoningTokens && reasoningTokens > 0 ? reasoningTokens : reasoning ? estimateTokensRough(reasoning) : 0
@@ -1002,7 +1008,7 @@ export const ToolTrail = memo(function ToolTrail({
       open: openThinking,
       render: rails => (
         <Thinking
-          active={reasoningActive}
+          active={thinkingLive}
           branch="last"
           mode="full"
           rails={rails}

--- a/ui-tui/src/config/limits.ts
+++ b/ui-tui/src/config/limits.ts
@@ -1,4 +1,6 @@
 export const LARGE_PASTE = { chars: 8000, lines: 80 }
+export const LIVE_RENDER_MAX_CHARS = 16_000
+export const LIVE_RENDER_MAX_LINES = 240
 export const LONG_MSG = 300
 export const MAX_HISTORY = 800
 export const THINKING_COT_MAX = 160

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -14,7 +14,9 @@ const gw = new GatewayClient()
 gw.start()
 
 const dumpNotice = (snap: MemorySnapshot, dump: HeapDumpResult | null) =>
-  `hermes-tui: ${snap.level} memory (${formatBytes(snap.heapUsed)}) — auto heap dump → ${dump?.heapPath ?? '(failed)'}\n`
+  snap.source === 'heap'
+    ? `hermes-tui: ${snap.level} heap (${formatBytes(snap.heapUsed)}, rss ${formatBytes(snap.rss)}) — auto heap dump → ${dump?.heapPath ?? '(failed)'}\n`
+    : `hermes-tui: ${snap.level} rss (${formatBytes(snap.rss)}, native ${formatBytes(snap.nativeUsed)}) — auto diagnostics → ${dump?.diagPath ?? '(failed)'}\n`
 
 setupGracefulExit({
   cleanups: [() => gw.kill()],

--- a/ui-tui/src/lib/memory.ts
+++ b/ui-tui/src/lib/memory.ts
@@ -145,11 +145,11 @@ export async function performHeapDump(trigger: MemoryTrigger = 'manual'): Promis
     // Diagnostics first — heap-snapshot serialization can crash on very large
     // heaps, and the JSON sidecar is the most actionable artifact if so.
     const diagnostics = await captureMemoryDiagnostics(trigger)
-    const dir = process.env.HERMES_HEAPDUMP_DIR?.trim() || join(homedir() || tmpdir(), '.hermes', 'heapdumps')
+    const dir = memoryDumpDir()
 
     await mkdir(dir, { recursive: true })
 
-    const base = `hermes-${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}-${trigger}`
+    const base = memoryDumpBase(trigger)
     const heapPath = join(dir, `${base}.heapsnapshot`)
     const diagPath = join(dir, `${base}.diagnostics.json`)
 
@@ -157,6 +157,23 @@ export async function performHeapDump(trigger: MemoryTrigger = 'manual'): Promis
     await pipeline(getHeapSnapshot(), createWriteStream(heapPath, { mode: 0o600 }))
 
     return { diagPath, heapPath, success: true }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e), success: false }
+  }
+}
+
+export async function performDiagnosticsDump(trigger: MemoryTrigger = 'manual'): Promise<HeapDumpResult> {
+  try {
+    const diagnostics = await captureMemoryDiagnostics(trigger)
+    const dir = memoryDumpDir()
+
+    await mkdir(dir, { recursive: true })
+
+    const diagPath = join(dir, `${memoryDumpBase(trigger)}.diagnostics.json`)
+
+    await writeFile(diagPath, JSON.stringify(diagnostics, null, 2), { mode: 0o600 })
+
+    return { diagPath, success: true }
   } catch (e) {
     return { error: e instanceof Error ? e.message : String(e), success: false }
   }
@@ -176,6 +193,11 @@ export function formatBytes(bytes: number): string {
 const UNITS = ['B', 'KB', 'MB', 'GB', 'TB']
 
 const STARTED_AT = { rss: process.memoryUsage().rss, uptime: process.uptime() }
+
+const memoryDumpDir = () => process.env.HERMES_HEAPDUMP_DIR?.trim() || join(homedir() || tmpdir(), '.hermes', 'heapdumps')
+
+const memoryDumpBase = (trigger: MemoryTrigger) =>
+  `hermes-${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}-${trigger}`
 
 // Returns undefined when the probe isn't available (non-Linux paths, sandboxed FS).
 const swallow = async <T>(fn: () => Promise<T>): Promise<T | undefined> => {

--- a/ui-tui/src/lib/memoryMonitor.test.ts
+++ b/ui-tui/src/lib/memoryMonitor.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const memory = vi.hoisted(() => ({
+  performDiagnosticsDump: vi.fn(async () => ({ diagPath: '/tmp/diag.json', success: true })),
+  performHeapDump: vi.fn(async () => ({ heapPath: '/tmp/heap.heapsnapshot', success: true }))
+}))
+
+vi.mock('./memory.js', () => memory)
+
+import { type MemorySnapshot, startMemoryMonitor } from './memoryMonitor.js'
+
+const GB = 1024 ** 3
+
+const usage = (heapUsed: number, rss: number): NodeJS.MemoryUsage =>
+  ({
+    arrayBuffers: 0,
+    external: 0,
+    heapTotal: heapUsed,
+    heapUsed,
+    rss
+  }) as NodeJS.MemoryUsage
+
+describe('startMemoryMonitor', () => {
+  let memoryUsageSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    memory.performDiagnosticsDump.mockClear()
+    memory.performHeapDump.mockClear()
+  })
+
+  afterEach(() => {
+    memoryUsageSpy?.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('captures diagnostics only for native RSS pressure', async () => {
+    memoryUsageSpy = vi.spyOn(process, 'memoryUsage').mockReturnValue(usage(100 * 1024 ** 2, 5 * GB))
+
+    const snaps: MemorySnapshot[] = []
+
+    const stop = startMemoryMonitor({
+      intervalMs: 1000,
+      onHigh: snap => snaps.push(snap),
+      rssHighBytes: 4 * GB
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    stop()
+
+    expect(memory.performDiagnosticsDump).toHaveBeenCalledWith('auto-high')
+    expect(memory.performHeapDump).not.toHaveBeenCalled()
+    expect(snaps[0]).toMatchObject({ level: 'high', source: 'rss' })
+    expect(snaps[0]?.nativeUsed).toBeGreaterThan(4 * GB)
+  })
+
+  it('keeps heap dumps for V8 heap pressure', async () => {
+    memoryUsageSpy = vi.spyOn(process, 'memoryUsage').mockReturnValue(usage(3 * GB, 3.5 * GB))
+
+    const snaps: MemorySnapshot[] = []
+
+    const stop = startMemoryMonitor({
+      intervalMs: 1000,
+      onCritical: snap => snaps.push(snap)
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    stop()
+
+    expect(memory.performHeapDump).toHaveBeenCalledWith('auto-critical')
+    expect(memory.performDiagnosticsDump).not.toHaveBeenCalled()
+    expect(snaps[0]).toMatchObject({ level: 'critical', source: 'heap' })
+  })
+})

--- a/ui-tui/src/lib/memoryMonitor.ts
+++ b/ui-tui/src/lib/memoryMonitor.ts
@@ -1,11 +1,14 @@
-import { type HeapDumpResult, performHeapDump } from './memory.js'
+import { type HeapDumpResult, performDiagnosticsDump, performHeapDump } from './memory.js'
 
 export type MemoryLevel = 'critical' | 'high' | 'normal'
+export type MemoryTriggerSource = 'heap' | 'rss'
 
 export interface MemorySnapshot {
   heapUsed: number
   level: MemoryLevel
+  nativeUsed: number
   rss: number
+  source: MemoryTriggerSource
 }
 
 export interface MemoryMonitorOptions {
@@ -14,35 +17,61 @@ export interface MemoryMonitorOptions {
   intervalMs?: number
   onCritical?: (snap: MemorySnapshot, dump: HeapDumpResult | null) => void
   onHigh?: (snap: MemorySnapshot, dump: HeapDumpResult | null) => void
+  rssCriticalBytes?: number
+  rssHighBytes?: number
 }
 
 const GB = 1024 ** 3
+
+const maxLevel = (heapLevel: MemoryLevel, rssLevel: MemoryLevel): MemoryLevel => {
+  if (heapLevel === 'critical' || rssLevel === 'critical') {
+    return 'critical'
+  }
+
+  return heapLevel === 'high' || rssLevel === 'high' ? 'high' : 'normal'
+}
 
 export function startMemoryMonitor({
   criticalBytes = 2.5 * GB,
   highBytes = 1.5 * GB,
   intervalMs = 10_000,
   onCritical,
-  onHigh
+  onHigh,
+  rssCriticalBytes = 8 * GB,
+  rssHighBytes = 4 * GB
 }: MemoryMonitorOptions = {}): () => void {
-  const dumped = new Set<Exclude<MemoryLevel, 'normal'>>()
+  const dumped = new Set<`${MemoryTriggerSource}:${Exclude<MemoryLevel, 'normal'>}`>()
 
   const tick = async () => {
     const { heapUsed, rss } = process.memoryUsage()
-    const level: MemoryLevel = heapUsed >= criticalBytes ? 'critical' : heapUsed >= highBytes ? 'high' : 'normal'
+    const nativeUsed = Math.max(0, rss - heapUsed)
+    const heapLevel: MemoryLevel = heapUsed >= criticalBytes ? 'critical' : heapUsed >= highBytes ? 'high' : 'normal'
+    const rssLevel: MemoryLevel = rss >= rssCriticalBytes ? 'critical' : rss >= rssHighBytes ? 'high' : 'normal'
+    const level = maxLevel(heapLevel, rssLevel)
 
     if (level === 'normal') {
       return void dumped.clear()
     }
 
-    if (dumped.has(level)) {
+    const source: MemoryTriggerSource =
+      heapLevel === level || (heapLevel !== 'normal' && rssLevel === level) ? 'heap' : 'rss'
+
+    const key = `${source}:${level}` as const
+
+    if (dumped.has(key)) {
       return
     }
 
-    dumped.add(level)
-    const dump = await performHeapDump(level === 'critical' ? 'auto-critical' : 'auto-high').catch(() => null)
+    dumped.add(key)
 
-    const snap: MemorySnapshot = { heapUsed, level, rss }
+    const trigger = level === 'critical' ? 'auto-critical' : 'auto-high'
+
+    const dump =
+      source === 'heap'
+        ? await performHeapDump(trigger).catch(() => null)
+        : await performDiagnosticsDump(trigger).catch(() => null)
+
+    const snap: MemorySnapshot = { heapUsed, level, nativeUsed, rss, source }
 
     ;(level === 'critical' ? onCritical : onHigh)?.(snap, dump)
   }

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -1,4 +1,4 @@
-import { THINKING_COT_MAX } from '../config/limits.js'
+import { LIVE_RENDER_MAX_CHARS, LIVE_RENDER_MAX_LINES, THINKING_COT_MAX } from '../config/limits.js'
 import type { ThinkingMode } from '../types.js'
 
 const ESC = String.fromCharCode(27)
@@ -74,6 +74,61 @@ export const thinkingPreview = (reasoning: string, mode: ThinkingMode, max: numb
   const raw = reasoning.trim()
 
   return !raw || mode === 'collapsed' ? '' : mode === 'full' ? raw : compactPreview(raw.replace(WS_RE, ' '), max)
+}
+
+export const boundedLiveRenderText = (
+  text: string,
+  { maxChars = LIVE_RENDER_MAX_CHARS, maxLines = LIVE_RENDER_MAX_LINES } = {}
+) => {
+  if (text.length <= maxChars && text.split('\n', maxLines + 1).length <= maxLines) {
+    return text
+  }
+
+  let start = 0
+  let idx = text.length
+
+  for (let seen = 0; seen < maxLines && idx > 0; seen++) {
+    idx = text.lastIndexOf('\n', idx - 1)
+    start = idx < 0 ? 0 : idx + 1
+
+    if (idx < 0) {
+      break
+    }
+  }
+
+  const lineStart = start
+  start = Math.max(lineStart, text.length - maxChars)
+
+  if (start > lineStart) {
+    const nextBreak = text.indexOf('\n', start)
+
+    if (nextBreak >= 0 && nextBreak < text.length - 1) {
+      start = nextBreak + 1
+    }
+  }
+
+  const tail = text.slice(start).trimStart()
+  const omittedLines = countNewlines(text, start)
+  const omittedChars = Math.max(0, text.length - tail.length)
+
+  const label =
+    omittedLines > 0
+      ? `[showing live tail; omitted ${fmtK(omittedLines)} lines / ${fmtK(omittedChars)} chars]\n`
+      : `[showing live tail; omitted ${fmtK(omittedChars)} chars]\n`
+
+  return `${label}${tail.trimStart()}`
+}
+
+const countNewlines = (text: string, end: number) => {
+  let count = 0
+
+  for (let i = 0; i < end; i++) {
+    if (text.charCodeAt(i) === 10) {
+      count++
+    }
+  }
+
+  return count
 }
 
 export const stripTrailingPasteNewlines = (text: string) => (/[^\n]/.test(text) ? text.replace(/\n+$/, '') : text)


### PR DESCRIPTION
## What does this PR do?

Bounds the live-rendered text surfaces in the TUI so active reasoning and assistant streaming do not ask Ink/Yoga to re-layout an ever-growing text blob on every render pulse. The full in-memory turn text is still retained for final completion; only the live display is capped to a tail preview with an omitted-lines/chars marker.

This also makes the TUI memory monitor distinguish V8 heap pressure from RSS/native pressure. Heap pressure still writes a heap snapshot, while RSS/native pressure writes diagnostics only, avoiding repeated multi-GB heap snapshots for native RSS growth cases.

## Related Issue

Refs #15141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `boundedLiveRenderText()` and live render caps in `ui-tui/src/lib/text.ts` / `ui-tui/src/config/limits.ts`.
- Applied the cap to live assistant streaming in `ui-tui/src/app/turnController.ts` and `ui-tui/src/components/messageLine.tsx`.
- Applied the cap to expanded thinking render in `ui-tui/src/components/thinking.tsx`.
- Stopped rendering an empty Thinking accordion just because the TUI is busy when no reasoning has arrived.
- Added RSS/native-memory source tracking in `ui-tui/src/lib/memoryMonitor.ts`.
- Added diagnostics-only native RSS capture in `ui-tui/src/lib/memory.ts` and updated the startup notice in `ui-tui/src/entry.tsx`.
- Added focused coverage in `ui-tui/src/__tests__/text.test.ts` and `ui-tui/src/lib/memoryMonitor.test.ts`.

## How to Test

1. Run `cd ui-tui && npm test -- --run src/__tests__/text.test.ts src/lib/memoryMonitor.test.ts src/__tests__/details.test.ts`.
2. Run `cd ui-tui && npm test`.
3. Run `cd ui-tui && npm run type-check`.
4. Run `cd ui-tui && npx eslint src/config/limits.ts src/lib/text.ts src/app/turnController.ts src/components/thinking.tsx src/components/messageLine.tsx src/lib/memory.ts src/lib/memoryMonitor.ts src/entry.tsx src/__tests__/text.test.ts src/lib/memoryMonitor.test.ts`.
5. If applying this PR manually to a local checkout, rebuild the TUI before testing because `hermes --tui` runs `ui-tui/dist/entry.js`:

```bash
cd ui-tui
npm install   # only needed if dependencies are not already installed
npm run build
cd ..
hermes --tui
```

6. Monitor the Node TUI process during active streaming and idle, for example: `ps -o pid,rss,vsz,comm -p <node pid>`.

Local smoke result from a fresh rebuilt `hermes --tui` run: Node RSS rose during active work, then stabilized while idle and dropped from about 537 MB to about 399 MB over the idle window. The Python gateway stayed flat around 51 MB.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux TUI with Node v24.14.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Live idle-monitor sample from the rebuilt bundle:

```text
16:36:08  Node RSS 533.6 MB
16:37:48  Node RSS 533.9 MB
16:39:28  Node RSS 536.8 MB
16:40:01  Node RSS 402.6 MB
16:41:47  Node RSS 398.8 MB
```
