### PR TITLE
fix(reasoning): promote reasoning field before empty-pad for DeepSeek/Kimi (#15812)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7762,11 +7762,20 @@ class AIAgent:
             api_msg["reasoning_content"] = existing
             return
 
-        # 2. DeepSeek / Kimi thinking mode: tool-call turns that lack
-        # reasoning_content are "poisoned history" — a prior provider (MiniMax,
-        # etc.) left them empty. DeepSeek returns HTTP 400 if reasoning_content
-        # is absent on replay; inject "" to satisfy the provider's requirement
-        # without forwarding any cross-provider reasoning content.
+        # 2. Healthy session: promote 'reasoning' field to 'reasoning_content'
+        # for providers that use the internal 'reasoning' key.  Must happen
+        # before the empty-string fallback below so that a tool-call message
+        # with a valid 'reasoning' field is not silently overwritten with "".
+        normalized_reasoning = source_msg.get("reasoning")
+        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            api_msg["reasoning_content"] = normalized_reasoning
+            return
+
+        # 3. DeepSeek / Kimi thinking mode: tool-call turns that lack both
+        # reasoning_content and reasoning are "poisoned history" — a prior
+        # provider (MiniMax, etc.) left them empty. DeepSeek returns HTTP 400
+        # if reasoning_content is absent on replay; inject "" to satisfy the
+        # provider's requirement without forwarding cross-provider content.
         needs_empty_reasoning = (
             source_msg.get("tool_calls")
             and (
@@ -7776,13 +7785,6 @@ class AIAgent:
         )
         if needs_empty_reasoning:
             api_msg["reasoning_content"] = ""
-            return
-
-        # 3. Healthy session: promote 'reasoning' field to 'reasoning_content'
-        # for providers that use the internal 'reasoning' key.
-        normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
-            api_msg["reasoning_content"] = normalized_reasoning
             return
 
         # 4. DeepSeek / Kimi thinking mode: all assistant messages need


### PR DESCRIPTION
## Summary

- `_copy_reasoning_content_for_api` had a step-ordering bug introduced by PR #15749: the tool-call empty-string injection (old step 2) ran before the `reasoning` field promotion (old step 3)
- A tool-call message with a valid `reasoning` field but no `reasoning_content` would hit the empty-string path, get `reasoning_content=""` injected, and return early — the `reasoning` value was silently discarded
- Fix: move the `reasoning` → `reasoning_content` promotion to step 2, before the empty-string fallbacks

## The bug

`run_agent.py` — `_copy_reasoning_content_for_api` (pre-fix):

```python
# Step 1: explicit reasoning_content → preserve ✓
# Step 2: tool_calls + DeepSeek/Kimi → inject ""  ← fires here
#         RETURNS EARLY
# Step 3: reasoning field → promote               ← never reached
```

A message like `{"role": "assistant", "reasoning": "thought trace", "tool_calls": [...]}` on a DeepSeek session would return `reasoning_content=""` instead of `reasoning_content="thought trace"`.

## The fix

Reorder steps 2 and 3 so `reasoning` promotion runs first:

```python
# Step 1: explicit reasoning_content → preserve
# Step 2: reasoning field present → promote to reasoning_content  ← moved up
# Step 3: tool_calls + DeepSeek/Kimi + no reasoning → inject ""
# Step 4: all other DeepSeek/Kimi + no reasoning → inject ""
# Step 5: non-string cleanup
```

Empty-string injection now only fires when neither `reasoning_content` nor `reasoning` is present — the poisoned-history case it was designed for.

## Test plan

- [x] **Before**: `test_deepseek_reasoning_field_promoted` → `AssertionError: assert '' == 'thought trace'`
- [x] **After**: all 21 tests in `test_deepseek_reasoning_content_echo.py` pass
- [x] **Regression guard**: reverted `run_agent.py` → `test_deepseek_reasoning_field_promoted` failed with `'' != 'thought trace'`; restored → 21 passing
- [x] **Broader suite**: `tests/run_agent/` — 1048 passed, 1 pre-existing baseline failure (`test_inf_stays_string_for_integer_only` reproduces on clean `origin/main`)

## Related

- Fixes #15812
- Regression introduced by #15749
- Related: #15748 (same code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)