### PR TITLE
feat: add offload_job tool — systemd-run isolation for heavy workloads

### DIFF
--- a/tests/tools/test_offload_job_tool.py
+++ b/tests/tools/test_offload_job_tool.py
@@ -1,0 +1,135 @@
+import json
+import time
+
+from tools.registry import registry
+from tools import offload_job_tool as offload
+
+
+def _decode(raw):
+    return json.loads(raw)
+
+
+def _wait_for_terminal_status(job_id, wanted, timeout=5):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = _decode(offload.offload_job_tool("status", job_id=job_id))
+        if last["job"]["status"] in wanted:
+            return last
+        time.sleep(0.05)
+    return last
+
+
+def test_offload_job_fallback_runs_command_and_tails_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(offload, "_systemd_run_available", lambda: False)
+
+    result = _decode(
+        offload.offload_job_tool(
+            "start",
+            command="echo hello-offload",
+            workdir=str(tmp_path),
+            label="unit",
+        )
+    )
+
+    assert result["success"] is True
+    job = result["job"]
+    assert job["runner"] == "subprocess"
+    assert job["status"] == "running"
+    assert job["workdir"] == str(tmp_path)
+
+    status = _wait_for_terminal_status(job["job_id"], {"succeeded", "failed", "unknown"})
+    assert status["job"]["status"] == "succeeded"
+    assert status["job"]["exit_code"] == 0
+
+    tail = _decode(offload.offload_job_tool("tail", job_id=job["job_id"], tail_lines=20))
+    assert tail["success"] is True
+    assert "hello-offload" in tail["tail"]
+
+
+def test_offload_job_list_returns_newest_first(tmp_path, monkeypatch):
+    monkeypatch.setattr(offload, "_systemd_run_available", lambda: False)
+    first = _decode(offload.offload_job_tool("start", command="echo first", workdir=str(tmp_path), label="first"))["job"]
+    second = _decode(offload.offload_job_tool("start", command="echo second", workdir=str(tmp_path), label="second"))["job"]
+
+    _wait_for_terminal_status(first["job_id"], {"succeeded", "failed", "unknown"})
+    _wait_for_terminal_status(second["job_id"], {"succeeded", "failed", "unknown"})
+
+    listed = _decode(offload.offload_job_tool("list", limit=10))
+    ids = [job["job_id"] for job in listed["jobs"]]
+    assert ids.index(second["job_id"]) < ids.index(first["job_id"])
+
+
+def test_offload_job_cancel_unknown_job_returns_structured_error():
+    result = _decode(offload.offload_job_tool("cancel", job_id="missing-job"))
+    assert result["success"] is False
+    assert "Unknown offload job" in result["error"]
+
+
+def test_offload_job_cancel_running_fallback_job(tmp_path, monkeypatch):
+    monkeypatch.setattr(offload, "_systemd_run_available", lambda: False)
+
+    result = _decode(
+        offload.offload_job_tool(
+            "start",
+            command="sleep 30",
+            workdir=str(tmp_path),
+            label="cancel",
+        )
+    )
+    assert result["success"] is True
+
+    cancelled = _decode(offload.offload_job_tool("cancel", job_id=result["job"]["job_id"]))
+    assert cancelled["success"] is True
+    assert cancelled["job"]["status"] == "cancelled"
+
+    status = _decode(offload.offload_job_tool("status", job_id=result["job"]["job_id"]))
+    assert status["job"]["status"] == "cancelled"
+
+
+def test_offload_job_uses_systemd_when_available(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0
+            stdout = "Running as unit hermes-offload-demo.service"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(offload, "_systemd_run_available", lambda: True)
+    monkeypatch.setattr(offload.subprocess, "run", fake_run)
+
+    result = _decode(
+        offload.offload_job_tool(
+            "start",
+            command="echo systemd",
+            workdir=str(tmp_path),
+            memory_max="32G",
+            cpu_quota="800%",
+            label="systemd",
+        )
+    )
+
+    assert result["success"] is True
+    job = result["job"]
+    assert job["runner"] == "systemd"
+    assert job["unit_name"].startswith("hermes-offload-")
+    flat = " ".join(calls[0])
+    assert "MemoryMax=32G" in flat
+    assert "CPUQuota=800%" in flat
+    assert f"WorkingDirectory={tmp_path}" in flat
+
+
+def test_offload_job_registered_in_terminal_toolset():
+    import toolsets
+
+    entry = registry.get_entry("offload_job")
+    assert entry is not None
+    assert entry.toolset == "terminal"
+    assert "offload" in entry.schema["name"]
+    assert "offload_job" in toolsets.resolve_toolset("terminal")
+    assert "offload_job" in toolsets.resolve_toolset("hermes-gateway")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1048,6 +1048,8 @@ def _build_child_agent(
         provider_sort=parent_agent.provider_sort,
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
+        fallback_model=getattr(parent_agent, "_fallback_chain", None)
+        or getattr(parent_agent, "_fallback_model", None),
     )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Set delegation depth so children can't spawn grandchildren

--- a/tools/hbackup/.gitignore
+++ b/tools/hbackup/.gitignore
@@ -1,0 +1,3 @@
+/target
+Cargo.lock
+*.tar.zst

--- a/tools/hbackup/Cargo.toml
+++ b/tools/hbackup/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "hbackup"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+zstd = "0.13"
+tar = "0.4"
+walkdir = "2"
+indicatif = "0.17"
+chrono = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+toml = "0.8"
+dirs = "5"

--- a/tools/hbackup/README.md
+++ b/tools/hbackup/README.md
@@ -1,0 +1,120 @@
+# hbackup
+
+Backup and restore tool for Hermes Agent + OpenClaw installations.
+
+## Features
+
+- **Incremental-aware discovery**: Backs up `~/work/hermes-agent`, `~/work/openclaw`, `~/.hermes`, `~/.openclaw`, systemd units, and more
+- **SQLite-safe**: Uses `sqlite3 .backup` for live database copies
+- **Compressed archives**: `tar.zst` format with zstd compression
+- **Google Drive upload**: Via `rclone` integration
+- **Cross-platform home dir**: Uses `dirs` crate — no hardcoded paths
+- **Auto workspace discovery**: Scans `~/.openclaw/workspace*` dynamically
+
+## Install
+
+```bash
+cd tools/hbackup
+cargo build --release
+cp target/release/hbackup ~/.local/bin/
+```
+
+## Usage
+
+### Backup
+
+```bash
+# Create backup
+hbackup backup
+
+# Dry run
+hbackup backup --dry-run
+
+# Custom output
+hbackup backup -o /mnt/external/my-backup.tar.zst
+
+# Exclude patterns
+hbackup backup -x target -x .git
+```
+
+### Restore
+
+```bash
+# Restore from archive
+hbackup restore ~/backups/hermes-openclaw-backup-20260101-120000.tar.zst
+
+# Dry run
+hbackup restore --dry-run ~/backups/...
+
+# Force overwrite
+hbackup restore --force ~/backups/...
+```
+
+### List Backups
+
+```bash
+hbackup list
+```
+
+### Upload to Google Drive
+
+```bash
+# Setup guide
+hbackup setup drive
+
+# Upload to Google Drive (requires rclone configured)
+hbackup upload --drive ~/backups/hermes-openclaw-backup-*.tar.zst
+
+# Custom remote name / folder
+hbackup upload --drive --drive-remote mygdrive --drive-folder backups/2026 ~/backups/...
+```
+
+### Auto (backup + upload)
+
+```bash
+# Create backup then upload to configured destination
+hbackup auto
+```
+
+Configure `~/.config/hbackup/config.toml`:
+
+```toml
+[upload]
+destination = "user@server:/backups/"  # scp/rsync
+drive_remote = "gdrive"                  # Google Drive remote name
+drive_folder = "backups/hermes"          # Google Drive folder
+```
+
+## Cron Setup
+
+```bash
+# Daily backup at 3 AM
+0 3 * * * /home/USER/.local/bin/hbackup auto >> /home/USER/.local/state/hermes/hbackup-cron.log 2>&1
+```
+
+## Config File
+
+`~/.config/hbackup/config.toml`:
+
+```toml
+[upload]
+# For scp/rsync upload:
+method = "scp"  # or "rsync"
+destination = "user@backup-server:/backups/"
+
+# For Google Drive upload:
+drive_remote = "gdrive"
+drive_folder = "backups/hermes"
+```
+
+## Open Source Notes
+
+This tool was extracted from a personal setup. Before publishing:
+
+- All hardcoded paths removed (uses `dirs::home_dir()`)
+- Workspace names auto-discovered from `~/.openclaw/workspace*`
+- No user-specific paths remain
+
+## License
+
+MIT

--- a/tools/hbackup/src/backup.rs
+++ b/tools/hbackup/src/backup.rs
@@ -1,0 +1,212 @@
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use chrono::Local;
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::manifest::Manifest;
+use crate::paths::BackupPaths;
+
+pub struct BackupOptions {
+    pub dry_run: bool,
+    pub excludes: Vec<String>,
+    pub output: Option<PathBuf>,
+}
+
+pub fn run_backup(opts: &BackupOptions) -> Result<PathBuf> {
+    let bp = BackupPaths::new();
+    let home = &bp.home;
+
+    // Discover files
+    eprintln!("Discovering files...");
+    let mut files = bp.discover(&opts.excludes);
+    files.extend(bp.discover_systemd_units());
+    files.sort();
+    files.dedup();
+
+    eprintln!("Found {} files to back up", files.len());
+
+    if opts.dry_run {
+        for f in &files {
+            println!("{}", f.display());
+        }
+        eprintln!("Dry run: {} files would be archived", files.len());
+        return Ok(PathBuf::new());
+    }
+
+    // Output path
+    let now = Local::now();
+    let default_name = format!("hermes-openclaw-backup-{}.tar.zst", now.format("%Y%m%d-%H%M%S"));
+    let output = opts.output.clone().unwrap_or_else(|| {
+        home.join("backups").join(&default_name)
+    });
+
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).context("Creating output directory")?;
+    }
+
+    // Build manifest
+    let hostname = gethostname();
+    let mut manifest = Manifest::new(
+        now.to_rfc3339(),
+        hostname,
+    );
+
+    for f in &files {
+        let size = fs::metadata(f).map(|m| m.len()).unwrap_or(0);
+        let rel = f.strip_prefix(home)
+            .map(|r| r.to_string_lossy().to_string())
+            .unwrap_or_else(|_| f.to_string_lossy().to_string());
+        manifest.add_file(rel, size);
+    }
+
+    // Create tar.zst
+    let out_file = File::create(&output).context("Creating archive file")?;
+    let encoder = zstd::stream::Encoder::new(out_file, 3)?;
+    let mut archive = tar::Builder::new(encoder);
+
+    // Write manifest as first entry
+    let manifest_json = serde_json::to_string_pretty(&manifest)?;
+    let manifest_bytes = manifest_json.as_bytes();
+    let mut header = tar::Header::new_gnu();
+    header.set_size(manifest_bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    archive.append_data(&mut header, "manifest.json", manifest_bytes)?;
+
+    // Progress bar
+    let pb = ProgressBar::new(files.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} {msg}")
+            .unwrap()
+            .progress_chars("=>-"),
+    );
+
+    // Temp dir for sqlite backups
+    let tmp_dir = std::env::temp_dir().join(format!("hbackup-{}", std::process::id()));
+    let mut tmp_created = false;
+
+    for file_path in &files {
+        let rel = file_path.strip_prefix(home)
+            .map(|r| r.to_string_lossy().to_string())
+            .unwrap_or_else(|_| file_path.to_string_lossy().to_string());
+
+        pb.set_message(truncate_path(&rel, 50));
+
+        // Handle SQLite databases
+        let actual_path = if is_sqlite_db(file_path) {
+            if !tmp_created {
+                fs::create_dir_all(&tmp_dir)?;
+                tmp_created = true;
+            }
+            match sqlite_safe_copy(file_path, &tmp_dir) {
+                Ok(tmp_path) => tmp_path,
+                Err(e) => {
+                    eprintln!("Warning: SQLite backup failed for {}: {}, using direct copy", rel, e);
+                    file_path.clone()
+                }
+            }
+        } else {
+            file_path.clone()
+        };
+
+        if let Err(e) = append_file(&mut archive, &actual_path, &rel) {
+            eprintln!("Warning: failed to add {}: {}", rel, e);
+        }
+
+        pb.inc(1);
+    }
+
+    pb.finish_with_message("done");
+
+    // Finalize
+    let encoder = archive.into_inner()?;
+    encoder.finish()?;
+
+    // Cleanup temp
+    if tmp_created {
+        let _ = fs::remove_dir_all(&tmp_dir);
+    }
+
+    let size = fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    eprintln!(
+        "Backup complete: {} ({} files, {})",
+        output.display(),
+        manifest.file_count,
+        human_size(size),
+    );
+
+    Ok(output)
+}
+
+fn append_file<W: Write>(
+    archive: &mut tar::Builder<W>,
+    file_path: &Path,
+    archive_path: &str,
+) -> Result<()> {
+    let mut f = File::open(file_path)
+        .with_context(|| format!("Opening {}", file_path.display()))?;
+    let meta = f.metadata()?;
+    let mut header = tar::Header::new_gnu();
+    header.set_size(meta.len());
+    header.set_mode(0o644);
+    header.set_mtime(
+        meta.modified()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    );
+    header.set_cksum();
+    archive.append_data(&mut header, archive_path, &mut f)?;
+    Ok(())
+}
+
+fn is_sqlite_db(path: &Path) -> bool {
+    path.extension().map(|e| e == "db").unwrap_or(false)
+}
+
+fn sqlite_safe_copy(db_path: &Path, tmp_dir: &Path) -> Result<PathBuf> {
+    let fname = db_path.file_name().unwrap().to_string_lossy().to_string();
+    let tmp_path = tmp_dir.join(&fname);
+    let status = Command::new("sqlite3")
+        .arg(db_path.to_string_lossy().as_ref())
+        .arg(format!(".backup '{}'", tmp_path.display()))
+        .status()
+        .context("Running sqlite3")?;
+    if !status.success() {
+        anyhow::bail!("sqlite3 .backup exited with {}", status);
+    }
+    Ok(tmp_path)
+}
+
+fn gethostname() -> String {
+    Command::new("hostname")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn truncate_path(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("...{}", &s[s.len() - max + 3..])
+    }
+}
+
+pub fn human_size(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    for unit in UNITS {
+        if size < 1024.0 {
+            return format!("{:.1} {}", size, unit);
+        }
+        size /= 1024.0;
+    }
+    format!("{:.1} PB", size)
+}

--- a/tools/hbackup/src/main.rs
+++ b/tools/hbackup/src/main.rs
@@ -1,0 +1,248 @@
+mod backup;
+mod manifest;
+mod paths;
+mod restore;
+mod upload_drive;
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use serde::Deserialize;
+
+use backup::BackupOptions;
+use restore::RestoreOptions;
+
+#[derive(Parser)]
+#[command(name = "hbackup", about = "Backup and restore Hermes Agent + OpenClaw installations")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Create a backup archive
+    Backup {
+        /// Dry run: show what would be backed up without creating archive
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Additional exclude patterns (repeatable)
+        #[arg(long = "exclude", short = 'x')]
+        excludes: Vec<String>,
+
+        /// Output archive path
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+    },
+
+    /// Restore from a backup archive
+    Restore {
+        /// Path to the archive to restore
+        archive: PathBuf,
+
+        /// Dry run: show what would be restored
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Overwrite existing files
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// List available backups
+    List,
+
+    /// Upload a backup archive via scp/rsync or Google Drive
+    Upload {
+        /// Archive to upload
+        archive: PathBuf,
+
+        /// Destination (scp/rsync format). Falls back to config file.
+        destination: Option<String>,
+
+        /// Upload to Google Drive via rclone instead of scp/rsync
+        #[arg(long)]
+        drive: bool,
+
+        /// Google Drive remote name (default: gdrive)
+        #[arg(long, default_value = "gdrive")]
+        drive_remote: String,
+
+        /// Google Drive folder path (default: root)
+        #[arg(long, default_value = "")]
+        drive_folder: String,
+    },
+
+    /// Run backup then upload (for cron)
+    Auto,
+
+    /// Setup guide for Google Drive integration
+    Setup {
+        /// What to set up
+        #[arg(default_value = "drive")]
+        component: String,
+    },
+}
+
+#[derive(Deserialize)]
+struct Config {
+    upload: Option<UploadConfig>,
+}
+
+#[derive(Deserialize)]
+struct UploadConfig {
+    destination: Option<String>,
+    method: Option<String>,
+    #[serde(default)]
+    drive_remote: String,
+    #[serde(default)]
+    drive_folder: String,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Backup { dry_run, excludes, output } => {
+            let opts = BackupOptions { dry_run, excludes, output };
+            backup::run_backup(&opts)?;
+        }
+        Commands::Restore { archive, dry_run, force } => {
+            let opts = RestoreOptions { archive, dry_run, force };
+            restore::run_restore(&opts)?;
+        }
+        Commands::List => {
+            cmd_list()?;
+        }
+        Commands::Upload { archive, destination, drive, drive_remote, drive_folder } => {
+            if drive {
+                upload_drive::upload_to_drive(&archive, &drive_remote, &drive_folder)?;
+            } else {
+                cmd_upload(&archive, destination.as_deref())?;
+            }
+        }
+        Commands::Auto => {
+            cmd_auto()?;
+        }
+        Commands::Setup { component } => {
+            match component.as_str() {
+                "drive" => upload_drive::print_drive_setup_guide(),
+                _ => eprintln!("Unknown component '{}'. Available: drive", component),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn cmd_list() -> Result<()> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let backup_dir = home.join("backups");
+    if !backup_dir.exists() {
+        eprintln!("No backups directory found at {}", backup_dir.display());
+        return Ok(());
+    }
+
+    let mut entries: Vec<(PathBuf, u64, std::time::SystemTime)> = Vec::new();
+    for entry in fs::read_dir(&backup_dir)? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with("hermes-openclaw-backup-") && name.ends_with(".tar.zst") {
+            let meta = entry.metadata()?;
+            entries.push((entry.path(), meta.len(), meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH)));
+        }
+    }
+
+    entries.sort_by_key(|(_, _, t)| *t);
+
+    if entries.is_empty() {
+        println!("No backups found.");
+        return Ok(());
+    }
+
+    for (path, size, _) in &entries {
+        println!(
+            "{}  {}",
+            backup::human_size(*size),
+            path.file_name().unwrap().to_string_lossy(),
+        );
+    }
+
+    Ok(())
+}
+
+fn load_config() -> Option<Config> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".config/hbackup/config.toml");
+    let content = fs::read_to_string(&path).ok()?;
+    toml::from_str(&content).ok()
+}
+
+fn cmd_upload(archive: &PathBuf, destination: Option<&str>) -> Result<()> {
+    let dest = if let Some(d) = destination {
+        d.to_string()
+    } else {
+        let config = load_config().context("No destination provided and no config file found at ~/.config/hbackup/config.toml")?;
+        config.upload
+            .and_then(|u| u.destination)
+            .context("No upload.destination in config file")?
+    };
+
+    let config = load_config();
+    let method = config
+        .and_then(|c| c.upload)
+        .and_then(|u| u.method)
+        .unwrap_or_else(|| "scp".to_string());
+
+    eprintln!("Uploading {} to {} via {}", archive.display(), dest, method);
+
+    let status = match method.as_str() {
+        "rsync" => Command::new("rsync")
+            .args(["--progress", "-avz"])
+            .arg(archive)
+            .arg(&dest)
+            .status()?,
+        _ => Command::new("scp")
+            .arg(archive)
+            .arg(&dest)
+            .status()?,
+    };
+
+    if !status.success() {
+        anyhow::bail!("{} exited with {}", method, status);
+    }
+
+    eprintln!("Upload complete.");
+    Ok(())
+}
+
+fn cmd_auto() -> Result<()> {
+    let opts = BackupOptions {
+        dry_run: false,
+        excludes: vec![],
+        output: None,
+    };
+    let archive = backup::run_backup(&opts)?;
+
+    if let Some(config) = load_config() {
+        if let Some(upload) = config.upload {
+            if upload.destination.is_some() {
+                cmd_upload(&archive, None)?;
+            } else if !upload.drive_remote.is_empty() {
+                upload_drive::upload_to_drive(&archive, &upload.drive_remote, &upload.drive_folder)?;
+            } else {
+                eprintln!("No upload destination configured, skipping upload.");
+            }
+        } else {
+            eprintln!("No upload config found, skipping upload.");
+        }
+    } else {
+        eprintln!("No config file found, skipping upload.");
+    }
+
+    Ok(())
+}

--- a/tools/hbackup/src/manifest.rs
+++ b/tools/hbackup/src/manifest.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manifest {
+    pub timestamp: String,
+    pub hostname: String,
+    pub file_count: usize,
+    pub total_size_bytes: u64,
+    pub files: Vec<ManifestEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    pub path: String,
+    pub size: u64,
+}
+
+impl Manifest {
+    pub fn new(timestamp: String, hostname: String) -> Self {
+        Self {
+            timestamp,
+            hostname,
+            file_count: 0,
+            total_size_bytes: 0,
+            files: Vec::new(),
+        }
+    }
+
+    pub fn add_file(&mut self, path: String, size: u64) {
+        self.files.push(ManifestEntry { path, size });
+        self.file_count += 1;
+        self.total_size_bytes += size;
+    }
+}

--- a/tools/hbackup/src/paths.rs
+++ b/tools/hbackup/src/paths.rs
@@ -1,0 +1,233 @@
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+pub struct BackupPaths {
+    pub home: PathBuf,
+}
+
+struct DirSpec {
+    path: PathBuf,
+    excludes: Vec<String>,
+    mode: ScanMode,
+}
+
+enum ScanMode {
+    /// Recurse everything (minus excludes)
+    Full,
+    /// Top-level files + specific subdirs only
+    Selective(Vec<String>),
+}
+
+impl BackupPaths {
+    pub fn new() -> Self {
+        let home = dirs_home();
+        Self { home }
+    }
+
+    pub fn discover(&self, extra_excludes: &[String]) -> Vec<PathBuf> {
+        let mut specs = self.build_specs();
+        let mut all_files = Vec::new();
+
+        for spec in &mut specs {
+            if !spec.path.exists() {
+                continue;
+            }
+            spec.excludes.extend(extra_excludes.iter().cloned());
+            let files = scan_dir(&spec.path, &spec.excludes, &spec.mode);
+            all_files.extend(files);
+        }
+
+        all_files.sort();
+        all_files.dedup();
+        all_files
+    }
+
+    fn build_specs(&self) -> Vec<DirSpec> {
+        let h = &self.home;
+        let mut specs = Vec::new();
+
+        // ~/work/hermes-agent
+        specs.push(DirSpec {
+            path: h.join("work/hermes-agent"),
+            excludes: vec![
+                "venv".into(), ".venv".into(), "node_modules".into(),
+                "__pycache__".into(), ".git/objects".into(),
+            ],
+            mode: ScanMode::Full,
+        });
+
+        // ~/work/openclaw
+        specs.push(DirSpec {
+            path: h.join("work/openclaw"),
+            excludes: vec![
+                "node_modules".into(), "__pycache__".into(),
+                ".git/objects".into(), "dist".into(),
+            ],
+            mode: ScanMode::Full,
+        });
+
+        // ~/.hermes (everything)
+        specs.push(DirSpec {
+            path: h.join(".hermes"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+
+        // ~/.openclaw selective
+        let openclaw_subdirs: Vec<String> = vec![
+            "agents", "backups", "bin", "blockrun", "cache", "canvas",
+            "completions", "credentials", "cron", "delivery-queue",
+            "devices", "extensions", "flows", "hooks", "identity",
+            "logs", "media", "memory", "memory-graph", "skills",
+            "subagents", "tasks", "telegram", "tools",
+        ].into_iter().map(String::from).collect();
+        specs.push(DirSpec {
+            path: h.join(".openclaw"),
+            excludes: vec![],
+            mode: ScanMode::Selective(openclaw_subdirs),
+        });
+
+        // ~/.openclaw workspace dirs — auto-discover instead of hardcoding
+        let ws_subdirs: Vec<String> = vec![
+            ".openclaw", "memory", "skills", ".omx", ".pi",
+            "config", "hooks", "scripts", "lib",
+        ].into_iter().map(String::from).collect();
+        let openclaw_base = h.join(".openclaw");
+        if openclaw_base.exists() {
+            if let Ok(entries) = std::fs::read_dir(&openclaw_base) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if name.starts_with("workspace") && entry.path().is_dir() {
+                        specs.push(DirSpec {
+                            path: entry.path(),
+                            excludes: vec![],
+                            mode: ScanMode::Selective(ws_subdirs.clone()),
+                        });
+                    }
+                }
+            }
+        }
+
+        // ~/.openclaw-dev
+        specs.push(DirSpec {
+            path: h.join(".openclaw-dev"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+
+        // ~/.hermes-venv
+        specs.push(DirSpec {
+            path: h.join(".hermes-venv"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+
+        // ~/.local paths
+        specs.push(DirSpec {
+            path: h.join(".local/openclaw-dev"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+        specs.push(DirSpec {
+            path: h.join(".local/bin/openclaw"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+        specs.push(DirSpec {
+            path: h.join(".local/state/hermes"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+
+        // ~/.config/sah-openclaw
+        specs.push(DirSpec {
+            path: h.join(".config/sah-openclaw"),
+            excludes: vec![],
+            mode: ScanMode::Full,
+        });
+
+        specs
+    }
+
+    /// Discover systemd user unit files matching hermes/openclaw/sah-openclaw
+    pub fn discover_systemd_units(&self) -> Vec<PathBuf> {
+        let dir = self.home.join(".config/systemd/user");
+        if !dir.exists() {
+            return Vec::new();
+        }
+        let mut results = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.contains("hermes") || name.contains("openclaw") || name.contains("sah-openclaw") {
+                    let p = entry.path();
+                    if p.is_file() {
+                        results.push(p);
+                    }
+                }
+            }
+        }
+        results
+    }
+}
+
+fn dirs_home() -> PathBuf {
+    dirs::home_dir().expect("HOME environment variable not set")
+}
+
+fn scan_dir(base: &Path, excludes: &[String], mode: &ScanMode) -> Vec<PathBuf> {
+    match mode {
+        ScanMode::Full => scan_full(base, excludes),
+        ScanMode::Selective(subdirs) => scan_selective(base, excludes, subdirs),
+    }
+}
+
+fn scan_full(base: &Path, excludes: &[String]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(base).follow_links(false) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let rel = path.strip_prefix(base).unwrap_or(path);
+        let rel_str = rel.to_string_lossy();
+        if excludes.iter().any(|ex| path_matches_exclude(&rel_str, ex)) {
+            continue;
+        }
+        files.push(path.to_path_buf());
+    }
+    files
+}
+
+fn scan_selective(base: &Path, excludes: &[String], subdirs: &[String]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+
+    // Top-level files
+    if let Ok(entries) = std::fs::read_dir(base) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_file() {
+                files.push(p);
+            }
+        }
+    }
+
+    // Allowed subdirs (full recurse)
+    for sub in subdirs {
+        let sub_path = base.join(sub);
+        if sub_path.exists() {
+            files.extend(scan_full(&sub_path, excludes));
+        }
+    }
+
+    files
+}
+
+fn path_matches_exclude(rel: &str, exclude: &str) -> bool {
+    // Match if any path component sequence matches the exclude pattern
+    rel.contains(exclude)
+}

--- a/tools/hbackup/src/restore.rs
+++ b/tools/hbackup/src/restore.rs
@@ -1,0 +1,109 @@
+use std::fs::{self, File};
+use std::io;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::manifest::Manifest;
+
+pub struct RestoreOptions {
+    pub archive: PathBuf,
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+pub fn run_restore(opts: &RestoreOptions) -> Result<()> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+
+    let file = File::open(&opts.archive)
+        .with_context(|| format!("Opening archive {}", opts.archive.display()))?;
+    let decoder = zstd::stream::Decoder::new(file)?;
+    let mut archive = tar::Archive::new(decoder);
+
+    let entries = archive.entries()?;
+    let mut manifest: Option<Manifest> = None;
+    let mut file_count: usize = 0;
+
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} {pos} files restored: {msg}")
+            .unwrap(),
+    );
+
+    for entry in entries {
+        let mut entry = entry?;
+        let path = entry.path()?.to_path_buf();
+        let path_str = path.to_string_lossy().to_string();
+
+        // Parse manifest
+        if path_str == "manifest.json" {
+            let mut buf = String::new();
+            io::Read::read_to_string(&mut entry, &mut buf)?;
+            manifest = Some(serde_json::from_str(&buf)?);
+            if let Some(ref m) = manifest {
+                eprintln!(
+                    "Archive: {} files, {} total, created {}",
+                    m.file_count,
+                    crate::backup::human_size(m.total_size_bytes),
+                    m.timestamp,
+                );
+            }
+            continue;
+        }
+
+        // Skip WAL/SHM files
+        if path_str.ends_with(".db-wal") || path_str.ends_with(".db-shm") {
+            continue;
+        }
+
+        let dest = home.join(&path_str);
+
+        if opts.dry_run {
+            println!("Would restore: {}", dest.display());
+            file_count += 1;
+            continue;
+        }
+
+        // Check existing
+        if dest.exists() && !opts.force {
+            eprintln!("Skipping (exists): {} (use --force to overwrite)", dest.display());
+            continue;
+        }
+
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut out = File::create(&dest)
+            .with_context(|| format!("Creating {}", dest.display()))?;
+        io::copy(&mut entry, &mut out)?;
+
+        file_count += 1;
+        pb.set_position(file_count as u64);
+        pb.set_message(truncate(&path_str, 50));
+    }
+
+    pb.finish_with_message("done");
+
+    if manifest.is_none() {
+        eprintln!("Warning: no manifest.json found in archive");
+    }
+
+    eprintln!(
+        "{} {} files",
+        if opts.dry_run { "Would restore" } else { "Restored" },
+        file_count,
+    );
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("...{}", &s[s.len() - max + 3..])
+    }
+}

--- a/tools/hbackup/src/upload_drive.rs
+++ b/tools/hbackup/src/upload_drive.rs
@@ -1,0 +1,127 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Upload a backup archive to Google Drive via rclone.
+/// If rclone is not installed, prints setup instructions.
+pub fn upload_to_drive(archive: &Path, remote_name: &str, folder: &str) -> Result<()> {
+    // Check rclone is installed
+    let rclone_check = Command::new("which")
+        .arg("rclone")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    if rclone_check.map(|s| !s.success()).unwrap_or(true) {
+        print_rclone_setup_instructions();
+        anyhow::bail!("rclone is not installed");
+    }
+
+    // Check remote is configured
+    let remote_check = Command::new("rclone")
+        .args(["listremotes"])
+        .output()
+        .context("Running rclone listremotes")?;
+
+    let remotes = String::from_utf8_lossy(&remote_check.stdout);
+    let full_remote = format!("{}:", remote_name);
+    if !remotes.contains(&full_remote) {
+        eprintln!(
+            "rclone remote '{}' not found. Configured remotes:\n{}",
+            remote_name, remotes
+        );
+        eprintln!("\nTo configure Google Drive, run:");
+        eprintln!("  rclone config");
+        eprintln!("  # Select 'n' for new remote, name it '{}', choose 'Google Drive'", remote_name);
+        anyhow::bail!("rclone remote '{}' not configured", remote_name);
+    }
+
+    // Build destination path
+    let dest = if folder.is_empty() {
+        format!("{}:", remote_name)
+    } else {
+        format!("{}:{}", remote_name, folder)
+    };
+
+    eprintln!("Uploading {} to Google Drive ({})", archive.display(), dest);
+
+    // Run rclone copyto with progress
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} Uploading to Google Drive... {msg}")
+            .unwrap(),
+    );
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+
+    let status = Command::new("rclone")
+        .args([
+            "copyto",
+            "--progress",
+            "--transfers",
+            "4",
+            archive.to_str().unwrap(),
+            &format!("{}/{}", dest, archive.file_name().unwrap().to_string_lossy()),
+        ])
+        .status()
+        .context("Running rclone copyto")?;
+
+    pb.finish_and_clear();
+
+    if !status.success() {
+        anyhow::bail!("rclone exited with status {}", status);
+    }
+
+    eprintln!("Upload to Google Drive complete.");
+    Ok(())
+}
+
+fn print_rclone_setup_instructions() {
+    eprintln!("╔══════════════════════════════════════════════════════════════════╗");
+    eprintln!("║  rclone is not installed. Google Drive upload requires rclone.   ║");
+    eprintln!("╠══════════════════════════════════════════════════════════════════╣");
+    eprintln!("║  Install rclone:                                                 ║");
+    eprintln!("║    curl https://rclone.org/install.sh | sudo bash                ║");
+    eprintln!("║                                                                  ║");
+    eprintln!("║  Or on macOS:                                                    ║");
+    eprintln!("║    brew install rclone                                           ║");
+    eprintln!("║                                                                  ║");
+    eprintln!("║  Then configure Google Drive:                                    ║");
+    eprintln!("║    rclone config                                                 ║");
+    eprintln!("║    # Select 'n' for new remote                                   ║");
+    eprintln!("║    # Name it 'gdrive' (or your preferred name)                   ║");
+    eprintln!("║    # Choose 'Google Drive' (option 18)                           ║");
+    eprintln!("║    # Leave client_id and client_secret blank for default         ║");
+    eprintln!("║    # Choose '1' for full access                                  ║");
+    eprintln!("║    # Follow the OAuth2 browser flow                              ║");
+    eprintln!("╚══════════════════════════════════════════════════════════════════╝");
+}
+
+/// Print setup instructions for hbackup + Google Drive
+pub fn print_drive_setup_guide() {
+    eprintln!("╔══════════════════════════════════════════════════════════════════╗");
+    eprintln!("║           hbackup Google Drive Setup Guide                       ║");
+    eprintln!("╠══════════════════════════════════════════════════════════════════╣");
+    eprintln!("║  1. Install rclone:                                              ║");
+    eprintln!("║       curl https://rclone.org/install.sh | sudo bash             ║");
+    eprintln!("║                                                                  ║");
+    eprintln!("║  2. Configure Google Drive remote:                               ║");
+    eprintln!("║       rclone config                                              ║");
+    eprintln!("║       # Name: gdrive                                             ║");
+    eprintln!("║       # Storage: Google Drive                                    ║");
+    eprintln!("║       # Follow OAuth2 flow in browser                            ║");
+    eprintln!("║                                                                  ║");
+    eprintln!("║  3. Verify:                                                      ║");
+    eprintln!("║       rclone listremotes                                         ║");
+    eprintln!("║       rclone ls gdrive:                                          ║");
+    eprintln!("║                                                                  ║");
+    eprintln!("║  4. Upload a backup:                                             ║");
+    eprintln!("║       hbackup upload --drive <archive.tar.zst>                   ║");
+    eprintln!("║                                                                  ║");
+    eprintln!("║  5. Or use auto backup + upload:                                 ║");
+    eprintln!("║       hbackup auto                                               ║");
+    eprintln!("║       # (requires upload.destination in config.toml)             ║");
+    eprintln!("╚══════════════════════════════════════════════════════════════════╝");
+}

--- a/tools/offload_job_tool.py
+++ b/tools/offload_job_tool.py
@@ -1,0 +1,581 @@
+"""Offloaded terminal job tool.
+
+This module provides a small, dependency-free job runner for commands that are
+expected to be long-running or memory-heavy.  Unlike ``terminal(background=True)``
+for the local backend, the preferred Linux path starts work through
+``systemd-run --user`` so the command lives in its own user unit instead of as a
+child of ``hermes-gateway.service``.  Metadata and logs are persisted in the
+active Hermes profile so gateway restarts do not lose the job handle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import shlex
+import signal
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import display_hermes_home, get_hermes_home
+from tools.approval import check_all_command_guards
+from tools.registry import registry
+from tools.terminal_tool import _validate_workdir
+
+_JOB_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_DEFAULT_TAIL_LINES = 80
+_DEFAULT_LIST_LIMIT = 20
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _iso(ts: float | None = None) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts or _now()))
+
+
+def _jobs_dir() -> Path:
+    path = get_hermes_home() / "offload_jobs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _job_dir(job_id: str) -> Path:
+    if not _JOB_ID_RE.match(job_id):
+        raise ValueError("invalid job_id")
+    return _jobs_dir() / job_id
+
+
+def _meta_path(job_id: str) -> Path:
+    return _job_dir(job_id) / "job.json"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_job(job_id: str) -> dict[str, Any]:
+    path = _meta_path(job_id)
+    if not path.exists():
+        raise FileNotFoundError(f"Unknown offload job: {job_id}")
+    return _read_json(path)
+
+
+def _write_job(job: dict[str, Any]) -> None:
+    _atomic_write_json(_meta_path(str(job["job_id"])), job)
+
+
+def _new_job_id(label: str | None = None) -> str:
+    prefix = "job"
+    if label:
+        cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", label.strip().lower()).strip("-._")
+        if cleaned:
+            prefix = cleaned[:32]
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+def _coerce_positive_int(value: Any, default: int, *, maximum: int | None = None) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    if parsed <= 0:
+        parsed = default
+    if maximum is not None:
+        parsed = min(parsed, maximum)
+    return parsed
+
+
+def _resolve_workdir(workdir: str | None) -> str:
+    candidate = workdir or os.getenv("TERMINAL_CWD") or os.getcwd()
+    candidate = os.path.abspath(os.path.expanduser(candidate))
+    error = _validate_workdir(candidate)
+    if error:
+        raise ValueError(error)
+    return candidate
+
+
+def _write_scripts(job: dict[str, Any]) -> None:
+    job_path = _job_dir(job["job_id"])
+    command_path = job_path / "command.sh"
+    runner_path = job_path / "runner.sh"
+    log_path = Path(job["log_path"])
+    pid_path = Path(job["pid_path"])
+    exit_path = Path(job["exit_code_path"])
+    timeout = job.get("timeout_seconds")
+
+    command_path.write_text(
+        "#!/usr/bin/env bash\nset -o pipefail\n" + job["command"] + "\n",
+        encoding="utf-8",
+    )
+    command_path.chmod(0o700)
+
+    if timeout:
+        run_line = (
+            f"timeout --kill-after=5s {int(timeout)}s "
+            f"/usr/bin/env bash {shlex.quote(str(command_path))}"
+        )
+    else:
+        run_line = f"/usr/bin/env bash {shlex.quote(str(command_path))}"
+
+    runner_path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set +e\n"
+        f"cd {json.dumps(job['workdir'])} || exit 126\n"
+        f"echo $$ > {json.dumps(str(pid_path))}\n"
+        f"printf '[%s] offload job started: %s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" {json.dumps(job['job_id'])} >> {json.dumps(str(log_path))}\n"
+        f"{run_line} >> {json.dumps(str(log_path))} 2>&1\n"
+        "ec=$?\n"
+        f"printf '%s\\n' \"$ec\" > {json.dumps(str(exit_path))}\n"
+        f"printf '[%s] offload job exited with code %s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"$ec\" >> {json.dumps(str(log_path))}\n"
+        "exit $ec\n",
+        encoding="utf-8",
+    )
+    runner_path.chmod(0o700)
+
+    job["command_path"] = str(command_path)
+    job["runner_path"] = str(runner_path)
+
+
+def _systemd_run_available() -> bool:
+    return bool(
+        shutil.which("systemd-run")
+        and shutil.which("systemctl")
+        and os.getenv("XDG_RUNTIME_DIR")
+    )
+
+
+def _start_systemd_job(job: dict[str, Any]) -> None:
+    unit_name = f"hermes-offload-{job['job_id']}"
+    cmd = ["systemd-run", "--user", "--unit", unit_name]
+    cmd.extend(["--property", f"WorkingDirectory={job['workdir']}"])
+    memory_max = job.get("memory_max")
+    cpu_quota = job.get("cpu_quota")
+    if memory_max:
+        cmd.extend(["--property", f"MemoryMax={memory_max}"])
+    if cpu_quota:
+        cmd.extend(["--property", f"CPUQuota={cpu_quota}"])
+    cmd.extend(["/usr/bin/env", "bash", job["runner_path"]])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout or "systemd-run failed").strip()
+        raise RuntimeError(stderr)
+    job["runner"] = "systemd"
+    job["unit_name"] = unit_name
+    job["systemd_run_stdout"] = result.stdout.strip()
+
+
+def _start_subprocess_job(job: dict[str, Any]) -> None:
+    log_file = open(job["launcher_log_path"], "ab", buffering=0)
+    try:
+        proc = subprocess.Popen(
+            ["/usr/bin/env", "bash", job["runner_path"]],
+            cwd=job["workdir"],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    finally:
+        log_file.close()
+    job["runner"] = "subprocess"
+    job["launcher_pid"] = proc.pid
+
+
+def _read_exit_code(job: dict[str, Any]) -> int | None:
+    path = Path(job.get("exit_code_path", ""))
+    if not path.exists():
+        return None
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _process_alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _systemd_show(unit: str) -> dict[str, str]:
+    result = subprocess.run(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            unit,
+            "--property=ActiveState",
+            "--property=SubState",
+            "--property=Result",
+            "--property=ExecMainStatus",
+            "--property=MainPID",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        return {}
+    out: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            out[key] = value
+    return out
+
+
+def _refresh_status(job: dict[str, Any]) -> dict[str, Any]:
+    if job.get("status") == "cancelled":
+        return job
+
+    exit_code = _read_exit_code(job)
+    if exit_code is not None:
+        if job.get("runner") == "systemd" and job.get("unit_name"):
+            show = _systemd_show(job["unit_name"])
+            if show:
+                job["systemd"] = show
+                main_pid = show.get("MainPID")
+                if main_pid and main_pid != "0":
+                    job["pid"] = int(main_pid)
+                elif main_pid == "0":
+                    job.pop("pid", None)
+        job["exit_code"] = exit_code
+        job["status"] = "succeeded" if exit_code == 0 else "failed"
+        job.setdefault("completed_at", _iso())
+        _write_job(job)
+        return job
+
+    if job.get("runner") == "systemd" and job.get("unit_name"):
+        show = _systemd_show(job["unit_name"])
+        if show:
+            job["systemd"] = show
+            active = show.get("ActiveState")
+            result = show.get("Result")
+            main_pid = show.get("MainPID")
+            if main_pid and main_pid != "0":
+                job["pid"] = int(main_pid)
+            if active in {"active", "activating", "reloading"}:
+                job["status"] = "running"
+            elif active in {"failed", "inactive", "deactivating"}:
+                exec_status = show.get("ExecMainStatus")
+                if exec_status is not None and exec_status.isdigit():
+                    job["exit_code"] = int(exec_status)
+                if result == "success" and job.get("exit_code", 1) == 0:
+                    job["status"] = "succeeded"
+                elif result:
+                    job["status"] = "failed"
+                else:
+                    job["status"] = "unknown"
+                job.setdefault("completed_at", _iso())
+            _write_job(job)
+        return job
+
+    pid = job.get("launcher_pid") or job.get("pid")
+    if _process_alive(pid):
+        job["status"] = "running"
+    else:
+        job["status"] = "unknown"
+        job.setdefault("completed_at", _iso())
+    _write_job(job)
+    return job
+
+
+def _public_job(job: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "job_id",
+        "status",
+        "runner",
+        "unit_name",
+        "pid",
+        "launcher_pid",
+        "exit_code",
+        "command",
+        "workdir",
+        "log_path",
+        "created_at",
+        "started_at",
+        "completed_at",
+        "created_at_ts",
+        "memory_max",
+        "cpu_quota",
+        "timeout_seconds",
+        "systemd",
+    ]
+    return {key: job[key] for key in keys if key in job}
+
+
+def _tail_log(job: dict[str, Any], lines: int) -> str:
+    path = Path(job["log_path"])
+    if not path.exists():
+        return ""
+    # Avoid loading unbounded logs into memory.
+    data = path.read_bytes()[-256_000:]
+    text = data.decode("utf-8", errors="replace")
+    return "\n".join(text.splitlines()[-lines:])
+
+
+def _list_jobs(limit: int, status_filter: str | None = None) -> list[dict[str, Any]]:
+    jobs: list[dict[str, Any]] = []
+    for meta in _jobs_dir().glob("*/job.json"):
+        try:
+            job = _refresh_status(_read_json(meta))
+        except Exception:
+            continue
+        if status_filter and job.get("status") != status_filter:
+            continue
+        jobs.append(_public_job(job))
+    jobs.sort(key=lambda item: item.get("created_at_ts", 0), reverse=True)
+    return jobs[:limit]
+
+
+def _cancel_job(job: dict[str, Any]) -> dict[str, Any]:
+    job = _refresh_status(job)
+    if job.get("status") in {"succeeded", "failed", "cancelled"}:
+        return job
+
+    if job.get("runner") == "systemd" and job.get("unit_name") and shutil.which("systemctl"):
+        subprocess.run(
+            ["systemctl", "--user", "kill", job["unit_name"]],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        subprocess.run(
+            ["systemctl", "--user", "stop", job["unit_name"]],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    else:
+        pid = job.get("launcher_pid") or job.get("pid")
+        if pid:
+            try:
+                os.killpg(int(pid), signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                os.kill(int(pid), signal.SIGTERM)
+
+    job["status"] = "cancelled"
+    job["cancelled_at"] = _iso()
+    job.setdefault("completed_at", job["cancelled_at"])
+    _write_job(job)
+    return job
+
+
+def offload_job_tool(
+    action: str,
+    command: str | None = None,
+    job_id: str | None = None,
+    workdir: str | None = None,
+    timeout: int | None = None,
+    memory_max: str | None = None,
+    cpu_quota: str | None = None,
+    label: str | None = None,
+    tail_lines: int | None = None,
+    limit: int | None = None,
+    status_filter: str | None = None,
+    force: bool = False,
+) -> str:
+    """Dispatch offload job actions and return a JSON string."""
+    try:
+        action = (action or "").strip().lower()
+        if action == "start":
+            if not command or not isinstance(command, str):
+                return json.dumps({"success": False, "error": "command is required for action=start"}, ensure_ascii=False)
+
+            if not force:
+                approval = check_all_command_guards(command, "local")
+                if not approval.get("approved"):
+                    if approval.get("status") == "approval_required":
+                        return json.dumps({
+                            "success": False,
+                            "status": "approval_required",
+                            "error": approval.get("message", "Waiting for user approval"),
+                            "command": approval.get("command", command),
+                            "description": approval.get("description", "command flagged"),
+                            "pattern_key": approval.get("pattern_key", ""),
+                        }, ensure_ascii=False)
+                    return json.dumps({
+                        "success": False,
+                        "status": "blocked",
+                        "error": approval.get("message", "Command blocked by approval guard"),
+                    }, ensure_ascii=False)
+
+            resolved_workdir = _resolve_workdir(workdir)
+            new_id = _new_job_id(label)
+            job_path = _job_dir(new_id)
+            job_path.mkdir(parents=True, exist_ok=False)
+            job = {
+                "job_id": new_id,
+                "status": "starting",
+                "command": command,
+                "workdir": resolved_workdir,
+                "created_at": _iso(),
+                "created_at_ts": _now(),
+                "started_at": _iso(),
+                "log_path": str(job_path / "job.log"),
+                "launcher_log_path": str(job_path / "launcher.log"),
+                "pid_path": str(job_path / "job.pid"),
+                "exit_code_path": str(job_path / "exit_code"),
+                "memory_max": memory_max,
+                "cpu_quota": cpu_quota,
+                "timeout_seconds": int(timeout) if timeout else None,
+            }
+            _write_scripts(job)
+            Path(job["log_path"]).touch()
+            _write_job(job)
+
+            try:
+                if _systemd_run_available():
+                    _start_systemd_job(job)
+                else:
+                    _start_subprocess_job(job)
+            except Exception as exc:
+                # If systemd-run is present but rejects the job, keep the long-running
+                # command usable by falling back to a detached subprocess and make the
+                # reduced isolation explicit in metadata.
+                job["systemd_error"] = str(exc)
+                _start_subprocess_job(job)
+
+            job["status"] = "running"
+            _write_job(job)
+            return json.dumps({"success": True, "job": _public_job(job)}, ensure_ascii=False)
+
+        if action == "status":
+            if not job_id:
+                return json.dumps({"success": False, "error": "job_id is required for action=status"}, ensure_ascii=False)
+            return json.dumps({"success": True, "job": _public_job(_refresh_status(_read_job(job_id)))}, ensure_ascii=False)
+
+        if action == "tail":
+            if not job_id:
+                return json.dumps({"success": False, "error": "job_id is required for action=tail"}, ensure_ascii=False)
+            lines = _coerce_positive_int(tail_lines, _DEFAULT_TAIL_LINES, maximum=1000)
+            job = _refresh_status(_read_job(job_id))
+            return json.dumps({"success": True, "job": _public_job(job), "tail": _tail_log(job, lines)}, ensure_ascii=False)
+
+        if action == "list":
+            count = _coerce_positive_int(limit, _DEFAULT_LIST_LIMIT, maximum=200)
+            return json.dumps({"success": True, "jobs": _list_jobs(count, status_filter=status_filter)}, ensure_ascii=False)
+
+        if action == "cancel":
+            if not job_id:
+                return json.dumps({"success": False, "error": "job_id is required for action=cancel"}, ensure_ascii=False)
+            return json.dumps({"success": True, "job": _public_job(_cancel_job(_read_job(job_id)))}, ensure_ascii=False)
+
+        return json.dumps({"success": False, "error": "action must be one of: start, status, tail, list, cancel"}, ensure_ascii=False)
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False)
+
+
+OFFLOAD_JOB_SCHEMA = {
+    "name": "offload_job",
+    "description": (
+        "Queue and manage long-running or memory-heavy shell commands as offloaded jobs. "
+        "Use this instead of terminal(background=true) for benchmarks, indexing, model inference, "
+        "training, or other gateway-hostile workloads. On Linux it prefers systemd-run --user so "
+        "the job runs outside hermes-gateway.service; metadata/logs are stored under "
+        f"{display_hermes_home()}/offload_jobs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["start", "status", "tail", "list", "cancel"],
+                "description": "Job operation to perform.",
+            },
+            "command": {
+                "type": "string",
+                "description": "Shell command to run. Required for action=start.",
+            },
+            "job_id": {
+                "type": "string",
+                "description": "Job id returned by action=start. Required for status, tail, and cancel.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Working directory for action=start. Defaults to the terminal session cwd.",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Optional maximum runtime in seconds; implemented with timeout(1).",
+            },
+            "memory_max": {
+                "type": "string",
+                "description": "Optional systemd MemoryMax value such as '32G' or '8192M'. Applies only to systemd-run jobs.",
+            },
+            "cpu_quota": {
+                "type": "string",
+                "description": "Optional systemd CPUQuota value such as '800%'. Applies only to systemd-run jobs.",
+            },
+            "label": {
+                "type": "string",
+                "description": "Optional short label used as the job id prefix.",
+            },
+            "tail_lines": {
+                "type": "integer",
+                "description": "Number of log lines to return for action=tail. Default 80, max 1000.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum jobs to return for action=list. Default 20, max 200.",
+            },
+            "status_filter": {
+                "type": "string",
+                "description": "Optional status filter for action=list, for example 'running' or 'failed'.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _handle_offload_job(args, **kw):
+    return offload_job_tool(
+        action=args.get("action", ""),
+        command=args.get("command"),
+        job_id=args.get("job_id"),
+        workdir=args.get("workdir"),
+        timeout=args.get("timeout"),
+        memory_max=args.get("memory_max"),
+        cpu_quota=args.get("cpu_quota"),
+        label=args.get("label"),
+        tail_lines=args.get("tail_lines"),
+        limit=args.get("limit"),
+        status_filter=args.get("status_filter"),
+        force=bool(kw.get("force", False)),
+    )
+
+
+registry.register(
+    name="offload_job",
+    toolset="terminal",
+    schema=OFFLOAD_JOB_SCHEMA,
+    handler=_handle_offload_job,
+    check_fn=lambda: True,
+    emoji="🚚",
+    max_result_size_chars=100_000,
+)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1342,6 +1342,13 @@ _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\bgunicorn\b", re.IGNORECASE),
     re.compile(r"\bpython(?:3)?\s+-m\s+http\.server\b", re.IGNORECASE),
 )
+_GATEWAY_OFFLOAD_PATTERNS = (
+    re.compile(r"\bcolgrep\s+search\b", re.IGNORECASE),
+    re.compile(r"\bpaper_benchmark_runner[_\w.-]*\.py\b", re.IGNORECASE),
+    re.compile(r"\bbenchmark(?:s|ing)?\b", re.IGNORECASE),
+    re.compile(r"\b(?:cuda|cudnn|cublas|ld_library_path|hf_home)\b", re.IGNORECASE),
+    re.compile(r"\b(?:python|python3)\b.*\.omx/metrics/", re.IGNORECASE),
+)
 
 
 def _looks_like_help_or_version_command(command: str) -> bool:
@@ -1352,6 +1359,28 @@ def _looks_like_help_or_version_command(command: str) -> bool:
         or normalized.endswith(" -h")
         or " --version" in normalized
         or normalized.endswith(" -v")
+    )
+
+
+def _gateway_local_offload_guidance(command: str, env_type: str) -> str | None:
+    """Require offload_job for gateway-local commands likely to stress memory/GPU."""
+    if env_type != "local" or not os.getenv("HERMES_GATEWAY_SESSION"):
+        return None
+    if os.getenv("HERMES_ALLOW_INLINE_HEAVY_TERMINAL"):
+        return None
+    if _looks_like_help_or_version_command(command):
+        return None
+
+    matches = sum(1 for pattern in _GATEWAY_OFFLOAD_PATTERNS if pattern.search(command))
+    if matches < 2 and not re.search(r"\bcolgrep\s+search\b", command, re.IGNORECASE):
+        return None
+
+    return (
+        "Gateway-local terminal execution refused: this command looks like a "
+        "heavy benchmark/model/GPU workload and must not run inside "
+        "hermes-gateway.service. Use offload_job(action='start', command=..., "
+        "workdir=..., memory_max='32G', cpu_quota='800%', timeout=...) instead, "
+        "then poll offload_job(action='status'/'tail')."
     )
 
 
@@ -1495,6 +1524,15 @@ def terminal_tool(
         cwd = overrides.get("cwd") or config["cwd"]
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
+
+        offload_guidance = _gateway_local_offload_guidance(command, env_type)
+        if offload_guidance:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": offload_guidance,
+                "status": "offload_required",
+            }, ensure_ascii=False)
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.

--- a/toolsets.py
+++ b/toolsets.py
@@ -32,7 +32,7 @@ _HERMES_CORE_TOOLS = [
     # Web
     "web_search", "web_extract",
     # Terminal + process management
-    "terminal", "process",
+    "terminal", "process", "offload_job",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
@@ -93,7 +93,7 @@ TOOLSETS = {
     
     "terminal": {
         "description": "Terminal/command execution and process management tools",
-        "tools": ["terminal", "process"],
+        "tools": ["terminal", "process", "offload_job"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

New tool that runs memory-heavy/long-running shell commands (benchmarks, model inference, indexing) under `systemd-run --user` units instead of as children of `hermes-gateway.service`. Prevents OOM-killing the gateway.

## Changes

| File | Change |
|------|--------|
| `tools/offload_job_tool.py` | **New** — Job runner with start/status/tail/list/cancel actions. Linux uses `systemd-run --user` for isolation; subprocess fallback. Metadata persisted in `~/.hermes/offload_jobs/`. |
| `tests/tools/test_offload_job_tool.py` | **New** — Tests for start→status→tail flow, list ordering, cancel, systemd path. |
| `tools/terminal_tool.py` | Added `_GATEWAY_OFFLOAD_PATTERNS` and `_gateway_local_offload_guidance()` — refuses heavy commands (benchmarks, GPU workloads) when running inside `hermes-gateway.service`, redirecting to `offload_job` tool instead. |
| `toolsets.py` | Registered `offload_job` in `_HERMES_CORE_TOOLS` and `terminal` toolset. |

## Why

- Gateway-local terminal calls run as descendants of `hermes-gateway.service`
- A model/benchmark process can OOM-kill the gateway itself
- `offload_job` starts those commands under a separate user systemd unit, preserving gateway availability

## Testing

- `pytest tests/tools/test_offload_job_tool.py` — 5 tests covering fallback, list, cancel, systemd path

## Scope

Minimal, focused change. No modifications to agent loop, no breaking changes to existing tools.