### PR TITLE
fix(model): preserve custom endpoint credentials during /model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5273,23 +5273,21 @@ class HermesCLI:
         # Parse --provider and --global flags
         model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
 
+        # Load providers for switch_model (picker path needs them below)
         user_provs = None
         custom_provs = None
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = get_compatible_custom_providers(cfg)
+        except Exception:
+            pass
 
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
             model_display = self.model or "unknown"
             provider_display = get_label(self.provider) if self.provider else "unknown"
-
-            user_provs = None
-            custom_provs = None
-            try:
-                from hermes_cli.config import get_compatible_custom_providers, load_config
-                cfg = load_config()
-                user_provs = cfg.get("providers")
-                custom_provs = get_compatible_custom_providers(cfg)
-            except Exception:
-                pass
 
             try:
                 providers = list_authenticated_providers(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -831,9 +831,14 @@ def switch_model(
                 requested=current_provider,
                 target_model=new_model,
             )
-            api_key = runtime.get("api_key", "")
-            base_url = runtime.get("base_url", "")
-            api_mode = runtime.get("api_mode", "")
+            # If resolution fell through to "custom" (e.g. named custom provider like
+            # "ollama-launch" that resolve_runtime_provider doesn't know), keep existing
+            # credentials. Otherwise use the resolved values (picks up credential rotation,
+            # base_url adjustments for OpenCode, etc.).
+            if runtime.get("provider") != "custom":
+                api_key = runtime.get("api_key", "")
+                base_url = runtime.get("base_url", "")
+                api_mode = runtime.get("api_mode", "")
         except Exception:
             pass
 
@@ -867,16 +872,31 @@ def switch_model(
             "message": f"Could not validate `{new_model}`: {e}",
         }
 
+    # Override rejection if model is in the user's saved provider config.
+    # API /v1/models may not list cloud/aliased models even though the server supports them.
     if not validation.get("accepted"):
-        msg = validation.get("message", "Invalid model")
-        return ModelSwitchResult(
-            success=False,
-            new_model=new_model,
-            target_provider=target_provider,
-            provider_label=provider_label,
-            is_global=is_global,
-            error_message=msg,
-        )
+        override = False
+        if user_providers:
+            for up in user_providers:
+                if isinstance(up, dict) and up.get("provider") == target_provider:
+                    cfg_models = up.get("models", [])
+                    if new_model in cfg_models or any(
+                        m.get("name") == new_model for m in cfg_models if isinstance(m, dict)
+                    ):
+                        override = True
+                        break
+        if override:
+            validation = {"accepted": True, "persist": True, "recognized": False, "message": validation.get("message", "")}
+        else:
+            msg = validation.get("message", "Invalid model")
+            return ModelSwitchResult(
+                success=False,
+                new_model=new_model,
+                target_provider=target_provider,
+                provider_label=provider_label,
+                is_global=is_global,
+                error_message=msg,
+            )
 
     # Apply auto-correction if validation found a closer match
     if validation.get("corrected_model"):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2622,8 +2622,8 @@ def validate_requested_model(
                 )
 
             return {
-                "accepted": False,
-                "persist": False,
+                "accepted": True,
+                "persist": True,
                 "recognized": False,
                 "message": message,
             }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -750,6 +750,18 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
         current_base_url = str(runtime.get("base_url", "") or "")
         current_api_key = str(runtime.get("api_key", "") or "")
 
+    # Load user-defined providers so switch_model can resolve named custom
+    # endpoints (e.g. "ollama-launch") and validate against saved model lists.
+    user_provs = None
+    custom_provs = None
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+        cfg = load_config()
+        user_provs = [{"provider": k, **v} for k, v in (cfg.get("providers") or {}).items()]
+        custom_provs = get_compatible_custom_providers(cfg)
+    except Exception:
+        pass
+
     result = switch_model(
         raw_input=model_input,
         current_provider=current_provider,
@@ -758,6 +770,8 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
         current_api_key=current_api_key,
         is_global=persist_global,
         explicit_provider=explicit_provider,
+        user_providers=user_provs,
+        custom_providers=custom_provs,
     )
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")


### PR DESCRIPTION
Salvage of #15088 by @kshitijk4poor onto current main.

## Summary
`/model <name>` on custom/local endpoints (ollama-launch, lmstudio, vllm, LAN servers, etc.) no longer silently probes OpenRouter and fails. Named custom providers keep their known-good credentials during switch, and cloud/aliased models absent from `/v1/models` are accepted instead of rejected.

## Changes
- `hermes_cli/model_switch.py`: when re-resolution returns bare `custom`, preserve existing `api_key`/`base_url`/`api_mode` from the live agent. Add user_providers override for models absent from `/v1/models` but present in saved provider config.
- `hermes_cli/models.py`: custom endpoints where `/v1/models` doesn't list the requested model now return `accepted: True` with a note instead of rejecting — matches real-world server behavior where cloud/aliased models are supported but not enumerated (glm-5:cloud, :latest variants).
- `tui_gateway/server.py`: wires `user_providers`/`custom_providers` into `switch_model()` so TUI gets the same named-custom resolution as CLI.
- `cli.py`: pull `user_provs`/`custom_provs` load out of the picker-only branch so `switch_model()` always gets them.

## Root cause
Named custom providers (config `providers: { ollama-launch: { ... } }`) resolve through `_resolve_named_custom_runtime()` returning `provider: "custom"`. When `switch_model()` re-resolves credentials with `requested="custom"`, `resolve_runtime_provider` can't find the original endpoint and falls through to OpenRouter. Validation then probes OpenRouter's `/v1/models` instead of the local server.

## Validation
- Targeted tests: 131/131 model_switch + validation tests pass. 1 pre-existing failure on main (`test_saved_model_still_probes_endpoint`) unrelated to this PR.
- E2E (this salvage): custom endpoint with model not in `/v1/models` now returns `accepted: True`; credential preservation guard wired correctly in `switch_model()`.

Credit: @kshitijk4poor (authorship preserved via cherry-pick). Closes #15088. Complements #15823 which fixed the `hermes doctor` false-positive on the same report.