### PR TITLE
fix chat provider choices for canonical providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7391,31 +7391,12 @@ For more help on a command:
         default=argparse.SUPPRESS,
         help="Preload one or more skills for the session (repeat flag or comma-separate)",
     )
+    from hermes_cli.models import CANONICAL_PROVIDERS
+
+    chat_provider_choices = ["auto", *[p.slug for p in CANONICAL_PROVIDERS]]
     chat_parser.add_argument(
         "--provider",
-        choices=[
-            "auto",
-            "openrouter",
-            "nous",
-            "openai-codex",
-            "copilot-acp",
-            "copilot",
-            "anthropic",
-            "gemini",
-            "xai",
-            "ollama-cloud",
-            "huggingface",
-            "zai",
-            "kimi-coding",
-            "kimi-coding-cn",
-            "stepfun",
-            "minimax",
-            "minimax-cn",
-            "kilocode",
-            "xiaomi",
-            "arcee",
-            "nvidia",
-        ],
+        choices=chat_provider_choices,
         default=None,
         help="Inference provider (default: auto)",
     )

--- a/tests/hermes_cli/test_chat_provider_choices.py
+++ b/tests/hermes_cli/test_chat_provider_choices.py
@@ -1,0 +1,41 @@
+"""Regression tests for `hermes chat --provider` choices.
+
+The chat CLI provider choices must stay in sync with the canonical provider
+registry. Otherwise supported providers can be blocked by argparse before the
+runtime provider resolver sees them.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("provider", ["opencode-go", "opencode-zen", "deepseek"])
+def test_chat_provider_accepts_canonical_providers(provider):
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "chat", "--provider", provider, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, (
+        f"provider={provider!r} should be accepted by chat parser\n"
+        f"stdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+
+
+def test_chat_provider_help_includes_new_canonical_providers():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "chat", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0
+    help_text = result.stdout + result.stderr
+    for provider in ("opencode-go", "opencode-zen", "deepseek"):
+        assert provider in help_text


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI parser mismatch where `hermes chat --provider` rejected providers that already exist in Hermes' canonical provider/model/auth/runtime layers.

`opencode-go`, `opencode-zen`, and `deepseek` are present in `CANONICAL_PROVIDERS` and related provider support, but the chat subcommand had a separate hard-coded `choices=[...]` list that omitted them. This PR derives the chat provider choices from `CANONICAL_PROVIDERS` plus `auto`, so the chat CLI stays aligned with the canonical registry.

## Related Issue

No issue exists yet.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: derive `hermes chat --provider` choices from `CANONICAL_PROVIDERS` plus `auto` instead of maintaining a stale hard-coded list.
- `tests/hermes_cli/test_chat_provider_choices.py`: add regression coverage proving `opencode-go`, `opencode-zen`, and `deepseek` are accepted by the chat parser and appear in help output.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the focused tests:

```bash
python -m pytest tests/hermes_cli/test_chat_provider_choices.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_opencode_go_in_model_list.py
```

2. Confirm `hermes chat --provider opencode-go --help` exits successfully.
3. Confirm `hermes chat --provider deepseek --help` exits successfully.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux Docker image based on `hermes-agent-local:latest`

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation was run in the Hermes Docker image:

```bash
docker run --rm \
  -v /root/deepseek-automation-work/hermes-opencode-go-pr:/work \
  -w /work \
  hermes-agent-local:latest \
  /opt/hermes/.venv/bin/python -m pytest \
  tests/hermes_cli/test_chat_provider_choices.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_opencode_go_in_model_list.py
```

Result:

```text
84 passed, 5 warnings in 4.99s
```