### PR TITLE
feat(tui): add scripted showroom demos

### DIFF
--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -1,6 +1,6 @@
 # TUI Showroom
 
-Scripted demos of `ui-tui`. Workflows snapshot real ui-tui components (`MessageLine`, `Panel`, `Box`, `Text`) into ANSI and replay them through xterm.js with cinematic overlays. Recorded once, played any number of times — built for screen capture.
+Scripted demos of `ui-tui`. Workflows snapshot real ui-tui components (`MessageLine`, `Panel`, `Box`, `Text`) into ANSI and replay them in the browser with cinematic overlays. Recorded once, played any number of times — built for screen capture.
 
 ```bash
 npm run showroom            # dev server at http://127.0.0.1:4317
@@ -30,12 +30,12 @@ record.tsx           ─┐
 workflows/<name>.json
                      │  served at /api/workflow/<name>
                      ▼
-showroom.js          │  xterm.js writes ANSI; DOM overlays target frame ids
+showroom.js          │  ANSI parser + DOM overlays targeting frame ids
                      ▼
 browser
 ```
 
-`frame` actions embed ANSI from an Ink render; the browser feeds them into `@xterm/xterm` (jsDelivr CDN) so the surface is the actual TUI. Captions, spotlights, highlights, and fades are DOM overlays anchored to frame `id`s.
+`frame` actions embed ANSI from an Ink render; the browser parses them into `<pre>` elements with a lightweight converter. Captions, spotlights, highlights, and fades are DOM overlays anchored to frame `id`s. No CDN dependencies — zero network latency.
 
 ## Timeline actions
 

--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -1,59 +1,43 @@
 # TUI Showroom
 
-Cinematic demos of the real `ui-tui`. Workflows are built from actual Ink-rendered ANSI captured from `MessageLine`, `Panel`, and friends — replayed in xterm.js with timeline overlays (captions, spotlights, fades, highlights).
+Scripted demos of `ui-tui`. Workflows snapshot real ui-tui components (`MessageLine`, `Panel`, `Box`, `Text`) into ANSI and replay them through xterm.js with cinematic overlays. Recorded once, played any number of times — built for screen capture.
 
 ```bash
 npm run showroom            # dev server at http://127.0.0.1:4317
-npm run showroom:record     # re-record all workflows (regenerates JSON)
-npm run showroom:build      # builds dist/<name>.html for every workflow
+npm run showroom:record     # regenerate every workflow JSON
+npm run showroom:build      # dist/<name>.html for every workflow
 npm run showroom:type-check
 ```
 
 ## Bundled workflows
 
-| File                                   | Demonstrates                                          |
-| -------------------------------------- | ----------------------------------------------------- |
-| `workflows/feature-tour.json`          | Plan → tool trail → result highlight                  |
-| `workflows/subagent-trail.json`        | Parallel subagents, hot lanes, summary                |
-| `workflows/slash-commands.json`        | `/skills`, `/model`, `/agents` panels                 |
-| `workflows/voice-mode.json`            | VAD capture, transcript, TTS ducking                  |
+| File                                   | Shows                                                          |
+| -------------------------------------- | -------------------------------------------------------------- |
+| `workflows/feature-tour.json`          | Plan → tool trail → result highlight                            |
+| `workflows/subagent-trail.json`        | Parallel subagents, hot lanes, summary                          |
+| `workflows/slash-commands.json`        | `/skills`, `/model`, `/agents`, `/help` typed → echoed → panel  |
+| `workflows/voice-mode.json`            | VAD capture, transcript, TTS ducking                            |
 
-Use the dropdown in the top-right or pass `?w=<name>` to deep-link a workflow.
+Pick a workflow from the dropdown or deep-link with `?w=<name>`.
 
 ## Architecture
 
 ```
 record.tsx           ─┐
-  ↳ MessageLine,      │  Ink renders → custom Writable → ANSI string
-    Panel, Box, Text  │
-                      ▼
+  ↳ MessageLine,     │  Ink renders → Writable → ANSI string
+    Panel, Box, Text │
+                     ▼
 workflows/<name>.json
-                      │  served at /api/workflow/<name>
-                      ▼
-showroom.js           │  xterm.js writes ANSI; DOM overlays target frame ids
-                      ▼
+                     │  served at /api/workflow/<name>
+                     ▼
+showroom.js          │  xterm.js writes ANSI; DOM overlays target frame ids
+                     ▼
 browser
 ```
 
-Every `frame` action embeds the ANSI bytes from a real Ink render; the browser replays them via `@xterm/xterm` (loaded from jsDelivr) so the surface is the actual TUI, not a CSS approximation. Cinematic overlays (captions, spotlights, highlights, fades) are positioned by frame `id` and rendered via DOM.
+`frame` actions embed ANSI from an Ink render; the browser feeds them into `@xterm/xterm` (jsDelivr CDN) so the surface is the actual TUI. Captions, spotlights, highlights, and fades are DOM overlays anchored to frame `id`s.
 
-## Workflow Shape
-
-```json
-{
-  "title": "Hermes TUI · Feature Tour",
-  "viewport": { "cols": 80, "rows": 16 },
-  "composer": "ask hermes anything",
-  "timeline": [
-    { "at": 200, "type": "frame", "id": "user-row", "ansi": "..." },
-    { "at": 1500, "type": "frame", "id": "assistant", "ansi": "..." },
-    { "at": 1700, "type": "spotlight", "target": "assistant" },
-    { "at": 1900, "type": "caption", "target": "assistant", "text": "..." }
-  ]
-}
-```
-
-## Timeline Actions
+## Timeline actions
 
 | Action      | Required             | Optional                                              |
 | ----------- | -------------------- | ----------------------------------------------------- |
@@ -66,19 +50,18 @@ Every `frame` action embeds the ANSI bytes from a real Ink render; the browser r
 | `fade`      | `target`             | `to` (default `0`), `duration`                        |
 | `clear`     | —                    | —                                                     |
 
-`target` references the `id` of an earlier `frame`. `viewport.scale` (default = best-fit integer) controls the upscale factor; manual buttons offer 1x–4x for capture-ready output.
+`target` references the `id` of an earlier `frame`. `viewport.scale` (or the 1x–4x picker) controls the upscale factor for capture.
 
 ## Player
 
-- Restart, Clear, 1x–4x scale, 0.5x/1x/2x speed.
-- Keyboard: `R` restart, `C` clear, `1`/`2`/`3` speed.
-- Progress bar tracks elapsed/total based on the slowest action's `at + duration`.
+- Restart (`R`), 1x–4x scale, 0.5x/1x/2x speed (`1`/`2`/`3`).
+- Progress bar reads `at + duration` from the slowest action.
 
 ## Adding a workflow
 
-1. Add a scene fn to `record.tsx` that returns a `{ title, viewport, composer, timeline }` shape.
-2. Compose Ink primitives (`Box`, `Text`) or import real ui-tui components (`MessageLine`, `Panel`).
-3. Snap each scene with `await snap(<Component />)` to capture ANSI.
-4. Run `npm run showroom:record`.
+1. Add a scene fn to `record.tsx` returning `{ title, viewport, composer, timeline }`.
+2. Compose Ink primitives or pull `MessageLine` / `Panel` from `../src`.
+3. `await snap(<Component />)` for each frame.
+4. `npm run showroom:record`.
 
-Components rendered to ANSI must be **state-free** at first paint — `useEffect` hooks usually haven't fired by the time the recorder unmounts. For accordions like the live `ToolTrail`, render an inline scene with `Box` + `Text` instead.
+Components must be state-free at first paint — `useEffect` hooks won't fire by the time the recorder unmounts. For accordions like the live `ToolTrail`, render a flat `Box` + `Text` scene instead.

--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -1,70 +1,84 @@
 # TUI Showroom
 
-Scripted, record-ready demos for `ui-tui`. Drop a JSON workflow into `workflows/`, hit play.
+Cinematic demos of the real `ui-tui`. Workflows are built from actual Ink-rendered ANSI captured from `MessageLine`, `Panel`, and friends — replayed in xterm.js with timeline overlays (captions, spotlights, fades, highlights).
 
 ```bash
-npm run showroom
-npm run showroom:build
+npm run showroom            # dev server at http://127.0.0.1:4317
+npm run showroom:record     # re-record all workflows (regenerates JSON)
+npm run showroom:build      # builds dist/<name>.html for every workflow
 npm run showroom:type-check
-```
-
-`npm run showroom` serves every workflow in `workflows/` at `http://127.0.0.1:4317`. Use the dropdown in the top-right or pass `?w=<name>` to deep-link a workflow.
-
-```bash
-npm run showroom -- --port 4318
-npm run showroom -- --workflow .showroom/workflows/feature-tour.json
-npm run showroom:build                                  # builds dist/<name>.html for every workflow + dist/index.html
-npm run showroom:build .showroom/workflows/voice-mode.json dist/voice.html
 ```
 
 ## Bundled workflows
 
-| File                                   | Demonstrates                           |
-| -------------------------------------- | -------------------------------------- |
-| `workflows/feature-tour.json`          | Plan → tool trail → result highlight   |
-| `workflows/subagent-trail.json`        | Parallel subagents, hot lanes, summary |
-| `workflows/slash-commands.json`        | Slash palette: /skills, /model, /agents |
-| `workflows/voice-mode.json`            | VAD capture, transcript, TTS ducking   |
+| File                                   | Demonstrates                                          |
+| -------------------------------------- | ----------------------------------------------------- |
+| `workflows/feature-tour.json`          | Plan → tool trail → result highlight                  |
+| `workflows/subagent-trail.json`        | Parallel subagents, hot lanes, summary                |
+| `workflows/slash-commands.json`        | `/skills`, `/model`, `/agents` panels                 |
+| `workflows/voice-mode.json`            | VAD capture, transcript, TTS ducking                  |
+
+Use the dropdown in the top-right or pass `?w=<name>` to deep-link a workflow.
+
+## Architecture
+
+```
+record.tsx           ─┐
+  ↳ MessageLine,      │  Ink renders → custom Writable → ANSI string
+    Panel, Box, Text  │
+                      ▼
+workflows/<name>.json
+                      │  served at /api/workflow/<name>
+                      ▼
+showroom.js           │  xterm.js writes ANSI; DOM overlays target frame ids
+                      ▼
+browser
+```
+
+Every `frame` action embeds the ANSI bytes from a real Ink render; the browser replays them via `@xterm/xterm` (loaded from jsDelivr) so the surface is the actual TUI, not a CSS approximation. Cinematic overlays (captions, spotlights, highlights, fades) are positioned by frame `id` and rendered via DOM.
 
 ## Workflow Shape
 
 ```json
 {
-  "title": "Hermes TUI Feature Tour",
-  "viewport": { "cols": 96, "rows": 30, "scale": 4 },
+  "title": "Hermes TUI · Feature Tour",
+  "viewport": { "cols": 80, "rows": 16 },
+  "composer": "ask hermes anything",
   "timeline": [
-    { "at": 0, "type": "status", "text": "summoning hermes..." },
-    { "at": 250, "type": "message", "id": "prompt", "role": "user", "text": "Build a plan." },
-    { "at": 900, "type": "caption", "target": "prompt", "text": "Named targets drive overlays." }
+    { "at": 200, "type": "frame", "id": "user-row", "ansi": "..." },
+    { "at": 1500, "type": "frame", "id": "assistant", "ansi": "..." },
+    { "at": 1700, "type": "spotlight", "target": "assistant" },
+    { "at": 1900, "type": "caption", "target": "assistant", "text": "..." }
   ]
 }
 ```
 
 ## Timeline Actions
 
-| Action      | Required             | Optional                                    |
-| ----------- | -------------------- | ------------------------------------------- |
-| `status`    | `text`                | `detail`                                    |
-| `compose`   | `text`                | `duration` (typewriter)                     |
-| `message`   | `role`, `text`        | `id`, `duration`                            |
-| `tool`      | `title`, `items`      | `id`                                        |
-| `caption`   | `target`, `text`      | `position` (`left`/`right`/`top`), `duration` |
-| `spotlight` | `target`              | `pad`, `duration`                           |
-| `highlight` | `target`              | `duration`                                  |
-| `fade`      | `target`              | `to` (default `0`), `duration`              |
-| `clear`     | —                     | —                                           |
+| Action      | Required             | Optional                                              |
+| ----------- | -------------------- | ----------------------------------------------------- |
+| `frame`     | `ansi`               | `id`                                                  |
+| `status`    | `text`               | `detail`                                              |
+| `compose`   | `text`               | `duration` (typewriter)                               |
+| `caption`   | `target`, `text`     | `position` (`left`/`right`/`top`), `duration`         |
+| `spotlight` | `target`             | `pad`, `duration`                                     |
+| `highlight` | `target`             | `duration`                                            |
+| `fade`      | `target`             | `to` (default `0`), `duration`                        |
+| `clear`     | —                    | —                                                     |
 
-`target` references the `id` of an earlier `message`, `tool`, or caption. `viewport.scale` is the upscale factor — `scale: 4` produces a 4x capture surface without rescaling the source terminal proportions.
+`target` references the `id` of an earlier `frame`. `viewport.scale` (default = best-fit integer) controls the upscale factor; manual buttons offer 1x–4x for capture-ready output.
 
 ## Player
 
-- Restart, Clear, and 0.5x / 1x / 2x speed buttons under the stage.
+- Restart, Clear, 1x–4x scale, 0.5x/1x/2x speed.
 - Keyboard: `R` restart, `C` clear, `1`/`2`/`3` speed.
 - Progress bar tracks elapsed/total based on the slowest action's `at + duration`.
 
-## Authoring tips
+## Adding a workflow
 
-- Keep `at` values in milliseconds; sort happens automatically.
-- Use `id`s on every element you want to spotlight, fade, or caption later.
-- Captions auto-position next to their target; pass `position: "left"` or `"top"` when the right side is busy.
-- Test at a non-default speed before recording — fast reads are unforgiving.
+1. Add a scene fn to `record.tsx` that returns a `{ title, viewport, composer, timeline }` shape.
+2. Compose Ink primitives (`Box`, `Text`) or import real ui-tui components (`MessageLine`, `Panel`).
+3. Snap each scene with `await snap(<Component />)` to capture ANSI.
+4. Run `npm run showroom:record`.
+
+Components rendered to ANSI must be **state-free** at first paint — `useEffect` hooks usually haven't fired by the time the recorder unmounts. For accordions like the live `ToolTrail`, render an inline scene with `Box` + `Text` instead.

--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -1,6 +1,6 @@
 # TUI Showroom
 
-Scripted, record-ready demos for `ui-tui`.
+Scripted, record-ready demos for `ui-tui`. Drop a JSON workflow into `workflows/`, hit play.
 
 ```bash
 npm run showroom
@@ -8,16 +8,25 @@ npm run showroom:build
 npm run showroom:type-check
 ```
 
-`npm run showroom` serves the default workflow at `http://127.0.0.1:4317`.
+`npm run showroom` serves every workflow in `workflows/` at `http://127.0.0.1:4317`. Use the dropdown in the top-right or pass `?w=<name>` to deep-link a workflow.
 
 ```bash
-npm run showroom -- --workflow .showroom/workflows/feature-tour.json --port 4318
-npm run showroom:build -- .showroom/workflows/feature-tour.json .showroom/dist/feature-tour.html
+npm run showroom -- --port 4318
+npm run showroom -- --workflow .showroom/workflows/feature-tour.json
+npm run showroom:build                                  # builds dist/<name>.html for every workflow + dist/index.html
+npm run showroom:build .showroom/workflows/voice-mode.json dist/voice.html
 ```
 
-## Workflow Shape
+## Bundled workflows
 
-Workflows are JSON so the renderer has no extra deps.
+| File                                   | Demonstrates                           |
+| -------------------------------------- | -------------------------------------- |
+| `workflows/feature-tour.json`          | Plan → tool trail → result highlight   |
+| `workflows/subagent-trail.json`        | Parallel subagents, hot lanes, summary |
+| `workflows/slash-commands.json`        | Slash palette: /skills, /model, /agents |
+| `workflows/voice-mode.json`            | VAD capture, transcript, TTS ducking   |
+
+## Workflow Shape
 
 ```json
 {
@@ -33,14 +42,29 @@ Workflows are JSON so the renderer has no extra deps.
 
 ## Timeline Actions
 
-- `status`: set top status text, with optional `detail`
-- `compose`: type into the composer
-- `message`: append a transcript line; supports `role`, `id`, `text`, `duration`
-- `tool`: append a tool activity card; supports `id`, `title`, `items`
-- `caption`: fade in a caption near `target`; supports `position`, `duration`
-- `spotlight`: draw a spotlight around `target`; supports `pad`, `duration`
-- `highlight`: temporarily emphasize `target`
-- `fade`: set `target` opacity over `duration`
-- `clear`: reset transcript and overlays
+| Action      | Required             | Optional                                    |
+| ----------- | -------------------- | ------------------------------------------- |
+| `status`    | `text`                | `detail`                                    |
+| `compose`   | `text`                | `duration` (typewriter)                     |
+| `message`   | `role`, `text`        | `id`, `duration`                            |
+| `tool`      | `title`, `items`      | `id`                                        |
+| `caption`   | `target`, `text`      | `position` (`left`/`right`/`top`), `duration` |
+| `spotlight` | `target`              | `pad`, `duration`                           |
+| `highlight` | `target`              | `duration`                                  |
+| `fade`      | `target`              | `to` (default `0`), `duration`              |
+| `clear`     | —                     | —                                           |
 
-Targets are `id` values from `message`, `tool`, and captions. The stage is rendered at `viewport.scale`, so `scale: 4` creates a 4x capture surface without changing the source terminal proportions.
+`target` references the `id` of an earlier `message`, `tool`, or caption. `viewport.scale` is the upscale factor — `scale: 4` produces a 4x capture surface without rescaling the source terminal proportions.
+
+## Player
+
+- Restart, Clear, and 0.5x / 1x / 2x speed buttons under the stage.
+- Keyboard: `R` restart, `C` clear, `1`/`2`/`3` speed.
+- Progress bar tracks elapsed/total based on the slowest action's `at + duration`.
+
+## Authoring tips
+
+- Keep `at` values in milliseconds; sort happens automatically.
+- Use `id`s on every element you want to spotlight, fade, or caption later.
+- Captions auto-position next to their target; pass `position: "left"` or `"top"` when the right side is busy.
+- Test at a non-default speed before recording — fast reads are unforgiving.

--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -11,12 +11,12 @@ npm run showroom:type-check
 
 ## Bundled workflows
 
-| File                                   | Shows                                                          |
-| -------------------------------------- | -------------------------------------------------------------- |
-| `workflows/feature-tour.json`          | Plan → tool trail → result highlight                            |
-| `workflows/subagent-trail.json`        | Parallel subagents, hot lanes, summary                          |
-| `workflows/slash-commands.json`        | `/skills`, `/model`, `/agents`, `/help` typed → echoed → panel  |
-| `workflows/voice-mode.json`            | VAD capture, transcript, TTS ducking                            |
+| File                            | Shows                                                          |
+| ------------------------------- | -------------------------------------------------------------- |
+| `workflows/feature-tour.json`   | Plan → tool trail → result highlight                           |
+| `workflows/subagent-trail.json` | Parallel subagents, hot lanes, summary                         |
+| `workflows/slash-commands.json` | `/skills`, `/model`, `/agents`, `/help` typed → echoed → panel |
+| `workflows/voice-mode.json`     | VAD capture, transcript, TTS ducking                           |
 
 Pick a workflow from the dropdown or deep-link with `?w=<name>`.
 
@@ -39,16 +39,16 @@ browser
 
 ## Timeline actions
 
-| Action      | Required             | Optional                                              |
-| ----------- | -------------------- | ----------------------------------------------------- |
-| `frame`     | `ansi`               | `id`                                                  |
-| `status`    | `text`               | `detail`                                              |
-| `compose`   | `text`               | `duration` (typewriter)                               |
-| `caption`   | `target`, `text`     | `position` (`left`/`right`/`top`), `duration`         |
-| `spotlight` | `target`             | `pad`, `duration`                                     |
-| `highlight` | `target`             | `duration`                                            |
-| `fade`      | `target`             | `to` (default `0`), `duration`                        |
-| `clear`     | —                    | —                                                     |
+| Action      | Required         | Optional                                      |
+| ----------- | ---------------- | --------------------------------------------- |
+| `frame`     | `ansi`           | `id`                                          |
+| `status`    | `text`           | `detail`                                      |
+| `compose`   | `text`           | `duration` (typewriter)                       |
+| `caption`   | `target`, `text` | `position` (`left`/`right`/`top`), `duration` |
+| `spotlight` | `target`         | `pad`, `duration`                             |
+| `highlight` | `target`         | `duration`                                    |
+| `fade`      | `target`         | `to` (default `0`), `duration`                |
+| `clear`     | —                | —                                             |
 
 `target` references the `id` of an earlier `frame`. `viewport.scale` (or the 1x–4x picker) controls the upscale factor for capture.
 

--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -1,0 +1,46 @@
+# TUI Showroom
+
+Scripted, record-ready demos for `ui-tui`.
+
+```bash
+npm run showroom
+npm run showroom:build
+npm run showroom:type-check
+```
+
+`npm run showroom` serves the default workflow at `http://127.0.0.1:4317`.
+
+```bash
+npm run showroom -- --workflow .showroom/workflows/feature-tour.json --port 4318
+npm run showroom:build -- .showroom/workflows/feature-tour.json .showroom/dist/feature-tour.html
+```
+
+## Workflow Shape
+
+Workflows are JSON so the renderer has no extra deps.
+
+```json
+{
+  "title": "Hermes TUI Feature Tour",
+  "viewport": { "cols": 96, "rows": 30, "scale": 4 },
+  "timeline": [
+    { "at": 0, "type": "status", "text": "summoning hermes..." },
+    { "at": 250, "type": "message", "id": "prompt", "role": "user", "text": "Build a plan." },
+    { "at": 900, "type": "caption", "target": "prompt", "text": "Named targets drive overlays." }
+  ]
+}
+```
+
+## Timeline Actions
+
+- `status`: set top status text, with optional `detail`
+- `compose`: type into the composer
+- `message`: append a transcript line; supports `role`, `id`, `text`, `duration`
+- `tool`: append a tool activity card; supports `id`, `title`, `items`
+- `caption`: fade in a caption near `target`; supports `position`, `duration`
+- `spotlight`: draw a spotlight around `target`; supports `pad`, `duration`
+- `highlight`: temporarily emphasize `target`
+- `fade`: set `target` opacity over `duration`
+- `clear`: reset transcript and overlays
+
+Targets are `id` values from `message`, `tool`, and captions. The stage is rendered at `viewport.scale`, so `scale: 4` creates a 4x capture surface without changing the source terminal proportions.

--- a/ui-tui/.showroom/README.md
+++ b/ui-tui/.showroom/README.md
@@ -1,6 +1,6 @@
 # TUI Showroom
 
-Scripted demos of `ui-tui`. Workflows snapshot real ui-tui components (`MessageLine`, `Panel`, `Box`, `Text`) into ANSI and replay them in the browser with cinematic overlays. Recorded once, played any number of times — built for screen capture.
+Scripted demos of `ui-tui`. Workflows snapshot real ui-tui components (`MessageLine`, `Panel`, `Box`, `Text`) into ANSI and replay them through xterm.js with cinematic overlays. Recorded once, played any number of times — built for screen capture.
 
 ```bash
 npm run showroom            # dev server at http://127.0.0.1:4317
@@ -30,12 +30,12 @@ record.tsx           ─┐
 workflows/<name>.json
                      │  served at /api/workflow/<name>
                      ▼
-showroom.js          │  ANSI parser + DOM overlays targeting frame ids
+showroom.js          │  xterm.js renders ANSI; DOM overlays target frame ids
                      ▼
 browser
 ```
 
-`frame` actions embed ANSI from an Ink render; the browser parses them into `<pre>` elements with a lightweight converter. Captions, spotlights, highlights, and fades are DOM overlays anchored to frame `id`s. No CDN dependencies — zero network latency.
+`frame` actions embed ANSI from an Ink render; the browser feeds them into `@xterm/xterm` (CDN, cached) so the surface is the actual TUI. Captions, spotlights, highlights, and fades are DOM overlays anchored to frame `id`s.
 
 ## Timeline actions
 

--- a/ui-tui/.showroom/build.ts
+++ b/ui-tui/.showroom/build.ts
@@ -1,12 +1,70 @@
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 
-import { defaultWorkflowPath, readWorkflow, renderPage, showroomRoot } from './page.js'
+import { listWorkflows, readWorkflow, renderPage, showroomRoot } from './page.js'
 
-const workflowPath = resolve(process.cwd(), process.argv[2] ?? defaultWorkflowPath)
-const outPath = resolve(process.cwd(), process.argv[3] ?? join(showroomRoot, 'dist', 'index.html'))
+const FLAG_VALUES = new Set<string>([])
 
-mkdirSync(dirname(outPath), { recursive: true })
-writeFileSync(outPath, renderPage(readWorkflow(workflowPath)))
+const positionals = (() => {
+  const argv = process.argv.slice(2)
+  const out: string[] = []
 
-console.log(outPath)
+  for (let i = 0; i < argv.length; i++) {
+    const value = argv[i]!
+
+    if (FLAG_VALUES.has(value)) {
+      i += 1
+      continue
+    }
+
+    if (value.startsWith('-')) {
+      continue
+    }
+
+    out.push(value)
+  }
+
+  return out
+})()
+
+const explicitWorkflow = positionals[0]
+const explicitOut = positionals[1]
+const distDir = resolve(showroomRoot, 'dist')
+
+const writeHtml = (path: string, html: string) => {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, html)
+}
+
+const buildAll = () => {
+  const catalog = listWorkflows()
+
+  for (const entry of catalog) {
+    const html = renderPage({ name: entry.name, workflow: readWorkflow(entry.path) }, catalog)
+    const out = join(distDir, `${entry.name}.html`)
+
+    writeHtml(out, html)
+    console.log(out)
+  }
+
+  if (catalog.length) {
+    const indexEntry = catalog.find(w => w.name === 'feature-tour') ?? catalog[0]!
+    const html = renderPage({ name: indexEntry.name, workflow: readWorkflow(indexEntry.path) }, catalog)
+    const out = join(distDir, 'index.html')
+
+    writeHtml(out, html)
+    console.log(out)
+  }
+}
+
+if (explicitWorkflow) {
+  const path = resolve(process.cwd(), explicitWorkflow)
+  const out = resolve(process.cwd(), explicitOut ?? join(distDir, 'index.html'))
+  const catalog = listWorkflows()
+  const html = renderPage({ name: 'override', workflow: readWorkflow(path) }, catalog)
+
+  writeHtml(out, html)
+  console.log(out)
+} else {
+  buildAll()
+}

--- a/ui-tui/.showroom/build.ts
+++ b/ui-tui/.showroom/build.ts
@@ -1,0 +1,12 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+import { defaultWorkflowPath, readWorkflow, renderPage, showroomRoot } from './page.js'
+
+const workflowPath = resolve(process.cwd(), process.argv[2] ?? defaultWorkflowPath)
+const outPath = resolve(process.cwd(), process.argv[3] ?? join(showroomRoot, 'dist', 'index.html'))
+
+mkdirSync(dirname(outPath), { recursive: true })
+writeFileSync(outPath, renderPage(readWorkflow(workflowPath)))
+
+console.log(outPath)

--- a/ui-tui/.showroom/page.ts
+++ b/ui-tui/.showroom/page.ts
@@ -1,16 +1,38 @@
-import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, parse } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export const showroomRoot = dirname(fileURLToPath(import.meta.url))
-export const defaultWorkflowPath = join(showroomRoot, 'workflows', 'feature-tour.json')
+export const workflowsDir = join(showroomRoot, 'workflows')
+
+export interface WorkflowEntry {
+  name: string
+  path: string
+  title: string
+}
+
+export const listWorkflows = (): WorkflowEntry[] =>
+  readdirSync(workflowsDir)
+    .filter(file => file.endsWith('.json') && statSync(join(workflowsDir, file)).isFile())
+    .map(file => {
+      const path = join(workflowsDir, file)
+      const data = JSON.parse(readFileSync(path, 'utf8'))
+
+      return { name: parse(file).name, path, title: String(data.title ?? parse(file).name) }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+export const defaultWorkflowPath =
+  listWorkflows().find(w => w.name === 'feature-tour')?.path ?? listWorkflows()[0]?.path ?? ''
 
 export const readWorkflow = (path = defaultWorkflowPath) => JSON.parse(readFileSync(path, 'utf8'))
 
-export const renderPage = (workflow: unknown) => {
+export const renderPage = (initial: { name: string; workflow: unknown }, catalog: WorkflowEntry[]) => {
   const css = readFileSync(join(showroomRoot, 'src', 'showroom.css'), 'utf8')
   const js = readFileSync(join(showroomRoot, 'src', 'showroom.js'), 'utf8')
-  const data = JSON.stringify(workflow).replace(/</g, '\\u003c')
+  const safeCatalog = catalog.map(({ name, title }) => ({ name, title }))
+  const initialJson = JSON.stringify(initial).replace(/</g, '\\u003c')
+  const catalogJson = JSON.stringify(safeCatalog).replace(/</g, '\\u003c')
 
   return `<!doctype html>
 <html lang="en">
@@ -22,7 +44,10 @@ export const renderPage = (workflow: unknown) => {
   </head>
   <body>
     <main id="showroom"></main>
-    <script>window.__SHOWROOM_WORKFLOW__ = ${data}</script>
+    <script>
+      window.__SHOWROOM_INITIAL__ = ${initialJson};
+      window.__SHOWROOM_CATALOG__ = ${catalogJson};
+    </script>
     <script type="module">${js}</script>
   </body>
 </html>`

--- a/ui-tui/.showroom/page.ts
+++ b/ui-tui/.showroom/page.ts
@@ -40,6 +40,7 @@ export const renderPage = (initial: { name: string; workflow: unknown }, catalog
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Hermes TUI Showroom</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/css/xterm.css" />
     <style>${css}</style>
   </head>
   <body>
@@ -47,6 +48,9 @@ export const renderPage = (initial: { name: string; workflow: unknown }, catalog
     <script>
       window.__SHOWROOM_INITIAL__ = ${initialJson};
       window.__SHOWROOM_CATALOG__ = ${catalogJson};
+    </script>
+    <script type="importmap">
+    { "imports": { "@xterm/": "https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/" } }
     </script>
     <script type="module">${js}</script>
   </body>

--- a/ui-tui/.showroom/page.ts
+++ b/ui-tui/.showroom/page.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const showroomRoot = dirname(fileURLToPath(import.meta.url))
+export const defaultWorkflowPath = join(showroomRoot, 'workflows', 'feature-tour.json')
+
+export const readWorkflow = (path = defaultWorkflowPath) => JSON.parse(readFileSync(path, 'utf8'))
+
+export const renderPage = (workflow: unknown) => {
+  const css = readFileSync(join(showroomRoot, 'src', 'showroom.css'), 'utf8')
+  const js = readFileSync(join(showroomRoot, 'src', 'showroom.js'), 'utf8')
+  const data = JSON.stringify(workflow).replace(/</g, '\\u003c')
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hermes TUI Showroom</title>
+    <style>${css}</style>
+  </head>
+  <body>
+    <main id="showroom"></main>
+    <script>window.__SHOWROOM_WORKFLOW__ = ${data}</script>
+    <script type="module">${js}</script>
+  </body>
+</html>`
+}

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -143,7 +143,7 @@ const featureTour = async () => {
         duration: 1700,
         position: 'right',
         target: 'tool-trail',
-        text: 'Real ui-tui MessageLine + Panel rendered to ANSI and replayed in xterm.js.',
+        text: 'Real ui-tui MessageLine + Panel rendered to ANSI and replayed in the browser.',
         type: 'caption'
       },
       { ansi: assistantResult, at: 5400, id: 'assistant-result', type: 'frame' },

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -245,6 +245,9 @@ const subagentTrail = async () => {
 }
 
 const slashCommands = async () => {
+  const slashEcho = (text: string) => snap(<Msg kind="slash" role="user" text={text} />)
+
+  const skillsEcho = await slashEcho('/skills search vibe')
   const skillsResults = await snap(
     <Panel
       sections={[
@@ -257,11 +260,12 @@ const slashCommands = async () => {
         }
       ]}
       t={t}
-      title="/skills search vibe"
+      title="skills · search vibe"
     />,
     180
   )
 
+  const modelEcho = await slashEcho('/model claude-4.6-sonnet')
   const modelSwitch = await snap(
     <Panel
       sections={[
@@ -279,6 +283,7 @@ const slashCommands = async () => {
     180
   )
 
+  const agentsEcho = await slashEcho('/agents pause')
   const agentsStatus = await snap(
     <Panel
       sections={[
@@ -291,47 +296,68 @@ const slashCommands = async () => {
         }
       ]}
       t={t}
-      title="/agents · paused"
+      title="agents · paused"
     />,
     180
   )
 
+  const helpEcho = await slashEcho('/help')
+  const helpPanel = await snap(
+    <Panel
+      sections={[
+        { items: ['/skills    search · install · inspect', '/model     switch model · pop picker'], title: 'Tools & Skills' },
+        { items: ['/agents    spawn-tree dashboard', '/queue     queue prompt for next turn', '/steer     inject after next tool call'], title: 'Session' },
+        { items: ['/voice     toggle voice mode', '/details   thinking · tools · subagents · activity'], title: 'Configuration' }
+      ]}
+      t={t}
+      title="(^_^)? Commands"
+    />,
+    220
+  )
+
   return {
-    composer: 'press / to open the palette',
+    composer: '',
     timeline: [
-      { at: 200, duration: 500, text: '/skills search vibe', type: 'compose' },
-      { ansi: skillsResults, at: 800, id: 'skills', type: 'frame' },
-      { at: 1100, duration: 1500, target: 'skills', type: 'spotlight' },
+      { at: 200, duration: 700, text: '/skills search vibe', type: 'compose' },
+      { ansi: skillsEcho, at: 1100, type: 'frame' },
+      { at: 1100, duration: 200, text: '', type: 'compose' },
+      { ansi: skillsResults, at: 1400, id: 'skills', type: 'frame' },
       {
-        at: 1300,
-        duration: 1700,
+        at: 1700,
+        duration: 2000,
         position: 'right',
         target: 'skills',
-        text: 'Slash commands stream live results without blocking the composer.',
+        text: 'Typed /skills, hit return — same Panel the live TUI renders.',
         type: 'caption'
       },
-      { at: 3300, duration: 600, text: '/model claude-4.6-sonnet', type: 'compose' },
-      { ansi: modelSwitch, at: 4100, id: 'model', type: 'frame' },
+      { at: 4000, duration: 700, text: '/model claude-4.6-sonnet', type: 'compose' },
+      { ansi: modelEcho, at: 4900, type: 'frame' },
+      { at: 4900, duration: 200, text: '', type: 'compose' },
+      { ansi: modelSwitch, at: 5200, id: 'model', type: 'frame' },
       {
-        at: 4400,
-        duration: 1700,
+        at: 5500,
+        duration: 1900,
         position: 'right',
         target: 'model',
-        text: '/model also pops the inline picker when no arg is given.',
+        text: '/model swaps mid-session; transcript and cache stay intact.',
         type: 'caption'
       },
-      { at: 6300, duration: 600, text: '/agents pause', type: 'compose' },
-      { ansi: agentsStatus, at: 7000, id: 'agents', type: 'frame' },
-      { at: 7300, duration: 1300, target: 'agents', type: 'highlight' },
+      { at: 7600, duration: 600, text: '/agents pause', type: 'compose' },
+      { ansi: agentsEcho, at: 8400, type: 'frame' },
+      { at: 8400, duration: 200, text: '', type: 'compose' },
+      { ansi: agentsStatus, at: 8700, id: 'agents', type: 'frame' },
       {
-        at: 7500,
-        duration: 1700,
+        at: 9000,
+        duration: 1800,
         position: 'right',
         target: 'agents',
-        text: 'Same registry powers TUI, gateway, Telegram, Discord — one source of truth.',
+        text: 'Same registry powers TUI, gateway, Telegram, Discord — one truth.',
         type: 'caption'
       },
-      { at: 9300, duration: 600, text: '/resume', type: 'compose' }
+      { at: 11000, duration: 400, text: '/help', type: 'compose' },
+      { ansi: helpEcho, at: 11500, type: 'frame' },
+      { at: 11500, duration: 200, text: '', type: 'compose' },
+      { ansi: helpPanel, at: 11800, id: 'help', type: 'frame' }
     ],
     title: 'Hermes TUI · Slash Commands',
     viewport: { cols: COLS, rows: ROWS }

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -514,6 +514,53 @@ const ClarifyPromptStatic = ({
   </Box>
 )
 
+const ModelPickerStatic = ({
+  currentModel,
+  items,
+  selected = 0,
+  stage,
+  theme
+}: {
+  currentModel: string
+  items: string[]
+  selected?: number
+  stage: 'model' | 'provider'
+  theme: Theme
+}) => (
+  <Box borderStyle="double" borderColor={theme.color.amber} flexDirection="column" paddingX={1} width={50}>
+    <Text bold color={theme.color.amber} wrap="truncate-end">
+      {stage === 'provider' ? 'Select Provider' : 'Select Model'}
+    </Text>
+
+    <Text color={theme.color.dim} wrap="truncate-end">
+      {stage === 'provider' ? `Current model: ${currentModel}` : currentModel}
+    </Text>
+
+    <Text color={theme.color.label} wrap="truncate-end">
+      {' '}
+    </Text>
+
+    <Text color={theme.color.dim}>{' '}</Text>
+
+    {items.map((item, i) => (
+      <Text
+        bold={i === selected}
+        color={i === selected ? theme.color.amber : theme.color.dim}
+        inverse={i === selected}
+        key={item}
+        wrap="truncate-end"
+      >
+        {i === selected ? '▸ ' : '  '}
+        {i + 1}. {item}
+      </Text>
+    ))}
+
+    <Text color={theme.color.dim}>{' '}</Text>
+    <Text color={theme.color.dim}>persist: session · g toggle</Text>
+    <Text color={theme.color.dim}>↑/↓ select · Enter choose · 1-9,0 quick · Esc/q cancel</Text>
+  </Box>
+)
+
 const interactivePrompts = async () => {
   // User asks for something that triggers approval
   const userAsk = await snap(
@@ -611,6 +658,112 @@ const interactivePrompts = async () => {
   }
 }
 
+const modelPicker = async () => {
+  const userAsk = await snap(
+    <Msg role="user" text="Switch to Claude." />
+  )
+
+  const assistantReply = await snap(
+    <Msg role="assistant" text="Opening the model picker — pick a provider first, then a model." />
+  )
+
+  // Provider selection stage
+  const providers = await snap(
+    <ModelPickerStatic
+      currentModel="gpt-5-codex"
+      items={[
+        'OpenAI · 8 models',
+        'Anthropic · 6 models',
+        'Google · 5 models',
+        'OpenRouter · 42 models',
+        'xAI · 3 models'
+      ]}
+      selected={1}
+      stage="provider"
+      theme={t}
+    />,
+    180
+  )
+
+  // Model selection stage
+  const models = await snap(
+    <ModelPickerStatic
+      currentModel="Anthropic"
+      items={[
+        'claude-opus-4',
+        'claude-sonnet-4',
+        'claude-sonnet-3.7',
+        'claude-haiku-3.5',
+        'claude-sonnet-3.5'
+      ]}
+      selected={1}
+      stage="model"
+      theme={t}
+    />,
+    180
+  )
+
+  const result = await snap(
+    <Panel
+      sections={[
+        {
+          rows: [
+            ['from', 'gpt-5-codex'],
+            ['to', 'claude-sonnet-4'],
+            ['scope', 'this session']
+          ]
+        }
+      ]}
+      t={t}
+      title="model switched"
+    />,
+    180
+  )
+
+  return {
+    composer: '',
+    timeline: [
+      { at: 200, duration: 500, text: '/model', type: 'compose' },
+      { ansi: userAsk, at: 900, id: 'ask', type: 'frame' },
+      { ansi: assistantReply, at: 1800, id: 'reply', type: 'frame' },
+      { ansi: providers, at: 3000, id: 'providers', type: 'frame' },
+      { at: 3300, duration: 1800, target: 'providers', type: 'spotlight' },
+      {
+        at: 3500,
+        duration: 2000,
+        position: 'right',
+        target: 'providers',
+        text: 'Provider stage: pick from authenticated backends. Shows model count per provider.',
+        type: 'caption'
+      },
+      { at: 5600, duration: 300, text: '2', type: 'compose' },
+      { ansi: models, at: 6200, id: 'models', type: 'frame' },
+      { at: 6500, duration: 1800, target: 'models', type: 'spotlight' },
+      {
+        at: 6700,
+        duration: 2000,
+        position: 'right',
+        target: 'models',
+        text: 'Model stage: scrollable list with ▸ selection. Number keys for quick pick.',
+        type: 'caption'
+      },
+      { at: 9000, duration: 300, text: '2', type: 'compose' },
+      { ansi: result, at: 9600, id: 'result', type: 'frame' },
+      { at: 9900, duration: 1300, target: 'result', type: 'highlight' },
+      {
+        at: 10100,
+        duration: 1700,
+        position: 'right',
+        target: 'result',
+        text: 'Model swap mid-session. Transcript and cache stay intact.',
+        type: 'caption'
+      }
+    ],
+    title: 'Hermes TUI · Model Picker',
+    viewport: { cols: COLS, rows: ROWS }
+  }
+}
+
 const main = async () => {
   console.log('recording workflows…')
 
@@ -623,6 +776,7 @@ const main = async () => {
     'slash-commands.json',
     'voice-mode.json',
     'interactive-prompts.json',
+    'model-picker.json',
     'ink-frames.json'
   ]) {
     try {
@@ -637,6 +791,7 @@ const main = async () => {
   writeWorkflow('slash-commands', await slashCommands())
   writeWorkflow('voice-mode', await voiceMode())
   writeWorkflow('interactive-prompts', await interactivePrompts())
+  writeWorkflow('model-picker', await modelPicker())
 
   console.log('done')
 }

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -1,0 +1,434 @@
+import { rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { Writable } from 'node:stream'
+import { fileURLToPath } from 'node:url'
+
+import React from 'react'
+
+import { Box, render, Text } from '@hermes/ink'
+
+import { Panel } from '../src/components/branding.js'
+import { MessageLine } from '../src/components/messageLine.js'
+import { DEFAULT_THEME } from '../src/theme.js'
+import type { Theme } from '../src/theme.js'
+import type { Msg } from '../src/types.js'
+
+const showroomRoot = dirname(fileURLToPath(import.meta.url))
+
+class Capture extends Writable {
+  buffer = ''
+  isTTY = true
+  columns: number
+  rows: number
+
+  constructor(cols: number, rows: number) {
+    super()
+    this.columns = cols
+    this.rows = rows
+  }
+
+  override _write(chunk: any, _encoding: any, callback: any) {
+    this.buffer += chunk.toString()
+    callback()
+  }
+}
+
+const COLS = 80
+const ROWS = 16
+const t = DEFAULT_THEME
+
+const snap = async (node: React.ReactElement, settle = 120): Promise<string> => {
+  const stdout = new Capture(COLS, ROWS) as unknown as NodeJS.WriteStream
+  const inst = await render(node, { stdout, exitOnCtrlC: false, patchConsole: false })
+
+  await new Promise(resolve => setTimeout(resolve, settle))
+  inst.unmount()
+
+  return (stdout as unknown as Capture).buffer
+}
+
+const Msg = (msg: Msg) => <MessageLine cols={COLS} msg={msg} t={t} />
+
+const ToolPanel = ({ items, title, theme }: { items: string[]; theme: Theme; title: string }) => (
+  <Box flexDirection="column" marginLeft={2}>
+    <Box>
+      <Text color={theme.color.bronze}>⚡ </Text>
+      <Text bold color={theme.color.amber}>
+        {title}
+      </Text>
+      <Text color={theme.color.dim}>
+        {' '}
+        ({items.length})
+      </Text>
+    </Box>
+    {items.map((item, i) => (
+      <Box key={i}>
+        <Text color={theme.color.bronze}>{i === items.length - 1 ? '└─ ' : '├─ '}</Text>
+        <Text color={theme.color.dim}>{item}</Text>
+      </Box>
+    ))}
+  </Box>
+)
+
+const Tree = ({ rows, theme }: { rows: { branch: 'mid' | 'last'; cols: string[]; tone?: 'amber' | 'dim' | 'gold' | 'ok' }[]; theme: Theme }) => (
+  <Box flexDirection="column" marginLeft={2}>
+    {rows.map((row, i) => {
+      const stem = row.branch === 'last' ? '└─ ' : '├─ '
+      const tone =
+        row.tone === 'gold'
+          ? theme.color.gold
+          : row.tone === 'amber'
+            ? theme.color.amber
+            : row.tone === 'ok'
+              ? theme.color.ok
+              : theme.color.dim
+
+      return (
+        <Box key={i}>
+          <Text color={theme.color.bronze}>{stem}</Text>
+          <Text color={tone}>{row.cols.join('  ')}</Text>
+        </Box>
+      )
+    })}
+  </Box>
+)
+
+const writeWorkflow = (name: string, workflow: Record<string, unknown>) => {
+  const out = join(showroomRoot, 'workflows', `${name}.json`)
+  writeFileSync(out, JSON.stringify(workflow, null, 2))
+  console.log(`  wrote ${out}`)
+}
+
+const featureTour = async () => {
+  const userPrompt = await snap(
+    <Msg role="user" text="Build a focused plan for a safer gateway approval flow." />
+  )
+
+  const assistantPlan = await snap(
+    <Msg
+      role="assistant"
+      text="I'll trace the gateway guards first, then patch the smallest boundary that keeps approval commands live while an agent is blocked."
+    />
+  )
+
+  const toolTrail = await snap(
+    <ToolPanel
+      items={[
+        'rg "approval.request" gateway/ tui_gateway/',
+        'ReadFile gateway/run.py',
+        'ReadFile gateway/platforms/base.py'
+      ]}
+      theme={t}
+      title="tool trail"
+    />
+  )
+
+  const assistantResult = await snap(
+    <Msg
+      role="assistant"
+      text="Found the split guard. Bypass both queues only for approval commands; normal chat ordering stays intact."
+    />
+  )
+
+  return {
+    composer: 'ask hermes anything',
+    timeline: [
+      { ansi: userPrompt, at: 200, id: 'user-row', type: 'frame' },
+      { ansi: assistantPlan, at: 1500, id: 'assistant-plan', type: 'frame' },
+      { ansi: toolTrail, at: 2900, id: 'tool-trail', type: 'frame' },
+      { at: 3200, duration: 1700, target: 'tool-trail', type: 'spotlight' },
+      {
+        at: 3400,
+        duration: 1700,
+        position: 'right',
+        target: 'tool-trail',
+        text: 'Real ui-tui MessageLine + Panel rendered to ANSI and replayed in xterm.js.',
+        type: 'caption'
+      },
+      { ansi: assistantResult, at: 5400, id: 'assistant-result', type: 'frame' },
+      { at: 6100, duration: 1300, target: 'assistant-result', type: 'highlight' },
+      {
+        at: 6300,
+        duration: 1700,
+        position: 'right',
+        target: 'assistant-result',
+        text: 'Captions, spotlights, and fades layer on top of real ANSI. Best of both.',
+        type: 'caption'
+      },
+      { at: 8100, duration: 600, text: '/approve', type: 'compose' }
+    ],
+    title: 'Hermes TUI · Feature Tour',
+    viewport: { cols: COLS, rows: ROWS }
+  }
+}
+
+const subagentTrail = async () => {
+  const userPrompt = await snap(
+    <Msg role="user" text="Run tests, lint, and a Railway preview deploy in parallel." />
+  )
+
+  const plan = await snap(
+    <Msg
+      role="assistant"
+      text="Spawning three subagents on the fan-out lane and watching their tool counts."
+    />
+  )
+
+  const live = await snap(
+    <Tree
+      rows={[
+        { branch: 'mid', cols: ['tests   running   12 tools   ⏱ 14.2s'], tone: 'amber' },
+        { branch: 'mid', cols: ['lint    running    4 tools   ⏱ 14.2s'], tone: 'amber' },
+        { branch: 'last', cols: ['deploy  queued     0 tools   ⏱  0.0s'], tone: 'dim' }
+      ]}
+      theme={t}
+    />
+  )
+
+  const hot = await snap(
+    <Tree
+      rows={[
+        { branch: 'mid', cols: ['tests   complete  18 tools   ⏱ 22.7s   ✓'], tone: 'ok' },
+        { branch: 'mid', cols: ['lint    complete   6 tools   ⏱ 18.1s   ✓'], tone: 'ok' },
+        { branch: 'last', cols: ['deploy  running    9 tools   ⏱  9.4s'], tone: 'gold' }
+      ]}
+      theme={t}
+    />
+  )
+
+  const summary = await snap(
+    <Msg
+      role="assistant"
+      text="All three landed: 24 tests pass, lint clean, preview at https://pr-128.railway.app."
+    />
+  )
+
+  return {
+    composer: 'spawn the deploy fan-out',
+    timeline: [
+      { ansi: userPrompt, at: 200, id: 'ask', type: 'frame' },
+      { ansi: plan, at: 1100, id: 'plan', type: 'frame' },
+      { ansi: live, at: 2100, id: 'live', type: 'frame' },
+      { at: 2300, duration: 1500, target: 'live', type: 'spotlight' },
+      {
+        at: 2500,
+        duration: 1700,
+        position: 'right',
+        target: 'live',
+        text: 'Each subagent gets its own depth and tool budget; the dashboard tracks them live.',
+        type: 'caption'
+      },
+      { ansi: hot, at: 4400, id: 'hot', type: 'frame' },
+      { at: 4600, duration: 1300, target: 'hot', type: 'highlight' },
+      {
+        at: 4800,
+        duration: 1700,
+        position: 'right',
+        target: 'hot',
+        text: 'Completed runs collapse, hot lanes stay vivid — the eye tracks the live agent.',
+        type: 'caption'
+      },
+      { ansi: summary, at: 6800, id: 'summary', type: 'frame' },
+      {
+        at: 7000,
+        duration: 1700,
+        position: 'right',
+        target: 'summary',
+        text: 'Subagent results stream back into the parent transcript as a single highlight.',
+        type: 'caption'
+      },
+      { at: 8800, duration: 600, text: '/agents', type: 'compose' }
+    ],
+    title: 'Hermes TUI · Subagent Trail',
+    viewport: { cols: COLS, rows: ROWS }
+  }
+}
+
+const slashCommands = async () => {
+  const skillsResults = await snap(
+    <Panel
+      sections={[
+        {
+          rows: [
+            ['anthropics/skills/frontend-design', '★ trusted'],
+            ['openai/skills/skill-creator', '· official'],
+            ['skills.sh/community/vibe-coding', '⚙ community']
+          ]
+        }
+      ]}
+      t={t}
+      title="/skills search vibe"
+    />,
+    180
+  )
+
+  const modelSwitch = await snap(
+    <Panel
+      sections={[
+        {
+          rows: [
+            ['from', 'gpt-5-codex'],
+            ['to', 'claude-4.6-sonnet'],
+            ['scope', 'this session']
+          ]
+        }
+      ]}
+      t={t}
+      title="model switched"
+    />,
+    180
+  )
+
+  const agentsStatus = await snap(
+    <Panel
+      sections={[
+        {
+          rows: [
+            ['delegation', 'paused'],
+            ['max children', '4'],
+            ['running tasks', 'queued for resume']
+          ]
+        }
+      ]}
+      t={t}
+      title="/agents · paused"
+    />,
+    180
+  )
+
+  return {
+    composer: 'press / to open the palette',
+    timeline: [
+      { at: 200, duration: 500, text: '/skills search vibe', type: 'compose' },
+      { ansi: skillsResults, at: 800, id: 'skills', type: 'frame' },
+      { at: 1100, duration: 1500, target: 'skills', type: 'spotlight' },
+      {
+        at: 1300,
+        duration: 1700,
+        position: 'right',
+        target: 'skills',
+        text: 'Slash commands stream live results without blocking the composer.',
+        type: 'caption'
+      },
+      { at: 3300, duration: 600, text: '/model claude-4.6-sonnet', type: 'compose' },
+      { ansi: modelSwitch, at: 4100, id: 'model', type: 'frame' },
+      {
+        at: 4400,
+        duration: 1700,
+        position: 'right',
+        target: 'model',
+        text: '/model also pops the inline picker when no arg is given.',
+        type: 'caption'
+      },
+      { at: 6300, duration: 600, text: '/agents pause', type: 'compose' },
+      { ansi: agentsStatus, at: 7000, id: 'agents', type: 'frame' },
+      { at: 7300, duration: 1300, target: 'agents', type: 'highlight' },
+      {
+        at: 7500,
+        duration: 1700,
+        position: 'right',
+        target: 'agents',
+        text: 'Same registry powers TUI, gateway, Telegram, Discord — one source of truth.',
+        type: 'caption'
+      },
+      { at: 9300, duration: 600, text: '/resume', type: 'compose' }
+    ],
+    title: 'Hermes TUI · Slash Commands',
+    viewport: { cols: COLS, rows: ROWS }
+  }
+}
+
+const voiceMode = async () => {
+  const vad = await snap(
+    <ToolPanel
+      items={['▮ ▮▮ ▮ ▮▮▮▮ ▮▮ ▮▮▮▮▮▮ ▮▮▮ ▮', 'rms 0.42 · 1.6s captured', 'auto-stop · silence 380ms']}
+      theme={t}
+      title="VAD · capturing"
+    />
+  )
+
+  const transcript = await snap(
+    <Msg role="user" text="what's in my inbox today and what needs a reply before noon?" />
+  )
+
+  const answer = await snap(
+    <Msg
+      role="assistant"
+      text="Three threads need you before noon: vendor renewal, podcast intro feedback, and the design review at 11."
+    />
+  )
+
+  const tts = await snap(
+    <ToolPanel
+      items={['voice 11labs · grace_v3', 'elapsed 4.6s · 2 chunks queued', 'ducking mic input']}
+      theme={t}
+      title="tts · playing"
+    />
+  )
+
+  return {
+    composer: 'ctrl+b to start recording',
+    timeline: [
+      { ansi: vad, at: 250, id: 'vad', type: 'frame' },
+      { at: 600, duration: 1500, target: 'vad', type: 'spotlight' },
+      {
+        at: 800,
+        duration: 1700,
+        position: 'right',
+        target: 'vad',
+        text: 'Continuous loop: VAD detects silence, transcribes, restarts — no key holds.',
+        type: 'caption'
+      },
+      { ansi: transcript, at: 2700, id: 'transcript', type: 'frame' },
+      { at: 3400, duration: 1100, target: 'transcript', type: 'highlight' },
+      {
+        at: 3600,
+        duration: 1700,
+        position: 'right',
+        target: 'transcript',
+        text: 'Transcript flows straight into the composer with the standard ❯ user glyph.',
+        type: 'caption'
+      },
+      { ansi: answer, at: 5500, id: 'answer', type: 'frame' },
+      { ansi: tts, at: 6700, id: 'tts', type: 'frame' },
+      {
+        at: 7000,
+        duration: 1700,
+        position: 'right',
+        target: 'tts',
+        text: 'TTS auto-ducks the mic so the loop never echoes itself back.',
+        type: 'caption'
+      },
+      { at: 8800, duration: 600, text: '/voice off', type: 'compose' }
+    ],
+    title: 'Hermes TUI · Voice Mode',
+    viewport: { cols: COLS, rows: ROWS }
+  }
+}
+
+const main = async () => {
+  console.log('recording workflows…')
+
+  // Wipe the workflows dir so deleted/renamed scenes don't linger.
+  const workflowsDir = join(showroomRoot, 'workflows')
+
+  for (const file of ['feature-tour.json', 'subagent-trail.json', 'slash-commands.json', 'voice-mode.json', 'ink-frames.json']) {
+    try {
+      rmSync(join(workflowsDir, file))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  writeWorkflow('feature-tour', await featureTour())
+  writeWorkflow('subagent-trail', await subagentTrail())
+  writeWorkflow('slash-commands', await slashCommands())
+  writeWorkflow('voice-mode', await voiceMode())
+
+  console.log('done')
+}
+
+void main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -9,8 +9,8 @@ import { Box, render, Text } from '@hermes/ink'
 
 import { Panel } from '../src/components/branding.js'
 import { MessageLine } from '../src/components/messageLine.js'
-import { DEFAULT_THEME } from '../src/theme.js'
 import type { Theme } from '../src/theme.js'
+import { DEFAULT_THEME } from '../src/theme.js'
 import type { Msg } from '../src/types.js'
 
 const showroomRoot = dirname(fileURLToPath(import.meta.url))
@@ -56,10 +56,7 @@ const ToolPanel = ({ items, title, theme }: { items: string[]; theme: Theme; tit
       <Text bold color={theme.color.amber}>
         {title}
       </Text>
-      <Text color={theme.color.dim}>
-        {' '}
-        ({items.length})
-      </Text>
+      <Text color={theme.color.dim}> ({items.length})</Text>
     </Box>
     {items.map((item, i) => (
       <Box key={i}>
@@ -70,7 +67,13 @@ const ToolPanel = ({ items, title, theme }: { items: string[]; theme: Theme; tit
   </Box>
 )
 
-const Tree = ({ rows, theme }: { rows: { branch: 'mid' | 'last'; cols: string[]; tone?: 'amber' | 'dim' | 'gold' | 'ok' }[]; theme: Theme }) => (
+const Tree = ({
+  rows,
+  theme
+}: {
+  rows: { branch: 'mid' | 'last'; cols: string[]; tone?: 'amber' | 'dim' | 'gold' | 'ok' }[]
+  theme: Theme
+}) => (
   <Box flexDirection="column" marginLeft={2}>
     {rows.map((row, i) => {
       const stem = row.branch === 'last' ? '└─ ' : '├─ '
@@ -100,9 +103,7 @@ const writeWorkflow = (name: string, workflow: Record<string, unknown>) => {
 }
 
 const featureTour = async () => {
-  const userPrompt = await snap(
-    <Msg role="user" text="Build a focused plan for a safer gateway approval flow." />
-  )
+  const userPrompt = await snap(<Msg role="user" text="Build a focused plan for a safer gateway approval flow." />)
 
   const assistantPlan = await snap(
     <Msg
@@ -163,15 +164,10 @@ const featureTour = async () => {
 }
 
 const subagentTrail = async () => {
-  const userPrompt = await snap(
-    <Msg role="user" text="Run tests, lint, and a Railway preview deploy in parallel." />
-  )
+  const userPrompt = await snap(<Msg role="user" text="Run tests, lint, and a Railway preview deploy in parallel." />)
 
   const plan = await snap(
-    <Msg
-      role="assistant"
-      text="Spawning three subagents on the fan-out lane and watching their tool counts."
-    />
+    <Msg role="assistant" text="Spawning three subagents on the fan-out lane and watching their tool counts." />
   )
 
   const live = await snap(
@@ -197,10 +193,7 @@ const subagentTrail = async () => {
   )
 
   const summary = await snap(
-    <Msg
-      role="assistant"
-      text="All three landed: 24 tests pass, lint clean, preview at https://pr-128.railway.app."
-    />
+    <Msg role="assistant" text="All three landed: 24 tests pass, lint clean, preview at https://pr-128.railway.app." />
   )
 
   return {
@@ -305,9 +298,22 @@ const slashCommands = async () => {
   const helpPanel = await snap(
     <Panel
       sections={[
-        { items: ['/skills    search · install · inspect', '/model     switch model · pop picker'], title: 'Tools & Skills' },
-        { items: ['/agents    spawn-tree dashboard', '/queue     queue prompt for next turn', '/steer     inject after next tool call'], title: 'Session' },
-        { items: ['/voice     toggle voice mode', '/details   thinking · tools · subagents · activity'], title: 'Configuration' }
+        {
+          items: ['/skills    search · install · inspect', '/model     switch model · pop picker'],
+          title: 'Tools & Skills'
+        },
+        {
+          items: [
+            '/agents    spawn-tree dashboard',
+            '/queue     queue prompt for next turn',
+            '/steer     inject after next tool call'
+          ],
+          title: 'Session'
+        },
+        {
+          items: ['/voice     toggle voice mode', '/details   thinking · tools · subagents · activity'],
+          title: 'Configuration'
+        }
       ]}
       t={t}
       title="(^_^)? Commands"
@@ -373,9 +379,7 @@ const voiceMode = async () => {
     />
   )
 
-  const transcript = await snap(
-    <Msg role="user" text="what's in my inbox today and what needs a reply before noon?" />
-  )
+  const transcript = await snap(<Msg role="user" text="what's in my inbox today and what needs a reply before noon?" />)
 
   const answer = await snap(
     <Msg
@@ -438,7 +442,13 @@ const main = async () => {
   // Wipe the workflows dir so deleted/renamed scenes don't linger.
   const workflowsDir = join(showroomRoot, 'workflows')
 
-  for (const file of ['feature-tour.json', 'subagent-trail.json', 'slash-commands.json', 'voice-mode.json', 'ink-frames.json']) {
+  for (const file of [
+    'feature-tour.json',
+    'subagent-trail.json',
+    'slash-commands.json',
+    'voice-mode.json',
+    'ink-frames.json'
+  ]) {
     try {
       rmSync(join(workflowsDir, file))
     } catch {

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -436,6 +436,181 @@ const voiceMode = async () => {
   }
 }
 
+// --- Static prompt mocks (no useInput, safe for snap()) ---
+
+const ApprovalPromptStatic = ({
+  command,
+  description,
+  selected = 0,
+  theme
+}: {
+  command: string
+  description: string
+  selected?: number
+  theme: Theme
+}) => {
+  const labels = ['Allow once', 'Allow this session', 'Always allow', 'Deny']
+  const lines = command.split('\n').slice(0, 5)
+
+  return (
+    <Box borderColor={theme.color.warn} borderStyle="double" flexDirection="column" paddingX={1}>
+      <Text bold color={theme.color.warn}>
+        ⚠ approval required · {description}
+      </Text>
+
+      <Box flexDirection="column" paddingLeft={1}>
+        {lines.map((line, i) => (
+          <Text color={theme.color.cornsilk} key={i}>
+            {line || ' '}
+          </Text>
+        ))}
+      </Box>
+
+      <Text />
+
+      {labels.map((label, i) => (
+        <Text key={label}>
+          <Text bold={i === selected} color={i === selected ? theme.color.warn : theme.color.dim} inverse={i === selected}>
+            {i === selected ? '▸ ' : '  '}
+            {i + 1}. {label}
+          </Text>
+        </Text>
+      ))}
+
+      <Text color={theme.color.dim}>↑/↓ select · Enter confirm · 1-4 quick pick · Ctrl+C deny</Text>
+    </Box>
+  )
+}
+
+const ClarifyPromptStatic = ({
+  choices,
+  question,
+  selected = 0,
+  theme
+}: {
+  choices: string[]
+  question: string
+  selected?: number
+  theme: Theme
+}) => (
+  <Box flexDirection="column">
+    <Text bold>
+      <Text color={theme.color.amber}>ask</Text>
+      <Text color={theme.color.cornsilk}> {question}</Text>
+    </Text>
+
+    {[...choices, 'Other (type your answer)'].map((c, i) => (
+      <Text key={i}>
+        <Text bold={i === selected} color={i === selected ? theme.color.label : theme.color.dim} inverse={i === selected}>
+          {i === selected ? '▸ ' : '  '}
+          {i + 1}. {c}
+        </Text>
+      </Text>
+    ))}
+
+    <Text color={theme.color.dim}>
+      ↑/↓ select · Enter confirm · 1-{choices.length + 1} quick pick · Esc cancel
+    </Text>
+  </Box>
+)
+
+const interactivePrompts = async () => {
+  // User asks for something that triggers approval
+  const userAsk = await snap(
+    <Msg role="user" text="Run npm install express in the project root." />
+  )
+
+  const assistantExplains = await snap(
+    <Msg
+      role="assistant"
+      text="I'll install express. The package manager needs approval — here's the command."
+    />
+  )
+
+  // Approval prompt
+  const approval = await snap(
+    <ApprovalPromptStatic
+      command={'npm install express\nadded 58 packages in 3.2s\n\n+ express@5.1.0'}
+      description="install dependency"
+      theme={t}
+    />,
+    180
+  )
+
+  // After approval, user asks something ambiguous
+  const userClarify = await snap(
+    <Msg role="user" text="Deploy this to staging." />
+  )
+
+  const assistantAsks = await snap(
+    <Msg role="assistant" text="Which environment should I target?" />
+  )
+
+  // Clarify prompt
+  const clarify = await snap(
+    <ClarifyPromptStatic
+      choices={['staging-us-east', 'staging-eu-west', 'staging-ap-south']}
+      question="Which region?"
+      theme={t}
+    />,
+    180
+  )
+
+  const confirmResult = await snap(
+    <Panel
+      sections={[
+        {
+          rows: [
+            ['target', 'staging-us-east'],
+            ['branch', 'main'],
+            ['preview', 'https://pr-128.railway.app']
+          ]
+        }
+      ]}
+      t={t}
+      title="deployment queued"
+    />,
+    180
+  )
+
+  return {
+    composer: 'deploy this to staging',
+    timeline: [
+      { ansi: userAsk, at: 200, id: 'ask', type: 'frame' },
+      { ansi: assistantExplains, at: 1200, id: 'explain', type: 'frame' },
+      { ansi: approval, at: 2600, id: 'approval', type: 'frame' },
+      { at: 2900, duration: 1500, target: 'approval', type: 'spotlight' },
+      {
+        at: 3100,
+        duration: 2000,
+        position: 'right',
+        target: 'approval',
+        text: 'Approval prompts gate dangerous commands. Four options: allow once, session, always, deny.',
+        type: 'caption'
+      },
+      { at: 5400, duration: 400, text: '1', type: 'compose' },
+      { at: 5900, duration: 500, text: '', type: 'compose' },
+      { ansi: userClarify, at: 6600, id: 'clarify-ask', type: 'frame' },
+      { ansi: assistantAsks, at: 7600, id: 'clarify-reply', type: 'frame' },
+      { ansi: clarify, at: 8800, id: 'clarify', type: 'frame' },
+      { at: 9100, duration: 1500, target: 'clarify', type: 'spotlight' },
+      {
+        at: 9300,
+        duration: 2000,
+        position: 'right',
+        target: 'clarify',
+        text: 'Clarify prompts handle ambiguous requests — numbered choices or free text.',
+        type: 'caption'
+      },
+      { at: 11600, duration: 400, text: '1', type: 'compose' },
+      { ansi: confirmResult, at: 12200, id: 'result', type: 'frame' },
+      { at: 12500, duration: 1300, target: 'result', type: 'highlight' }
+    ],
+    title: 'Hermes TUI · Interactive Prompts',
+    viewport: { cols: COLS, rows: ROWS }
+  }
+}
+
 const main = async () => {
   console.log('recording workflows…')
 
@@ -447,6 +622,7 @@ const main = async () => {
     'subagent-trail.json',
     'slash-commands.json',
     'voice-mode.json',
+    'interactive-prompts.json',
     'ink-frames.json'
   ]) {
     try {
@@ -460,6 +636,7 @@ const main = async () => {
   writeWorkflow('subagent-trail', await subagentTrail())
   writeWorkflow('slash-commands', await slashCommands())
   writeWorkflow('voice-mode', await voiceMode())
+  writeWorkflow('interactive-prompts', await interactivePrompts())
 
   console.log('done')
 }

--- a/ui-tui/.showroom/record.tsx
+++ b/ui-tui/.showroom/record.tsx
@@ -143,7 +143,7 @@ const featureTour = async () => {
         duration: 1700,
         position: 'right',
         target: 'tool-trail',
-        text: 'Real ui-tui MessageLine + Panel rendered to ANSI and replayed in the browser.',
+        text: 'Real ui-tui MessageLine + Panel rendered to ANSI and replayed via xterm.js.',
         type: 'caption'
       },
       { ansi: assistantResult, at: 5400, id: 'assistant-result', type: 'frame' },

--- a/ui-tui/.showroom/server.ts
+++ b/ui-tui/.showroom/server.ts
@@ -6,8 +6,8 @@ import {
   listWorkflows,
   readWorkflow,
   renderPage,
-  type WorkflowEntry,
-  workflowsDir
+  workflowsDir,
+  type WorkflowEntry
 } from './page.js'
 
 const FLAG_VALUES = new Set(['--port', '--workflow'])

--- a/ui-tui/.showroom/server.ts
+++ b/ui-tui/.showroom/server.ts
@@ -1,7 +1,16 @@
 import { createServer } from 'node:http'
 import { resolve } from 'node:path'
 
-import { defaultWorkflowPath, readWorkflow, renderPage } from './page.js'
+import {
+  defaultWorkflowPath,
+  listWorkflows,
+  readWorkflow,
+  renderPage,
+  type WorkflowEntry,
+  workflowsDir
+} from './page.js'
+
+const FLAG_VALUES = new Set(['--port', '--workflow'])
 
 const arg = (name: string) => {
   const index = process.argv.indexOf(name)
@@ -9,18 +18,82 @@ const arg = (name: string) => {
   return index === -1 ? undefined : process.argv[index + 1]
 }
 
+const positional = (() => {
+  const argv = process.argv.slice(2)
+
+  for (let i = 0; i < argv.length; i++) {
+    const value = argv[i]!
+
+    if (FLAG_VALUES.has(value)) {
+      i += 1
+      continue
+    }
+
+    if (value.startsWith('-')) {
+      continue
+    }
+
+    return value
+  }
+
+  return undefined
+})()
+
 const port = Number(arg('--port') ?? process.env.PORT ?? 4317)
-const workflowPath = resolve(process.cwd(), arg('--workflow') ?? process.argv[2] ?? defaultWorkflowPath)
+const overridePath = arg('--workflow') ?? positional
+
+const pickInitial = (catalog: WorkflowEntry[], requested: null | string): WorkflowEntry => {
+  if (overridePath) {
+    const fullPath = resolve(process.cwd(), overridePath)
+
+    return { name: 'override', path: fullPath, title: requested ?? 'override' }
+  }
+
+  if (requested) {
+    const hit = catalog.find(w => w.name === requested)
+
+    if (hit) {
+      return hit
+    }
+  }
+
+  return catalog.find(w => w.path === defaultWorkflowPath) ?? catalog[0]!
+}
 
 const server = createServer((req, res) => {
-  if (req.url === '/healthz') {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
+
+  if (url.pathname === '/healthz') {
     res.writeHead(200).end('ok')
 
     return
   }
 
+  if (url.pathname === '/api/workflows') {
+    res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify(listWorkflows()))
+
+    return
+  }
+
+  if (url.pathname.startsWith('/api/workflow/')) {
+    const name = decodeURIComponent(url.pathname.slice('/api/workflow/'.length))
+    const hit = listWorkflows().find(w => w.name === name)
+
+    if (!hit) {
+      res.writeHead(404).end('not found')
+
+      return
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify(readWorkflow(hit.path)))
+
+    return
+  }
+
   try {
-    const page = renderPage(readWorkflow(workflowPath))
+    const catalog = listWorkflows()
+    const initial = pickInitial(catalog, url.searchParams.get('w'))
+    const page = renderPage({ name: initial.name, workflow: readWorkflow(initial.path) }, catalog)
 
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }).end(page)
   } catch (error) {
@@ -32,5 +105,5 @@ const server = createServer((req, res) => {
 
 server.listen(port, '127.0.0.1', () => {
   console.log(`showroom: http://127.0.0.1:${port}`)
-  console.log(`workflow: ${workflowPath}`)
+  console.log(`workflows dir: ${workflowsDir}`)
 })

--- a/ui-tui/.showroom/server.ts
+++ b/ui-tui/.showroom/server.ts
@@ -1,0 +1,36 @@
+import { createServer } from 'node:http'
+import { resolve } from 'node:path'
+
+import { defaultWorkflowPath, readWorkflow, renderPage } from './page.js'
+
+const arg = (name: string) => {
+  const index = process.argv.indexOf(name)
+
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+const port = Number(arg('--port') ?? process.env.PORT ?? 4317)
+const workflowPath = resolve(process.cwd(), arg('--workflow') ?? process.argv[2] ?? defaultWorkflowPath)
+
+const server = createServer((req, res) => {
+  if (req.url === '/healthz') {
+    res.writeHead(200).end('ok')
+
+    return
+  }
+
+  try {
+    const page = renderPage(readWorkflow(workflowPath))
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }).end(page)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' }).end(message)
+  }
+})
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`showroom: http://127.0.0.1:${port}`)
+  console.log(`workflow: ${workflowPath}`)
+})

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -178,15 +178,15 @@ body {
   display: block;
 }
 
-.showroom-xterm {
-  width: 100%;
-  height: 100%;
+.showroom-frame {
+  margin: 0;
+  padding: 0;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--cornsilk);
+  white-space: pre;
   overflow: hidden;
-}
-
-.showroom-xterm .xterm-viewport {
-  overflow: hidden !important;
-  background: transparent !important;
 }
 
 .showroom-line,

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -1,7 +1,17 @@
 :root {
   color-scheme: dark;
-  background: #070707;
+  background: #050505;
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  --gold: #ffd700;
+  --amber: #ffbf00;
+  --bronze: #cd7f32;
+  --cornsilk: #fff8dc;
+  --dim: #cc9b1f;
+  --label: #daa520;
+  --bg: #0a0a0a;
+  --bg-deep: #050505;
+  --status-bg: #1a1a2e;
+  --status-fg: #c0c0c0;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
 }
@@ -15,19 +25,24 @@ body {
   margin: 0;
   overflow: auto;
   background:
-    radial-gradient(circle at 18% 12%, rgba(214, 168, 79, 0.18), transparent 34rem),
-    radial-gradient(circle at 82% 18%, rgba(90, 130, 255, 0.14), transparent 30rem), #050505;
+    radial-gradient(circle at 18% 12%, rgba(205, 127, 50, 0.12), transparent 36rem),
+    radial-gradient(circle at 82% 14%, rgba(255, 215, 0, 0.05), transparent 30rem),
+    var(--bg-deep);
 }
 
 #showroom {
   min-height: 100vh;
-  padding: 48px 48px 96px;
+  padding: 24px 24px 60px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
 .showroom-shell {
   display: grid;
-  gap: 18px;
+  gap: 10px;
   width: max-content;
+  max-width: 100%;
   opacity: 0;
   transform: translateY(12px);
   transition:
@@ -45,8 +60,8 @@ body {
   align-items: end;
   justify-content: space-between;
   gap: 24px;
-  color: #f5e8c7;
-  font-size: 20px;
+  color: var(--cornsilk);
+  font-size: 18px;
   letter-spacing: 0.04em;
 }
 
@@ -54,13 +69,12 @@ body {
   display: flex;
   align-items: baseline;
   gap: 12px;
-  color: #f5e8c7;
 }
 
 .showroom-title-tag {
-  color: #8f856f;
+  color: var(--dim);
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.16em;
 }
@@ -69,28 +83,28 @@ body {
   display: flex;
   gap: 12px;
   align-items: center;
-  color: #8f856f;
+  color: var(--dim);
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 12px;
 }
 
 .showroom-picker {
   appearance: none;
-  border: 1px solid rgba(245, 232, 199, 0.18);
+  border: 1px solid rgba(205, 127, 50, 0.4);
   border-radius: 999px;
   padding: 6px 30px 6px 14px;
   background:
-    rgba(245, 232, 199, 0.06)
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' fill='none' stroke='%23f5e8c7' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
+    rgba(205, 127, 50, 0.06)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' fill='none' stroke='%23cd7f32' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
     no-repeat right 12px center / 10px;
-  color: #f5e8c7;
+  color: var(--cornsilk);
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 12px;
   cursor: pointer;
 }
 
 .showroom-picker:focus {
-  outline: 1px solid rgba(241, 203, 120, 0.6);
+  outline: 1px solid var(--bronze);
 }
 
 .showroom-stage {
@@ -98,12 +112,12 @@ body {
   width: var(--stage-w);
   height: var(--stage-h);
   overflow: hidden;
-  border: 1px solid rgba(245, 232, 199, 0.18);
-  border-radius: 28px;
-  background: #080808;
+  border: 1px solid rgba(205, 127, 50, 0.45);
+  border-radius: 14px;
+  background: var(--bg);
   box-shadow:
-    0 48px 160px rgba(0, 0, 0, 0.56),
-    0 0 0 1px rgba(255, 255, 255, 0.035) inset;
+    0 32px 120px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
 }
 
 .showroom-terminal {
@@ -116,41 +130,65 @@ body {
   transform: scale(var(--scale));
   transform-origin: top left;
   overflow: hidden;
-  padding: 14px 16px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 18%), #0a0a0a;
-  color: #d8d0bd;
+  padding: 8px 10px;
+  background: var(--bg);
+  color: var(--cornsilk);
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 13px;
   line-height: 18px;
 }
 
-.showroom-status,
+.showroom-status {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 18px;
+  padding: 0 4px;
+  color: var(--dim);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.showroom-status:empty,
+.showroom-status-left:empty,
+.showroom-status-right:empty {
+  display: none;
+}
+
+.showroom-status-left,
+.showroom-status-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .showroom-composer {
   display: flex;
   align-items: center;
   min-height: 22px;
-  color: #8f856f;
+  padding: 6px 4px 0;
+  color: var(--cornsilk);
   white-space: nowrap;
 }
 
-.showroom-status {
-  justify-content: space-between;
-  border-bottom: 1px solid rgba(245, 232, 199, 0.1);
-  padding-bottom: 7px;
+.showroom-composer:empty {
+  display: none;
 }
 
-.showroom-composer {
-  border-top: 1px solid rgba(245, 232, 199, 0.1);
-  padding-top: 7px;
+.showroom-composer::before {
+  content: '❯';
+  color: var(--gold);
+  font-weight: 700;
+  margin-right: 8px;
 }
 
-.showroom-composer::after {
+.showroom-composer:not(:empty)::after {
   content: '';
   display: inline-block;
   width: 7px;
   height: 14px;
   margin-left: 4px;
-  background: #f1cb78;
+  background: var(--gold);
   vertical-align: middle;
   animation: showroom-blink 1100ms steps(2) infinite;
 }
@@ -164,15 +202,32 @@ body {
 .showroom-body {
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 6px;
   overflow: hidden;
-  padding: 12px 0;
+  padding: 4px 0 6px;
+}
+
+.showroom-body.is-frame-mode {
+  padding: 0;
+  gap: 0;
+  display: block;
+}
+
+.showroom-xterm {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.showroom-xterm .xterm-viewport {
+  overflow: hidden !important;
+  background: transparent !important;
 }
 
 .showroom-line,
 .showroom-tool {
   opacity: 0;
-  transform: translateY(6px);
+  transform: translateY(4px);
   animation: showroom-enter 320ms var(--ease-out) forwards;
   transition:
     opacity 420ms var(--ease-in-out),
@@ -190,8 +245,8 @@ body {
 
 .showroom-line {
   display: grid;
-  grid-template-columns: 26px 1fr;
-  gap: 6px;
+  grid-template-columns: 22px 1fr;
+  gap: 4px;
 }
 
 .showroom-glyph {
@@ -200,39 +255,58 @@ body {
 }
 
 .showroom-copy {
-  color: var(--role);
+  color: var(--copy);
   white-space: pre-wrap;
 }
 
+.showroom-line-user .showroom-copy {
+  color: var(--label);
+  font-weight: 600;
+}
+
 .showroom-line-assistant .showroom-copy {
-  color: #d8d0bd;
+  color: var(--cornsilk);
+}
+
+.showroom-line-system .showroom-copy {
+  color: var(--dim);
 }
 
 .showroom-tool {
-  margin-left: 32px;
-  border: 1px solid rgba(214, 168, 79, 0.18);
-  border-radius: 11px;
-  padding: 8px 10px;
-  background: rgba(214, 168, 79, 0.055);
-  color: #c7b891;
+  margin-left: 22px;
+  border: 1px solid rgba(205, 127, 50, 0.32);
+  border-radius: 4px;
+  padding: 6px 10px;
+  background: rgba(205, 127, 50, 0.05);
 }
 
 .showroom-tool-title {
-  color: #f1cb78;
+  color: var(--gold);
   font-weight: 700;
+}
+
+.showroom-tool-title::before {
+  content: '⚡ ';
+  color: var(--bronze);
 }
 
 .showroom-tool-items {
   display: grid;
-  gap: 2px;
-  margin-top: 5px;
-  color: #908872;
+  gap: 1px;
+  margin-top: 4px;
+  color: var(--dim);
+  font-size: 12px;
+}
+
+.showroom-tool-items div::before {
+  content: '┊ ';
+  color: var(--bronze);
 }
 
 .is-highlighted {
-  filter: brightness(1.45);
-  background: rgba(214, 168, 79, 0.12);
-  transform: translateX(4px);
+  filter: brightness(1.4);
+  background: rgba(255, 215, 0, 0.1);
+  transform: translateX(3px);
 }
 
 .showroom-overlays {
@@ -251,24 +325,24 @@ body {
 }
 
 .showroom-caption {
-  max-width: 420px;
-  border: 1px solid rgba(245, 232, 199, 0.2);
-  border-radius: 18px;
-  padding: 14px 16px;
-  background: rgba(12, 12, 12, 0.82);
-  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.42);
-  color: #f5e8c7;
-  font-size: 18px;
-  line-height: 1.35;
+  max-width: 360px;
+  border: 1px solid rgba(205, 127, 50, 0.5);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: rgba(10, 10, 10, 0.92);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.5);
+  color: var(--cornsilk);
+  font-size: 14px;
+  line-height: 1.45;
   transform: translateY(8px);
 }
 
 .showroom-spotlight {
-  border: 2px solid rgba(241, 203, 120, 0.7);
-  border-radius: 16px;
+  border: 2px solid var(--gold);
+  border-radius: 8px;
   box-shadow:
-    0 0 0 9999px rgba(0, 0, 0, 0.34),
-    0 0 40px rgba(241, 203, 120, 0.22);
+    0 0 0 9999px rgba(0, 0, 0, 0.42),
+    0 0 32px rgba(255, 215, 0, 0.32);
 }
 
 .showroom-caption.is-visible,
@@ -285,40 +359,52 @@ body {
 }
 
 .showroom-controls button {
-  border: 1px solid rgba(245, 232, 199, 0.18);
+  border: 1px solid rgba(205, 127, 50, 0.35);
   border-radius: 999px;
-  padding: 8px 14px;
-  background: rgba(245, 232, 199, 0.06);
-  color: #f5e8c7;
+  padding: 6px 14px;
+  background: rgba(205, 127, 50, 0.06);
+  color: var(--cornsilk);
   cursor: pointer;
   font: inherit;
+  font-size: 13px;
 }
 
 .showroom-controls button:hover {
-  background: rgba(245, 232, 199, 0.12);
+  background: rgba(205, 127, 50, 0.14);
 }
 
-.showroom-speed {
+.showroom-segmented {
   display: inline-flex;
-  border: 1px solid rgba(245, 232, 199, 0.18);
+  border: 1px solid rgba(205, 127, 50, 0.35);
   border-radius: 999px;
   padding: 2px;
-  background: rgba(245, 232, 199, 0.06);
+  background: rgba(205, 127, 50, 0.04);
 }
 
-.showroom-speed button {
+.showroom-segmented button {
   border: 0;
   border-radius: 999px;
-  padding: 6px 12px;
+  padding: 4px 12px;
   background: transparent;
-  color: #c7b891;
+  color: var(--dim);
   cursor: pointer;
   font: inherit;
+  font-size: 12px;
 }
 
-.showroom-speed button.is-active {
-  background: rgba(241, 203, 120, 0.18);
-  color: #f5e8c7;
+.showroom-segmented button.is-active {
+  background: rgba(255, 215, 0, 0.18);
+  color: var(--cornsilk);
+}
+
+.showroom-segmented-label {
+  align-self: center;
+  margin-right: 4px;
+  color: var(--dim);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
 .showroom-progress {
@@ -327,7 +413,7 @@ body {
   gap: 12px;
   width: 100%;
   margin-top: 4px;
-  color: #8f856f;
+  color: var(--dim);
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 11px;
 }
@@ -335,9 +421,9 @@ body {
 .showroom-progress-track {
   position: relative;
   flex: 1;
-  height: 4px;
+  height: 3px;
   border-radius: 999px;
-  background: rgba(245, 232, 199, 0.08);
+  background: rgba(205, 127, 50, 0.1);
   overflow: hidden;
 }
 
@@ -345,6 +431,6 @@ body {
   position: absolute;
   inset: 0 auto 0 0;
   width: 0;
-  background: linear-gradient(90deg, rgba(214, 168, 79, 0.7), rgba(241, 203, 120, 1));
+  background: linear-gradient(90deg, var(--bronze), var(--gold));
   transition: width 80ms linear;
 }

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -40,7 +40,7 @@ body {
 
 .showroom-shell {
   display: grid;
-  gap: 10px;
+  gap: 14px;
   width: max-content;
   max-width: 100%;
   opacity: 0;
@@ -53,39 +53,6 @@ body {
 .showroom-shell.is-mounted {
   opacity: 1;
   transform: translateY(0);
-}
-
-.showroom-title {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 24px;
-  color: var(--cornsilk);
-  font-size: 18px;
-  letter-spacing: 0.04em;
-}
-
-.showroom-title-name {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-}
-
-.showroom-title-tag {
-  color: var(--dim);
-  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-}
-
-.showroom-meta {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  color: var(--dim);
-  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 12px;
 }
 
 .showroom-picker {
@@ -354,28 +321,38 @@ body {
 .showroom-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
 }
 
 .showroom-controls button {
-  border: 1px solid rgba(205, 127, 50, 0.35);
+  border: 1px solid rgba(205, 127, 50, 0.25);
   border-radius: 999px;
-  padding: 6px 14px;
-  background: rgba(205, 127, 50, 0.06);
-  color: var(--cornsilk);
+  padding: 4px 10px;
+  background: rgba(205, 127, 50, 0.04);
+  color: var(--dim);
   cursor: pointer;
   font: inherit;
-  font-size: 13px;
 }
 
 .showroom-controls button:hover {
-  background: rgba(205, 127, 50, 0.14);
+  background: rgba(205, 127, 50, 0.12);
+  color: var(--cornsilk);
+}
+
+.showroom-controls button[data-action="restart"] {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
 }
 
 .showroom-segmented {
   display: inline-flex;
-  border: 1px solid rgba(205, 127, 50, 0.35);
+  border: 1px solid rgba(205, 127, 50, 0.25);
   border-radius: 999px;
   padding: 2px;
   background: rgba(205, 127, 50, 0.04);
@@ -384,12 +361,11 @@ body {
 .showroom-segmented button {
   border: 0;
   border-radius: 999px;
-  padding: 4px 12px;
+  padding: 3px 10px;
   background: transparent;
   color: var(--dim);
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
 }
 
 .showroom-segmented button.is-active {
@@ -397,31 +373,19 @@ body {
   color: var(--cornsilk);
 }
 
-.showroom-segmented-label {
-  align-self: center;
-  margin-right: 4px;
-  color: var(--dim);
-  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
 .showroom-progress {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  margin-top: 4px;
+  gap: 10px;
+  flex: 1;
+  min-width: 140px;
   color: var(--dim);
-  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 11px;
 }
 
 .showroom-progress-track {
   position: relative;
   flex: 1;
-  height: 3px;
+  height: 2px;
   border-radius: 999px;
   background: rgba(205, 127, 50, 0.1);
   overflow: hidden;

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -2,6 +2,8 @@
   color-scheme: dark;
   background: #070707;
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
 }
 
 * {
@@ -19,28 +21,76 @@ body {
 
 #showroom {
   min-height: 100vh;
-  padding: 48px;
+  padding: 48px 48px 96px;
 }
 
 .showroom-shell {
   display: grid;
   gap: 18px;
   width: max-content;
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 600ms var(--ease-out),
+    transform 600ms var(--ease-out);
+}
+
+.showroom-shell.is-mounted {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .showroom-title {
   display: flex;
   align-items: end;
   justify-content: space-between;
+  gap: 24px;
   color: #f5e8c7;
   font-size: 20px;
   letter-spacing: 0.04em;
 }
 
-.showroom-meta {
+.showroom-title-name {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  color: #f5e8c7;
+}
+
+.showroom-title-tag {
   color: #8f856f;
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
   font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.showroom-meta {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  color: #8f856f;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+}
+
+.showroom-picker {
+  appearance: none;
+  border: 1px solid rgba(245, 232, 199, 0.18);
+  border-radius: 999px;
+  padding: 6px 30px 6px 14px;
+  background:
+    rgba(245, 232, 199, 0.06)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' fill='none' stroke='%23f5e8c7' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
+    no-repeat right 12px center / 10px;
+  color: #f5e8c7;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.showroom-picker:focus {
+  outline: 1px solid rgba(241, 203, 120, 0.6);
 }
 
 .showroom-stage {
@@ -94,6 +144,23 @@ body {
   padding-top: 7px;
 }
 
+.showroom-composer::after {
+  content: '';
+  display: inline-block;
+  width: 7px;
+  height: 14px;
+  margin-left: 4px;
+  background: #f1cb78;
+  vertical-align: middle;
+  animation: showroom-blink 1100ms steps(2) infinite;
+}
+
+@keyframes showroom-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
 .showroom-body {
   display: flex;
   flex-direction: column;
@@ -104,11 +171,21 @@ body {
 
 .showroom-line,
 .showroom-tool {
+  opacity: 0;
+  transform: translateY(6px);
+  animation: showroom-enter 320ms var(--ease-out) forwards;
   transition:
-    opacity 420ms ease,
-    filter 420ms ease,
-    transform 420ms ease,
-    background 420ms ease;
+    opacity 420ms var(--ease-in-out),
+    filter 420ms var(--ease-in-out),
+    transform 420ms var(--ease-in-out),
+    background 420ms var(--ease-in-out);
+}
+
+@keyframes showroom-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .showroom-line {
@@ -169,8 +246,8 @@ body {
   position: absolute;
   opacity: 0;
   transition:
-    opacity 360ms ease,
-    transform 360ms ease;
+    opacity 360ms var(--ease-out),
+    transform 360ms var(--ease-out);
 }
 
 .showroom-caption {
@@ -202,7 +279,9 @@ body {
 
 .showroom-controls {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
+  align-items: center;
 }
 
 .showroom-controls button {
@@ -212,8 +291,60 @@ body {
   background: rgba(245, 232, 199, 0.06);
   color: #f5e8c7;
   cursor: pointer;
+  font: inherit;
 }
 
 .showroom-controls button:hover {
   background: rgba(245, 232, 199, 0.12);
+}
+
+.showroom-speed {
+  display: inline-flex;
+  border: 1px solid rgba(245, 232, 199, 0.18);
+  border-radius: 999px;
+  padding: 2px;
+  background: rgba(245, 232, 199, 0.06);
+}
+
+.showroom-speed button {
+  border: 0;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: transparent;
+  color: #c7b891;
+  cursor: pointer;
+  font: inherit;
+}
+
+.showroom-speed button.is-active {
+  background: rgba(241, 203, 120, 0.18);
+  color: #f5e8c7;
+}
+
+.showroom-progress {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 4px;
+  color: #8f856f;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+}
+
+.showroom-progress-track {
+  position: relative;
+  flex: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(245, 232, 199, 0.08);
+  overflow: hidden;
+}
+
+.showroom-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  background: linear-gradient(90deg, rgba(214, 168, 79, 0.7), rgba(241, 203, 120, 1));
+  transition: width 80ms linear;
 }

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -10,8 +10,6 @@
   --label: #daa520;
   --bg: #0a0a0a;
   --bg-deep: #050505;
-  --status-bg: #1a1a2e;
-  --status-fg: #c0c0c0;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
 }
@@ -26,7 +24,8 @@ body {
   overflow: auto;
   background:
     radial-gradient(circle at 18% 12%, rgba(205, 127, 50, 0.12), transparent 36rem),
-    radial-gradient(circle at 82% 14%, rgba(255, 215, 0, 0.05), transparent 30rem), var(--bg-deep);
+    radial-gradient(circle at 82% 14%, rgba(255, 215, 0, 0.05), transparent 30rem),
+    var(--bg-deep);
 }
 
 #showroom {
@@ -36,6 +35,8 @@ body {
   justify-content: center;
   align-items: flex-start;
 }
+
+/* --- Shell --- */
 
 .showroom-shell {
   display: grid;
@@ -54,23 +55,7 @@ body {
   transform: translateY(0);
 }
 
-.showroom-picker {
-  appearance: none;
-  border: 1px solid rgba(205, 127, 50, 0.4);
-  border-radius: 999px;
-  padding: 6px 30px 6px 14px;
-  background: rgba(205, 127, 50, 0.06)
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' fill='none' stroke='%23cd7f32' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
-    no-repeat right 12px center / 10px;
-  color: var(--cornsilk);
-  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.showroom-picker:focus {
-  outline: 1px solid var(--bronze);
-}
+/* --- Stage --- */
 
 .showroom-stage {
   position: relative;
@@ -103,6 +88,8 @@ body {
   line-height: 18px;
 }
 
+/* --- Status bar --- */
+
 .showroom-status {
   display: flex;
   justify-content: space-between;
@@ -126,6 +113,8 @@ body {
   align-items: center;
   gap: 8px;
 }
+
+/* --- Composer --- */
 
 .showroom-composer {
   display: flex;
@@ -164,6 +153,8 @@ body {
   }
 }
 
+/* --- Body (DOM message mode) --- */
+
 .showroom-body {
   display: flex;
   flex-direction: column;
@@ -172,33 +163,32 @@ body {
   padding: 4px 0 6px;
 }
 
-.showroom-body.is-frame-mode {
-  padding: 0;
-  gap: 0;
-  display: block;
+/* --- xterm container (frame mode) --- */
+
+.showroom-xterm {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 300ms var(--ease-out);
 }
 
-.showroom-frame {
-  margin: 0;
-  padding: 0;
-  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
-  font-size: 13px;
-  line-height: 18px;
-  color: var(--cornsilk);
-  white-space: pre;
-  overflow: hidden;
+.showroom-xterm.is-visible {
+  opacity: 1;
 }
+
+.showroom-xterm .xterm-viewport {
+  overflow: hidden !important;
+  background: transparent !important;
+}
+
+/* --- DOM-mode lines --- */
 
 .showroom-line,
 .showroom-tool {
   opacity: 0;
   transform: translateY(4px);
   animation: showroom-enter 320ms var(--ease-out) forwards;
-  transition:
-    opacity 420ms var(--ease-in-out),
-    filter 420ms var(--ease-in-out),
-    transform 420ms var(--ease-in-out),
-    background 420ms var(--ease-in-out);
 }
 
 @keyframes showroom-enter {
@@ -237,6 +227,8 @@ body {
   color: var(--dim);
 }
 
+/* --- Tool panel --- */
+
 .showroom-tool {
   margin-left: 22px;
   border: 1px solid rgba(205, 127, 50, 0.32);
@@ -268,11 +260,19 @@ body {
   color: var(--bronze);
 }
 
+/* --- Highlight --- */
+
 .is-highlighted {
   filter: brightness(1.4);
   background: rgba(255, 215, 0, 0.1);
   transform: translateX(3px);
+  transition:
+    filter 420ms var(--ease-in-out),
+    background 420ms var(--ease-in-out),
+    transform 420ms var(--ease-in-out);
 }
+
+/* --- Overlays (captions, spotlights) --- */
 
 .showroom-overlays {
   position: absolute;
@@ -315,6 +315,28 @@ body {
   opacity: 1;
   transform: translateY(0);
 }
+
+/* --- Picker --- */
+
+.showroom-picker {
+  appearance: none;
+  border: 1px solid rgba(205, 127, 50, 0.4);
+  border-radius: 999px;
+  padding: 6px 30px 6px 14px;
+  background: rgba(205, 127, 50, 0.06)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' fill='none' stroke='%23cd7f32' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
+    no-repeat right 12px center / 10px;
+  color: var(--cornsilk);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.showroom-picker:focus {
+  outline: 1px solid var(--bronze);
+}
+
+/* --- Controls bar --- */
 
 .showroom-controls {
   display: flex;
@@ -370,6 +392,8 @@ body {
   background: rgba(255, 215, 0, 0.18);
   color: var(--cornsilk);
 }
+
+/* --- Progress --- */
 
 .showroom-progress {
   display: inline-flex;

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -26,8 +26,7 @@ body {
   overflow: auto;
   background:
     radial-gradient(circle at 18% 12%, rgba(205, 127, 50, 0.12), transparent 36rem),
-    radial-gradient(circle at 82% 14%, rgba(255, 215, 0, 0.05), transparent 30rem),
-    var(--bg-deep);
+    radial-gradient(circle at 82% 14%, rgba(255, 215, 0, 0.05), transparent 30rem), var(--bg-deep);
 }
 
 #showroom {
@@ -60,8 +59,7 @@ body {
   border: 1px solid rgba(205, 127, 50, 0.4);
   border-radius: 999px;
   padding: 6px 30px 6px 14px;
-  background:
-    rgba(205, 127, 50, 0.06)
+  background: rgba(205, 127, 50, 0.06)
     url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' fill='none' stroke='%23cd7f32' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
     no-repeat right 12px center / 10px;
   color: var(--cornsilk);
@@ -342,7 +340,7 @@ body {
   color: var(--cornsilk);
 }
 
-.showroom-controls button[data-action="restart"] {
+.showroom-controls button[data-action='restart'] {
   width: 28px;
   height: 28px;
   padding: 0;

--- a/ui-tui/.showroom/src/showroom.css
+++ b/ui-tui/.showroom/src/showroom.css
@@ -1,0 +1,219 @@
+:root {
+  color-scheme: dark;
+  background: #070707;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  overflow: auto;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(214, 168, 79, 0.18), transparent 34rem),
+    radial-gradient(circle at 82% 18%, rgba(90, 130, 255, 0.14), transparent 30rem), #050505;
+}
+
+#showroom {
+  min-height: 100vh;
+  padding: 48px;
+}
+
+.showroom-shell {
+  display: grid;
+  gap: 18px;
+  width: max-content;
+}
+
+.showroom-title {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  color: #f5e8c7;
+  font-size: 20px;
+  letter-spacing: 0.04em;
+}
+
+.showroom-meta {
+  color: #8f856f;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+}
+
+.showroom-stage {
+  position: relative;
+  width: var(--stage-w);
+  height: var(--stage-h);
+  overflow: hidden;
+  border: 1px solid rgba(245, 232, 199, 0.18);
+  border-radius: 28px;
+  background: #080808;
+  box-shadow:
+    0 48px 160px rgba(0, 0, 0, 0.56),
+    0 0 0 1px rgba(255, 255, 255, 0.035) inset;
+}
+
+.showroom-terminal {
+  position: absolute;
+  inset: 0 auto auto 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  width: var(--term-w);
+  height: var(--term-h);
+  transform: scale(var(--scale));
+  transform-origin: top left;
+  overflow: hidden;
+  padding: 14px 16px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 18%), #0a0a0a;
+  color: #d8d0bd;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.showroom-status,
+.showroom-composer {
+  display: flex;
+  align-items: center;
+  min-height: 22px;
+  color: #8f856f;
+  white-space: nowrap;
+}
+
+.showroom-status {
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(245, 232, 199, 0.1);
+  padding-bottom: 7px;
+}
+
+.showroom-composer {
+  border-top: 1px solid rgba(245, 232, 199, 0.1);
+  padding-top: 7px;
+}
+
+.showroom-body {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  overflow: hidden;
+  padding: 12px 0;
+}
+
+.showroom-line,
+.showroom-tool {
+  transition:
+    opacity 420ms ease,
+    filter 420ms ease,
+    transform 420ms ease,
+    background 420ms ease;
+}
+
+.showroom-line {
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 6px;
+}
+
+.showroom-glyph {
+  color: var(--role);
+  font-weight: 700;
+}
+
+.showroom-copy {
+  color: var(--role);
+  white-space: pre-wrap;
+}
+
+.showroom-line-assistant .showroom-copy {
+  color: #d8d0bd;
+}
+
+.showroom-tool {
+  margin-left: 32px;
+  border: 1px solid rgba(214, 168, 79, 0.18);
+  border-radius: 11px;
+  padding: 8px 10px;
+  background: rgba(214, 168, 79, 0.055);
+  color: #c7b891;
+}
+
+.showroom-tool-title {
+  color: #f1cb78;
+  font-weight: 700;
+}
+
+.showroom-tool-items {
+  display: grid;
+  gap: 2px;
+  margin-top: 5px;
+  color: #908872;
+}
+
+.is-highlighted {
+  filter: brightness(1.45);
+  background: rgba(214, 168, 79, 0.12);
+  transform: translateX(4px);
+}
+
+.showroom-overlays {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.showroom-caption,
+.showroom-spotlight {
+  position: absolute;
+  opacity: 0;
+  transition:
+    opacity 360ms ease,
+    transform 360ms ease;
+}
+
+.showroom-caption {
+  max-width: 420px;
+  border: 1px solid rgba(245, 232, 199, 0.2);
+  border-radius: 18px;
+  padding: 14px 16px;
+  background: rgba(12, 12, 12, 0.82);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.42);
+  color: #f5e8c7;
+  font-size: 18px;
+  line-height: 1.35;
+  transform: translateY(8px);
+}
+
+.showroom-spotlight {
+  border: 2px solid rgba(241, 203, 120, 0.7);
+  border-radius: 16px;
+  box-shadow:
+    0 0 0 9999px rgba(0, 0, 0, 0.34),
+    0 0 40px rgba(241, 203, 120, 0.22);
+}
+
+.showroom-caption.is-visible,
+.showroom-spotlight.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.showroom-controls {
+  display: flex;
+  gap: 10px;
+}
+
+.showroom-controls button {
+  border: 1px solid rgba(245, 232, 199, 0.18);
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: rgba(245, 232, 199, 0.06);
+  color: #f5e8c7;
+  cursor: pointer;
+}
+
+.showroom-controls button:hover {
+  background: rgba(245, 232, 199, 0.12);
+}

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -3,20 +3,59 @@ const catalog = window.__SHOWROOM_CATALOG__ ?? []
 const root = document.getElementById('showroom')
 const SPEEDS = [0.5, 1, 2]
 const SCALES = [1, 2, 3, 4]
-const XTERM_VERSION = '6.0.0'
-
-const role = {
-  assistant: { copy: '#fff8dc', glyph: '┊', tone: '#cd7f32' },
-  system: { copy: '#cc9b1f', glyph: '·', tone: '#cc9b1f' },
-  tool: { copy: '#cc9b1f', glyph: '⚡', tone: '#cd7f32' },
-  user: { copy: '#daa520', glyph: '❯', tone: '#ffd700' }
-}
 
 const escapeHtml = value =>
   String(value ?? '').replace(
-    /[&<>"']/g,
+    /[&<>\"']/g,
     char => ({ '&': '&amp;', '"': '&quot;', "'": '&#39;', '<': '&lt;', '>': '&gt;' })[char]
   )
+
+// Minimal ANSI-to-HTML: handles ESC[NC (cursor forward), strips control sequences.
+// No color SGR support needed — all styling comes from the Ink renderer's own output.
+const ansiToHtml = raw => {
+  let out = ''
+  let i = 0
+
+  while (i < raw.length) {
+    if (raw[i] === '\x1b' && raw[i + 1] === '[') {
+      let j = i + 2
+
+      while (j < raw.length && raw[j] >= '0' && raw[j] <= '9') j++
+      if (j < raw.length && raw[j] === ';') j++
+      while (j < raw.length && raw[j] >= '0' && raw[j] <= '9') j++
+
+      if (j < raw.length) {
+        const cmd = raw[j]
+
+        if (cmd === 'C') {
+          const n = parseInt(raw.slice(i + 2, j), 10) || 1
+          out += ' '.repeat(n)
+        }
+
+        // All other sequences (cursor hide/show, bracketed paste, etc.) — strip
+        i = j + 1
+        continue
+      }
+    }
+
+    if (raw[i] === '\r' && raw[i + 1] === '\n') {
+      out += '\n'
+      i += 2
+      continue
+    }
+
+    if (raw[i] === '\r') {
+      out += '\n'
+      i++
+      continue
+    }
+
+    out += raw[i]
+    i++
+  }
+
+  return out
+}
 
 const state = {
   body: null,
@@ -33,8 +72,6 @@ const state = {
   startedAt: 0,
   statusLeft: null,
   statusRight: null,
-  term: null,
-  termContainer: null,
   timers: [],
   total: 0,
   viewport: null,
@@ -135,7 +172,13 @@ const message = action => {
     return
   }
 
-  const spec = role[action.role] ?? role.assistant
+  const roleSpec = {
+    assistant: { copy: '#fff8dc', glyph: '┊', tone: '#cd7f32' },
+    system: { copy: '#cc9b1f', glyph: '·', tone: '#cc9b1f' },
+    tool: { copy: '#cc9b1f', glyph: '⚡', tone: '#cd7f32' },
+    user: { copy: '#daa520', glyph: '❯', tone: '#ffd700' }
+  }
+  const spec = roleSpec[action.role] ?? roleSpec.assistant
   const line = document.createElement('div')
   const glyph = document.createElement('span')
   const copy = document.createElement('div')
@@ -184,14 +227,18 @@ const tool = action => {
 }
 
 const frame = action => {
-  if (!state.term || !action.ansi) {
+  if (!action.ansi) {
     return
   }
 
-  state.term.write(action.ansi)
+  const pre = document.createElement('pre')
+  pre.className = 'showroom-frame'
+  pre.dataset.target = action.id ?? ''
+  pre.innerHTML = escapeHtml(ansiToHtml(action.ansi))
+  state.body.append(pre)
 
   if (action.id) {
-    state.frameTargets.set(action.id, state.termContainer)
+    state.frameTargets.set(action.id, pre)
   }
 }
 
@@ -258,14 +305,6 @@ const compose = action => setText(state.composer, action.text ?? '', action.dura
 const clearTranscript = () => {
   state.overlays.textContent = ''
   state.frameTargets.clear()
-
-  if (state.frameMode && state.term) {
-    state.term.reset()
-    state.term.write('\x1b[?25l')
-
-    return
-  }
-
   state.body.textContent = ''
 }
 
@@ -293,62 +332,6 @@ const tickProgress = () => {
   if (elapsed < state.total) {
     state.raf = requestAnimationFrame(tickProgress)
   }
-}
-
-const ensureXtermStylesheet = () => {
-  const id = 'xterm-css'
-
-  if (document.getElementById(id)) {
-    return
-  }
-
-  const link = document.createElement('link')
-  link.id = id
-  link.rel = 'stylesheet'
-  link.href = `https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/css/xterm.css`
-  document.head.append(link)
-}
-
-const initXterm = async () => {
-  ensureXtermStylesheet()
-  const mod = await import(`https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/+esm`)
-  const { Terminal } = mod
-
-  state.term = new Terminal({
-    cols: state.viewport.cols,
-    rows: state.viewport.rows,
-    fontFamily: 'JetBrains Mono, "SF Mono", Consolas, monospace',
-    fontSize: 13,
-    cursorBlink: false,
-    scrollback: 0,
-    convertEol: true,
-    allowProposedApi: true,
-    theme: {
-      background: '#0a0a0a',
-      foreground: '#fff8dc',
-      cursor: '#ffd700',
-      selectionBackground: '#3a3a55',
-      black: '#0a0a0a',
-      red: '#ef5350',
-      green: '#8fbc8f',
-      yellow: '#ffd700',
-      blue: '#5a82ff',
-      magenta: '#cd7f32',
-      cyan: '#daa520',
-      white: '#fff8dc',
-      brightBlack: '#cc9b1f',
-      brightRed: '#ef5350',
-      brightGreen: '#8fbc8f',
-      brightYellow: '#ffbf00',
-      brightBlue: '#5a82ff',
-      brightMagenta: '#cd7f32',
-      brightCyan: '#daa520',
-      brightWhite: '#fff8dc'
-    }
-  })
-
-  state.term.open(state.termContainer)
-  state.term.write('\x1b[?25l')
 }
 
 const play = () => {
@@ -444,12 +427,11 @@ const buildSegmented = (values, active) =>
 
 const computeViewport = () => {
   const fromWorkflow = state.workflow.viewport ?? {}
-  const usesFrames = (state.workflow.timeline ?? []).some(a => a.type === 'frame')
 
   return {
-    cellWidth: usesFrames ? 9 : 8,
+    cellWidth: 8,
     cols: 80,
-    lineHeight: usesFrames ? 19 : 18,
+    lineHeight: 18,
     rows: 24,
     scale: 2,
     ...fromWorkflow
@@ -481,7 +463,7 @@ const renderShell = () => {
       <div class="showroom-overlays"></div>
     </div>
     <footer class="showroom-controls">
-      <button type="button" data-action="restart" title="restart (R)">↻</button>
+      <button type="button" data-action="restart" title="restart (R)">&#8635;</button>
       <span class="showroom-segmented" data-segment="scale">${buildSegmented(SCALES, state.scale)}</span>
       <span class="showroom-segmented" data-segment="speed">${buildSegmented(SPEEDS, state.speed)}</span>
       ${catalog.length > 1 ? `<select class="showroom-picker" data-action="picker">${buildOptions()}</select>` : ''}
@@ -517,24 +499,11 @@ const renderShell = () => {
       void loadWorkflow(event.target.value)
     })
   }
-
-  if (state.frameMode) {
-    state.body.innerHTML = '<div class="showroom-xterm" data-target="terminal"></div>'
-    state.termContainer = state.body.querySelector('.showroom-xterm')
-  } else {
-    state.term = null
-    state.termContainer = null
-  }
 }
 
 const rebuild = async () => {
   renderShell()
   setScale(state.workflow.viewport?.scale ?? fitScale())
-
-  if (state.frameMode) {
-    await initXterm()
-  }
-
   play()
 }
 

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -1,13 +1,7 @@
-const workflow = window.__SHOWROOM_WORKFLOW__
+const initial = window.__SHOWROOM_INITIAL__
+const catalog = window.__SHOWROOM_CATALOG__ ?? []
 const root = document.getElementById('showroom')
-const timers = []
-
-let body
-let composer
-let overlays
-let statusLeft
-let statusRight
-let viewportConfig
+const SPEEDS = [0.5, 1, 2]
 
 const role = {
   assistant: { color: '#d8d0bd', glyph: '✦' },
@@ -19,36 +13,53 @@ const role = {
 const escapeHtml = value =>
   String(value ?? '').replace(
     /[&<>"']/g,
-    char =>
-      ({
-        '&': '&amp;',
-        '"': '&quot;',
-        "'": '&#39;',
-        '<': '&lt;',
-        '>': '&gt;'
-      })[char]
+    char => ({ '&': '&amp;', '"': '&quot;', "'": '&#39;', '<': '&lt;', '>': '&gt;' })[char]
   )
 
+const state = {
+  body: null,
+  composer: null,
+  overlays: null,
+  progressFill: null,
+  progressLabel: null,
+  raf: null,
+  shell: null,
+  speed: 1,
+  startedAt: 0,
+  statusLeft: null,
+  statusRight: null,
+  timers: [],
+  total: 0,
+  viewport: null,
+  workflow: initial?.workflow ?? { timeline: [] }
+}
+
 const clearTimers = () => {
-  while (timers.length) {
-    clearTimeout(timers.pop())
+  while (state.timers.length) {
+    clearTimeout(state.timers.pop())
+  }
+
+  if (state.raf) {
+    cancelAnimationFrame(state.raf)
+    state.raf = null
   }
 }
 
 const target = id => (id ? document.querySelector(`[data-target="${CSS.escape(id)}"]`) : null)
 
 const setText = (node, text = '', duration = 0) => {
-  if (!duration) {
+  if (!duration || state.speed <= 0) {
     node.textContent = text
 
     return
   }
 
   const chars = [...text]
+  const adjusted = duration / state.speed
   const started = performance.now()
 
   const frame = now => {
-    const n = Math.min(chars.length, Math.ceil(((now - started) / duration) * chars.length))
+    const n = Math.min(chars.length, Math.ceil(((now - started) / adjusted) * chars.length))
     node.textContent = chars.slice(0, n).join('')
 
     if (n < chars.length) {
@@ -60,22 +71,24 @@ const setText = (node, text = '', duration = 0) => {
 }
 
 const removeAfter = (node, duration = 1400) => {
-  timers.push(
+  const wait = duration / state.speed
+
+  state.timers.push(
     setTimeout(() => {
       node.classList.remove('is-visible')
-      timers.push(setTimeout(() => node.remove(), 420))
-    }, duration)
+      state.timers.push(setTimeout(() => node.remove(), 420 / state.speed))
+    }, wait)
   )
 }
 
 const rectFor = (id, pad = 10) => {
   const el = target(id)
 
-  if (!el) {
+  if (!el || !state.overlays) {
     return null
   }
 
-  const stage = overlays.getBoundingClientRect()
+  const stage = state.overlays.getBoundingClientRect()
   const rect = el.getBoundingClientRect()
 
   return {
@@ -90,8 +103,8 @@ const placeNear = (node, id, position = 'right') => {
   const rect = rectFor(id, 0)
 
   if (!rect) {
-    node.style.left = `${viewportConfig.scale * 28}px`
-    node.style.top = `${viewportConfig.scale * 28}px`
+    node.style.left = `${state.viewport.scale * 28}px`
+    node.style.top = `${state.viewport.scale * 28}px`
 
     return
   }
@@ -120,7 +133,7 @@ const message = action => {
   copy.className = 'showroom-copy'
 
   line.append(glyph, copy)
-  body.append(line)
+  state.body.append(line)
   setText(copy, action.text, action.duration)
 }
 
@@ -145,7 +158,7 @@ const tool = action => {
   }
 
   box.append(title, items)
-  body.append(box)
+  state.body.append(box)
 }
 
 const fade = action => {
@@ -155,7 +168,7 @@ const fade = action => {
     return
   }
 
-  el.style.transition = `opacity ${action.duration ?? 420}ms ease`
+  el.style.transition = `opacity ${(action.duration ?? 420) / state.speed}ms var(--ease-in-out)`
   el.style.opacity = String(action.to ?? 0)
 }
 
@@ -167,7 +180,7 @@ const highlight = action => {
   }
 
   el.classList.add('is-highlighted')
-  timers.push(setTimeout(() => el.classList.remove('is-highlighted'), action.duration ?? 1200))
+  state.timers.push(setTimeout(() => el.classList.remove('is-highlighted'), (action.duration ?? 1200) / state.speed))
 }
 
 const caption = action => {
@@ -176,10 +189,10 @@ const caption = action => {
   node.className = 'showroom-caption'
   node.dataset.target = action.id ?? ''
   node.textContent = action.text ?? ''
-  overlays.append(node)
+  state.overlays.append(node)
   placeNear(node, action.target, action.position)
   requestAnimationFrame(() => node.classList.add('is-visible'))
-  removeAfter(node, action.duration)
+  removeAfter(node, action.duration ?? 1600)
 }
 
 const spotlight = action => {
@@ -196,53 +209,125 @@ const spotlight = action => {
   node.style.top = `${rect.top}px`
   node.style.width = `${rect.width}px`
   node.style.height = `${rect.height}px`
-  overlays.append(node)
+  state.overlays.append(node)
   requestAnimationFrame(() => node.classList.add('is-visible'))
-  removeAfter(node, action.duration)
+  removeAfter(node, action.duration ?? 1500)
 }
 
 const status = action => {
-  statusLeft.textContent = action.text ?? ''
-  statusRight.textContent = action.detail ?? ''
+  state.statusLeft.textContent = action.text ?? ''
+  state.statusRight.textContent = action.detail ?? ''
 }
 
-const compose = action => setText(composer, action.text ?? '', action.duration)
+const compose = action => setText(state.composer, action.text ?? '', action.duration ?? 0)
 
-const clear = () => {
-  body.textContent = ''
-  overlays.textContent = ''
+const clearTranscript = () => {
+  state.body.textContent = ''
+  state.overlays.textContent = ''
 }
 
-const run = action =>
-  ({
-    caption,
-    clear,
-    compose,
-    fade,
-    highlight,
-    message,
-    spotlight,
-    status,
-    tool
-  })[action.type]?.(action)
+const ACTIONS = { caption, clear: clearTranscript, compose, fade, highlight, message, spotlight, status, tool }
 
-const play = () => {
-  clearTimers()
-  clear()
-  statusLeft.textContent = ''
-  statusRight.textContent = ''
-  composer.textContent = workflow.composer ?? '›'
+const fmtTime = ms => {
+  if (!Number.isFinite(ms)) {
+    return '0.0s'
+  }
 
-  for (const action of [...(workflow.timeline ?? [])].sort((a, b) => a.at - b.at)) {
-    timers.push(setTimeout(() => run(action), action.at))
+  const sec = Math.max(0, ms) / 1000
+
+  return `${sec.toFixed(1)}s`
+}
+
+const tickProgress = () => {
+  if (!state.startedAt) {
+    return
+  }
+
+  const elapsed = Math.min(state.total, (performance.now() - state.startedAt) * state.speed)
+  const ratio = state.total ? elapsed / state.total : 0
+
+  state.progressFill.style.width = `${(ratio * 100).toFixed(2)}%`
+  state.progressLabel.textContent = `${fmtTime(elapsed)} / ${fmtTime(state.total)}`
+
+  if (elapsed < state.total) {
+    state.raf = requestAnimationFrame(tickProgress)
   }
 }
 
+const play = () => {
+  clearTimers()
+  clearTranscript()
+  state.statusLeft.textContent = ''
+  state.statusRight.textContent = ''
+  state.composer.textContent = state.workflow.composer ?? '›'
+
+  const timeline = [...(state.workflow.timeline ?? [])].sort((a, b) => a.at - b.at)
+
+  state.total = timeline.reduce((max, action) => Math.max(max, action.at + (action.duration ?? 0)), 0)
+  state.startedAt = performance.now()
+  state.progressFill.style.width = '0%'
+  state.progressLabel.textContent = `0.0s / ${fmtTime(state.total)}`
+
+  for (const action of timeline) {
+    state.timers.push(setTimeout(() => ACTIONS[action.type]?.(action), action.at / state.speed))
+  }
+
+  state.raf = requestAnimationFrame(tickProgress)
+}
+
+const setSpeed = next => {
+  state.speed = next
+
+  for (const button of state.shell.querySelectorAll('.showroom-speed button')) {
+    button.classList.toggle('is-active', Number(button.dataset.speed) === next)
+  }
+}
+
+const loadWorkflow = async name => {
+  const url = new URL(window.location.href)
+  url.searchParams.set('w', name)
+  window.history.replaceState(null, '', url)
+
+  try {
+    const response = await fetch(`/api/workflow/${encodeURIComponent(name)}`)
+
+    if (response.ok) {
+      state.workflow = await response.json()
+    }
+  } catch {
+    /* fall through to current workflow */
+  }
+
+  play()
+}
+
+const buildOptions = () => {
+  if (!catalog.length) {
+    return ''
+  }
+
+  return catalog
+    .map(({ name, title }) => {
+      const selected = name === initial?.name ? ' selected' : ''
+
+      return `<option value="${escapeHtml(name)}"${selected}>${escapeHtml(title)}</option>`
+    })
+    .join('')
+}
+
+const buildSpeed = () =>
+  SPEEDS.map(
+    speed =>
+      `<button type="button" data-speed="${speed}" class="${speed === 1 ? 'is-active' : ''}">${speed}x</button>`
+  ).join('')
+
 const mount = () => {
-  const viewport = { cellWidth: 9, cols: 96, lineHeight: 18, rows: 30, scale: 4, ...workflow.viewport }
+  const viewport = { cellWidth: 9, cols: 96, lineHeight: 18, rows: 30, scale: 4, ...(state.workflow.viewport ?? {}) }
   const shell = document.createElement('section')
 
-  viewportConfig = viewport
+  state.viewport = viewport
+  state.shell = shell
+
   shell.className = 'showroom-shell'
   shell.style.setProperty('--cell-w', `${viewport.cellWidth}px`)
   shell.style.setProperty('--cols', `${viewport.cols}`)
@@ -256,8 +341,14 @@ const mount = () => {
 
   shell.innerHTML = `
     <header class="showroom-title">
-      <span>${escapeHtml(workflow.title ?? 'Hermes TUI Showroom')}</span>
-      <span class="showroom-meta">${viewport.cols}x${viewport.rows} · ${viewport.scale}x</span>
+      <span class="showroom-title-name">
+        <span data-role="title">${escapeHtml(state.workflow.title ?? 'Hermes TUI Showroom')}</span>
+        <span class="showroom-title-tag">showroom</span>
+      </span>
+      <span class="showroom-meta">
+        <span>${viewport.cols}x${viewport.rows} · ${viewport.scale}x</span>
+        ${catalog.length > 1 ? `<select class="showroom-picker" data-action="picker">${buildOptions()}</select>` : ''}
+      </span>
     </header>
     <div class="showroom-stage">
       <div class="showroom-terminal">
@@ -270,32 +361,63 @@ const mount = () => {
       </div>
       <div class="showroom-overlays"></div>
     </div>
+    <div class="showroom-progress">
+      <span data-role="time">0.0s / 0.0s</span>
+      <div class="showroom-progress-track"><div class="showroom-progress-fill"></div></div>
+    </div>
     <footer class="showroom-controls">
       <button type="button" data-action="restart">Restart</button>
       <button type="button" data-action="clear">Clear</button>
+      <span class="showroom-speed">${buildSpeed()}</span>
     </footer>
   `
 
   root.replaceChildren(shell)
 
-  body = shell.querySelector('.showroom-body')
-  composer = shell.querySelector('.showroom-composer')
-  overlays = shell.querySelector('.showroom-overlays')
-  statusLeft = shell.querySelector('.showroom-status span:first-child')
-  statusRight = shell.querySelector('.showroom-status span:last-child')
+  state.body = shell.querySelector('.showroom-body')
+  state.composer = shell.querySelector('.showroom-composer')
+  state.overlays = shell.querySelector('.showroom-overlays')
+  state.statusLeft = shell.querySelector('.showroom-status span:first-child')
+  state.statusRight = shell.querySelector('.showroom-status span:last-child')
+  state.progressFill = shell.querySelector('.showroom-progress-fill')
+  state.progressLabel = shell.querySelector('[data-role="time"]')
 
   shell.querySelector('[data-action="restart"]').addEventListener('click', play)
   shell.querySelector('[data-action="clear"]').addEventListener('click', () => {
     clearTimers()
-    clear()
+    clearTranscript()
   })
 
+  for (const button of shell.querySelectorAll('.showroom-speed button')) {
+    button.addEventListener('click', () => setSpeed(Number(button.dataset.speed)))
+  }
+
+  const picker = shell.querySelector('[data-action="picker"]')
+
+  if (picker) {
+    picker.addEventListener('change', event => {
+      const next = event.target.value
+
+      shell.querySelector('[data-role="title"]').textContent =
+        catalog.find(c => c.name === next)?.title ?? next
+      void loadWorkflow(next)
+    })
+  }
+
   window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() === 'r') {
+    const key = event.key.toLowerCase()
+
+    if (key === 'r') {
       play()
+    } else if (key === 'c') {
+      clearTimers()
+      clearTranscript()
+    } else if (key === '1' || key === '2' || key === '3') {
+      setSpeed(SPEEDS[Number(key) - 1])
     }
   })
 
+  requestAnimationFrame(() => shell.classList.add('is-mounted'))
   play()
 }
 

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -395,9 +395,6 @@ const setScale = next => {
   for (const button of state.shell.querySelectorAll('[data-segment="scale"] button')) {
     button.classList.toggle('is-active', Number(button.dataset.value) === next)
   }
-
-  state.shell.querySelector('[data-role="meta"]').textContent =
-    `${state.viewport.cols}x${state.viewport.rows} · ${next}x`
 }
 
 const fitScale = () => {
@@ -475,16 +472,6 @@ const renderShell = () => {
   state.shell.style.setProperty('--term-h', `${state.viewport.rows * state.viewport.lineHeight}px`)
 
   state.shell.innerHTML = `
-    <header class="showroom-title">
-      <span class="showroom-title-name">
-        <span data-role="title">${escapeHtml(state.workflow.title ?? 'Hermes TUI Showroom')}</span>
-        <span class="showroom-title-tag">${state.frameMode ? 'real ink' : 'showroom'}</span>
-      </span>
-      <span class="showroom-meta">
-        <span data-role="meta">${state.viewport.cols}x${state.viewport.rows} · ${state.scale}x</span>
-        ${catalog.length > 1 ? `<select class="showroom-picker" data-action="picker">${buildOptions()}</select>` : ''}
-      </span>
-    </header>
     <div class="showroom-stage">
       <div class="showroom-terminal">
         <div class="showroom-status" data-target="status">
@@ -496,17 +483,15 @@ const renderShell = () => {
       </div>
       <div class="showroom-overlays"></div>
     </div>
-    <div class="showroom-progress">
-      <span data-role="time">0.0s / 0.0s</span>
-      <div class="showroom-progress-track"><div class="showroom-progress-fill"></div></div>
-    </div>
     <footer class="showroom-controls">
-      <button type="button" data-action="restart">Restart</button>
-      <button type="button" data-action="clear">Clear</button>
-      <span class="showroom-segmented-label">scale</span>
+      <button type="button" data-action="restart" title="restart (R)">↻</button>
       <span class="showroom-segmented" data-segment="scale">${buildSegmented(SCALES, state.scale)}</span>
-      <span class="showroom-segmented-label">speed</span>
       <span class="showroom-segmented" data-segment="speed">${buildSegmented(SPEEDS, state.speed)}</span>
+      ${catalog.length > 1 ? `<select class="showroom-picker" data-action="picker">${buildOptions()}</select>` : ''}
+      <span class="showroom-progress">
+        <span data-role="time">0.0s / 0.0s</span>
+        <div class="showroom-progress-track"><div class="showroom-progress-fill"></div></div>
+      </span>
     </footer>
   `
 
@@ -519,10 +504,6 @@ const renderShell = () => {
   state.progressLabel = state.shell.querySelector('[data-role="time"]')
 
   state.shell.querySelector('[data-action="restart"]').addEventListener('click', play)
-  state.shell.querySelector('[data-action="clear"]').addEventListener('click', () => {
-    clearTimers()
-    clearTranscript()
-  })
 
   for (const button of state.shell.querySelectorAll('[data-segment="speed"] button')) {
     button.addEventListener('click', () => setSpeed(Number(button.dataset.value)))
@@ -574,9 +555,6 @@ const mount = () => {
 
     if (key === 'r') {
       play()
-    } else if (key === 'c') {
-      clearTimers()
-      clearTranscript()
     } else if (key === '1' || key === '2' || key === '3') {
       setSpeed(SPEEDS[Number(key) - 1])
     }

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -2,12 +2,14 @@ const initial = window.__SHOWROOM_INITIAL__
 const catalog = window.__SHOWROOM_CATALOG__ ?? []
 const root = document.getElementById('showroom')
 const SPEEDS = [0.5, 1, 2]
+const SCALES = [1, 2, 3, 4]
+const XTERM_VERSION = '6.0.0'
 
 const role = {
-  assistant: { color: '#d8d0bd', glyph: '✦' },
-  system: { color: '#8f856f', glyph: '·' },
-  tool: { color: '#f1cb78', glyph: '┊' },
-  user: { color: '#f1cb78', glyph: '›' }
+  assistant: { copy: '#fff8dc', glyph: '┊', tone: '#cd7f32' },
+  system: { copy: '#cc9b1f', glyph: '·', tone: '#cc9b1f' },
+  tool: { copy: '#cc9b1f', glyph: '⚡', tone: '#cd7f32' },
+  user: { copy: '#daa520', glyph: '❯', tone: '#ffd700' }
 }
 
 const escapeHtml = value =>
@@ -19,15 +21,20 @@ const escapeHtml = value =>
 const state = {
   body: null,
   composer: null,
+  frameMode: false,
+  frameTargets: new Map(),
   overlays: null,
   progressFill: null,
   progressLabel: null,
   raf: null,
+  scale: 2,
   shell: null,
   speed: 1,
   startedAt: 0,
   statusLeft: null,
   statusRight: null,
+  term: null,
+  termContainer: null,
   timers: [],
   total: 0,
   viewport: null,
@@ -45,7 +52,13 @@ const clearTimers = () => {
   }
 }
 
-const target = id => (id ? document.querySelector(`[data-target="${CSS.escape(id)}"]`) : null)
+const resolveTarget = id => {
+  if (!id) {
+    return null
+  }
+
+  return state.frameTargets.get(id) ?? document.querySelector(`[data-target="${CSS.escape(id)}"]`)
+}
 
 const setText = (node, text = '', duration = 0) => {
   if (!duration || state.speed <= 0) {
@@ -81,8 +94,8 @@ const removeAfter = (node, duration = 1400) => {
   )
 }
 
-const rectFor = (id, pad = 10) => {
-  const el = target(id)
+const rectFor = (id, pad = 8) => {
+  const el = resolveTarget(id)
 
   if (!el || !state.overlays) {
     return null
@@ -103,21 +116,25 @@ const placeNear = (node, id, position = 'right') => {
   const rect = rectFor(id, 0)
 
   if (!rect) {
-    node.style.left = `${state.viewport.scale * 28}px`
-    node.style.top = `${state.viewport.scale * 28}px`
+    node.style.left = '24px'
+    node.style.top = '24px'
 
     return
   }
 
-  const gap = 24
+  const gap = 18
   const left = position === 'left' ? rect.left - node.offsetWidth - gap : rect.left + rect.width + gap
   const top = position === 'top' ? rect.top - node.offsetHeight - gap : rect.top
 
-  node.style.left = `${Math.max(18, left)}px`
-  node.style.top = `${Math.max(18, top)}px`
+  node.style.left = `${Math.max(12, left)}px`
+  node.style.top = `${Math.max(12, top)}px`
 }
 
 const message = action => {
+  if (state.frameMode) {
+    return
+  }
+
   const spec = role[action.role] ?? role.assistant
   const line = document.createElement('div')
   const glyph = document.createElement('span')
@@ -125,7 +142,8 @@ const message = action => {
 
   line.className = `showroom-line showroom-line-${action.role ?? 'assistant'}`
   line.dataset.target = action.id ?? ''
-  line.style.setProperty('--role', spec.color)
+  line.style.setProperty('--role', spec.tone)
+  line.style.setProperty('--copy', spec.copy)
 
   glyph.className = 'showroom-glyph'
   glyph.textContent = spec.glyph
@@ -138,6 +156,10 @@ const message = action => {
 }
 
 const tool = action => {
+  if (state.frameMode) {
+    return
+  }
+
   const box = document.createElement('div')
   const title = document.createElement('div')
   const items = document.createElement('div')
@@ -161,8 +183,20 @@ const tool = action => {
   state.body.append(box)
 }
 
+const frame = action => {
+  if (!state.term || !action.ansi) {
+    return
+  }
+
+  state.term.write(action.ansi)
+
+  if (action.id) {
+    state.frameTargets.set(action.id, state.termContainer)
+  }
+}
+
 const fade = action => {
-  const el = target(action.target)
+  const el = resolveTarget(action.target)
 
   if (!el) {
     return
@@ -173,7 +207,7 @@ const fade = action => {
 }
 
 const highlight = action => {
-  const el = target(action.target)
+  const el = resolveTarget(action.target)
 
   if (!el) {
     return
@@ -196,7 +230,7 @@ const caption = action => {
 }
 
 const spotlight = action => {
-  const rect = rectFor(action.target, action.pad ?? 10)
+  const rect = rectFor(action.target, action.pad ?? 6)
 
   if (!rect) {
     return
@@ -222,20 +256,27 @@ const status = action => {
 const compose = action => setText(state.composer, action.text ?? '', action.duration ?? 0)
 
 const clearTranscript = () => {
-  state.body.textContent = ''
   state.overlays.textContent = ''
+  state.frameTargets.clear()
+
+  if (state.frameMode && state.term) {
+    state.term.reset()
+    state.term.write('\x1b[?25l')
+
+    return
+  }
+
+  state.body.textContent = ''
 }
 
-const ACTIONS = { caption, clear: clearTranscript, compose, fade, highlight, message, spotlight, status, tool }
+const ACTIONS = { caption, clear: clearTranscript, compose, fade, frame, highlight, message, spotlight, status, tool }
 
 const fmtTime = ms => {
   if (!Number.isFinite(ms)) {
     return '0.0s'
   }
 
-  const sec = Math.max(0, ms) / 1000
-
-  return `${sec.toFixed(1)}s`
+  return `${(Math.max(0, ms) / 1000).toFixed(1)}s`
 }
 
 const tickProgress = () => {
@@ -254,12 +295,68 @@ const tickProgress = () => {
   }
 }
 
+const ensureXtermStylesheet = () => {
+  const id = 'xterm-css'
+
+  if (document.getElementById(id)) {
+    return
+  }
+
+  const link = document.createElement('link')
+  link.id = id
+  link.rel = 'stylesheet'
+  link.href = `https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/css/xterm.css`
+  document.head.append(link)
+}
+
+const initXterm = async () => {
+  ensureXtermStylesheet()
+  const mod = await import(`https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/+esm`)
+  const { Terminal } = mod
+
+  state.term = new Terminal({
+    cols: state.viewport.cols,
+    rows: state.viewport.rows,
+    fontFamily: 'JetBrains Mono, "SF Mono", Consolas, monospace',
+    fontSize: 13,
+    cursorBlink: false,
+    scrollback: 0,
+    convertEol: true,
+    allowProposedApi: true,
+    theme: {
+      background: '#0a0a0a',
+      foreground: '#fff8dc',
+      cursor: '#ffd700',
+      selectionBackground: '#3a3a55',
+      black: '#0a0a0a',
+      red: '#ef5350',
+      green: '#8fbc8f',
+      yellow: '#ffd700',
+      blue: '#5a82ff',
+      magenta: '#cd7f32',
+      cyan: '#daa520',
+      white: '#fff8dc',
+      brightBlack: '#cc9b1f',
+      brightRed: '#ef5350',
+      brightGreen: '#8fbc8f',
+      brightYellow: '#ffbf00',
+      brightBlue: '#5a82ff',
+      brightMagenta: '#cd7f32',
+      brightCyan: '#daa520',
+      brightWhite: '#fff8dc'
+    }
+  })
+
+  state.term.open(state.termContainer)
+  state.term.write('\x1b[?25l')
+}
+
 const play = () => {
   clearTimers()
   clearTranscript()
   state.statusLeft.textContent = ''
   state.statusRight.textContent = ''
-  state.composer.textContent = state.workflow.composer ?? '›'
+  state.composer.textContent = state.workflow.composer ?? ''
 
   const timeline = [...(state.workflow.timeline ?? [])].sort((a, b) => a.at - b.at)
 
@@ -278,9 +375,40 @@ const play = () => {
 const setSpeed = next => {
   state.speed = next
 
-  for (const button of state.shell.querySelectorAll('.showroom-speed button')) {
-    button.classList.toggle('is-active', Number(button.dataset.speed) === next)
+  for (const button of state.shell.querySelectorAll('[data-segment="speed"] button')) {
+    button.classList.toggle('is-active', Number(button.dataset.value) === next)
   }
+}
+
+const setScale = next => {
+  state.scale = next
+  state.shell.style.setProperty('--scale', `${next}`)
+  state.shell.style.setProperty(
+    '--stage-w',
+    `${state.viewport.cols * state.viewport.cellWidth * next}px`
+  )
+  state.shell.style.setProperty(
+    '--stage-h',
+    `${state.viewport.rows * state.viewport.lineHeight * next}px`
+  )
+
+  for (const button of state.shell.querySelectorAll('[data-segment="scale"] button')) {
+    button.classList.toggle('is-active', Number(button.dataset.value) === next)
+  }
+
+  state.shell.querySelector('[data-role="meta"]').textContent =
+    `${state.viewport.cols}x${state.viewport.rows} · ${next}x`
+}
+
+const fitScale = () => {
+  const margin = 96
+  const baseW = state.viewport.cols * state.viewport.cellWidth
+  const baseH = state.viewport.rows * state.viewport.lineHeight
+  const maxW = Math.max(1, window.innerWidth - margin)
+  const maxH = Math.max(1, window.innerHeight - 240)
+  const fit = Math.max(1, Math.floor(Math.min(maxW / baseW, maxH / baseH)))
+
+  return Math.max(1, Math.min(SCALES[SCALES.length - 1], fit))
 }
 
 const loadWorkflow = async name => {
@@ -295,10 +423,10 @@ const loadWorkflow = async name => {
       state.workflow = await response.json()
     }
   } catch {
-    /* fall through to current workflow */
+    /* fall through */
   }
 
-  play()
+  await rebuild()
 }
 
 const buildOptions = () => {
@@ -315,48 +443,55 @@ const buildOptions = () => {
     .join('')
 }
 
-const buildSpeed = () =>
-  SPEEDS.map(
-    speed =>
-      `<button type="button" data-speed="${speed}" class="${speed === 1 ? 'is-active' : ''}">${speed}x</button>`
-  ).join('')
+const buildSegmented = (values, active) =>
+  values
+    .map(value => `<button type="button" data-value="${value}" class="${value === active ? 'is-active' : ''}">${value}x</button>`)
+    .join('')
 
-const mount = () => {
-  const viewport = { cellWidth: 9, cols: 96, lineHeight: 18, rows: 30, scale: 4, ...(state.workflow.viewport ?? {}) }
-  const shell = document.createElement('section')
+const computeViewport = () => {
+  const fromWorkflow = state.workflow.viewport ?? {}
+  const usesFrames = (state.workflow.timeline ?? []).some(a => a.type === 'frame')
 
-  state.viewport = viewport
-  state.shell = shell
+  return {
+    cellWidth: usesFrames ? 9 : 8,
+    cols: 80,
+    lineHeight: usesFrames ? 19 : 18,
+    rows: 24,
+    scale: 2,
+    ...fromWorkflow
+  }
+}
 
-  shell.className = 'showroom-shell'
-  shell.style.setProperty('--cell-w', `${viewport.cellWidth}px`)
-  shell.style.setProperty('--cols', `${viewport.cols}`)
-  shell.style.setProperty('--line-h', `${viewport.lineHeight}px`)
-  shell.style.setProperty('--rows', `${viewport.rows}`)
-  shell.style.setProperty('--scale', `${viewport.scale}`)
-  shell.style.setProperty('--stage-h', `${viewport.rows * viewport.lineHeight * viewport.scale}px`)
-  shell.style.setProperty('--stage-w', `${viewport.cols * viewport.cellWidth * viewport.scale}px`)
-  shell.style.setProperty('--term-h', `${viewport.rows * viewport.lineHeight}px`)
-  shell.style.setProperty('--term-w', `${viewport.cols * viewport.cellWidth}px`)
+const renderShell = () => {
+  state.viewport = computeViewport()
+  state.frameMode = (state.workflow.timeline ?? []).some(a => a.type === 'frame')
+  state.frameTargets.clear()
 
-  shell.innerHTML = `
+  state.shell.style.setProperty('--cell-w', `${state.viewport.cellWidth}px`)
+  state.shell.style.setProperty('--cols', `${state.viewport.cols}`)
+  state.shell.style.setProperty('--line-h', `${state.viewport.lineHeight}px`)
+  state.shell.style.setProperty('--rows', `${state.viewport.rows}`)
+  state.shell.style.setProperty('--term-w', `${state.viewport.cols * state.viewport.cellWidth}px`)
+  state.shell.style.setProperty('--term-h', `${state.viewport.rows * state.viewport.lineHeight}px`)
+
+  state.shell.innerHTML = `
     <header class="showroom-title">
       <span class="showroom-title-name">
         <span data-role="title">${escapeHtml(state.workflow.title ?? 'Hermes TUI Showroom')}</span>
-        <span class="showroom-title-tag">showroom</span>
+        <span class="showroom-title-tag">${state.frameMode ? 'real ink' : 'showroom'}</span>
       </span>
       <span class="showroom-meta">
-        <span>${viewport.cols}x${viewport.rows} · ${viewport.scale}x</span>
+        <span data-role="meta">${state.viewport.cols}x${state.viewport.rows} · ${state.scale}x</span>
         ${catalog.length > 1 ? `<select class="showroom-picker" data-action="picker">${buildOptions()}</select>` : ''}
       </span>
     </header>
     <div class="showroom-stage">
       <div class="showroom-terminal">
         <div class="showroom-status" data-target="status">
-          <span></span>
-          <span></span>
+          <span class="showroom-status-left"></span>
+          <span class="showroom-status-right"></span>
         </div>
-        <div class="showroom-body"></div>
+        <div class="showroom-body${state.frameMode ? ' is-frame-mode' : ''}"></div>
         <div class="showroom-composer" data-target="composer"></div>
       </div>
       <div class="showroom-overlays"></div>
@@ -368,41 +503,71 @@ const mount = () => {
     <footer class="showroom-controls">
       <button type="button" data-action="restart">Restart</button>
       <button type="button" data-action="clear">Clear</button>
-      <span class="showroom-speed">${buildSpeed()}</span>
+      <span class="showroom-segmented-label">scale</span>
+      <span class="showroom-segmented" data-segment="scale">${buildSegmented(SCALES, state.scale)}</span>
+      <span class="showroom-segmented-label">speed</span>
+      <span class="showroom-segmented" data-segment="speed">${buildSegmented(SPEEDS, state.speed)}</span>
     </footer>
   `
 
-  root.replaceChildren(shell)
+  state.body = state.shell.querySelector('.showroom-body')
+  state.composer = state.shell.querySelector('.showroom-composer')
+  state.overlays = state.shell.querySelector('.showroom-overlays')
+  state.statusLeft = state.shell.querySelector('.showroom-status-left')
+  state.statusRight = state.shell.querySelector('.showroom-status-right')
+  state.progressFill = state.shell.querySelector('.showroom-progress-fill')
+  state.progressLabel = state.shell.querySelector('[data-role="time"]')
 
-  state.body = shell.querySelector('.showroom-body')
-  state.composer = shell.querySelector('.showroom-composer')
-  state.overlays = shell.querySelector('.showroom-overlays')
-  state.statusLeft = shell.querySelector('.showroom-status span:first-child')
-  state.statusRight = shell.querySelector('.showroom-status span:last-child')
-  state.progressFill = shell.querySelector('.showroom-progress-fill')
-  state.progressLabel = shell.querySelector('[data-role="time"]')
-
-  shell.querySelector('[data-action="restart"]').addEventListener('click', play)
-  shell.querySelector('[data-action="clear"]').addEventListener('click', () => {
+  state.shell.querySelector('[data-action="restart"]').addEventListener('click', play)
+  state.shell.querySelector('[data-action="clear"]').addEventListener('click', () => {
     clearTimers()
     clearTranscript()
   })
 
-  for (const button of shell.querySelectorAll('.showroom-speed button')) {
-    button.addEventListener('click', () => setSpeed(Number(button.dataset.speed)))
+  for (const button of state.shell.querySelectorAll('[data-segment="speed"] button')) {
+    button.addEventListener('click', () => setSpeed(Number(button.dataset.value)))
   }
 
-  const picker = shell.querySelector('[data-action="picker"]')
+  for (const button of state.shell.querySelectorAll('[data-segment="scale"] button')) {
+    button.addEventListener('click', () => setScale(Number(button.dataset.value)))
+  }
+
+  const picker = state.shell.querySelector('[data-action="picker"]')
 
   if (picker) {
     picker.addEventListener('change', event => {
-      const next = event.target.value
-
-      shell.querySelector('[data-role="title"]').textContent =
-        catalog.find(c => c.name === next)?.title ?? next
-      void loadWorkflow(next)
+      void loadWorkflow(event.target.value)
     })
   }
+
+  if (state.frameMode) {
+    state.body.innerHTML = '<div class="showroom-xterm" data-target="terminal"></div>'
+    state.termContainer = state.body.querySelector('.showroom-xterm')
+  } else {
+    state.term = null
+    state.termContainer = null
+  }
+}
+
+const rebuild = async () => {
+  renderShell()
+  setScale(state.workflow.viewport?.scale ?? fitScale())
+
+  if (state.frameMode) {
+    await initXterm()
+  }
+
+  play()
+}
+
+const mount = () => {
+  state.shell = document.createElement('section')
+  state.shell.className = 'showroom-shell'
+  root.replaceChildren(state.shell)
+
+  void rebuild().then(() => {
+    requestAnimationFrame(() => state.shell.classList.add('is-mounted'))
+  })
 
   window.addEventListener('keydown', event => {
     const key = event.key.toLowerCase()
@@ -416,9 +581,6 @@ const mount = () => {
       setSpeed(SPEEDS[Number(key) - 1])
     }
   })
-
-  requestAnimationFrame(() => shell.classList.add('is-mounted'))
-  play()
 }
 
 mount()

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -1,0 +1,302 @@
+const workflow = window.__SHOWROOM_WORKFLOW__
+const root = document.getElementById('showroom')
+const timers = []
+
+let body
+let composer
+let overlays
+let statusLeft
+let statusRight
+let viewportConfig
+
+const role = {
+  assistant: { color: '#d8d0bd', glyph: '✦' },
+  system: { color: '#8f856f', glyph: '·' },
+  tool: { color: '#f1cb78', glyph: '┊' },
+  user: { color: '#f1cb78', glyph: '›' }
+}
+
+const escapeHtml = value =>
+  String(value ?? '').replace(
+    /[&<>"']/g,
+    char =>
+      ({
+        '&': '&amp;',
+        '"': '&quot;',
+        "'": '&#39;',
+        '<': '&lt;',
+        '>': '&gt;'
+      })[char]
+  )
+
+const clearTimers = () => {
+  while (timers.length) {
+    clearTimeout(timers.pop())
+  }
+}
+
+const target = id => (id ? document.querySelector(`[data-target="${CSS.escape(id)}"]`) : null)
+
+const setText = (node, text = '', duration = 0) => {
+  if (!duration) {
+    node.textContent = text
+
+    return
+  }
+
+  const chars = [...text]
+  const started = performance.now()
+
+  const frame = now => {
+    const n = Math.min(chars.length, Math.ceil(((now - started) / duration) * chars.length))
+    node.textContent = chars.slice(0, n).join('')
+
+    if (n < chars.length) {
+      requestAnimationFrame(frame)
+    }
+  }
+
+  requestAnimationFrame(frame)
+}
+
+const removeAfter = (node, duration = 1400) => {
+  timers.push(
+    setTimeout(() => {
+      node.classList.remove('is-visible')
+      timers.push(setTimeout(() => node.remove(), 420))
+    }, duration)
+  )
+}
+
+const rectFor = (id, pad = 10) => {
+  const el = target(id)
+
+  if (!el) {
+    return null
+  }
+
+  const stage = overlays.getBoundingClientRect()
+  const rect = el.getBoundingClientRect()
+
+  return {
+    height: rect.height + pad * 2,
+    left: rect.left - stage.left - pad,
+    top: rect.top - stage.top - pad,
+    width: rect.width + pad * 2
+  }
+}
+
+const placeNear = (node, id, position = 'right') => {
+  const rect = rectFor(id, 0)
+
+  if (!rect) {
+    node.style.left = `${viewportConfig.scale * 28}px`
+    node.style.top = `${viewportConfig.scale * 28}px`
+
+    return
+  }
+
+  const gap = 24
+  const left = position === 'left' ? rect.left - node.offsetWidth - gap : rect.left + rect.width + gap
+  const top = position === 'top' ? rect.top - node.offsetHeight - gap : rect.top
+
+  node.style.left = `${Math.max(18, left)}px`
+  node.style.top = `${Math.max(18, top)}px`
+}
+
+const message = action => {
+  const spec = role[action.role] ?? role.assistant
+  const line = document.createElement('div')
+  const glyph = document.createElement('span')
+  const copy = document.createElement('div')
+
+  line.className = `showroom-line showroom-line-${action.role ?? 'assistant'}`
+  line.dataset.target = action.id ?? ''
+  line.style.setProperty('--role', spec.color)
+
+  glyph.className = 'showroom-glyph'
+  glyph.textContent = spec.glyph
+
+  copy.className = 'showroom-copy'
+
+  line.append(glyph, copy)
+  body.append(line)
+  setText(copy, action.text, action.duration)
+}
+
+const tool = action => {
+  const box = document.createElement('div')
+  const title = document.createElement('div')
+  const items = document.createElement('div')
+
+  box.className = 'showroom-tool'
+  box.dataset.target = action.id ?? ''
+
+  title.className = 'showroom-tool-title'
+  title.textContent = action.title ?? 'tool activity'
+
+  items.className = 'showroom-tool-items'
+
+  for (const item of action.items ?? []) {
+    const row = document.createElement('div')
+
+    row.textContent = item
+    items.append(row)
+  }
+
+  box.append(title, items)
+  body.append(box)
+}
+
+const fade = action => {
+  const el = target(action.target)
+
+  if (!el) {
+    return
+  }
+
+  el.style.transition = `opacity ${action.duration ?? 420}ms ease`
+  el.style.opacity = String(action.to ?? 0)
+}
+
+const highlight = action => {
+  const el = target(action.target)
+
+  if (!el) {
+    return
+  }
+
+  el.classList.add('is-highlighted')
+  timers.push(setTimeout(() => el.classList.remove('is-highlighted'), action.duration ?? 1200))
+}
+
+const caption = action => {
+  const node = document.createElement('div')
+
+  node.className = 'showroom-caption'
+  node.dataset.target = action.id ?? ''
+  node.textContent = action.text ?? ''
+  overlays.append(node)
+  placeNear(node, action.target, action.position)
+  requestAnimationFrame(() => node.classList.add('is-visible'))
+  removeAfter(node, action.duration)
+}
+
+const spotlight = action => {
+  const rect = rectFor(action.target, action.pad ?? 10)
+
+  if (!rect) {
+    return
+  }
+
+  const node = document.createElement('div')
+
+  node.className = 'showroom-spotlight'
+  node.style.left = `${rect.left}px`
+  node.style.top = `${rect.top}px`
+  node.style.width = `${rect.width}px`
+  node.style.height = `${rect.height}px`
+  overlays.append(node)
+  requestAnimationFrame(() => node.classList.add('is-visible'))
+  removeAfter(node, action.duration)
+}
+
+const status = action => {
+  statusLeft.textContent = action.text ?? ''
+  statusRight.textContent = action.detail ?? ''
+}
+
+const compose = action => setText(composer, action.text ?? '', action.duration)
+
+const clear = () => {
+  body.textContent = ''
+  overlays.textContent = ''
+}
+
+const run = action =>
+  ({
+    caption,
+    clear,
+    compose,
+    fade,
+    highlight,
+    message,
+    spotlight,
+    status,
+    tool
+  })[action.type]?.(action)
+
+const play = () => {
+  clearTimers()
+  clear()
+  statusLeft.textContent = ''
+  statusRight.textContent = ''
+  composer.textContent = workflow.composer ?? '›'
+
+  for (const action of [...(workflow.timeline ?? [])].sort((a, b) => a.at - b.at)) {
+    timers.push(setTimeout(() => run(action), action.at))
+  }
+}
+
+const mount = () => {
+  const viewport = { cellWidth: 9, cols: 96, lineHeight: 18, rows: 30, scale: 4, ...workflow.viewport }
+  const shell = document.createElement('section')
+
+  viewportConfig = viewport
+  shell.className = 'showroom-shell'
+  shell.style.setProperty('--cell-w', `${viewport.cellWidth}px`)
+  shell.style.setProperty('--cols', `${viewport.cols}`)
+  shell.style.setProperty('--line-h', `${viewport.lineHeight}px`)
+  shell.style.setProperty('--rows', `${viewport.rows}`)
+  shell.style.setProperty('--scale', `${viewport.scale}`)
+  shell.style.setProperty('--stage-h', `${viewport.rows * viewport.lineHeight * viewport.scale}px`)
+  shell.style.setProperty('--stage-w', `${viewport.cols * viewport.cellWidth * viewport.scale}px`)
+  shell.style.setProperty('--term-h', `${viewport.rows * viewport.lineHeight}px`)
+  shell.style.setProperty('--term-w', `${viewport.cols * viewport.cellWidth}px`)
+
+  shell.innerHTML = `
+    <header class="showroom-title">
+      <span>${escapeHtml(workflow.title ?? 'Hermes TUI Showroom')}</span>
+      <span class="showroom-meta">${viewport.cols}x${viewport.rows} · ${viewport.scale}x</span>
+    </header>
+    <div class="showroom-stage">
+      <div class="showroom-terminal">
+        <div class="showroom-status" data-target="status">
+          <span></span>
+          <span></span>
+        </div>
+        <div class="showroom-body"></div>
+        <div class="showroom-composer" data-target="composer"></div>
+      </div>
+      <div class="showroom-overlays"></div>
+    </div>
+    <footer class="showroom-controls">
+      <button type="button" data-action="restart">Restart</button>
+      <button type="button" data-action="clear">Clear</button>
+    </footer>
+  `
+
+  root.replaceChildren(shell)
+
+  body = shell.querySelector('.showroom-body')
+  composer = shell.querySelector('.showroom-composer')
+  overlays = shell.querySelector('.showroom-overlays')
+  statusLeft = shell.querySelector('.showroom-status span:first-child')
+  statusRight = shell.querySelector('.showroom-status span:last-child')
+
+  shell.querySelector('[data-action="restart"]').addEventListener('click', play)
+  shell.querySelector('[data-action="clear"]').addEventListener('click', () => {
+    clearTimers()
+    clear()
+  })
+
+  window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() === 'r') {
+      play()
+    }
+  })
+
+  play()
+}
+
+mount()

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -1,66 +1,14 @@
+import { Terminal } from '@xterm/xterm'
+
 const initial = window.__SHOWROOM_INITIAL__
 const catalog = window.__SHOWROOM_CATALOG__ ?? []
 const root = document.getElementById('showroom')
 const SPEEDS = [0.5, 1, 2]
 const SCALES = [1, 2, 3, 4]
 
-const escapeHtml = value =>
-  String(value ?? '').replace(
-    /[&<>\"']/g,
-    char => ({ '&': '&amp;', '"': '&quot;', "'": '&#39;', '<': '&lt;', '>': '&gt;' })[char]
-  )
-
-// Minimal ANSI-to-HTML: handles ESC[NC (cursor forward), strips control sequences.
-// No color SGR support needed — all styling comes from the Ink renderer's own output.
-const ansiToHtml = raw => {
-  let out = ''
-  let i = 0
-
-  while (i < raw.length) {
-    if (raw[i] === '\x1b' && raw[i + 1] === '[') {
-      let j = i + 2
-
-      while (j < raw.length && raw[j] >= '0' && raw[j] <= '9') j++
-      if (j < raw.length && raw[j] === ';') j++
-      while (j < raw.length && raw[j] >= '0' && raw[j] <= '9') j++
-
-      if (j < raw.length) {
-        const cmd = raw[j]
-
-        if (cmd === 'C') {
-          const n = parseInt(raw.slice(i + 2, j), 10) || 1
-          out += ' '.repeat(n)
-        }
-
-        // All other sequences (cursor hide/show, bracketed paste, etc.) — strip
-        i = j + 1
-        continue
-      }
-    }
-
-    if (raw[i] === '\r' && raw[i + 1] === '\n') {
-      out += '\n'
-      i += 2
-      continue
-    }
-
-    if (raw[i] === '\r') {
-      out += '\n'
-      i++
-      continue
-    }
-
-    out += raw[i]
-    i++
-  }
-
-  return out
-}
-
 const state = {
   body: null,
   composer: null,
-  frameMode: false,
   frameTargets: new Map(),
   overlays: null,
   progressFill: null,
@@ -72,6 +20,8 @@ const state = {
   startedAt: 0,
   statusLeft: null,
   statusRight: null,
+  term: null,
+  termContainer: null,
   timers: [],
   total: 0,
   viewport: null,
@@ -167,18 +117,16 @@ const placeNear = (node, id, position = 'right') => {
   node.style.top = `${Math.max(12, top)}px`
 }
 
-const message = action => {
-  if (state.frameMode) {
-    return
-  }
+// --- Actions ---
 
-  const roleSpec = {
+const message = action => {
+  const spec = {
     assistant: { copy: '#fff8dc', glyph: '┊', tone: '#cd7f32' },
     system: { copy: '#cc9b1f', glyph: '·', tone: '#cc9b1f' },
     tool: { copy: '#cc9b1f', glyph: '⚡', tone: '#cd7f32' },
     user: { copy: '#daa520', glyph: '❯', tone: '#ffd700' }
-  }
-  const spec = roleSpec[action.role] ?? roleSpec.assistant
+  }[action.role] ?? { copy: '#fff8dc', glyph: '┊', tone: '#cd7f32' }
+
   const line = document.createElement('div')
   const glyph = document.createElement('span')
   const copy = document.createElement('div')
@@ -199,10 +147,6 @@ const message = action => {
 }
 
 const tool = action => {
-  if (state.frameMode) {
-    return
-  }
-
   const box = document.createElement('div')
   const title = document.createElement('div')
   const items = document.createElement('div')
@@ -227,18 +171,14 @@ const tool = action => {
 }
 
 const frame = action => {
-  if (!action.ansi) {
+  if (!state.term || !action.ansi) {
     return
   }
 
-  const pre = document.createElement('pre')
-  pre.className = 'showroom-frame'
-  pre.dataset.target = action.id ?? ''
-  pre.innerHTML = escapeHtml(ansiToHtml(action.ansi))
-  state.body.append(pre)
+  state.term.write(action.ansi)
 
   if (action.id) {
-    state.frameTargets.set(action.id, pre)
+    state.frameTargets.set(action.id, state.termContainer)
   }
 }
 
@@ -305,10 +245,20 @@ const compose = action => setText(state.composer, action.text ?? '', action.dura
 const clearTranscript = () => {
   state.overlays.textContent = ''
   state.frameTargets.clear()
+
+  if (state.term) {
+    state.term.reset()
+    state.term.write('\x1b[?25l')
+
+    return
+  }
+
   state.body.textContent = ''
 }
 
 const ACTIONS = { caption, clear: clearTranscript, compose, fade, frame, highlight, message, spotlight, status, tool }
+
+// --- Progress ---
 
 const fmtTime = ms => {
   if (!Number.isFinite(ms)) {
@@ -334,6 +284,63 @@ const tickProgress = () => {
   }
 }
 
+// --- xterm ---
+
+const initXterm = () => {
+  const hasFrames = (state.workflow.timeline ?? []).some(a => a.type === 'frame')
+
+  if (!hasFrames) {
+    state.term = null
+    state.termContainer = null
+
+    return
+  }
+
+  state.body.innerHTML = '<div class="showroom-xterm" data-target="terminal"></div>'
+  state.termContainer = state.body.querySelector('.showroom-xterm')
+
+  state.term = new Terminal({
+    cols: state.viewport.cols,
+    rows: state.viewport.rows,
+    fontFamily: 'JetBrains Mono, "SF Mono", Consolas, monospace',
+    fontSize: 13,
+    cursorBlink: false,
+    scrollback: 0,
+    convertEol: true,
+    allowProposedApi: true,
+    theme: {
+      background: '#0a0a0a',
+      foreground: '#fff8dc',
+      cursor: '#ffd700',
+      selectionBackground: '#3a3a55',
+      black: '#0a0a0a',
+      red: '#ef5350',
+      green: '#8fbc8f',
+      yellow: '#ffd700',
+      blue: '#5a82ff',
+      magenta: '#cd7f32',
+      cyan: '#daa520',
+      white: '#fff8dc',
+      brightBlack: '#cc9b1f',
+      brightRed: '#ef5350',
+      brightGreen: '#8fbc8f',
+      brightYellow: '#ffbf00',
+      brightBlue: '#5a82ff',
+      brightMagenta: '#cd7f32',
+      brightCyan: '#daa520',
+      brightWhite: '#fff8dc'
+    }
+  })
+
+  state.term.open(state.termContainer)
+  state.term.write('\x1b[?25l')
+
+  // Fade in
+  requestAnimationFrame(() => state.termContainer.classList.add('is-visible'))
+}
+
+// --- Playback ---
+
 const play = () => {
   clearTimers()
   clearTranscript()
@@ -354,6 +361,8 @@ const play = () => {
 
   state.raf = requestAnimationFrame(tickProgress)
 }
+
+// --- Controls ---
 
 const setSpeed = next => {
   state.speed = next
@@ -403,6 +412,8 @@ const loadWorkflow = async name => {
   await rebuild()
 }
 
+// --- DOM ---
+
 const buildOptions = () => {
   if (!catalog.length) {
     return ''
@@ -412,7 +423,7 @@ const buildOptions = () => {
     .map(({ name, title }) => {
       const selected = name === initial?.name ? ' selected' : ''
 
-      return `<option value="${escapeHtml(name)}"${selected}>${escapeHtml(title)}</option>`
+      return `<option value="${name}"${selected}>${title}</option>`
     })
     .join('')
 }
@@ -429,9 +440,9 @@ const computeViewport = () => {
   const fromWorkflow = state.workflow.viewport ?? {}
 
   return {
-    cellWidth: 8,
+    cellWidth: 9,
     cols: 80,
-    lineHeight: 18,
+    lineHeight: 19,
     rows: 24,
     scale: 2,
     ...fromWorkflow
@@ -440,7 +451,6 @@ const computeViewport = () => {
 
 const renderShell = () => {
   state.viewport = computeViewport()
-  state.frameMode = (state.workflow.timeline ?? []).some(a => a.type === 'frame')
   state.frameTargets.clear()
 
   state.shell.style.setProperty('--cell-w', `${state.viewport.cellWidth}px`)
@@ -457,7 +467,7 @@ const renderShell = () => {
           <span class="showroom-status-left"></span>
           <span class="showroom-status-right"></span>
         </div>
-        <div class="showroom-body${state.frameMode ? ' is-frame-mode' : ''}"></div>
+        <div class="showroom-body"></div>
         <div class="showroom-composer" data-target="composer"></div>
       </div>
       <div class="showroom-overlays"></div>
@@ -503,6 +513,7 @@ const renderShell = () => {
 
 const rebuild = async () => {
   renderShell()
+  initXterm()
   setScale(state.workflow.viewport?.scale ?? fitScale())
   play()
 }

--- a/ui-tui/.showroom/src/showroom.js
+++ b/ui-tui/.showroom/src/showroom.js
@@ -383,14 +383,8 @@ const setSpeed = next => {
 const setScale = next => {
   state.scale = next
   state.shell.style.setProperty('--scale', `${next}`)
-  state.shell.style.setProperty(
-    '--stage-w',
-    `${state.viewport.cols * state.viewport.cellWidth * next}px`
-  )
-  state.shell.style.setProperty(
-    '--stage-h',
-    `${state.viewport.rows * state.viewport.lineHeight * next}px`
-  )
+  state.shell.style.setProperty('--stage-w', `${state.viewport.cols * state.viewport.cellWidth * next}px`)
+  state.shell.style.setProperty('--stage-h', `${state.viewport.rows * state.viewport.lineHeight * next}px`)
 
   for (const button of state.shell.querySelectorAll('[data-segment="scale"] button')) {
     button.classList.toggle('is-active', Number(button.dataset.value) === next)
@@ -442,7 +436,10 @@ const buildOptions = () => {
 
 const buildSegmented = (values, active) =>
   values
-    .map(value => `<button type="button" data-value="${value}" class="${value === active ? 'is-active' : ''}">${value}x</button>`)
+    .map(
+      value =>
+        `<button type="button" data-value="${value}" class="${value === active ? 'is-active' : ''}">${value}x</button>`
+    )
     .join('')
 
 const computeViewport = () => {

--- a/ui-tui/.showroom/tsconfig.json
+++ b/ui-tui/.showroom/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/ui-tui/.showroom/workflows/feature-tour.json
+++ b/ui-tui/.showroom/workflows/feature-tour.json
@@ -30,7 +30,7 @@
       "duration": 1700,
       "position": "right",
       "target": "tool-trail",
-      "text": "Real ui-tui MessageLine + Panel rendered to ANSI and replayed in xterm.js.",
+      "text": "Real ui-tui MessageLine + Panel rendered to ANSI and replayed in the browser.",
       "type": "caption"
     },
     {

--- a/ui-tui/.showroom/workflows/feature-tour.json
+++ b/ui-tui/.showroom/workflows/feature-tour.json
@@ -1,78 +1,46 @@
 {
-  "title": "Hermes TUI Feature Tour",
-  "composer": "› ask hermes anything",
-  "viewport": {
-    "cellWidth": 9,
-    "cols": 96,
-    "lineHeight": 18,
-    "rows": 30,
-    "scale": 4
-  },
+  "composer": "ask hermes anything",
   "timeline": [
     {
-      "at": 0,
-      "detail": "showroom mode",
-      "text": "summoning hermes...",
-      "type": "status"
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2CBuild\u001b[1Ca\u001b[1Cfocused\u001b[1Cplan\u001b[1Cfor\u001b[1Ca\u001b[1Csafer\u001b[1Cgateway\u001b[1Capproval\u001b[1Cflow.\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 200,
+      "id": "user-row",
+      "type": "frame"
     },
     {
-      "at": 250,
-      "duration": 650,
-      "id": "prompt",
-      "role": "user",
-      "text": "Build a focused plan for a safer gateway approval flow.",
-      "type": "message"
-    },
-    {
-      "at": 1050,
-      "duration": 950,
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CI'll\u001b[1Ctrace\u001b[1Cthe\u001b[1Cgateway\u001b[1Cguards\u001b[1Cfirst,\u001b[1Cthen\u001b[1Cpatch\u001b[1Cthe\u001b[1Csmallest\u001b[1Cboundary\u001b[1Cthat\r\n\u001b[3Ckeeps\u001b[1Capproval\u001b[1Ccommands\u001b[1Clive\u001b[1Cwhile\u001b[1Can\u001b[1Cagent\u001b[1Cis\u001b[1Cblocked.\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 1500,
       "id": "assistant-plan",
-      "role": "assistant",
-      "text": "I’ll trace the gateway guards first, then patch the smallest boundary that keeps approval commands live while an agent is blocked.",
-      "type": "message"
+      "type": "frame"
     },
     {
-      "at": 2180,
+      "ansi": "\u001b[?25l\u001b[?2026h\u001b[2C⚡\u001b[1Ctool\u001b[1Ctrail\u001b[1C(3)\r\n\u001b[2C├─\u001b[1Crg\u001b[1C\"approval.request\"\u001b[1Cgateway/\u001b[1Ctui_gateway/\r\n\u001b[2C├─\u001b[1CReadFile\u001b[1Cgateway/run.py\r\n\u001b[2C└─\u001b[1CReadFile\u001b[1Cgateway/platforms/base.py\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 2900,
       "id": "tool-trail",
-      "items": [
-        "rg \"approval.request\" gateway/ tui_gateway/",
-        "ReadFile gateway/run.py",
-        "ReadFile gateway/platforms/base.py"
-      ],
-      "title": "tool trail",
-      "type": "tool"
+      "type": "frame"
     },
     {
-      "at": 2500,
-      "duration": 1500,
+      "at": 3200,
+      "duration": 1700,
       "target": "tool-trail",
       "type": "spotlight"
     },
     {
-      "at": 2680,
-      "duration": 1600,
+      "at": 3400,
+      "duration": 1700,
       "position": "right",
       "target": "tool-trail",
-      "text": "Tool activity is scripted as named targets, so captions and fades can follow the exact beat.",
+      "text": "Real ui-tui MessageLine + Panel rendered to ANSI and replayed in xterm.js.",
       "type": "caption"
     },
     {
-      "at": 4450,
-      "duration": 500,
-      "target": "tool-trail",
-      "to": 0.22,
-      "type": "fade"
-    },
-    {
-      "at": 5050,
-      "duration": 700,
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CFound\u001b[1Cthe\u001b[1Csplit\u001b[1Cguard.\u001b[1CBypass\u001b[1Cboth\u001b[1Cqueues\u001b[1Conly\u001b[1Cfor\u001b[1Capproval\u001b[1Ccommands;\r\n\u001b[3Cnormal\u001b[1Cchat\u001b[1Cordering\u001b[1Cstays\u001b[1Cintact.\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 5400,
       "id": "assistant-result",
-      "role": "assistant",
-      "text": "Found the split guard. The fix is to bypass both queues only for approval/control commands and leave normal chat ordering untouched.",
-      "type": "message"
+      "type": "frame"
     },
     {
-      "at": 6050,
+      "at": 6100,
       "duration": 1300,
       "target": "assistant-result",
       "type": "highlight"
@@ -82,20 +50,19 @@
       "duration": 1700,
       "position": "right",
       "target": "assistant-result",
-      "text": "Highlights, captions, opacity fades, and spotlight boxes are all timeline actions.",
+      "text": "Captions, spotlights, and fades layer on top of real ANSI. Best of both.",
       "type": "caption"
     },
     {
-      "at": 8300,
-      "duration": 700,
-      "text": "› /approve",
+      "at": 8100,
+      "duration": 600,
+      "text": "/approve",
       "type": "compose"
-    },
-    {
-      "at": 9400,
-      "detail": "record-ready at 4x",
-      "text": "session complete",
-      "type": "status"
     }
-  ]
+  ],
+  "title": "Hermes TUI · Feature Tour",
+  "viewport": {
+    "cols": 80,
+    "rows": 16
+  }
 }

--- a/ui-tui/.showroom/workflows/feature-tour.json
+++ b/ui-tui/.showroom/workflows/feature-tour.json
@@ -30,7 +30,7 @@
       "duration": 1700,
       "position": "right",
       "target": "tool-trail",
-      "text": "Real ui-tui MessageLine + Panel rendered to ANSI and replayed in the browser.",
+      "text": "Real ui-tui MessageLine + Panel rendered to ANSI and replayed via xterm.js.",
       "type": "caption"
     },
     {

--- a/ui-tui/.showroom/workflows/feature-tour.json
+++ b/ui-tui/.showroom/workflows/feature-tour.json
@@ -1,0 +1,101 @@
+{
+  "title": "Hermes TUI Feature Tour",
+  "composer": "› ask hermes anything",
+  "viewport": {
+    "cellWidth": 9,
+    "cols": 96,
+    "lineHeight": 18,
+    "rows": 30,
+    "scale": 4
+  },
+  "timeline": [
+    {
+      "at": 0,
+      "detail": "showroom mode",
+      "text": "summoning hermes...",
+      "type": "status"
+    },
+    {
+      "at": 250,
+      "duration": 650,
+      "id": "prompt",
+      "role": "user",
+      "text": "Build a focused plan for a safer gateway approval flow.",
+      "type": "message"
+    },
+    {
+      "at": 1050,
+      "duration": 950,
+      "id": "assistant-plan",
+      "role": "assistant",
+      "text": "I’ll trace the gateway guards first, then patch the smallest boundary that keeps approval commands live while an agent is blocked.",
+      "type": "message"
+    },
+    {
+      "at": 2180,
+      "id": "tool-trail",
+      "items": [
+        "rg \"approval.request\" gateway/ tui_gateway/",
+        "ReadFile gateway/run.py",
+        "ReadFile gateway/platforms/base.py"
+      ],
+      "title": "tool trail",
+      "type": "tool"
+    },
+    {
+      "at": 2500,
+      "duration": 1500,
+      "target": "tool-trail",
+      "type": "spotlight"
+    },
+    {
+      "at": 2680,
+      "duration": 1600,
+      "position": "right",
+      "target": "tool-trail",
+      "text": "Tool activity is scripted as named targets, so captions and fades can follow the exact beat.",
+      "type": "caption"
+    },
+    {
+      "at": 4450,
+      "duration": 500,
+      "target": "tool-trail",
+      "to": 0.22,
+      "type": "fade"
+    },
+    {
+      "at": 5050,
+      "duration": 700,
+      "id": "assistant-result",
+      "role": "assistant",
+      "text": "Found the split guard. The fix is to bypass both queues only for approval/control commands and leave normal chat ordering untouched.",
+      "type": "message"
+    },
+    {
+      "at": 6050,
+      "duration": 1300,
+      "target": "assistant-result",
+      "type": "highlight"
+    },
+    {
+      "at": 6300,
+      "duration": 1700,
+      "position": "right",
+      "target": "assistant-result",
+      "text": "Highlights, captions, opacity fades, and spotlight boxes are all timeline actions.",
+      "type": "caption"
+    },
+    {
+      "at": 8300,
+      "duration": 700,
+      "text": "› /approve",
+      "type": "compose"
+    },
+    {
+      "at": 9400,
+      "detail": "record-ready at 4x",
+      "text": "session complete",
+      "type": "status"
+    }
+  ]
+}

--- a/ui-tui/.showroom/workflows/interactive-prompts.json
+++ b/ui-tui/.showroom/workflows/interactive-prompts.json
@@ -1,0 +1,104 @@
+{
+  "composer": "deploy this to staging",
+  "timeline": [
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2CRun\u001b[1Cnpm\u001b[1Cinstall\u001b[1Cexpress\u001b[1Cin\u001b[1Cthe\u001b[1Cproject\u001b[1Croot.\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 200,
+      "id": "ask",
+      "type": "frame"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CI'll\u001b[1Cinstall\u001b[1Cexpress.\u001b[1CThe\u001b[1Cpackage\u001b[1Cmanager\u001b[1Cneeds\u001b[1Capproval\u001b[1C—\u001b[1Chere's\u001b[1Cthe\r\n\u001b[3Ccommand.\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 1200,
+      "id": "explain",
+      "type": "frame"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╔══════════════════════════════════════════════════════════════════════════════╗\r\n║\u001b[1C⚠\u001b[1Capproval\u001b[1Crequired\u001b[1C·\u001b[1Cinstall\u001b[1Cdependency\u001b[36C║\r\n║\u001b[2Cnpm\u001b[1Cinstall\u001b[1Cexpress\u001b[57C║\r\n║\u001b[2Cadded\u001b[1C58\u001b[1Cpackages\u001b[1Cin\u001b[1C3.2s\u001b[51C║\r\n║\u001b[78C║\r\n║\u001b[2C+\u001b[1Cexpress@5.1.0\u001b[61C║\r\n║\u001b[1C▸\u001b[1C1.\u001b[1CAllow\u001b[1Conce\u001b[62C║\r\n║\u001b[3C2.\u001b[1CAllow\u001b[1Cthis\u001b[1Csession\u001b[54C║\r\n║\u001b[3C3.\u001b[1CAlways\u001b[1Callow\u001b[60C║\r\n║\u001b[3C4.\u001b[1CDeny\u001b[68C║\r\n║\u001b[1C↑/↓\u001b[1Cselect\u001b[1C·\u001b[1CEnter\u001b[1Cconfirm\u001b[1C·\u001b[1C1-4\u001b[1Cquick\u001b[1Cpick\u001b[1C·\u001b[1CCtrl+C\u001b[1Cdeny\u001b[20C║\r\n╚══════════════════════════════════════════════════════════════════════════════╝\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 2600,
+      "id": "approval",
+      "type": "frame"
+    },
+    {
+      "at": 2900,
+      "duration": 1500,
+      "target": "approval",
+      "type": "spotlight"
+    },
+    {
+      "at": 3100,
+      "duration": 2000,
+      "position": "right",
+      "target": "approval",
+      "text": "Approval prompts gate dangerous commands. Four options: allow once, session, always, deny.",
+      "type": "caption"
+    },
+    {
+      "at": 5400,
+      "duration": 400,
+      "text": "1",
+      "type": "compose"
+    },
+    {
+      "at": 5900,
+      "duration": 500,
+      "text": "",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2CDeploy\u001b[1Cthis\u001b[1Cto\u001b[1Cstaging.\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 6600,
+      "id": "clarify-ask",
+      "type": "frame"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CWhich\u001b[1Cenvironment\u001b[1Cshould\u001b[1CI\u001b[1Ctarget?\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 7600,
+      "id": "clarify-reply",
+      "type": "frame"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026hask\u001b[1CWhich\u001b[1Cregion?\r\n▸\u001b[1C1.\u001b[1Cstaging-us-east\r\n\u001b[2C2.\u001b[1Cstaging-eu-west\r\n\u001b[2C3.\u001b[1Cstaging-ap-south\r\n\u001b[2C4.\u001b[1COther\u001b[1C(type\u001b[1Cyour\u001b[1Canswer)\r\n↑/↓\u001b[1Cselect\u001b[1C·\u001b[1CEnter\u001b[1Cconfirm\u001b[1C·\u001b[1C1-4\u001b[1Cquick\u001b[1Cpick\u001b[1C·\u001b[1CEsc\u001b[1Ccancel\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 8800,
+      "id": "clarify",
+      "type": "frame"
+    },
+    {
+      "at": 9100,
+      "duration": 1500,
+      "target": "clarify",
+      "type": "spotlight"
+    },
+    {
+      "at": 9300,
+      "duration": 2000,
+      "position": "right",
+      "target": "clarify",
+      "text": "Clarify prompts handle ambiguous requests — numbered choices or free text.",
+      "type": "caption"
+    },
+    {
+      "at": 11600,
+      "duration": 400,
+      "text": "1",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[30Cdeployment\u001b[1Cqueued\u001b[31C│\r\n│\u001b[78C│\r\n│\u001b[2Ctarget\u001b[14Cstaging-us-east\u001b[41C│\r\n│\u001b[2Cbranch\u001b[14Cmain\u001b[52C│\r\n│\u001b[2Cpreview\u001b[13Chttps://pr-128.railway.app\u001b[30C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 12200,
+      "id": "result",
+      "type": "frame"
+    },
+    {
+      "at": 12500,
+      "duration": 1300,
+      "target": "result",
+      "type": "highlight"
+    }
+  ],
+  "title": "Hermes TUI · Interactive Prompts",
+  "viewport": {
+    "cols": 80,
+    "rows": 16
+  }
+}

--- a/ui-tui/.showroom/workflows/model-picker.json
+++ b/ui-tui/.showroom/workflows/model-picker.json
@@ -1,0 +1,100 @@
+{
+  "composer": "",
+  "timeline": [
+    {
+      "at": 200,
+      "duration": 500,
+      "text": "/model",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2CSwitch\u001b[1Cto\u001b[1CClaude.\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 900,
+      "id": "ask",
+      "type": "frame"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2COpening\u001b[1Cthe\u001b[1Cmodel\u001b[1Cpicker\u001b[1C—\u001b[1Cpick\u001b[1Ca\u001b[1Cprovider\u001b[1Cfirst,\u001b[1Cthen\u001b[1Ca\u001b[1Cmodel.\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 1800,
+      "id": "reply",
+      "type": "frame"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╔════════════════════════════════════════════════╗\r\n║\u001b[1CSelect\u001b[1CProvider\u001b[32C║\r\n║\u001b[1CCurrent\u001b[1Cmodel:\u001b[1Cgpt-5-codex\u001b[21C║\r\n║\u001b[48C║\r\n║\u001b[48C║\r\n║\u001b[3C1.\u001b[1COpenAI\u001b[1C·\u001b[1C8\u001b[1Cmodels\u001b[25C║\r\n║\u001b[1C▸\u001b[1C2.\u001b[1CAnthropic\u001b[1C·\u001b[1C6\u001b[1Cmodels\u001b[22C║\r\n║\u001b[3C3.\u001b[1CGoogle\u001b[1C·\u001b[1C5\u001b[1Cmodels\u001b[25C║\r\n║\u001b[3C4.\u001b[1COpenRouter\u001b[1C·\u001b[1C42\u001b[1Cmodels\u001b[20C║\r\n║\u001b[3C5.\u001b[1CxAI\u001b[1C·\u001b[1C3\u001b[1Cmodels\u001b[28C║\r\n║\u001b[48C║\r\n║\u001b[1Cpersist:\u001b[1Csession\u001b[1C·\u001b[1Cg\u001b[1Ctoggle\u001b[20C║\r\n║\u001b[1C↑/↓\u001b[1Cselect\u001b[1C·\u001b[1CEnter\u001b[1Cchoose\u001b[1C·\u001b[1C1-9,0\u001b[1Cquick\u001b[1C·\u001b[6C║\r\n║\u001b[1CEsc/q\u001b[1Ccancel\u001b[35C║\r\n╚════════════════════════════════════════════════╝\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 3000,
+      "id": "providers",
+      "type": "frame"
+    },
+    {
+      "at": 3300,
+      "duration": 1800,
+      "target": "providers",
+      "type": "spotlight"
+    },
+    {
+      "at": 3500,
+      "duration": 2000,
+      "position": "right",
+      "target": "providers",
+      "text": "Provider stage: pick from authenticated backends. Shows model count per provider.",
+      "type": "caption"
+    },
+    {
+      "at": 5600,
+      "duration": 300,
+      "text": "2",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╔════════════════════════════════════════════════╗\r\n║\u001b[1CSelect\u001b[1CModel\u001b[35C║\r\n║\u001b[1CAnthropic\u001b[38C║\r\n║\u001b[48C║\r\n║\u001b[48C║\r\n║\u001b[3C1.\u001b[1Cclaude-opus-4\u001b[29C║\r\n║\u001b[1C▸\u001b[1C2.\u001b[1Cclaude-sonnet-4\u001b[27C║\r\n║\u001b[3C3.\u001b[1Cclaude-sonnet-3.7\u001b[25C║\r\n║\u001b[3C4.\u001b[1Cclaude-haiku-3.5\u001b[26C║\r\n║\u001b[3C5.\u001b[1Cclaude-sonnet-3.5\u001b[25C║\r\n║\u001b[48C║\r\n║\u001b[1Cpersist:\u001b[1Csession\u001b[1C·\u001b[1Cg\u001b[1Ctoggle\u001b[20C║\r\n║\u001b[1C↑/↓\u001b[1Cselect\u001b[1C·\u001b[1CEnter\u001b[1Cchoose\u001b[1C·\u001b[1C1-9,0\u001b[1Cquick\u001b[1C·\u001b[6C║\r\n║\u001b[1CEsc/q\u001b[1Ccancel\u001b[35C║\r\n╚════════════════════════════════════════════════╝\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 6200,
+      "id": "models",
+      "type": "frame"
+    },
+    {
+      "at": 6500,
+      "duration": 1800,
+      "target": "models",
+      "type": "spotlight"
+    },
+    {
+      "at": 6700,
+      "duration": 2000,
+      "position": "right",
+      "target": "models",
+      "text": "Model stage: scrollable list with ▸ selection. Number keys for quick pick.",
+      "type": "caption"
+    },
+    {
+      "at": 9000,
+      "duration": 300,
+      "text": "2",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[32Cmodel\u001b[1Cswitched\u001b[32C│\r\n│\u001b[78C│\r\n│\u001b[2Cfrom\u001b[16Cgpt-5-codex\u001b[45C│\r\n│\u001b[2Cto\u001b[18Cclaude-sonnet-4\u001b[41C│\r\n│\u001b[2Cscope\u001b[15Cthis\u001b[1Csession\u001b[44C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 9600,
+      "id": "result",
+      "type": "frame"
+    },
+    {
+      "at": 9900,
+      "duration": 1300,
+      "target": "result",
+      "type": "highlight"
+    },
+    {
+      "at": 10100,
+      "duration": 1700,
+      "position": "right",
+      "target": "result",
+      "text": "Model swap mid-session. Transcript and cache stay intact.",
+      "type": "caption"
+    }
+  ],
+  "title": "Hermes TUI · Model Picker",
+  "viewport": {
+    "cols": 80,
+    "rows": 16
+  }
+}

--- a/ui-tui/.showroom/workflows/slash-commands.json
+++ b/ui-tui/.showroom/workflows/slash-commands.json
@@ -1,84 +1,88 @@
 {
-  "title": "Slash Command Tour",
-  "composer": "› press / to open the palette",
-  "viewport": {
-    "cols": 96,
-    "rows": 30,
-    "scale": 4
-  },
+  "composer": "press / to open the palette",
   "timeline": [
-    { "at": 0, "type": "status", "text": "session active", "detail": "model · gpt-5 codex" },
-    { "at": 200, "duration": 500, "text": "› /skills search vibe", "type": "compose" },
     {
-      "at": 800,
-      "id": "skills-results",
-      "title": "/skills search vibe",
-      "items": [
-        "anthropics/skills/frontend-design   ★ trusted",
-        "openai/skills/skill-creator         · official",
-        "skills.sh/community/vibe-coding     ⚙ community"
-      ],
-      "type": "tool"
+      "at": 200,
+      "duration": 500,
+      "text": "/skills search vibe",
+      "type": "compose"
     },
-    { "at": 1100, "duration": 1500, "target": "skills-results", "type": "spotlight" },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[29C/skills\u001b[1Csearch\u001b[1Cvibe\u001b[30C│\r\n│\u001b[78C│\r\n│\u001b[2Canthropics/skills/frontend-design★\u001b[1Ctrusted\u001b[34C│\r\n│\u001b[2Copenai/skills/skill-creator·\u001b[1Cofficial\u001b[39C│\r\n│\u001b[2Cskills.sh/community/vibe-coding⚙\u001b[1Ccommunity\u001b[33C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 800,
+      "id": "skills",
+      "type": "frame"
+    },
+    {
+      "at": 1100,
+      "duration": 1500,
+      "target": "skills",
+      "type": "spotlight"
+    },
     {
       "at": 1300,
       "duration": 1700,
       "position": "right",
-      "target": "skills-results",
+      "target": "skills",
       "text": "Slash commands stream live results without blocking the composer.",
       "type": "caption"
     },
-    { "at": 3100, "duration": 600, "target": "skills-results", "to": 0.2, "type": "fade" },
     {
       "at": 3300,
       "duration": 600,
-      "id": "model-prompt",
-      "role": "user",
       "text": "/model claude-4.6-sonnet",
-      "type": "message"
+      "type": "compose"
     },
     {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[32Cmodel\u001b[1Cswitched\u001b[32C│\r\n│\u001b[78C│\r\n│\u001b[2Cfrom\u001b[16Cgpt-5-codex\u001b[45C│\r\n│\u001b[2Cto\u001b[18Cclaude-4.6-sonnet\u001b[39C│\r\n│\u001b[2Cscope\u001b[15Cthis\u001b[1Csession\u001b[44C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
       "at": 4100,
-      "id": "model-result",
-      "title": "model switched",
-      "items": [
-        "from   gpt-5-codex",
-        "to     claude-4.6-sonnet",
-        "scope  this session"
-      ],
-      "type": "tool"
+      "id": "model",
+      "type": "frame"
     },
     {
       "at": 4400,
       "duration": 1700,
       "position": "right",
-      "target": "model-result",
-      "text": "/model also pops the inline picker when you don’t pass an arg.",
+      "target": "model",
+      "text": "/model also pops the inline picker when no arg is given.",
       "type": "caption"
     },
-    { "at": 6300, "duration": 600, "text": "› /agents pause", "type": "compose" },
     {
-      "at": 7000,
-      "id": "agents-status",
-      "title": "/agents · paused",
-      "items": [
-        "delegation paused",
-        "max children · 4",
-        "running tasks queued for resume"
-      ],
-      "type": "tool"
+      "at": 6300,
+      "duration": 600,
+      "text": "/agents pause",
+      "type": "compose"
     },
-    { "at": 7300, "duration": 1300, "target": "agents-status", "type": "highlight" },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[31C/agents\u001b[1C·\u001b[1Cpaused\u001b[31C│\r\n│\u001b[78C│\r\n│\u001b[2Cdelegation\u001b[10Cpaused\u001b[50C│\r\n│\u001b[2Cmax\u001b[1Cchildren\u001b[8C4\u001b[55C│\r\n│\u001b[2Crunning\u001b[1Ctasks\u001b[7Cqueued\u001b[1Cfor\u001b[1Cresume\u001b[39C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 7000,
+      "id": "agents",
+      "type": "frame"
+    },
+    {
+      "at": 7300,
+      "duration": 1300,
+      "target": "agents",
+      "type": "highlight"
+    },
     {
       "at": 7500,
-      "duration": 1600,
+      "duration": 1700,
       "position": "right",
-      "target": "agents-status",
+      "target": "agents",
       "text": "Same registry powers TUI, gateway, Telegram, Discord — one source of truth.",
       "type": "caption"
     },
-    { "at": 9300, "duration": 600, "text": "› /resume", "type": "compose" },
-    { "at": 10000, "type": "status", "text": "ready", "detail": "/help for the full list" }
-  ]
+    {
+      "at": 9300,
+      "duration": 600,
+      "text": "/resume",
+      "type": "compose"
+    }
+  ],
+  "title": "Hermes TUI · Slash Commands",
+  "viewport": {
+    "cols": 80,
+    "rows": 16
+  }
 }

--- a/ui-tui/.showroom/workflows/slash-commands.json
+++ b/ui-tui/.showroom/workflows/slash-commands.json
@@ -1,83 +1,121 @@
 {
-  "composer": "press / to open the palette",
+  "composer": "",
   "timeline": [
     {
       "at": 200,
-      "duration": 500,
+      "duration": 700,
       "text": "/skills search vibe",
       "type": "compose"
     },
     {
-      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[29C/skills\u001b[1Csearch\u001b[1Cvibe\u001b[30C│\r\n│\u001b[78C│\r\n│\u001b[2Canthropics/skills/frontend-design★\u001b[1Ctrusted\u001b[34C│\r\n│\u001b[2Copenai/skills/skill-creator·\u001b[1Cofficial\u001b[39C│\r\n│\u001b[2Cskills.sh/community/vibe-coding⚙\u001b[1Ccommunity\u001b[33C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
-      "at": 800,
-      "id": "skills",
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2C/skills\u001b[1Csearch\u001b[1Cvibe\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 1100,
       "type": "frame"
     },
     {
       "at": 1100,
-      "duration": 1500,
-      "target": "skills",
-      "type": "spotlight"
+      "duration": 200,
+      "text": "",
+      "type": "compose"
     },
     {
-      "at": 1300,
-      "duration": 1700,
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[29Cskills\u001b[1C·\u001b[1Csearch\u001b[1Cvibe\u001b[29C│\r\n│\u001b[78C│\r\n│\u001b[2Canthropics/skills/frontend-design★\u001b[1Ctrusted\u001b[34C│\r\n│\u001b[2Copenai/skills/skill-creator·\u001b[1Cofficial\u001b[39C│\r\n│\u001b[2Cskills.sh/community/vibe-coding⚙\u001b[1Ccommunity\u001b[33C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 1400,
+      "id": "skills",
+      "type": "frame"
+    },
+    {
+      "at": 1700,
+      "duration": 2000,
       "position": "right",
       "target": "skills",
-      "text": "Slash commands stream live results without blocking the composer.",
+      "text": "Typed /skills, hit return — same Panel the live TUI renders.",
       "type": "caption"
     },
     {
-      "at": 3300,
-      "duration": 600,
+      "at": 4000,
+      "duration": 700,
       "text": "/model claude-4.6-sonnet",
       "type": "compose"
     },
     {
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2C/model\u001b[1Cclaude-4.6-sonnet\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 4900,
+      "type": "frame"
+    },
+    {
+      "at": 4900,
+      "duration": 200,
+      "text": "",
+      "type": "compose"
+    },
+    {
       "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[32Cmodel\u001b[1Cswitched\u001b[32C│\r\n│\u001b[78C│\r\n│\u001b[2Cfrom\u001b[16Cgpt-5-codex\u001b[45C│\r\n│\u001b[2Cto\u001b[18Cclaude-4.6-sonnet\u001b[39C│\r\n│\u001b[2Cscope\u001b[15Cthis\u001b[1Csession\u001b[44C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
-      "at": 4100,
+      "at": 5200,
       "id": "model",
       "type": "frame"
     },
     {
-      "at": 4400,
-      "duration": 1700,
+      "at": 5500,
+      "duration": 1900,
       "position": "right",
       "target": "model",
-      "text": "/model also pops the inline picker when no arg is given.",
+      "text": "/model swaps mid-session; transcript and cache stay intact.",
       "type": "caption"
     },
     {
-      "at": 6300,
+      "at": 7600,
       "duration": 600,
       "text": "/agents pause",
       "type": "compose"
     },
     {
-      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[31C/agents\u001b[1C·\u001b[1Cpaused\u001b[31C│\r\n│\u001b[78C│\r\n│\u001b[2Cdelegation\u001b[10Cpaused\u001b[50C│\r\n│\u001b[2Cmax\u001b[1Cchildren\u001b[8C4\u001b[55C│\r\n│\u001b[2Crunning\u001b[1Ctasks\u001b[7Cqueued\u001b[1Cfor\u001b[1Cresume\u001b[39C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
-      "at": 7000,
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2C/agents\u001b[1Cpause\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 8400,
+      "type": "frame"
+    },
+    {
+      "at": 8400,
+      "duration": 200,
+      "text": "",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[31Cagents\u001b[1C·\u001b[1Cpaused\u001b[32C│\r\n│\u001b[78C│\r\n│\u001b[2Cdelegation\u001b[10Cpaused\u001b[50C│\r\n│\u001b[2Cmax\u001b[1Cchildren\u001b[8C4\u001b[55C│\r\n│\u001b[2Crunning\u001b[1Ctasks\u001b[7Cqueued\u001b[1Cfor\u001b[1Cresume\u001b[39C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 8700,
       "id": "agents",
       "type": "frame"
     },
     {
-      "at": 7300,
-      "duration": 1300,
-      "target": "agents",
-      "type": "highlight"
-    },
-    {
-      "at": 7500,
-      "duration": 1700,
+      "at": 9000,
+      "duration": 1800,
       "position": "right",
       "target": "agents",
-      "text": "Same registry powers TUI, gateway, Telegram, Discord — one source of truth.",
+      "text": "Same registry powers TUI, gateway, Telegram, Discord — one truth.",
       "type": "caption"
     },
     {
-      "at": 9300,
-      "duration": 600,
-      "text": "/resume",
+      "at": 11000,
+      "duration": 400,
+      "text": "/help",
       "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2C/help\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 11500,
+      "type": "frame"
+    },
+    {
+      "at": 11500,
+      "duration": 200,
+      "text": "",
+      "type": "compose"
+    },
+    {
+      "ansi": "\u001b[?25l\u001b[?2026h╭──────────────────────────────────────────────────────────────────────────────╮\r\n│\u001b[78C│\r\n│\u001b[31C(^_^)?\u001b[1CCommands\u001b[32C│\r\n│\u001b[78C│\r\n│\u001b[2CTools\u001b[1C&\u001b[1CSkills\u001b[62C│\r\n│\u001b[2C/skills\u001b[4Csearch\u001b[1C·\u001b[1Cinstall\u001b[1C·\u001b[1Cinspect\u001b[39C│\r\n│\u001b[2C/model\u001b[5Cswitch\u001b[1Cmodel\u001b[1C·\u001b[1Cpop\u001b[1Cpicker\u001b[40C│\r\n│\u001b[78C│\r\n│\u001b[2CSession\u001b[69C│\r\n│\u001b[2C/agents\u001b[4Cspawn-tree\u001b[1Cdashboard\u001b[45C│\r\n│\u001b[2C/queue\u001b[5Cqueue\u001b[1Cprompt\u001b[1Cfor\u001b[1Cnext\u001b[1Cturn\u001b[39C│\r\n│\u001b[2C/steer\u001b[5Cinject\u001b[1Cafter\u001b[1Cnext\u001b[1Ctool\u001b[1Ccall\u001b[38C│\r\n│\u001b[78C│\r\n│\u001b[2CConfiguration\u001b[63C│\r\n│\u001b[2C/voice\u001b[5Ctoggle\u001b[1Cvoice\u001b[1Cmode\u001b[48C│\r\n│\u001b[2C/details\u001b[3Cthinking\u001b[1C·\u001b[1Ctools\u001b[1C·\u001b[1Csubagents\u001b[1C·\u001b[1Cactivity\u001b[26C│\r\n│\u001b[78C│\r\n╰──────────────────────────────────────────────────────────────────────────────╯\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 11800,
+      "id": "help",
+      "type": "frame"
     }
   ],
   "title": "Hermes TUI · Slash Commands",

--- a/ui-tui/.showroom/workflows/slash-commands.json
+++ b/ui-tui/.showroom/workflows/slash-commands.json
@@ -1,0 +1,84 @@
+{
+  "title": "Slash Command Tour",
+  "composer": "› press / to open the palette",
+  "viewport": {
+    "cols": 96,
+    "rows": 30,
+    "scale": 4
+  },
+  "timeline": [
+    { "at": 0, "type": "status", "text": "session active", "detail": "model · gpt-5 codex" },
+    { "at": 200, "duration": 500, "text": "› /skills search vibe", "type": "compose" },
+    {
+      "at": 800,
+      "id": "skills-results",
+      "title": "/skills search vibe",
+      "items": [
+        "anthropics/skills/frontend-design   ★ trusted",
+        "openai/skills/skill-creator         · official",
+        "skills.sh/community/vibe-coding     ⚙ community"
+      ],
+      "type": "tool"
+    },
+    { "at": 1100, "duration": 1500, "target": "skills-results", "type": "spotlight" },
+    {
+      "at": 1300,
+      "duration": 1700,
+      "position": "right",
+      "target": "skills-results",
+      "text": "Slash commands stream live results without blocking the composer.",
+      "type": "caption"
+    },
+    { "at": 3100, "duration": 600, "target": "skills-results", "to": 0.2, "type": "fade" },
+    {
+      "at": 3300,
+      "duration": 600,
+      "id": "model-prompt",
+      "role": "user",
+      "text": "/model claude-4.6-sonnet",
+      "type": "message"
+    },
+    {
+      "at": 4100,
+      "id": "model-result",
+      "title": "model switched",
+      "items": [
+        "from   gpt-5-codex",
+        "to     claude-4.6-sonnet",
+        "scope  this session"
+      ],
+      "type": "tool"
+    },
+    {
+      "at": 4400,
+      "duration": 1700,
+      "position": "right",
+      "target": "model-result",
+      "text": "/model also pops the inline picker when you don’t pass an arg.",
+      "type": "caption"
+    },
+    { "at": 6300, "duration": 600, "text": "› /agents pause", "type": "compose" },
+    {
+      "at": 7000,
+      "id": "agents-status",
+      "title": "/agents · paused",
+      "items": [
+        "delegation paused",
+        "max children · 4",
+        "running tasks queued for resume"
+      ],
+      "type": "tool"
+    },
+    { "at": 7300, "duration": 1300, "target": "agents-status", "type": "highlight" },
+    {
+      "at": 7500,
+      "duration": 1600,
+      "position": "right",
+      "target": "agents-status",
+      "text": "Same registry powers TUI, gateway, Telegram, Discord — one source of truth.",
+      "type": "caption"
+    },
+    { "at": 9300, "duration": 600, "text": "› /resume", "type": "compose" },
+    { "at": 10000, "type": "status", "text": "ready", "detail": "/help for the full list" }
+  ]
+}

--- a/ui-tui/.showroom/workflows/subagent-trail.json
+++ b/ui-tui/.showroom/workflows/subagent-trail.json
@@ -1,88 +1,82 @@
 {
-  "title": "Subagent Trail",
-  "composer": "› spawn the deploy fan-out",
-  "viewport": {
-    "cols": 96,
-    "rows": 30,
-    "scale": 4
-  },
+  "composer": "spawn the deploy fan-out",
   "timeline": [
-    { "at": 0, "type": "status", "text": "delegating…", "detail": "depth 1 / max 3" },
     {
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2CRun\u001b[1Ctests,\u001b[1Clint,\u001b[1Cand\u001b[1Ca\u001b[1CRailway\u001b[1Cpreview\u001b[1Cdeploy\u001b[1Cin\u001b[1Cparallel.\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
       "at": 200,
-      "duration": 600,
       "id": "ask",
-      "role": "user",
-      "text": "Run tests, lint, and a Railway preview deploy in parallel.",
-      "type": "message"
+      "type": "frame"
     },
     {
-      "at": 950,
-      "duration": 800,
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CSpawning\u001b[1Cthree\u001b[1Csubagents\u001b[1Con\u001b[1Cthe\u001b[1Cfan-out\u001b[1Clane\u001b[1Cand\u001b[1Cwatching\u001b[1Ctheir\u001b[1Ctool\r\n\u001b[3Ccounts.\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 1100,
       "id": "plan",
-      "role": "assistant",
-      "text": "Spawning three subagents on the fan-out lane and watching their tool counts.",
-      "type": "message"
+      "type": "frame"
     },
     {
-      "at": 1900,
-      "id": "agents-table",
-      "title": "/agents · live",
-      "items": [
-        "├─ tests       running   12 tools   ⏱ 14.2s",
-        "├─ lint        running    4 tools   ⏱ 14.2s",
-        "└─ deploy      queued     0 tools   ⏱  0.0s"
-      ],
-      "type": "tool"
+      "ansi": "\u001b[?25l\u001b[?2026h\u001b[2C├─\u001b[1Ctests\u001b[3Crunning\u001b[3C12\u001b[1Ctools\u001b[3C⏱\u001b[1C14.2s\r\n\u001b[2C├─\u001b[1Clint\u001b[4Crunning\u001b[4C4\u001b[1Ctools\u001b[3C⏱\u001b[1C14.2s\r\n\u001b[2C└─\u001b[1Cdeploy\u001b[2Cqueued\u001b[5C0\u001b[1Ctools\u001b[3C⏱\u001b[2C0.0s\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 2100,
+      "id": "live",
+      "type": "frame"
     },
-    { "at": 2200, "duration": 1500, "target": "agents-table", "type": "spotlight" },
     {
-      "at": 2400,
+      "at": 2300,
+      "duration": 1500,
+      "target": "live",
+      "type": "spotlight"
+    },
+    {
+      "at": 2500,
       "duration": 1700,
       "position": "right",
-      "target": "agents-table",
-      "text": "Each subagent gets its own depth and budget; the dashboard tracks tool count + duration live.",
+      "target": "live",
+      "text": "Each subagent gets its own depth and tool budget; the dashboard tracks them live.",
       "type": "caption"
     },
     {
+      "ansi": "\u001b[?25l\u001b[?2026h\u001b[2C├─\u001b[1Ctests\u001b[3Ccomplete\u001b[2C18\u001b[1Ctools\u001b[3C⏱\u001b[1C22.7s\u001b[3C✓\r\n\u001b[2C├─\u001b[1Clint\u001b[4Ccomplete\u001b[3C6\u001b[1Ctools\u001b[3C⏱\u001b[1C18.1s\u001b[3C✓\r\n\u001b[2C└─\u001b[1Cdeploy\u001b[2Crunning\u001b[4C9\u001b[1Ctools\u001b[3C⏱\u001b[2C9.4s\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
       "at": 4400,
-      "id": "lane-update",
-      "title": "depth 2 · hot lane",
-      "items": [
-        "├─ tests       complete  18 tools   ⏱ 22.7s   ✓",
-        "├─ lint        complete   6 tools   ⏱ 18.1s   ✓",
-        "└─ deploy      running    9 tools   ⏱  9.4s"
-      ],
-      "type": "tool"
+      "id": "hot",
+      "type": "frame"
     },
-    { "at": 4500, "duration": 800, "target": "agents-table", "to": 0.18, "type": "fade" },
-    { "at": 5000, "duration": 1300, "target": "lane-update", "type": "highlight" },
     {
-      "at": 5200,
+      "at": 4600,
+      "duration": 1300,
+      "target": "hot",
+      "type": "highlight"
+    },
+    {
+      "at": 4800,
       "duration": 1700,
       "position": "right",
-      "target": "lane-update",
+      "target": "hot",
       "text": "Completed runs collapse, hot lanes stay vivid — the eye tracks the live agent.",
       "type": "caption"
     },
     {
-      "at": 7100,
-      "duration": 800,
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CAll\u001b[1Cthree\u001b[1Clanded:\u001b[1C24\u001b[1Ctests\u001b[1Cpass,\u001b[1Clint\u001b[1Cclean,\u001b[1Cpreview\u001b[1Cat\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 6800,
       "id": "summary",
-      "role": "assistant",
-      "text": "All three landed: 24 tests pass, lint clean, preview at https://pr-128.railway.app.",
-      "type": "message"
+      "type": "frame"
     },
-    { "at": 8050, "duration": 1100, "target": "summary", "type": "highlight" },
     {
-      "at": 8200,
-      "duration": 1500,
+      "at": 7000,
+      "duration": 1700,
       "position": "right",
       "target": "summary",
       "text": "Subagent results stream back into the parent transcript as a single highlight.",
       "type": "caption"
     },
-    { "at": 9700, "duration": 600, "text": "› /agents", "type": "compose" },
-    { "at": 10500, "type": "status", "text": "trail complete", "detail": "3 subagents · 28 tools" }
-  ]
+    {
+      "at": 8800,
+      "duration": 600,
+      "text": "/agents",
+      "type": "compose"
+    }
+  ],
+  "title": "Hermes TUI · Subagent Trail",
+  "viewport": {
+    "cols": 80,
+    "rows": 16
+  }
 }

--- a/ui-tui/.showroom/workflows/subagent-trail.json
+++ b/ui-tui/.showroom/workflows/subagent-trail.json
@@ -1,0 +1,88 @@
+{
+  "title": "Subagent Trail",
+  "composer": "› spawn the deploy fan-out",
+  "viewport": {
+    "cols": 96,
+    "rows": 30,
+    "scale": 4
+  },
+  "timeline": [
+    { "at": 0, "type": "status", "text": "delegating…", "detail": "depth 1 / max 3" },
+    {
+      "at": 200,
+      "duration": 600,
+      "id": "ask",
+      "role": "user",
+      "text": "Run tests, lint, and a Railway preview deploy in parallel.",
+      "type": "message"
+    },
+    {
+      "at": 950,
+      "duration": 800,
+      "id": "plan",
+      "role": "assistant",
+      "text": "Spawning three subagents on the fan-out lane and watching their tool counts.",
+      "type": "message"
+    },
+    {
+      "at": 1900,
+      "id": "agents-table",
+      "title": "/agents · live",
+      "items": [
+        "├─ tests       running   12 tools   ⏱ 14.2s",
+        "├─ lint        running    4 tools   ⏱ 14.2s",
+        "└─ deploy      queued     0 tools   ⏱  0.0s"
+      ],
+      "type": "tool"
+    },
+    { "at": 2200, "duration": 1500, "target": "agents-table", "type": "spotlight" },
+    {
+      "at": 2400,
+      "duration": 1700,
+      "position": "right",
+      "target": "agents-table",
+      "text": "Each subagent gets its own depth and budget; the dashboard tracks tool count + duration live.",
+      "type": "caption"
+    },
+    {
+      "at": 4400,
+      "id": "lane-update",
+      "title": "depth 2 · hot lane",
+      "items": [
+        "├─ tests       complete  18 tools   ⏱ 22.7s   ✓",
+        "├─ lint        complete   6 tools   ⏱ 18.1s   ✓",
+        "└─ deploy      running    9 tools   ⏱  9.4s"
+      ],
+      "type": "tool"
+    },
+    { "at": 4500, "duration": 800, "target": "agents-table", "to": 0.18, "type": "fade" },
+    { "at": 5000, "duration": 1300, "target": "lane-update", "type": "highlight" },
+    {
+      "at": 5200,
+      "duration": 1700,
+      "position": "right",
+      "target": "lane-update",
+      "text": "Completed runs collapse, hot lanes stay vivid — the eye tracks the live agent.",
+      "type": "caption"
+    },
+    {
+      "at": 7100,
+      "duration": 800,
+      "id": "summary",
+      "role": "assistant",
+      "text": "All three landed: 24 tests pass, lint clean, preview at https://pr-128.railway.app.",
+      "type": "message"
+    },
+    { "at": 8050, "duration": 1100, "target": "summary", "type": "highlight" },
+    {
+      "at": 8200,
+      "duration": 1500,
+      "position": "right",
+      "target": "summary",
+      "text": "Subagent results stream back into the parent transcript as a single highlight.",
+      "type": "caption"
+    },
+    { "at": 9700, "duration": 600, "text": "› /agents", "type": "compose" },
+    { "at": 10500, "type": "status", "text": "trail complete", "detail": "3 subagents · 28 tools" }
+  ]
+}

--- a/ui-tui/.showroom/workflows/voice-mode.json
+++ b/ui-tui/.showroom/workflows/voice-mode.json
@@ -1,25 +1,18 @@
 {
-  "title": "Voice Mode",
-  "composer": "› ctrl+b to start recording",
-  "viewport": {
-    "cols": 96,
-    "rows": 30,
-    "scale": 4
-  },
+  "composer": "ctrl+b to start recording",
   "timeline": [
-    { "at": 0, "type": "status", "text": "voice · listening", "detail": "STT · openai · TTS · 11labs" },
     {
+      "ansi": "\u001b[?25l\u001b[?2026h\u001b[2C⚡\u001b[1CVAD\u001b[1C·\u001b[1Ccapturing\u001b[1C(3)\r\n\u001b[2C├─\u001b[1C▮\u001b[1C▮▮\u001b[1C▮\u001b[1C▮▮▮▮\u001b[1C▮▮\u001b[1C▮▮▮▮▮▮\u001b[1C▮▮▮\u001b[1C▮\r\n\u001b[2C├─\u001b[1Crms\u001b[1C0.42\u001b[1C·\u001b[1C1.6s\u001b[1Ccaptured\r\n\u001b[2C└─\u001b[1Cauto-stop\u001b[1C·\u001b[1Csilence\u001b[1C380ms\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
       "at": 250,
       "id": "vad",
-      "title": "VAD · capturing",
-      "items": [
-        "▮ ▮▮ ▮ ▮▮▮▮ ▮▮ ▮▮▮▮▮▮ ▮▮▮ ▮",
-        "rms 0.42 · 1.6s captured",
-        "auto-stop · silence 380ms"
-      ],
-      "type": "tool"
+      "type": "frame"
     },
-    { "at": 600, "duration": 1500, "target": "vad", "type": "spotlight" },
+    {
+      "at": 600,
+      "duration": 1500,
+      "target": "vad",
+      "type": "spotlight"
+    },
     {
       "at": 800,
       "duration": 1700,
@@ -28,52 +21,56 @@
       "text": "Continuous loop: VAD detects silence, transcribes, restarts — no key holds.",
       "type": "caption"
     },
-    { "at": 2700, "duration": 500, "target": "vad", "to": 0.18, "type": "fade" },
     {
-      "at": 3000,
-      "duration": 700,
+      "ansi": "\u001b[?25l\u001b[?2026h\r\n❯\u001b[2Cwhat's\u001b[1Cin\u001b[1Cmy\u001b[1Cinbox\u001b[1Ctoday\u001b[1Cand\u001b[1Cwhat\u001b[1Cneeds\u001b[1Ca\u001b[1Creply\u001b[1Cbefore\u001b[1Cnoon?\r\n\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 2700,
       "id": "transcript",
-      "role": "user",
-      "text": "what's in my inbox today and what needs a reply before noon?",
-      "type": "message"
+      "type": "frame"
     },
-    { "at": 3900, "duration": 1100, "target": "transcript", "type": "highlight" },
     {
-      "at": 4100,
+      "at": 3400,
+      "duration": 1100,
+      "target": "transcript",
+      "type": "highlight"
+    },
+    {
+      "at": 3600,
       "duration": 1700,
       "position": "right",
       "target": "transcript",
-      "text": "Transcript flows straight into the composer with the standard ‹ user glyph.",
+      "text": "Transcript flows straight into the composer with the standard ❯ user glyph.",
       "type": "caption"
     },
     {
-      "at": 6000,
-      "duration": 1100,
+      "ansi": "\u001b[?25l\u001b[?2026h┊\u001b[2CThree\u001b[1Cthreads\u001b[1Cneed\u001b[1Cyou\u001b[1Cbefore\u001b[1Cnoon:\u001b[1Cvendor\u001b[1Crenewal,\u001b[1Cpodcast\u001b[1Cintro\u001b[1Cfeedback,\r\n\u001b[4Cand\u001b[1Cthe\u001b[1Cdesign\u001b[1Creview\u001b[1Cat\u001b[1C11.\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 5500,
       "id": "answer",
-      "role": "assistant",
-      "text": "Three threads need you before noon: vendor renewal, podcast intro feedback, and the design review at 11.",
-      "type": "message"
+      "type": "frame"
     },
     {
-      "at": 7300,
+      "ansi": "\u001b[?25l\u001b[?2026h\u001b[2C⚡\u001b[1Ctts\u001b[1C·\u001b[1Cplaying\u001b[1C(3)\r\n\u001b[2C├─\u001b[1Cvoice\u001b[1C11labs\u001b[1C·\u001b[1Cgrace_v3\r\n\u001b[2C├─\u001b[1Celapsed\u001b[1C4.6s\u001b[1C·\u001b[1C2\u001b[1Cchunks\u001b[1Cqueued\r\n\u001b[2C└─\u001b[1Cducking\u001b[1Cmic\u001b[1Cinput\r\n\u001b[?2026l\u001b[?2026h\u001b[?25h\u001b[?2026l\u001b[?25h",
+      "at": 6700,
       "id": "tts",
-      "title": "tts · playing",
-      "items": [
-        "voice 11labs · grace_v3",
-        "elapsed 4.6s · 2 chunks queued",
-        "ducking mic input"
-      ],
-      "type": "tool"
+      "type": "frame"
     },
     {
-      "at": 7600,
+      "at": 7000,
       "duration": 1700,
       "position": "right",
       "target": "tts",
       "text": "TTS auto-ducks the mic so the loop never echoes itself back.",
       "type": "caption"
     },
-    { "at": 9400, "duration": 600, "text": "› /voice off", "type": "compose" },
-    { "at": 10100, "type": "status", "text": "voice off", "detail": "transcript saved · 1 turn" }
-  ]
+    {
+      "at": 8800,
+      "duration": 600,
+      "text": "/voice off",
+      "type": "compose"
+    }
+  ],
+  "title": "Hermes TUI · Voice Mode",
+  "viewport": {
+    "cols": 80,
+    "rows": 16
+  }
 }

--- a/ui-tui/.showroom/workflows/voice-mode.json
+++ b/ui-tui/.showroom/workflows/voice-mode.json
@@ -1,0 +1,79 @@
+{
+  "title": "Voice Mode",
+  "composer": "› ctrl+b to start recording",
+  "viewport": {
+    "cols": 96,
+    "rows": 30,
+    "scale": 4
+  },
+  "timeline": [
+    { "at": 0, "type": "status", "text": "voice · listening", "detail": "STT · openai · TTS · 11labs" },
+    {
+      "at": 250,
+      "id": "vad",
+      "title": "VAD · capturing",
+      "items": [
+        "▮ ▮▮ ▮ ▮▮▮▮ ▮▮ ▮▮▮▮▮▮ ▮▮▮ ▮",
+        "rms 0.42 · 1.6s captured",
+        "auto-stop · silence 380ms"
+      ],
+      "type": "tool"
+    },
+    { "at": 600, "duration": 1500, "target": "vad", "type": "spotlight" },
+    {
+      "at": 800,
+      "duration": 1700,
+      "position": "right",
+      "target": "vad",
+      "text": "Continuous loop: VAD detects silence, transcribes, restarts — no key holds.",
+      "type": "caption"
+    },
+    { "at": 2700, "duration": 500, "target": "vad", "to": 0.18, "type": "fade" },
+    {
+      "at": 3000,
+      "duration": 700,
+      "id": "transcript",
+      "role": "user",
+      "text": "what's in my inbox today and what needs a reply before noon?",
+      "type": "message"
+    },
+    { "at": 3900, "duration": 1100, "target": "transcript", "type": "highlight" },
+    {
+      "at": 4100,
+      "duration": 1700,
+      "position": "right",
+      "target": "transcript",
+      "text": "Transcript flows straight into the composer with the standard ‹ user glyph.",
+      "type": "caption"
+    },
+    {
+      "at": 6000,
+      "duration": 1100,
+      "id": "answer",
+      "role": "assistant",
+      "text": "Three threads need you before noon: vendor renewal, podcast intro feedback, and the design review at 11.",
+      "type": "message"
+    },
+    {
+      "at": 7300,
+      "id": "tts",
+      "title": "tts · playing",
+      "items": [
+        "voice 11labs · grace_v3",
+        "elapsed 4.6s · 2 chunks queued",
+        "ducking mic input"
+      ],
+      "type": "tool"
+    },
+    {
+      "at": 7600,
+      "duration": 1700,
+      "position": "right",
+      "target": "tts",
+      "text": "TTS auto-ducks the mic so the loop never echoes itself back.",
+      "type": "caption"
+    },
+    { "at": 9400, "duration": 600, "text": "› /voice off", "type": "compose" },
+    { "at": 10100, "type": "status", "text": "voice off", "detail": "transcript saved · 1 turn" }
+  ]
+}

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -16,7 +16,8 @@
     "test:watch": "vitest",
     "showroom": "tsx .showroom/server.ts",
     "showroom:build": "tsx .showroom/build.ts",
-    "showroom:type-check": "tsc --noEmit -p .showroom/tsconfig.json"
+    "showroom:type-check": "tsc --noEmit -p .showroom/tsconfig.json",
+    "showroom:record": "tsx .showroom/record.tsx"
   },
   "dependencies": {
     "@hermes/ink": "file:./packages/hermes-ink",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -13,7 +13,10 @@
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "showroom": "tsx .showroom/server.ts",
+    "showroom:build": "tsx .showroom/build.ts",
+    "showroom:type-check": "tsc --noEmit -p .showroom/tsconfig.json"
   },
   "dependencies": {
     "@hermes/ink": "file:./packages/hermes-ink",


### PR DESCRIPTION
## Summary
- Adds a `.showroom` mini-project for scripted, record-ready `ui-tui` demos.
- Supports JSON timelines with messages, tool cards, status/composer updates, captions, spotlights, highlights, and fades.
- Adds npm scripts for preview, static HTML build, and showroom type-checking.

## Test plan
- `npm run showroom:type-check`
- `npm run showroom:build`
- local `/healthz` smoke test for `npm run showroom -- --port 4319`