### PR TITLE
fix(telegram): fall back to send_document when send_photo rejects a local image

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1796,13 +1796,37 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.error(
-                "[%s] Failed to send Telegram local image, falling back to base adapter: %s",
+            logger.warning(
+                "[%s] Failed to send Telegram local image as photo, trying document fallback: %s",
                 self.name,
                 e,
                 exc_info=True,
             )
-            return await super().send_image_file(chat_id, image_path, caption, reply_to)
+            # Telegram rejects some valid local images as photos (for example
+            # very tall screenshots, extreme aspect ratios, or images outside
+            # photo dimension limits).  Do not degrade to a text-only
+            # "Image: /path" message; upload the same file as a document so the
+            # user still receives an openable attachment.
+            try:
+                _thread = self._metadata_thread_id(metadata)
+                with open(image_path, "rb") as image_file:
+                    msg = await self._bot.send_document(
+                        chat_id=int(chat_id),
+                        document=image_file,
+                        filename=os.path.basename(image_path),
+                        caption=caption[:1024] if caption else None,
+                        reply_to_message_id=int(reply_to) if reply_to else None,
+                        message_thread_id=self._message_thread_id_for_send(_thread),
+                    )
+                return SendResult(success=True, message_id=str(msg.message_id))
+            except Exception as document_error:
+                logger.error(
+                    "[%s] Failed to send Telegram local image as document, falling back to base adapter: %s",
+                    self.name,
+                    document_error,
+                    exc_info=True,
+                )
+                return await super().send_image_file(chat_id, image_path, caption, reply_to)
 
     async def send_document(
         self,


### PR DESCRIPTION
## Summary

When `TelegramAdapter.send_image_file` calls `send_photo` and Telegram rejects the image (very tall screenshots, extreme aspect ratios, files outside photo dimension limits, etc.), the current handler degrades straight to the base adapter — which sends a text-only \`Image: /path/to/file.png\` message. The user sees a path string instead of an openable attachment.

This change inserts a `send_document` fallback in between: same file, uploaded as a Telegram document. The user still receives a downloadable, openable attachment with the original caption. Only if document upload also fails do we fall back to the base adapter's text path.

## Why

Hit in production with a long browser screenshot bot reply. The current behavior leaks an internal local filesystem path into the chat (\`Image: /Users/<user>/.hermes/profiles/.../cache/screenshots/browser_screenshot_…png\`), which is both useless to the recipient and a small privacy leak.

## Behavior matrix

| Telegram response to `send_photo` | Before | After |
|---|---|---|
| Accepted | photo sent ✅ | photo sent ✅ |
| Rejected (dimensions / ratio / size) | text \`Image: /local/path.png\` ❌ | document attachment ✅ |
| Rejected by photo *and* document | text \`Image: /local/path.png\` | text \`Image: /local/path.png\` (unchanged) |

## Implementation notes

- Reuses the existing `_metadata_thread_id` / `_message_thread_id_for_send` helpers so forum-thread routing is preserved.
- Caption is still trimmed to the document caption limit (1024 chars) just like the photo path.
- The first failure is now logged at `warning` (recoverable) instead of `error`; the document failure stays `error`.

## Test plan
- [x] `python -m py_compile gateway/platforms/telegram.py`
- [x] Manual: in a deployment that previously surfaced \`Image: /…/browser_screenshot_….png\`, the same payload now arrives as a document.
- [ ] (Reviewer) Confirm \`send_document\`'s `caption` length limit (1024) is the same the rest of the codebase assumes.