### PR TITLE
fix(auth): hand auth.json to the data-dir owner when login runs as root

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -798,6 +798,30 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
     try:
         raw = json.loads(auth_file.read_text())
+    except PermissionError as exc:
+        # Distinct from "corrupt": file exists, looks valid on disk, but
+        # the current process can't read it.  Most common in containers
+        # where ``hermes login`` ran as a different user than the gateway
+        # (#15718).  Don't pollute the path with a .corrupt copy.
+        try:
+            file_stat = auth_file.stat()
+            owner_info = f"uid={file_stat.st_uid} gid={file_stat.st_gid} mode={oct(file_stat.st_mode & 0o777)}"
+        except OSError:
+            owner_info = "stat failed"
+        try:
+            current_uid = os.getuid() if hasattr(os, "getuid") else "n/a"
+        except OSError:
+            current_uid = "n/a"
+        logger.warning(
+            "auth: %s exists but is not readable by the current process "
+            "(running uid=%s, file %s). Treating as empty store. "
+            "If this followed `docker exec -it ... hermes login` as root, "
+            "chown the file to the gateway user: chown %s %s",
+            auth_file, current_uid, owner_info,
+            os.environ.get("HERMES_UID") or current_uid,
+            auth_file,
+        )
+        return {"version": AUTH_STORE_VERSION, "providers": {}}
     except Exception as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
@@ -829,6 +853,42 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
                 "active_provider": "nous" if providers else None}
 
     return {"version": AUTH_STORE_VERSION, "providers": {}}
+
+
+def _align_owner_to_parent(path: Path) -> None:
+    """If running as root and *path*'s parent is owned by a non-root user,
+    chown *path* to match the parent's UID/GID.
+
+    This is the fix for the ``docker exec -it ... hermes login`` flow
+    (#15718): the ``hermes`` user's data dir is owned by UID 10000, but
+    ``docker exec`` defaults to root inside the container.  Without
+    this, ``auth.json`` ends up ``root:root 0600`` and the gateway
+    process — running as the non-root user — silently can't read it.
+
+    Best-effort: any failure is logged at debug level and swallowed.
+    """
+    if os.name != "posix" or not hasattr(os, "geteuid"):
+        return
+    try:
+        if os.geteuid() != 0:
+            return
+    except OSError:
+        return
+    try:
+        parent_stat = path.parent.stat()
+    except OSError:
+        return
+    parent_uid = parent_stat.st_uid
+    parent_gid = parent_stat.st_gid
+    if parent_uid == 0:
+        return  # Parent is root-owned: leave the file as root too.
+    try:
+        os.chown(path, parent_uid, parent_gid)
+    except OSError as exc:
+        logger.debug(
+            "auth: could not align %s owner to parent (uid=%s gid=%s): %s",
+            path, parent_uid, parent_gid, exc,
+        )
 
 
 def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
@@ -864,6 +924,10 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
         auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:
         pass
+    # When ``hermes login`` runs as root inside a container whose data
+    # dir is owned by a non-root user, hand ownership of auth.json over
+    # to that user so the gateway can read its own credentials.
+    _align_owner_to_parent(auth_file)
     return auth_file
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -570,6 +570,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/hermes_cli/test_auth_store_ownership.py
+++ b/tests/hermes_cli/test_auth_store_ownership.py
@@ -1,0 +1,125 @@
+"""Tests for ``_save_auth_store`` ownership alignment and ``_load_auth_store``
+PermissionError handling — guards the docker-exec login flow described in #15718.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import auth as auth_mod
+
+
+@pytest.fixture()
+def isolated_auth_file(tmp_path, monkeypatch):
+    auth_file = tmp_path / "auth.json"
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: auth_file)
+    return auth_file
+
+
+# =========================================================================
+# _align_owner_to_parent
+# =========================================================================
+
+class TestAlignOwnerToParent:
+    def test_skips_when_not_root(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}")
+        with (
+            patch("os.geteuid", return_value=1234, create=True),
+            patch("os.chown") as mock_chown,
+        ):
+            auth_mod._align_owner_to_parent(target)
+        mock_chown.assert_not_called()
+
+    def test_skips_when_parent_owned_by_root(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}")
+        fake_parent_stat = type(
+            "FakeStat", (), {"st_uid": 0, "st_gid": 0, "st_mode": 0o755}
+        )()
+        with (
+            patch("os.geteuid", return_value=0, create=True),
+            patch("pathlib.Path.stat", return_value=fake_parent_stat),
+            patch("os.chown") as mock_chown,
+        ):
+            auth_mod._align_owner_to_parent(target)
+        mock_chown.assert_not_called()
+
+    def test_chowns_when_root_and_parent_owned_by_user(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}")
+        fake_parent_stat = type(
+            "FakeStat", (), {"st_uid": 10000, "st_gid": 10000, "st_mode": 0o755}
+        )()
+        with (
+            patch("os.geteuid", return_value=0, create=True),
+            patch.object(type(target.parent), "stat", return_value=fake_parent_stat),
+            patch("os.chown") as mock_chown,
+        ):
+            auth_mod._align_owner_to_parent(target)
+        mock_chown.assert_called_once_with(target, 10000, 10000)
+
+    def test_chown_failure_is_swallowed(self, tmp_path, caplog):
+        target = tmp_path / "auth.json"
+        target.write_text("{}")
+        fake_parent_stat = type(
+            "FakeStat", (), {"st_uid": 10000, "st_gid": 10000, "st_mode": 0o755}
+        )()
+        with (
+            patch("os.geteuid", return_value=0, create=True),
+            patch.object(type(target.parent), "stat", return_value=fake_parent_stat),
+            patch("os.chown", side_effect=PermissionError("nope")),
+            caplog.at_level(logging.DEBUG, logger="hermes_cli.auth"),
+        ):
+            # Must not raise.
+            auth_mod._align_owner_to_parent(target)
+
+
+# =========================================================================
+# _save_auth_store wires _align_owner_to_parent in
+# =========================================================================
+
+class TestSaveAuthStoreOwnership:
+    def test_save_calls_align_owner_to_parent(self, isolated_auth_file):
+        with patch("hermes_cli.auth._align_owner_to_parent") as mock_align:
+            saved = auth_mod._save_auth_store({"providers": {"openai-codex": {"token": "x"}}})
+        assert saved == isolated_auth_file
+        mock_align.assert_called_once_with(isolated_auth_file)
+        # And the file actually got written.
+        on_disk = json.loads(saved.read_text())
+        assert on_disk["providers"]["openai-codex"]["token"] == "x"
+
+
+# =========================================================================
+# _load_auth_store distinguishes PermissionError from "corrupt"
+# =========================================================================
+
+class TestLoadAuthStorePermissionError:
+    def test_permission_error_does_not_create_corrupt_copy(
+        self, isolated_auth_file, caplog,
+    ):
+        isolated_auth_file.write_text(json.dumps({"providers": {}}))
+        with (
+            patch.object(type(isolated_auth_file), "read_text",
+                         side_effect=PermissionError("EACCES")),
+            caplog.at_level(logging.WARNING, logger="hermes_cli.auth"),
+        ):
+            store = auth_mod._load_auth_store()
+
+        assert store == {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+        corrupt = isolated_auth_file.with_suffix(".json.corrupt")
+        assert not corrupt.exists(), "PermissionError shouldn't create a .corrupt copy"
+        assert "not readable" in caplog.text
+        assert "chown" in caplog.text  # Hint surfaced for the docker-exec case.
+
+    def test_other_exceptions_still_create_corrupt_copy(self, isolated_auth_file):
+        # Sanity-check: the existing path still treats a real parse error as corrupt.
+        isolated_auth_file.write_text("{not valid json")
+        store = auth_mod._load_auth_store()
+        assert store["providers"] == {}
+        corrupt = isolated_auth_file.with_suffix(".json.corrupt")
+        assert corrupt.exists()


### PR DESCRIPTION
## Summary

When \`hermes login\` runs via \`docker exec -it\` against a container whose data dir is owned by the gateway user (UID 10000 by default), the resulting \`auth.json\` is written \`root:root 0600\`.  The gateway process — running as the non-root user — silently can't read its own credentials and surfaces the misleading \"no Codex credentials stored\" error, while the TUI (also launched as root) shows a fully working login (#15718).

This is the user's suggested fix #1 (chown on save) plus #2 (clearer error on load):

- New \`_align_owner_to_parent()\` helper: when running as root and the parent dir is owned by a non-root UID, chown the file to match.  Best-effort, swallows \`OSError\`s.  No-op on Windows or when not running as root.
- \`_save_auth_store\` calls it after the atomic replace, so the fix applies to every credential write.
- \`_load_auth_store\` now distinguishes \`PermissionError\` from a parse failure.  Previously both fell into the \"corrupt\" branch, leaving a stray \`auth.json.corrupt\` copy and an opaque warning.  The new path names the file's owner/mode and surfaces the chown command to recover already-broken installations.

## Test plan
- [x] \`pytest tests/hermes_cli/test_auth_store_ownership.py\` — 7 passed (new file)
- [x] \`pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_nous_provider.py\` — 88 passed (existing auth tests unaffected)

Closes #15718

🤖 Generated with [Claude Code](https://claude.com/claude-code)