### PR TITLE
Bridge ACP interim assistant messages

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -185,7 +185,10 @@ def make_message_cb(
 ) -> Callable:
     """Create a callback that streams agent response text to the editor."""
 
-    def _message(text: str) -> None:
+    def _message(text: str, *args: Any, **kwargs: Any) -> None:
+        # AIAgent's interim_assistant_callback passes keyword-only metadata
+        # such as already_streamed; ACP only needs the visible text chunk.
+        del args, kwargs
         if not text:
             return
         update = acp.update_agent_message_text(text)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -516,6 +516,7 @@ class HermesACPAgent(acp.Agent):
         agent.thinking_callback = thinking_cb
         agent.step_callback = step_cb
         agent.message_callback = message_cb
+        agent.interim_assistant_callback = message_cb
 
         if approval_cb:
             try:

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -315,6 +315,21 @@ class TestMessageCallback:
 
         mock_rcts.assert_called_once()
 
+    def test_accepts_interim_callback_metadata(self, mock_conn, event_loop_fixture):
+        """AIAgent interim callbacks pass already_streamed as keyword metadata."""
+        loop = event_loop_fixture
+
+        cb = make_message_cb(mock_conn, "session-1", loop)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb("Phase 1 complete.", already_streamed=False)
+
+        mock_rcts.assert_called_once()
+
     def test_ignores_empty_message(self, mock_conn, event_loop_fixture):
         """Empty text should not emit any update."""
         loop = event_loop_fixture

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -401,6 +401,44 @@ class TestPrompt:
         state.agent.run_conversation.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_prompt_bridges_interim_assistant_messages(self, agent):
+        """Mid-turn assistant commentary should be emitted as ACP message chunks."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def run_conversation(**kwargs):
+            assert state.agent.interim_assistant_callback is not None
+            state.agent.interim_assistant_callback(
+                "Phase 1 complete. Continuing research.",
+                already_streamed=False,
+            )
+            return {
+                "final_response": "Done.",
+                "messages": [
+                    {"role": "user", "content": "research this"},
+                    {"role": "assistant", "content": "Done."},
+                ],
+            }
+
+        state.agent.run_conversation = MagicMock(side_effect=run_conversation)
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="research this")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "end_turn"
+        message_updates = [
+            (call.kwargs.get("update") or call.args[1])
+            for call in mock_conn.session_update.call_args_list
+            if (call.kwargs.get("update") or call.args[1]).session_update == "agent_message_chunk"
+        ]
+        assert len(message_updates) >= 2
+        assert message_updates[0].content.text == "Phase 1 complete. Continuing research."
+
+    @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):
         """After a prompt, session history should be updated."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## Summary
- wire Hermes ACP sessions to forward `interim_assistant_callback` through the existing ACP message chunk callback
- allow ACP message callback to accept interim metadata such as `already_streamed`
- add ACP tests covering interim callback metadata and prompt-time streaming behavior

## Why
ACP clients currently receive tool progress and final assistant text, but not Hermes mid-turn assistant commentary. Hermes core emits that commentary via `interim_assistant_callback`, while the ACP adapter only assigned `message_callback`. This bridges the existing callback into ACP without changing the protocol surface.

## Tests
- `./venv/bin/python -m pytest tests/acp/test_events.py tests/acp/test_server.py`
- `git diff --check -- acp_adapter/events.py acp_adapter/server.py tests/acp/test_events.py tests/acp/test_server.py`

Note: pytest passes with existing AsyncMock runtime warnings in the ACP test suite.