### PR TITLE
fix(agent): cap non-stream stale timeout via SDK + disable SDK retries

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5123,6 +5123,17 @@ class AIAgent:
             return primary_client
         with self._openai_client_lock():
             request_kwargs = dict(self._client_kwargs)
+        # Per-request OpenAI-wire clients (used by both the non-streaming
+        # chat-completions path and the streaming chat-completions path
+        # in `_interruptible_api_call`) should not run the SDK's built-in
+        # retry loop: the agent's outer loop owns retries with credential
+        # rotation, provider fallback, and backoff that the SDK can't
+        # see.  Leaving SDK retries on (default 2) compounds with our
+        # outer retries and lets a single hung provider request stretch
+        # to ~3× the per-call timeout before our stale detector reports
+        # it (#dailydev-stale).  Shared/primary clients and Anthropic /
+        # Bedrock paths are unaffected (they don't go through here).
+        request_kwargs["max_retries"] = 0
         return self._create_openai_client(request_kwargs, reason=reason, shared=False)
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
@@ -5657,6 +5668,16 @@ class AIAgent:
         result = {"response": None, "error": None}
         request_client_holder = {"client": None}
 
+        # ── Stale-call timeout (mirrors streaming stale detector) ────────
+        # Non-streaming calls return nothing until the full response is
+        # ready.  Without this, a hung provider can block for the full
+        # httpx timeout (default 1800s) with zero feedback.  The stale
+        # detector kills the connection early so the main retry loop can
+        # apply richer recovery (credential rotation, provider fallback).
+        _stale_timeout = self._compute_non_stream_stale_timeout(
+            api_kwargs.get("messages", [])
+        )
+
         def _call():
             try:
                 if self.api_mode == "codex_responses":
@@ -5693,23 +5714,23 @@ class AIAgent:
                     result["response"] = normalize_converse_response(raw_response)
                 else:
                     request_client_holder["client"] = self._create_request_openai_client(reason="chat_completion_request")
-                    result["response"] = request_client_holder["client"].chat.completions.create(**api_kwargs)
+                    # Push the read-timeout down to the SDK as a per-call
+                    # kwarg so a hung provider fails at exactly
+                    # _stale_timeout regardless of GIL/thread scheduling.
+                    # SDK-internal retries are disabled at client
+                    # construction (max_retries=0) so this single timeout
+                    # is the true upper bound; the agent's outer loop
+                    # owns retry with richer recovery (credential
+                    # rotation, provider fallback, backoff).
+                    _call_kwargs = dict(api_kwargs)
+                    _call_kwargs.setdefault("timeout", _stale_timeout)
+                    result["response"] = request_client_holder["client"].chat.completions.create(**_call_kwargs)
             except Exception as e:
                 result["error"] = e
             finally:
                 request_client = request_client_holder.get("client")
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="request_complete")
-
-        # ── Stale-call timeout (mirrors streaming stale detector) ────────
-        # Non-streaming calls return nothing until the full response is
-        # ready.  Without this, a hung provider can block for the full
-        # httpx timeout (default 1800s) with zero feedback.  The stale
-        # detector kills the connection early so the main retry loop can
-        # apply richer recovery (credential rotation, provider fallback).
-        _stale_timeout = self._compute_non_stream_stale_timeout(
-            api_kwargs.get("messages", [])
-        )
 
         _call_start = time.time()
         self._touch_activity("waiting for non-streaming API response")


### PR DESCRIPTION
## Summary

The non-streaming chat-completions path in `_interruptible_api_call` reports stale calls at ~3× the configured threshold (e.g. `Non-streaming API call timed out after 967s with no response (threshold: 300s)`). Two surgical changes in `run_agent.py` make the per-call read-timeout the true upper bound.

## Symptom

Running gpt-5.x via `openai-codex` from a Telegram-bot deployment, the agent's outer loop logged:

```
⚠️ No response from provider for 940-1050s (non-streaming, model: gpt-5.x). Aborting call.
API call failed after 3 retries.
Non-streaming API call timed out after 967s with no response (threshold: 300s)
```

`_compute_non_stream_stale_timeout` was returning the right value (300/450/600s depending on context size), but `int(_elapsed)` reported by the stale detector was always ~3× that.

## Root cause

The OpenAI Python SDK defaults to `max_retries=2`. When the provider hangs, the SDK's httpx client times out (default ~600s read timeout) and the SDK retries internally — twice — while the worker thread stays inside `chat.completions.create`. By the time control returns to the polling loop in `_interruptible_api_call` and `_elapsed > _stale_timeout` finally evaluates True, ~3× the per-attempt timeout has already burned. The in-process polling-based stale detector cannot interrupt those internal retries because they happen below the SDK boundary.

## Fix

1. `_create_request_openai_client` injects `max_retries=0` into `request_kwargs`. The agent already has its own outer retry loop (`_api_max_retries`, default 3) with credential rotation, provider fallback, and backoff that the SDK can't see — leaving SDK retries on double-counts. Per-request OpenAI-wire clients are used by both the streaming and non-streaming chat-completions paths; shared/primary clients and Anthropic / Bedrock paths go through other constructors and are unaffected.
2. In `_interruptible_api_call`, hoist `_stale_timeout = self._compute_non_stream_stale_timeout(...)` above the `_call` closure so the closure captures it, then inject it as a per-call `timeout=` kwarg into `chat.completions.create` (via `setdefault`, so callers that explicitly pass a timeout still win). This pushes the read-timeout down to httpx so a hung provider fails at exactly `_stale_timeout` regardless of GIL/thread scheduling.

Other branches in `_interruptible_api_call` (`codex_responses`, `anthropic_messages`, `bedrock_converse`) are intentionally untouched — each has its own timeout / stale handling.

## Net effect

A single hung non-streaming chat completion now aborts within `_stale_timeout` seconds (300 / 450 / 600 depending on context size) instead of ~3×, and the agent's outer retry loop sees the failure in time to do real recovery.

## Test plan
- [x] `tests/run_agent/test_openai_client_lifecycle.py` — 11 passed
- [x] `tests/run_agent/test_interrupt_propagation.py` — passed
- [x] `tests/run_agent/test_streaming.py` — passed
- [x] `tests/run_agent/test_run_agent.py` + `test_run_agent_codex_responses.py` + `test_anthropic_error_handling.py` + `test_context_token_tracking.py` — all green
- [x] Total: 403 tests passed across the seven files above
- [ ] (Reviewer) Confirm `setdefault` for `timeout=` is the right contract for any callers that build their own `api_kwargs` with an explicit timeout