### PR TITLE
fix(cli): /copy falls back to native clipboard on OSC 52-blind terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4119,6 +4119,42 @@ class HermesCLI:
         sys.stdout.write(seq)
         sys.stdout.flush()
 
+    def _write_native_clipboard(self, text: str) -> bool:
+        """Best-effort native clipboard copy.  Returns True on success.
+
+        OSC 52 is the right answer for SSH/tmux scenarios but is silently
+        ignored by some terminals (notably macOS Terminal.app), so we
+        also try the platform's native clipboard helper.
+        """
+        import subprocess
+
+        if sys.platform == "darwin":
+            candidates = (["pbcopy"],)
+        elif sys.platform.startswith("linux"):
+            candidates = (
+                ["wl-copy"],
+                ["xclip", "-selection", "clipboard"],
+                ["xsel", "--clipboard", "--input"],
+            )
+        elif sys.platform.startswith("win"):
+            candidates = (["clip"],)
+        else:
+            return False
+
+        for cmd in candidates:
+            if shutil.which(cmd[0]) is None:
+                continue
+            try:
+                proc = subprocess.run(
+                    cmd, input=text, text=True, timeout=2, check=False,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                continue
+            if proc.returncode == 0:
+                return True
+        return False
+
     def _handle_copy_command(self, cmd_original: str) -> None:
         """Handle /copy [number] — copy assistant output to clipboard."""
         parts = cmd_original.split(maxsplit=1)
@@ -4151,11 +4187,25 @@ class HermesCLI:
             _cprint("  Nothing to copy in that assistant response.")
             return
 
+        # OSC 52 covers SSH/tmux; native clipboard covers terminals (e.g.
+        # macOS Terminal.app) that silently ignore the OSC 52 sequence.
+        # Only one of the two needs to land for the copy to count.
+        osc_err: Exception | None = None
         try:
             self._write_osc52_clipboard(text)
-            _cprint(f"  Copied assistant response #{idx + 1} to clipboard")
+            osc_ok = True
         except Exception as e:
-            _cprint(f"  Clipboard copy failed: {e}")
+            osc_err = e
+            osc_ok = False
+        try:
+            native_ok = self._write_native_clipboard(text)
+        except Exception:
+            native_ok = False
+
+        if osc_ok or native_ok:
+            _cprint(f"  Copied assistant response #{idx + 1} to clipboard")
+        else:
+            _cprint(f"  Clipboard copy failed: {osc_err}")
 
     def _handle_image_command(self, cmd_original: str):
         """Handle /image <path> — attach a local image file for the next prompt."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -570,6 +570,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/cli/test_cli_copy_command.py
+++ b/tests/cli/test_cli_copy_command.py
@@ -17,6 +17,14 @@ def _make_cli() -> HermesCLI:
     return cli_obj
 
 
+def _patch_clipboard(cli_obj):
+    """Patch both clipboard writers to keep tests off the host clipboard."""
+    return (
+        patch.object(cli_obj, "_write_osc52_clipboard"),
+        patch.object(cli_obj, "_write_native_clipboard", return_value=True),
+    )
+
+
 def test_copy_copies_latest_assistant_message():
     cli_obj = _make_cli()
     cli_obj.conversation_history = [
@@ -25,11 +33,13 @@ def test_copy_copies_latest_assistant_message():
         {"role": "assistant", "content": "latest"},
     ]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
+    osc_patch, native_patch = _patch_clipboard(cli_obj)
+    with osc_patch as mock_osc, native_patch as mock_native:
         result = cli_obj.process_command("/copy")
 
     assert result is True
-    mock_copy.assert_called_once_with("latest")
+    mock_osc.assert_called_once_with("latest")
+    mock_native.assert_called_once_with("latest")
 
 
 def test_copy_with_index_uses_requested_assistant_message():
@@ -39,10 +49,11 @@ def test_copy_with_index_uses_requested_assistant_message():
         {"role": "assistant", "content": "two"},
     ]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
+    osc_patch, native_patch = _patch_clipboard(cli_obj)
+    with osc_patch as mock_osc, native_patch:
         cli_obj.process_command("/copy 1")
 
-    mock_copy.assert_called_once_with("one")
+    mock_osc.assert_called_once_with("one")
 
 
 def test_copy_strips_reasoning_blocks_before_copy():
@@ -54,18 +65,102 @@ def test_copy_strips_reasoning_blocks_before_copy():
         }
     ]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
+    osc_patch, native_patch = _patch_clipboard(cli_obj)
+    with osc_patch as mock_osc, native_patch:
         cli_obj.process_command("/copy")
 
-    mock_copy.assert_called_once_with("Visible answer")
+    mock_osc.assert_called_once_with("Visible answer")
 
 
 def test_copy_invalid_index_does_not_copy():
     cli_obj = _make_cli()
     cli_obj.conversation_history = [{"role": "assistant", "content": "only"}]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy, patch("cli._cprint") as mock_print:
+    osc_patch, native_patch = _patch_clipboard(cli_obj)
+    with osc_patch as mock_osc, native_patch as mock_native, \
+            patch("cli._cprint") as mock_print:
         cli_obj.process_command("/copy 99")
 
-    mock_copy.assert_not_called()
+    mock_osc.assert_not_called()
+    mock_native.assert_not_called()
     assert any("Invalid response number" in str(call) for call in mock_print.call_args_list)
+
+
+def test_copy_succeeds_when_native_works_and_osc52_raises():
+    """Terminal.app silently swallows OSC 52, but pbcopy works fine —
+    if the native helper succeeds we should report success even when
+    OSC 52 raises (or, in practice, would no-op)."""
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "hello"}]
+
+    with (
+        patch.object(cli_obj, "_write_osc52_clipboard", side_effect=RuntimeError("no tty")),
+        patch.object(cli_obj, "_write_native_clipboard", return_value=True),
+        patch("cli._cprint") as mock_print,
+    ):
+        cli_obj.process_command("/copy")
+
+    assert any("Copied assistant response" in str(call) for call in mock_print.call_args_list)
+    assert not any("Clipboard copy failed" in str(call) for call in mock_print.call_args_list)
+
+
+def test_copy_reports_failure_only_when_both_writers_fail():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "hello"}]
+
+    with (
+        patch.object(cli_obj, "_write_osc52_clipboard", side_effect=RuntimeError("no tty")),
+        patch.object(cli_obj, "_write_native_clipboard", return_value=False),
+        patch("cli._cprint") as mock_print,
+    ):
+        cli_obj.process_command("/copy")
+
+    assert any("Clipboard copy failed" in str(call) for call in mock_print.call_args_list)
+
+
+class TestWriteNativeClipboard:
+    def test_macos_uses_pbcopy(self, monkeypatch):
+        cli_obj = _make_cli()
+        monkeypatch.setattr("cli.sys.platform", "darwin")
+        monkeypatch.setattr("cli.shutil.which", lambda cmd: "/usr/bin/pbcopy" if cmd == "pbcopy" else None)
+        completed = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            assert cli_obj._write_native_clipboard("hi") is True
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["pbcopy"]
+        assert mock_run.call_args.kwargs["input"] == "hi"
+
+    def test_linux_prefers_wl_copy(self, monkeypatch):
+        cli_obj = _make_cli()
+        monkeypatch.setattr("cli.sys.platform", "linux")
+        present = {"wl-copy": "/usr/bin/wl-copy"}
+        monkeypatch.setattr("cli.shutil.which", lambda cmd: present.get(cmd))
+        completed = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            assert cli_obj._write_native_clipboard("hi") is True
+        assert mock_run.call_args.args[0] == ["wl-copy"]
+
+    def test_linux_falls_back_to_xclip(self, monkeypatch):
+        cli_obj = _make_cli()
+        monkeypatch.setattr("cli.sys.platform", "linux")
+        present = {"xclip": "/usr/bin/xclip"}
+        monkeypatch.setattr("cli.shutil.which", lambda cmd: present.get(cmd))
+        completed = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            assert cli_obj._write_native_clipboard("hi") is True
+        assert mock_run.call_args.args[0] == ["xclip", "-selection", "clipboard"]
+
+    def test_returns_false_when_no_tool_available(self, monkeypatch):
+        cli_obj = _make_cli()
+        monkeypatch.setattr("cli.sys.platform", "linux")
+        monkeypatch.setattr("cli.shutil.which", lambda _cmd: None)
+        with patch("subprocess.run") as mock_run:
+            assert cli_obj._write_native_clipboard("hi") is False
+        mock_run.assert_not_called()
+
+    def test_unknown_platform_returns_false(self, monkeypatch):
+        cli_obj = _make_cli()
+        monkeypatch.setattr("cli.sys.platform", "freebsd14")
+        with patch("subprocess.run") as mock_run:
+            assert cli_obj._write_native_clipboard("hi") is False
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary
- macOS Terminal.app silently swallows OSC 52, so \`/copy\` reported success while the host clipboard never changed (#15664).
- Add \`_write_native_clipboard()\` that runs alongside the existing OSC 52 write, picking the right helper per platform: \`pbcopy\` (macOS), \`wl-copy\`/\`xclip\`/\`xsel\` (Linux), \`clip\` (Windows).
- The command now reports success when either OSC 52 *or* the native helper lands, so SSH/tmux scenarios still work and Terminal.app users finally get a real copy.

## Test plan
- [x] \`pytest tests/cli/test_cli_copy_command.py\` — 11 passed
  - 4 existing tests updated to patch both clipboard writers
  - 5 new tests for \`_write_native_clipboard\` per platform
  - 2 new tests for the success/failure logic (success when only native works; failure only when both fail)

Closes #15664

🤖 Generated with [Claude Code](https://claude.com/claude-code)