### PR TITLE
fix(run_agent): wire up should_compress_preflight() per-turn ingest hook

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9444,6 +9444,23 @@ class AIAgent:
             self._api_call_count = api_call_count
             self._touch_activity(f"starting API call #{api_call_count}")
 
+            # Per-turn ingest hook for context-engine plugins.
+            # ContextEngine.should_compress_preflight() is the per-turn entry
+            # point that plugin engines (e.g. LCM) override to ingest the
+            # rolling message list each turn. The base class returns False
+            # with no work, so this is zero overhead for the built-in
+            # ContextCompressor and any engine that does not override it.
+            # The decision logic later in this loop still uses the more
+            # accurate provider-reported token count via should_compress();
+            # the return value here is intentionally discarded.
+            try:
+                self.context_compressor.should_compress_preflight(messages)
+            except Exception as _ce_preflight_err:
+                logger.debug(
+                    "Context engine preflight ingest skipped: %s",
+                    _ce_preflight_err,
+                )
+
             # Grace call: the budget is exhausted but we gave the model one
             # more chance.  Consume the grace flag so the loop exits after
             # this iteration regardless of outcome.
@@ -12410,6 +12427,18 @@ class AIAgent:
         # provider before the second message. Actual session-end cleanup is
         # handled by the CLI (atexit / /reset) and gateway (session expiry /
         # _reset_session).
+
+        # Final ingest flush for context-engine plugins so the last
+        # assistant message reaches the engine even when this turn exited
+        # via the no-tool-calls (final response) branch and therefore
+        # never hit the per-turn hook above.
+        try:
+            self.context_compressor.should_compress_preflight(messages)
+        except Exception as _ce_flush_err:
+            logger.debug(
+                "Context engine end-of-turn ingest skipped: %s",
+                _ce_flush_err,
+            )
 
         # Plugin hook: on_session_end
         # Fired at the very end of every run_conversation call.


### PR DESCRIPTION
ContextEngine.should_compress_preflight() is documented as the per-turn ingest entry for plugin engines, but run_agent.py never calls it. PR #10088 explicitly noted this as dead code when skipping #9675:

> #9675 (preflight check) — dead code, run_agent.py never calls
> should_compress_preflight()

This breaks plugin context engines that rely on the hook for per-turn message ingest. hermes-lcm overrides should_compress_preflight() to persist messages each turn into its DAG store, but with the hook never called, the lossless message store stays empty until compress() fires at the threshold (typically ~96K tokens). Reproducible:

  $ hermes chat -q "test" -Q
  $ sqlite3 ~/.hermes/lcm.db "SELECT COUNT(*) FROM messages;"
  0

(Verified on hermes-agent v0.11.0 with hermes-lcm v0.7.0.)

Add two calls to should_compress_preflight(messages):

1. Top of the main loop, right after api_call_count is incremented — per-turn ingest before each API call.
2. End of run_conversation(), before the on_session_end plugin hook — final flush so the last assistant message reaches the engine when the turn exited via the no-tool-calls branch and skipped the per-turn hook above.

The return value is discarded; compression is still decided by the later should_compress(_real_tokens) call which uses the provider- reported token count. Both calls are wrapped in try/except so a misbehaving plugin engine cannot break the conversation loop.

Default ContextEngine.should_compress_preflight() returns False with no work, so this is zero overhead for the built-in ContextCompressor and any engine that does not override the hook.

After this fix:
  $ hermes chat -q "test" -Q
  $ sqlite3 ~/.hermes/lcm.db "SELECT COUNT(*) FROM messages;"
  2

Refs:
- #9675 (closed: feat(compressor): implement preflight compression check)
- #10088 (merged body: skipped #9675 as dead code)
- stephenschoettler/hermes-lcm#68 (LCM author flagged host integration issue but could not file upstream because GitHub Issues was off on a different fork)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

