### PR TITLE
Integrate official Obsidian skills for working with Obsidian Bases and Canvases

### DIFF
--- a/skills/apple/apple-notes/SKILL.md
+++ b/skills/apple/apple-notes/SKILL.md
@@ -8,7 +8,7 @@ platforms: [macos]
 metadata:
   hermes:
     tags: [Notes, Apple, macOS, note-taking]
-    related_skills: [obsidian]
+    related_skills: [obsidian, obsidian-markdown]
 prerequisites:
   commands: [memo]
 ---
@@ -32,7 +32,7 @@ Use `memo` to manage Apple Notes directly from the terminal. Notes sync across a
 
 ## When NOT to Use
 
-- Obsidian vault management → use the `obsidian` skill
+- Obsidian vault management or Obsidian-specific Markdown note authoring → use the `obsidian` or `obsidian-markdown` skill
 - Bear Notes → separate app (not supported here)
 - Quick agent-only notes → use the `memory` tool instead
 
@@ -87,4 +87,4 @@ memo notes -ex                    # Export to HTML/Markdown
 
 1. Prefer Apple Notes when user wants cross-device sync (iPhone/iPad/Mac)
 2. Use the `memory` tool for agent-internal notes that don't need to sync
-3. Use the `obsidian` skill for Markdown-native knowledge management
+3. Use the `obsidian` skill for broad vault workflows, or `obsidian-markdown` for Obsidian-specific Markdown authoring

--- a/skills/apple/apple-notes/SKILL.md
+++ b/skills/apple/apple-notes/SKILL.md
@@ -8,7 +8,7 @@ platforms: [macos]
 metadata:
   hermes:
     tags: [Notes, Apple, macOS, note-taking]
-    related_skills: [obsidian]
+    related_skills: [obsidian, obsidian-markdown]
 prerequisites:
   commands: [memo]
 ---
@@ -32,7 +32,7 @@ Use `memo` to manage Apple Notes directly from the terminal. Notes sync across a
 
 ## When NOT to Use
 
-- Obsidian vault management → use the `obsidian` skill
+- Obsidian vault management or Obsidian-specific Markdown note authoring → use the `obsidian` or `obsidian-markdown` skill
 - Bear Notes → separate app (not supported here)
 - Quick agent-only notes → use the `memory` tool instead
 
@@ -91,4 +91,4 @@ memo notes -ex                    # Export to HTML/Markdown
 
 1. Prefer Apple Notes when user wants cross-device sync (iPhone/iPad/Mac)
 2. Use the `memory` tool for agent-internal notes that don't need to sync
-3. Use the `obsidian` skill for Markdown-native knowledge management
+3. Use the `obsidian` skill for broad vault workflows, or `obsidian-markdown` for Obsidian-specific Markdown authoring

--- a/skills/note-taking/THIRD_PARTY_NOTICES.md
+++ b/skills/note-taking/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,30 @@
+# Third-Party Notices
+
+The `obsidian-markdown`, `obsidian-cli`, `obsidian-bases`, and `json-canvas`
+skills in this directory are adapted from Steph Ango's official Obsidian
+skills ([kepano/obsidian-skills](https://github.com/kepano/obsidian-skills))
+and redistributed under the MIT License below, as required by that license.
+
+```
+MIT License
+
+Copyright (c) 2026 Steph Ango (@kepano)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/note-taking/json-canvas/SKILL.md
+++ b/skills/note-taking/json-canvas/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: json-canvas
+description: Create and edit .canvas files with nodes and edges.
+platforms: [linux, macos, windows]
+version: 1.1.0
+author: Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills)
+license: MIT
+metadata:
+  hermes:
+    tags: [obsidian, json-canvas, canvas, note-taking, diagrams]
+    related_skills: [obsidian, obsidian-markdown, obsidian-cli, obsidian-bases]
+---
+
+# JSON Canvas Skill
+
+Create and edit JSON Canvas files (`.canvas`) — the open format behind
+Obsidian's Canvas: mind maps, flowcharts, and visual boards built from
+nodes, edges, and groups per the
+[JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/). Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Creating or editing `.canvas` files
+- The user asks for a visual canvas, mind map, flowchart, or project board
+  in Obsidian
+
+Route elsewhere for broad vault work (`obsidian`), Markdown notes
+(`obsidian-markdown`), or `.base` database views (`obsidian-bases`).
+
+## Prerequisites
+
+None — `.canvas` files are plain JSON and no running Obsidian app is
+required. Resolve the vault path first (see the `obsidian` skill).
+
+## How to Run
+
+Read canvases with `read_file`, create them with `write_file`, and make
+targeted edits with `patch`. After any change, validate with the bundled
+checker (run via `terminal`, from this skill's directory):
+
+```bash
+python scripts/validate_canvas.py /absolute/path/to/file.canvas
+```
+
+It checks JSON validity, ID uniqueness, edge reference integrity, required
+per-type fields, and enum values, and exits non-zero with per-error
+messages on failure.
+
+## Quick Reference
+
+A `.canvas` file is a JSON object with two optional top-level arrays:
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+### Generic node attributes
+
+Array order determines z-index: first node = bottom layer.
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `id` | Yes | string | Unique string (convention: 16-char hex) |
+| `type` | Yes | string | `text`, `file`, `link`, or `group` |
+| `x`, `y` | Yes | integer | Position in pixels (top-left corner) |
+| `width`, `height` | Yes | integer | Size in pixels |
+| `color` | No | canvasColor | Preset `"1"`-`"6"` or hex (e.g., `"#FF0000"`) |
+
+### Per-type attributes
+
+| Node type | Required | Optional |
+|-----------|----------|----------|
+| `text` | `text` (Markdown string) | — |
+| `file` | `file` (vault path) | `subpath` (starts with `#`) |
+| `link` | `url` | — |
+| `group` | — | `label`, `background`, `backgroundStyle` (`cover`/`ratio`/`repeat`) |
+
+```json
+{
+  "id": "6f0ad84f44ce9c17",
+  "type": "text",
+  "x": 0,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "text": "# Hello World\n\nThis is **Markdown** content."
+}
+```
+
+### Edge attributes
+
+| Attribute | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `id` | Yes | - | Unique identifier |
+| `fromNode`, `toNode` | Yes | - | Source / target node IDs |
+| `fromSide`, `toSide` | No | - | `top`, `right`, `bottom`, or `left` |
+| `fromEnd`, `toEnd` | No | `none` / `arrow` | `none` or `arrow` |
+| `color` | No | - | Line color (canvasColor) |
+| `label` | No | - | Text label |
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "toNode": "a1b2c3d4e5f67890",
+  "toSide": "left",
+  "label": "leads to"
+}
+```
+
+### Colors
+
+`canvasColor` is either a hex string (`"#FF0000"`; 3-, 4-, 6-, and 8-digit
+forms are accepted) or a preset: `"1"` red, `"2"` orange, `"3"` yellow,
+`"4"` green, `"5"` cyan, `"6"` purple. Preset rendering is
+application-defined.
+
+### Layout guidelines
+
+- Coordinates can be negative; `x` increases right, `y` increases down
+- Any unique string is a valid ID; generate 16-character lowercase hex
+  strings (64-bit random) to match Obsidian's convention
+- Space nodes 50-100px apart; leave 20-50px padding inside groups
+- Align to multiples of 10 or 20 for cleaner layouts
+- Suggested sizes: small text 250x100, large text 500x400, file preview
+  400x300, link preview 300x150
+
+## Procedure
+
+Creating a new canvas:
+
+1. Start from the base structure `{"nodes": [], "edges": []}`.
+2. Generate a unique 16-char hex ID for each node.
+3. Add nodes with the required fields (`id`, `type`, `x`, `y`, `width`,
+   `height`) plus the per-type required field.
+4. Add edges referencing valid node IDs via `fromNode`/`toNode`.
+5. Write the file with `write_file`, then validate (see Verification).
+
+Editing an existing canvas:
+
+1. Read the file with `read_file` and locate the target node/edge by `id`.
+2. For a new node, pick a position that avoids overlapping existing nodes
+   and an ID that collides with nothing.
+3. Group nodes visually by adding a `group` node whose bounds enclose them.
+4. Apply the change with `patch` (or rewrite with `write_file` when the
+   change is structural), then validate.
+
+## Pitfalls
+
+- **Newlines in text nodes**: use `\n` inside the JSON string. A literal
+  `\\n` renders as the characters `\` and `n` in Obsidian.
+- Duplicate IDs and dangling `fromNode`/`toNode` references break rendering
+  silently — always validate after editing.
+- `file` node paths are vault-relative; a wrong path shows a broken
+  embed only when Obsidian opens the canvas.
+- Do not add trailing commas or comments — `.canvas` is strict JSON.
+
+## Verification
+
+Run `python scripts/validate_canvas.py <file.canvas>` via `terminal`; it
+must exit 0. It enforces: valid JSON; unique `id` values across nodes and
+edges; every edge endpoint resolves to a node; required per-type fields
+present; `type`, side, and end values within their enums; colors are
+presets `"1"`-`"6"` or hex. For a final visual check, open the canvas in
+Obsidian if it is available.
+
+## References
+
+- Complete worked examples (mind map, project board, flowchart):
+  [references/EXAMPLES.md](references/EXAMPLES.md)
+- [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/)
+- [JSON Canvas GitHub](https://github.com/obsidianmd/jsoncanvas)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md)

--- a/skills/note-taking/json-canvas/references/EXAMPLES.md
+++ b/skills/note-taking/json-canvas/references/EXAMPLES.md
@@ -1,0 +1,329 @@
+# JSON Canvas Complete Examples
+
+## Simple Canvas with Text and Connections
+
+```json
+{
+  "nodes": [
+    {
+      "id": "8a9b0c1d2e3f4a5b",
+      "type": "text",
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 150,
+      "text": "# Main Idea\n\nThis is the central concept."
+    },
+    {
+      "id": "1a2b3c4d5e6f7a8b",
+      "type": "text",
+      "x": 400,
+      "y": -100,
+      "width": 250,
+      "height": 100,
+      "text": "## Supporting Point A\n\nDetails here."
+    },
+    {
+      "id": "2b3c4d5e6f7a8b9c",
+      "type": "text",
+      "x": 400,
+      "y": 100,
+      "width": 250,
+      "height": 100,
+      "text": "## Supporting Point B\n\nMore details."
+    }
+  ],
+  "edges": [
+    {
+      "id": "3c4d5e6f7a8b9c0d",
+      "fromNode": "8a9b0c1d2e3f4a5b",
+      "fromSide": "right",
+      "toNode": "1a2b3c4d5e6f7a8b",
+      "toSide": "left"
+    },
+    {
+      "id": "4d5e6f7a8b9c0d1e",
+      "fromNode": "8a9b0c1d2e3f4a5b",
+      "fromSide": "right",
+      "toNode": "2b3c4d5e6f7a8b9c",
+      "toSide": "left"
+    }
+  ]
+}
+```
+
+## Project Board with Groups
+
+```json
+{
+  "nodes": [
+    {
+      "id": "5e6f7a8b9c0d1e2f",
+      "type": "group",
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "To Do",
+      "color": "1"
+    },
+    {
+      "id": "6f7a8b9c0d1e2f3a",
+      "type": "group",
+      "x": 350,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "In Progress",
+      "color": "3"
+    },
+    {
+      "id": "7a8b9c0d1e2f3a4b",
+      "type": "group",
+      "x": 700,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "Done",
+      "color": "4"
+    },
+    {
+      "id": "8b9c0d1e2f3a4b5c",
+      "type": "text",
+      "x": 20,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 1\n\nImplement feature X"
+    },
+    {
+      "id": "9c0d1e2f3a4b5c6d",
+      "type": "text",
+      "x": 370,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 2\n\nReview PR #123",
+      "color": "2"
+    },
+    {
+      "id": "0d1e2f3a4b5c6d7e",
+      "type": "text",
+      "x": 720,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 3\n\n~~Setup CI/CD~~"
+    }
+  ],
+  "edges": []
+}
+```
+
+## Research Canvas with Files and Links
+
+```json
+{
+  "nodes": [
+    {
+      "id": "1e2f3a4b5c6d7e8f",
+      "type": "text",
+      "x": 300,
+      "y": 200,
+      "width": 400,
+      "height": 200,
+      "text": "# Research Topic\n\n## Key Questions\n\n- How does X affect Y?\n- What are the implications?",
+      "color": "5"
+    },
+    {
+      "id": "2f3a4b5c6d7e8f9a",
+      "type": "file",
+      "x": 0,
+      "y": 0,
+      "width": 250,
+      "height": 150,
+      "file": "Literature/Paper A.pdf"
+    },
+    {
+      "id": "3a4b5c6d7e8f9a0b",
+      "type": "file",
+      "x": 0,
+      "y": 200,
+      "width": 250,
+      "height": 150,
+      "file": "Notes/Meeting Notes.md",
+      "subpath": "#Key Insights"
+    },
+    {
+      "id": "4b5c6d7e8f9a0b1c",
+      "type": "link",
+      "x": 0,
+      "y": 400,
+      "width": 250,
+      "height": 100,
+      "url": "https://example.com/research"
+    },
+    {
+      "id": "5c6d7e8f9a0b1c2d",
+      "type": "file",
+      "x": 750,
+      "y": 150,
+      "width": 300,
+      "height": 250,
+      "file": "Attachments/diagram.png"
+    }
+  ],
+  "edges": [
+    {
+      "id": "6d7e8f9a0b1c2d3e",
+      "fromNode": "2f3a4b5c6d7e8f9a",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "label": "supports"
+    },
+    {
+      "id": "7e8f9a0b1c2d3e4f",
+      "fromNode": "3a4b5c6d7e8f9a0b",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "label": "informs"
+    },
+    {
+      "id": "8f9a0b1c2d3e4f5a",
+      "fromNode": "4b5c6d7e8f9a0b1c",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "toEnd": "arrow",
+      "color": "6"
+    },
+    {
+      "id": "9a0b1c2d3e4f5a6b",
+      "fromNode": "1e2f3a4b5c6d7e8f",
+      "fromSide": "right",
+      "toNode": "5c6d7e8f9a0b1c2d",
+      "toSide": "left",
+      "label": "visualized by"
+    }
+  ]
+}
+```
+
+## Flowchart
+
+```json
+{
+  "nodes": [
+    {
+      "id": "a0b1c2d3e4f5a6b7",
+      "type": "text",
+      "x": 200,
+      "y": 0,
+      "width": 150,
+      "height": 60,
+      "text": "**Start**",
+      "color": "4"
+    },
+    {
+      "id": "b1c2d3e4f5a6b7c8",
+      "type": "text",
+      "x": 200,
+      "y": 100,
+      "width": 150,
+      "height": 60,
+      "text": "Step 1:\nGather data"
+    },
+    {
+      "id": "c2d3e4f5a6b7c8d9",
+      "type": "text",
+      "x": 200,
+      "y": 200,
+      "width": 150,
+      "height": 80,
+      "text": "**Decision**\n\nIs data valid?",
+      "color": "3"
+    },
+    {
+      "id": "d3e4f5a6b7c8d9e0",
+      "type": "text",
+      "x": 400,
+      "y": 200,
+      "width": 150,
+      "height": 60,
+      "text": "Process data"
+    },
+    {
+      "id": "e4f5a6b7c8d9e0f1",
+      "type": "text",
+      "x": 0,
+      "y": 200,
+      "width": 150,
+      "height": 60,
+      "text": "Request new data",
+      "color": "1"
+    },
+    {
+      "id": "f5a6b7c8d9e0f1a2",
+      "type": "text",
+      "x": 400,
+      "y": 320,
+      "width": 150,
+      "height": 60,
+      "text": "**End**",
+      "color": "4"
+    }
+  ],
+  "edges": [
+    {
+      "id": "a6b7c8d9e0f1a2b3",
+      "fromNode": "a0b1c2d3e4f5a6b7",
+      "fromSide": "bottom",
+      "toNode": "b1c2d3e4f5a6b7c8",
+      "toSide": "top"
+    },
+    {
+      "id": "b7c8d9e0f1a2b3c4",
+      "fromNode": "b1c2d3e4f5a6b7c8",
+      "fromSide": "bottom",
+      "toNode": "c2d3e4f5a6b7c8d9",
+      "toSide": "top"
+    },
+    {
+      "id": "c8d9e0f1a2b3c4d5",
+      "fromNode": "c2d3e4f5a6b7c8d9",
+      "fromSide": "right",
+      "toNode": "d3e4f5a6b7c8d9e0",
+      "toSide": "left",
+      "label": "Yes",
+      "color": "4"
+    },
+    {
+      "id": "d9e0f1a2b3c4d5e6",
+      "fromNode": "c2d3e4f5a6b7c8d9",
+      "fromSide": "left",
+      "toNode": "e4f5a6b7c8d9e0f1",
+      "toSide": "right",
+      "label": "No",
+      "color": "1"
+    },
+    {
+      "id": "e0f1a2b3c4d5e6f7",
+      "fromNode": "e4f5a6b7c8d9e0f1",
+      "fromSide": "top",
+      "fromEnd": "none",
+      "toNode": "b1c2d3e4f5a6b7c8",
+      "toSide": "left",
+      "toEnd": "arrow"
+    },
+    {
+      "id": "f1a2b3c4d5e6f7a8",
+      "fromNode": "d3e4f5a6b7c8d9e0",
+      "fromSide": "bottom",
+      "toNode": "f5a6b7c8d9e0f1a2",
+      "toSide": "top"
+    }
+  ]
+}
+```

--- a/skills/note-taking/json-canvas/scripts/validate_canvas.py
+++ b/skills/note-taking/json-canvas/scripts/validate_canvas.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Validate JSON Canvas (.canvas) files against the JSON Canvas 1.0 spec.
+
+Usage:
+    python validate_canvas.py FILE [FILE ...]
+
+Exits 0 when every file is valid, 1 otherwise. Errors are printed one per
+line, prefixed with the file path. Stdlib only.
+
+Spec: https://jsoncanvas.org/spec/1.0/
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+NODE_TYPES = {"text", "file", "link", "group"}
+SIDES = {"top", "right", "bottom", "left"}
+ENDS = {"none", "arrow"}
+BACKGROUND_STYLES = {"cover", "ratio", "repeat"}
+COLOR_PRESETS = {"1", "2", "3", "4", "5", "6"}
+# 3-, 4-, 6-, and 8-digit hex forms (#RGB, #RGBA, #RRGGBB, #RRGGBBAA); the
+# spec says only "color in hex format", so accept all common CSS hex forms.
+HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
+
+# type -> attribute that must be present on nodes of that type
+REQUIRED_BY_TYPE = {"text": "text", "file": "file", "link": "url"}
+GEOMETRY_FIELDS = ("x", "y", "width", "height")
+
+
+def _check_color(value: object, where: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or not (
+        value in COLOR_PRESETS or HEX_COLOR_RE.match(value)
+    ):
+        errors.append(
+            f'{where}: color must be a preset "1"-"6" or hex string, got {value!r}'
+        )
+
+
+def _check_node(node: object, index: int, seen_ids: set[str], errors: list[str]) -> None:
+    where = f"nodes[{index}]"
+    if not isinstance(node, dict):
+        errors.append(f"{where}: node must be an object")
+        return
+
+    node_id = node.get("id")
+    if not isinstance(node_id, str) or not node_id:
+        errors.append(f"{where}: missing or non-string required field 'id'")
+    elif node_id in seen_ids:
+        errors.append(f"{where}: duplicate id {node_id!r}")
+    else:
+        seen_ids.add(node_id)
+
+    node_type = node.get("type")
+    # isinstance guard first: non-string values (lists, dicts) are unhashable
+    # and would crash the set-membership test.
+    if not isinstance(node_type, str) or node_type not in NODE_TYPES:
+        errors.append(
+            f"{where}: 'type' must be one of {sorted(NODE_TYPES)}, got {node_type!r}"
+        )
+    else:
+        required = REQUIRED_BY_TYPE.get(node_type)
+        if required is not None and not isinstance(node.get(required), str):
+            errors.append(
+                f"{where}: {node_type} node requires string field {required!r}"
+            )
+        if node_type == "group":
+            style = node.get("backgroundStyle")
+            if style is not None and (
+                not isinstance(style, str) or style not in BACKGROUND_STYLES
+            ):
+                errors.append(
+                    f"{where}: 'backgroundStyle' must be one of "
+                    f"{sorted(BACKGROUND_STYLES)}, got {style!r}"
+                )
+            for str_field in ("label", "background"):
+                value = node.get(str_field)
+                if value is not None and not isinstance(value, str):
+                    errors.append(f"{where}: {str_field!r} must be a string")
+
+    for field in GEOMETRY_FIELDS:
+        value = node.get(field)
+        # The spec calls for integers; bools are ints in Python, reject them.
+        if not isinstance(value, int) or isinstance(value, bool):
+            errors.append(f"{where}: missing or non-integer required field {field!r}")
+
+    if "color" in node:
+        _check_color(node["color"], where, errors)
+
+    subpath = node.get("subpath")
+    if subpath is not None and (
+        not isinstance(subpath, str) or not subpath.startswith("#")
+    ):
+        errors.append(f"{where}: 'subpath' must be a string starting with '#'")
+
+
+def _check_edge(
+    edge: object,
+    index: int,
+    node_ids: set[str],
+    seen_ids: set[str],
+    errors: list[str],
+) -> None:
+    where = f"edges[{index}]"
+    if not isinstance(edge, dict):
+        errors.append(f"{where}: edge must be an object")
+        return
+
+    edge_id = edge.get("id")
+    if not isinstance(edge_id, str) or not edge_id:
+        errors.append(f"{where}: missing or non-string required field 'id'")
+    elif edge_id in seen_ids:
+        errors.append(f"{where}: duplicate id {edge_id!r}")
+    else:
+        seen_ids.add(edge_id)
+
+    for endpoint in ("fromNode", "toNode"):
+        value = edge.get(endpoint)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{where}: missing or non-string required field {endpoint!r}")
+        elif value not in node_ids:
+            errors.append(
+                f"{where}: {endpoint} {value!r} does not reference an existing node"
+            )
+
+    for field, allowed in (
+        ("fromSide", SIDES),
+        ("toSide", SIDES),
+        ("fromEnd", ENDS),
+        ("toEnd", ENDS),
+    ):
+        value = edge.get(field)
+        if value is not None and (
+            not isinstance(value, str) or value not in allowed
+        ):
+            errors.append(
+                f"{where}: {field!r} must be one of {sorted(allowed)}, got {value!r}"
+            )
+
+    label = edge.get("label")
+    if label is not None and not isinstance(label, str):
+        errors.append(f"{where}: 'label' must be a string")
+
+    if "color" in edge:
+        _check_color(edge["color"], where, errors)
+
+
+def validate_canvas_text(text: str) -> list[str]:
+    """Validate raw .canvas file content. Returns a list of error strings."""
+    errors: list[str] = []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return [f"invalid JSON: {exc}"]
+
+    if not isinstance(data, dict):
+        return ["top level must be a JSON object"]
+
+    nodes = data.get("nodes", [])
+    edges = data.get("edges", [])
+    if not isinstance(nodes, list):
+        errors.append("'nodes' must be an array")
+        nodes = []
+    if not isinstance(edges, list):
+        errors.append("'edges' must be an array")
+        edges = []
+
+    seen_ids: set[str] = set()
+    for index, node in enumerate(nodes):
+        _check_node(node, index, seen_ids, errors)
+
+    node_ids = set(seen_ids)
+    for index, edge in enumerate(edges):
+        _check_edge(edge, index, node_ids, seen_ids, errors)
+
+    return errors
+
+
+def validate_canvas_file(path: Path) -> list[str]:
+    """Validate one .canvas file. Returns a list of error strings."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"cannot read file: {exc}"]
+    return validate_canvas_text(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+
+    failed = False
+    for arg in argv:
+        path = Path(arg)
+        errors = validate_canvas_file(path)
+        if errors:
+            failed = True
+            for error in errors:
+                print(f"{path}: {error}")
+        else:
+            print(f"{path}: OK")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/note-taking/obsidian-bases/SKILL.md
+++ b/skills/note-taking/obsidian-bases/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: obsidian-bases
+description: Create and edit .base database views, filters, and formulas.
+platforms: [linux, macos, windows]
+version: 1.1.0
+author: Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills)
+license: MIT
+metadata:
+  hermes:
+    tags: [obsidian, note-taking, yaml, bases, database-views]
+    related_skills: [obsidian, obsidian-markdown, obsidian-cli, json-canvas]
+---
+
+# Obsidian Bases Skill
+
+Create and edit Obsidian Bases: YAML `.base` files that render database-like
+views (tables, cards, lists, maps) over the notes in a vault, with filters,
+computed formula properties, and summaries. Adapted from Steph Ango's
+MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Creating or editing `.base` files
+- The user mentions Bases, table/card views over notes, filters, formulas,
+  or summaries in Obsidian
+
+Route elsewhere for broad vault work (`obsidian`), regular note authoring
+(`obsidian-markdown`), `.canvas` files (`json-canvas`), or driving the
+running app (`obsidian-cli`).
+
+## Prerequisites
+
+None — `.base` files are plain YAML and no running Obsidian app is
+required (only Obsidian can render the views). Resolve the vault path
+first (see the `obsidian` skill).
+
+## How to Run
+
+Read `.base` files with `read_file`, create them with `write_file`, and
+make focused edits with `patch`. Find existing bases with `search_files`
+using `pattern: "*.base"` and `target: "files"`.
+
+## Quick Reference
+
+### Schema
+
+```yaml
+# Global filters apply to ALL views in the base.
+# A filter is either a single expression string, or an object with
+# exactly ONE key (and / or / not) whose list items are themselves filters.
+filters:
+  and:
+    - 'status == "active"'
+    - not:
+        - 'file.hasTag("archived")'
+
+# Formula properties computed for every note, usable in all views
+formulas:
+  formula_name: 'expression'
+
+# Display names and settings for properties
+properties:
+  property_name:
+    displayName: "Display Name"
+  formula.formula_name:
+    displayName: "Formula Display Name"
+
+# Custom summary formulas
+summaries:
+  custom_summary_name: 'values.mean().round(3)'
+
+# One or more views
+views:
+  - type: table            # table | cards | list | map
+    name: "View Name"
+    limit: 10              # optional
+    groupBy:               # optional
+      property: property_name
+      direction: ASC       # ASC | DESC
+    filters:               # view-specific, same rules as global filters
+      and:
+        - 'status == "active"'
+    order:                 # properties to display, in order
+      - file.name
+      - property_name
+      - formula.formula_name
+    summaries:             # map properties to summary formulas
+      property_name: Average
+```
+
+### Filters
+
+Expressions compare properties with `==`, `!=`, `>`, `<`, `>=`, `<=` and
+combine with `&&`, `||`, `!`. Common predicates: `file.hasTag("x")`,
+`file.hasLink("Note")`, `file.inFolder("Folder")`. Nest by making a list
+item an `and`/`or`/`not` object.
+
+### Properties
+
+1. **Note properties** — frontmatter values: `note.author` or just `author`
+2. **File properties** — metadata: `file.name`, `file.basename`,
+   `file.path`, `file.folder`, `file.ext`, `file.size`, `file.ctime`,
+   `file.mtime`, `file.tags`, `file.links`, `file.backlinks`, `file.embeds`
+3. **Formula properties** — computed values: `formula.my_formula`
+
+`this` refers to the base file itself in the main content area, to the
+embedding file when embedded, and to the active file in the sidebar.
+
+### Formulas
+
+```yaml
+formulas:
+  total: "price * quantity"
+  status_icon: 'if(done, "✅", "⏳")'
+  created: 'file.ctime.format("YYYY-MM-DD")'
+  days_old: '((now() - file.ctime) / 86400000).round(0)'
+  days_until_due: 'if(due_date, ((date(due_date) - today()) / 86400000).round(0), "")'
+```
+
+Key functions: `date()`, `now()`, `today()`, `if(condition, then, else?)`,
+`duration()`, `file()`, `link()`. The function reference for all types
+(Date, String, Number, List, File, Link, Object, RegExp) is in
+[FUNCTIONS_REFERENCE.md](references/FUNCTIONS_REFERENCE.md).
+
+Subtracting two dates yields the difference in **milliseconds** — divide by
+86400000 to get days (see `days_old` above). Add or subtract durations with
+strings: `now() + "1 day"`, `today() + "7d"`; `duration()` is only needed
+for arithmetic on parsed durations themselves.
+
+### Views and summaries
+
+View types: `table`, `cards`, `list`, and `map` (map needs lat/long
+properties and the Maps community plugin). Built-in summary formulas
+include `Average`, `Min`, `Max`, `Sum`, `Median`, `Stddev`, `Earliest`,
+`Latest`, `Checked`, `Empty`, `Filled`, `Unique`. Worked examples (task
+tracker, reading list, daily-notes index) are in
+[EXAMPLES.md](references/EXAMPLES.md).
+
+### Embedding
+
+```markdown
+![[MyBase.base]]              Embed base in a note
+![[MyBase.base#View Name]]    Embed a specific view
+```
+
+## Procedure
+
+1. Create the `.base` file in the vault with `write_file`.
+2. Define scope with global `filters` (tag, folder, property, or date).
+3. Add computed properties in `formulas` as needed.
+4. Configure one or more `views`, each with `order` listing the properties
+   to display; add `groupBy`, view filters, and `summaries` as needed.
+5. Validate YAML syntax and references (see Verification).
+6. If a running Obsidian instance is available, open the file to confirm
+   the view renders (the `obsidian-cli` skill can do this).
+
+## Pitfalls
+
+- **Quoting**: wrap formulas containing double quotes in single quotes:
+  `'if(done, "Yes", "No")'`. Quote any YAML string containing `:`, `#`,
+  `[`, `{`, or other special characters.
+- **Filter objects take exactly one key** — `and`, `or`, or `not`. Do not
+  put several of them at the same level of the same object; nest instead.
+- **Date subtraction returns milliseconds**, not days: divide by 86400000
+  before rounding — `'((date(due) - today()) / 86400000).round(0)'`.
+- **Missing null guards**: properties may be absent on some notes. Guard
+  with `if()`: `'if(due, ((date(due) - today()) / 86400000).round(0), "")'`.
+- **Undefined formula references**: every `formula.X` used in `order`,
+  `properties`, or `summaries` must be defined under `formulas` — unknown
+  references fail silently in Obsidian.
+
+## Verification
+
+Parse the file to confirm it is valid YAML (via `terminal`:
+`python -c 'import yaml, sys; yaml.safe_load(open(sys.argv[1]))' file.base`).
+Then re-read it with `read_file` and check: each filter object has exactly
+one of `and`/`or`/`not`; every `formula.X` reference is defined; every view
+has a `type` (and a distinct `name` when there are multiple views). Finally,
+open it in Obsidian if available — a YAML error banner means a quoting
+problem (see Pitfalls).
+
+## References
+
+- Worked examples: [references/EXAMPLES.md](references/EXAMPLES.md)
+- Full function reference: [references/FUNCTIONS_REFERENCE.md](references/FUNCTIONS_REFERENCE.md)
+- [Bases Syntax](https://help.obsidian.md/bases/syntax) ·
+  [Functions](https://help.obsidian.md/bases/functions) ·
+  [Views](https://help.obsidian.md/bases/views)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md)

--- a/skills/note-taking/obsidian-bases/references/EXAMPLES.md
+++ b/skills/note-taking/obsidian-bases/references/EXAMPLES.md
@@ -1,0 +1,198 @@
+# Obsidian Bases Complete Examples
+
+Full `.base` files demonstrating filters, formulas, properties, views,
+grouping, and summaries.
+
+## Task Tracker Base
+
+```yaml
+filters:
+  and:
+    - file.hasTag("task")
+    - 'file.ext == "md"'
+
+formulas:
+  days_until_due: 'if(due, ((date(due) - today()) / 86400000).round(0), "")'
+  is_overdue: 'if(due, date(due) < today() && status != "done", false)'
+  priority_label: 'if(priority == 1, "🔴 High", if(priority == 2, "🟡 Medium", "🟢 Low"))'
+
+properties:
+  status:
+    displayName: Status
+  formula.days_until_due:
+    displayName: "Days Until Due"
+  formula.priority_label:
+    displayName: Priority
+
+views:
+  - type: table
+    name: "Active Tasks"
+    filters:
+      and:
+        - 'status != "done"'
+    order:
+      - file.name
+      - status
+      - formula.priority_label
+      - due
+      - formula.days_until_due
+    groupBy:
+      property: status
+      direction: ASC
+    summaries:
+      formula.days_until_due: Average
+
+  - type: table
+    name: "Completed"
+    filters:
+      and:
+        - 'status == "done"'
+    order:
+      - file.name
+      - completed_date
+```
+
+## Reading List Base
+
+```yaml
+filters:
+  or:
+    - file.hasTag("book")
+    - file.hasTag("article")
+
+formulas:
+  reading_time: 'if(pages, (pages * 2).toString() + " min", "")'
+  status_icon: 'if(status == "reading", "📖", if(status == "done", "✅", "📚"))'
+  year_read: 'if(finished_date, date(finished_date).year, "")'
+
+properties:
+  author:
+    displayName: Author
+  formula.status_icon:
+    displayName: ""
+  formula.reading_time:
+    displayName: "Est. Time"
+
+views:
+  - type: cards
+    name: "Library"
+    order:
+      - cover
+      - file.name
+      - author
+      - formula.status_icon
+    filters:
+      not:
+        - 'status == "dropped"'
+
+  - type: table
+    name: "Reading List"
+    filters:
+      and:
+        - 'status == "to-read"'
+    order:
+      - file.name
+      - author
+      - pages
+      - formula.reading_time
+```
+
+## Daily Notes Index
+
+```yaml
+filters:
+  and:
+    - file.inFolder("Daily Notes")
+    - '/^\d{4}-\d{2}-\d{2}$/.matches(file.basename)'
+
+formulas:
+  word_estimate: '(file.size / 5).round(0)'
+  day_of_week: 'date(file.basename).format("dddd")'
+
+properties:
+  formula.day_of_week:
+    displayName: "Day"
+  formula.word_estimate:
+    displayName: "~Words"
+
+views:
+  - type: table
+    name: "Recent Notes"
+    limit: 30
+    order:
+      - file.name
+      - formula.day_of_week
+      - formula.word_estimate
+      - file.mtime
+```
+
+## View Type Snippets
+
+### Table view with summaries
+
+```yaml
+views:
+  - type: table
+    name: "My Table"
+    order:
+      - file.name
+      - status
+      - due_date
+    summaries:
+      price: Sum
+      count: Average
+```
+
+### Cards view
+
+```yaml
+views:
+  - type: cards
+    name: "Gallery"
+    order:
+      - file.name
+      - cover_image
+      - description
+```
+
+### List view
+
+```yaml
+views:
+  - type: list
+    name: "Simple List"
+    order:
+      - file.name
+      - status
+```
+
+### Map view
+
+Requires latitude/longitude properties and the Maps community plugin.
+
+```yaml
+views:
+  - type: map
+    name: "Locations"
+    # Map-specific settings for lat/lng properties
+```
+
+## Default Summary Formulas
+
+| Name | Input Type | Description |
+|------|------------|-------------|
+| `Average` | Number | Mathematical mean |
+| `Min` | Number | Smallest number |
+| `Max` | Number | Largest number |
+| `Sum` | Number | Sum of all numbers |
+| `Range` | Number | Max - Min |
+| `Median` | Number | Mathematical median |
+| `Stddev` | Number | Standard deviation |
+| `Earliest` | Date | Earliest date |
+| `Latest` | Date | Latest date |
+| `Range` | Date | Latest - Earliest |
+| `Checked` | Boolean | Count of true values |
+| `Unchecked` | Boolean | Count of false values |
+| `Empty` | Any | Count of empty values |
+| `Filled` | Any | Count of non-empty values |
+| `Unique` | Any | Count of unique values |

--- a/skills/note-taking/obsidian-bases/references/FUNCTIONS_REFERENCE.md
+++ b/skills/note-taking/obsidian-bases/references/FUNCTIONS_REFERENCE.md
@@ -1,0 +1,162 @@
+# Functions Reference
+
+## Global Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date(string): date` | Parse string to date. Format: `YYYY-MM-DD HH:mm:ss` |
+| `duration()` | `duration(string): duration` | Parse duration string |
+| `now()` | `now(): date` | Current date and time |
+| `today()` | `today(): date` | Current date (time = 00:00:00) |
+| `random()` | `random(): number` | Random number in [0, 1); refreshes when a view loads |
+| `if()` | `if(condition, trueResult, falseResult?)` | Conditional |
+| `min()` | `min(n1, n2, ...): number` | Smallest number |
+| `max()` | `max(n1, n2, ...): number` | Largest number |
+| `number()` | `number(any): number` | Convert to number |
+| `link()` | `link(path, display?): Link` | Create a link |
+| `list()` | `list(element): List` | Wrap in list if not already |
+| `file()` | `file(path): file` | Get file object |
+| `image()` | `image(path): image` | Create image for rendering |
+| `icon()` | `icon(name): icon` | Lucide icon by name |
+| `html()` | `html(string): html` | Render as HTML |
+| `escapeHTML()` | `escapeHTML(string): string` | Escape HTML characters |
+
+## Any Type Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isTruthy()` | `any.isTruthy(): boolean` | Coerce to boolean |
+| `isType()` | `any.isType(type): boolean` | Check type |
+| `toString()` | `any.toString(): string` | Convert to string |
+
+## Date Functions & Fields
+
+**Fields:** `date.year`, `date.month`, `date.day`, `date.hour`, `date.minute`, `date.second`, `date.millisecond`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date.date(): date` | Remove time portion |
+| `format()` | `date.format(string): string` | Format with Moment.js pattern |
+| `time()` | `date.time(): string` | Get time as string |
+| `relative()` | `date.relative(): string` | Human-readable relative time |
+| `isEmpty()` | `date.isEmpty(): boolean` | Always false for dates |
+
+## Date Subtraction and Durations
+
+Subtracting two dates returns the difference as a **number of milliseconds**
+(per the official Bases syntax docs), not a duration object. Convert to the
+unit you need with plain arithmetic:
+
+```yaml
+# Days between dates (86400000 ms per day)
+"((date(due_date) - today()) / 86400000).round(0)"
+# Hours since created (3600000 ms per hour)
+"((now() - file.ctime) / 3600000).round(0)"
+```
+
+Duration *strings* (`"1 day"`, `"7d"`, `"2h"`) can be added to or subtracted
+from dates directly; use `duration()` only when performing arithmetic on
+parsed durations themselves.
+
+## Date Arithmetic
+
+```yaml
+# Duration units: y/year/years, M/month/months, d/day/days,
+#                 w/week/weeks, h/hour/hours, m/minute/minutes, s/second/seconds
+
+# Add/subtract durations
+"date + \"1M\""           # Add 1 month
+"date - \"2h\""           # Subtract 2 hours
+"now() + \"1 day\""       # Tomorrow
+"today() + \"7d\""        # A week from today
+
+# Subtracting dates returns milliseconds (a number)
+"now() - file.ctime"                            # Milliseconds since created
+"((now() - file.ctime) / 86400000).round(0)"    # Days since created
+
+# Complex duration arithmetic
+"now() + (duration('1d') * 2)"
+```
+
+## String Functions
+
+**Field:** `string.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `string.contains(value): boolean` | Check substring |
+| `containsAll()` | `string.containsAll(...values): boolean` | All substrings present |
+| `containsAny()` | `string.containsAny(...values): boolean` | Any substring present |
+| `startsWith()` | `string.startsWith(query): boolean` | Starts with query |
+| `endsWith()` | `string.endsWith(query): boolean` | Ends with query |
+| `isEmpty()` | `string.isEmpty(): boolean` | Empty or not present |
+| `lower()` | `string.lower(): string` | To lowercase |
+| `title()` | `string.title(): string` | To Title Case |
+| `trim()` | `string.trim(): string` | Remove whitespace |
+| `replace()` | `string.replace(pattern, replacement): string` | Replace pattern |
+| `repeat()` | `string.repeat(count): string` | Repeat string |
+| `reverse()` | `string.reverse(): string` | Reverse string |
+| `slice()` | `string.slice(start, end?): string` | Substring |
+| `split()` | `string.split(separator, n?): list` | Split to list |
+
+## Number Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `abs()` | `number.abs(): number` | Absolute value |
+| `ceil()` | `number.ceil(): number` | Round up |
+| `floor()` | `number.floor(): number` | Round down |
+| `round()` | `number.round(digits?): number` | Round to digits |
+| `toFixed()` | `number.toFixed(precision): string` | Fixed-point notation |
+| `isEmpty()` | `number.isEmpty(): boolean` | Not present |
+
+## List Functions
+
+**Field:** `list.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `list.contains(value): boolean` | Element exists |
+| `containsAll()` | `list.containsAll(...values): boolean` | All elements exist |
+| `containsAny()` | `list.containsAny(...values): boolean` | Any element exists |
+| `filter()` | `list.filter(expression): list` | Filter by condition (uses `value`, `index`) |
+| `map()` | `list.map(expression): list` | Transform elements (uses `value`, `index`) |
+| `reduce()` | `list.reduce(expression, initial): any` | Reduce to single value (uses `value`, `index`, `acc`) |
+| `flat()` | `list.flat(): list` | Flatten nested lists |
+| `join()` | `list.join(separator): string` | Join to string |
+| `reverse()` | `list.reverse(): list` | Reverse order |
+| `slice()` | `list.slice(start, end?): list` | Sublist |
+| `sort()` | `list.sort(): list` | Sort ascending |
+| `unique()` | `list.unique(): list` | Remove duplicates |
+| `isEmpty()` | `list.isEmpty(): boolean` | No elements |
+
+## File Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asLink()` | `file.asLink(display?): Link` | Convert to link |
+| `hasLink()` | `file.hasLink(otherFile): boolean` | Has link to file |
+| `hasTag()` | `file.hasTag(...tags): boolean` | Has any of the tags |
+| `hasProperty()` | `file.hasProperty(name): boolean` | Has property |
+| `inFolder()` | `file.inFolder(folder): boolean` | In folder or subfolder |
+
+## Link Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asFile()` | `link.asFile(): file` | Get file object |
+| `linksTo()` | `link.linksTo(file): boolean` | Links to file |
+
+## Object Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isEmpty()` | `object.isEmpty(): boolean` | No properties |
+| `keys()` | `object.keys(): list` | List of keys |
+| `values()` | `object.values(): list` | List of values |
+
+## Regular Expression Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `matches()` | `regexp.matches(string): boolean` | Test if matches |

--- a/skills/note-taking/obsidian-cli/SKILL.md
+++ b/skills/note-taking/obsidian-cli/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: obsidian-cli
+description: Drive the live Obsidian app from the command line.
+platforms: [linux, macos, windows]
+version: 1.1.0
+author: Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills)
+license: MIT
+metadata:
+  hermes:
+    tags: [obsidian, cli, plugin-development, theme-development, note-taking]
+    related_skills: [obsidian, obsidian-markdown, obsidian-bases, json-canvas]
+prerequisites:
+  commands: [obsidian]
+---
+
+# Obsidian CLI Skill
+
+Operate a live Obsidian instance through its official `obsidian` CLI: note
+operations, search, tasks, properties, and a plugin/theme development loop
+with reload, error capture, screenshots, and DOM inspection. Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- The task needs the *running* Obsidian app: opening notes, live search,
+  daily notes, tasks, properties, or vault commands
+- Developing or debugging an Obsidian plugin or theme
+
+Route elsewhere when the app is not required: generic vault filesystem work
+→ `obsidian`; `.md` authoring semantics → `obsidian-markdown`; `.base`
+files → `obsidian-bases`; `.canvas` files → `json-canvas`.
+
+## Prerequisites
+
+- The `obsidian` CLI installed and on `PATH`
+  ([install docs](https://help.obsidian.md/cli))
+- The Obsidian desktop app installed. It does not have to be running: if
+  it is not, the first CLI command launches it (expect a startup delay
+  and a GUI window — there is no headless mode)
+
+## How to Run
+
+Run `obsidian <command>` via the `terminal` tool. `obsidian help` lists
+every command and is always up to date; full docs live at
+https://help.obsidian.md/cli.
+
+Syntax rules:
+
+- **Parameters** take `key=value`; quote values with spaces:
+  `obsidian create name="My Note" content="Hello world"`
+- **Flags** are bare words: `obsidian create name="My Note" overwrite`
+- Use `\n` and `\t` escapes for multiline content
+- **File targeting**: `file=<name>` resolves like a wikilink (no path or
+  extension needed); `path=<path>` is exact from the vault root. Without
+  either, the active file is used.
+- **Vault targeting** (in order): `vault=<name>` or `vault=<id>` as the
+  first parameter pins a vault; otherwise, if the terminal's working
+  directory is inside a vault, that vault is used; otherwise the currently
+  active vault.
+
+## Quick Reference
+
+```bash
+obsidian read file="My Note"
+obsidian create name="New Note" content="# Hello" template="Template"
+obsidian append file="My Note" content="New line"
+obsidian search query="search term" limit=10
+obsidian daily:read
+obsidian daily:append content="- [ ] New task"
+obsidian property:set name="status" value="done" file="My Note"
+obsidian tasks daily todo
+obsidian tags sort=count counts
+obsidian backlinks file="My Note"
+```
+
+Use `--copy` on any command to copy output to the clipboard, the `open`
+flag where supported to open the affected file in Obsidian (files are not
+opened by default), and `total` on list commands to get a count.
+
+## Procedure
+
+Plugin/theme develop-test cycle — after each code change:
+
+1. Reload the plugin: `obsidian plugin:reload id=my-plugin`
+2. Check for errors, fix, and repeat from step 1 if any appear:
+   `obsidian dev:errors`
+3. Verify visually: `obsidian dev:screenshot path=screenshot.png` or
+   `obsidian dev:dom selector=".workspace-leaf" text`
+4. Check console output: `obsidian dev:console level=error`
+
+Additional developer commands:
+
+```bash
+obsidian eval code="app.vault.getFiles().length"          # run JS in app
+obsidian dev:css selector=".workspace-leaf" prop=background-color
+obsidian dev:mobile on                                    # mobile emulation
+```
+
+`obsidian help` lists further developer commands, including CDP and
+debugger controls.
+
+## Pitfalls
+
+- The first command launches Obsidian when it is not already running —
+  on a headless machine (no display) the CLI cannot work at all.
+- Multi-vault setups: without `vault=`, the vault is inferred from the
+  working directory or falls back to the active vault — pin it explicitly
+  in scripts.
+- `file=` resolves wikilink-style and may match an unexpected note; use
+  `path=` when exactness matters.
+- Prefer native file tools (`read_file`, `write_file`, `patch`) for bulk
+  file edits — the CLI is for app-side state (open notes, live search,
+  plugin reloads), not mass file rewriting.
+
+## Verification
+
+Check the command's stdout and exit code in `terminal`. For state-changing
+operations, confirm the result: re-read the note (`obsidian read` or
+`read_file`), or take a screenshot with `obsidian dev:screenshot` for
+UI-facing changes. For plugin work, `obsidian dev:errors` must come back
+clean after a reload.
+
+## References
+
+- [Obsidian CLI docs](https://help.obsidian.md/cli)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md)

--- a/skills/note-taking/obsidian-markdown/SKILL.md
+++ b/skills/note-taking/obsidian-markdown/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: obsidian-markdown
+description: Write Obsidian notes with wikilinks, embeds, and callouts.
+platforms: [linux, macos, windows]
+version: 1.1.0
+author: Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills)
+license: MIT
+metadata:
+  hermes:
+    tags: [obsidian, markdown, note-taking, wikilinks, callouts, frontmatter]
+    related_skills: [obsidian, obsidian-cli, obsidian-bases, json-canvas]
+---
+
+# Obsidian Flavored Markdown Skill
+
+Author and edit Obsidian Flavored Markdown, which extends CommonMark and GFM
+with wikilinks, embeds, callouts, properties, comments, and highlights. This
+skill covers only the Obsidian-specific extensions — standard Markdown
+(headings, lists, tables, code blocks) is assumed knowledge. Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Notes that need Obsidian-specific syntax: wikilinks, embeds, callouts,
+  frontmatter properties, tags, comments, or highlights
+- Converting plain Markdown into Obsidian-idiomatic notes
+
+Plain note creation, reading, listing, and searching stays with the generic
+`obsidian` skill — load this one for the syntax layer. Route `.base`
+database views → `obsidian-bases`; `.canvas` files → `json-canvas`; driving
+the running app or plugin development → `obsidian-cli`.
+
+## Prerequisites
+
+None — notes are plain text files and no running Obsidian app is required.
+Resolve the vault path first (see the `obsidian` skill): the
+`OBSIDIAN_VAULT_PATH` environment variable, falling back to
+`~/Documents/Obsidian Vault`.
+
+## How to Run
+
+Use the native file tools: `read_file` to inspect a note, `write_file` to
+create one, `patch` for targeted edits with stable context, and
+`search_files` to find notes by name or content. Pass concrete absolute
+paths — file tools do not expand `$OBSIDIAN_VAULT_PATH`.
+
+## Quick Reference
+
+### Internal links (wikilinks)
+
+```markdown
+[[Note Name]]                Link to note
+[[Note Name|Display Text]]   Custom display text
+[[Note Name#Heading]]        Link to heading
+[[Note Name#^block-id]]      Link to block
+[[#Heading in same note]]    Same-note heading link
+```
+
+Define a block ID by appending `^block-id` to a paragraph or to a single
+list item. To reference a whole list or quote, place the block ID on its
+own line after the block.
+
+### Embeds
+
+Prefix any wikilink with `!` to embed its content inline:
+
+```markdown
+![[Note Name]]               Embed full note
+![[Note Name#Heading]]       Embed section
+![[image.png|300]]           Embed image with width
+![[document.pdf#page=3]]     Embed PDF page
+![[MyBase.base#View Name]]   Embed a Bases view
+```
+
+See [EMBEDS.md](references/EMBEDS.md) for audio, video, Bases, search
+embeds, and external images.
+
+### Callouts
+
+```markdown
+> [!note]
+> Basic callout.
+
+> [!warning] Custom Title
+> Callout with a custom title.
+
+> [!faq]- Collapsed by default
+> Foldable callout (- collapsed, + expanded).
+```
+
+Common types: `note`, `tip`, `warning`, `info`, `example`, `quote`, `bug`,
+`danger`, `success`, `failure`, `question`, `abstract`, `todo`. See
+[CALLOUTS.md](references/CALLOUTS.md) for aliases, nesting, and custom CSS
+callouts.
+
+### Properties (frontmatter)
+
+```yaml
+---
+title: My Note
+date: 2026-01-15
+tags:
+  - project
+aliases:
+  - Alternative Name
+cssclasses:
+  - custom-class
+---
+```
+
+See [PROPERTIES.md](references/PROPERTIES.md) for all property types and
+tag syntax rules.
+
+### Other Obsidian syntax
+
+```markdown
+#tag  #nested/tag            Inline tags
+==Highlighted text==         Highlight
+%%hidden comment%%           Hidden in reading view
+$e^{i\pi} + 1 = 0$           Inline LaTeX ($$ ... $$ for blocks)
+Text with a footnote[^1].    Footnotes ([^1]: content)
+```
+
+Mermaid diagrams go in fenced `mermaid` code blocks; add
+`class NodeName internal-link;` to link diagram nodes to notes.
+
+## Procedure
+
+Creating an Obsidian note:
+
+1. Add frontmatter properties (title, tags, aliases) at the top of the file.
+2. Write content using standard Markdown structure plus the Obsidian syntax
+   above.
+3. Link related notes with `[[wikilinks]]`; use `[text](url)` Markdown links
+   for external URLs.
+4. Embed supporting content (notes, images, PDFs) with `![[...]]`.
+5. Add callouts for highlighted information with `> [!type]`.
+6. Write the note with `write_file`, or apply focused changes to an existing
+   note with `patch`.
+
+## Pitfalls
+
+- Both `[[wikilinks]]` and standard Markdown links work for vault-internal
+  targets; wikilinks are Obsidian's compact default and what this skill
+  uses. Match the vault's existing convention when editing.
+- Block IDs for lists and quotes must sit on a separate line after the
+  block, not appended to the last line.
+- Tags cannot start with a number; allowed characters are letters, numbers,
+  underscores, hyphens, and forward slashes.
+- Frontmatter must be the very first thing in the file, delimited by `---`
+  lines, and must be valid YAML — quote values containing `:` or `#`.
+- `%%` comments are invisible in reading view but still ship with the file.
+
+## Verification
+
+Re-read the result with `read_file` and check: frontmatter parses as YAML
+between the opening `---` pair; every `[[wikilink]]` target exists in the
+vault (check with `search_files` when correctness matters); `%%` markers
+are balanced. If a running Obsidian instance is available, confirm
+rendering in reading view (the `obsidian-cli` skill can open the note).
+
+## References
+
+- [Obsidian Flavored Markdown](https://help.obsidian.md/obsidian-flavored-markdown)
+- [Internal links](https://help.obsidian.md/links)
+- [Embed files](https://help.obsidian.md/embeds)
+- [Callouts](https://help.obsidian.md/callouts)
+- [Properties](https://help.obsidian.md/properties)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md)

--- a/skills/note-taking/obsidian-markdown/references/CALLOUTS.md
+++ b/skills/note-taking/obsidian-markdown/references/CALLOUTS.md
@@ -1,0 +1,58 @@
+# Callouts Reference
+
+## Basic Callout
+
+```markdown
+> [!note]
+> This is a note callout.
+
+> [!info] Custom Title
+> This callout has a custom title.
+
+> [!tip] Title Only
+```
+
+## Foldable Callouts
+
+```markdown
+> [!faq]- Collapsed by default
+> This content is hidden until expanded.
+
+> [!faq]+ Expanded by default
+> This content is visible but can be collapsed.
+```
+
+## Nested Callouts
+
+```markdown
+> [!question] Outer callout
+> > [!note] Inner callout
+> > Nested content
+```
+
+## Supported Callout Types
+
+| Type | Aliases | Color / Icon |
+|------|---------|-------------|
+| `note` | - | Blue, pencil |
+| `abstract` | `summary`, `tldr` | Teal, clipboard |
+| `info` | - | Blue, info |
+| `todo` | - | Blue, checkbox |
+| `tip` | `hint`, `important` | Cyan, flame |
+| `success` | `check`, `done` | Green, checkmark |
+| `question` | `help`, `faq` | Yellow, question mark |
+| `warning` | `caution`, `attention` | Orange, warning |
+| `failure` | `fail`, `missing` | Red, X |
+| `danger` | `error` | Red, zap |
+| `bug` | - | Red, bug |
+| `example` | - | Purple, list |
+| `quote` | `cite` | Gray, quote |
+
+## Custom Callouts (CSS)
+
+```css
+.callout[data-callout="custom-type"] {
+  --callout-color: 255, 0, 0;
+  --callout-icon: lucide-alert-circle;
+}
+```

--- a/skills/note-taking/obsidian-markdown/references/EMBEDS.md
+++ b/skills/note-taking/obsidian-markdown/references/EMBEDS.md
@@ -1,0 +1,77 @@
+# Embeds Reference
+
+## Embed Notes
+
+```markdown
+![[Note Name]]
+![[Note Name#Heading]]
+![[Note Name#^block-id]]
+```
+
+## Embed Images
+
+```markdown
+![[image.png]]
+![[image.png|640x480]]    Width x Height
+![[image.png|300]]        Width only (maintains aspect ratio)
+```
+
+## External Images
+
+```markdown
+![Alt text](https://example.com/image.png)
+![Alt text|300](https://example.com/image.png)
+```
+
+## Embed Audio
+
+```markdown
+![[audio.mp3]]
+![[audio.ogg]]
+```
+
+## Embed Video
+
+```markdown
+![[video.mp4]]
+![[video.webm]]
+```
+
+## Embed PDF
+
+```markdown
+![[document.pdf]]
+![[document.pdf#page=3]]
+![[document.pdf#height=400]]
+```
+
+## Embed Bases
+
+```markdown
+![[BaseFile.base]]
+![[BaseFile.base#View Name]]
+```
+
+## Embed Lists
+
+```markdown
+![[Note#^list-id]]
+```
+
+Where the list has a block ID:
+
+```markdown
+- Item 1
+- Item 2
+- Item 3
+
+^list-id
+```
+
+## Embed Search Results
+
+````markdown
+```query
+tag:#project status:done
+```
+````

--- a/skills/note-taking/obsidian-markdown/references/PROPERTIES.md
+++ b/skills/note-taking/obsidian-markdown/references/PROPERTIES.md
@@ -1,0 +1,63 @@
+# Properties (Frontmatter) Reference
+
+Properties use YAML frontmatter at the start of a note:
+
+```yaml
+---
+title: My Note Title
+date: 2024-01-15
+tags:
+  - project
+  - important
+aliases:
+  - My Note
+  - Alternative Name
+cssclasses:
+  - custom-class
+status: in-progress
+rating: 4.5
+completed: false
+due: 2024-02-01T14:30:00
+---
+```
+
+## Property Types
+
+| Type | Example |
+|------|---------|
+| Text | `title: My Title` |
+| Number | `rating: 4.5` |
+| Checkbox | `completed: true` |
+| Date | `date: 2024-01-15` |
+| Date & Time | `due: 2024-01-15T14:30:00` |
+| List | `tags: [one, two]` or YAML list |
+
+Internal links inside Text or List values are recognized when quoted:
+`related: "[[Other Note]]"` (there is no separate link property type).
+
+## Default Properties
+
+- `tags` - Note tags (searchable, shown in graph view)
+- `aliases` - Alternative names for the note (used in link suggestions)
+- `cssclasses` - CSS classes applied to the note in reading/editing view
+
+## Tags
+
+```markdown
+#tag
+#nested/tag
+#tag-with-dashes
+#tag_with_underscores
+```
+
+Tags can contain: letters (any language), numbers, underscores `_`, hyphens `-`, forward slashes `/` (for nesting). A tag must include at least one non-numerical character — `#2024` is invalid, `#y2024` works.
+
+In frontmatter:
+
+```yaml
+---
+tags:
+  - tag1
+  - nested/tag2
+---
+```

--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -2,11 +2,24 @@
 name: obsidian
 description: Read, search, create, and edit notes in the Obsidian vault.
 platforms: [linux, macos, windows]
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [obsidian, note-taking, vault, markdown]
+    related_skills: [obsidian-markdown, obsidian-cli, obsidian-bases, json-canvas]
 ---
 
 # Obsidian Vault
 
 Use this skill for filesystem-first Obsidian vault work: reading notes, listing notes, searching note files, creating notes, appending content, and adding wikilinks.
+
+When the task is format-specific or app-specific, route to the specialized skills instead:
+- `.md` note authoring with wikilinks, properties/frontmatter, callouts, embeds, or Obsidian-specific Markdown semantics -> `obsidian-markdown`
+- running Obsidian app workflows, Obsidian CLI usage, plugin development, or theme development -> `obsidian-cli`
+- editing `.base` files or working with Bases filters, views, and formulas -> `obsidian-bases`
+- editing `.canvas` files or visual canvases -> `json-canvas`
 
 ## Vault path
 

--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: obsidian
 description: Read, search, create, and edit notes in the Obsidian vault.
-version: 1.0.0
+version: 1.1.0
 author: Teknium (teknium1), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [Obsidian, Notes, Markdown, Vault]
-    related_skills: []
+    related_skills: [obsidian-markdown, obsidian-cli, obsidian-bases, json-canvas]
 ---
 
 # Obsidian Vault
 
 Use this skill for filesystem-first Obsidian vault work: reading notes, listing notes, searching note files, creating notes, appending content, and adding wikilinks.
+
+When the task is format-specific or app-specific, route to the specialized skills instead:
+- `.md` note authoring with wikilinks, properties/frontmatter, callouts, embeds, or Obsidian-specific Markdown semantics -> `obsidian-markdown`
+- running Obsidian app workflows, Obsidian CLI usage, plugin development, or theme development -> `obsidian-cli`
+- editing `.base` files or working with Bases filters, views, and formulas -> `obsidian-bases`
+- editing `.canvas` files or visual canvases -> `json-canvas`
 
 ## Vault path
 

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -9,7 +9,12 @@ metadata:
   hermes:
     tags: [wiki, knowledge-base, research, notes, markdown, rag-alternative]
     category: research
-    related_skills: [obsidian, arxiv]
+    related_skills: [obsidian, obsidian-markdown, arxiv]
+    config:
+      - key: wiki.path
+        description: Path to the LLM Wiki knowledge base directory
+        default: "~/wiki"
+        prompt: Wiki directory path
 ---
 
 # Karpathy's LLM Wiki
@@ -35,16 +40,21 @@ Use this skill when the user:
 
 ## Wiki Location
 
-**Location:** Set via `WIKI_PATH` environment variable (e.g. in `${HERMES_HOME:-~/.hermes}/.env`).
+**Location:** Set via `wiki.path` in Hermes config (`hermes config`), or via the
+`WIKI_PATH` environment variable (e.g. in `${HERMES_HOME:-~/.hermes}/.env`). The
+config value takes precedence when present (shown in the `[Skill config: ...]`
+block above).
 
-If unset, defaults to `~/wiki`.
+If neither is set, defaults to `~/wiki`.
 
 ```bash
 WIKI="${WIKI_PATH:-$HOME/wiki}"
 ```
 
 The wiki is just a directory of markdown files — open it in Obsidian, VS Code, or
-any editor. No database, no special tooling required.
+any editor. Use the broad `obsidian` skill for generic vault/file workflows and
+`obsidian-markdown` when you need Obsidian-specific syntax such as properties,
+callouts, embeds, or wikilinks.
 
 ## Architecture: Three Layers
 
@@ -98,7 +108,7 @@ at hand before creating anything new.
 
 When the user asks to create or start a wiki:
 
-1. Determine the wiki path (from `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
+1. Determine the wiki path (from skill config `wiki.path`, `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)

--- a/tests/skills/test_obsidian_skills.py
+++ b/tests/skills/test_obsidian_skills.py
@@ -1,0 +1,335 @@
+"""Tests for the Obsidian skill bundle under skills/note-taking/.
+
+Invariant-style checks (no data snapshots): frontmatter contracts from the
+skill authoring standards, routing coherence between the generic wrapper and
+the specialized skills, reference-link and attribution integrity, catalog
+coverage, and unit tests for the bundled JSON Canvas validator script.
+
+The bundle members are enumerated explicitly so that adding an unrelated
+note-taking skill later does not drag it into bundle-specific contracts
+(authorship, routing, attribution).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = REPO_ROOT / "skills"
+BUNDLE_ROOT = SKILLS_ROOT / "note-taking"
+SKILLS_CATALOG = REPO_ROOT / "website" / "docs" / "reference" / "skills-catalog.md"
+THIRD_PARTY_NOTICES = BUNDLE_ROOT / "THIRD_PARTY_NOTICES.md"
+VALIDATOR_PATH = BUNDLE_ROOT / "json-canvas" / "scripts" / "validate_canvas.py"
+
+# The Obsidian bundle salvaged from PR #15848. Explicit on purpose — see
+# module docstring.
+SPECIALIZED_SKILLS = [
+    "json-canvas",
+    "obsidian-bases",
+    "obsidian-cli",
+    "obsidian-markdown",
+]
+BUNDLE_SKILLS = ["obsidian", *SPECIALIZED_SKILLS]
+
+MARKETING_WORDS = {"powerful", "comprehensive", "seamless", "advanced"}
+
+
+def _frontmatter_field(text: str, field: str) -> str | None:
+    match = re.search(rf"^{field}: (.*)$", text, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+def _skill_text(name: str) -> str:
+    return (BUNDLE_ROOT / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", BUNDLE_SKILLS)
+def test_bundle_skill_exists(name):
+    assert (BUNDLE_ROOT / name / "SKILL.md").is_file(), f"missing skill {name}"
+
+
+@pytest.mark.parametrize("name", BUNDLE_SKILLS)
+def test_description_meets_authoring_standard(name):
+    description = _frontmatter_field(_skill_text(name), "description")
+    assert description, f"{name}: missing description"
+    assert len(description) <= 60, (
+        f"{name}: description is {len(description)} chars (limit 60)"
+    )
+    assert description.endswith("."), f"{name}: description must end with a period"
+    assert ". " not in description[:-1], f"{name}: description must be one sentence"
+    lowered = description.lower()
+    hits = sorted(w for w in MARKETING_WORDS if w in lowered)
+    assert not hits, f"{name}: marketing words in description: {hits}"
+
+
+@pytest.mark.parametrize("name", SPECIALIZED_SKILLS)
+def test_description_does_not_repeat_skill_name(name):
+    description = _frontmatter_field(_skill_text(name), "description")
+    spaced = name.replace("-", " ").lower()
+    assert spaced not in description.lower(), (
+        f"{name}: description repeats the skill name"
+    )
+
+
+@pytest.mark.parametrize("name", BUNDLE_SKILLS)
+def test_platforms_declared(name):
+    platforms = _frontmatter_field(_skill_text(name), "platforms")
+    assert platforms, f"{name}: missing platforms frontmatter"
+    entries = {p.strip() for p in platforms.strip("[]").split(",")}
+    assert entries <= {"linux", "macos", "windows"}, (
+        f"{name}: unknown platform entries {entries}"
+    )
+
+
+@pytest.mark.parametrize("name", SPECIALIZED_SKILLS)
+def test_adapted_skills_credit_human_contributor_first(name):
+    author = _frontmatter_field(_skill_text(name), "author")
+    assert author, f"{name}: missing author"
+    # Contract: the agent is never the primary author of an adapted skill.
+    assert not author.lower().startswith("hermes agent"), (
+        f"{name}: author must credit the human contributor first, got {author!r}"
+    )
+
+
+@pytest.mark.parametrize("name", SPECIALIZED_SKILLS)
+def test_adapted_skills_carry_upstream_attribution(name):
+    text = _skill_text(name)
+    assert "kepano/obsidian-skills" in text, f"{name}: missing source attribution"
+    assert "THIRD_PARTY_NOTICES.md" in text, (
+        f"{name}: missing pointer to the bundled MIT notice"
+    )
+
+
+def test_third_party_notice_preserves_upstream_mit_text():
+    notice = THIRD_PARTY_NOTICES.read_text(encoding="utf-8")
+    assert "Copyright (c) 2026 Steph Ango (@kepano)" in notice
+    assert "Permission is hereby granted, free of charge" in notice
+
+
+@pytest.mark.parametrize("name", SPECIALIZED_SKILLS)
+def test_modern_section_order(name):
+    text = _skill_text(name)
+    required = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.find(section) for section in required]
+    missing = [s for s, pos in zip(required, positions) if pos == -1]
+    assert not missing, f"{name}: missing sections {missing}"
+    assert positions == sorted(positions), (
+        f"{name}: sections out of order: {list(zip(required, positions))}"
+    )
+
+
+def test_wrapper_routes_to_every_specialized_skill():
+    wrapper = _skill_text("obsidian")
+    missing = [name for name in SPECIALIZED_SKILLS if name not in wrapper]
+    assert not missing, f"obsidian wrapper missing routing guidance for: {missing}"
+
+
+@pytest.mark.parametrize("name", BUNDLE_SKILLS)
+def test_related_skills_resolve_to_bundled_skills(name):
+    related = _frontmatter_field(_skill_text(name), "    related_skills")
+    assert related, f"{name}: missing related_skills"
+    entries = [e.strip() for e in related.strip("[]").split(",")]
+    all_bundled = {p.parent.name for p in SKILLS_ROOT.glob("*/*/SKILL.md")}
+    unresolved = [e for e in entries if e not in all_bundled]
+    assert not unresolved, f"{name}: related_skills do not exist: {unresolved}"
+
+
+@pytest.mark.parametrize("name", BUNDLE_SKILLS)
+def test_relative_links_resolve(name):
+    skill_dir = BUNDLE_ROOT / name
+    text = _skill_text(name)
+    targets = re.findall(r"\]\(((?:\.\./|references/|scripts/)[^)#]+)\)", text)
+    broken = [t for t in targets if not (skill_dir / t).is_file()]
+    assert not broken, f"{name}: broken relative links: {broken}"
+
+
+def test_catalog_lists_every_bundle_skill():
+    catalog = SKILLS_CATALOG.read_text(encoding="utf-8")
+    missing = [
+        name
+        for name in BUNDLE_SKILLS
+        if f"note-taking/{name}`" not in catalog
+    ]
+    assert not missing, f"skills-catalog.md is missing rows for: {missing}"
+
+
+# --- validate_canvas.py -----------------------------------------------------
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("validate_canvas", VALIDATOR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_canvas() -> dict:
+    return {
+        "nodes": [
+            {
+                "id": "6f0ad84f44ce9c17",
+                "type": "text",
+                "x": 0,
+                "y": 0,
+                "width": 300,
+                "height": 150,
+                "text": "# Hello",
+            },
+            {
+                "id": "a1b2c3d4e5f67890",
+                "type": "link",
+                "x": 400,
+                "y": 0,
+                "width": 300,
+                "height": 100,
+                "url": "https://obsidian.md",
+                "color": "4",
+            },
+            {
+                "id": "feedfacefeedface",
+                "type": "group",
+                "x": -50,
+                "y": -50,
+                "width": 900,
+                "height": 400,
+                "label": "Everything",
+            },
+        ],
+        "edges": [
+            {
+                "id": "0123456789abcdef",
+                "fromNode": "6f0ad84f44ce9c17",
+                "toNode": "a1b2c3d4e5f67890",
+                "fromSide": "right",
+                "toSide": "left",
+                "toEnd": "arrow",
+                "label": "leads to",
+            }
+        ],
+    }
+
+
+def _errors_for(canvas) -> list[str]:
+    mod = _load_validator()
+    return mod.validate_canvas_text(json.dumps(canvas))
+
+
+def test_validator_accepts_valid_canvas():
+    assert _errors_for(_valid_canvas()) == []
+
+
+def test_validator_accepts_empty_canvas():
+    mod = _load_validator()
+    assert mod.validate_canvas_text('{"nodes": [], "edges": []}') == []
+    assert mod.validate_canvas_text("{}") == []
+
+
+@pytest.mark.parametrize(
+    "color", ["#F00", "#F00A", "#FF0000", "#FF0000AA", "1", "6"]
+)
+def test_validator_accepts_spec_valid_colors(color):
+    canvas = _valid_canvas()
+    canvas["nodes"][0]["color"] = color
+    assert _errors_for(canvas) == []
+
+
+@pytest.mark.parametrize("color", ["#FF00 0", "#FF000", "0", "7", "red", 4, ["#F00"]])
+def test_validator_rejects_invalid_colors(color):
+    canvas = _valid_canvas()
+    canvas["nodes"][0]["color"] = color
+    assert any("color must be a preset" in e for e in _errors_for(canvas))
+
+
+def test_validator_rejects_malformed_json():
+    mod = _load_validator()
+    errors = mod.validate_canvas_text('{"nodes": [')
+    assert len(errors) == 1 and "invalid JSON" in errors[0]
+
+
+def test_validator_rejects_duplicate_ids():
+    canvas = _valid_canvas()
+    canvas["nodes"][1]["id"] = canvas["nodes"][0]["id"]
+    assert any("duplicate id" in e for e in _errors_for(canvas))
+
+
+def test_validator_rejects_dangling_edge_reference():
+    canvas = _valid_canvas()
+    canvas["edges"][0]["toNode"] = "0000000000000000"
+    assert any(
+        "does not reference an existing node" in e for e in _errors_for(canvas)
+    )
+
+
+def test_validator_rejects_unknown_node_type_and_bad_enum():
+    canvas = _valid_canvas()
+    canvas["nodes"][0]["type"] = "widget"
+    canvas["edges"][0]["fromSide"] = "diagonal"
+    errors = _errors_for(canvas)
+    assert any("'type' must be one of" in e for e in errors)
+    assert any("'fromSide'" in e for e in errors)
+
+
+@pytest.mark.parametrize("hostile", [[], {}, 7, True, ["top"]])
+def test_validator_reports_non_string_enums_without_crashing(hostile):
+    # Unhashable or otherwise non-string enum values must produce validation
+    # errors, not a TypeError from set membership.
+    canvas = _valid_canvas()
+    canvas["nodes"][0]["type"] = hostile
+    canvas["nodes"][2]["backgroundStyle"] = hostile
+    canvas["edges"][0]["toEnd"] = hostile
+    errors = _errors_for(canvas)
+    assert any("'type' must be one of" in e for e in errors)
+    assert any("'backgroundStyle'" in e for e in errors)
+    assert any("'toEnd'" in e for e in errors)
+
+
+def test_validator_rejects_missing_type_specific_field():
+    canvas = _valid_canvas()
+    del canvas["nodes"][1]["url"]
+    assert any(
+        "link node requires string field 'url'" in e for e in _errors_for(canvas)
+    )
+
+
+@pytest.mark.parametrize("bad_value", ["0", 1.5, True, None])
+def test_validator_rejects_non_integer_geometry(bad_value):
+    canvas = _valid_canvas()
+    canvas["nodes"][0]["x"] = bad_value
+    assert any(
+        "non-integer required field 'x'" in e for e in _errors_for(canvas)
+    )
+
+
+def test_validator_rejects_non_string_labels():
+    canvas = _valid_canvas()
+    canvas["nodes"][2]["label"] = 42
+    canvas["edges"][0]["label"] = ["not", "a", "string"]
+    errors = _errors_for(canvas)
+    assert sum("'label' must be a string" in e for e in errors) == 2
+
+
+def test_validator_cli_exit_codes(tmp_path):
+    mod = _load_validator()
+    good = tmp_path / "good.canvas"
+    good.write_text(json.dumps(_valid_canvas()), encoding="utf-8")
+    bad = tmp_path / "bad.canvas"
+    bad.write_text("not json", encoding="utf-8")
+    assert mod.main([str(good)]) == 0
+    assert mod.main([str(bad)]) == 1
+    assert mod.main([]) == 2

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -112,7 +112,11 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
+| [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) | Create and edit .canvas files with nodes and edges. | `note-taking/json-canvas` |
 | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) | Read, search, create, and edit notes in the Obsidian vault. | `note-taking/obsidian` |
+| [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases) | Create and edit .base database views, filters, and formulas. | `note-taking/obsidian-bases` |
+| [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli) | Drive the live Obsidian app from the command line. | `note-taking/obsidian-cli` |
+| [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown) | Write Obsidian notes with wikilinks, embeds, and callouts. | `note-taking/obsidian-markdown` |
 
 ## productivity
 

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -93,7 +93,11 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
+| [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) | Create and edit .canvas files with nodes and edges. | `note-taking/json-canvas` |
 | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) | Read, search, create, and edit notes in the Obsidian vault. | `note-taking/obsidian` |
+| [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases) | Create and edit .base database views, filters, and formulas. | `note-taking/obsidian-bases` |
+| [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli) | Drive the live Obsidian app from the command line. | `note-taking/obsidian-cli` |
+| [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown) | Write Obsidian notes with wikilinks, embeds, and callouts. | `note-taking/obsidian-markdown` |
 
 ## productivity
 

--- a/website/docs/user-guide/skills/bundled/apple/apple-apple-notes.md
+++ b/website/docs/user-guide/skills/bundled/apple/apple-apple-notes.md
@@ -21,7 +21,7 @@ Manage Apple Notes via memo CLI: create, search, edit.
 | License | MIT |
 | Platforms | macos |
 | Tags | `Notes`, `Apple`, `macOS`, `note-taking` |
-| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown) |
 
 ## Reference: full SKILL.md
 
@@ -48,7 +48,7 @@ Use `memo` to manage Apple Notes directly from the terminal. Notes sync across a
 
 ## When NOT to Use
 
-- Obsidian vault management → use the `obsidian` skill
+- Obsidian vault management or Obsidian-specific Markdown note authoring → use the `obsidian` or `obsidian-markdown` skill
 - Bear Notes → separate app (not supported here)
 - Quick agent-only notes → use the `memory` tool instead
 
@@ -103,4 +103,4 @@ memo notes -ex                    # Export to HTML/Markdown
 
 1. Prefer Apple Notes when user wants cross-device sync (iPhone/iPad/Mac)
 2. Use the `memory` tool for agent-internal notes that don't need to sync
-3. Use the `obsidian` skill for Markdown-native knowledge management
+3. Use the `obsidian` skill for broad vault workflows, or `obsidian-markdown` for Obsidian-specific Markdown authoring

--- a/website/docs/user-guide/skills/bundled/apple/apple-apple-notes.md
+++ b/website/docs/user-guide/skills/bundled/apple/apple-apple-notes.md
@@ -21,7 +21,7 @@ Manage Apple Notes via memo CLI: create, search, edit.
 | License | MIT |
 | Platforms | macos |
 | Tags | `Notes`, `Apple`, `macOS`, `note-taking` |
-| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown) |
 
 ## Reference: full SKILL.md
 
@@ -48,7 +48,7 @@ Use `memo` to manage Apple Notes directly from the terminal. Notes sync across a
 
 ## When NOT to Use
 
-- Obsidian vault management → use the `obsidian` skill
+- Obsidian vault management or Obsidian-specific Markdown note authoring → use the `obsidian` or `obsidian-markdown` skill
 - Bear Notes → separate app (not supported here)
 - Quick agent-only notes → use the `memory` tool instead
 
@@ -107,4 +107,4 @@ memo notes -ex                    # Export to HTML/Markdown
 
 1. Prefer Apple Notes when user wants cross-device sync (iPhone/iPad/Mac)
 2. Use the `memory` tool for agent-internal notes that don't need to sync
-3. Use the `obsidian` skill for Markdown-native knowledge management
+3. Use the `obsidian` skill for broad vault workflows, or `obsidian-markdown` for Obsidian-specific Markdown authoring

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas.md
@@ -1,0 +1,197 @@
+---
+title: "Json Canvas — Create and edit"
+sidebar_label: "Json Canvas"
+description: "Create and edit"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Json Canvas
+
+Create and edit .canvas files with nodes and edges.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/note-taking/json-canvas` |
+| Version | `1.1.0` |
+| Author | Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `json-canvas`, `canvas`, `note-taking`, `diagrams` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# JSON Canvas Skill
+
+Create and edit JSON Canvas files (`.canvas`) — the open format behind
+Obsidian's Canvas: mind maps, flowcharts, and visual boards built from
+nodes, edges, and groups per the
+[JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/). Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Creating or editing `.canvas` files
+- The user asks for a visual canvas, mind map, flowchart, or project board
+  in Obsidian
+
+Route elsewhere for broad vault work (`obsidian`), Markdown notes
+(`obsidian-markdown`), or `.base` database views (`obsidian-bases`).
+
+## Prerequisites
+
+None — `.canvas` files are plain JSON and no running Obsidian app is
+required. Resolve the vault path first (see the `obsidian` skill).
+
+## How to Run
+
+Read canvases with `read_file`, create them with `write_file`, and make
+targeted edits with `patch`. After any change, validate with the bundled
+checker (run via `terminal`, from this skill's directory):
+
+```bash
+python scripts/validate_canvas.py /absolute/path/to/file.canvas
+```
+
+It checks JSON validity, ID uniqueness, edge reference integrity, required
+per-type fields, and enum values, and exits non-zero with per-error
+messages on failure.
+
+## Quick Reference
+
+A `.canvas` file is a JSON object with two optional top-level arrays:
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+### Generic node attributes
+
+Array order determines z-index: first node = bottom layer.
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `id` | Yes | string | Unique string (convention: 16-char hex) |
+| `type` | Yes | string | `text`, `file`, `link`, or `group` |
+| `x`, `y` | Yes | integer | Position in pixels (top-left corner) |
+| `width`, `height` | Yes | integer | Size in pixels |
+| `color` | No | canvasColor | Preset `"1"`-`"6"` or hex (e.g., `"#FF0000"`) |
+
+### Per-type attributes
+
+| Node type | Required | Optional |
+|-----------|----------|----------|
+| `text` | `text` (Markdown string) | — |
+| `file` | `file` (vault path) | `subpath` (starts with `#`) |
+| `link` | `url` | — |
+| `group` | — | `label`, `background`, `backgroundStyle` (`cover`/`ratio`/`repeat`) |
+
+```json
+{
+  "id": "6f0ad84f44ce9c17",
+  "type": "text",
+  "x": 0,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "text": "# Hello World\n\nThis is **Markdown** content."
+}
+```
+
+### Edge attributes
+
+| Attribute | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `id` | Yes | - | Unique identifier |
+| `fromNode`, `toNode` | Yes | - | Source / target node IDs |
+| `fromSide`, `toSide` | No | - | `top`, `right`, `bottom`, or `left` |
+| `fromEnd`, `toEnd` | No | `none` / `arrow` | `none` or `arrow` |
+| `color` | No | - | Line color (canvasColor) |
+| `label` | No | - | Text label |
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "toNode": "a1b2c3d4e5f67890",
+  "toSide": "left",
+  "label": "leads to"
+}
+```
+
+### Colors
+
+`canvasColor` is either a hex string (`"#FF0000"`; 3-, 4-, 6-, and 8-digit
+forms are accepted) or a preset: `"1"` red, `"2"` orange, `"3"` yellow,
+`"4"` green, `"5"` cyan, `"6"` purple. Preset rendering is
+application-defined.
+
+### Layout guidelines
+
+- Coordinates can be negative; `x` increases right, `y` increases down
+- Any unique string is a valid ID; generate 16-character lowercase hex
+  strings (64-bit random) to match Obsidian's convention
+- Space nodes 50-100px apart; leave 20-50px padding inside groups
+- Align to multiples of 10 or 20 for cleaner layouts
+- Suggested sizes: small text 250x100, large text 500x400, file preview
+  400x300, link preview 300x150
+
+## Procedure
+
+Creating a new canvas:
+
+1. Start from the base structure `{"nodes": [], "edges": []}`.
+2. Generate a unique 16-char hex ID for each node.
+3. Add nodes with the required fields (`id`, `type`, `x`, `y`, `width`,
+   `height`) plus the per-type required field.
+4. Add edges referencing valid node IDs via `fromNode`/`toNode`.
+5. Write the file with `write_file`, then validate (see Verification).
+
+Editing an existing canvas:
+
+1. Read the file with `read_file` and locate the target node/edge by `id`.
+2. For a new node, pick a position that avoids overlapping existing nodes
+   and an ID that collides with nothing.
+3. Group nodes visually by adding a `group` node whose bounds enclose them.
+4. Apply the change with `patch` (or rewrite with `write_file` when the
+   change is structural), then validate.
+
+## Pitfalls
+
+- **Newlines in text nodes**: use `\n` inside the JSON string. A literal
+  `\\n` renders as the characters `\` and `n` in Obsidian.
+- Duplicate IDs and dangling `fromNode`/`toNode` references break rendering
+  silently — always validate after editing.
+- `file` node paths are vault-relative; a wrong path shows a broken
+  embed only when Obsidian opens the canvas.
+- Do not add trailing commas or comments — `.canvas` is strict JSON.
+
+## Verification
+
+Run `python scripts/validate_canvas.py <file.canvas>` via `terminal`; it
+must exit 0. It enforces: valid JSON; unique `id` values across nodes and
+edges; every edge endpoint resolves to a node; required per-type fields
+present; `type`, side, and end values within their enums; colors are
+presets `"1"`-`"6"` or hex. For a final visual check, open the canvas in
+Obsidian if it is available.
+
+## References
+
+- Complete worked examples (mind map, project board, flowchart):
+  [references/EXAMPLES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/json-canvas/references/EXAMPLES.md)
+- [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/)
+- [JSON Canvas GitHub](https://github.com/obsidianmd/jsoncanvas)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/json-canvas/../THIRD_PARTY_NOTICES.md)

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas.md
@@ -1,0 +1,197 @@
+---
+title: "Json Canvas — Create and edit .canvas files with nodes and edges"
+sidebar_label: "Json Canvas"
+description: "Create and edit .canvas files with nodes and edges"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Json Canvas
+
+Create and edit .canvas files with nodes and edges.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/note-taking/json-canvas` |
+| Version | `1.1.0` |
+| Author | Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `json-canvas`, `canvas`, `note-taking`, `diagrams` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# JSON Canvas Skill
+
+Create and edit JSON Canvas files (`.canvas`) — the open format behind
+Obsidian's Canvas: mind maps, flowcharts, and visual boards built from
+nodes, edges, and groups per the
+[JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/). Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Creating or editing `.canvas` files
+- The user asks for a visual canvas, mind map, flowchart, or project board
+  in Obsidian
+
+Route elsewhere for broad vault work (`obsidian`), Markdown notes
+(`obsidian-markdown`), or `.base` database views (`obsidian-bases`).
+
+## Prerequisites
+
+None — `.canvas` files are plain JSON and no running Obsidian app is
+required. Resolve the vault path first (see the `obsidian` skill).
+
+## How to Run
+
+Read canvases with `read_file`, create them with `write_file`, and make
+targeted edits with `patch`. After any change, validate with the bundled
+checker (run via `terminal`, from this skill's directory):
+
+```bash
+python scripts/validate_canvas.py /absolute/path/to/file.canvas
+```
+
+It checks JSON validity, ID uniqueness, edge reference integrity, required
+per-type fields, and enum values, and exits non-zero with per-error
+messages on failure.
+
+## Quick Reference
+
+A `.canvas` file is a JSON object with two optional top-level arrays:
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+### Generic node attributes
+
+Array order determines z-index: first node = bottom layer.
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `id` | Yes | string | Unique string (convention: 16-char hex) |
+| `type` | Yes | string | `text`, `file`, `link`, or `group` |
+| `x`, `y` | Yes | integer | Position in pixels (top-left corner) |
+| `width`, `height` | Yes | integer | Size in pixels |
+| `color` | No | canvasColor | Preset `"1"`-`"6"` or hex (e.g., `"#FF0000"`) |
+
+### Per-type attributes
+
+| Node type | Required | Optional |
+|-----------|----------|----------|
+| `text` | `text` (Markdown string) | — |
+| `file` | `file` (vault path) | `subpath` (starts with `#`) |
+| `link` | `url` | — |
+| `group` | — | `label`, `background`, `backgroundStyle` (`cover`/`ratio`/`repeat`) |
+
+```json
+{
+  "id": "6f0ad84f44ce9c17",
+  "type": "text",
+  "x": 0,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "text": "# Hello World\n\nThis is **Markdown** content."
+}
+```
+
+### Edge attributes
+
+| Attribute | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `id` | Yes | - | Unique identifier |
+| `fromNode`, `toNode` | Yes | - | Source / target node IDs |
+| `fromSide`, `toSide` | No | - | `top`, `right`, `bottom`, or `left` |
+| `fromEnd`, `toEnd` | No | `none` / `arrow` | `none` or `arrow` |
+| `color` | No | - | Line color (canvasColor) |
+| `label` | No | - | Text label |
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "toNode": "a1b2c3d4e5f67890",
+  "toSide": "left",
+  "label": "leads to"
+}
+```
+
+### Colors
+
+`canvasColor` is either a hex string (`"#FF0000"`; 3-, 4-, 6-, and 8-digit
+forms are accepted) or a preset: `"1"` red, `"2"` orange, `"3"` yellow,
+`"4"` green, `"5"` cyan, `"6"` purple. Preset rendering is
+application-defined.
+
+### Layout guidelines
+
+- Coordinates can be negative; `x` increases right, `y` increases down
+- Any unique string is a valid ID; generate 16-character lowercase hex
+  strings (64-bit random) to match Obsidian's convention
+- Space nodes 50-100px apart; leave 20-50px padding inside groups
+- Align to multiples of 10 or 20 for cleaner layouts
+- Suggested sizes: small text 250x100, large text 500x400, file preview
+  400x300, link preview 300x150
+
+## Procedure
+
+Creating a new canvas:
+
+1. Start from the base structure `{"nodes": [], "edges": []}`.
+2. Generate a unique 16-char hex ID for each node.
+3. Add nodes with the required fields (`id`, `type`, `x`, `y`, `width`,
+   `height`) plus the per-type required field.
+4. Add edges referencing valid node IDs via `fromNode`/`toNode`.
+5. Write the file with `write_file`, then validate (see Verification).
+
+Editing an existing canvas:
+
+1. Read the file with `read_file` and locate the target node/edge by `id`.
+2. For a new node, pick a position that avoids overlapping existing nodes
+   and an ID that collides with nothing.
+3. Group nodes visually by adding a `group` node whose bounds enclose them.
+4. Apply the change with `patch` (or rewrite with `write_file` when the
+   change is structural), then validate.
+
+## Pitfalls
+
+- **Newlines in text nodes**: use `\n` inside the JSON string. A literal
+  `\\n` renders as the characters `\` and `n` in Obsidian.
+- Duplicate IDs and dangling `fromNode`/`toNode` references break rendering
+  silently — always validate after editing.
+- `file` node paths are vault-relative; a wrong path shows a broken
+  embed only when Obsidian opens the canvas.
+- Do not add trailing commas or comments — `.canvas` is strict JSON.
+
+## Verification
+
+Run `python scripts/validate_canvas.py <file.canvas>` via `terminal`; it
+must exit 0. It enforces: valid JSON; unique `id` values across nodes and
+edges; every edge endpoint resolves to a node; required per-type fields
+present; `type`, side, and end values within their enums; colors are
+presets `"1"`-`"6"` or hex. For a final visual check, open the canvas in
+Obsidian if it is available.
+
+## References
+
+- Complete worked examples (mind map, project board, flowchart):
+  [references/EXAMPLES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/json-canvas/references/EXAMPLES.md)
+- [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/)
+- [JSON Canvas GitHub](https://github.com/obsidianmd/jsoncanvas)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/json-canvas/../THIRD_PARTY_NOTICES.md)

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases.md
@@ -1,0 +1,208 @@
+---
+title: "Obsidian Bases — Create and edit"
+sidebar_label: "Obsidian Bases"
+description: "Create and edit"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Obsidian Bases
+
+Create and edit .base database views, filters, and formulas.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/note-taking/obsidian-bases` |
+| Version | `1.1.0` |
+| Author | Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `note-taking`, `yaml`, `bases`, `database-views` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Obsidian Bases Skill
+
+Create and edit Obsidian Bases: YAML `.base` files that render database-like
+views (tables, cards, lists, maps) over the notes in a vault, with filters,
+computed formula properties, and summaries. Adapted from Steph Ango's
+MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Creating or editing `.base` files
+- The user mentions Bases, table/card views over notes, filters, formulas,
+  or summaries in Obsidian
+
+Route elsewhere for broad vault work (`obsidian`), regular note authoring
+(`obsidian-markdown`), `.canvas` files (`json-canvas`), or driving the
+running app (`obsidian-cli`).
+
+## Prerequisites
+
+None — `.base` files are plain YAML and no running Obsidian app is
+required (only Obsidian can render the views). Resolve the vault path
+first (see the `obsidian` skill).
+
+## How to Run
+
+Read `.base` files with `read_file`, create them with `write_file`, and
+make focused edits with `patch`. Find existing bases with `search_files`
+using `pattern: "*.base"` and `target: "files"`.
+
+## Quick Reference
+
+### Schema
+
+```yaml
+# Global filters apply to ALL views in the base.
+# A filter is either a single expression string, or an object with
+# exactly ONE key (and / or / not) whose list items are themselves filters.
+filters:
+  and:
+    - 'status == "active"'
+    - not:
+        - 'file.hasTag("archived")'
+
+# Formula properties computed for every note, usable in all views
+formulas:
+  formula_name: 'expression'
+
+# Display names and settings for properties
+properties:
+  property_name:
+    displayName: "Display Name"
+  formula.formula_name:
+    displayName: "Formula Display Name"
+
+# Custom summary formulas
+summaries:
+  custom_summary_name: 'values.mean().round(3)'
+
+# One or more views
+views:
+  - type: table            # table | cards | list | map
+    name: "View Name"
+    limit: 10              # optional
+    groupBy:               # optional
+      property: property_name
+      direction: ASC       # ASC | DESC
+    filters:               # view-specific, same rules as global filters
+      and:
+        - 'status == "active"'
+    order:                 # properties to display, in order
+      - file.name
+      - property_name
+      - formula.formula_name
+    summaries:             # map properties to summary formulas
+      property_name: Average
+```
+
+### Filters
+
+Expressions compare properties with `==`, `!=`, `>`, `<`, `>=`, `<=` and
+combine with `&&`, `||`, `!`. Common predicates: `file.hasTag("x")`,
+`file.hasLink("Note")`, `file.inFolder("Folder")`. Nest by making a list
+item an `and`/`or`/`not` object.
+
+### Properties
+
+1. **Note properties** — frontmatter values: `note.author` or just `author`
+2. **File properties** — metadata: `file.name`, `file.basename`,
+   `file.path`, `file.folder`, `file.ext`, `file.size`, `file.ctime`,
+   `file.mtime`, `file.tags`, `file.links`, `file.backlinks`, `file.embeds`
+3. **Formula properties** — computed values: `formula.my_formula`
+
+`this` refers to the base file itself in the main content area, to the
+embedding file when embedded, and to the active file in the sidebar.
+
+### Formulas
+
+```yaml
+formulas:
+  total: "price * quantity"
+  status_icon: 'if(done, "✅", "⏳")'
+  created: 'file.ctime.format("YYYY-MM-DD")'
+  days_old: '((now() - file.ctime) / 86400000).round(0)'
+  days_until_due: 'if(due_date, ((date(due_date) - today()) / 86400000).round(0), "")'
+```
+
+Key functions: `date()`, `now()`, `today()`, `if(condition, then, else?)`,
+`duration()`, `file()`, `link()`. The function reference for all types
+(Date, String, Number, List, File, Link, Object, RegExp) is in
+[FUNCTIONS_REFERENCE.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/FUNCTIONS_REFERENCE.md).
+
+Subtracting two dates yields the difference in **milliseconds** — divide by
+86400000 to get days (see `days_old` above). Add or subtract durations with
+strings: `now() + "1 day"`, `today() + "7d"`; `duration()` is only needed
+for arithmetic on parsed durations themselves.
+
+### Views and summaries
+
+View types: `table`, `cards`, `list`, and `map` (map needs lat/long
+properties and the Maps community plugin). Built-in summary formulas
+include `Average`, `Min`, `Max`, `Sum`, `Median`, `Stddev`, `Earliest`,
+`Latest`, `Checked`, `Empty`, `Filled`, `Unique`. Worked examples (task
+tracker, reading list, daily-notes index) are in
+[EXAMPLES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/EXAMPLES.md).
+
+### Embedding
+
+```markdown
+![[MyBase.base]]              Embed base in a note
+![[MyBase.base#View Name]]    Embed a specific view
+```
+
+## Procedure
+
+1. Create the `.base` file in the vault with `write_file`.
+2. Define scope with global `filters` (tag, folder, property, or date).
+3. Add computed properties in `formulas` as needed.
+4. Configure one or more `views`, each with `order` listing the properties
+   to display; add `groupBy`, view filters, and `summaries` as needed.
+5. Validate YAML syntax and references (see Verification).
+6. If a running Obsidian instance is available, open the file to confirm
+   the view renders (the `obsidian-cli` skill can do this).
+
+## Pitfalls
+
+- **Quoting**: wrap formulas containing double quotes in single quotes:
+  `'if(done, "Yes", "No")'`. Quote any YAML string containing `:`, `#`,
+  `[`, `{`, or other special characters.
+- **Filter objects take exactly one key** — `and`, `or`, or `not`. Do not
+  put several of them at the same level of the same object; nest instead.
+- **Date subtraction returns milliseconds**, not days: divide by 86400000
+  before rounding — `'((date(due) - today()) / 86400000).round(0)'`.
+- **Missing null guards**: properties may be absent on some notes. Guard
+  with `if()`: `'if(due, ((date(due) - today()) / 86400000).round(0), "")'`.
+- **Undefined formula references**: every `formula.X` used in `order`,
+  `properties`, or `summaries` must be defined under `formulas` — unknown
+  references fail silently in Obsidian.
+
+## Verification
+
+Parse the file to confirm it is valid YAML (via `terminal`:
+`python -c 'import yaml, sys; yaml.safe_load(open(sys.argv[1]))' file.base`).
+Then re-read it with `read_file` and check: each filter object has exactly
+one of `and`/`or`/`not`; every `formula.X` reference is defined; every view
+has a `type` (and a distinct `name` when there are multiple views). Finally,
+open it in Obsidian if available — a YAML error banner means a quoting
+problem (see Pitfalls).
+
+## References
+
+- Worked examples: [references/EXAMPLES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/EXAMPLES.md)
+- Full function reference: [references/FUNCTIONS_REFERENCE.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/FUNCTIONS_REFERENCE.md)
+- [Bases Syntax](https://help.obsidian.md/bases/syntax) ·
+  [Functions](https://help.obsidian.md/bases/functions) ·
+  [Views](https://help.obsidian.md/bases/views)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/../THIRD_PARTY_NOTICES.md)

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases.md
@@ -1,0 +1,208 @@
+---
+title: "Obsidian Bases — Create and edit .base database views, filters, and formulas"
+sidebar_label: "Obsidian Bases"
+description: "Create and edit .base database views, filters, and formulas"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Obsidian Bases
+
+Create and edit .base database views, filters, and formulas.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/note-taking/obsidian-bases` |
+| Version | `1.1.0` |
+| Author | Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `note-taking`, `yaml`, `bases`, `database-views` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Obsidian Bases Skill
+
+Create and edit Obsidian Bases: YAML `.base` files that render database-like
+views (tables, cards, lists, maps) over the notes in a vault, with filters,
+computed formula properties, and summaries. Adapted from Steph Ango's
+MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Creating or editing `.base` files
+- The user mentions Bases, table/card views over notes, filters, formulas,
+  or summaries in Obsidian
+
+Route elsewhere for broad vault work (`obsidian`), regular note authoring
+(`obsidian-markdown`), `.canvas` files (`json-canvas`), or driving the
+running app (`obsidian-cli`).
+
+## Prerequisites
+
+None — `.base` files are plain YAML and no running Obsidian app is
+required (only Obsidian can render the views). Resolve the vault path
+first (see the `obsidian` skill).
+
+## How to Run
+
+Read `.base` files with `read_file`, create them with `write_file`, and
+make focused edits with `patch`. Find existing bases with `search_files`
+using `pattern: "*.base"` and `target: "files"`.
+
+## Quick Reference
+
+### Schema
+
+```yaml
+# Global filters apply to ALL views in the base.
+# A filter is either a single expression string, or an object with
+# exactly ONE key (and / or / not) whose list items are themselves filters.
+filters:
+  and:
+    - 'status == "active"'
+    - not:
+        - 'file.hasTag("archived")'
+
+# Formula properties computed for every note, usable in all views
+formulas:
+  formula_name: 'expression'
+
+# Display names and settings for properties
+properties:
+  property_name:
+    displayName: "Display Name"
+  formula.formula_name:
+    displayName: "Formula Display Name"
+
+# Custom summary formulas
+summaries:
+  custom_summary_name: 'values.mean().round(3)'
+
+# One or more views
+views:
+  - type: table            # table | cards | list | map
+    name: "View Name"
+    limit: 10              # optional
+    groupBy:               # optional
+      property: property_name
+      direction: ASC       # ASC | DESC
+    filters:               # view-specific, same rules as global filters
+      and:
+        - 'status == "active"'
+    order:                 # properties to display, in order
+      - file.name
+      - property_name
+      - formula.formula_name
+    summaries:             # map properties to summary formulas
+      property_name: Average
+```
+
+### Filters
+
+Expressions compare properties with `==`, `!=`, `>`, `<`, `>=`, `<=` and
+combine with `&&`, `||`, `!`. Common predicates: `file.hasTag("x")`,
+`file.hasLink("Note")`, `file.inFolder("Folder")`. Nest by making a list
+item an `and`/`or`/`not` object.
+
+### Properties
+
+1. **Note properties** — frontmatter values: `note.author` or just `author`
+2. **File properties** — metadata: `file.name`, `file.basename`,
+   `file.path`, `file.folder`, `file.ext`, `file.size`, `file.ctime`,
+   `file.mtime`, `file.tags`, `file.links`, `file.backlinks`, `file.embeds`
+3. **Formula properties** — computed values: `formula.my_formula`
+
+`this` refers to the base file itself in the main content area, to the
+embedding file when embedded, and to the active file in the sidebar.
+
+### Formulas
+
+```yaml
+formulas:
+  total: "price * quantity"
+  status_icon: 'if(done, "✅", "⏳")'
+  created: 'file.ctime.format("YYYY-MM-DD")'
+  days_old: '((now() - file.ctime) / 86400000).round(0)'
+  days_until_due: 'if(due_date, ((date(due_date) - today()) / 86400000).round(0), "")'
+```
+
+Key functions: `date()`, `now()`, `today()`, `if(condition, then, else?)`,
+`duration()`, `file()`, `link()`. The function reference for all types
+(Date, String, Number, List, File, Link, Object, RegExp) is in
+[FUNCTIONS_REFERENCE.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/FUNCTIONS_REFERENCE.md).
+
+Subtracting two dates yields the difference in **milliseconds** — divide by
+86400000 to get days (see `days_old` above). Add or subtract durations with
+strings: `now() + "1 day"`, `today() + "7d"`; `duration()` is only needed
+for arithmetic on parsed durations themselves.
+
+### Views and summaries
+
+View types: `table`, `cards`, `list`, and `map` (map needs lat/long
+properties and the Maps community plugin). Built-in summary formulas
+include `Average`, `Min`, `Max`, `Sum`, `Median`, `Stddev`, `Earliest`,
+`Latest`, `Checked`, `Empty`, `Filled`, `Unique`. Worked examples (task
+tracker, reading list, daily-notes index) are in
+[EXAMPLES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/EXAMPLES.md).
+
+### Embedding
+
+```markdown
+![[MyBase.base]]              Embed base in a note
+![[MyBase.base#View Name]]    Embed a specific view
+```
+
+## Procedure
+
+1. Create the `.base` file in the vault with `write_file`.
+2. Define scope with global `filters` (tag, folder, property, or date).
+3. Add computed properties in `formulas` as needed.
+4. Configure one or more `views`, each with `order` listing the properties
+   to display; add `groupBy`, view filters, and `summaries` as needed.
+5. Validate YAML syntax and references (see Verification).
+6. If a running Obsidian instance is available, open the file to confirm
+   the view renders (the `obsidian-cli` skill can do this).
+
+## Pitfalls
+
+- **Quoting**: wrap formulas containing double quotes in single quotes:
+  `'if(done, "Yes", "No")'`. Quote any YAML string containing `:`, `#`,
+  `[`, `{`, or other special characters.
+- **Filter objects take exactly one key** — `and`, `or`, or `not`. Do not
+  put several of them at the same level of the same object; nest instead.
+- **Date subtraction returns milliseconds**, not days: divide by 86400000
+  before rounding — `'((date(due) - today()) / 86400000).round(0)'`.
+- **Missing null guards**: properties may be absent on some notes. Guard
+  with `if()`: `'if(due, ((date(due) - today()) / 86400000).round(0), "")'`.
+- **Undefined formula references**: every `formula.X` used in `order`,
+  `properties`, or `summaries` must be defined under `formulas` — unknown
+  references fail silently in Obsidian.
+
+## Verification
+
+Parse the file to confirm it is valid YAML (via `terminal`:
+`python -c 'import yaml, sys; yaml.safe_load(open(sys.argv[1]))' file.base`).
+Then re-read it with `read_file` and check: each filter object has exactly
+one of `and`/`or`/`not`; every `formula.X` reference is defined; every view
+has a `type` (and a distinct `name` when there are multiple views). Finally,
+open it in Obsidian if available — a YAML error banner means a quoting
+problem (see Pitfalls).
+
+## References
+
+- Worked examples: [references/EXAMPLES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/EXAMPLES.md)
+- Full function reference: [references/FUNCTIONS_REFERENCE.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/references/FUNCTIONS_REFERENCE.md)
+- [Bases Syntax](https://help.obsidian.md/bases/syntax) ·
+  [Functions](https://help.obsidian.md/bases/functions) ·
+  [Views](https://help.obsidian.md/bases/views)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-bases/../THIRD_PARTY_NOTICES.md)

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli.md
@@ -1,0 +1,143 @@
+---
+title: "Obsidian Cli — Drive the live Obsidian app from the command line"
+sidebar_label: "Obsidian Cli"
+description: "Drive the live Obsidian app from the command line"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Obsidian Cli
+
+Drive the live Obsidian app from the command line.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/note-taking/obsidian-cli` |
+| Version | `1.1.0` |
+| Author | Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `cli`, `plugin-development`, `theme-development`, `note-taking` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases), [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Obsidian CLI Skill
+
+Operate a live Obsidian instance through its official `obsidian` CLI: note
+operations, search, tasks, properties, and a plugin/theme development loop
+with reload, error capture, screenshots, and DOM inspection. Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- The task needs the *running* Obsidian app: opening notes, live search,
+  daily notes, tasks, properties, or vault commands
+- Developing or debugging an Obsidian plugin or theme
+
+Route elsewhere when the app is not required: generic vault filesystem work
+→ `obsidian`; `.md` authoring semantics → `obsidian-markdown`; `.base`
+files → `obsidian-bases`; `.canvas` files → `json-canvas`.
+
+## Prerequisites
+
+- The `obsidian` CLI installed and on `PATH`
+  ([install docs](https://help.obsidian.md/cli))
+- The Obsidian desktop app installed. It does not have to be running: if
+  it is not, the first CLI command launches it (expect a startup delay
+  and a GUI window — there is no headless mode)
+
+## How to Run
+
+Run `obsidian <command>` via the `terminal` tool. `obsidian help` lists
+every command and is always up to date; full docs live at
+https://help.obsidian.md/cli.
+
+Syntax rules:
+
+- **Parameters** take `key=value`; quote values with spaces:
+  `obsidian create name="My Note" content="Hello world"`
+- **Flags** are bare words: `obsidian create name="My Note" overwrite`
+- Use `\n` and `\t` escapes for multiline content
+- **File targeting**: `file=<name>` resolves like a wikilink (no path or
+  extension needed); `path=<path>` is exact from the vault root. Without
+  either, the active file is used.
+- **Vault targeting** (in order): `vault=<name>` or `vault=<id>` as the
+  first parameter pins a vault; otherwise, if the terminal's working
+  directory is inside a vault, that vault is used; otherwise the currently
+  active vault.
+
+## Quick Reference
+
+```bash
+obsidian read file="My Note"
+obsidian create name="New Note" content="# Hello" template="Template"
+obsidian append file="My Note" content="New line"
+obsidian search query="search term" limit=10
+obsidian daily:read
+obsidian daily:append content="- [ ] New task"
+obsidian property:set name="status" value="done" file="My Note"
+obsidian tasks daily todo
+obsidian tags sort=count counts
+obsidian backlinks file="My Note"
+```
+
+Use `--copy` on any command to copy output to the clipboard, the `open`
+flag where supported to open the affected file in Obsidian (files are not
+opened by default), and `total` on list commands to get a count.
+
+## Procedure
+
+Plugin/theme develop-test cycle — after each code change:
+
+1. Reload the plugin: `obsidian plugin:reload id=my-plugin`
+2. Check for errors, fix, and repeat from step 1 if any appear:
+   `obsidian dev:errors`
+3. Verify visually: `obsidian dev:screenshot path=screenshot.png` or
+   `obsidian dev:dom selector=".workspace-leaf" text`
+4. Check console output: `obsidian dev:console level=error`
+
+Additional developer commands:
+
+```bash
+obsidian eval code="app.vault.getFiles().length"          # run JS in app
+obsidian dev:css selector=".workspace-leaf" prop=background-color
+obsidian dev:mobile on                                    # mobile emulation
+```
+
+`obsidian help` lists further developer commands, including CDP and
+debugger controls.
+
+## Pitfalls
+
+- The first command launches Obsidian when it is not already running —
+  on a headless machine (no display) the CLI cannot work at all.
+- Multi-vault setups: without `vault=`, the vault is inferred from the
+  working directory or falls back to the active vault — pin it explicitly
+  in scripts.
+- `file=` resolves wikilink-style and may match an unexpected note; use
+  `path=` when exactness matters.
+- Prefer native file tools (`read_file`, `write_file`, `patch`) for bulk
+  file edits — the CLI is for app-side state (open notes, live search,
+  plugin reloads), not mass file rewriting.
+
+## Verification
+
+Check the command's stdout and exit code in `terminal`. For state-changing
+operations, confirm the result: re-read the note (`obsidian read` or
+`read_file`), or take a screenshot with `obsidian dev:screenshot` for
+UI-facing changes. For plugin work, `obsidian dev:errors` must come back
+clean after a reload.
+
+## References
+
+- [Obsidian CLI docs](https://help.obsidian.md/cli)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-cli/../THIRD_PARTY_NOTICES.md)

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown.md
@@ -1,0 +1,188 @@
+---
+title: "Obsidian Markdown — Write Obsidian notes with wikilinks, embeds, and callouts"
+sidebar_label: "Obsidian Markdown"
+description: "Write Obsidian notes with wikilinks, embeds, and callouts"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Obsidian Markdown
+
+Write Obsidian notes with wikilinks, embeds, and callouts.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/note-taking/obsidian-markdown` |
+| Version | `1.1.0` |
+| Author | Harish Kukreja (counterposition), Hermes Agent (adapted from Steph Ango's official Obsidian skills) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `markdown`, `note-taking`, `wikilinks`, `callouts`, `frontmatter` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases), [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Obsidian Flavored Markdown Skill
+
+Author and edit Obsidian Flavored Markdown, which extends CommonMark and GFM
+with wikilinks, embeds, callouts, properties, comments, and highlights. This
+skill covers only the Obsidian-specific extensions — standard Markdown
+(headings, lists, tables, code blocks) is assumed knowledge. Adapted from
+Steph Ango's MIT-licensed official Obsidian skills.
+
+## When to Use
+
+- Notes that need Obsidian-specific syntax: wikilinks, embeds, callouts,
+  frontmatter properties, tags, comments, or highlights
+- Converting plain Markdown into Obsidian-idiomatic notes
+
+Plain note creation, reading, listing, and searching stays with the generic
+`obsidian` skill — load this one for the syntax layer. Route `.base`
+database views → `obsidian-bases`; `.canvas` files → `json-canvas`; driving
+the running app or plugin development → `obsidian-cli`.
+
+## Prerequisites
+
+None — notes are plain text files and no running Obsidian app is required.
+Resolve the vault path first (see the `obsidian` skill): the
+`OBSIDIAN_VAULT_PATH` environment variable, falling back to
+`~/Documents/Obsidian Vault`.
+
+## How to Run
+
+Use the native file tools: `read_file` to inspect a note, `write_file` to
+create one, `patch` for targeted edits with stable context, and
+`search_files` to find notes by name or content. Pass concrete absolute
+paths — file tools do not expand `$OBSIDIAN_VAULT_PATH`.
+
+## Quick Reference
+
+### Internal links (wikilinks)
+
+```markdown
+[[Note Name]]                Link to note
+[[Note Name|Display Text]]   Custom display text
+[[Note Name#Heading]]        Link to heading
+[[Note Name#^block-id]]      Link to block
+[[#Heading in same note]]    Same-note heading link
+```
+
+Define a block ID by appending `^block-id` to a paragraph or to a single
+list item. To reference a whole list or quote, place the block ID on its
+own line after the block.
+
+### Embeds
+
+Prefix any wikilink with `!` to embed its content inline:
+
+```markdown
+![[Note Name]]               Embed full note
+![[Note Name#Heading]]       Embed section
+![[image.png|300]]           Embed image with width
+![[document.pdf#page=3]]     Embed PDF page
+![[MyBase.base#View Name]]   Embed a Bases view
+```
+
+See [EMBEDS.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-markdown/references/EMBEDS.md) for audio, video, Bases, search
+embeds, and external images.
+
+### Callouts
+
+```markdown
+> [!note]
+> Basic callout.
+
+> [!warning] Custom Title
+> Callout with a custom title.
+
+> [!faq]- Collapsed by default
+> Foldable callout (- collapsed, + expanded).
+```
+
+Common types: `note`, `tip`, `warning`, `info`, `example`, `quote`, `bug`,
+`danger`, `success`, `failure`, `question`, `abstract`, `todo`. See
+[CALLOUTS.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-markdown/references/CALLOUTS.md) for aliases, nesting, and custom CSS
+callouts.
+
+### Properties (frontmatter)
+
+```yaml
+---
+title: My Note
+date: 2026-01-15
+tags:
+  - project
+aliases:
+  - Alternative Name
+cssclasses:
+  - custom-class
+---
+```
+
+See [PROPERTIES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-markdown/references/PROPERTIES.md) for all property types and
+tag syntax rules.
+
+### Other Obsidian syntax
+
+```markdown
+#tag  #nested/tag            Inline tags
+==Highlighted text==         Highlight
+%%hidden comment%%           Hidden in reading view
+$e^{i\pi} + 1 = 0$           Inline LaTeX ($$ ... $$ for blocks)
+Text with a footnote[^1].    Footnotes ([^1]: content)
+```
+
+Mermaid diagrams go in fenced `mermaid` code blocks; add
+`class NodeName internal-link;` to link diagram nodes to notes.
+
+## Procedure
+
+Creating an Obsidian note:
+
+1. Add frontmatter properties (title, tags, aliases) at the top of the file.
+2. Write content using standard Markdown structure plus the Obsidian syntax
+   above.
+3. Link related notes with `[[wikilinks]]`; use `[text](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-markdown/url)` Markdown links
+   for external URLs.
+4. Embed supporting content (notes, images, PDFs) with `![[...]]`.
+5. Add callouts for highlighted information with `> [!type]`.
+6. Write the note with `write_file`, or apply focused changes to an existing
+   note with `patch`.
+
+## Pitfalls
+
+- Both `[[wikilinks]]` and standard Markdown links work for vault-internal
+  targets; wikilinks are Obsidian's compact default and what this skill
+  uses. Match the vault's existing convention when editing.
+- Block IDs for lists and quotes must sit on a separate line after the
+  block, not appended to the last line.
+- Tags cannot start with a number; allowed characters are letters, numbers,
+  underscores, hyphens, and forward slashes.
+- Frontmatter must be the very first thing in the file, delimited by `---`
+  lines, and must be valid YAML — quote values containing `:` or `#`.
+- `%%` comments are invisible in reading view but still ship with the file.
+
+## Verification
+
+Re-read the result with `read_file` and check: frontmatter parses as YAML
+between the opening `---` pair; every `[[wikilink]]` target exists in the
+vault (check with `search_files` when correctness matters); `%%` markers
+are balanced. If a running Obsidian instance is available, confirm
+rendering in reading view (the `obsidian-cli` skill can open the note).
+
+## References
+
+- [Obsidian Flavored Markdown](https://help.obsidian.md/obsidian-flavored-markdown)
+- [Internal links](https://help.obsidian.md/links)
+- [Embed files](https://help.obsidian.md/embeds)
+- [Callouts](https://help.obsidian.md/callouts)
+- [Properties](https://help.obsidian.md/properties)
+- Source: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) by Steph Ango,
+  MIT — full license in [THIRD_PARTY_NOTICES.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian-markdown/../THIRD_PARTY_NOTICES.md)

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
@@ -16,7 +16,12 @@ Read, search, create, and edit notes in the Obsidian vault.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/note-taking/obsidian` |
+| Version | `1.1.0` |
+| Author | Hermes Agent |
+| License | MIT |
 | Platforms | linux, macos, windows |
+| Tags | `obsidian`, `note-taking`, `vault`, `markdown` |
+| Related skills | [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases), [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) |
 
 ## Reference: full SKILL.md
 
@@ -27,6 +32,12 @@ The following is the complete skill definition that Hermes loads when this skill
 # Obsidian Vault
 
 Use this skill for filesystem-first Obsidian vault work: reading notes, listing notes, searching note files, creating notes, appending content, and adding wikilinks.
+
+When the task is format-specific or app-specific, route to the specialized skills instead:
+- `.md` note authoring with wikilinks, properties/frontmatter, callouts, embeds, or Obsidian-specific Markdown semantics -> `obsidian-markdown`
+- running Obsidian app workflows, Obsidian CLI usage, plugin development, or theme development -> `obsidian-cli`
+- editing `.base` files or working with Bases filters, views, and formulas -> `obsidian-bases`
+- editing `.canvas` files or visual canvases -> `json-canvas`
 
 ## Vault path
 

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
@@ -16,11 +16,12 @@ Read, search, create, and edit notes in the Obsidian vault.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/note-taking/obsidian` |
-| Version | `1.0.0` |
+| Version | `1.1.0` |
 | Author | Teknium (teknium1), Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `Obsidian`, `Notes`, `Markdown`, `Vault` |
+| Related skills | [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`obsidian-cli`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-cli), [`obsidian-bases`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-bases), [`json-canvas`](/docs/user-guide/skills/bundled/note-taking/note-taking-json-canvas) |
 
 ## Reference: full SKILL.md
 
@@ -31,6 +32,12 @@ The following is the complete skill definition that Hermes loads when this skill
 # Obsidian Vault
 
 Use this skill for filesystem-first Obsidian vault work: reading notes, listing notes, searching note files, creating notes, appending content, and adding wikilinks.
+
+When the task is format-specific or app-specific, route to the specialized skills instead:
+- `.md` note authoring with wikilinks, properties/frontmatter, callouts, embeds, or Obsidian-specific Markdown semantics -> `obsidian-markdown`
+- running Obsidian app workflows, Obsidian CLI usage, plugin development, or theme development -> `obsidian-cli`
+- editing `.base` files or working with Bases filters, views, and formulas -> `obsidian-bases`
+- editing `.canvas` files or visual canvases -> `json-canvas`
 
 ## Vault path
 

--- a/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
+++ b/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
@@ -21,7 +21,7 @@ Karpathy's LLM Wiki: build/query interlinked markdown KB.
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `wiki`, `knowledge-base`, `research`, `notes`, `markdown`, `rag-alternative` |
-| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`arxiv`](/docs/user-guide/skills/bundled/research/research-arxiv) |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`obsidian-markdown`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown), [`arxiv`](/docs/user-guide/skills/bundled/research/research-arxiv) |
 
 ## Reference: full SKILL.md
 
@@ -52,16 +52,21 @@ Use this skill when the user:
 
 ## Wiki Location
 
-**Location:** Set via `WIKI_PATH` environment variable (e.g. in `${HERMES_HOME:-~/.hermes}/.env`).
+**Location:** Set via `wiki.path` in Hermes config (`hermes config`), or via the
+`WIKI_PATH` environment variable (e.g. in `${HERMES_HOME:-~/.hermes}/.env`). The
+config value takes precedence when present (shown in the `[Skill config: ...]`
+block above).
 
-If unset, defaults to `~/wiki`.
+If neither is set, defaults to `~/wiki`.
 
 ```bash
 WIKI="${WIKI_PATH:-$HOME/wiki}"
 ```
 
 The wiki is just a directory of markdown files — open it in Obsidian, VS Code, or
-any editor. No database, no special tooling required.
+any editor. Use the broad `obsidian` skill for generic vault/file workflows and
+`obsidian-markdown` when you need Obsidian-specific syntax such as properties,
+callouts, embeds, or wikilinks.
 
 ## Architecture: Three Layers
 
@@ -117,7 +122,7 @@ at hand before creating anything new.
 
 When the user asks to create or start a wiki:
 
-1. Determine the wiki path (from `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
+1. Determine the wiki path (from skill config `wiki.path`, `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -257,7 +257,11 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-bundled-note-taking',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/bundled/note-taking/note-taking-json-canvas',
                     'user-guide/skills/bundled/note-taking/note-taking-obsidian',
+                    'user-guide/skills/bundled/note-taking/note-taking-obsidian-bases',
+                    'user-guide/skills/bundled/note-taking/note-taking-obsidian-cli',
+                    'user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown',
                   ],
                 },
                 {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -253,7 +253,11 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-bundled-note-taking',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/bundled/note-taking/note-taking-json-canvas',
                     'user-guide/skills/bundled/note-taking/note-taking-obsidian',
+                    'user-guide/skills/bundled/note-taking/note-taking-obsidian-bases',
+                    'user-guide/skills/bundled/note-taking/note-taking-obsidian-cli',
+                    'user-guide/skills/bundled/note-taking/note-taking-obsidian-markdown',
                   ],
                 },
                 {


### PR DESCRIPTION
## Rationale

Hermes currently has a useful generic Obsidian skill for filesystem-first vault work, but it does not cover several important parts of modern Obsidian usage.

This PR gives Hermes better first-class support for Obsidian-specific workflows while preserving the existing `obsidian` entry point. In particular, it adds focused guidance for:

- Obsidian Bases (`.base` files), including views, filters, formulas, and summaries
- Obsidian canvases (`.canvas` files), including JSON Canvas nodes, edges, groups, and validation
- Obsidian-flavored Markdown, including properties, wikilinks, embeds, and callouts
- Obsidian CLI workflows that can interact with a running vault, including note operations, search, tasks, properties, screenshots, DOM inspection, and plugin/theme development loops

The goal is to improve Hermes's ability to handle real Obsidian vault work without replacing the broad generic skill that existing users and related skills already rely on.

## Summary

- add focused `obsidian-markdown`, `obsidian-cli`, `obsidian-bases`, and `json-canvas` bundled skills
- keep `obsidian` as the generic filesystem-first vault skill and route specialized tasks to the focused skills
- update related-skill references for Apple Notes and LLM Wiki
- regenerate the skill catalog, per-skill docs, and sidebar entries
- add a focused regression test for the Obsidian skill bundle and generated catalog rows

## Test

```bash
scripts/run_tests.sh tests/skills/test_obsidian_skill_bundle.py -q
```

Result: `3 passed`
