### PR TITLE
feat(context): configurable CONTEXT_FILE_MAX_CHARS via env var

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -454,7 +454,18 @@ def build_environment_hints() -> str:
     return "\n\n".join(hints)
 
 
-CONTEXT_FILE_MAX_CHARS = 20_000
+def _context_file_max_chars() -> int:
+    raw = os.getenv("HERMES_CONTEXT_FILE_MAX_CHARS")
+    if raw is None:
+        return 20_000
+    try:
+        val = int(raw)
+    except ValueError:
+        return 20_000
+    return max(val, 1_000)
+
+
+CONTEXT_FILE_MAX_CHARS = _context_file_max_chars()
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -10,6 +10,7 @@ import pytest
 from agent.prompt_builder import (
     _scan_context_content,
     _truncate_content,
+    _context_file_max_chars,
     _parse_skill_file,
     _skill_should_show,
     _find_hermes_md,
@@ -138,6 +139,33 @@ class TestTruncateContent:
         content = "x" * CONTEXT_FILE_MAX_CHARS
         result = _truncate_content(content, "exact.md")
         assert result == content
+
+
+# =========================================================================
+# _context_file_max_chars — env-var override with validation
+# =========================================================================
+
+
+class TestContextFileMaxChars:
+    def test_default_without_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CONTEXT_FILE_MAX_CHARS", raising=False)
+        assert _context_file_max_chars() == 20_000
+
+    def test_custom_value(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CONTEXT_FILE_MAX_CHARS", "60000")
+        assert _context_file_max_chars() == 60_000
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CONTEXT_FILE_MAX_CHARS", "oops")
+        assert _context_file_max_chars() == 20_000
+
+    def test_floor_clamp(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CONTEXT_FILE_MAX_CHARS", "500")
+        assert _context_file_max_chars() == 1_000
+
+    def test_negative_clamped_to_floor(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CONTEXT_FILE_MAX_CHARS", "-1")
+        assert _context_file_max_chars() == 1_000
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
- Adds `HERMES_CONTEXT_FILE_MAX_CHARS` environment variable to override the 20k bootstrap context file truncation limit
- Gracefully falls back to 20k default on missing or invalid values; clamps to a 1k floor to prevent broken truncation
- Adds 5 test cases covering: default, custom value, invalid input, floor clamp, negative value

## Motivation
Users with large `AGENTS.md` files (>20k chars) currently hit hard truncation with no way to raise the limit ([Discord thread](https://discord.com/channels/...)). This follows the existing env-var config pattern used elsewhere in the agent (e.g. `HERMES_WRITE_SAFE_ROOT`, `HERMES_NOUS_TIMEOUT_SECONDS`).

The subdirectory hint cap (`_MAX_HINT_CHARS = 8_000` in `subdirectory_hints.py`) is intentionally left unchanged — those are injected per-tool-call, so a lower fixed cap is appropriate.

## Test plan
- [x] `TestContextFileMaxChars::test_default_without_env` — 20k when env var unset
- [x] `TestContextFileMaxChars::test_custom_value` — respects custom value
- [x] `TestContextFileMaxChars::test_invalid_value_falls_back_to_default` — no crash on garbage
- [x] `TestContextFileMaxChars::test_floor_clamp` — values below 1k clamped
- [x] `TestContextFileMaxChars::test_negative_clamped_to_floor` — negative values clamped
- [x] All existing `TestTruncateContent` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)