### PR TITLE
fix(tui): restore skills search RPC

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -5,6 +5,7 @@ import json
 import sys
 import threading
 import time
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -309,6 +310,36 @@ def test_command_dispatch_queue_requires_arg(server):
 
     assert "error" in resp
     assert resp["error"]["code"] == 4004
+
+
+def test_skills_manage_search_uses_tools_hub_sources(server):
+    result = type("Result", (), {
+        "description": "Build better terminal demos",
+        "name": "showroom",
+    })()
+    auth = MagicMock(return_value="auth")
+    router = MagicMock(return_value=["source"])
+    search = MagicMock(return_value=[result])
+    fake_hub = types.SimpleNamespace(
+        GitHubAuth=auth,
+        create_source_router=router,
+        unified_search=search,
+    )
+
+    with patch.dict(sys.modules, {"tools.skills_hub": fake_hub}):
+        resp = server.handle_request({
+            "id": "skills-search",
+            "method": "skills.manage",
+            "params": {"action": "search", "query": "showroom"},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {
+        "results": [{"description": "Build better terminal demos", "name": "showroom"}]
+    }
+    auth.assert_called_once_with()
+    router.assert_called_once_with("auth")
+    search.assert_called_once_with("showroom", ["source"], source_filter="all", limit=20)
 
 
 def test_command_dispatch_steer_fallback_sends_message(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4569,11 +4569,7 @@ def _(rid, params: dict) -> dict:
 
             return _ok(rid, {"skills": get_available_skills()})
         if action == "search":
-            from hermes_cli.skills_hub import (
-                unified_search,
-                GitHubAuth,
-                create_source_router,
-            )
+            from tools.skills_hub import GitHubAuth, create_source_router, unified_search
 
             raw = (
                 unified_search(


### PR DESCRIPTION
## Summary
- Fixes TUI `/skills search` by importing Skills Hub search primitives from `tools.skills_hub`, where they are actually defined.
- Adds a TUI gateway regression test for `skills.manage` search so client-side slash routing coverage is backed by the RPC handler.

## Root cause
TUI `/skills search` bypasses the classic CLI slash handler and calls `skills.manage` in `tui_gateway/server.py`. That handler copied the wrong import boundary and tried to load `unified_search`, `GitHubAuth`, and `create_source_router` from `hermes_cli.skills_hub`; the CLI module only wraps those primitives and imports them from `tools.skills_hub` internally.

## Pattern check
- Searched TUI gateway `skills.manage` and TUI slash handlers for sibling `/skills` actions.
- `list`, `install`, `browse`, and `inspect` use existing wrappers/surfaces that resolve correctly; only `search` imported lower-level primitives from the wrong module.

## Test plan
- `npm run fix`
- `npm run type-check`
- `scripts/run_tests.sh tests/tui_gateway/test_protocol.py tests/hermes_cli/test_skills_hub.py::test_handle_skills_slash_search_accepts_chatconsole_without_status_errors -q`
- `npm test -- createSlashHandler`