### PR TITLE
feat(progress): show tool count and elapsed time in progress footer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10041,6 +10041,8 @@ class GatewayRunner:
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
         _LONG_TOOL_THRESHOLD_S = 30.0
+        tool_call_count = [0]  # Total tool calls observed
+        _progress_start_ts = [0.0]  # Wall-clock start of tool activity
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
@@ -10097,6 +10099,9 @@ class GatewayRunner:
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
+            tool_call_count[0] += 1
+            if _progress_start_ts[0] == 0.0:
+                _progress_start_ts[0] = time.monotonic()
             
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
@@ -10296,6 +10301,10 @@ class GatewayRunner:
                             break
                     # Final edit with all remaining tools (only if editing works)
                     if can_edit and progress_lines and progress_msg_id:
+                        # Append a summary footer: tool count + elapsed time
+                        if tool_call_count[0] > 0 and _progress_start_ts[0] > 0:
+                            elapsed = time.monotonic() - _progress_start_ts[0]
+                            progress_lines.append(f"⏳ {tool_call_count[0]} tools · {elapsed:.0f}s")
                         full_text = "\n".join(progress_lines)
                         try:
                             await adapter.edit_message(


### PR DESCRIPTION
Tracks total `tool_call_count` and wall-clock start time during progress message updates. On the final edit, appends a summary line like `⏳ 12 tools · 45s` so users can see how many tool calls the agent made and how long the thinking phase took.

Reimplements #10483 (source branch was deleted).

### Changes
- **`gateway/run.py`**: Add `tool_call_count[0]` and `_progress_start_ts[0]` mutable closures alongside existing progress trackers
- Increment counter on each `tool.started` event, record start timestamp on first event
- Append `⏳ N tools · Xs` footer on the final progress message edit
