### PR TITLE
docs(obliteratus): link YouTube video guide in SKILL.md

### DIFF
--- a/skills/mlops/inference/obliteratus/SKILL.md
+++ b/skills/mlops/inference/obliteratus/SKILL.md
@@ -17,6 +17,13 @@ Remove refusal behaviors (guardrails) from open-weight LLMs without retraining o
 
 **License warning:** OBLITERATUS is AGPL-3.0. NEVER import it as a Python library. Always invoke via CLI (`obliteratus` command) or subprocess. This keeps Hermes Agent's MIT license clean.
 
+## Video Guide
+
+Walkthrough of OBLITERATUS used by a Hermes agent to abliterate Gemma:
+https://www.youtube.com/watch?v=8fG9BrNTeHs ("OBLITERATUS: An AI Agent Removed Gemma 4's Safety Guardrails")
+
+Useful when the user wants a visual overview of the end-to-end workflow before running it themselves.
+
 ## When to Use This Skill
 
 Trigger when the user:


### PR DESCRIPTION
## Summary
Adds a 'Video Guide' section to the obliteratus built-in skill pointing at the walkthrough of a Hermes agent abliterating Gemma with OBLITERATUS, so the agent can surface it when a user wants a visual overview before running the workflow.

## Changes
- skills/mlops/inference/obliteratus/SKILL.md: new 'Video Guide' section with https://www.youtube.com/watch?v=8fG9BrNTeHs

## Validation
Markdown-only change. No code paths affected.