### PR TITLE
fix(tui): prefer exact slash command matches

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -221,6 +221,45 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
   })
 
+  it('lets exact catalog commands win over longer prefix matches', async () => {
+    const ctx = buildCtx({
+      local: {
+        catalog: {
+          canon: {
+            '/status': '/status',
+            '/statusbar': '/statusbar'
+          }
+        }
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/status')).toBe(true)
+    await vi.waitFor(() => {
+      expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+        command: 'status',
+        session_id: null
+      })
+    })
+    expect(ctx.transcript.sys).not.toHaveBeenCalledWith(expect.stringContaining('ambiguous command'))
+  })
+
+  it('keeps ambiguous prefix handling when there is no exact catalog match', () => {
+    const ctx = buildCtx({
+      local: {
+        catalog: {
+          canon: {
+            '/status': '/status',
+            '/statusbar': '/statusbar'
+          }
+        }
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/stat')).toBe(true)
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('ambiguous command: /status, /statusbar')
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('falls through to command.dispatch for skill commands and sends the message', async () => {
     const skillMessage = 'Use this skill to do X.\n\n## Steps\n1. First step'
 

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -47,23 +47,30 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
 
     if (catalog?.canon) {
       const needle = `/${parsed.name}`.toLowerCase()
+      const exact = Object.entries(catalog.canon).find(([alias]) => alias.toLowerCase() === needle)?.[1]
 
-      const matches = [
-        ...new Set(
-          Object.entries(catalog.canon)
-            .filter(([alias]) => alias.startsWith(needle))
-            .map(([, canon]) => canon)
-        )
-      ]
+      if (exact) {
+        if (exact.toLowerCase() !== needle) {
+          return handler(`${exact}${argTail}`)
+        }
+      } else {
+        const matches = [
+          ...new Set(
+            Object.entries(catalog.canon)
+              .filter(([alias]) => alias.startsWith(needle))
+              .map(([, canon]) => canon)
+          )
+        ]
 
-      if (matches.length === 1 && matches[0]!.toLowerCase() !== needle) {
-        return handler(`${matches[0]}${argTail}`)
-      }
+        if (matches.length === 1 && matches[0]!.toLowerCase() !== needle) {
+          return handler(`${matches[0]}${argTail}`)
+        }
 
-      if (matches.length > 1) {
-        sys(`ambiguous command: ${matches.slice(0, 6).join(', ')}${matches.length > 6 ? ', …' : ''}`)
+        if (matches.length > 1) {
+          sys(`ambiguous command: ${matches.slice(0, 6).join(', ')}${matches.length > 6 ? ', …' : ''}`)
 
-        return true
+          return true
+        }
       }
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes TUI slash command resolution so exact catalog matches win before prefix matching. This lets `/status` run normally instead of being reported as ambiguous with `/statusbar`, while preserving ambiguous partial prefixes like `/stat`.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1485307775444844625/threads/1497615525415485450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `ui-tui/src/app/createSlashHandler.ts` to check exact catalog aliases/names before prefix ambiguity.
- Added regression coverage in `ui-tui/src/__tests__/createSlashHandler.test.ts` for exact `/status` and ambiguous `/stat`.

## How to Test

1. Run `cd ui-tui && npm test -- --run src/__tests__/createSlashHandler.test.ts`.
2. Run `cd ui-tui && npm run type-check`.
3. In `hermes --tui`, enter `/status` and verify it runs instead of showing `ambiguous command: /status, /statusbar`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix/feature.
- [ ] I've run `pytest tests/ -q` and all tests pass. Full local suite was run via `scripts/run_tests.sh` with 4 workers; it failed with 68 unrelated failures, 15625 passed, 40 skipped.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Ubuntu/WSL terminal.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact. This is TUI command resolution logic and is platform independent.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## For New Skills

N/A

## Screenshots / Logs

Targeted checks:

- `cd ui-tui && npm test -- --run src/__tests__/createSlashHandler.test.ts` passed: 1 file, 21 tests.
- `cd ui-tui && npm run type-check` passed.
- Manual TUI check confirmed `/status` works after the fix.

Full suite:

- `scripts/run_tests.sh` ran with 4 workers and failed: 68 failed, 15625 passed, 40 skipped in 315.32s. The failures were broad existing gateway/config/provider failures and not in the changed TUI files.