### PR TITLE
test(discord): add guild to fake e2e messages

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -346,6 +346,7 @@ def make_discord_message(
 
     return SimpleNamespace(
         id=message_id, content=content, author=author, channel=channel,
+        guild=getattr(channel, "guild", None),
         mentions=mentions, attachments=attachments,
         type=getattr(discord, "MessageType", SimpleNamespace()).default,
         reference=None, created_at=datetime.now(timezone.utc),


### PR DESCRIPTION
Salvaged from #15735 by @Wysie.

## Summary
Restores the e2e suite — broken on main since 47b02e961 (`feat(discord): populate guild_id, parent_chat_id, message_id on SessionSource`), which reads `message.guild` but the `SimpleNamespace` test fake lacked the attribute.

## Changes
- `tests/e2e/conftest.py`: mirror `channel.guild` onto the fake message, matching the real `discord.Message.guild` attribute.

## Validation
|  | Before | After |
|---|---|---|
| `tests/e2e/` | 5 failed / 46 passed | 51 passed |

Salvaged Wysie's fixture commit (3569c3eff) with authorship preserved. Dropped the defensive `getattr(message, 'guild', None)` in `gateway/platforms/discord.py` from the original PR — real `discord.Message` always has `.guild`, so the production code stays unchanged (as Wysie's own PR body claimed).

Closes #15735.