### PR TITLE
fix(discord): scan all attachments for type; don't stop at first unrecognized (#15701)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3814,15 +3814,22 @@ class DiscordAdapter(BasePlatformAdapter):
         if normalized_content.startswith("/"):
             msg_type = MessageType.COMMAND
         elif message.attachments:
-            # Check attachment types
+            # Scan all attachments; stop at the first one that resolves to a
+            # recognised type.  The old code broke unconditionally after the
+            # first attachment that had *any* content_type, so an unsupported
+            # first attachment (e.g. application/octet-stream) caused
+            # subsequent image/audio/video attachments to be missed (#15701).
             for att in message.attachments:
                 if att.content_type:
                     if att.content_type.startswith("image/"):
                         msg_type = MessageType.PHOTO
+                        break
                     elif att.content_type.startswith("video/"):
                         msg_type = MessageType.VIDEO
+                        break
                     elif att.content_type.startswith("audio/"):
                         msg_type = MessageType.AUDIO
+                        break
                     else:
                         doc_ext = ""
                         if att.filename:
@@ -3830,7 +3837,7 @@ class DiscordAdapter(BasePlatformAdapter):
                             doc_ext = doc_ext.lower()
                         if doc_ext in SUPPORTED_DOCUMENT_TYPES:
                             msg_type = MessageType.DOCUMENT
-                    break
+                            break
 
         # When auto-threading kicked in, route responses to the new thread
         effective_channel = auto_threaded_channel or message.channel

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -9,6 +9,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -111,7 +112,7 @@ def adapter(monkeypatch):
 def make_attachment(
     *,
     filename: str,
-    content_type: str,
+    content_type: Optional[str],
     size: int = 1024,
     url: str = "https://cdn.discordapp.com/attachments/fake/file",
 ) -> SimpleNamespace:

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -132,7 +132,8 @@ def make_message(attachments: list, content: str = "") -> SimpleNamespace:
         reference=None,
         created_at=datetime.now(timezone.utc),
         channel=FakeDMChannel(),
-        author=SimpleNamespace(id=42, display_name="Tester", name="Tester"),
+        guild=None,  # DM — no guild; build_source reads message.guild directly
+        author=SimpleNamespace(id=42, display_name="Tester", name="Tester", bot=False),
     )
 
 
@@ -383,3 +384,88 @@ class TestIncomingDocumentHandling:
         assert event.message_type == MessageType.PHOTO
         assert event.media_urls == ["/tmp/cached_image.png"]
         assert event.media_types == ["image/png"]
+
+
+class TestAttachmentTypeDetection:
+    """msg_type classification scans all attachments, not just the first (#15701).
+
+    The old code broke out of the attachment loop unconditionally after the
+    first attachment that had *any* content_type, so an unsupported attachment
+    type at position 0 caused all later image/audio/video attachments to be
+    missed and the message to be classified as TEXT.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unsupported_first_recognized_image_second(self, adapter):
+        """Unsupported first attachment (application/octet-stream / .bin) must
+        not block classification; the second image attachment wins."""
+        with patch.object(
+            adapter, "_cache_discord_image",
+            new_callable=AsyncMock,
+            return_value="/tmp/photo.png",
+        ):
+            msg = make_message([
+                make_attachment(filename="data.bin", content_type="application/octet-stream"),
+                make_attachment(filename="photo.png", content_type="image/png"),
+            ])
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO, (
+            "Unsupported first attachment should not prevent image classification"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_content_type_on_first_falls_through_to_image(self, adapter):
+        """First attachment with content_type=None is silently skipped; the
+        subsequent image attachment is still classified correctly."""
+        with patch.object(
+            adapter, "_cache_discord_image",
+            new_callable=AsyncMock,
+            return_value="/tmp/photo.png",
+        ):
+            msg = make_message([
+                make_attachment(filename="data.bin", content_type=None),
+                make_attachment(filename="photo.png", content_type="image/png"),
+            ])
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+
+    @pytest.mark.asyncio
+    async def test_first_recognized_type_wins(self, adapter):
+        """When the first attachment is a recognized image, later audio
+        attachments do not downgrade the classification."""
+        with (
+            patch.object(
+                adapter, "_cache_discord_image",
+                new_callable=AsyncMock,
+                return_value="/tmp/photo.jpg",
+            ),
+            patch.object(
+                adapter, "_cache_discord_audio",
+                new_callable=AsyncMock,
+                return_value="/tmp/voice.ogg",
+            ),
+        ):
+            msg = make_message([
+                make_attachment(filename="photo.jpg", content_type="image/jpeg"),
+                make_attachment(filename="voice.ogg", content_type="audio/ogg"),
+            ])
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+
+    @pytest.mark.asyncio
+    async def test_unsupported_only_stays_text(self, adapter):
+        """A single unsupported attachment with no recognized type keeps msg_type TEXT."""
+        adapter._text_batch_delay_seconds = 0  # skip batching so handle_message is called inline
+        msg = make_message([
+            make_attachment(filename="data.bin", content_type="application/octet-stream"),
+        ])
+        await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.TEXT


### PR DESCRIPTION
## Summary

- The `msg_type` detection loop in `DiscordAdapter._handle_message()` unconditionally `break`ed after the first attachment that had *any* `content_type` string, even if that type was unrecognised (e.g. `application/octet-stream`)
- A mixed message with an unsupported file first and an image second was classified as `TEXT`, bypassing the vision tool and causing the message to be silently batched instead of dispatched as `PHOTO`
- The media-download loop already iterates all attachments correctly; this fix aligns the classification loop with it

## The bug

`gateway/platforms/discord.py` — classification loop (pre-fix):

```python
for att in message.attachments:
    if att.content_type:
        if att.content_type.startswith("image/"):
            msg_type = MessageType.PHOTO
        elif att.content_type.startswith("video/"):
            msg_type = MessageType.VIDEO
        elif att.content_type.startswith("audio/"):
            msg_type = MessageType.AUDIO
        else:
            ...
            if doc_ext in SUPPORTED_DOCUMENT_TYPES:
                msg_type = MessageType.DOCUMENT
    break   # ← breaks after first attachment with any content_type
```

When attachment[0] is `application/octet-stream` (not a supported document extension), `msg_type` stays `TEXT` and `break` fires — attachment[1]'s `image/png` is never inspected.

## The fix

Moved each `break` inside its own recognized-type branch.  Unrecognised attachment types fall through the `if att.content_type:` block without setting a type and without breaking, so the loop continues to the next attachment.

Also fixes the `make_message` test helper (added `guild=None` and `bot=False` on the author stub) which was broken by a recent upstream addition of `guild_id` to the `build_source` call — restoring the pre-existing `TestIncomingDocumentHandling` tests that had become red on `main`.

## Test plan

- [x] **Before**: `test_unsupported_first_recognized_image_second` — `handle_message` was never called (message batched as TEXT); `call_args` was `None` → `TypeError`
- [x] **After**: 4 new tests in `TestAttachmentTypeDetection` all pass; 11 pre-existing tests restored to green
- [x] **Regression guard**: reverted `gateway/platforms/discord.py` → `test_unsupported_first_recognized_image_second` failed; restored → 15 tests green
- [x] Adjacent suites unchanged: `test_discord_attachment_download` baseline unchanged

## Related

- Fixes #15701

🤖 Generated with [Claude Code](https://claude.com/claude-code)