### PR TITLE
fix(gateway): bypass slash commands during pending update prompts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3210,6 +3210,10 @@ class GatewayRunner:
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via
         # .update_response so the update process can continue.
+        #
+        # IMPORTANT: recognized slash commands must bypass this interception.
+        # Otherwise control/session commands like /new or /help get silently
+        # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
@@ -3221,7 +3225,22 @@ class GatewayRunner:
             elif cmd in ("deny", "no"):
                 response_text = "n"
             else:
-                response_text = raw
+                _recognized_cmd = None
+                if cmd:
+                    try:
+                        from hermes_cli.commands import resolve_command as _resolve_update_cmd
+                    except Exception:
+                        _resolve_update_cmd = None
+                    if _resolve_update_cmd is not None:
+                        try:
+                            _cmd_def = _resolve_update_cmd(cmd)
+                            _recognized_cmd = _cmd_def.name if _cmd_def else None
+                        except Exception:
+                            _recognized_cmd = None
+                if _recognized_cmd:
+                    response_text = ""
+                else:
+                    response_text = raw
             if response_text:
                 response_path = _hermes_home / ".update_response"
                 try:
@@ -8706,13 +8725,17 @@ class GatewayRunner:
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:
-        """Clear approval state that must not survive a real conversation switch."""
+        """Clear per-session control state that must not survive a boundary switch."""
         if not session_key:
             return
 
         pending_approvals = getattr(self, "_pending_approvals", None)
         if isinstance(pending_approvals, dict):
             pending_approvals.pop(session_key, None)
+
+        update_prompt_pending = getattr(self, "_update_prompt_pending", None)
+        if isinstance(update_prompt_pending, dict):
+            update_prompt_pending.pop(session_key, None)
 
         try:
             from tools.approval import clear_session as _clear_approval_session

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -76,6 +76,7 @@ def _make_resume_runner():
     runner._running_agents_ts = {}
     runner._busy_ack_ts = {}
     runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
     runner._agent_cache_lock = None
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = current_entry
@@ -102,6 +103,7 @@ def _make_branch_runner():
     runner._running_agents_ts = {}
     runner._busy_ack_ts = {}
     runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
     runner._agent_cache_lock = None
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = current_entry
@@ -127,6 +129,8 @@ async def test_resume_clears_session_scoped_approval_and_yolo_state():
     enable_session_yolo(other_key)
     runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
     runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
+    runner._update_prompt_pending[session_key] = True
+    runner._update_prompt_pending[other_key] = True
 
     result = await runner._handle_resume_command(_make_event("/resume Resumed Work"))
 
@@ -134,9 +138,11 @@ async def test_resume_clears_session_scoped_approval_and_yolo_state():
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
     assert session_key not in runner._pending_approvals
+    assert session_key not in runner._update_prompt_pending
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
     assert other_key in runner._pending_approvals
+    assert other_key in runner._update_prompt_pending
 
 
 @pytest.mark.asyncio
@@ -150,6 +156,8 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     enable_session_yolo(other_key)
     runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
     runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
+    runner._update_prompt_pending[session_key] = True
+    runner._update_prompt_pending[other_key] = True
 
     result = await runner._handle_branch_command(_make_event("/branch"))
 
@@ -157,9 +165,11 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
     assert session_key not in runner._pending_approvals
+    assert session_key not in runner._update_prompt_pending
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
     assert other_key in runner._pending_approvals
+    assert other_key in runner._update_prompt_pending
 
 
 def test_clear_session_boundary_security_state_is_scoped():
@@ -172,6 +182,7 @@ def test_clear_session_boundary_security_state_is_scoped():
 
     runner = object.__new__(GatewayRunner)
     runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
 
     source = _make_source()
     session_key = build_session_key(source)
@@ -183,6 +194,8 @@ def test_clear_session_boundary_security_state_is_scoped():
     enable_session_yolo(other_key)
     runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
     runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
+    runner._update_prompt_pending[session_key] = True
+    runner._update_prompt_pending[other_key] = True
 
     runner._clear_session_boundary_security_state(session_key)
 
@@ -190,11 +203,14 @@ def test_clear_session_boundary_security_state_is_scoped():
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
     assert session_key not in runner._pending_approvals
+    assert session_key not in runner._update_prompt_pending
     # Other session untouched
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
     assert other_key in runner._pending_approvals
+    assert other_key in runner._update_prompt_pending
 
     # Empty session_key is a no-op
     runner._clear_session_boundary_security_state("")
     assert is_approved(other_key, "recursive delete") is True
+    assert other_key in runner._update_prompt_pending

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -251,7 +251,7 @@ class TestWatchUpdateProgress:
                    "session_key": "agent:main:telegram:dm:111"}
         (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
         # Write output
-        (hermes_home / ".update_output.txt").write_text("→ Fetching updates...\n")
+        (hermes_home / ".update_output.txt").write_text("→ Fetching updates...\n", encoding="utf-8")
 
         mock_adapter = AsyncMock()
         runner.adapters = {Platform.TELEGRAM: mock_adapter}
@@ -261,7 +261,7 @@ class TestWatchUpdateProgress:
             await asyncio.sleep(0.3)
             (hermes_home / ".update_output.txt").write_text(
                 "→ Fetching updates...\n✓ Code updated!\n"
-            )
+            , encoding="utf-8")
             (hermes_home / ".update_exit_code").write_text("0")
 
         with patch("gateway.run._hermes_home", hermes_home):
@@ -488,6 +488,28 @@ class TestUpdatePromptInterception:
         assert response_path.read_text() == "y"
         # Should clear the pending flag
         assert session_key not in runner._update_prompt_pending
+
+    @pytest.mark.asyncio
+    async def test_recognized_slash_command_bypasses_pending_update_prompt(self, tmp_path):
+        """Known slash commands must dispatch normally instead of being consumed."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        event = _make_event(text="/new", chat_id="67890")
+        session_key = "agent:main:telegram:dm:67890"
+        runner._update_prompt_pending[session_key] = True
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._session_key_for_source = MagicMock(return_value=session_key)
+        runner._handle_reset_command = AsyncMock(return_value="reset ok")
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._handle_message(event)
+
+        assert result == "reset ok"
+        runner._handle_reset_command.assert_awaited_once_with(event)
+        assert not (hermes_home / ".update_response").exists()
+        assert runner._update_prompt_pending[session_key] is True
 
     @pytest.mark.asyncio
     async def test_normal_message_when_no_prompt_pending(self, tmp_path):


### PR DESCRIPTION
## Summary

This fixes a gateway control-flow bug where a pending `/update` prompt could consume real slash commands like `/new` or `/help` as if they were update responses.

While `_update_prompt_pending[session_key]` was set, `_handle_message()` intercepted the next message before normal command dispatch. That worked for plain text answers and `/approve`/`/deny`, but it also swallowed recognized gateway commands and wrote them to `.update_response` instead of executing them.

This PR narrows that interception path so recognized slash commands bypass the update-response flow and continue through normal gateway dispatch.

It also clears `_update_prompt_pending` during real session-boundary transitions, alongside the existing approval-state cleanup, so stale update prompt state does not leak across `/new`, `/resume`, or `/branch`.

## Problem

Before this change:

1. Trigger an update flow that leaves `_update_prompt_pending[session_key] = True`
2. Send `/new` (or another recognized slash command)
3. The gateway writes `/new` into `.update_response`
4. The session command never runs

That is the wrong control-plane behavior. Session/control commands should not be reinterpreted as update prompt answers.

## Fix

- In `gateway/run.py`, when an update prompt is pending:
  - keep treating `/approve` and `/deny` as shorthand yes/no responses
  - keep accepting plain text replies as update responses
  - but bypass interception for recognized slash commands so they dispatch normally
- Extend `_clear_session_boundary_security_state()` to also clear `_update_prompt_pending` for the target session

## Tests

Added regression coverage for:

- recognized slash commands bypassing pending update prompt interception
- `_update_prompt_pending` being cleared on session-boundary cleanup
- `/resume` and `/branch` preserving scoped cleanup behavior for other sessions

Test result:

```text
21 passed, 3 warnings
