### PR TITLE
fix(delegate): inherit parent api_key when delegation.base_url set without delegation.api_key (#15810)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -821,7 +821,9 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
-    def test_direct_endpoint_falls_back_to_openai_api_key_env(self):
+    def test_direct_endpoint_returns_none_api_key_when_not_configured(self):
+        # When base_url is set without api_key, api_key should be None so
+        # _spawn_child inherits the parent's key (effective_api_key = override or parent).
         parent = _make_mock_parent(depth=0)
         cfg = {
             "model": "qwen2.5-coder",
@@ -829,10 +831,11 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         }
         with patch.dict(os.environ, {"OPENAI_API_KEY": "env-openai-key"}, clear=False):
             creds = _resolve_delegation_credentials(cfg, parent)
-        self.assertEqual(creds["api_key"], "env-openai-key")
+        self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
-    def test_direct_endpoint_does_not_fall_back_to_openrouter_api_key_env(self):
+    def test_direct_endpoint_no_raise_when_only_provider_env_key_present(self):
+        # Even if OPENAI_API_KEY is absent, no ValueError — parent key is the fallback.
         parent = _make_mock_parent(depth=0)
         cfg = {
             "model": "qwen2.5-coder",
@@ -846,9 +849,8 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             },
             clear=False,
         ):
-            with self.assertRaises(ValueError) as ctx:
-                _resolve_delegation_credentials(cfg, parent)
-        self.assertIn("OPENAI_API_KEY", str(ctx.exception))
+            creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertIsNone(creds["api_key"])
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_nous_provider_resolves_nous_credentials(self, mock_resolve):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -823,7 +823,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
 
     def test_direct_endpoint_returns_none_api_key_when_not_configured(self):
         # When base_url is set without api_key, api_key should be None so
-        # _spawn_child inherits the parent's key (effective_api_key = override or parent).
+        # _build_child_agent inherits the parent's key (effective_api_key = override or parent).
         parent = _make_mock_parent(depth=0)
         cfg = {
             "model": "qwen2.5-coder",
@@ -835,7 +835,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["provider"], "custom")
 
     def test_direct_endpoint_no_raise_when_only_provider_env_key_present(self):
-        # Even if OPENAI_API_KEY is absent, no ValueError — parent key is the fallback.
+        # Even if OPENAI_API_KEY is absent, no ValueError — _build_child_agent uses parent key.
         parent = _make_mock_parent(depth=0)
         cfg = {
             "model": "qwen2.5-coder",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2231,8 +2231,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
     If ``delegation.base_url`` is configured, subagents use that direct
     OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
-    omitted, ``api_key`` is returned as None so ``_spawn_child`` inherits the
-    parent agent's key (``effective_api_key = override_api_key or parent_api_key``).
+    omitted, ``api_key`` is returned as None so ``_build_child_agent`` inherits
+    the parent agent's key (``effective_api_key = override_api_key or parent_api_key``).
     This lets providers that store their key outside ``OPENAI_API_KEY`` (e.g.
     ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work without a duplicate config entry.
 
@@ -2251,13 +2251,13 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
     if configured_base_url:
-        # When delegation.api_key is not set, return None so _spawn_child falls
-        # back to the parent agent's API key via the credential inheritance path
-        # (effective_api_key = override_api_key or parent_api_key).  This lets
-        # providers that store their key in a non-OPENAI_API_KEY env var (e.g.
-        # MINIMAX_API_KEY, DASHSCOPE_API_KEY) work without requiring callers to
-        # duplicate the key under delegation.api_key.
-        api_key = configured_api_key  # None → inherited from parent in _spawn_child
+        # When delegation.api_key is not set, return None so _build_child_agent
+        # falls back to the parent agent's API key via the credential inheritance
+        # path (effective_api_key = override_api_key or parent_api_key).  This
+        # lets providers that store their key in a non-OPENAI_API_KEY env var
+        # (e.g. MINIMAX_API_KEY, DASHSCOPE_API_KEY) work without requiring
+        # callers to duplicate the key under delegation.api_key.
+        api_key = configured_api_key  # None → inherited from parent in _build_child_agent
 
         base_lower = configured_base_url.lower()
         provider = "custom"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2230,11 +2230,15 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
-    OpenAI-compatible endpoint. Otherwise, if ``delegation.provider`` is
-    configured, the full credential bundle (base_url, api_key, api_mode,
-    provider) is resolved via the runtime provider system — the same path used
-    by CLI/gateway startup. This lets subagents run on a completely different
-    provider:model pair.
+    OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
+    omitted, ``api_key`` is returned as None so ``_spawn_child`` inherits the
+    parent agent's key (``effective_api_key = override_api_key or parent_api_key``).
+    This lets providers that store their key outside ``OPENAI_API_KEY`` (e.g.
+    ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work without a duplicate config entry.
+
+    If ``delegation.provider`` is configured instead, the full credential bundle
+    (base_url, api_key, api_mode, provider) is resolved via the runtime provider
+    system — the same path used by CLI/gateway startup.
 
     If neither base_url nor provider is configured, returns None values so the
     child inherits everything from the parent agent.
@@ -2247,12 +2251,13 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
     if configured_base_url:
-        api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
-        if not api_key:
-            raise ValueError(
-                "Delegation base_url is configured but no API key was found. "
-                "Set delegation.api_key or OPENAI_API_KEY."
-            )
+        # When delegation.api_key is not set, return None so _spawn_child falls
+        # back to the parent agent's API key via the credential inheritance path
+        # (effective_api_key = override_api_key or parent_api_key).  This lets
+        # providers that store their key in a non-OPENAI_API_KEY env var (e.g.
+        # MINIMAX_API_KEY, DASHSCOPE_API_KEY) work without requiring callers to
+        # duplicate the key under delegation.api_key.
+        api_key = configured_api_key  # None → inherited from parent in _spawn_child
 
         base_lower = configured_base_url.lower()
         provider = "custom"


### PR DESCRIPTION
## Summary
- When `delegation.base_url` is configured without `delegation.api_key`, the child agent now inherits the parent's resolved API key instead of falling back to `OPENAI_API_KEY`
- Explicit `delegation.api_key` still overrides as before
- Two tests updated to reflect the corrected behaviour

## The bug

`_resolve_delegation_credentials()` handled the `delegation.base_url` path as:

```python
api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
if not api_key:
    raise ValueError("... Set delegation.api_key or OPENAI_API_KEY.")
```

This bypassed the provider credential pool entirely. Providers that store their key outside `OPENAI_API_KEY` (e.g. `MINIMAX_API_KEY`, `DASHSCOPE_API_KEY`) therefore caused the child agent to receive an empty API key → 401 Unauthorized. By contrast, the `delegation.provider`-only path correctly resolved credentials via `resolve_runtime_provider()`.

## The fix

When `delegation.api_key` is absent, return `api_key = None` instead of the `OPENAI_API_KEY` fallback. `_spawn_child` already has the correct inheritance logic:

```python
effective_api_key = override_api_key or parent_api_key
```

With `override_api_key = None`, this naturally falls through to `parent_api_key`, which holds the key the parent agent resolved through the full provider credential chain.

## Test plan
- [x] **Before**: `test_direct_endpoint_returns_none_api_key_when_not_configured` and `test_direct_endpoint_no_raise_when_only_provider_env_key_present` — both **FAIL** on unpatched code (one gets wrong `"env-openai-key"`, one expects no `ValueError` but gets one)
- [x] **After**: 115/115 tests pass in `tests/tools/test_delegate.py`
- [x] **Regression guard**: reverted production change → both new tests fail; restored → 0 failures
- [x] Adjacent toolset tests unchanged

## Related
- Fixes #15810

🤖 Generated with [Claude Code](https://claude.com/claude-code)