### PR TITLE
fix(model): avoid persisting key_env-resolved secrets

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3202,20 +3202,16 @@ def _model_flow_named_custom(config, provider_info):
     Falls back to the saved model if probing fails.
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import get_env_value, load_config, save_config
     from hermes_cli.models import fetch_api_models
 
     name = provider_info["name"]
     base_url = provider_info["base_url"]
     api_mode = provider_info.get("api_mode", "")
-    api_key = provider_info.get("api_key", "")
     key_env = provider_info.get("key_env", "")
+    api_key = (get_env_value(key_env) or "") if key_env else provider_info.get("api_key", "")
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
-
-    # Resolve key from env var if api_key not set directly
-    if not api_key and key_env:
-        api_key = os.environ.get(key_env, "")
     config_api_key = _custom_provider_api_key_config_value(provider_info, api_key)
 
     print(f"  Provider: {name}")
@@ -3358,7 +3354,8 @@ def _model_flow_named_custom(config, provider_info):
                 cfg["providers"] = providers_cfg
                 save_config(cfg)
     else:
-        # Save model name to the custom_providers entry for next time
+        # Save model name to the custom_providers entry for next time. Keep an
+        # env reference, not the key_env-resolved secret, when applicable.
         _save_custom_provider(base_url, config_api_key, model_name)
 
     print(f"\n✅ Model set to: {model_name}")

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -104,3 +104,63 @@ def test_named_custom_provider_model_picker_falls_back_on_terminalmenu_runtime_e
     assert reloaded["model"]["provider"] == "custom"
     assert reloaded["model"]["base_url"] == "http://localhost:8000/v1"
     assert reloaded["model"]["default"] == "model-b"
+
+
+def test_named_provider_model_picker_uses_key_env_without_persisting_secret(tmp_path, monkeypatch):
+    from hermes_cli.main import _model_flow_named_custom
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_CUSTOM_KEY", "env-secret")
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
+    )
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["model-a"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    cfg = load_config()
+    cfg["providers"] = {
+        "local-custom": {
+            "name": "Local Custom",
+            "base_url": "http://localhost:8000/v1",
+            "key_env": "LOCAL_CUSTOM_KEY",
+            "api_key": "inline-secret",
+            "default_model": "old-model",
+        }
+    }
+    save_config(cfg)
+
+    responses = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    _model_flow_named_custom(
+        cfg,
+        {
+            "name": "Local Custom",
+            "base_url": "http://localhost:8000/v1",
+            "key_env": "LOCAL_CUSTOM_KEY",
+            "model": "old-model",
+            "provider_key": "local-custom",
+        },
+    )
+
+    assert calls
+    assert calls[0][0] == "env-secret"
+    assert calls[0][1] == "http://localhost:8000/v1"
+
+    reloaded = load_config()
+    assert reloaded["model"]["provider"] == "local-custom"
+    assert reloaded["model"].get("api_key") in (None, "")
+    provider_cfg = reloaded["providers"]["local-custom"]
+    assert provider_cfg["key_env"] == "LOCAL_CUSTOM_KEY"
+    assert provider_cfg["default_model"] == "model-a"
+    assert provider_cfg.get("api_key") == "inline-secret"
+    assert "env-secret" not in str(reloaded)


### PR DESCRIPTION
## Summary

Fixes #15803.

Simplifies `_model_flow_named_custom()` credential handling for `/models` discovery:

1. If `key_env` is set, resolve it and use that value for the `/models` request.
2. If `key_env` is missing, fall back to inline `api_key`.
3. When saving config, write only `provider_info["api_key"]`; never write the value resolved from `key_env`.

## Why

Named providers in the new keyed `providers:` schema can be configured securely with:

```yaml
providers:
  local-custom:
    base_url: http://localhost:8000/v1
    key_env: LOCAL_CUSTOM_KEY
```

Selecting a model should not copy `LOCAL_CUSTOM_KEY`'s runtime value into `providers.<name>.api_key`.

## Tests

- [x] `python -m pytest tests/hermes_cli/test_terminal_menu_fallbacks.py::test_named_provider_model_picker_uses_key_env_without_persisting_secret tests/hermes_cli/test_terminal_menu_fallbacks.py::test_named_custom_provider_model_picker_falls_back_on_terminalmenu_runtime_error -q`
- [x] `python -m pytest tests/hermes_cli/test_terminal_menu_fallbacks.py -q`