### PR TITLE
fix(codex): honor runtime base url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -829,6 +829,23 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
+def _resolve_codex_runtime_api() -> Tuple[Optional[str], str]:
+    """Return a fresh Codex OAuth token plus its runtime base URL."""
+    try:
+        from hermes_cli.auth import resolve_codex_runtime_credentials
+
+        creds = resolve_codex_runtime_credentials()
+        token = str(creds.get("api_key") or "").strip()
+        base_url = str(creds.get("base_url") or "").strip().rstrip("/")
+        if token:
+            return token, base_url or _CODEX_AUX_BASE_URL
+    except Exception as exc:
+        logger.debug("Could not resolve Codex runtime credentials: %s", exc)
+
+    token = _read_codex_access_token()
+    return token, _CODEX_AUX_BASE_URL
+
+
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
     """Try each API-key provider in PROVIDER_REGISTRY order.
 
@@ -1201,15 +1218,13 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
         if codex_token:
             base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
         else:
-            codex_token = _read_codex_access_token()
+            codex_token, base_url = _resolve_codex_runtime_api()
             if not codex_token:
                 return None, None
-            base_url = _CODEX_AUX_BASE_URL
     else:
-        codex_token = _read_codex_access_token()
+        codex_token, base_url = _resolve_codex_runtime_api()
         if not codex_token:
             return None, None
-        base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
     real_client = OpenAI(
         api_key=codex_token,
@@ -1797,7 +1812,7 @@ def resolve_provider_client(
         if raw_codex:
             # Return the raw OpenAI client for callers that need direct
             # access to responses.stream() (e.g., the main agent loop).
-            codex_token = _read_codex_access_token()
+            codex_token, codex_base_url = _resolve_codex_runtime_api()
             if not codex_token:
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")
@@ -1805,7 +1820,7 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model or _CODEX_AUX_MODEL, provider)
             raw_client = OpenAI(
                 api_key=codex_token,
-                base_url=_CODEX_AUX_BASE_URL,
+                base_url=codex_base_url,
                 default_headers=_codex_cloudflare_headers(codex_token),
             )
             return (raw_client, final_model)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1250,7 +1250,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "auth_type": AUTH_TYPE_OAUTH,
                     "access_token": tokens.get("access_token", ""),
                     "refresh_token": tokens.get("refresh_token"),
-                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "base_url": (
+                        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+                        or auth_mod.DEFAULT_CODEX_BASE_URL
+                    ),
                     "last_refresh": state.get("last_refresh"),
                     "label": label_from_token(tokens.get("access_token", ""), "device_code"),
                 },

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -263,7 +263,13 @@ class TestTryCodex:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (
             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
-            patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+            patch(
+                "hermes_cli.auth.resolve_codex_runtime_credentials",
+                return_value={
+                    "api_key": "codex-auth-token",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                },
+            ),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
             mock_openai.return_value = MagicMock()
@@ -275,6 +281,54 @@ class TestTryCodex:
         assert model == "gpt-5.2-codex"
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+    def test_auth_store_fallback_uses_runtime_base_url(self):
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch(
+                "hermes_cli.auth.resolve_codex_runtime_credentials",
+                return_value={
+                    "api_key": "codex-auth-token",
+                    "base_url": "https://codex-lb.example.com/backend-api/codex",
+                },
+            ),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _try_codex
+
+            client, model = _try_codex()
+
+        assert client is not None
+        assert model == "gpt-5.2-codex"
+        assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://codex-lb.example.com/backend-api/codex"
+
+    def test_raw_codex_uses_runtime_base_url(self):
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch(
+                "hermes_cli.auth.resolve_codex_runtime_credentials",
+                return_value={
+                    "api_key": "codex-auth-token",
+                    "base_url": "https://codex-lb.example.com/backend-api/codex",
+                },
+            ),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client(
+                "openai-codex",
+                "gpt-5.5",
+                raw_codex=True,
+            )
+
+        assert client is not None
+        assert model == "gpt-5.5"
+        assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://codex-lb.example.com/backend-api/codex"
 
 
 class TestExpiredCodexFallback:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -381,6 +381,35 @@ def test_load_pool_removes_stale_seeded_env_entry(tmp_path, monkeypatch):
     assert auth_payload["credential_pool"]["openrouter"] == []
 
 
+def test_load_pool_seeds_codex_provider_state_with_runtime_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("HERMES_CODEX_BASE_URL", "https://codex-lb.example.com/backend-api/codex/")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "codex-access-token",
+                        "refresh_token": "codex-refresh-token",
+                    },
+                    "last_refresh": "2026-04-26T00:00:00Z",
+                }
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "device_code"
+    assert entry.base_url == "https://codex-lb.example.com/backend-api/codex"
+
+
 def test_load_pool_migrates_nous_provider_state(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(


### PR DESCRIPTION
## summary

- route Codex auxiliary auth-store fallback through `resolve_codex_runtime_credentials()` so `HERMES_CODEX_BASE_URL` is honored
- seed `openai-codex` credential-pool entries with the runtime Codex base URL instead of always storing the ChatGPT default
- keep `raw_codex=True` clients on the same runtime-resolved Codex URL and add regressions for both auxiliary paths

Fixes https://github.com/NousResearch/hermes-agent/issues/5875

## verification

- `uv run --extra dev python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_credential_pool.py tests/hermes_cli/test_runtime_provider_resolution.py -q` -> `208 passed, 12 warnings`
- `uv run --extra dev ruff check .` -> passes with the current repo config (`warning: No Python files found under the given path(s)` because `[tool.ruff] exclude = ["*"]`)
- `uv run --extra dev python -m py_compile agent/auxiliary_client.py agent/credential_pool.py`
- `uv run --extra dev python -m pytest tests/ -q` -> not green locally: missing optional deps (`acp`, `numpy`, `fastapi`) and unrelated failures across gateway/web/transcription/filesystem tests
