### PR TITLE
feat(discord): add message edit and delete admin actions

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1883,7 +1883,8 @@ DEFAULT_CONFIG = {
         # or YAML list. Unknown names are dropped with a warning at load time.
         # Actions: list_guilds, server_info, list_channels, channel_info,
         # list_roles, member_info, search_members, fetch_messages, list_pins,
-        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        # pin_message, unpin_message, delete_message, edit_message, create_thread,
+        # add_role, remove_role.
         "server_actions": "",
         # DEPRECATED / no-op. Any uploaded file is now always cached and
         # surfaced to the agent regardless of file type — authorization to

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -183,6 +183,16 @@ class TestDiscordServerValidation:
         assert "user_id" in result["error"]
         assert "role_id" in result["error"]
 
+    @patch("tools.discord_tool._discord_request")
+    def test_missing_required_content(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="edit_message", channel_id="11", message_id="500",
+        ))
+        assert "error" in result
+        assert "content" in result["error"]
+        mock_req.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Action: list_guilds
@@ -428,6 +438,50 @@ class TestPinUnpin:
 
 
 # ---------------------------------------------------------------------------
+# Actions: edit_message / delete_message
+# ---------------------------------------------------------------------------
+
+class TestEditDeleteMessage:
+    @patch("tools.discord_tool._discord_request")
+    def test_edit_message(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "500",
+            "content": "Updated announcement",
+            "edited_timestamp": "2024-01-01T00:01:00Z",
+        }
+        result = json.loads(discord_admin_handler(
+            action="edit_message",
+            channel_id="11",
+            message_id="500",
+            content="Updated announcement",
+        ))
+        assert result["success"] is True
+        assert result["message_id"] == "500"
+        assert result["content"] == "Updated announcement"
+        assert result["edited_timestamp"] == "2024-01-01T00:01:00Z"
+        mock_req.assert_called_once_with(
+            "PATCH",
+            "/channels/11/messages/500",
+            "test-token",
+            body={"content": "Updated announcement"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_delete_message(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = None
+        result = json.loads(discord_admin_handler(
+            action="delete_message", channel_id="11", message_id="500",
+        ))
+        assert result["success"] is True
+        assert result["message_id"] == "500"
+        mock_req.assert_called_once_with(
+            "DELETE", "/channels/11/messages/500", "test-token",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Action: create_thread
 # ---------------------------------------------------------------------------
 
@@ -539,12 +593,34 @@ class TestRegistration:
         assert entry.check_fn is not None
         assert entry.requires_env == ["DISCORD_BOT_TOKEN"]
 
+    @patch("tools.discord_tool._discord_request")
+    def test_registry_handler_passes_content(self, mock_req, monkeypatch):
+        from tools.registry import registry
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "500", "content": "Updated via registry"}
+        result = json.loads(registry._tools["discord_admin"].handler({
+            "action": "edit_message",
+            "channel_id": "11",
+            "message_id": "500",
+            "content": "Updated via registry",
+        }))
+        assert result["success"] is True
+        assert result["content"] == "Updated via registry"
+        mock_req.assert_called_once_with(
+            "PATCH",
+            "/channels/11/messages/500",
+            "test-token",
+            body={"content": "Updated via registry"},
+        )
+
     def test_core_schema_actions(self):
         """Core static schema should list only core actions."""
         from tools.registry import registry
         entry = registry._tools["discord"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
         assert actions == {"fetch_messages", "search_members", "create_thread"}
+        assert "edit_message" not in actions
+        assert "delete_message" not in actions
 
     def test_admin_schema_actions(self):
         """Admin static schema should list only admin actions."""
@@ -553,6 +629,8 @@ class TestRegistration:
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
         expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
         assert actions == expected_admin
+        assert "edit_message" in actions
+        assert "delete_message" in actions
 
     def test_all_actions_covered(self):
         """Core + admin actions should cover all known actions."""
@@ -566,6 +644,8 @@ class TestRegistration:
         assert props["limit"]["minimum"] == 1
         assert props["limit"]["maximum"] == 100
         assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
+        assert props["content"]["type"] == "string"
+        assert "edit_message" in props["content"]["description"]
 
     def test_core_schema_description(self):
         """Core schema description should mention core actions."""
@@ -586,6 +666,8 @@ class TestRegistration:
         desc = entry.schema["description"]
         assert "list_guilds()" in desc
         assert "add_role(guild_id, user_id, role_id)" in desc
+        assert "edit_message(channel_id, message_id, content)" in desc
+        assert "delete_message(channel_id, message_id)" in desc
         # Core actions should NOT be in admin description
         assert "fetch_messages(" not in desc
         assert "create_thread(" not in desc
@@ -1000,6 +1082,12 @@ class Test403Enrichment:
         msg = _enrich_403("add_role", '{"message":"Missing Permissions"}')
         assert "MANAGE_ROLES" in msg
         assert "Missing Permissions" in msg  # Raw body preserved
+
+    def test_enrich_message_admin_actions(self):
+        edit_msg = _enrich_403("edit_message", '{"message":"Missing Access"}')
+        delete_msg = _enrich_403("delete_message", '{"message":"Missing Permissions"}')
+        assert "only edit messages it authored" in edit_msg
+        assert "MANAGE_MESSAGES" in delete_msg
 
     def test_enrich_unknown_action_includes_body(self):
         msg = _enrich_403("some_new_action", '{"message":"weird"}')

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -129,6 +129,14 @@ class TestDiscordServerValidation:
         assert "user_id" in result["error"]
         assert "role_id" in result["error"]
 
+    def test_edit_message_requires_content(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="edit_message", channel_id="11", message_id="500",
+        ))
+        assert "error" in result
+        assert "content" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # Action: list_channels
@@ -218,6 +226,41 @@ class TestFetchMessages:
 
 
 # ---------------------------------------------------------------------------
+# Action: edit_message
+# ---------------------------------------------------------------------------
+
+class TestEditMessage:
+    @patch("tools.discord_tool._discord_request")
+    def test_edit_message(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "500",
+            "content": "Updated announcement",
+            "edited_timestamp": "2026-08-02T00:01:00Z",
+        }
+
+        result = json.loads(discord_admin_handler(
+            action="edit_message",
+            channel_id="11",
+            message_id="500",
+            content="Updated announcement",
+        ))
+
+        assert result == {
+            "success": True,
+            "message_id": "500",
+            "content": "Updated announcement",
+            "edited_timestamp": "2026-08-02T00:01:00Z",
+        }
+        mock_req.assert_called_once_with(
+            "PATCH",
+            "/channels/11/messages/500",
+            "test-token",
+            body={"content": "Updated announcement"},
+        )
+
+
+# ---------------------------------------------------------------------------
 # Action: create_thread
 # ---------------------------------------------------------------------------
 
@@ -284,6 +327,28 @@ class TestRegistration:
         assert entry.toolset == "discord"
         assert entry.check_fn is not None
         assert entry.requires_env == ["DISCORD_BOT_TOKEN"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_admin_registry_forwards_edit_content(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"content": "Updated announcement"}
+
+        from tools.registry import registry
+        entry = registry._tools["discord_admin"]
+        result = json.loads(entry.handler({
+            "action": "edit_message",
+            "channel_id": "11",
+            "message_id": "500",
+            "content": "Updated announcement",
+        }))
+
+        assert result["content"] == "Updated announcement"
+        mock_req.assert_called_once_with(
+            "PATCH",
+            "/channels/11/messages/500",
+            "test-token",
+            body={"content": "Updated announcement"},
+        )
 
     def test_all_actions_covered(self):
         """Core + admin actions should cover all known actions."""
@@ -622,6 +687,13 @@ class TestRuntimeAllowlistEnforcement:
 # ---------------------------------------------------------------------------
 
 class Test403Enrichment:
+    def test_edit_message_hint_explains_authorship(self):
+        from tools.discord_tool import _enrich_403
+
+        assert "only edit messages it authored" in _enrich_403(
+            "edit_message", '{"message":"Missing Access"}',
+        )
+
     @patch("tools.discord_tool._discord_request")
     def test_403_in_runtime_is_enriched(self, mock_req, monkeypatch):
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -410,6 +410,36 @@ def _unpin_message(token: str, channel_id: str, message_id: str, **_kwargs: Any)
     return json.dumps({"success": True, "message": f"Message {message_id} unpinned."})
 
 
+def _edit_message(
+    token: str,
+    channel_id: str,
+    message_id: str,
+    content: str,
+    **_kwargs: Any,
+) -> str:
+    """Edit a message in a channel."""
+    message = _discord_request(
+        "PATCH",
+        f"/channels/{channel_id}/messages/{message_id}",
+        token,
+        body={"content": content},
+    )
+    result = {
+        "success": True,
+        "message_id": message_id,
+        "content": message.get("content", content) if isinstance(message, dict) else content,
+    }
+    if isinstance(message, dict) and message.get("edited_timestamp") is not None:
+        result["edited_timestamp"] = message.get("edited_timestamp")
+    return json.dumps(result)
+
+
+def _delete_message(token: str, channel_id: str, message_id: str, **_kwargs: Any) -> str:
+    """Delete a message from a channel."""
+    _discord_request("DELETE", f"/channels/{channel_id}/messages/{message_id}", token)
+    return json.dumps({"success": True, "message_id": message_id})
+
+
 def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
@@ -468,6 +498,8 @@ _ACTIONS = {
     "list_pins": _list_pins,
     "pin_message": _pin_message,
     "unpin_message": _unpin_message,
+    "edit_message": _edit_message,
+    "delete_message": _delete_message,
     "create_thread": _create_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
@@ -494,6 +526,8 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("list_pins", "(channel_id)", "pinned messages in a channel"),
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
+    ("edit_message", "(channel_id, message_id, content)", "edit a message's content"),
+    ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
@@ -514,6 +548,8 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "list_pins": ["channel_id"],
     "pin_message": ["channel_id", "message_id"],
     "unpin_message": ["channel_id", "message_id"],
+    "edit_message": ["channel_id", "message_id", "content"],
+    "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
@@ -668,6 +704,10 @@ def _build_schema(
             "type": "string",
             "description": "Discord message ID.",
         },
+        "content": {
+            "type": "string",
+            "description": "New message content (edit_message).",
+        },
         "query": {
             "type": "string",
             "description": "Member name prefix to search for (search_members).",
@@ -750,6 +790,14 @@ _ACTION_403_HINT = {
     "unpin_message": (
         "Bot lacks MANAGE_MESSAGES permission in this channel."
     ),
+    "edit_message": (
+        "Bot can only edit messages it authored, and must be able to view and send "
+        "messages in this channel."
+    ),
+    "delete_message": (
+        "Bot lacks MANAGE_MESSAGES permission in this channel, or cannot delete "
+        "that specific message."
+    ),
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
     ),
@@ -813,6 +861,7 @@ def _run_discord_action(
     user_id: str = "",
     role_id: str = "",
     message_id: str = "",
+    content: str = "",
     query: str = "",
     name: str = "",
     limit: int = 50,
@@ -850,6 +899,7 @@ def _run_discord_action(
         "user_id": user_id,
         "role_id": role_id,
         "message_id": message_id,
+        "content": content,
         "query": query,
         "name": name,
     }
@@ -868,6 +918,7 @@ def _run_discord_action(
             user_id=user_id,
             role_id=role_id,
             message_id=message_id,
+            content=content,
             query=query,
             name=name,
             limit=limit,
@@ -901,7 +952,7 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
-    "role_id": "", "message_id": "", "query": "", "name": "",
+    "role_id": "", "message_id": "", "content": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -583,6 +583,30 @@ def _delete_message(token: str, channel_id: str, message_id: str, **_kwargs: Any
     return json.dumps({"success": True, "message": f"Message {message_id} deleted."})
 
 
+def _edit_message(
+    token: str,
+    channel_id: str,
+    message_id: str,
+    content: str,
+    **_kwargs: Any,
+) -> str:
+    """Edit the bot-authored content of a message in a channel or thread."""
+    message = _discord_request(
+        "PATCH",
+        f"/channels/{channel_id}/messages/{message_id}",
+        token,
+        body={"content": content},
+    )
+    result = {
+        "success": True,
+        "message_id": message_id,
+        "content": message.get("content", content) if isinstance(message, dict) else content,
+    }
+    if isinstance(message, dict) and message.get("edited_timestamp") is not None:
+        result["edited_timestamp"] = message["edited_timestamp"]
+    return json.dumps(result)
+
+
 def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
@@ -642,6 +666,7 @@ _ACTIONS = {
     "pin_message": _pin_message,
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
+    "edit_message": _edit_message,
     "create_thread": _create_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
@@ -669,6 +694,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
+    ("edit_message", "(channel_id, message_id, content)", "edit a bot-authored message's content"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
@@ -690,6 +716,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "pin_message": ["channel_id", "message_id"],
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
+    "edit_message": ["channel_id", "message_id", "content"],
     "create_thread": ["channel_id", "name"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
@@ -844,6 +871,10 @@ def _build_schema(
             "type": "string",
             "description": "Discord message ID.",
         },
+        "content": {
+            "type": "string",
+            "description": "Replacement message content (edit_message).",
+        },
         "query": {
             "type": "string",
             "description": "Member name prefix to search for (search_members).",
@@ -929,6 +960,10 @@ _ACTION_403_HINT = {
     "delete_message": (
         "Bot lacks MANAGE_MESSAGES permission in this channel, or cannot view the channel/message."
     ),
+    "edit_message": (
+        "Bot can only edit messages it authored, and must be able to view and send "
+        "messages in this channel."
+    ),
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
     ),
@@ -992,6 +1027,7 @@ def _run_discord_action(
     user_id: str = "",
     role_id: str = "",
     message_id: str = "",
+    content: str = "",
     query: str = "",
     name: str = "",
     limit: int = 50,
@@ -1027,6 +1063,7 @@ def _run_discord_action(
         "user_id": user_id,
         "role_id": role_id,
         "message_id": message_id,
+        "content": content,
         "query": query,
         "name": name,
     }
@@ -1045,6 +1082,7 @@ def _run_discord_action(
             user_id=user_id,
             role_id=role_id,
             message_id=message_id,
+            content=content,
             query=query,
             name=name,
             limit=limit,
@@ -1078,7 +1116,7 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
-    "role_id": "", "message_id": "", "query": "", "name": "",
+    "role_id": "", "message_id": "", "content": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 


### PR DESCRIPTION
## Summary
- add `discord_admin.edit_message(channel_id, message_id, content)`
- add `discord_admin.delete_message(channel_id, message_id)`
- wire both through the existing Discord action manifest, schema, handler defaults, required-parameter validation, and 403 hints
- add tests for action calls, registry handler content propagation, admin/core schema split, validation, and 403 enrichment

Part of #1559.

## Test Plan
- `python3 -m pytest tests/tools/test_discord_tool.py -q -o addopts=`