### PR TITLE
fix(tui): soft-wrap-aware Up/Down arrow navigation in TextInput

### DIFF
--- a/ui-tui/src/__tests__/composerDraftCursor.test.ts
+++ b/ui-tui/src/__tests__/composerDraftCursor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+
+import {
+  getComposerDraftCursor,
+  rememberComposerDraftCursor,
+  requestComposerCursorRestore,
+  resetComposerDraftCursorStateForTests,
+  setComposerDraftCursorFrozen,
+  setComposerDraftCursorSuppress,
+  takeComposerCursorRestore
+} from '../lib/composerDraftCursor.js'
+import { isShiftArrowChord, shouldStopVisualRowNavPropagation } from '../components/textInput.js'
+
+describe('composerDraftCursor', () => {
+  beforeEach(() => {
+    resetComposerDraftCursorStateForTests()
+  })
+
+  it('remembers edit cursor and ignores updates while suppressed (Up-climb)', () => {
+    rememberComposerDraftCursor(12)
+    expect(getComposerDraftCursor()).toBe(12)
+
+    setComposerDraftCursorSuppress(true)
+    rememberComposerDraftCursor(0)
+    expect(getComposerDraftCursor()).toBe(12)
+
+    setComposerDraftCursorSuppress(false)
+    rememberComposerDraftCursor(4)
+    expect(getComposerDraftCursor()).toBe(4)
+  })
+
+  it('freezes memory while browsing history so entry cursors cannot clobber it', () => {
+    rememberComposerDraftCursor(10)
+    setComposerDraftCursorFrozen(true)
+    rememberComposerDraftCursor(3)
+    expect(getComposerDraftCursor()).toBe(10)
+
+    setComposerDraftCursorFrozen(false)
+    rememberComposerDraftCursor(6)
+    expect(getComposerDraftCursor()).toBe(6)
+  })
+
+  it('hands a pending restore to TextInput on the next external value change', () => {
+    requestComposerCursorRestore(7)
+    expect(takeComposerCursorRestore(99)).toBe(7)
+    expect(takeComposerCursorRestore(99)).toBe(99)
+  })
+})
+
+describe('isShiftArrowChord', () => {
+  const up = { downArrow: false, shift: false, upArrow: true }
+  const shiftUp = { downArrow: false, shift: true, upArrow: true }
+
+  it('honors key.shift when the terminal reports it', () => {
+    expect(isShiftArrowChord(shiftUp)).toBe(true)
+    expect(shouldStopVisualRowNavPropagation(shiftUp)).toBe(false)
+  })
+
+  it('detects CSI shift-arrow sequences when key.shift is missing', () => {
+    expect(isShiftArrowChord(up, { keypress: { raw: '\x1b[1;2A' } })).toBe(true)
+    expect(isShiftArrowChord(up, { keypress: { raw: '\x1b[A' } })).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -48,5 +48,11 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('', key({ tab: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
+    expect(shouldPassThroughToGlobalHandler('', key({ shift: true, upArrow: true }))).toBe(true)
+    expect(
+      shouldPassThroughToGlobalHandler('', key({ upArrow: true }), undefined, {
+        keypress: { raw: '\x1b[1;2A' }
+      })
+    ).toBe(true)
   })
 })

--- a/ui-tui/src/__tests__/textInputVisualRowNav.test.ts
+++ b/ui-tui/src/__tests__/textInputVisualRowNav.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import { visualRowNav } from '../components/textInput.js'
+
+describe('visualRowNav', () => {
+  // ── Hard-newline cases (parity with lineNav) ──────────────────────────
+
+  it('returns null for single-line input that fits in one row (up)', () => {
+    expect(visualRowNav('hello', 3, -1, 80)).toBeNull()
+  })
+
+  it('returns null for single-line input that fits in one row (down)', () => {
+    expect(visualRowNav('hello', 3, 1, 80)).toBeNull()
+  })
+
+  it('moves up across a hard newline preserving column', () => {
+    // "hello\nworld", cols=80 → two visual rows, both under 80 chars
+    // cursor at offset 9 = col 3 of "world" → col 3 of "hello" = offset 3
+    expect(visualRowNav('hello\nworld', 9, -1, 80)).toBe(3)
+  })
+
+  it('moves down across a hard newline preserving column', () => {
+    // cursor at offset 2 = col 2 of "hello" → col 2 of "world" = offset 8
+    expect(visualRowNav('hello\nworld', 2, 1, 80)).toBe(8)
+  })
+
+  it('clamps to end of shorter destination line on up', () => {
+    // "abc\nlong long text" — cursor at col 10 of line 1 → clamp to end of "abc"
+    expect(visualRowNav('abc\nlong long text', 14, -1, 80)).toBe(3)
+  })
+
+  it('clamps to end of shorter destination line on down', () => {
+    // "long long text\nabc" — cursor at col 10 → clamp to end of "abc"
+    expect(visualRowNav('long long text\nabc', 10, 1, 80)).toBe(18)
+  })
+
+  it('returns null when on first line going up', () => {
+    expect(visualRowNav('one\ntwo\nthree', 2, -1, 80)).toBeNull()
+  })
+
+  it('returns null when on last line going down', () => {
+    expect(visualRowNav('one\ntwo\nthree', 10, 1, 80)).toBeNull()
+  })
+
+  // ── Soft-wrap cases (the new behavior) ────────────────────────────────
+
+  it('navigates up within a soft-wrapped line', () => {
+    // "abcdefghij" with cols=5 → visual rows: "abcde" (row 0), "fghij" (row 1)
+    // cursor at offset 7 = 'h' → visual col 2 on row 1 → same col on row 0 = offset 2
+    expect(visualRowNav('abcdefghij', 7, -1, 5)).toBe(2)
+  })
+
+  it('navigates down within a soft-wrapped line', () => {
+    // "abcdefghij" with cols=5 → visual rows: "abcde" (row 0), "fghij" (row 1)
+    // cursor at offset 2 = 'c' → visual col 2 on row 0 → same col on row 1 = offset 7
+    expect(visualRowNav('abcdefghij', 2, 1, 5)).toBe(7)
+  })
+
+  it('returns null going up from first visual row of a soft-wrapped line', () => {
+    // "abcdefghij" with cols=5 → cursor on row 0 → up returns null (history)
+    expect(visualRowNav('abcdefghij', 2, -1, 5)).toBeNull()
+  })
+
+  it('returns null going down from last visual row of a soft-wrapped line', () => {
+    // "abcdefgh" with cols=5 → rows: "abcde" (row 0), "fgh" (row 1)
+    // cursor at offset 6 on row 1 → down returns null (no row 2)
+    expect(visualRowNav('abcdefgh', 6, 1, 5)).toBeNull()
+  })
+
+  it('clamps column when soft-wrapped destination row is shorter', () => {
+    // "abcdefgh" with cols=5 → rows: "abcde" (row 0, 5 chars), "fgh" (row 1, 3 chars)
+    // cursor at offset 4 = 'e' → visual col 4 on row 0 → row 1 only has cols 0-2
+    // should clamp to end of row 1 = offset 8 (end of string)
+    expect(visualRowNav('abcdefgh', 4, 1, 5)).toBe(8)
+  })
+
+  // ── Mixed: hard newlines + soft wraps ─────────────────────────────────
+
+  it('navigates down from a soft-wrapped row into a hard-newline row', () => {
+    // "abcdefghij\nxy" with cols=5
+    // visual rows: "abcde" (row 0), "fghij" (row 1), "xy" (row 2)
+    // cursor at offset 7 = 'h' → visual col 2 on row 1 → row 2 col 2 = offset 13
+    expect(visualRowNav('abcdefghij\nxy', 7, 1, 5)).toBe(13)
+  })
+
+  it('navigates up from a hard-newline row into a soft-wrapped row', () => {
+    // "abcdefghij\nxy" with cols=5
+    // visual rows: "abcde" (row 0), "fghij" (row 1), "xy" (row 2)
+    // cursor at offset 11 = 'x' → visual col 0 on row 2 → row 1 col 0 = offset 5
+    expect(visualRowNav('abcdefghij\nxy', 11, -1, 5)).toBe(5)
+  })
+
+  it('navigates across multiple soft-wrapped rows step by step', () => {
+    // "abcdefghijklmno" with cols=5
+    // visual rows: "abcde" (row 0), "fghij" (row 1), "klmno" (row 2)
+    expect(visualRowNav('abcdefghijklmno', 12, -1, 5)).toBe(7)
+    expect(visualRowNav('abcdefghijklmno', 7, -1, 5)).toBe(2)
+    expect(visualRowNav('abcdefghijklmno', 2, -1, 5)).toBeNull()
+  })
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  it('handles empty string', () => {
+    expect(visualRowNav('', 0, -1, 80)).toBeNull()
+    expect(visualRowNav('', 0, 1, 80)).toBeNull()
+  })
+
+  it('handles cols=1 (every character is its own visual row)', () => {
+    // "abc" with cols=1 → rows: "a" (row 0), "b" (row 1), "c" (row 2)
+    // cursor at offset 1 = 'b' → up → offset 0
+    expect(visualRowNav('abc', 1, -1, 1)).toBe(0)
+    // cursor at offset 1 = 'b' → down → offset 2
+    expect(visualRowNav('abc', 1, 1, 1)).toBe(2)
+  })
+
+  it('handles cursor at end of string on a soft-wrap boundary', () => {
+    // "abcde" with cols=5 fills exactly one visual row; cursor at offset 5
+    // (end) stays on that row under wrap-ansi-aligned cursorLayout.
+    expect(visualRowNav('abcde', 5, 1, 5)).toBeNull()
+    expect(visualRowNav('abcde', 5, -1, 5)).toBeNull()
+  })
+})

--- a/ui-tui/src/__tests__/textInputVisualRowNav.test.ts
+++ b/ui-tui/src/__tests__/textInputVisualRowNav.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { visualRowNav } from '../components/textInput.js'
+import { shouldStopVisualRowNavPropagation, visualRowNav } from '../components/textInput.js'
 
 describe('visualRowNav', () => {
   // ── Hard-newline cases (parity with lineNav) ──────────────────────────
@@ -118,5 +118,28 @@ describe('visualRowNav', () => {
     // (end) stays on that row under wrap-ansi-aligned cursorLayout.
     expect(visualRowNav('abcde', 5, 1, 5)).toBeNull()
     expect(visualRowNav('abcde', 5, -1, 5)).toBeNull()
+  })
+})
+
+describe('shouldStopVisualRowNavPropagation — plain arrows vs Shift+Arrow scroll', () => {
+  const plainUp = { downArrow: false, shift: false, upArrow: true }
+  const plainDown = { downArrow: true, shift: false, upArrow: false }
+  const shiftUp = { downArrow: false, shift: true, upArrow: true }
+  const shiftDown = { downArrow: true, shift: true, upArrow: false }
+
+  it('stops propagation for unmodified Up/Down so history does not also fire', () => {
+    expect(shouldStopVisualRowNavPropagation(plainUp)).toBe(true)
+    expect(shouldStopVisualRowNavPropagation(plainDown)).toBe(true)
+  })
+
+  it('does NOT stop propagation for Shift+Up/Down (transcript scroll)', () => {
+    expect(shouldStopVisualRowNavPropagation(shiftUp)).toBe(false)
+    expect(shouldStopVisualRowNavPropagation(shiftDown)).toBe(false)
+  })
+
+  it('does NOT stop propagation for non-arrow keys', () => {
+    expect(shouldStopVisualRowNavPropagation({ downArrow: false, shift: false, upArrow: false })).toBe(
+      false
+    )
   })
 })

--- a/ui-tui/src/__tests__/textInputVisualRowNav.test.ts
+++ b/ui-tui/src/__tests__/textInputVisualRowNav.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import { visualRowNav } from '../components/textInput.js'
+
+describe('visualRowNav', () => {
+  // ── Hard-newline cases (parity with lineNav) ──────────────────────────
+
+  it('returns null for single-line input that fits in one row (up)', () => {
+    expect(visualRowNav('hello', 3, -1, 80)).toBeNull()
+  })
+
+  it('returns null for single-line input that fits in one row (down)', () => {
+    expect(visualRowNav('hello', 3, 1, 80)).toBeNull()
+  })
+
+  it('moves up across a hard newline preserving column', () => {
+    // "hello\nworld", cols=80 → two visual rows, both under 80 chars
+    // cursor at offset 9 = col 3 of "world" → col 3 of "hello" = offset 3
+    expect(visualRowNav('hello\nworld', 9, -1, 80)).toBe(3)
+  })
+
+  it('moves down across a hard newline preserving column', () => {
+    // cursor at offset 2 = col 2 of "hello" → col 2 of "world" = offset 8
+    expect(visualRowNav('hello\nworld', 2, 1, 80)).toBe(8)
+  })
+
+  it('clamps to end of shorter destination line on up', () => {
+    // "abc\nlong long text" — cursor at col 10 of line 1 → clamp to end of "abc"
+    expect(visualRowNav('abc\nlong long text', 14, -1, 80)).toBe(3)
+  })
+
+  it('clamps to end of shorter destination line on down', () => {
+    // "long long text\nabc" — cursor at col 10 → clamp to end of "abc"
+    expect(visualRowNav('long long text\nabc', 10, 1, 80)).toBe(18)
+  })
+
+  it('returns null when on first line going up', () => {
+    expect(visualRowNav('one\ntwo\nthree', 2, -1, 80)).toBeNull()
+  })
+
+  it('returns null when on last line going down', () => {
+    expect(visualRowNav('one\ntwo\nthree', 10, 1, 80)).toBeNull()
+  })
+
+  // ── Soft-wrap cases (the new behavior) ────────────────────────────────
+
+  it('navigates up within a soft-wrapped line', () => {
+    // "abcdefghij" with cols=5 → visual rows: "abcde" (row 0), "fghij" (row 1)
+    // cursor at offset 7 = 'h' → visual col 2 on row 1
+    // Soft-wrap drift compensation: adjusted col = 2 + (-1) = 1 → offset 1
+    expect(visualRowNav('abcdefghij', 7, -1, 5)).toBe(1)
+  })
+
+  it('navigates down within a soft-wrapped line', () => {
+    // "abcdefghij" with cols=5 → visual rows: "abcde" (row 0), "fghij" (row 1)
+    // cursor at offset 2 = 'c' → visual col 2 on row 0
+    // Soft-wrap drift compensation: adjusted col = 2 + 1 = 3 → offset 8
+    expect(visualRowNav('abcdefghij', 2, 1, 5)).toBe(8)
+  })
+
+  it('returns null going up from first visual row of a soft-wrapped line', () => {
+    // "abcdefghij" with cols=5 → cursor on row 0 → up returns null (history)
+    expect(visualRowNav('abcdefghij', 2, -1, 5)).toBeNull()
+  })
+
+  it('returns null going down from last visual row of a soft-wrapped line', () => {
+    // "abcdefgh" with cols=5 → rows: "abcde" (row 0), "fgh" (row 1)
+    // cursor at offset 6 on row 1 → down returns null (no row 2)
+    expect(visualRowNav('abcdefgh', 6, 1, 5)).toBeNull()
+  })
+
+  it('clamps column when soft-wrapped destination row is shorter', () => {
+    // "abcdefgh" with cols=5 → rows: "abcde" (row 0, 5 chars), "fgh" (row 1, 3 chars)
+    // cursor at offset 4 = 'e' → visual col 4 on row 0 → row 1 only has cols 0-2
+    // should clamp to end of row 1 = offset 8 (end of string)
+    expect(visualRowNav('abcdefgh', 4, 1, 5)).toBe(8)
+  })
+
+  // ── Mixed: hard newlines + soft wraps ─────────────────────────────────
+
+  it('navigates down from a soft-wrapped row into a hard-newline row', () => {
+    // "abcdefghij\nxy" with cols=5
+    // visual rows: "abcde" (row 0), "fghij" (row 1), "xy" (row 2)
+    // cursor at offset 7 = 'h' → visual col 2 on row 1
+    // srcDrift=1 (row 1 within "abcdefghij"), dstDrift=0 (row 0 within "xy")
+    // compensation = -1, adjustedCol = 1 → offset 12 ('y')
+    expect(visualRowNav('abcdefghij\nxy', 7, 1, 5)).toBe(12)
+  })
+
+  it('navigates up from a hard-newline row into a soft-wrapped row', () => {
+    // "abcdefghij\nxy" with cols=5
+    // visual rows: "abcde" (row 0), "fghij" (row 1), "xy" (row 2)
+    // cursor at offset 11 = 'x' → visual col 0 on row 2
+    // srcDrift=0 (row 0 within "xy"), dstDrift=1 (row 1 within "abcdefghij")
+    // compensation = +1, adjustedCol = 1 → offset 6 ('g')
+    expect(visualRowNav('abcdefghij\nxy', 11, -1, 5)).toBe(6)
+  })
+
+  it('navigates across multiple soft-wrapped rows step by step', () => {
+    // "abcdefghijklmno" with cols=5
+    // visual rows: "abcde" (row 0), "fghij" (row 1), "klmno" (row 2)
+    // cursor at offset 12 = 'm' → visual col 2, adjusted col 1 → offset 6
+    expect(visualRowNav('abcdefghijklmno', 12, -1, 5)).toBe(6)
+    // then from offset 6 = 'g' → visual col 1, adjusted col 0 → offset 0
+    expect(visualRowNav('abcdefghijklmno', 6, -1, 5)).toBe(0)
+  })
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  it('handles empty string', () => {
+    expect(visualRowNav('', 0, -1, 80)).toBeNull()
+    expect(visualRowNav('', 0, 1, 80)).toBeNull()
+  })
+
+  it('handles cols=1 (every character is its own visual row)', () => {
+    // "abc" with cols=1 → rows: "a" (row 0), "b" (row 1), "c" (row 2)
+    // cursor at offset 1 = 'b' → up → offset 0
+    expect(visualRowNav('abc', 1, -1, 1)).toBe(0)
+    // cursor at offset 1 = 'b' → down → offset 2
+    expect(visualRowNav('abc', 1, 1, 1)).toBe(2)
+  })
+
+  it('handles cursor at end of string on a soft-wrap boundary', () => {
+    // "abcde" with cols=5 → row 0 = "abcde", cursor at offset 5 (end)
+    // cursorLayout puts this on row 1 col 0 (trailing overflow)
+    // down from row 1 → null (no row 2)
+    expect(visualRowNav('abcde', 5, 1, 5)).toBeNull()
+    // up from row 1 → row 0 col 0 = offset 0
+    expect(visualRowNav('abcde', 5, -1, 5)).toBe(0)
+  })
+})

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -16,6 +16,12 @@ import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionW
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 
 import { getInputSelection } from './inputSelectionStore.js'
+import {
+  getComposerDraftCursor,
+  rememberComposerDraftCursor,
+  requestComposerCursorRestore,
+  setComposerDraftCursorFrozen
+} from '../lib/composerDraftCursor.js'
 import type {
   GatewayRpc,
   InputHandlerActions,
@@ -243,6 +249,16 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       if (cur === null) {
         cRefs.historyDraftRef.current = cState.input
+        // Seed memory if the composer never recorded an edit cursor yet.
+        if (getComposerDraftCursor() === null) {
+          const live = getInputSelection()
+          const liveCursor =
+            live && live.start === live.end ? live.start : (live?.end ?? cState.input.length)
+
+          rememberComposerDraftCursor(liveCursor)
+        }
+        // Freeze so history-entry cursors cannot overwrite the draft position.
+        setComposerDraftCursorFrozen(true)
       }
 
       const index = cur === null ? h.length - 1 : Math.max(0, cur - 1)
@@ -262,7 +278,9 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
     if (next >= h.length) {
       cActions.setHistoryIdx(null)
+      requestComposerCursorRestore(getComposerDraftCursor())
       cActions.setInput(cRefs.historyDraftRef.current)
+      setComposerDraftCursorFrozen(false)
     } else {
       cActions.setHistoryIdx(next)
       cActions.setInput(h[next] ?? '')

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -4,6 +4,11 @@ import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'rea
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import {
+  rememberComposerDraftCursor,
+  setComposerDraftCursorSuppress,
+  takeComposerCursorRestore
+} from '../lib/composerDraftCursor.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
@@ -269,6 +274,28 @@ export function shouldStopVisualRowNavPropagation(
   key: Pick<Key, 'downArrow' | 'shift' | 'upArrow'>
 ): boolean {
   return (key.upArrow || key.downArrow) && !key.shift
+}
+
+/**
+ * Detect Shift+Arrow even when a terminal reports the CSI sequence but leaves
+ * `key.shift` false (some macOS / SSH setups). Matches `;2A/B` style modifiers
+ * and kitty CSI-u shift encodings in the raw keypress.
+ */
+export function isShiftArrowChord(
+  key: Pick<Key, 'downArrow' | 'shift' | 'upArrow'>,
+  event?: { keypress?: { raw?: string; sequence?: string } }
+): boolean {
+  if (!(key.upArrow || key.downArrow)) {
+    return false
+  }
+
+  if (key.shift) {
+    return true
+  }
+
+  const raw = `${event?.keypress?.raw ?? ''}${event?.keypress?.sequence ?? ''}`
+
+  return /;2[AB](?:$|[^0-9])/.test(raw) || /\[\d+;2u/.test(raw) || /\x1b\[(?:1;2|2)[AB]/.test(raw)
 }
 
 export { offsetFromPosition }
@@ -678,14 +705,18 @@ export function TextInput({
     if (self.current) {
       self.current = false
     } else {
-      setCur(value.length)
+      const nextCur = Math.max(0, Math.min(takeComposerCursorRestore(value.length), value.length))
+
+      setCur(nextCur)
       setSel(null)
-      curRef.current = value.length
+      curRef.current = nextCur
       selRef.current = null
       vRef.current = value
       lineWidthRef.current = stringWidth(value.includes('\n') ? value.slice(value.lastIndexOf('\n') + 1) : value)
       undo.current = []
       redo.current = []
+      // Do not remember here — external value changes include history browse,
+      // which must not clobber the frozen draft edit cursor.
     }
   }, [value])
 
@@ -823,6 +854,7 @@ export function TextInput({
 
     curRef.current = c
     vRef.current = next
+    rememberComposerDraftCursor(c)
     lineWidthRef.current =
       nextLineWidth ?? stringWidth(next.includes('\n') ? next.slice(next.lastIndexOf('\n') + 1) : next)
 
@@ -939,6 +971,7 @@ export function TextInput({
 
     setCur(c)
     curRef.current = c
+    rememberComposerDraftCursor(c)
   }
 
   const selRange = () => {
@@ -1039,7 +1072,7 @@ export function TextInput({
       // actually get voice toggled instead of a paste (Copilot round-7
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
-      if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
+      if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey, event)) {
         flushKeyBurst()
 
         return
@@ -1084,22 +1117,28 @@ export function TextInput({
 
       if (k.upArrow || k.downArrow) {
         // Shift+Up/Down scrolls the transcript in useInputHandlers — leave those alone.
-        if (k.shift) {
+        if (k.shift || isShiftArrowChord(k, event)) {
           return
         }
 
         flushKeyBurst()
 
-        const next = visualRowNav(vRef.current, curRef.current, k.upArrow ? -1 : 1, columns)
+        // Climbing Up toward history must not overwrite the last edit cursor with 0.
+        setComposerDraftCursorSuppress(k.upArrow)
+        try {
+          const next = visualRowNav(vRef.current, curRef.current, k.upArrow ? -1 : 1, columns)
 
-        if (next !== null && shouldStopVisualRowNavPropagation(k)) {
-          event.stopImmediatePropagation?.()
-          moveCursor(next)
+          if (next !== null && shouldStopVisualRowNavPropagation(k)) {
+            event.stopImmediatePropagation?.()
+            moveCursor(next)
+
+            return
+          }
 
           return
+        } finally {
+          setComposerDraftCursorSuppress(false)
         }
-
-        return
       }
 
       if (k.return) {
@@ -1462,7 +1501,8 @@ export function decideRightClickAction(
 export const shouldPassThroughToGlobalHandler = (
   input: string,
   key: Key,
-  voiceRecordKey: ParsedVoiceRecordKey = DEFAULT_VOICE_RECORD_KEY
+  voiceRecordKey: ParsedVoiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
+  event?: { keypress?: { raw?: string; sequence?: string } }
 ): boolean =>
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
@@ -1471,6 +1511,7 @@ export const shouldPassThroughToGlobalHandler = (
   key.pageUp ||
   key.pageDown ||
   key.escape ||
+  isShiftArrowChord(key, event) ||
   isVoiceToggleKey(key, input, voiceRecordKey)
 
 export interface TextInputMouseApi {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -237,6 +237,29 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
   return snapPos(s, Math.min(nextBreak + 1 + col, lineEnd))
 }
 
+/**
+ * Move cursor one visual row up or down, taking into account both hard newlines
+ * and soft-wrap boundaries at the given column width. Uses cursorLayout()
+ * to find the cursor's current visual row/col, then offsetFromPosition()
+ * to land on the same column in the adjacent row.
+ *
+ * Returns null when the cursor is already on the first visual row (up) or
+ * last visual row (down). Callers use that to fall through to history navigation.
+ */
+export function visualRowNav(s: string, p: number, dir: -1 | 1, cols: number): null | number {
+  const w = Math.max(1, cols)
+  const pos = snapPos(s, p)
+  const { line: curRow, column: curCol } = cursorLayout(s, pos, w)
+  const { line: lastRow } = cursorLayout(s, s.length, w)
+  const targetRow = curRow + dir
+
+  if (targetRow < 0 || targetRow > lastRow) {
+    return null
+  }
+
+  return snapPos(s, offsetFromPosition(s, targetRow, curCol, w))
+}
+
 export { offsetFromPosition }
 
 const ASCII_PRINTABLE_RE = /^[\x20-\x7e]+$/
@@ -1051,9 +1074,10 @@ export function TextInput({
       if (k.upArrow || k.downArrow) {
         flushKeyBurst()
 
-        const next = lineNav(vRef.current, curRef.current, k.upArrow ? -1 : 1)
+        const next = visualRowNav(vRef.current, curRef.current, k.upArrow ? -1 : 1, columns)
 
         if (next !== null) {
+          event.stopImmediatePropagation?.()
           moveCursor(next, k.shift)
 
           return

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -260,6 +260,17 @@ export function visualRowNav(s: string, p: number, dir: -1 | 1, cols: number): n
   return snapPos(s, offsetFromPosition(s, targetRow, curCol, w))
 }
 
+/**
+ * Whether a successful visual-row Up/Down move should stop the event from
+ * reaching useInputHandlers (history cycling). Plain arrows: yes.
+ * Shift+Up/Down: no — those chords scroll the transcript.
+ */
+export function shouldStopVisualRowNavPropagation(
+  key: Pick<Key, 'downArrow' | 'shift' | 'upArrow'>
+): boolean {
+  return (key.upArrow || key.downArrow) && !key.shift
+}
+
 export { offsetFromPosition }
 
 const ASCII_PRINTABLE_RE = /^[\x20-\x7e]+$/
@@ -1072,13 +1083,18 @@ export function TextInput({
       }
 
       if (k.upArrow || k.downArrow) {
+        // Shift+Up/Down scrolls the transcript in useInputHandlers — leave those alone.
+        if (k.shift) {
+          return
+        }
+
         flushKeyBurst()
 
         const next = visualRowNav(vRef.current, curRef.current, k.upArrow ? -1 : 1, columns)
 
-        if (next !== null) {
+        if (next !== null && shouldStopVisualRowNavPropagation(k)) {
           event.stopImmediatePropagation?.()
-          moveCursor(next, k.shift)
+          moveCursor(next)
 
           return
         }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -167,6 +167,62 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
   return snapPos(s, Math.min(nextBreak + 1 + col, lineEnd))
 }
 
+/**
+ * Return the visual row index of the start of the logical (hard-newline-
+ * delimited) line that contains string offset `pos`. This tells us how many
+ * soft-wrap rows precede `pos` within its logical line.
+ */
+function logicalLineStartRow(s: string, pos: number, w: number): number {
+  const lineStart = s.lastIndexOf('\n', pos - 1) + 1 // 0 if no prior \n
+  return cursorLayout(s, lineStart, w).line
+}
+
+/**
+ * Move cursor one visual row up or down, taking into account both hard newlines
+ * and softwrap boundaries at the given column width. Uses cursorLayout()
+ * to find the cursor's current visual row/col, then offsetFromPosition()
+ * to land on the same column in the adjacent row.
+ *
+ * Returns null when the cursor is already on the first visual row (up) or
+ * last visual row (down). This tells the caller to fall through to history navigation.
+ */
+export function visualRowNav(s: string, p: number, dir: -1 | 1, cols: number): null | number {
+  const w = Math.max(1, cols)
+  const pos = snapPos(s, p)
+  const { line: curRow, column: curCol } = cursorLayout(s, pos, w)
+
+  // Compute total visual rows by measuring the layout position at the end of
+  // the string. The trailing-cursor overflow in cursorLayout means that if the
+  // last character exactly fills the row, the cursor sits on a new empty row,
+  // which is correct — that empty row is navigable.
+  const { line: lastRow } = cursorLayout(s, s.length, w)
+
+  const targetRow = curRow + dir
+
+  if (targetRow < 0 || targetRow > lastRow) {
+    return null
+  }
+
+  // The Ink rendering pipeline introduces a cumulative visual drift on soft-
+  // wrapped rows: visual row N within a logical line is shifted by N columns
+  // relative to the data model. When crossing between rows we must compensate
+  // for the difference in accumulated drift between the source and destination.
+  //
+  // srcDrift = curRow - (visual row of source logical line start)
+  // dstDrift = targetRow - (visual row of destination logical line start)
+  // compensation = dstDrift - srcDrift
+  const rawNext = offsetFromPosition(s, targetRow, curCol, w)
+  const srcDrift = curRow - logicalLineStartRow(s, pos, w)
+  const dstDrift = targetRow - logicalLineStartRow(s, Math.min(rawNext, s.length), w)
+  const compensation = dstDrift - srcDrift
+  const adjustedCol = Math.min(w - 1, Math.max(0, curCol + compensation))
+  const next = compensation !== 0
+    ? offsetFromPosition(s, targetRow, adjustedCol, w)
+    : rawNext
+
+  return snapPos(s, next)
+}
+
 // mirrors wrap-ansi(..., { wordWrap: false, hard: true }) so the declared
 // cursor lines up with what <Text wrap="wrap-char"> actually renders
 export function cursorLayout(value: string, cursor: number, cols: number) {
@@ -610,9 +666,10 @@ export function TextInput({
       }
 
       if (k.upArrow || k.downArrow) {
-        const next = lineNav(vRef.current, curRef.current, k.upArrow ? -1 : 1)
+        const next = visualRowNav(vRef.current, curRef.current, k.upArrow ? -1 : 1, columns)
 
         if (next !== null) {
+          ;(event as unknown as { stopImmediatePropagation: () => void }).stopImmediatePropagation()
           clearSel()
           setCur(next)
           curRef.current = next

--- a/ui-tui/src/lib/composerDraftCursor.ts
+++ b/ui-tui/src/lib/composerDraftCursor.ts
@@ -1,0 +1,68 @@
+/**
+ * Draft-cursor memory for classic-style Up/Down history in the TUI composer.
+ *
+ * TextInput parks the cursor at end-of-value on external `value` changes unless
+ * we request a restore. Climbing Up through rows, and browsing history entries,
+ * must not overwrite the last real edit position on the working draft.
+ */
+
+type DraftCursorSlot = {
+  pos: number | null
+  /** True while Up-climbing visual rows toward history. */
+  suppress: boolean
+  /** True while browsing history (not on the working draft). */
+  frozen: boolean
+  pendingRestore: number | null
+}
+
+const slot: DraftCursorSlot = {
+  pos: null,
+  suppress: false,
+  frozen: false,
+  pendingRestore: null
+}
+
+export function rememberComposerDraftCursor(pos: number): void {
+  if (slot.suppress || slot.frozen) {
+    return
+  }
+
+  slot.pos = Math.max(0, pos)
+}
+
+export function getComposerDraftCursor(): number | null {
+  return slot.pos
+}
+
+export function setComposerDraftCursorSuppress(on: boolean): void {
+  slot.suppress = on
+}
+
+/** Lock memory while history entries are shown so their cursors cannot clobber it. */
+export function setComposerDraftCursorFrozen(on: boolean): void {
+  slot.frozen = on
+}
+
+/** Ask TextInput to use this cursor on the next external `value` change. */
+export function requestComposerCursorRestore(pos: number | null): void {
+  slot.pendingRestore = pos === null ? null : Math.max(0, pos)
+}
+
+export function takeComposerCursorRestore(fallback: number): number {
+  if (slot.pendingRestore === null) {
+    return fallback
+  }
+
+  const next = slot.pendingRestore
+  slot.pendingRestore = null
+
+  return next
+}
+
+/** Test helper — reset module state between cases. */
+export function resetComposerDraftCursorStateForTests(): void {
+  slot.pos = null
+  slot.suppress = false
+  slot.frozen = false
+  slot.pendingRestore = null
+}


### PR DESCRIPTION
### What does this PR do?

Up/Down arrow keys in the new TUI's `TextInput` component allow navigation between lines with hard returns, but do not navigate between the visual rows of soft-wrapped input. Pressing Up or Down on a long prompt that wraps across multiple lines visually does not bring you to the visual line above or below within the same logical line. It either moves up/down a logical line, or correctly falls through to history cycling if at the topmost or bottom-most line in the prompt (handled by `useInputHandlers`). Gemini CLI and others do handle softwrapped cursor movement correctly, so I decided to submit this PR so that Hermes Agent could have it too.

PR #13726 (merged Apr 21) addressed a related problem for **hard newlines** (Shift-Enter): it detects logical lines and moves the cursor between them, instead of immediately falling through to history navigation. However, soft-wrapped rows within a single logical line are still not handled — the cursor still cannot move up or down within a long single-line prompt that visually spans multiple rows.

My own PR #12763 provides this fix for the CLI (`cli.py`) using `prompt_toolkit`'s `WindowRenderInfo`. This PR brings the same capability to TUI v2's `TextInput`.

### Changes Made

This is minimally invasive, building upon the existing codebase in a low impact way. The added/removed lines are just 58/1 and only `textInput.tsx` is touched. A new `visualRowNav()` function in `textInput.tsx` uses `cursorLayout()` to find the cursor's current visual row and column, then `offsetFromPosition()` to land on the same column in the adjacent row. When navigation succeeds (the cursor is not on the first or last visual row), the event is stopped with `stopImmediatePropagation()` so it does not bubble to `useInputHandlers` for history cycling. This turned out to be very important as both were getting fired. When `visualRowNav` returns `null` (boundary reached), the existing fall-through to history navigation is preserved.

A helper function `logicalLineStartRow()` supports the drift compensation described below.

#### Drift compensation for `@hermes/ink` rendering problem

The `@hermes/ink` rendering pipeline (which uses `wrap-ansi` for text wrapping) seems to introduce a cumulative visual column drift on soft-wrapped rows: when moving down to the next row from the bottom visual row of a softwrapped line, the cursor is weirdly shifted by n columns to the right, where n is the no. of visual lines minus one. For example, in a 3-visual-row soft-wrapped line, pressing down arrow on the bottom line moves to the next line correctly but the cursor is visually offset by +2 columns, even though the data shows that it is at a position directly below.

`visualRowNav` compensates by computing the drift at the source and destination rows (`srcDrift` and `dstDrift`, each being the visual row's index within its logical line) and adjusting the target column by `dstDrift - srcDrift`. Hard-newline boundaries have zero drift, so no compensation is applied when both sides are at row 0 of their respective logical lines. I decided to do this in order to have the arrows work perfectly, without disturbing ink or Hermes code, and I have tested various edge conditions so it is solid.

**Note to the maintainer:** If the core `@hermes/ink` / `wrap-ansi` text wrapping is ever updated to eliminate this per-row visual shift, the compensation block in `visualRowNav` (the `logicalLineStartRow` / `srcDrift` / `dstDrift` / `compensation` logic) should be removed.

### How to Test

1. Start the TUI: `hermes --tui`
2. Type or paste a prompt long enough to soft-wrap across 2-3 visual rows
3. Press Up/Down arrows — the cursor should move vertically, preserving its column position
4. Verify that pressing Up on the first visual row or Down on the last visual row still moves to the previous/next logical line in the `TextInput`, or cycles through history if there is no such line
5. For mixed content: paste text containing hard newlines alongside soft-wrapped lines, and verify Up/Down navigates correctly across both boundary types (I had to copy-paste because on MacOS control-J or shift-return were not working when I tested my code).

### Checklist

**Code**
- [x] I've read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — 19 new unit tests added to `textInputVisualRowNav.test.ts` covering single-line, hard-newline, soft-wrap, mixed boundary, and edge cases
- [x] I've tested on my platform: macOS (terminal widths 105 and 125 columns)

**Documentation & Housekeeping**
- [x] I've updated relevant documentation — N/A (no public API or config change)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fix relies purely on string manipulation and column counting, which are platform-independent
- [x] I've updated tool descriptions/schemas — N/A

### Related PRs

| PR | Status | Scope | Relationship |
|---|---|---|---|
| #13726 | Merged | TUI v2 | Hard-newline Up/Down navigation; this PR extends it to soft-wrapped rows |
| #12763 | Open | CLI (`cli.py`) | Equivalent soft-wrap fix for the Hermes CLI using `prompt_toolkit` |
| #14103 | Closed (cherry-picked) | TUI v2 | Fixed `columns` width mismatch (`cols - pw - 2`) and GoodVibesHeart overpaint; both fixes are already in the current codebase and our change depends on the correct width |

### Known upstream issue (not addressed here)

With terminal width 105, the softwrapped line kept rewrapping, but that problem was not there with 125 cols. This is a pre-existing layout interaction in `@hermes/ink` (likely a yoga layout recalculation when content changes near the wrap boundary) and is independent of cursor navigation. It reproduces with and without this PR.

## Files changed

| File | Removed | Added | Change |
|---|---|---|---|
| `ui-tui/src/components/textInput.tsx` | 1 | 58 | Added `logicalLineStartRow()`, `visualRowNav()`; replaced `lineNav` call with `visualRowNav` in the Up/Down handler; added `stopImmediatePropagation()` |
| `ui-tui/src/__tests__/textInputVisualRowNav.test.ts` | 0 | 131 | New: 19 unit tests covering single-line, hard-newline, soft-wrap, mixed boundary, and edge cases |
