### PR TITLE
feat(skills): add bundled Airtable productivity skill

### DIFF
--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: airtable
+description: Read/write Airtable bases via REST API
+metadata:
+  hermes:
+    tags: [Productivity, Database, API]
+    config:
+      - key: airtable.api_key
+        description: Airtable personal access token or API key for REST API calls
+        prompt: Airtable API key
+---
+
+# Airtable REST API
+
+Use Airtable's REST API with `curl` and Python stdlib only. Do not add third-party Python packages for this skill.
+
+## When to Use
+
+- Load this skill when the user mentions an Airtable base, table, or record.
+- Use it for listing bases and tables, reading records, filtering records, and creating, updating, or deleting records.
+- Prefer the REST API over browser/UI automation for routine Airtable data work.
+
+## Quick Reference
+
+Use a token header on every request:
+
+```bash
+AIRTABLE_API_KEY="..."  # from skills.config.airtable.api_key
+AUTH_HEADER="Authorization: Bearer $AIRTABLE_API_KEY"
+```
+
+List records:
+
+```bash
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=10" \
+  -H "$AUTH_HEADER"
+```
+
+Create a record:
+
+```bash
+curl -s -X POST "https://api.airtable.com/v0/$BASE_ID/$TABLE" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d '{"fields":{"Name":"New task","Status":"Todo"}}'
+```
+
+Update a record:
+
+```bash
+curl -s -X PATCH "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d '{"fields":{"Status":"Done"}}'
+```
+
+Delete a record:
+
+```bash
+curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
+  -H "$AUTH_HEADER"
+```
+
+## Procedure
+
+1. Authenticate first. Read `airtable.api_key` from skill config and use it as the bearer token for every request. If the credential is missing or invalid, stop and ask the user to configure it before continuing.
+2. List bases to find the right `baseId`. Prefer:
+   ```bash
+   curl -s "https://api.airtable.com/v0/meta/bases" \
+     -H "$AUTH_HEADER"
+   ```
+   If this fails because the token lacks metadata scopes, ask the user for the base ID directly or ask them to provide a token with base schema access.
+3. List tables for the chosen base:
+   ```bash
+   curl -s "https://api.airtable.com/v0/meta/bases/$BASE_ID/tables" \
+     -H "$AUTH_HEADER"
+   ```
+   Use this to confirm table names, table IDs, and field names before mutating data.
+4. Perform CRUD against the target table:
+   - Read records with `GET /v0/$BASE_ID/$TABLE`.
+   - Create with `POST /v0/$BASE_ID/$TABLE` and a JSON body shaped like `{"fields": {...}}`.
+   - Update with `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID` and only the fields that should change.
+   - Delete with `DELETE /v0/$BASE_ID/$TABLE/$RECORD_ID`.
+5. For tables with many records, follow Airtable pagination. Keep requesting the same list endpoint with the returned `offset` value until the response stops including `offset`.
+6. Prefer stable IDs (`app...`, `tbl...`, `rec...`) over human-readable names when the base is large, table names contain spaces, or the user may rename objects while the session is active.
+
+## Pitfalls
+
+- Airtable's Web API rate limit is `5 req/sec/base`. If you hit HTTP `429`, slow down, retry with backoff, and avoid firing parallel mutations into the same base.
+- `filterByFormula` must be URL-encoded when you are using raw `curl`. Use Python stdlib instead of extra packages:
+  ```bash
+  python -c "import urllib.parse; print(urllib.parse.quote(\"{Status}='Todo'\", safe=''))"
+  ```
+  Then pass the encoded value as `filterByFormula=...`.
+- List-record responses can omit empty fields. If field names look incomplete, inspect the table schema first instead of assuming the field does not exist.
+
+## Verification
+
+Run:
+
+```bash
+hermes -q "List records in my Airtable base X"
+```
+
+Successful verification means Hermes identifies the right base and table, authenticates, and returns records through the REST API instead of asking for extra dependencies.


### PR DESCRIPTION
## What does this PR do?

Adds a new bundled skill at `skills/productivity/airtable/SKILL.md` for working with Airtable bases, tables, and records via the REST API.

The skill is intentionally lightweight and follows the existing bundled productivity skill pattern: it uses `curl` plus Python stdlib only, with no new Hermes tool integration and no external Python dependencies.

This was written with `skills/productivity/notion/SKILL.md` and `skills/productivity/linear/SKILL.md` as the primary references.

## Related Issue

Fixes #

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `skills/productivity/airtable/SKILL.md`
- Added the requested frontmatter:
  - `name: airtable`
  - `description: "Read/write Airtable bases via REST API"`
  - `metadata.hermes.tags: [Productivity, Database, API]`
  - `metadata.hermes.config` entry for `airtable.api_key`
- Added the requested body sections:
  - `When to Use`
  - `Quick Reference`
  - `Procedure`
  - `Pitfalls`
  - `Verification`
- Documented the expected Airtable workflow:
  - auth
  - list bases
  - list tables
  - CRUD operations
- Included notes for Airtable-specific API behavior:
  - `5 req/sec/base` rate limit
  - `filterByFormula` URL encoding
  - pagination via `offset`

## Why this approach?

Airtable is a strong fit for a bundled skill rather than a new built-in tool. The workflow is fully expressible through instructions plus existing terminal access, and keeping it dependency-free makes it portable across Hermes environments.

## How to Test

1. Frontmatter parse

   Run:

   `python - <<'PY'
   from pathlib import Path
   from agent.skill_utils import parse_frontmatter
   p = Path("skills/productivity/airtable/SKILL.md")
   frontmatter, body = parse_frontmatter(p.read_text(encoding="utf-8"))
   print(frontmatter)
   print(body.strip().splitlines()[0])
   PY`

2. Skill config extraction

   Run:

   `python - <<'PY'
   from pathlib import Path
   from agent.skill_utils import parse_frontmatter, extract_skill_config_vars
   p = Path("skills/productivity/airtable/SKILL.md")
   frontmatter, _ = parse_frontmatter(p.read_text(encoding="utf-8"))
   print(extract_skill_config_vars(frontmatter))
   PY`

3. Skill discovery

   Run:

   `python - <<'PY'
   from pathlib import Path
   from agent.prompt_builder import _parse_skill_file
   p = Path("skills/productivity/airtable/SKILL.md")
   print(_parse_skill_file(p))
   PY`

4. Related test suite

   Run:

   `uv run pytest tests/test_plugin_skills.py`

## Test Results

Validated locally:

- frontmatter parsing succeeded
- `metadata.hermes.config` extraction succeeded
- `_parse_skill_file()` returned the expected result
- `uv run pytest tests/test_plugin_skills.py` passed: `27 passed`

Attempted smoke test:

`uv run hermes chat --toolsets skills -q "Use the airtable skill to list records in my Airtable base X"`

## Checklist

- [x] Broadly useful enough for `skills/`
- [x] Follows standard `SKILL.md` structure
- [x] No new external dependencies
- [x] Based on existing bundled productivity skill patterns
