### PR TITLE
Show reasoning effort in classic and TUI status bars

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4644,6 +4644,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return "class:status-bar-warn"
         return "class:status-bar-dim"
 
+    def _reasoning_effort_label(self) -> str:
+        """Return a short label for the active reasoning effort level."""
+        from hermes_constants import reasoning_effort_label
+
+        return reasoning_effort_label(getattr(self, "reasoning_config", None))
+
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
@@ -4727,6 +4733,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "reasoning_label": self._reasoning_effort_label(),
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -5256,13 +5263,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             battery_prefix = f"{battery_label} │ " if battery_label else ""
 
             yolo_active = self._is_session_yolo_active()
+            rl = snapshot["reasoning_label"]
+            # Blank label (no explicit reasoning config) renders as the bare
+            # model name — never an empty "()".
+            model_label = snapshot["model_short"]
+            if rl:
+                model_label = f"{model_label} ({rl})"
+
             if width < 52:
                 text = f"{battery_prefix}⚕ {snapshot['model_short']} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {model_label}", percent_label]
                 if battery_label:
                     parts.insert(0, battery_label)
                 compressions = snapshot.get("compressions", 0)
@@ -5290,7 +5304,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {model_label}", context_label, percent_label]
             if battery_label:
                 parts.insert(0, battery_label)
             if compressions:
@@ -5332,6 +5346,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             yolo_active = self._is_session_yolo_active()
             battery_label = snapshot.get("battery_label") or ""
             battery_style = self._battery_status_style(snapshot.get("battery_category", "dim"))
+            rl = snapshot["reasoning_label"]
 
             if width < 52:
                 frags = [
@@ -5358,6 +5373,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if rl:
+                        frags.insert(2, ("class:status-bar-dim", f" ({rl})"))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5401,6 +5418,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if rl:
+                        frags.insert(2, ("class:status-bar-dim", f" ({rl})"))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1050,6 +1050,33 @@ def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
     return result
 
 
+def reasoning_effort_label(reasoning_config: dict | None) -> str:
+    """Return the canonical display label for an explicit reasoning config.
+
+    Shared by the classic CLI status bar and the TUI gateway's session.info
+    payload so both label identically (the desktop consumes the same string
+    but applies its own presentation, e.g. rendering blank as its default).
+
+    Semantics: this is the *configured* session-level effort (config.yaml,
+    ``/reasoning``), not the per-request wire value — transports remap or
+    clamp efforts per model at request-build time, and auxiliary tasks pin
+    their own efforts, so there is no single "effective" value to display.
+    Unset or malformed configs return "" — no explicit session-level effort
+    is configured (a transport may still synthesize its own default), so
+    labeling it "medium" would claim more than we know. Disabled returns
+    "none", which must stay distinguishable from unset "" (the desktop keeps
+    a sticky "thinking off" pick alive off that distinction).
+    """
+    if not isinstance(reasoning_config, dict) or not reasoning_config:
+        return ""
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    if effort in VALID_REASONING_EFFORTS:
+        return effort
+    return ""
+
+
 def is_termux() -> bool:
     """Return True when running inside a Termux (Android) environment.
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -7,12 +7,13 @@ import cli as cli_mod
 from cli import HermesCLI
 
 
-def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
+def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514", reasoning_config=None):
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.model = model
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj.reasoning_config = reasoning_config
     return cli_obj
 
 
@@ -63,6 +64,107 @@ class TestCLIStatusBar:
         assert cli_obj._status_bar_context_style(81) == "class:status-bar-bad"
         assert cli_obj._status_bar_context_style(95) == "class:status-bar-critical"
 
+    def test_reasoning_effort_label_is_blank_when_unset(self):
+        # No explicit reasoning config -> labeling it "(medium)" would claim
+        # more than we know. Blank hides the label entirely.
+        cli_obj = _make_cli()
+        assert cli_obj._reasoning_effort_label() == ""
+
+    def test_reasoning_effort_label_explicit_effort(self):
+        cli_obj = _make_cli(reasoning_config={"enabled": True, "effort": "high"})
+        assert cli_obj._reasoning_effort_label() == "high"
+
+    def test_reasoning_effort_label_disabled(self):
+        cli_obj = _make_cli(reasoning_config={"enabled": False})
+        assert cli_obj._reasoning_effort_label() == "none"
+
+    def test_build_status_bar_text_shows_reasoning_effort(self):
+        cli_obj = _attach_agent(
+            _make_cli(reasoning_config={"enabled": True, "effort": "high"}),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "(high)" in text
+
+    def test_build_status_bar_text_shows_explicit_medium(self):
+        # An explicit medium config is a deliberate user pick, unlike unset —
+        # the label must distinguish the two.
+        cli_obj = _attach_agent(
+            _make_cli(reasoning_config={"enabled": True, "effort": "medium"}),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "(medium)" in text
+
+    def test_build_status_bar_text_medium_width_hides_unset_reasoning(self):
+        # The 52-75 column branch is a separate render path — it must also
+        # skip the empty "()" for unset reasoning.
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=60)
+        assert "()" not in text
+
+    def test_build_status_bar_text_narrow_hides_reasoning(self):
+        cli_obj = _attach_agent(
+            _make_cli(reasoning_config={"enabled": True, "effort": "high"}),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=45)
+        assert "(high)" not in text
+
+    def _fragments_cli(self, reasoning_config=None):
+        cli_obj = _attach_agent(
+            _make_cli(reasoning_config=reasoning_config),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        cli_obj._get_tui_terminal_width = lambda: 120
+        return cli_obj
+
+    def test_status_bar_fragments_show_reasoning_effort(self):
+        frags = self._fragments_cli(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )._get_status_bar_fragments()
+        joined = "".join(text for _style, text in frags)
+        assert "(high)" in joined
+
+    def test_status_bar_fragments_hide_unset_reasoning(self):
+        frags = self._fragments_cli()._get_status_bar_fragments()
+        joined = "".join(text for _style, text in frags)
+        assert joined  # render path exercised, not the exception fallback
+        assert "()" not in joined
+
     def test_build_status_bar_text_for_wide_terminal(self):
         cli_obj = _attach_agent(
             _make_cli(),
@@ -77,6 +179,9 @@ class TestCLIStatusBar:
         text = cli_obj._build_status_bar_text(width=120)
 
         assert "claude-sonnet-4-20250514" in text
+        # Unset reasoning: no default "(medium)" label and no empty "()".
+        assert "(medium)" not in text
+        assert "()" not in text
         assert "12.4K/200K" in text
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -24,6 +24,7 @@ from hermes_constants import (
     node_tool_runnable,
     parse_reasoning_effort,
     reset_hermes_home_override,
+    reasoning_effort_label,
     secure_parent_dir,
     set_hermes_home_override,
     with_hermes_node_path,
@@ -1205,3 +1206,35 @@ class TestWslPathTranslation:
         assert hermes_constants.translate_cwd_for_wsl_backend(r"\\wsl.localhost\Ubuntu\home\alex") == "/home/alex"
         # Already-POSIX paths pass through untouched.
         assert hermes_constants.translate_cwd_for_wsl_backend("/home/alex") == "/home/alex"
+
+
+@pytest.mark.parametrize(
+    ("reasoning_config", "expected"),
+    [
+        # Unset / malformed -> blank: no explicit session-level effort is
+        # configured, so no label (a default "medium" would be misleading).
+        (None, ""),
+        ({}, ""),
+        ("high", ""),
+        ({"enabled": True, "effort": "bogus"}, ""),
+        ({"enabled": True, "effort": ""}, ""),
+        # Disabled -> "none", even with a stale effort left in the dict.
+        ({"enabled": False}, "none"),
+        ({"enabled": False, "effort": "high"}, "none"),
+        # Explicit efforts pass through, including "medium".
+        ({"enabled": True, "effort": "medium"}, "medium"),
+        ({"effort": "low"}, "low"),
+    ],
+)
+def test_reasoning_effort_label(reasoning_config, expected):
+    assert reasoning_effort_label(reasoning_config) == expected
+
+
+def test_reasoning_effort_label_round_trips_every_parseable_effort():
+    """Invariant: whatever parse_reasoning_effort accepts, the label shows
+    verbatim ("none" for disabled, "" for unset) — no drift between the two
+    helpers as effort levels are added."""
+    for effort in VALID_REASONING_EFFORTS:
+        assert reasoning_effort_label(parse_reasoning_effort(effort)) == effort
+    assert reasoning_effort_label(parse_reasoning_effort("none")) == "none"
+    assert reasoning_effort_label(parse_reasoning_effort("")) == ""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10903,6 +10903,7 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         # the client never clobbers its sticky pick before the build lands.
         assert resp["result"]["info"]["model"] == "claude-sonnet-4.6"
         assert resp["result"]["info"]["provider"] == "anthropic"
+        assert resp["result"]["info"]["reasoning_effort"] == "high"
 
         # Explicit false is not the same as omission: it must suppress a Fast
         # profile default for this session's first request.
@@ -10920,6 +10921,91 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         assert plain_sess["create_service_tier_override"] is None
     finally:
         server._sessions.clear()
+
+
+def test_session_create_initial_info_reasoning_falls_back_to_config(
+    monkeypatch, tmp_path
+):
+    """Without a per-session effort override, the immediate session.create
+    info reports the config default — the same value the deferred build's
+    session.info will report — so the status bar never flashes blank."""
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-5\n"
+        "agent:\n"
+        "  reasoning_effort: low\n"
+        "  reasoning_overrides:\n"
+        "    gpt-5: xhigh\n"
+        "    claude-opus-4.8: high\n",
+        encoding="utf-8",
+    )
+    try:
+        resp = server._methods["session.create"]("r1", {"cols": 80})
+        assert resp["result"]["info"]["reasoning_effort"] == "xhigh"
+
+        # A per-session model pick must resolve against that model, matching
+        # the deferred agent build rather than the profile's default model.
+        picked = server._methods["session.create"](
+            "r-model", {"cols": 80, "model": "claude-opus-4.8"}
+        )
+        assert picked["result"]["info"]["reasoning_effort"] == "high"
+
+        # Explicitly disabled reasoning ("none") must survive the round trip,
+        # not collapse into unset "".
+        off = server._methods["session.create"](
+            "r2", {"cols": 80, "reasoning_effort": "none"}
+        )
+        assert off["result"]["info"]["reasoning_effort"] == "none"
+    finally:
+        server._sessions.clear()
+
+
+def test_session_info_reasoning_effort_labels(monkeypatch):
+    """_session_info reports the canonical shared label: explicit efforts
+    verbatim, disabled as "none", unset as "" (see reasoning_effort_label)."""
+    explicit = server._session_info(
+        types.SimpleNamespace(
+            tools=[], model="m", provider="", reasoning_config={"enabled": True, "effort": "medium"}
+        )
+    )
+    assert explicit["reasoning_effort"] == "medium"
+
+    disabled = server._session_info(
+        types.SimpleNamespace(
+            tools=[], model="m", provider="", reasoning_config={"enabled": False}
+        )
+    )
+    assert disabled["reasoning_effort"] == "none"
+
+    unset = server._session_info(
+        types.SimpleNamespace(tools=[], model="m", provider="", reasoning_config=None)
+    )
+    assert unset["reasoning_effort"] == ""
+
+
+def test_lazy_resume_info_includes_reasoning_effort(monkeypatch, tmp_path):
+    """Cold resume's immediate info must carry the stored session effort (or
+    the config default the deferred build will use) so the first render
+    matches the session.info the build emits — no blank/stale flash."""
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: low\n", encoding="utf-8"
+    )
+
+    stored = server._lazy_resume_info(
+        str(tmp_path), reasoning_config={"enabled": True, "effort": "max"}
+    )
+    assert stored["reasoning_effort"] == "max"
+
+    fallback = server._lazy_resume_info(str(tmp_path))
+    assert fallback["reasoning_effort"] == "low"
 
 
 @pytest.mark.parametrize("service_tier_override", ["priority", ""])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3887,18 +3887,20 @@ def _session_info(agent, session: dict | None = None) -> dict:
     )
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
-    reasoning_config = getattr(agent, "reasoning_config", None)
-    reasoning_effort = ""
-    if isinstance(reasoning_config, dict):
-        if reasoning_config.get("enabled") is False:
-            # Disabled must be distinguishable from unset ("" = provider
-            # default). Reporting "" here made the desktop adopt the empty
-            # value after the first turn, wiping its sticky "thinking off"
-            # pick and re-creating every later chat at the default effort.
-            reasoning_effort = "none"
-        else:
-            reasoning_effort = str(reasoning_config.get("effort", "") or "")
-    service_tier = getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    # Canonical label shared with the classic CLI status bar: "" for unset
+    # (provider default), "none" for disabled. Disabled must stay
+    # distinguishable from unset — reporting "" for disabled made the
+    # desktop adopt the empty value after the first turn, wiping its sticky
+    # "thinking off" pick and re-creating every later chat at the default
+    # effort.
+    from hermes_constants import reasoning_effort_label
+
+    reasoning_effort = reasoning_effort_label(
+        getattr(agent, "reasoning_config", None)
+    )
+    service_tier = (
+        getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    )
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
     # (approvals.mode=off), the process-scoped --yolo env, and the
@@ -5873,6 +5875,8 @@ def _queued_prompt_snapshot(session: dict) -> dict | None:
 
 @method("session.create")
 def _(rid, params: dict) -> dict:
+    from hermes_constants import reasoning_effort_label
+
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
     cols = int(params.get("cols", 80))
@@ -6009,6 +6013,15 @@ def _(rid, params: dict) -> dict:
                     {"provider": session_model_override["provider"]}
                     if session_model_override and session_model_override.get("provider")
                     else {}
+                ),
+                # Same sticky-pick rule for reasoning effort: prefer the
+                # per-session override, fall back to the config default the
+                # deferred build will use — matching what its session.info
+                # reports moments later.
+                "reasoning_effort": reasoning_effort_label(
+                    create_reasoning_override
+                    if create_reasoning_override is not None
+                    else _load_reasoning_config(create_model or _resolve_model())
                 ),
                 "tools": {},
                 "skills": {},
@@ -6155,14 +6168,32 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"verification": {"status": "unknown", "evidence": None}})
 
 
-def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
+def _lazy_resume_info(
+    cwd: str,
+    *,
+    model: str = "",
+    provider: str = "",
+    reasoning_config: dict | None = None,
+) -> dict:
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
+    from hermes_constants import reasoning_effort_label
+
+    resolved_model = model or _resolve_model()
+    resolved_reasoning_config = (
+        reasoning_config
+        if reasoning_config is not None
+        else _load_reasoning_config(resolved_model)
+    )
     info = {
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
-        "model": model or _resolve_model(),
+        "model": resolved_model,
+        # Stored session effort when the resume carries one, else the config
+        # default the deferred build will use — so the first render matches
+        # the session.info the build emits, instead of flashing blank/stale.
+        "reasoning_effort": reasoning_effort_label(resolved_reasoning_config),
         "tools": {},
         "skills": {},
         "lazy": True,
@@ -6506,6 +6537,7 @@ def _(rid, params: dict) -> dict:
                     cwd,
                     model=model_override.get("model") or "",
                     provider=overrides.get("provider_override") or "",
+                    reasoning_config=overrides.get("reasoning_config_override"),
                 ),
                 "inflight": None,
                 "running": False,

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -467,3 +467,38 @@ describe('StatusRule idle-since read-out', () => {
     expect(findComponentByName(element, 'IdleSince')).toBeNull()
   })
 })
+
+describe('StatusRule reasoning-effort label', () => {
+  // session.info reasoning_effort contract: '' = unset (no explicit effort
+  // configured — hide), 'none' = explicitly disabled, anything else is an
+  // explicit user pick and shows — including 'medium', which the backend
+  // only sends when the user configured it.
+  it('shows an explicit effort next to the model', () => {
+    const element = StatusRule({ ...baseProps, modelReasoningEffort: 'high' })
+
+    expect(textContent(element)).toContain('opus 4.8 high')
+  })
+
+  it('shows an explicit medium', () => {
+    const element = StatusRule({ ...baseProps, modelReasoningEffort: 'medium' })
+
+    expect(textContent(element)).toContain('opus 4.8 medium')
+  })
+
+  it('shows "none" when reasoning is explicitly disabled', () => {
+    const element = StatusRule({ ...baseProps, modelReasoningEffort: 'none' })
+
+    expect(textContent(element)).toContain('opus 4.8 none')
+  })
+
+  it('hides the label when unset or a legacy placeholder', () => {
+    for (const unset of [undefined, '', 'default', 'normal']) {
+      const element = StatusRule({ ...baseProps, modelReasoningEffort: unset })
+
+      expect(textContent(element)).toContain('opus 4.8')
+      expect(textContent(element)).not.toContain('medium')
+      expect(textContent(element)).not.toContain('default')
+      expect(textContent(element)).not.toContain('normal')
+    }
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -386,12 +386,17 @@ function IdleSince({ endedAt }: { endedAt: number }) {
   return `✓ ${fmtDuration(now - endedAt)}`
 }
 
+// session.info reasoning_effort contract: '' = unset (no explicit effort
+// configured — hide), 'none' = explicitly disabled, anything else is an
+// explicit user pick and shows — including 'medium', which the backend only
+// sends when the user configured it. 'normal'/'default' are legacy
+// placeholder values from older backends, never valid efforts.
 const effortLabel = (effort?: string) => {
   const value = String(effort ?? '')
     .trim()
     .toLowerCase()
 
-  return value && value !== 'medium' && value !== 'normal' && value !== 'default' ? value : ''
+  return value && value !== 'normal' && value !== 'default' ? value : ''
 }
 
 const shortModelLabel = (model: string) =>


### PR DESCRIPTION
# Rationale

Hermes already lets users configure reasoning effort, but the active explicit level was not consistently visible during CLI sessions. That makes it harder to understand latency, cost, and behavior differences after setup, model changes, or live `/reasoning` changes because the classic status bar only showed the model.

The Ink TUI already has a model-label path on current `main`; this PR keeps that design and makes sure the backend sends canonical reasoning-effort metadata for it.

# What changed

- Adds a shared `reasoning_effort_label()` helper beside `parse_reasoning_effort()` so display labels stay canonical.
- Treats unset or malformed reasoning config as blank for display, avoiding a misleading default `(medium)` label when no reasoning config is being sent.
- Shows explicit reasoning effort next to the model name in the classic prompt_toolkit status bar at medium/wide widths.
- Includes `reasoning_effort` in TUI `session.info` for initial session creation, full session info, and live `/reasoning <effort>` updates.
- Leaves `/reasoning show|hide` as display-only toggles; they no longer emit unchanged `session.info` payloads.
- Relies on the existing Ink TUI model-label renderer, which shows explicit efforts from `session.info` and hides default/unset values.
- Adds focused Python coverage for the label helper, classic status text, TUI session info propagation, live `/reasoning` updates, and cleanup around session creation tests.

# Validation

- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py tests/test_hermes_constants.py tests/test_tui_gateway_server.py -q` -> 168 passed
- `git diff --check upstream/main...HEAD` -> clean
- Claude Opus 4.7 adversarial review with `--effort max`; addressed findings around the misleading default `(medium)` status label and redundant `/reasoning show|hide` emits.
