### PR TITLE
feat: add resumable Responses streams

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1206,14 +1206,18 @@ class APIServerAdapter(BasePlatformAdapter):
           shape as the non-streaming path for parity)
         - ``response.failed`` — terminal event on agent error
 
-        If the client disconnects mid-stream, ``agent.interrupt()`` is
-        called so the agent stops issuing upstream LLM calls, then the
-        asyncio task is cancelled.  When ``store=True`` an initial
-        ``in_progress`` snapshot is persisted immediately after
-        ``response.created`` and disconnects update it to an
-        ``incomplete`` snapshot so GET /v1/responses/{id} and
-        ``previous_response_id`` chaining still have something to
-        recover from.
+        When ``store=True`` an initial ``in_progress`` snapshot is persisted
+        immediately after ``response.created``. If the client disconnects
+        mid-stream, the agent is allowed to continue running so the completed
+        response is persisted to ``ResponseStore`` and can be recovered via
+        ``GET /v1/responses/{response_id}``. Server-side cancellation still
+        updates the snapshot to ``incomplete`` so GET /v1/responses/{id} and
+        ``previous_response_id`` chaining have something to recover from.
+
+        For ``store=False`` the legacy behavior is preserved: ``agent.interrupt()``
+        is called on disconnect so the agent stops issuing upstream LLM calls
+        and the asyncio task is cancelled — no token spend on a response no one
+        will ever read.
         """
         import queue as _q
 
@@ -1230,6 +1234,15 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
+
+        # When `store=True` we want the run to complete and be persisted
+        # even if the client drops. This flag flips to False the first time
+        # a write raises a disconnect error; subsequent writes become no-ops
+        # and the main loop keeps draining the stream queue so the agent
+        # reaches its natural completion. The terminal persistence block
+        # still writes into ResponseStore so a later GET /v1/responses/{id}
+        # returns the completed snapshot.
+        client_connected = True
 
         # State accumulated during the stream
         final_text_parts: List[str] = []
@@ -1254,13 +1267,41 @@ class APIServerAdapter(BasePlatformAdapter):
         message_output_index: Optional[int] = None
         message_opened = False
 
+        async def _safe_write(payload: bytes) -> None:
+            """Write to the client; flip ``client_connected=False`` on drop.
+
+            When ``store=True`` we want the loop to keep running after the
+            client disconnects so the response can be persisted.  This helper
+            turns disconnect-related ``response.write`` failures into a
+            silent transition rather than an exception that would abort the
+            whole coroutine and skip the persistence branch.
+
+            For ``store=False`` we re-raise so the outer exception handler
+            can interrupt the agent and cancel the task promptly.
+            """
+            nonlocal client_connected
+            if not client_connected:
+                return
+            try:
+                await response.write(payload)
+            except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError) as exc:
+                client_connected = False
+                if not store:
+                    raise
+                logger.info(
+                    "SSE client disconnected mid-stream; continuing agent run "
+                    "for store=True response %s (%s)",
+                    response_id,
+                    type(exc).__name__,
+                )
+
         async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
             nonlocal sequence_number
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
             sequence_number += 1
             payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
-            await response.write(payload.encode())
+            await _safe_write(payload.encode())
 
         def _envelope(status: str) -> Dict[str, Any]:
             env: Dict[str, Any] = {
@@ -1518,7 +1559,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 break
                         break
                     if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
-                        await response.write(b": keepalive\n\n")
+                        await _safe_write(b": keepalive\n\n")
                         last_activity = time.monotonic()
                     continue
 
@@ -1636,9 +1677,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
 
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
-            _persist_incomplete_if_needed()
-            # Client disconnected — interrupt the agent so it stops
-            # making upstream LLM calls, then cancel the task.
+            # Only reached for ``store=False``: the _safe_write helper flips
+            # the connected flag silently when ``store=True``.  For ephemeral
+            # responses the user will never look at the output, so interrupt
+            # the agent to save tokens and cancel its task.
             agent = agent_ref[0] if agent_ref else None
             if agent is not None:
                 try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5,6 +5,7 @@ Exposes an HTTP server with endpoints:
 - POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header)
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
+- GET  /v1/responses/{response_id}/events — Replay + live-tail SSE events for a response (resume-from-cursor)
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent as an available model
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
@@ -315,6 +316,25 @@ class ResponseStore:
                 response_id TEXT NOT NULL
             )"""
         )
+        # Per-response event log for /v1/responses/{id}/events replay.
+        # Populated as events are emitted by the streaming handler so a client
+        # that drops mid-stream can reconnect with ?after=<sequence_number>
+        # and resume without losing events.  Rows are deleted when the
+        # parent response is evicted from ``responses`` (see ``put``/``delete``).
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS response_events (
+                response_id TEXT NOT NULL,
+                sequence_number INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (response_id, sequence_number)
+            )"""
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_response_events_rid "
+            "ON response_events(response_id, sequence_number)"
+        )
         self._conn.commit()
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
@@ -340,11 +360,29 @@ class ResponseStore:
         # Evict oldest entries beyond max_size
         count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
         if count > self._max_size:
-            self._conn.execute(
-                "DELETE FROM responses WHERE response_id IN "
-                "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
-                (count - self._max_size,),
-            )
+            # Fetch the ids we're about to evict so we can cascade-delete
+            # their event-log rows in the same transaction.  We can't rely
+            # on SQLite foreign keys because ``responses`` is intentionally
+            # bounded in size while ``response_events`` is keyed by the
+            # same id, not an FK to the parent row.
+            to_evict = [
+                row[0]
+                for row in self._conn.execute(
+                    "SELECT response_id FROM responses "
+                    "ORDER BY accessed_at ASC LIMIT ?",
+                    (count - self._max_size,),
+                ).fetchall()
+            ]
+            if to_evict:
+                placeholders = ",".join("?" for _ in to_evict)
+                self._conn.execute(
+                    f"DELETE FROM responses WHERE response_id IN ({placeholders})",
+                    to_evict,
+                )
+                self._conn.execute(
+                    f"DELETE FROM response_events WHERE response_id IN ({placeholders})",
+                    to_evict,
+                )
         self._conn.commit()
 
     def delete(self, response_id: str) -> bool:
@@ -352,8 +390,107 @@ class ResponseStore:
         cursor = self._conn.execute(
             "DELETE FROM responses WHERE response_id = ?", (response_id,)
         )
+        # Drop any event-log rows for this response too so we don't leak
+        # rows for an id that can no longer be looked up.
+        self._conn.execute(
+            "DELETE FROM response_events WHERE response_id = ?", (response_id,)
+        )
         self._conn.commit()
         return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Per-response event log (used by GET /v1/responses/{id}/events)
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        response_id: str,
+        sequence_number: int,
+        event_type: str,
+        data: Dict[str, Any],
+    ) -> None:
+        """Persist an SSE event for later replay.
+
+        ``(response_id, sequence_number)`` is the primary key so duplicate
+        appends for the same sequence number are idempotent via INSERT OR
+        IGNORE — a useful safety net if the streaming handler ever retries
+        a write.
+        """
+        try:
+            payload = json.dumps(data, default=str)
+        except (TypeError, ValueError):
+            # Last-resort: stringify the entire payload so we never drop an
+            # event because of a rogue non-serializable value.
+            payload = json.dumps({"repr": repr(data)})
+        self._conn.execute(
+            "INSERT OR IGNORE INTO response_events "
+            "(response_id, sequence_number, event_type, data, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (response_id, int(sequence_number), event_type, payload, time.time()),
+        )
+        self._conn.commit()
+
+    def get_events(
+        self,
+        response_id: str,
+        after: int = -1,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return stored events for ``response_id`` with ``sequence_number > after``.
+
+        Each row is returned as a dict with keys ``sequence_number``,
+        ``event_type``, and ``data`` (already parsed back from JSON).
+        Rows are ordered by ``sequence_number`` ASC.
+        """
+        query = (
+            "SELECT sequence_number, event_type, data FROM response_events "
+            "WHERE response_id = ? AND sequence_number > ? "
+            "ORDER BY sequence_number ASC"
+        )
+        params: List[Any] = [response_id, int(after)]
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+        rows = self._conn.execute(query, params).fetchall()
+        out: List[Dict[str, Any]] = []
+        for seq, event_type, data_json in rows:
+            try:
+                data = json.loads(data_json)
+            except (TypeError, ValueError):
+                data = {}
+            out.append({
+                "sequence_number": seq,
+                "event_type": event_type,
+                "data": data,
+            })
+        return out
+
+    def has_events(self, response_id: str) -> bool:
+        """Return True iff at least one event row exists for ``response_id``."""
+        row = self._conn.execute(
+            "SELECT 1 FROM response_events WHERE response_id = ? LIMIT 1",
+            (response_id,),
+        ).fetchone()
+        return row is not None
+
+    def latest_event_sequence(self, response_id: str) -> Optional[int]:
+        """Return the highest stored ``sequence_number`` for a response, or None."""
+        row = self._conn.execute(
+            "SELECT MAX(sequence_number) FROM response_events WHERE response_id = ?",
+            (response_id,),
+        ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return int(row[0])
+
+    def clear_events(self, response_id: str) -> int:
+        """Delete every stored event row for ``response_id``.  Returns rowcount."""
+        cursor = self._conn.execute(
+            "DELETE FROM response_events WHERE response_id = ?",
+            (response_id,),
+        )
+        self._conn.commit()
+        return int(cursor.rowcount or 0)
 
     def get_conversation(self, name: str) -> Optional[str]:
         """Get the latest response_id for a conversation name."""
@@ -590,6 +727,19 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        # --- Phase 2 replay state (POST /v1/responses streaming) ---
+        # response_id -> set of asyncio.Queue subscribers.  Each queue gets
+        # a copy of every SSE event the writer emits for that response so
+        # GET /v1/responses/{id}/events can tail the live stream after
+        # catching up on stored events.  The sentinel None is pushed when
+        # the response reaches a terminal event (completed/failed) so
+        # subscribers know to close.
+        self._response_event_subscribers: Dict[str, set] = {}
+        # response_id -> True while the streaming handler is actively
+        # emitting events.  Set to False (via pop) in the writer's finally
+        # block so GET /events can tell the response is over even if no
+        # terminal event was persisted (e.g. agent task crashed hard).
+        self._active_responses: Dict[str, bool] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
 
     @staticmethod
@@ -1296,10 +1446,58 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
+            """Emit one SSE event: persist + publish + write.
+
+            Order matters here.  We persist to ``ResponseStore.append_event``
+            and broadcast to any GET ``/events`` subscribers BEFORE writing
+            to the live client.  That way a client disconnect in the middle
+            of a write never costs subscribers (or the replay cursor) an
+            event they should have received.
+
+            When ``store=False`` we skip persistence — the whole point of
+            store=False is that the response is ephemeral and disconnect
+            should interrupt the agent anyway (see the outer exception
+            handler in ``_write_sse_responses``).
+            """
             nonlocal sequence_number
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
+            seq_used = sequence_number
             sequence_number += 1
+
+            # 1) Persistent event log for replay after drop.
+            if store:
+                try:
+                    self._response_store.append_event(
+                        response_id, seq_used, event_type, data,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "append_event failed for response %s seq %d",
+                        response_id, seq_used, exc_info=True,
+                    )
+
+            # 2) Fan-out to live /events subscribers.  Each queue gets its
+            #    own dict snapshot so a subscriber can't mutate the shared
+            #    payload.  Copy the subscriber set first so that a
+            #    subscriber unsubscribing mid-broadcast can't mutate us.
+            subs = self._response_event_subscribers.get(response_id)
+            if subs:
+                event_record = {
+                    "sequence_number": seq_used,
+                    "event_type": event_type,
+                    "data": dict(data),
+                }
+                for q in list(subs):
+                    try:
+                        q.put_nowait(event_record)
+                    except Exception:
+                        # A full or closed subscriber queue is not the
+                        # writer's problem — the replay handler owns its
+                        # own lifecycle.
+                        pass
+
+            # 3) Live client write.  Safe-write quietly no-ops after drop.
             payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
             await _safe_write(payload.encode())
 
@@ -1370,6 +1568,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 incomplete_env,
                 conversation_history_snapshot=incomplete_history,
             )
+
+        # Mark the response as active so GET /v1/responses/{id}/events knows
+        # it should tail live events rather than only replay stored ones.
+        # Cleared in ``_finalize_active_response`` below, which also pushes
+        # a ``None`` sentinel to every /events subscriber so they close
+        # cleanly instead of waiting on a dead producer.
+        self._active_responses[response_id] = True
+
+        def _finalize_active_response() -> None:
+            self._active_responses.pop(response_id, None)
+            subs = self._response_event_subscribers.get(response_id)
+            if not subs:
+                return
+            for q in list(subs):
+                try:
+                    q.put_nowait(None)
+                except Exception:
+                    pass
 
         try:
             # response.created — initial envelope, status=in_progress
@@ -1710,6 +1926,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_task.cancel()
             logger.info("SSE task cancelled; persisted incomplete snapshot for %s", response_id)
             raise
+        finally:
+            # The response is no longer live.  Wake any /events subscribers
+            # waiting on our queue so they can settle to a completed/failed
+            # state (or, for store=False, give up cleanly).
+            _finalize_active_response()
 
         return response
 
@@ -2007,6 +2228,212 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "deleted": True,
         })
+
+    async def _handle_get_response_events(
+        self, request: "web.Request"
+    ) -> "web.StreamResponse":
+        """GET /v1/responses/{response_id}/events?after=<sequence_number>
+
+        Phase 2 replay endpoint for the OpenAI Responses API streaming flow.
+
+        Behavior:
+        - Replay every stored event with ``sequence_number > after`` in the
+          same on-the-wire format as the original SSE stream
+          (``event: <type>\\ndata: <json>\\n\\n``).
+        - If the response is still active (live ``POST /v1/responses``
+          handler emitting events), keep the HTTP connection open and tail
+          the live event stream via an in-memory pub/sub queue.  Closes
+          naturally when the streaming handler finalizes.
+        - If the response is already complete, replay whatever was stored
+          and close without waiting.
+        - If the response id is unknown and nothing was ever stored,
+          return 404 with an OpenAI-style error envelope.
+
+        The ``after`` query parameter defaults to -1, which means "send me
+        every event from the beginning" — matching the client-side reducer
+        sentinel documented in the resumable-sse-streaming skill.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        response_id = request.match_info["response_id"]
+
+        # Parse the ?after cursor; reject garbage explicitly so clients
+        # don't silently get "everything from the start" when they meant
+        # something else.
+        raw_after = request.query.get("after", "-1")
+        try:
+            after = int(raw_after)
+        except (TypeError, ValueError):
+            return web.json_response(
+                _openai_error(
+                    "'after' must be an integer sequence number",
+                    param="after",
+                    code="invalid_query_parameter",
+                ),
+                status=400,
+            )
+
+        # 404 when we have no trace of this response at all.  Note: a
+        # completed response keeps its event-log rows in ResponseStore, so
+        # a successful replay for a completed-but-forgotten response is
+        # still possible until the row is evicted by LRU.
+        has_events = self._response_store.has_events(response_id)
+        has_stored_response = self._response_store.get(response_id) is not None
+        is_active = response_id in self._active_responses
+        if not has_events and not has_stored_response and not is_active:
+            return web.json_response(
+                _openai_error(
+                    f"Response not found: {response_id}",
+                    code="response_not_found",
+                ),
+                status=404,
+            )
+
+        # Subscribe to live events BEFORE replaying stored ones.  This
+        # ordering closes a narrow race: if the writer emits seq=N+1 after
+        # we read the store but before we add our queue, the event would
+        # otherwise be lost.  Since stored + live are deduplicated client-
+        # side by sequence_number (and we dedupe via a local "seen set"
+        # below), a temporary double-delivery is fine.
+        live_q: "asyncio.Queue" = asyncio.Queue()
+        subs = self._response_event_subscribers.setdefault(response_id, set())
+        subs.add(live_q)
+
+        sse_headers = {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        }
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            sse_headers.update(cors)
+        response = web.StreamResponse(status=200, headers=sse_headers)
+        await response.prepare(request)
+
+        last_seq_sent = after
+        seen_seqs: set = set()
+        client_alive = True
+
+        async def _safe_write_replay(payload: bytes) -> bool:
+            nonlocal client_alive
+            if not client_alive:
+                return False
+            try:
+                await response.write(payload)
+                return True
+            except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
+                client_alive = False
+                return False
+
+        async def _emit(seq: int, event_type: str, data: Dict[str, Any]) -> bool:
+            nonlocal last_seq_sent
+            if seq in seen_seqs:
+                return True
+            seen_seqs.add(seq)
+            # Make sure the sequence_number is carried on the event
+            # payload so clients that only parse `data:` can still drive
+            # their cursor without inspecting `event:`.
+            if "sequence_number" not in data:
+                data = dict(data)
+                data["sequence_number"] = seq
+            line = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+            ok = await _safe_write_replay(line.encode())
+            if ok:
+                last_seq_sent = max(last_seq_sent, seq)
+            return ok
+
+        try:
+            # 1) Replay phase: stored events that beat the cursor.
+            stored_events = self._response_store.get_events(response_id, after=after)
+            for row in stored_events:
+                if not client_alive:
+                    break
+                await _emit(
+                    int(row["sequence_number"]),
+                    str(row["event_type"]),
+                    row.get("data") or {},
+                )
+
+            # 2) Live tail phase: only if the streaming handler is still
+            #    active.  Otherwise the response is either already fully
+            #    persisted or was never live in this process; in both
+            #    cases the replay above is the whole story.
+            keepalive_every = 15.0
+            while client_alive and response_id in self._active_responses:
+                try:
+                    event = await asyncio.wait_for(live_q.get(), timeout=keepalive_every)
+                except asyncio.TimeoutError:
+                    if not await _safe_write_replay(b": keepalive\n\n"):
+                        break
+                    continue
+                if event is None:
+                    # Writer signaled terminal state.
+                    break
+                seq = int(event.get("sequence_number", -1))
+                if seq <= last_seq_sent:
+                    continue
+                if not await _emit(
+                    seq,
+                    str(event.get("event_type", "")),
+                    event.get("data") or {},
+                ):
+                    break
+
+            # 3) Terminal drain: after the live producer finalizes, there
+            #    might still be queued events we haven't relayed yet
+            #    (e.g. the final response.completed that was published
+            #    just before the finalize sentinel).  Drain without
+            #    blocking.
+            while client_alive:
+                try:
+                    event = live_q.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if event is None:
+                    continue
+                seq = int(event.get("sequence_number", -1))
+                if seq <= last_seq_sent:
+                    continue
+                if not await _emit(
+                    seq,
+                    str(event.get("event_type", "")),
+                    event.get("data") or {},
+                ):
+                    break
+
+            # 4) Final sweep of stored rows in case the writer committed
+            #    events we never saw on the queue (defensive; closes the
+            #    race where we subscribed after the writer emitted the
+            #    last event but before the finalize sentinel reached us).
+            if client_alive and last_seq_sent >= -1:
+                for row in self._response_store.get_events(response_id, after=last_seq_sent):
+                    if not client_alive:
+                        break
+                    await _emit(
+                        int(row["sequence_number"]),
+                        str(row["event_type"]),
+                        row.get("data") or {},
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[api_server] /v1/responses/%s/events error: %s",
+                response_id, exc,
+            )
+        finally:
+            subs = self._response_event_subscribers.get(response_id)
+            if subs is not None:
+                subs.discard(live_q)
+                if not subs:
+                    self._response_event_subscribers.pop(response_id, None)
+            try:
+                await _safe_write_replay(b": stream closed\n\n")
+            except Exception:
+                pass
+
+        return response
 
     # ------------------------------------------------------------------
     # Cron jobs API
@@ -2666,6 +3093,10 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
+            self._app.router.add_get(
+                "/v1/responses/{response_id}/events",
+                self._handle_get_response_events,
+            )
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1449,63 +1449,152 @@ class TestResponsesStreaming:
         )
         assert "partial output" in output_text
 
-    @pytest.mark.asyncio
-    async def test_stream_client_disconnect_persists_incomplete_snapshot(self, adapter):
-        """Client disconnect (ConnectionResetError) during streaming must
-        persist an ``incomplete`` snapshot in ResponseStore.  Regression
-        for PR #15171."""
-        fake_request = MagicMock()
-        fake_request.headers = {}
+    async def test_stream_continues_after_client_disconnect_when_stored(self, adapter):
+        """Client disconnect mid-stream must NOT cancel the agent for
+        store=True runs. The response should still reach response.completed
+        and be persisted to ResponseStore so a later GET recovers it.
+        """
+        from aiohttp import web as _aw
 
-        write_call_count = {"n": 0}
+        original_write = _aw.StreamResponse.write
+        disconnect_after = {"count": 0, "trigger": 2}
 
-        class _DisconnectingStreamResponse:
-            async def prepare(self, req):
-                pass
+        async def _flaky_write(self, data, *args, **kwargs):
+            disconnect_after["count"] += 1
+            if disconnect_after["count"] > disconnect_after["trigger"]:
+                raise ConnectionResetError("simulated client disconnect")
+            return await original_write(self, data, *args, **kwargs)
 
-            async def write(self, payload):
-                # First two writes succeed (prepare + response.created).
-                # On the third write (a text delta), the "client"
-                # disconnects — simulate with ConnectionResetError.
-                write_call_count["n"] += 1
-                if write_call_count["n"] >= 3:
-                    raise ConnectionResetError("simulated client disconnect")
+        agent_ran_to_completion = asyncio.Event()
+        captured_response_id = {"value": None}
 
-        import gateway.platforms.api_server as api_mod
-        import queue as _q
-
-        stream_q: _q.Queue = _q.Queue()
-        stream_q.put("some streamed text")
-        stream_q.put(None)  # EOS sentinel
-
-        async def _agent_coro():
-            await asyncio.sleep(0.01)
-            return ({"final_response": "", "messages": [], "api_calls": 0},
-                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
-
-        agent_task = asyncio.ensure_future(_agent_coro())
-        response_id = f"resp_{uuid.uuid4().hex[:28]}"
-
-        with patch.object(api_mod.web, "StreamResponse", return_value=_DisconnectingStreamResponse()):
-            await adapter._write_sse_responses(
-                request=fake_request,
-                response_id=response_id,
-                model="hermes-agent",
-                created_at=int(time.time()),
-                stream_q=stream_q,
-                agent_task=agent_task,
-                agent_ref=[None],
-                conversation_history=[],
-                user_message="will disconnect",
-                instructions=None,
-                conversation=None,
-                store=True,
-                session_id=None,
+        async def _mock_run_agent(**kwargs):
+            cb = kwargs.get("stream_delta_callback")
+            if cb:
+                # Yield control between deltas so the SSE loop has a chance
+                # to attempt a write and hit the simulated disconnect.
+                cb("Recovered")
+                await asyncio.sleep(0)
+                cb(" answer")
+                await asyncio.sleep(0)
+            agent_ran_to_completion.set()
+            return (
+                {"final_response": "Recovered answer", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
             )
 
-        stored = adapter._response_store.get(response_id)
-        assert stored is not None, "snapshot must survive client disconnect"
-        assert stored["response"]["status"] == "incomplete"
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent), \
+                 patch.object(_aw.StreamResponse, "write", _flaky_write):
+                # Fire the request — the stream will abort mid-way server-side
+                # but the agent should still run to completion for store=True.
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "will drop",
+                        "stream": True,
+                        "store": True,
+                    },
+                )
+                # Drain whatever events we did receive so we can record the id.
+                try:
+                    body = await resp.text()
+                except Exception:
+                    body = ""
+                for line in body.splitlines():
+                    if line.startswith("data: "):
+                        try:
+                            payload = json.loads(line[len("data: "):])
+                        except json.JSONDecodeError:
+                            continue
+                        if payload.get("type") == "response.created":
+                            captured_response_id["value"] = payload["response"]["id"]
+                            break
+
+            # Wait for the mocked agent to finish; without the fix the task
+            # would be cancelled by the disconnect handler and this would
+            # time out.
+            await asyncio.wait_for(agent_ran_to_completion.wait(), timeout=5.0)
+
+            assert captured_response_id["value"], "response.created must have been seen before the drop"
+
+            # Give the persistence branch a moment to finish writing after the
+            # agent task returned.
+            for _ in range(50):
+                if adapter._response_store.get(captured_response_id["value"]) is not None:
+                    break
+                await asyncio.sleep(0.05)
+
+            # GET /v1/responses/{id} returns the completed snapshot.
+            get_resp = await cli.get(f"/v1/responses/{captured_response_id['value']}")
+            assert get_resp.status == 200
+            data = await get_resp.json()
+            assert data["status"] == "completed"
+            assert data["output"][-1]["content"][0]["text"] == "Recovered answer"
+
+    @pytest.mark.asyncio
+    async def test_stream_interrupts_agent_on_disconnect_when_not_stored(self, adapter):
+        """Legacy behavior for store=False: disconnect still cancels the
+        agent so we don't spend tokens on a response no one will read.
+        """
+        from aiohttp import web as _aw
+
+        original_write = _aw.StreamResponse.write
+        # Let a couple of writes through so the mocked agent task has time
+        # to populate agent_ref[0] with our fake before the drop fires.
+        disconnect_after = {"count": 0, "trigger": 2}
+
+        async def _flaky_write(self, data, *args, **kwargs):
+            disconnect_after["count"] += 1
+            if disconnect_after["count"] > disconnect_after["trigger"]:
+                raise ConnectionResetError("simulated client disconnect")
+            return await original_write(self, data, *args, **kwargs)
+
+        interrupted = asyncio.Event()
+
+        async def _mock_run_agent(**kwargs):
+            agent_ref = kwargs.get("agent_ref")
+
+            class _FakeAgent:
+                def interrupt(self, _reason):
+                    interrupted.set()
+
+            if isinstance(agent_ref, list):
+                agent_ref[0] = _FakeAgent()
+            # Push one delta so the SSE loop does a second write and crosses
+            # the disconnect trigger.
+            cb = kwargs.get("stream_delta_callback")
+            if cb:
+                cb("hi")
+            # Sleep long enough that cancellation actually wins the race.
+            await asyncio.sleep(5)
+            return (
+                {"final_response": "never sent", "messages": [], "api_calls": 1},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent), \
+                 patch.object(_aw.StreamResponse, "write", _flaky_write):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "drop me",
+                        "stream": True,
+                        "store": False,
+                    },
+                )
+                try:
+                    await resp.read()
+                except Exception:
+                    pass
+
+            # interrupt() must have been invoked on the agent.
+            await asyncio.wait_for(interrupted.wait(), timeout=5.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -295,12 +295,18 @@ class TestAuth:
 
 
 def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
-    """Create an adapter with optional API key."""
+    """Create an adapter with optional API key.
+
+    ``cors_origins`` defaults to the empty string so tests are hermetic
+    and don't inherit ``API_SERVER_CORS_ORIGINS`` from the shell
+    environment (which would silently enable CORS for whatever origins
+    the developer happens to have configured locally).  Pass an explicit
+    list/tuple/string to enable CORS for a test.
+    """
     extra = {}
     if api_key:
         extra["key"] = api_key
-    if cors_origins is not None:
-        extra["cors_origins"] = cors_origins
+    extra["cors_origins"] = "" if cors_origins is None else cors_origins
     config = PlatformConfig(enabled=True, extra=extra)
     return APIServerAdapter(config)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -317,6 +317,10 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
+    app.router.add_get(
+        "/v1/responses/{response_id}/events",
+        adapter._handle_get_response_events,
+    )
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
     return app
 
@@ -1449,6 +1453,7 @@ class TestResponsesStreaming:
         )
         assert "partial output" in output_text
 
+    @pytest.mark.asyncio
     async def test_stream_continues_after_client_disconnect_when_stored(self, adapter):
         """Client disconnect mid-stream must NOT cancel the agent for
         store=True runs. The response should still reach response.completed
@@ -2404,3 +2409,346 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+# ---------------------------------------------------------------------------
+# ResponseStore event-log helpers (Phase 2 replay primitives)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseStoreEventLog:
+    def test_append_and_get_events_preserves_order(self):
+        store = ResponseStore(max_size=10)
+        store.append_event("resp_1", 0, "response.created", {"x": 0})
+        store.append_event("resp_1", 1, "response.output_text.delta", {"x": 1})
+        store.append_event("resp_1", 2, "response.completed", {"x": 2})
+
+        events = store.get_events("resp_1")
+        assert [e["sequence_number"] for e in events] == [0, 1, 2]
+        assert [e["event_type"] for e in events] == [
+            "response.created",
+            "response.output_text.delta",
+            "response.completed",
+        ]
+        assert events[1]["data"] == {"x": 1}
+
+    def test_get_events_respects_after_cursor(self):
+        store = ResponseStore(max_size=10)
+        for seq in range(5):
+            store.append_event("resp_1", seq, "e", {"seq": seq})
+        tail = store.get_events("resp_1", after=2)
+        assert [e["sequence_number"] for e in tail] == [3, 4]
+
+    def test_append_event_is_idempotent_on_duplicate_seq(self):
+        store = ResponseStore(max_size=10)
+        store.append_event("resp_1", 0, "e", {"a": 1})
+        store.append_event("resp_1", 0, "e", {"a": 2})  # duplicate seq
+        events = store.get_events("resp_1")
+        assert len(events) == 1
+        assert events[0]["data"] == {"a": 1}  # first-write wins
+
+    def test_has_events_and_latest_event_sequence(self):
+        store = ResponseStore(max_size=10)
+        assert store.has_events("resp_x") is False
+        assert store.latest_event_sequence("resp_x") is None
+        store.append_event("resp_x", 0, "e", {})
+        store.append_event("resp_x", 7, "e", {})
+        assert store.has_events("resp_x") is True
+        assert store.latest_event_sequence("resp_x") == 7
+
+    def test_delete_response_clears_event_log(self):
+        store = ResponseStore(max_size=10)
+        store.put("resp_1", {"output": "done"})
+        store.append_event("resp_1", 0, "e", {})
+        store.append_event("resp_1", 1, "e", {})
+        assert store.has_events("resp_1") is True
+        store.delete("resp_1")
+        assert store.has_events("resp_1") is False
+        assert store.get("resp_1") is None
+
+    def test_lru_eviction_cascades_to_event_log(self):
+        store = ResponseStore(max_size=2)
+        store.put("resp_1", {"output": "one"})
+        store.append_event("resp_1", 0, "e", {})
+        store.put("resp_2", {"output": "two"})
+        store.append_event("resp_2", 0, "e", {})
+        # Adding a 3rd response evicts resp_1, including its event log
+        store.put("resp_3", {"output": "three"})
+        assert store.get("resp_1") is None
+        assert store.has_events("resp_1") is False
+        assert store.has_events("resp_2") is True
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/responses/{id}/events — replay + live-tail endpoint
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse_events(body: str):
+    """Parse an SSE body into a list of {event, data} dicts.
+
+    Silently skips keepalive and ``: stream closed`` comment lines as well
+    as any ``data:`` line that isn't valid JSON.  Order preserved.
+    """
+    out = []
+    current = {}
+    for line in body.splitlines():
+        if not line:
+            if current:
+                out.append(current)
+                current = {}
+            continue
+        if line.startswith("event:"):
+            current["event"] = line[len("event:"):].strip()
+        elif line.startswith("data:"):
+            raw = line[len("data:"):].strip()
+            try:
+                current["data"] = json.loads(raw)
+            except json.JSONDecodeError:
+                current["data"] = None
+        # ":" comment lines are ignored.
+    if current:
+        out.append(current)
+    return out
+
+
+class TestResponsesEventsReplay:
+    @pytest.mark.asyncio
+    async def test_events_replays_stored_events_after_completion(self, adapter):
+        """After a response is fully streamed, GET /events returns every
+        stored event in order and closes without hanging on a live tail."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Hello")
+                    cb(" world")
+                return (
+                    {"final_response": "Hello world", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                post_resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True, "store": True},
+                )
+                body = await post_resp.text()
+
+            # Pick the response_id out of the response.created event.
+            response_id = None
+            for evt in _parse_sse_events(body):
+                data = evt.get("data") or {}
+                if data.get("type") == "response.created":
+                    response_id = data["response"]["id"]
+                    break
+            assert response_id is not None
+
+            # Now replay — the response is already completed.
+            replay = await cli.get(f"/v1/responses/{response_id}/events?after=-1")
+            assert replay.status == 200
+            assert "text/event-stream" in replay.headers.get("Content-Type", "")
+            replay_body = await replay.text()
+            events = [e for e in _parse_sse_events(replay_body) if e.get("data")]
+            # The first replayed event must be response.created with seq=0
+            assert events, "at least one replayed event expected"
+            first = events[0]
+            assert first["data"]["type"] == "response.created"
+            assert first["data"]["sequence_number"] == 0
+            # Sequence numbers strictly increase by 1 starting from 0.
+            seqs = [e["data"]["sequence_number"] for e in events]
+            assert seqs == list(range(len(seqs)))
+            # Terminal event is response.completed.
+            assert events[-1]["data"]["type"] == "response.completed"
+
+    @pytest.mark.asyncio
+    async def test_events_after_cursor_only_returns_newer_events(self, adapter):
+        """?after=N must only send events with sequence_number > N."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Hello")
+                    cb(" world")
+                return (
+                    {"final_response": "Hello world", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                post_resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True, "store": True},
+                )
+                body = await post_resp.text()
+
+            # Find the response id and the top sequence number so we can
+            # request "give me nothing new" with after=max_seq.
+            events = [e for e in _parse_sse_events(body) if e.get("data")]
+            response_id = None
+            max_seq = -1
+            for e in events:
+                data = e["data"]
+                if data.get("type") == "response.created":
+                    response_id = data["response"]["id"]
+                seq = data.get("sequence_number")
+                if isinstance(seq, int) and seq > max_seq:
+                    max_seq = seq
+            assert response_id is not None
+            assert max_seq >= 0
+
+            # after=max_seq must return zero real events.
+            replay = await cli.get(f"/v1/responses/{response_id}/events?after={max_seq}")
+            assert replay.status == 200
+            replay_body = await replay.text()
+            replayed = [e for e in _parse_sse_events(replay_body) if e.get("data")]
+            assert replayed == [], f"expected no events, got {replayed!r}"
+
+            # after=0 must return every event with seq > 0 and none with seq == 0.
+            replay2 = await cli.get(f"/v1/responses/{response_id}/events?after=0")
+            body2 = await replay2.text()
+            replayed2 = [e for e in _parse_sse_events(body2) if e.get("data")]
+            assert replayed2, "some events should be replayed"
+            assert all(e["data"]["sequence_number"] > 0 for e in replayed2)
+
+    @pytest.mark.asyncio
+    async def test_events_returns_404_for_unknown_response(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/responses/resp_does_not_exist/events")
+            assert resp.status == 404
+            data = await resp.json()
+            assert data["error"]["code"] == "response_not_found"
+
+    @pytest.mark.asyncio
+    async def test_events_rejects_non_integer_after(self, adapter):
+        # Pre-populate the store so the id lookup won't 404 first.
+        adapter._response_store.put("resp_live", {"response": {"id": "resp_live"}})
+        adapter._response_store.append_event("resp_live", 0, "response.created", {})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/responses/resp_live/events?after=not-a-number")
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["code"] == "invalid_query_parameter"
+
+    @pytest.mark.asyncio
+    async def test_events_tails_live_stream_and_closes_on_completion(self, adapter):
+        """Subscribe to /events while the response is still streaming and
+        confirm we receive every live event + the terminal response.completed,
+        then the stream closes."""
+        app = _create_app(adapter)
+
+        # Gate the mock agent so the POST is still running when the
+        # replay client subscribes.
+        agent_gate = asyncio.Event()
+        created_seen = asyncio.Event()
+
+        async def _mock_run_agent(**kwargs):
+            cb = kwargs.get("stream_delta_callback")
+            # Stream 1 delta immediately so response.created fires and
+            # the response gets registered in _active_responses.
+            if cb:
+                cb("Hello")
+            # Signal the test it can issue the replay GET now.
+            created_seen.set()
+            # Wait for the test to subscribe.
+            await agent_gate.wait()
+            if cb:
+                cb(" world")
+            return (
+                {"final_response": "Hello world", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                # Kick off the streaming POST and an events GET in parallel.
+                async def _drive_post():
+                    r = await cli.post(
+                        "/v1/responses",
+                        json={
+                            "model": "hermes-agent",
+                            "input": "go",
+                            "stream": True,
+                            "store": True,
+                        },
+                    )
+                    return await r.text()
+
+                post_task = asyncio.create_task(_drive_post())
+
+                # Wait until the agent has emitted response.created + the
+                # first delta, so the response_id is discoverable and the
+                # response is registered as active.
+                await asyncio.wait_for(created_seen.wait(), timeout=5.0)
+
+                # Find the response_id by peeking at the writer's own
+                # event log (guaranteed to contain response.created by now
+                # since that is the very first _write_event call).
+                for _ in range(50):
+                    ids = [rid for rid in adapter._active_responses.keys()]
+                    if ids:
+                        response_id = ids[0]
+                        break
+                    await asyncio.sleep(0.02)
+                else:
+                    raise AssertionError("response never became active")
+
+                # Subscribe to /events with a fresh cursor — we want the
+                # replay handler to relay every live event after this
+                # point, then the final response.completed, then close.
+                replay_task = asyncio.create_task(
+                    cli.get(f"/v1/responses/{response_id}/events?after=-1")
+                )
+                # Give the handler a moment to subscribe.
+                await asyncio.sleep(0.05)
+
+                # Let the agent finish.
+                agent_gate.set()
+
+                replay_resp = await asyncio.wait_for(replay_task, timeout=5.0)
+                assert replay_resp.status == 200
+                replay_body = await asyncio.wait_for(replay_resp.text(), timeout=5.0)
+                post_body = await asyncio.wait_for(post_task, timeout=5.0)
+
+            replay_events = [e for e in _parse_sse_events(replay_body) if e.get("data")]
+            post_events = [e for e in _parse_sse_events(post_body) if e.get("data")]
+
+            # Every sequence number the POST client saw must also appear
+            # in the replay stream exactly once (idempotency by seq).
+            post_seqs = [
+                e["data"]["sequence_number"]
+                for e in post_events
+                if "sequence_number" in e["data"]
+            ]
+            replay_seqs = [
+                e["data"]["sequence_number"]
+                for e in replay_events
+                if "sequence_number" in e["data"]
+            ]
+            assert replay_seqs == sorted(replay_seqs), "replay must be in order"
+            assert len(replay_seqs) == len(set(replay_seqs)), "no duplicate seqs"
+            for seq in post_seqs:
+                assert seq in replay_seqs, f"missing seq {seq} in replay"
+
+            # Replay stream must end with response.completed.
+            assert replay_events[-1]["data"]["type"] == "response.completed"
+
+    @pytest.mark.asyncio
+    async def test_events_stored_response_without_event_log_still_404s_unless_stored(self, adapter):
+        """A response stored via direct put() but without any event log
+        rows still allows a 200 empty replay (so legacy snapshots don't
+        accidentally 404).  The inverse — nothing stored, no events — is
+        the 404 path tested above."""
+        adapter._response_store.put("resp_legacy", {"response": {"id": "resp_legacy"}})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/responses/resp_legacy/events?after=-1")
+            assert resp.status == 200
+            body = await resp.text()
+            events = [e for e in _parse_sse_events(body) if e.get("data")]
+            assert events == []
+

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -186,9 +186,34 @@ The server automatically chains to the latest response in that conversation. Lik
 
 Retrieve a previously stored response by ID.
 
+### GET /v1/responses/\{id\}/events
+
+Replay + live-tail the Server-Sent Events stream of a stored response.
+Designed to let clients resume a dropped `/v1/responses` stream without
+replaying the user turn or creating a duplicate response.
+
+- `?after=<sequence_number>` — return only events strictly newer than the
+  given cursor.  Defaults to `-1`, meaning replay every event from the
+  start (matching the client-side sentinel for "nothing applied yet").
+- If the response is still running, the connection stays open and tails
+  new events as they are emitted, then closes when the response reaches
+  a terminal event (`response.completed` / `response.failed`).
+- If the response is already complete, the replay closes as soon as the
+  stored event log has been flushed.
+- Returns `404 response_not_found` when the id has never existed and is
+  not currently active.  Returns `400` for non-integer `after` values.
+- The `sequence_number` on each event is monotonic and matches the
+  original stream; clients should dedupe by `sequence_number` to make
+  reconnects idempotent.
+
+Combined with `store: true` and the "continue after disconnect" behavior
+of the streaming POST, this closes the loop on resumable Responses
+streams without requiring `EventSource`'s `Last-Event-ID` handshake.
+
 ### DELETE /v1/responses/\{id\}
 
-Delete a stored response.
+Delete a stored response.  This also clears the replay event log for
+that response.
 
 ### GET /v1/models
 


### PR DESCRIPTION
## What does this PR do?

I have my own front end client that uses the API server. I wanted it to work similar to messaging platforms - shoot off a message, come back to it in the middle of the agent response or after it’s done and see everything it did. As well as having multiple sessions going at once, that I can pop in and out of without any connection issues. These changes achieve that.

Adds backend support for resumable `/v1/responses` streams so clients can recover after dropped SSE connections, page reloads, or returning to an in-progress response.

For `store=true` streaming responses, the agent task now continues running after a client disconnect, records the response event stream, and persists the completed response for later recovery via `GET /v1/responses/{id}`. For `store=false`, the existing token-saving behavior is preserved: disconnecting the client interrupts and cancels the agent task.

This approach keeps non-stored streams inexpensive while enabling messaging-style clients to safely reconnect, replay missed events, and live-tail active stored responses without losing response state.

## Related Issue

N/A — no linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Keeps `store=true` streaming responses alive after client disconnects.
  - Persists a per-response event log in `ResponseStore`.
  - Adds cursor-based event replay at `GET /v1/responses/{id}/events?after=<sequence_number>`.
  - Replays stored events, live-tails active responses with in-memory subscribers, and uses terminal sentinel handling plus final drain/sweep logic to avoid hangs or missed tail events.
  - Preserves existing cancellation behavior for `store=false` streams.
- `tests/gateway/test_api_server.py`
  - Adds coverage for response event-log helpers, replay cursor semantics, live-tail behavior, 404 handling, invalid query handling, stored-stream disconnect continuation, non-stored disconnect cancellation, and cancelled snapshot persistence.
  - Makes API-server CORS tests hermetic by ignoring the ambient `API_SERVER_CORS_ORIGINS` environment variable.
- `website/docs/user-guide/features/api-server.md`
  - Documents resumable stored streams and the response event replay endpoint.

## How to Test

1. Run the targeted disconnect/replay coverage:
   ```bash
   python -m pytest tests/gateway/test_api_server.py -k 'ResponseStoreEventLog or ResponsesEventsReplay or stream_continues_after_client_disconnect_when_stored or stream_interrupts_agent_on_disconnect_when_not_stored or stream_cancelled_persists_incomplete_snapshot'
   ```
2. Run the full API server test module:
   ```bash
   python -m pytest tests/gateway/test_api_server.py
   ```
3. Expected result from the full API server module:
   ```text
   132 passed, 82 warnings
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted gateway/API server tests were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 25.10 via the API server pytest suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/features/api-server.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; backend API behavior only, no platform-specific paths, shell commands, or terminal handling added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Backend/API change; no screenshots.

```text
python -m pytest tests/gateway/test_api_server.py
132 passed, 82 warnings
```