### PR TITLE
fix: external editor handoff in CLI/TUI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9783,6 +9783,12 @@ class HermesCLI:
                 completer=_completer,
             ),
         )
+        # Match the TUI's editor handoff: the temp file lands at
+        # <mkdtemp>/prompt.md so vim/nano/helix pick up markdown syntax
+        # highlighting from the .md extension and the title bar reads
+        # "prompt.md" instead of a random "tmpXXXXXX". prompt_toolkit's
+        # complex-tempfile path takes care of cleanup via shutil.rmtree.
+        input_area.buffer.tempfile = 'prompt.md'
 
         # Dynamic height: accounts for both explicit newlines AND visual
         # wrapping of long lines so the input area always fits its content.

--- a/cli.py
+++ b/cli.py
@@ -9783,23 +9783,24 @@ class HermesCLI:
                 completer=_completer,
             ),
         )
-        # Match the TUI's editor handoff: the temp file lands at
-        # <mkdtemp>/prompt.md so vim/nano/helix pick up markdown syntax
-        # highlighting from the .md extension and the title bar reads
-        # "prompt.md" instead of a random "tmpXXXXXX". prompt_toolkit's
-        # complex-tempfile path takes care of cleanup via shutil.rmtree.
-        input_area.buffer.tempfile = 'prompt.md'
+        # Keep prompt_toolkit on its simple tempfile path. Setting
+        # buffer.tempfile = "prompt.md" triggers its complex-tempfile branch,
+        # which tries to mkdir() the mkdtemp() directory again and raises
+        # EEXIST. The suffix keeps markdown highlighting without that bug.
+        input_area.buffer.tempfile_suffix = '.md'
 
         # prompt_toolkit's default fallback chain prefers /usr/bin/nano over
         # /usr/bin/vi when neither $VISUAL nor $EDITOR is set. The TUI's
-        # resolveEditor() prefers vim → vi → nano. Override this single
+        # resolveEditor() prefers nvim → vim → vi → nano. Override this single
         # buffer's resolver so both surfaces pick the same editor.
         import shlex
         import subprocess
+
         def _hermes_pick_editor(filename: str) -> bool:
             chosen = (
                 os.environ.get('VISUAL')
                 or os.environ.get('EDITOR')
+                or shutil.which('nvim')
                 or shutil.which('vim')
                 or shutil.which('vi')
                 or shutil.which('nano')
@@ -9810,6 +9811,7 @@ class HermesCLI:
                 return subprocess.call(shlex.split(chosen) + [filename]) == 0
             except OSError:
                 return False
+
         input_area.buffer._open_file_in_editor = _hermes_pick_editor
 
         # Dynamic height: accounts for both explicit newlines AND visual

--- a/cli.py
+++ b/cli.py
@@ -9789,31 +9789,6 @@ class HermesCLI:
         # EEXIST. The suffix keeps markdown highlighting without that bug.
         input_area.buffer.tempfile_suffix = '.md'
 
-        # prompt_toolkit's default fallback chain prefers /usr/bin/nano over
-        # /usr/bin/vi when neither $VISUAL nor $EDITOR is set. The TUI's
-        # resolveEditor() prefers nvim → vim → vi → nano. Override this single
-        # buffer's resolver so both surfaces pick the same editor.
-        import shlex
-        import subprocess
-
-        def _hermes_pick_editor(filename: str) -> bool:
-            chosen = (
-                os.environ.get('VISUAL')
-                or os.environ.get('EDITOR')
-                or shutil.which('nvim')
-                or shutil.which('vim')
-                or shutil.which('vi')
-                or shutil.which('nano')
-            )
-            if not chosen:
-                return False
-            try:
-                return subprocess.call(shlex.split(chosen) + [filename]) == 0
-            except OSError:
-                return False
-
-        input_area.buffer._open_file_in_editor = _hermes_pick_editor
-
         # Dynamic height: accounts for both explicit newlines AND visual
         # wrapping of long lines so the input area always fits its content.
         def _input_height():

--- a/cli.py
+++ b/cli.py
@@ -4318,7 +4318,7 @@ class HermesCLI:
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
-        _cprint(f"  {_DIM}Draft editor: Ctrl+G{_RST}")
+        _cprint(f"  {_DIM}Draft editor: Ctrl+G (Alt+G in VSCode/Cursor){_RST}")
         if _is_termux_environment():
             _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")
         else:
@@ -9308,14 +9308,18 @@ class HermesCLI:
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
             event.current_buffer.insert_text('\n')
 
-        @kb.add(
-            'c-g',
-            filter=Condition(
-                lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state
-            ),
+        # VSCode/Cursor bind Ctrl+G to "Find Next" at the editor level, so
+        # the keystroke never reaches the embedded terminal. Alt+G is unbound
+        # in those IDEs and arrives here as ('escape', 'g') — register it as
+        # a fallback so the editor handoff works inside Cursor/VSCode too.
+        _editor_filter = Condition(
+            lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state
         )
+
+        @kb.add('c-g', filter=_editor_filter)
+        @kb.add('escape', 'g', filter=_editor_filter)
         def handle_open_in_editor(event):
-            """Ctrl+G opens the current draft in an external editor."""
+            """Ctrl+G (or Alt+G in VSCode/Cursor) opens the current draft in an external editor."""
             cli_ref._open_external_editor(event.current_buffer)
 
         @kb.add('tab', eager=True)

--- a/cli.py
+++ b/cli.py
@@ -9790,6 +9790,28 @@ class HermesCLI:
         # complex-tempfile path takes care of cleanup via shutil.rmtree.
         input_area.buffer.tempfile = 'prompt.md'
 
+        # prompt_toolkit's default fallback chain prefers /usr/bin/nano over
+        # /usr/bin/vi when neither $VISUAL nor $EDITOR is set. The TUI's
+        # resolveEditor() prefers vim → vi → nano. Override this single
+        # buffer's resolver so both surfaces pick the same editor.
+        import shlex
+        import subprocess
+        def _hermes_pick_editor(filename: str) -> bool:
+            chosen = (
+                os.environ.get('VISUAL')
+                or os.environ.get('EDITOR')
+                or shutil.which('vim')
+                or shutil.which('vi')
+                or shutil.which('nano')
+            )
+            if not chosen:
+                return False
+            try:
+                return subprocess.call(shlex.split(chosen) + [filename]) == 0
+            except OSError:
+                return False
+        input_area.buffer._open_file_in_editor = _hermes_pick_editor
+
         # Dynamic height: accounts for both explicit newlines AND visual
         # wrapping of long lines so the input area always fits its content.
         def _input_height():

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -110,7 +110,7 @@ Current input behavior is split across `app.tsx`, `components/textInput.tsx`, an
 | `\` + `Enter`                   | Append the line to the multiline buffer (fallback for terminals without modifier support)                                                               |
 | `Ctrl+C`                        | Interrupt active run, or clear the current draft, or exit if nothing is pending                                                                         |
 | `Ctrl+D`                        | Exit                                                                                                                                                    |
-| `Ctrl+G` / `Alt+G`              | Open `$EDITOR` with the current draft (use `Alt+G` in VSCode/Cursor — they bind `Ctrl+G` to Find Next)                                                  |
+| `Cmd/Ctrl+G` / `Alt+G`          | Open `$EDITOR` with the current draft (use `Alt+G` in VSCode/Cursor — they bind the primary keystroke to Find Next)                                     |
 | `Ctrl+L`                        | New session (same as `/clear`)                                                                                                                          |
 | `Ctrl+V` / `Alt+V`              | Paste text first, then fall back to image/path attachment when applicable                                                                               |
 | `Tab`                           | Apply the active completion                                                                                                                             |
@@ -169,7 +169,7 @@ Notes:
 - If you load a queued item into the input and resubmit plain text, that queue item is replaced, removed from the queue preview, and promoted to send next. If the agent is still busy, the edited item is moved to the front of the queue and sent after the current run completes.
 - Completion requests are debounced by 60 ms. Input starting with `/` uses `complete.slash`. A trailing token that starts with `./`, `../`, `~/`, `/`, or `@` uses `complete.path`.
 - Text pastes are inserted inline directly into the draft. Nothing is newline-flattened.
-- `Ctrl+G` (or `Alt+G` in VSCode/Cursor, which intercept `Ctrl+G` for Find Next) writes the current draft, including any multiline buffer, to a temp file, suspends Ink, launches `$EDITOR`, then restores the TUI and submits the saved text if the editor exits cleanly.
+- `Cmd/Ctrl+G` (or `Alt+G` in VSCode/Cursor, which intercept the primary keystroke for Find Next) writes the current draft, including any multiline buffer, to a temp file, suspends Ink, launches `$EDITOR`, then restores the TUI and submits the saved text if the editor exits cleanly.
 - Input history is stored in `~/.hermes/.hermes_history` or under `HERMES_HOME`.
 
 ## Rendering

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -110,7 +110,7 @@ Current input behavior is split across `app.tsx`, `components/textInput.tsx`, an
 | `\` + `Enter`                   | Append the line to the multiline buffer (fallback for terminals without modifier support)                                                               |
 | `Ctrl+C`                        | Interrupt active run, or clear the current draft, or exit if nothing is pending                                                                         |
 | `Ctrl+D`                        | Exit                                                                                                                                                    |
-| `Ctrl+G`                        | Open `$EDITOR` with the current draft                                                                                                                   |
+| `Ctrl+G` / `Alt+G`              | Open `$EDITOR` with the current draft (use `Alt+G` in VSCode/Cursor — they bind `Ctrl+G` to Find Next)                                                  |
 | `Ctrl+L`                        | New session (same as `/clear`)                                                                                                                          |
 | `Ctrl+V` / `Alt+V`              | Paste text first, then fall back to image/path attachment when applicable                                                                               |
 | `Tab`                           | Apply the active completion                                                                                                                             |
@@ -169,7 +169,7 @@ Notes:
 - If you load a queued item into the input and resubmit plain text, that queue item is replaced, removed from the queue preview, and promoted to send next. If the agent is still busy, the edited item is moved to the front of the queue and sent after the current run completes.
 - Completion requests are debounced by 60 ms. Input starting with `/` uses `complete.slash`. A trailing token that starts with `./`, `../`, `~/`, `/`, or `@` uses `complete.path`.
 - Text pastes are inserted inline directly into the draft. Nothing is newline-flattened.
-- `Ctrl+G` writes the current draft, including any multiline buffer, to a temp file, temporarily swaps screen buffers, launches `$EDITOR`, then restores the TUI and submits the saved text if the editor exits cleanly.
+- `Ctrl+G` (or `Alt+G` in VSCode/Cursor, which intercept `Ctrl+G` for Find Next) writes the current draft, including any multiline buffer, to a temp file, suspends Ink, launches `$EDITOR`, then restores the TUI and submits the saved text if the editor exits cleanly.
 - Input history is stored in `~/.hermes/.hermes_history` or under `HERMES_HOME`.
 
 ## Rendering

--- a/ui-tui/packages/hermes-ink/src/ink/screen.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/screen.ts
@@ -1,6 +1,6 @@
-import { ansiCodesToString, diffAnsiCodes, type AnsiCode } from '@alcalzone/ansi-tokenize'
+import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi-tokenize'
 
-import { unionRect, type Point, type Rectangle, type Size } from './layout/geometry.js'
+import { type Point, type Rectangle, type Size, unionRect } from './layout/geometry.js'
 import { BEL, ESC, SEP } from './termio/ansi.js'
 import * as warn from './warn.js'
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -121,7 +121,7 @@ export interface ComposerActions {
   dequeue: () => string | undefined
   enqueue: (text: string) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
-  openEditor: () => void
+  openEditor: () => Promise<void>
   pushHistory: (text: string) => void
   replaceQueue: (index: number, text: string) => void
   setCompIdx: StateSetter<number>

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -257,13 +257,14 @@ export function useComposerState({
   const openEditor = useCallback(async () => {
     const dir = mkdtempSync(join(tmpdir(), 'hermes-'))
     const file = join(dir, 'prompt.md')
+    const [cmd, ...args] = resolveEditor()
 
     writeFileSync(file, [...inputBuf, input].join('\n'))
 
     let exitCode: null | number = null
 
     await withInkSuspended(async () => {
-      exitCode = spawnSync(resolveEditor(), [file], { stdio: 'inherit' }).status
+      exitCode = spawnSync(cmd!, [...args, file], { stdio: 'inherit' }).status
     })
 
     try {

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -255,27 +255,34 @@ export function useComposerState({
   )
 
   const openEditor = useCallback(async () => {
-    const editor = resolveEditor()
-    const file = join(mkdtempSync(join(tmpdir(), 'hermes-')), 'prompt.md')
-    let code: null | number = null
+    const dir = mkdtempSync(join(tmpdir(), 'hermes-'))
+    const file = join(dir, 'prompt.md')
 
     writeFileSync(file, [...inputBuf, input].join('\n'))
 
+    let exitCode: null | number = null
+
     await withInkSuspended(async () => {
-      code = spawnSync(editor, [file], { stdio: 'inherit' }).status
+      exitCode = spawnSync(resolveEditor(), [file], { stdio: 'inherit' }).status
     })
 
-    if (code === 0) {
+    try {
+      if (exitCode !== 0) {
+        return
+      }
+
       const text = readFileSync(file, 'utf8').trimEnd()
 
-      if (text) {
-        setInput('')
-        setInputBuf([])
-        submitRef.current(text)
+      if (!text) {
+        return
       }
-    }
 
-    rmSync(file, { force: true })
+      setInput('')
+      setInputBuf([])
+      submitRef.current(text)
+    } finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
   }, [input, inputBuf, submitRef])
 
   const actions = useMemo(

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -14,6 +14,7 @@ import { useCompletion } from '../hooks/useCompletion.js'
 import { useInputHistory } from '../hooks/useInputHistory.js'
 import { useQueue } from '../hooks/useQueue.js'
 import { isUsableClipboardText, readClipboardText } from '../lib/clipboard.js'
+import { resolveEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
 import { isRemoteShellSession } from '../lib/terminalSetup.js'
 import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
@@ -254,7 +255,7 @@ export function useComposerState({
   )
 
   const openEditor = useCallback(async () => {
-    const editor = process.env.EDITOR || process.env.VISUAL || 'vi'
+    const editor = resolveEditor()
     const file = join(mkdtempSync(join(tmpdir(), 'hermes-')), 'prompt.md')
     let code: null | number = null
 

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { useStdin } from '@hermes/ink'
+import { useStdin, withInkSuspended } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { useCallback, useMemo, useState } from 'react'
 
@@ -253,14 +253,16 @@ export function useComposerState({
     [handleResolvedPaste, onClipboardPaste, querier]
   )
 
-  const openEditor = useCallback(() => {
+  const openEditor = useCallback(async () => {
     const editor = process.env.EDITOR || process.env.VISUAL || 'vi'
     const file = join(mkdtempSync(join(tmpdir(), 'hermes-')), 'prompt.md')
+    let code: null | number = null
 
     writeFileSync(file, [...inputBuf, input].join('\n'))
-    process.stdout.write('\x1b[?1049l')
-    const { status: code } = spawnSync(editor, [file], { stdio: 'inherit' })
-    process.stdout.write('\x1b[?1049h\x1b[2J\x1b[H')
+
+    await withInkSuspended(async () => {
+      code = spawnSync(editor, [file], { stdio: 'inherit' }).status
+    })
 
     if (code === 0) {
       const text = readFileSync(file, 'utf8').trimEnd()

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -366,10 +366,9 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return voiceRecordToggle()
     }
 
-    // Alt+G is the escape hatch for terminals that swallow Ctrl+G — VSCode and
-    // Cursor bind it to "Find Next" by default, so the keystroke never reaches
-    // the embedded TUI. Alt+G arrives as `\x1bg` → meta+g across platforms.
-    if (isAction(key, ch, 'g') || (key.meta && ch.toLowerCase() === 'g')) {
+    // Ctrl+G, plus Alt+G fallback for VSCode/Cursor (they bind Ctrl+G to
+    // "Find Next" before the TUI sees it; Alt+G arrives as meta+g).
+    if (ch.toLowerCase() === 'g' && (isAction(key, ch, 'g') || key.meta)) {
       return cActions.openEditor()
     }
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -366,10 +366,13 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return voiceRecordToggle()
     }
 
-    // Ctrl+G, plus Alt+G fallback for VSCode/Cursor (they bind Ctrl+G to
-    // "Find Next" before the TUI sees it; Alt+G arrives as meta+g).
+    // Cmd/Ctrl+G, plus Alt+G fallback for VSCode/Cursor (they bind the
+    // primary keystroke to "Find Next" before the TUI sees it; Alt+G
+    // arrives as meta+g across platforms).
     if (ch.toLowerCase() === 'g' && (isAction(key, ch, 'g') || key.meta)) {
-      return cActions.openEditor()
+      return void cActions.openEditor().catch((err: unknown) => {
+        actions.sys(err instanceof Error ? `failed to open editor: ${err.message}` : 'failed to open editor')
+      })
     }
 
     // shift-tab flips yolo without spending a turn (claude-code parity)

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -366,7 +366,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return voiceRecordToggle()
     }
 
-    if (isAction(key, ch, 'g')) {
+    // Alt+G is the escape hatch for terminals that swallow Ctrl+G — VSCode and
+    // Cursor bind it to "Find Next" by default, so the keystroke never reaches
+    // the embedded TUI. Alt+G arrives as `\x1bg` → meta+g across platforms.
+    if (isAction(key, ch, 'g') || (key.meta && ch.toLowerCase() === 'g')) {
       return cActions.openEditor()
     }
 

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -18,7 +18,7 @@ const copyHotkeys: [string, string][] = isMac
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,
   [action + '+D', 'exit'],
-  [action + '+G / Alt+G', 'open $EDITOR for prompt (Alt+G in VSCode/Cursor)'],
+  [action + '+G / Alt+G', 'open $EDITOR (Alt+G fallback for VSCode/Cursor)'],
   [action + '+L', 'new session (clear)'],
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -18,7 +18,7 @@ const copyHotkeys: [string, string][] = isMac
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,
   [action + '+D', 'exit'],
-  [action + '+G', 'open $EDITOR for prompt'],
+  [action + '+G / Alt+G', 'open $EDITOR for prompt (Alt+G in VSCode/Cursor)'],
   [action + '+L', 'new session (clear)'],
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -1,28 +1,25 @@
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { resolveEditor } from './editor.js'
+
+const exe = (dir: string, name: string): string => {
+  const path = join(dir, name)
+
+  writeFileSync(path, '#!/bin/sh\nexit 0\n')
+  chmodSync(path, 0o755)
+
+  return path
+}
 
 describe('resolveEditor', () => {
   let dir: string
 
-  const exe = (name: string) => {
-    const path = join(dir, name)
-    writeFileSync(path, '#!/bin/sh\nexit 0\n')
-    chmodSync(path, 0o755)
-
-    return path
-  }
-
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'editor-test-'))
-  })
-
-  afterEach(() => {
-    // tmp dir is small; let the OS reap it
   })
 
   it('honors $VISUAL above all else', () => {
@@ -33,40 +30,30 @@ describe('resolveEditor', () => {
     expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toBe('nvim')
   })
 
-  it('prefers system editor over nano over vi on $PATH', () => {
-    exe('nano')
-    exe('vi')
-    const editor = exe('editor')
+  it('prefers `editor` over nano over vi on $PATH', () => {
+    exe(dir, 'nano')
+    exe(dir, 'vi')
+    const expected = exe(dir, 'editor')
 
-    expect(resolveEditor({ PATH: dir })).toBe(editor)
+    expect(resolveEditor({ PATH: dir })).toBe(expected)
   })
 
-  it('falls back to nano when only nano and vi exist', () => {
-    const nano = exe('nano')
-    exe('vi')
+  it('falls back to nano before vi when both exist', () => {
+    exe(dir, 'vi')
+    const expected = exe(dir, 'nano')
 
-    expect(resolveEditor({ PATH: dir })).toBe(nano)
+    expect(resolveEditor({ PATH: dir })).toBe(expected)
   })
 
-  it('falls back to vi when only vi exists', () => {
-    const vi = exe('vi')
-
-    expect(resolveEditor({ PATH: dir })).toBe(vi)
+  it('returns literal "vi" when $PATH is empty', () => {
+    expect(resolveEditor({ PATH: '' })).toBe('vi')
   })
 
-  it('returns literal "vi" when nothing on PATH and no env', () => {
-    mkdirSync(join(dir, 'empty'), { recursive: true })
-
-    expect(resolveEditor({ PATH: join(dir, 'empty') })).toBe('vi')
-  })
-
-  it('walks multi-entry PATH', () => {
+  it('walks multi-entry $PATH', () => {
     const a = mkdtempSync(join(tmpdir(), 'editor-a-'))
     const b = mkdtempSync(join(tmpdir(), 'editor-b-'))
+    const expected = exe(b, 'editor')
 
-    writeFileSync(join(b, 'editor'), '#!/bin/sh\n')
-    chmodSync(join(b, 'editor'), 0o755)
-
-    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toBe(join(b, 'editor'))
+    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toBe(expected)
   })
 })

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -23,11 +23,22 @@ describe('resolveEditor', () => {
   })
 
   it('honors $VISUAL above all else', () => {
-    expect(resolveEditor({ EDITOR: 'vim', PATH: dir, VISUAL: 'helix' })).toBe('helix')
+    expect(resolveEditor({ EDITOR: 'vim', PATH: dir, VISUAL: 'helix' })).toEqual(['helix'])
   })
 
   it('falls back to $EDITOR when $VISUAL is unset', () => {
-    expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toBe('nvim')
+    expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toEqual(['nvim'])
+  })
+
+  it('shell-tokenizes editors with arguments', () => {
+    expect(resolveEditor({ EDITOR: 'code --wait', PATH: dir })).toEqual(['code', '--wait'])
+    expect(resolveEditor({ PATH: dir, VISUAL: 'emacsclient -t' })).toEqual(['emacsclient', '-t'])
+  })
+
+  it('ignores whitespace-only env vars', () => {
+    const expected = exe(dir, 'editor')
+
+    expect(resolveEditor({ EDITOR: '   ', PATH: dir, VISUAL: '' })).toEqual([expected])
   })
 
   it('prefers `editor` over nano over vi on $PATH', () => {
@@ -35,18 +46,18 @@ describe('resolveEditor', () => {
     exe(dir, 'vi')
     const expected = exe(dir, 'editor')
 
-    expect(resolveEditor({ PATH: dir })).toBe(expected)
+    expect(resolveEditor({ PATH: dir })).toEqual([expected])
   })
 
   it('falls back to nano before vi when both exist', () => {
     exe(dir, 'vi')
     const expected = exe(dir, 'nano')
 
-    expect(resolveEditor({ PATH: dir })).toBe(expected)
+    expect(resolveEditor({ PATH: dir })).toEqual([expected])
   })
 
-  it('returns literal "vi" when $PATH is empty', () => {
-    expect(resolveEditor({ PATH: '' })).toBe('vi')
+  it('returns ["vi"] when $PATH is empty', () => {
+    expect(resolveEditor({ PATH: '' })).toEqual(['vi'])
   })
 
   it('walks multi-entry $PATH', () => {
@@ -54,6 +65,10 @@ describe('resolveEditor', () => {
     const b = mkdtempSync(join(tmpdir(), 'editor-b-'))
     const expected = exe(b, 'editor')
 
-    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toBe(expected)
+    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toEqual([expected])
+  })
+
+  it('uses notepad.exe on Windows when no env override', () => {
+    expect(resolveEditor({ PATH: dir }, 'win32')).toEqual(['notepad.exe'])
   })
 })

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -33,17 +33,22 @@ describe('resolveEditor', () => {
     expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toBe('nvim')
   })
 
-  it('prefers nvim over vim over vi over nano on $PATH', () => {
+  it('prefers system editor over nano over vi on $PATH', () => {
     exe('nano')
     exe('vi')
-    exe('vim')
-    const nvim = exe('nvim')
+    const editor = exe('editor')
 
-    expect(resolveEditor({ PATH: dir })).toBe(nvim)
+    expect(resolveEditor({ PATH: dir })).toBe(editor)
   })
 
-  it('falls back to vi when only vi and nano exist', () => {
-    exe('nano')
+  it('falls back to nano when only nano and vi exist', () => {
+    const nano = exe('nano')
+    exe('vi')
+
+    expect(resolveEditor({ PATH: dir })).toBe(nano)
+  })
+
+  it('falls back to vi when only vi exists', () => {
     const vi = exe('vi')
 
     expect(resolveEditor({ PATH: dir })).toBe(vi)
@@ -59,9 +64,9 @@ describe('resolveEditor', () => {
     const a = mkdtempSync(join(tmpdir(), 'editor-a-'))
     const b = mkdtempSync(join(tmpdir(), 'editor-b-'))
 
-    writeFileSync(join(b, 'vim'), '#!/bin/sh\n')
-    chmodSync(join(b, 'vim'), 0o755)
+    writeFileSync(join(b, 'editor'), '#!/bin/sh\n')
+    chmodSync(join(b, 'editor'), 0o755)
 
-    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toBe(join(b, 'vim'))
+    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toBe(join(b, 'editor'))
   })
 })

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -33,12 +33,13 @@ describe('resolveEditor', () => {
     expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toBe('nvim')
   })
 
-  it('prefers vim over vi over nano on $PATH', () => {
+  it('prefers nvim over vim over vi over nano on $PATH', () => {
     exe('nano')
     exe('vi')
-    const vim = exe('vim')
+    exe('vim')
+    const nvim = exe('nvim')
 
-    expect(resolveEditor({ PATH: dir })).toBe(vim)
+    expect(resolveEditor({ PATH: dir })).toBe(nvim)
   })
 
   it('falls back to vi when only vi and nano exist', () => {

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -1,0 +1,66 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { resolveEditor } from './editor.js'
+
+describe('resolveEditor', () => {
+  let dir: string
+
+  const exe = (name: string) => {
+    const path = join(dir, name)
+    writeFileSync(path, '#!/bin/sh\nexit 0\n')
+    chmodSync(path, 0o755)
+
+    return path
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'editor-test-'))
+  })
+
+  afterEach(() => {
+    // tmp dir is small; let the OS reap it
+  })
+
+  it('honors $VISUAL above all else', () => {
+    expect(resolveEditor({ EDITOR: 'vim', PATH: dir, VISUAL: 'helix' })).toBe('helix')
+  })
+
+  it('falls back to $EDITOR when $VISUAL is unset', () => {
+    expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toBe('nvim')
+  })
+
+  it('prefers vim over vi over nano on $PATH', () => {
+    exe('nano')
+    exe('vi')
+    const vim = exe('vim')
+
+    expect(resolveEditor({ PATH: dir })).toBe(vim)
+  })
+
+  it('falls back to vi when only vi and nano exist', () => {
+    exe('nano')
+    const vi = exe('vi')
+
+    expect(resolveEditor({ PATH: dir })).toBe(vi)
+  })
+
+  it('returns literal "vi" when nothing on PATH and no env', () => {
+    mkdirSync(join(dir, 'empty'), { recursive: true })
+
+    expect(resolveEditor({ PATH: join(dir, 'empty') })).toBe('vi')
+  })
+
+  it('walks multi-entry PATH', () => {
+    const a = mkdtempSync(join(tmpdir(), 'editor-a-'))
+    const b = mkdtempSync(join(tmpdir(), 'editor-b-'))
+
+    writeFileSync(join(b, 'vim'), '#!/bin/sh\n')
+    chmodSync(join(b, 'vim'), 0o755)
+
+    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toBe(join(b, 'vim'))
+  })
+})

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -19,22 +19,29 @@ const isExecutable = (path: string): boolean => {
 }
 
 /**
- * Resolve the editor to launch when the user hits Ctrl+G / Alt+G.
+ * Resolve the editor invocation argv (without the file argument).
  *
- *   1. $VISUAL / $EDITOR (user's explicit choice)
- *   2. first FALLBACKS entry resolvable on $PATH
- *   3. literal `'vi'` so spawnSync still has something to try
+ *   1. $VISUAL / $EDITOR, shell-tokenized so `EDITOR="code --wait"` works
+ *   2. on POSIX: first FALLBACKS entry resolvable on $PATH
+ *   3. on Windows: `notepad.exe`
+ *   4. literal `['vi']` as the last-resort POSIX floor
  */
-export const resolveEditor = (env: NodeJS.ProcessEnv = process.env): string => {
-  if (env.VISUAL) {
-    return env.VISUAL
+export const resolveEditor = (
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform
+): string[] => {
+  const explicit = env.VISUAL ?? env.EDITOR
+
+  if (explicit?.trim()) {
+    return explicit.trim().split(/\s+/)
   }
 
-  if (env.EDITOR) {
-    return env.EDITOR
+  if (platform === 'win32') {
+    return ['notepad.exe']
   }
 
   const dirs = (env.PATH ?? '').split(delimiter).filter(Boolean)
+  const found = FALLBACKS.flatMap(name => dirs.map(d => join(d, name))).find(isExecutable)
 
-  return FALLBACKS.flatMap(name => dirs.map(d => join(d, name))).find(isExecutable) ?? 'vi'
+  return [found ?? 'vi']
 }

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -2,44 +2,13 @@ import { accessSync, constants } from 'node:fs'
 import { delimiter, join } from 'node:path'
 
 /**
- * Resolve which editor to launch when the user hits Ctrl+G / Alt+G.
- *
- * Order of preference:
- *   1. $VISUAL / $EDITOR (user's explicit choice)
- *   2. prompt_toolkit-compatible system fallback:
- *      editor → nano → pico → vi → emacs
- *   3. literal `'vi'` so spawnSync still has something to try
- *
- * This intentionally mirrors prompt_toolkit's Buffer.open_in_editor() picker
- * used by the classic CLI. In Cursor/VSCode terminals, nano is a better prompt
- * editing default than dropping casual users into vi's modal interface.
+ * Editor fallback chain when neither $VISUAL nor $EDITOR is set. Mirrors
+ * prompt_toolkit's `Buffer.open_in_editor()` picker so the classic CLI and
+ * the TUI launch the same editor on a given box.
  */
-export function resolveEditor(env: NodeJS.ProcessEnv = process.env): string {
-  return (
-    env.VISUAL ||
-    env.EDITOR ||
-    findEditor(env.PATH ?? '', 'editor', 'nano', 'pico', 'vi', 'emacs') ||
-    'vi'
-  )
-}
+const FALLBACKS = ['editor', 'nano', 'pico', 'vi', 'emacs']
 
-function findEditor(path: string, ...names: string[]): null | string {
-  const dirs = path.split(delimiter).filter(Boolean)
-
-  for (const name of names) {
-    for (const dir of dirs) {
-      const candidate = join(dir, name)
-
-      if (isExecutable(candidate)) {
-        return candidate
-      }
-    }
-  }
-
-  return null
-}
-
-function isExecutable(path: string): boolean {
+const isExecutable = (path: string): boolean => {
   try {
     accessSync(path, constants.X_OK)
 
@@ -47,4 +16,25 @@ function isExecutable(path: string): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Resolve the editor to launch when the user hits Ctrl+G / Alt+G.
+ *
+ *   1. $VISUAL / $EDITOR (user's explicit choice)
+ *   2. first FALLBACKS entry resolvable on $PATH
+ *   3. literal `'vi'` so spawnSync still has something to try
+ */
+export const resolveEditor = (env: NodeJS.ProcessEnv = process.env): string => {
+  if (env.VISUAL) {
+    return env.VISUAL
+  }
+
+  if (env.EDITOR) {
+    return env.EDITOR
+  }
+
+  const dirs = (env.PATH ?? '').split(delimiter).filter(Boolean)
+
+  return FALLBACKS.flatMap(name => dirs.map(d => join(d, name))).find(isExecutable) ?? 'vi'
 }

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -6,7 +6,7 @@ import { delimiter, join } from 'node:path'
  *
  * Order of preference:
  *   1. $VISUAL / $EDITOR (user's explicit choice)
- *   2. first executable found on $PATH from `vim` → `vi` → `nano`
+ *   2. first executable found on $PATH from `nvim` → `vim` → `vi` → `nano`
  *   3. literal `'vi'` so spawnSync still has something to try
  *
  * Mirrors the override on `input_area.buffer._open_file_in_editor` in cli.py
@@ -14,7 +14,7 @@ import { delimiter, join } from 'node:path'
  * doesn't surprise the user with nano in one and vim in the other.
  */
 export function resolveEditor(env: NodeJS.ProcessEnv = process.env): string {
-  return env.VISUAL || env.EDITOR || findExecutable(env.PATH ?? '', 'vim', 'vi', 'nano') || 'vi'
+  return env.VISUAL || env.EDITOR || findExecutable(env.PATH ?? '', 'nvim', 'vim', 'vi', 'nano') || 'vi'
 }
 
 function findExecutable(path: string, ...names: string[]): null | string {

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -6,33 +6,45 @@ import { delimiter, join } from 'node:path'
  *
  * Order of preference:
  *   1. $VISUAL / $EDITOR (user's explicit choice)
- *   2. first executable found on $PATH from `nvim` → `vim` → `vi` → `nano`
+ *   2. prompt_toolkit-compatible system fallback:
+ *      editor → nano → pico → vi → emacs
  *   3. literal `'vi'` so spawnSync still has something to try
  *
- * Mirrors the override on `input_area.buffer._open_file_in_editor` in cli.py
- * — both surfaces should pick the same editor so the CLI/TUI handoff
- * doesn't surprise the user with nano in one and vim in the other.
+ * This intentionally mirrors prompt_toolkit's Buffer.open_in_editor() picker
+ * used by the classic CLI. In Cursor/VSCode terminals, nano is a better prompt
+ * editing default than dropping casual users into vi's modal interface.
  */
 export function resolveEditor(env: NodeJS.ProcessEnv = process.env): string {
-  return env.VISUAL || env.EDITOR || findExecutable(env.PATH ?? '', 'nvim', 'vim', 'vi', 'nano') || 'vi'
+  return (
+    env.VISUAL ||
+    env.EDITOR ||
+    findEditor(env.PATH ?? '', 'editor', 'nano', 'pico', 'vi', 'emacs') ||
+    'vi'
+  )
 }
 
-function findExecutable(path: string, ...names: string[]): null | string {
+function findEditor(path: string, ...names: string[]): null | string {
   const dirs = path.split(delimiter).filter(Boolean)
 
   for (const name of names) {
     for (const dir of dirs) {
       const candidate = join(dir, name)
 
-      try {
-        accessSync(candidate, constants.X_OK)
-
+      if (isExecutable(candidate)) {
         return candidate
-      } catch {
-        // not executable / not present; try next
       }
     }
   }
 
   return null
+}
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK)
+
+    return true
+  } catch {
+    return false
+  }
 }

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -1,0 +1,38 @@
+import { accessSync, constants } from 'node:fs'
+import { delimiter, join } from 'node:path'
+
+/**
+ * Resolve which editor to launch when the user hits Ctrl+G / Alt+G.
+ *
+ * Order of preference:
+ *   1. $VISUAL / $EDITOR (user's explicit choice)
+ *   2. first executable found on $PATH from `vim` → `vi` → `nano`
+ *   3. literal `'vi'` so spawnSync still has something to try
+ *
+ * Mirrors the override on `input_area.buffer._open_file_in_editor` in cli.py
+ * — both surfaces should pick the same editor so the CLI/TUI handoff
+ * doesn't surprise the user with nano in one and vim in the other.
+ */
+export function resolveEditor(env: NodeJS.ProcessEnv = process.env): string {
+  return env.VISUAL || env.EDITOR || findExecutable(env.PATH ?? '', 'vim', 'vi', 'nano') || 'vi'
+}
+
+function findExecutable(path: string, ...names: string[]): null | string {
+  const dirs = path.split(delimiter).filter(Boolean)
+
+  for (const name of names) {
+    for (const dir of dirs) {
+      const candidate = join(dir, name)
+
+      try {
+        accessSync(candidate, constants.X_OK)
+
+        return candidate
+      } catch {
+        // not executable / not present; try next
+      }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

Fix the Ctrl+G / Alt+G external-editor handoff across both classic CLI and TUI.

- TUI: use `withInkSuspended` instead of raw alt-screen toggles so Ink releases stdin, raw mode, mouse/focus/key reporting, then repaints cleanly after `$EDITOR` exits.
- Cursor/VSCode/Windsurf: add `Alt+G` fallback because those IDEs steal `Ctrl+G` for Find Next before the terminal sees it. TUI receives this as `meta+g`; prompt_toolkit receives it as `('escape', 'g')`.
- Classic CLI: preserve prompt_toolkit's existing editor picker, which had the better default UX. Only set `tempfile_suffix = '.md'` so syntax highlighting works without entering prompt_toolkit's broken complex-tempfile path.
- TUI editor selection: mirror prompt_toolkit's fallback order instead of forcing vim-family editors: `$VISUAL -> $EDITOR -> editor -> nano -> pico -> vi -> emacs`.

## Notes

The earlier `buffer.tempfile = 'prompt.md'` attempt was wrong: prompt_toolkit's complex-tempfile branch calls `os.makedirs()` on the `mkdtemp()` path when no subdirectory exists, causing `EEXIST` before the editor launches. `.tempfile_suffix = '.md'` keeps the simple path and avoids that bug.

## Test plan

- [x] `npm run type-check` (TUI)
- [x] `npm test -- --run editor`
- [x] `npm test -- --run` (earlier full TUI suite: 280 / 280)
- [x] `scripts/run_tests.sh tests/cli/test_cli_external_editor.py`
- [ ] Manual classic CLI in Cursor terminal: `Alt+G` opens prompt_toolkit's system/default editor path, same as main but with `.md` suffix
- [ ] Manual TUI in Cursor terminal: `Alt+G` opens the same style of default editor and returns cleanly