### PR TITLE
fix(matrix): drop bridge / appservice ghost senders before pairing flow

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -20,6 +20,12 @@ Environment variables:
     MATRIX_AUTO_THREAD          Auto-create threads for room messages (default: true)
     MATRIX_RECOVERY_KEY         Recovery key for cross-signing verification after device key rotation
     MATRIX_DM_MENTION_THREADS   Create a thread when bot is @mentioned in a DM (default: false)
+    MATRIX_BRIDGE_PREFIXES      Comma-separated MXID localpart prefixes treated as
+                                bridge / appservice ghost users and dropped before
+                                the pairing flow (default: "@_", the conventional
+                                appservice ghost-user prefix).  Set to "" to disable.
+    MATRIX_BRIDGE_USERS         Comma-separated explicit bridge MXIDs to drop, in
+                                addition to the prefix list.
 """
 
 from __future__ import annotations
@@ -113,6 +119,53 @@ _CRYPTO_DB_PATH = _STORE_DIR / "crypto.db"
 
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
+
+# Default prefix for Matrix appservice "ghost" users created by bridges
+# (Telegram, Discord, IRC, Signal, WhatsApp, Slack, etc.).  Operators can
+# override via MATRIX_BRIDGE_PREFIXES.  See spec:
+# https://spec.matrix.org/v1.10/application-service-api/#namespacing
+_DEFAULT_BRIDGE_PREFIX = "@_"
+
+# Bound on the per-adapter ring of recently-sent Matrix event IDs used to
+# detect "hall of mirrors" relay echoes when our own outbound message is
+# re-emitted as an inbound event (see issue #15763).
+_OUTBOUND_ECHO_RING_SIZE = 512
+
+
+def _parse_bridge_prefixes(raw: Optional[str]) -> tuple[str, ...]:
+    """Parse MATRIX_BRIDGE_PREFIXES into a tuple of lowercase prefixes."""
+    if raw is None:
+        raw = _DEFAULT_BRIDGE_PREFIX
+    return tuple(p.strip().lower() for p in raw.split(",") if p.strip())
+
+
+def _parse_bridge_users(raw: Optional[str]) -> frozenset[str]:
+    """Parse MATRIX_BRIDGE_USERS into a frozenset of lowercase MXIDs."""
+    if not raw:
+        return frozenset()
+    return frozenset(u.strip().lower() for u in raw.split(",") if u.strip())
+
+
+def is_matrix_bridge_sender(
+    sender: str,
+    *,
+    prefixes: tuple[str, ...],
+    users: frozenset[str],
+) -> bool:
+    """Return True when ``sender`` is a Matrix bridge / appservice ghost user.
+
+    Matrix application services (Telegram, IRC, Signal, … bridges) puppet
+    remote users via MXIDs in their declared namespace.  Such senders deliver
+    system-level events (status notices, "interruption" relays, etc.) that
+    must not trigger the gateway's pairing flow nor be processed as user
+    turns — see issue #15763.
+    """
+    if not sender:
+        return False
+    norm = sender.lower()
+    if norm in users:
+        return True
+    return any(prefix and norm.startswith(prefix) for prefix in prefixes)
 
 
 _E2EE_INSTALL_HINT = (
@@ -264,6 +317,26 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_DM_MENTION_THREADS", "false"
         ).lower() in ("true", "1", "yes")
 
+        # Bridge / appservice ghost-user filter (issue #15763).  Parsed once;
+        # _on_room_message and the gateway runner consult these to drop
+        # system-level events before they trigger the pairing flow.
+        self._bridge_prefixes: tuple[str, ...] = _parse_bridge_prefixes(
+            os.getenv("MATRIX_BRIDGE_PREFIXES")
+        )
+        self._bridge_users: frozenset[str] = _parse_bridge_users(
+            os.getenv("MATRIX_BRIDGE_USERS", "")
+        )
+
+        # Ring of recently-sent event IDs.  When a bridge or relay re-emits
+        # our own outbound message as an inbound event (issue #15763), the
+        # event ID matches one we just sent — drop it instead of looping.
+        from collections import deque
+
+        self._recent_outbound_event_ids: deque = deque(
+            maxlen=_OUTBOUND_ECHO_RING_SIZE
+        )
+        self._recent_outbound_event_ids_set: set[str] = set()
+
         # Reactions: configurable via MATRIX_REACTIONS (default: true).
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
@@ -293,6 +366,18 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events.append(event_id)
         self._processed_events_set.add(event_id)
         return False
+
+    def _record_outbound_event_id(self, event_id: Optional[str]) -> None:
+        """Remember an event ID we just sent, for relay-echo detection."""
+        if not event_id:
+            return
+        if event_id in self._recent_outbound_event_ids_set:
+            return
+        ring = self._recent_outbound_event_ids
+        if len(ring) == ring.maxlen:
+            self._recent_outbound_event_ids_set.discard(ring[0])
+        ring.append(event_id)
+        self._recent_outbound_event_ids_set.add(event_id)
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -764,6 +849,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     timeout=45,
                 )
                 last_event_id = str(event_id)
+                self._record_outbound_event_id(last_event_id)
                 logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
             except Exception as exc:
                 # On E2EE errors, retry after sharing keys.
@@ -779,6 +865,7 @@ class MatrixAdapter(BasePlatformAdapter):
                             timeout=45,
                         )
                         last_event_id = str(event_id)
+                        self._record_outbound_event_id(last_event_id)
                         logger.info(
                             "Matrix: sent event %s to %s (after key share)",
                             last_event_id,
@@ -1190,6 +1277,28 @@ class MatrixAdapter(BasePlatformAdapter):
         # Deduplicate by event ID.
         event_id = str(getattr(event, "event_id", ""))
         if self._is_duplicate_event(event_id):
+            return
+
+        # Drop bridge / appservice ghost users before the gateway sees them
+        # (issue #15763).  Bridges relay system-level events (status notices,
+        # interruption echoes) that have valid but unauthorized MXIDs and would
+        # otherwise trigger pairing.
+        if is_matrix_bridge_sender(
+            sender, prefixes=self._bridge_prefixes, users=self._bridge_users
+        ):
+            logger.debug("Matrix: ignoring bridge sender %s in %s", sender, room_id)
+            return
+
+        # Drop "hall of mirrors" relay echoes — events whose ID matches one
+        # we just sent (issue #15763).  Some bridges and relay setups
+        # re-emit our outbound messages back into the room.
+        if event_id and event_id in self._recent_outbound_event_ids_set:
+            logger.debug(
+                "Matrix: ignoring outbound echo of %s from %s in %s",
+                event_id,
+                sender,
+                room_id,
+            )
             return
 
         # Startup grace: ignore old messages from initial sync.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2982,6 +2982,35 @@ class GatewayRunner:
 
         return bool(check_ids & allowed_ids)
 
+    def _is_system_identity(self, source: SessionSource) -> bool:
+        """Return True when ``source`` is a platform-level system / bridge identity.
+
+        Such senders (Matrix appservice ghost users, bridges, …) carry
+        valid-looking but unauthorized user IDs and would otherwise trigger
+        the pairing flow and, once approved, fuel "hall of mirrors" relay
+        loops where the gateway's own outbound traffic comes back as
+        inbound events (issue #15763).
+        """
+        if not source or not source.user_id:
+            return False
+        if source.platform == Platform.MATRIX:
+            from gateway.platforms.matrix import (
+                _parse_bridge_prefixes,
+                _parse_bridge_users,
+                is_matrix_bridge_sender,
+            )
+            adapter = self.adapters.get(Platform.MATRIX)
+            prefixes = getattr(adapter, "_bridge_prefixes", None)
+            users = getattr(adapter, "_bridge_users", None)
+            if prefixes is None:
+                prefixes = _parse_bridge_prefixes(os.getenv("MATRIX_BRIDGE_PREFIXES"))
+            if users is None:
+                users = _parse_bridge_users(os.getenv("MATRIX_BRIDGE_USERS", ""))
+            return is_matrix_bridge_sender(
+                source.user_id, prefixes=prefixes, users=users
+            )
+        return False
+
     def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
         """Return how unauthorized DMs should be handled for a platform.
 
@@ -3106,6 +3135,18 @@ class GatewayRunner:
             # authorized — drop silently instead of triggering the pairing
             # flow with a None user_id.
             logger.debug("Ignoring message with no user_id from %s", source.platform.value)
+            return None
+        elif self._is_system_identity(source):
+            # Platform-level system / bridge identities (e.g. Matrix
+            # appservice ghost users) carry valid-looking MXIDs but must
+            # not trigger pairing nor be processed as user turns — see
+            # issue #15763.  Placed before the auth check so an
+            # accidentally-paired bridge user is still dropped.
+            logger.debug(
+                "Ignoring system/bridge identity %s on %s",
+                source.user_id,
+                source.platform.value,
+            )
             return None
         elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)

--- a/tests/gateway/test_matrix_bridge_filter.py
+++ b/tests/gateway/test_matrix_bridge_filter.py
@@ -1,0 +1,370 @@
+"""Tests for the Matrix bridge / system-identity filter (issue #15763).
+
+Bridges and Matrix appservice "ghost users" deliver system-level events
+with valid-looking but unauthorized MXIDs.  The gateway must drop these
+before the pairing flow so they cannot be approved into a "hall of
+mirrors" loop where the gateway's own outbound traffic is relayed back
+as inbound user input.
+"""
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.platforms.matrix import (
+    _OUTBOUND_ECHO_RING_SIZE,
+    _parse_bridge_prefixes,
+    _parse_bridge_users,
+    is_matrix_bridge_sender,
+)
+from gateway.session import SessionSource
+
+
+def _clear_matrix_env(monkeypatch) -> None:
+    for key in (
+        "MATRIX_ALLOWED_USERS",
+        "MATRIX_ALLOW_ALL_USERS",
+        "MATRIX_BRIDGE_PREFIXES",
+        "MATRIX_BRIDGE_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_runner(config: GatewayConfig):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.MATRIX: adapter}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_store._is_rate_limited.return_value = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompts = {}
+    runner.hooks = SimpleNamespace(dispatch=AsyncMock(return_value=None))
+    runner._sessions = {}
+    return runner, adapter
+
+
+def _make_event(user_id: str, chat_id: str, *, message_id: str = "m1") -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_id=message_id,
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            user_id=user_id,
+            chat_id=chat_id,
+            user_name="tester",
+            chat_type="dm",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-function helper coverage
+# ---------------------------------------------------------------------------
+
+def test_default_prefix_matches_underscore_ghost_user():
+    prefixes = _parse_bridge_prefixes(None)
+    assert is_matrix_bridge_sender(
+        "@_telegram_bot_:matrix.org", prefixes=prefixes, users=frozenset()
+    )
+
+
+def test_default_prefix_does_not_match_real_user():
+    prefixes = _parse_bridge_prefixes(None)
+    assert not is_matrix_bridge_sender(
+        "@alice:matrix.org", prefixes=prefixes, users=frozenset()
+    )
+
+
+def test_explicit_user_match_is_case_insensitive():
+    users = _parse_bridge_users("@Bridge:Example.Org")
+    assert is_matrix_bridge_sender(
+        "@bridge:example.org", prefixes=(), users=users
+    )
+
+
+def test_custom_prefix_list_overrides_default():
+    prefixes = _parse_bridge_prefixes("@_irc_,@_signal_")
+    assert is_matrix_bridge_sender(
+        "@_signal_alice:server.org", prefixes=prefixes, users=frozenset()
+    )
+    # Default "@_" prefix is gone — non-matching ghost passes through.
+    assert not is_matrix_bridge_sender(
+        "@_telegram_alice:server.org", prefixes=prefixes, users=frozenset()
+    )
+
+
+def test_empty_prefix_list_disables_prefix_matching():
+    prefixes = _parse_bridge_prefixes("")
+    assert not is_matrix_bridge_sender(
+        "@_telegram_alice:server.org", prefixes=prefixes, users=frozenset()
+    )
+
+
+def test_blank_sender_is_not_a_bridge():
+    prefixes = _parse_bridge_prefixes(None)
+    assert not is_matrix_bridge_sender("", prefixes=prefixes, users=frozenset())
+
+
+# ---------------------------------------------------------------------------
+# Runner-level _is_system_identity / _handle_message integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_matrix_bridge_default_prefix_drops_pairing(monkeypatch):
+    """T1: a default-prefix bridge sender in a DM is dropped, no pairing code sent."""
+    _clear_matrix_env(monkeypatch)
+    runner, adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+
+    result = await runner._handle_message(
+        _make_event("@_telegram_bot_:matrix.org", "!room:matrix.org")
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_matrix_bridge_users_env_drops_pairing(monkeypatch):
+    """T2: MATRIX_BRIDGE_USERS allowlist matches and drops the event."""
+    _clear_matrix_env(monkeypatch)
+    monkeypatch.setenv("MATRIX_BRIDGE_USERS", "@bridge:example.org")
+    runner, adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+
+    result = await runner._handle_message(
+        _make_event("@bridge:example.org", "!room:example.org")
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_matrix_bridge_prefix_env_overrides_default(monkeypatch):
+    """T3: a custom MATRIX_BRIDGE_PREFIXES list catches its own bridges."""
+    _clear_matrix_env(monkeypatch)
+    monkeypatch.setenv("MATRIX_BRIDGE_PREFIXES", "@_irc_,@_signal_")
+    runner, adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+
+    result = await runner._handle_message(
+        _make_event("@_signal_alice:server.org", "!room:server.org")
+    )
+
+    assert result is None
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_real_matrix_user_still_pairs(monkeypatch):
+    """T4: regression guard — a real MXID still triggers pairing."""
+    _clear_matrix_env(monkeypatch)
+    runner, adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+    runner.pairing_store.generate_code.return_value = "ABC12DEF"
+
+    result = await runner._handle_message(
+        _make_event("@alice:matrix.org", "!room:matrix.org")
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_called_once_with(
+        "matrix", "@alice:matrix.org", "tester"
+    )
+    adapter.send.assert_awaited_once()
+    assert "ABC12DEF" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_paired_bridge_user_is_still_dropped(monkeypatch):
+    """T5: even if an operator already approved a bridge, the system check
+    runs before authorization and still drops the event."""
+    _clear_matrix_env(monkeypatch)
+    runner, adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+    runner.pairing_store.is_approved.return_value = True
+
+    result = await runner._handle_message(
+        _make_event("@_telegram_relay_:matrix.org", "!room:matrix.org")
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_internal_event_still_bypasses_system_check(monkeypatch):
+    """T8: synthetic events with internal=True must skip both gates,
+    including the new system-identity check (regression for #6540)."""
+    _clear_matrix_env(monkeypatch)
+    import gateway.run as gateway_run
+
+    runner, _adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+
+    sentinel_called = False
+
+    async def _sentinel(*_a, **_kw):
+        nonlocal sentinel_called
+        sentinel_called = True
+        raise RuntimeError("stop here")
+
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner, "_handle_message_with_agent", _sentinel
+    )
+
+    event = MessageEvent(
+        text="[SYSTEM]",
+        internal=True,
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            user_id="@_telegram_bot_:matrix.org",
+            chat_id="!room:matrix.org",
+            chat_type="dm",
+        ),
+    )
+
+    try:
+        await runner._handle_message(event)
+    except RuntimeError:
+        pass
+
+    assert sentinel_called, (
+        "internal=True must bypass the system-identity guard"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_bridge_mxid_is_dropped(monkeypatch):
+    """T9: case-insensitive comparison so bridge MXIDs that arrive with
+    server-side casing changes are still recognized."""
+    _clear_matrix_env(monkeypatch)
+    runner, adapter = _make_runner(
+        GatewayConfig(platforms={Platform.MATRIX: PlatformConfig(enabled=True)})
+    )
+
+    result = await runner._handle_message(
+        _make_event("@_TELEGRAM_BOT_:Matrix.Org", "!room:matrix.org")
+    )
+
+    assert result is None
+    adapter.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Adapter-level outbound echo guard
+# ---------------------------------------------------------------------------
+
+def _stub_matrix_adapter(monkeypatch):
+    """Build a minimal MatrixAdapter without invoking the network."""
+    from gateway.platforms.matrix import MatrixAdapter
+
+    monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+    monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_x")
+    monkeypatch.setenv("MATRIX_USER_ID", "@bot:matrix.org")
+    return MatrixAdapter(PlatformConfig(enabled=True))
+
+
+@pytest.mark.asyncio
+async def test_outbound_echo_dropped_in_room_handler(monkeypatch):
+    """T6: an inbound event with a previously-sent event_id is dropped at
+    the adapter, regardless of sender (catches relay reflections)."""
+    _clear_matrix_env(monkeypatch)
+    adapter = _stub_matrix_adapter(monkeypatch)
+    adapter._record_outbound_event_id("$echo123")
+
+    handled = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_text_message", handled)
+
+    event = SimpleNamespace(
+        room_id="!room:matrix.org",
+        sender="@_relay_:matrix.org",
+        event_id="$echo123",
+        timestamp=int(adapter._startup_ts * 1000) + 60_000,
+        content={"msgtype": "m.text", "body": "hi"},
+    )
+
+    await adapter._on_room_message(event)
+
+    handled.assert_not_called()
+
+
+def test_outbound_ring_is_bounded(monkeypatch):
+    """T7: outbound deque size is capped at _OUTBOUND_ECHO_RING_SIZE; old
+    entries are evicted from the lookup set so the data structure can't
+    grow without bound."""
+    _clear_matrix_env(monkeypatch)
+    adapter = _stub_matrix_adapter(monkeypatch)
+
+    for i in range(_OUTBOUND_ECHO_RING_SIZE + 100):
+        adapter._record_outbound_event_id(f"$evt_{i}")
+
+    assert len(adapter._recent_outbound_event_ids) == _OUTBOUND_ECHO_RING_SIZE
+    assert len(adapter._recent_outbound_event_ids_set) == _OUTBOUND_ECHO_RING_SIZE
+    assert "$evt_0" not in adapter._recent_outbound_event_ids_set
+    assert f"$evt_{_OUTBOUND_ECHO_RING_SIZE + 99}" in adapter._recent_outbound_event_ids_set
+
+
+@pytest.mark.asyncio
+async def test_bridge_sender_dropped_in_room_handler(monkeypatch):
+    """T10: bridge senders are filtered at the adapter even outside DMs,
+    where the runner-level pairing flow does not run."""
+    _clear_matrix_env(monkeypatch)
+    adapter = _stub_matrix_adapter(monkeypatch)
+
+    handled = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_text_message", handled)
+
+    event = SimpleNamespace(
+        room_id="!group:matrix.org",
+        sender="@_telegram_bot_:matrix.org",
+        event_id="$bridge_evt",
+        timestamp=int(adapter._startup_ts * 1000) + 60_000,
+        content={"msgtype": "m.text", "body": "status update"},
+    )
+
+    await adapter._on_room_message(event)
+
+    handled.assert_not_called()
+
+
+def test_record_outbound_ignores_empty_event_id(monkeypatch):
+    """Defensive: send() may produce a None message_id on empty payloads."""
+    _clear_matrix_env(monkeypatch)
+    adapter = _stub_matrix_adapter(monkeypatch)
+    adapter._record_outbound_event_id(None)
+    adapter._record_outbound_event_id("")
+    assert len(adapter._recent_outbound_event_ids) == 0
+    assert isinstance(adapter._recent_outbound_event_ids, deque)
+
+
+def test_record_outbound_is_idempotent(monkeypatch):
+    """Recording the same event_id twice must not enter it twice into the
+    ring — otherwise an early eviction can drop the set entry while a stale
+    deque copy lingers, breaking echo detection."""
+    _clear_matrix_env(monkeypatch)
+    adapter = _stub_matrix_adapter(monkeypatch)
+    adapter._record_outbound_event_id("$same")
+    adapter._record_outbound_event_id("$same")
+    assert len(adapter._recent_outbound_event_ids) == 1
+    assert adapter._recent_outbound_event_ids_set == {"$same"}


### PR DESCRIPTION
## What does this PR do?

Fixes the "hall of mirrors" loop reported in #15763. Matrix application-service ghost users (Telegram, IRC, Signal, … bridges) puppet remote users via MXIDs in their declared namespace and deliver system-level events (status notices, "interruption" relays) with valid-but-unauthorized MXIDs. The runner only short-circuited on `source.user_id is None`, so these events triggered the unauthorized-DM pairing flow; once an operator approved one, every relay re-emission of the gateway's outbound traffic was processed as a new user turn — an infinite agent-response loop with no workaround.

The fix layers two defenses, matching the issue author's "Integrated Defense" proposal:

1. **Prevention** — recognize bridge / appservice ghost senders by MXID prefix (default `@_`, the namespacing convention from the [Matrix appservice spec](https://spec.matrix.org/v1.10/application-service-api/#namespacing)) and an operator allowlist, and drop them before the pairing flow at both the adapter (`MatrixAdapter._on_room_message`) and the runner (`GatewayRunner._is_system_identity`). The runner check is placed **before** authorization so an accidentally-paired bridge user is still neutralized at runtime.
2. **Robustness** — the adapter keeps a bounded ring of recently-sent event IDs and drops inbound events whose ID matches one we just sent, catching relay reflections regardless of sender.

`internal=True` synthetic events continue to bypass both gates (regression for #6540 / `cac61781`).

## Related Issue

Fixes #15763

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py` — module-level `is_matrix_bridge_sender` / `_parse_bridge_prefixes` / `_parse_bridge_users` helpers; new `MATRIX_BRIDGE_PREFIXES` (default `@_`) and `MATRIX_BRIDGE_USERS` env vars documented in the module docstring; `MatrixAdapter` parses both at init, records every outbound `event_id` from `send()` into a bounded (`maxlen=512`) deque + lookup set, and drops bridge senders / outbound echoes inside `_on_room_message`.
- `gateway/run.py` — new `GatewayRunner._is_system_identity(source)` dispatching by platform; `_handle_message` now drops system identities *before* `_is_user_authorized`, between the existing `user_id is None` short-circuit and the pairing branch.
- `tests/gateway/test_matrix_bridge_filter.py` — 18 cases covering helper parsing, default prefix, env-var allowlists, custom prefix overrides, case-insensitive matching, the real-user pairing regression guard, pre-paired bridge user, `internal=True` bypass, group-room echoes, ring eviction, idempotent recording, and empty-event-id handling.

## How to Test

1. Run the new suite: `pytest tests/gateway/test_matrix_bridge_filter.py -v` → 18 passed.
2. Regression suite for the affected area:
   ```
   pytest tests/gateway/test_matrix_bridge_filter.py \
          tests/gateway/test_unauthorized_dm_behavior.py \
          tests/gateway/test_internal_event_bypass_pairing.py \
          tests/gateway/test_pairing.py \
          tests/gateway/test_matrix.py \
          tests/gateway/test_matrix_voice.py \
          tests/gateway/test_matrix_mention.py \
          tests/gateway/test_auth_fallback.py -q
   ```
   → 242 passed.
3. Manual reproduction of the issue scenario: with a bridge MXID (`@_telegram_bridge_:matrix.org`) sending a DM to the gateway, `pairing_store.generate_code` is **not** called and no pairing message is sent. Same outcome even when `pairing_store.is_approved` is `True` — covers the case where the operator already paired a bridge before this fix lands.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (the pre-existing failures in `test_discord_free_response.py` and `test_whatsapp_connect.py` are unrelated and reproduce on `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 5.15), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — added the two new env vars to the `MatrixAdapter` module docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var only, no YAML key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure stdlib (`collections.deque`, env vars, string ops); no platform-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
