### PR TITLE
feat(slack): convert markdown tables to monospace code blocks

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -496,6 +496,58 @@ class SlackAdapter(BasePlatformAdapter):
         # 2) Protect inline code (`...`)
         text = re.sub(r'(`[^`]+`)', lambda m: _ph(m.group(0)), text)
 
+        # 2b) Convert markdown tables → monospace code blocks.
+        # Slack has no native table support; wrapping in ``` gives clean fixed-width rendering.
+        # Handles two styles:
+        #   A) Pipe tables:  | col | col |  (GFM standard)
+        #   B) Space-aligned tables: plain text header + dash separator line + rows
+        def _wrap_as_code_block(raw: str) -> str:
+            """Wrap raw text as a fenced code block placeholder, stripping inline markup."""
+            # Strip markdown bold (**text** or __text__) and inline code (`text`) markers
+            # so they don't get mangled by later passes inside the code block
+            clean = re.sub(r'\*\*(.+?)\*\*', r'\1', raw)
+            clean = re.sub(r'__(.+?)__', r'\1', clean)
+            clean = re.sub(r'`([^`]+)`', r'\1', clean)
+            return _ph('```\n' + clean.rstrip() + '\n```\n')
+
+        def _convert_pipe_table(m: re.Match) -> str:
+            raw = m.group(0)
+            lines = raw.splitlines()
+            # Filter out separator rows (---|---|---) to keep the block compact
+            visible = [l for l in lines if not re.match(r'^\s*\|?[\s:]*-+[\s:|-]*\|?\s*$', l)]
+            if not visible:
+                return _wrap_as_code_block(raw)
+            def _cells(row: str):
+                return [c.strip() for c in row.strip().strip('|').split('|')]
+            rows = [_cells(l) for l in visible]
+            col_widths = [max(len(re.sub(r'\*\*(.+?)\*\*', r'\1', re.sub(r'`([^`]+)`', r'\1', r[i]))) if i < len(r) else 0 for r in rows)
+                          for i in range(max(len(r) for r in rows))]
+            formatted_lines = []
+            for i, row in enumerate(rows):
+                # Strip inline markup from cells before aligning
+                clean_row = [re.sub(r'\*\*(.+?)\*\*', r'\1', re.sub(r'`([^`]+)`', r'\1', c)) for c in row]
+                padded = '  '.join(c.ljust(col_widths[j]) if j < len(clean_row) else ' ' * col_widths[j]
+                                   for j, c in enumerate(clean_row))
+                formatted_lines.append(padded.rstrip())
+                if i == 0:
+                    formatted_lines.append('-' * sum(col_widths) + '-' * (2 * (len(col_widths) - 1)))
+            return _ph('```\n' + '\n'.join(formatted_lines).rstrip() + '\n```\n')
+
+        # Style A: pipe tables  | col | col |
+        text = re.sub(
+            r'(?m)^(\|.+\|\s*\n)(\|[\s:|-]+\|\s*\n)(\|.+\|\s*\n?)*',
+            _convert_pipe_table,
+            text,
+        )
+
+        # Style B: space-aligned tables — header line + pure-dashes separator (≥10 dashes) + data rows
+        # The separator line is a row of dashes/spaces only, at least 10 chars wide.
+        text = re.sub(
+            r'(?m)^([^\n|`]{10,}\n)([-]{10,}[-\s]*\n)([^\n|`]{1,}\n?)+',
+            lambda m: _wrap_as_code_block(m.group(0)),
+            text,
+        )
+
         # 3) Convert markdown links [text](url) → <url|text>
         def _convert_markdown_link(m):
             label = m.group(1)


### PR DESCRIPTION
## Summary

Slack has no native table rendering support. When the LLM produces markdown tables, they render as broken pipe-delimited text in Slack messages.

This PR converts markdown tables into monospace code blocks during the markdown-to-Slack formatting pass, producing clean fixed-width rendering.

### Two table styles handled:

**Style A — GFM pipe tables:**
```
| Metric | Value |
|--------|-------|
| CPU    | 85%   |
```

**Style B — Space-aligned tables:**
```
Service Name     Status    Latency
--------------------------------------
payment-api      healthy   12ms
```

Both are wrapped in fenced code blocks with:
- Inline markup stripped (bold, code) so they don't get mangled
- Column alignment preserved via padding
- Separator rows filtered for compactness (pipe tables)

### Insertion point

Added as step 2b (between inline code protection and link conversion) in `_md_to_slack()`, so tables are captured before other transformations modify pipe characters or formatting.

Ref: NousResearch/hermes-agent#11198 (original PR with deleted source branch)