### PR TITLE
fix: determine api_mode before validation for alias model switches

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -341,13 +341,17 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
 
     Some third-party /anthropic endpoints implement Anthropic's Messages API but
     require Authorization: Bearer *** of Anthropic's native x-api-key header.
-    MiniMax's global and China Anthropic-compatible endpoints follow this pattern.
+    MiniMax, LongCat, and similar providers follow this pattern.
     """
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return False
     normalized = normalized.rstrip("/").lower()
-    return normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+    return normalized.startswith((
+        "https://api.minimax.io/anthropic",
+        "https://api.minimaxi.com/anthropic",
+        "https://api.longcat.chat/anthropic",
+    ))
 
 
 def _common_betas_for_base_url(base_url: str | None) -> list[str]:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -176,6 +176,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     # MiniMax — official docs: 204,800 context for all models
     # https://platform.minimax.io/docs/api-reference/text-anthropic-api
     "minimax": 204800,
+    # LongCat — official docs: 256K context for Flash-Chat/Flash-Thinking/Flash-Lite,
+    # 128K for Flash-Omni. Since LongCat doesn't expose a /models endpoint,
+    # we use the conservative 256K for the default LongCat-Flash-Lite.
+    "longcat-flash-lite": 256000,
+    "longcat-flash-chat": 256000,
+    "longcat-flash-thinking": 256000,
+    "longcat-omni": 128000,
     # GLM
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
@@ -297,6 +304,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
     "ollama.com": "ollama-cloud",
+    "api.longcat.chat": "longcat",
 }
 
 

--- a/docs/superpowers/plans/2026-05-02-vibe-trading-natural-language.md
+++ b/docs/superpowers/plans/2026-05-02-vibe-trading-natural-language.md
@@ -1,0 +1,43 @@
+# Vibe-Trading Natural Language Forwarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Hermes forward stock-related Feishu questions to Vibe-Trading Agent in natural language, defaulting A-share analysis to free AKShare-backed workflows.
+
+**Architecture:** Extend the existing `plugins/vibe-trading` user plugin, not Hermes core. Add high-level tools that create a Vibe session, send the user's original question, poll session messages until the assistant answer is written, then return that report to Hermes. Keep Tushare/QVeris out of phase 1.
+
+**Tech Stack:** Hermes plugin API, Python stdlib `urllib.request`, Vibe-Trading session REST API, pytest.
+
+---
+
+### Task 1: Natural-Language Forwarding Tests
+
+**Files:**
+- Modify: `tests/plugins/test_vibe_trading_plugin.py`
+
+- [x] Add a test for `vibe_ask` that verifies it creates a session, sends the raw user question, polls messages, and returns the assistant report.
+- [x] Add a test for `vibe_ask_ashare` that verifies the prompt includes the user's raw question plus an A-share/AKShare instruction.
+- [x] Add a registration test expectation for `vibe_ask` and `vibe_ask_ashare`.
+
+### Task 2: Plugin Implementation
+
+**Files:**
+- Modify: `plugins/vibe-trading/__init__.py`
+- Modify: `plugins/vibe-trading/plugin.yaml`
+
+- [x] Add `VIBE_TRADING_AGENT_TIMEOUT_SECONDS` and `VIBE_TRADING_AGENT_POLL_SECONDS` config helpers.
+- [x] Add `_vibe_agent_ask(question, title, instruction)` helper.
+- [x] Add `vibe_ask(question)` for generic Vibe-Trading Agent forwarding.
+- [x] Add `vibe_ask_ashare(question)` for stock/A-share forwarding with free AKShare-first instructions.
+- [x] Register both tools with clear schema descriptions so Hermes can choose them for natural language stock questions.
+
+### Task 3: Verify and Deploy
+
+**Files:**
+- Copy: `plugins/vibe-trading/` to `192.168.1.63:/root/.hermes/plugins/vibe-trading/`
+
+- [x] Run focused pytest.
+- [x] Copy updated plugin to the Hermes host.
+- [x] Restart Hermes container.
+- [x] Verify `vibe_ask_ashare` can return a Vibe Agent report for a small A-share prompt.
+- [ ] Commit and push to `fork`.

--- a/docs/superpowers/plans/2026-05-02-vibe-trading-plugin.md
+++ b/docs/superpowers/plans/2026-05-02-vibe-trading-plugin.md
@@ -1,0 +1,46 @@
+# Vibe-Trading Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a versioned Hermes user plugin that lets Hermes Agent call the existing Vibe-Trading API from Feishu conversations.
+
+**Architecture:** Keep Hermes core unchanged. Add `plugins/vibe-trading` with a `plugin.yaml`, a focused Python registration module, and tests that exercise HTTP request construction, error handling, and registered tool handlers. Deploy by syncing the plugin directory to `/root/.hermes/plugins/vibe-trading` and enabling it in `/root/.hermes/config.yaml`.
+
+**Tech Stack:** Hermes plugin API, Python stdlib `urllib.request`, `pytest`, Docker-deployed Hermes Agent v0.12.0, Vibe-Trading REST API at `http://192.168.1.58:8899`.
+
+---
+
+### Task 1: Tests
+
+**Files:**
+- Create: `tests/plugins/test_vibe_trading_plugin.py`
+
+- [ ] Write tests that import `plugins/vibe-trading/__init__.py` by path.
+- [ ] Verify `_request_json()` sends GET and POST requests to the configured base URL.
+- [ ] Verify HTTP or JSON errors are returned as JSON error payloads instead of raising.
+- [ ] Verify `register(ctx)` registers the expected tool names.
+
+### Task 2: Plugin
+
+**Files:**
+- Create: `plugins/vibe-trading/plugin.yaml`
+- Create: `plugins/vibe-trading/__init__.py`
+
+- [ ] Add plugin metadata for `vibe-trading`.
+- [ ] Implement a small HTTP helper with `VIBE_TRADING_BASE_URL` and `VIBE_TRADING_TIMEOUT_SECONDS`.
+- [ ] Register conservative first-version tools: health, skills, swarm presets, swarm run, swarm result, sessions, session message, run result, run list.
+- [ ] Return JSON strings from every handler and never raise tool exceptions.
+
+### Task 3: Verify, Deploy, Publish
+
+**Files:**
+- Modify: remote `/root/.hermes/config.yaml`
+- Copy: `plugins/vibe-trading/` to remote `/root/.hermes/plugins/vibe-trading/`
+
+- [ ] Run focused pytest.
+- [ ] Sync plugin to `root@192.168.1.63`.
+- [ ] Enable plugin next to `tencent-news`.
+- [ ] Restart Hermes container.
+- [ ] Verify `vibe_health` can reach `http://192.168.1.58:8899/health`.
+- [ ] Commit only the new plugin, tests, and docs.
+- [ ] Push commit to the `fork` remote.

--- a/docs/vibe_trading_ashare_integration.md
+++ b/docs/vibe_trading_ashare_integration.md
@@ -3,7 +3,7 @@
 记录日期：2026-05-02  
 目标：通过飞书与 Hermes Agent 对话时，让 Hermes 调用 Vibe-Trading 完成 A 股研究、买卖建议辅助、策略回测和风险检查。
 
-实施状态：第一版 Hermes 插件已完成并部署到 `192.168.1.63:/root/.hermes/plugins/vibe-trading/`，已在 Hermes 配置中启用。
+实施状态：第一阶段 Hermes 插件已完成并部署到 `192.168.1.63:/root/.hermes/plugins/vibe-trading/`，已在 Hermes 配置中启用。当前阶段使用免费的 AKShare 优先方案，不默认使用 Tushare Pro 或 QVerisAI。
 
 ## 1. 当前部署事实
 
@@ -48,7 +48,7 @@ plugins:
     - vibe-trading
 ```
 
-尚未配置 `mcp_servers`。第一版集成已沿用现有插件模式，没有在 Hermes 容器内安装 Vibe-Trading 的 MCP 依赖。
+尚未配置 `mcp_servers`。第一阶段集成已沿用现有插件模式，没有在 Hermes 容器内安装 Vibe-Trading 的 MCP 依赖。
 
 ## 2. 推荐集成方式
 
@@ -152,8 +152,8 @@ Vibe-Trading 仓库中包含：
 
 Vibe-Trading 支持 A 股行情数据源：
 
-- `tushare`：适合更稳定的 A 股数据，需要 `TUSHARE_TOKEN`。
-- `akshare`：免费数据源，可作为 fallback。
+- `akshare`：免费数据源，第一阶段默认优先使用。
+- `tushare`：适合更稳定的 A 股数据，需要 `TUSHARE_TOKEN`；第一阶段不默认使用。
 - `auto`：根据证券代码自动判断并选择数据源。
 
 适用问题：
@@ -291,14 +291,16 @@ Vibe-Trading 提供 29 个 swarm preset。A 股买卖建议相关场景中优先
 分析我的同花顺交割单，提取影子账户策略，并回测过去一年如果按这些规则交易会有什么差异。
 ```
 
-第一版 Hermes 集成可以暂不开放文件上传，等基础查询和分析稳定后再处理飞书附件到 Vibe `/upload` 的链路。
+第一阶段 Hermes 集成暂不开放文件上传，等基础查询和分析稳定后再处理飞书附件到 Vibe `/upload` 的链路。
 
-## 5. 第一版插件建议暴露的工具
+## 5. 第一阶段插件工具
 
-第一版建议只暴露高价值且可控的工具：
+第一阶段已暴露高价值且可控的工具。其中飞书里的股票自然语言问题应优先走 `vibe_ask_ashare`。
 
 | Hermes 工具名 | 调用目标 | 用途 |
 | --- | --- | --- |
+| `vibe_ask_ashare` | `POST /sessions` + `POST /sessions/{session_id}/messages` + 轮询 `GET /sessions/{session_id}/messages` | A 股或股票问题的自然语言入口，默认要求 Vibe Agent 优先使用免费 AKShare |
+| `vibe_ask` | 同上 | 通用 Vibe-Trading Agent 自然语言转发 |
 | `vibe_health` | `GET /health` | 检查 Vibe-Trading 服务是否可用 |
 | `vibe_list_skills` | `GET /skills` | 查看可用金融技能 |
 | `vibe_list_swarm_presets` | `GET /swarm/presets` | 查看可用多代理团队 |
@@ -319,6 +321,22 @@ Vibe-Trading 提供 29 个 swarm preset。A 股买卖建议相关场景中优先
 这些能力有用，但需要额外做路径、权限、文件大小、敏感信息和金融风险边界设计。
 
 ## 6. 飞书使用示例
+
+### 自然语言 A 股分析
+
+用户在飞书中不需要记工具名，也不需要记参数。直接问股票问题即可：
+
+```text
+我想看看南山铝业600219的投资策略，在什么位置买入或者卖出比较好
+```
+
+Hermes 应选择 `vibe_ask_ashare`，把用户原始问题转发给 Vibe-Trading Agent，并附加第一阶段约束：
+
+- 优先使用免费 AKShare 数据源和 Vibe-Trading 内置 A 股能力。
+- 不默认调用 Tushare 或 QVeris。
+- 输出中文结构化报告。
+- 明确说明数据时效和限制。
+- 保留“仅供研究参考，不构成投资建议”的免责声明。
 
 ### 个股买卖建议
 
@@ -382,15 +400,24 @@ A 股买卖建议高度依赖实时或准实时数据。每次输出应说明：
 
 ### 操作边界
 
-第一版只做分析和研究，不连接券商交易接口，不自动下单。
+第一阶段只做分析和研究，不连接券商交易接口，不自动下单。
 
-## 8. 下一步实施计划
+### 响应耗时边界
 
-第一版已完成：
+完整 Vibe Agent 分析通常需要几十秒到两分钟以上。插件默认等待 `180` 秒，可以通过环境变量调整：
+
+```text
+VIBE_TRADING_AGENT_TIMEOUT_SECONDS=180
+VIBE_TRADING_AGENT_POLL_SECONDS=3
+```
+
+## 8. 第一阶段完成情况
+
+第一阶段已完成：
 
 1. 已在 `192.168.1.63:/root/.hermes/plugins/vibe-trading/` 创建 Hermes 插件。
 2. 插件默认连接 `http://192.168.1.58:8899`，也支持通过 `VIBE_TRADING_BASE_URL` 覆盖。
-3. 已注册第一版工具：健康检查、技能列表、swarm preset、运行 swarm、查询 run、会话发送消息。
+3. 已注册第一阶段工具：自然语言 A 股转发、通用 Vibe Agent 转发、健康检查、技能列表、swarm preset、运行 swarm、查询 run、会话发送消息。
 4. 已更新 `/root/.hermes/config.yaml`：
 
 ```yaml
@@ -402,11 +429,13 @@ plugins:
 
 5. 已重启 Hermes 容器。
 6. 已验证 `vibe_health` 到 Vibe-Trading API 的连通性。
+7. 已验证 `vibe_ask_ashare` 可以创建 Vibe session、发送股票自然语言问题、等待 Agent 完成并返回中文报告。
 
 后续可以在飞书中测试：
 
 ```text
 检查 Vibe-Trading 是否可用
+我想看看南山铝业600219的投资策略，在什么位置买入或者卖出比较好
 用 Vibe-Trading 的 investment_committee 分析 600519.SH
 ```
 

--- a/docs/vibe_trading_ashare_integration.md
+++ b/docs/vibe_trading_ashare_integration.md
@@ -404,10 +404,10 @@ A 股买卖建议高度依赖实时或准实时数据。每次输出应说明：
 
 ### 响应耗时边界
 
-完整 Vibe Agent 分析通常需要几十秒到数分钟。插件默认等待 `300` 秒，并会在超时边界再读取一次结果，避免 Vibe 已完成但 Hermes 刚好错过最后一轮轮询。可以通过环境变量调整：
+完整 Vibe Agent 分析通常需要几十秒到数分钟。插件默认等待 `600` 秒，并会在超时边界再读取一次结果，避免 Vibe 已完成但 Hermes 刚好错过最后一轮轮询。如果 Vibe 返回了 `<minimax:tool_call>` 或 `<invoke>` 这类未执行工具标记，插件会在同一个 Vibe session 内追问一次，要求它直接输出干净的最终中文报告。可以通过环境变量调整：
 
 ```text
-VIBE_TRADING_AGENT_TIMEOUT_SECONDS=300
+VIBE_TRADING_AGENT_TIMEOUT_SECONDS=600
 VIBE_TRADING_AGENT_POLL_SECONDS=3
 ```
 

--- a/docs/vibe_trading_ashare_integration.md
+++ b/docs/vibe_trading_ashare_integration.md
@@ -1,0 +1,413 @@
+# Hermes Agent 集成 Vibe-Trading：A 股分析方案
+
+记录日期：2026-05-02  
+目标：通过飞书与 Hermes Agent 对话时，让 Hermes 调用 Vibe-Trading 完成 A 股研究、买卖建议辅助、策略回测和风险检查。
+
+实施状态：第一版 Hermes 插件已完成并部署到 `192.168.1.63:/root/.hermes/plugins/vibe-trading/`，已在 Hermes 配置中启用。
+
+## 1. 当前部署事实
+
+Vibe-Trading 已部署在：
+
+```text
+主机：toddsun@192.168.1.58
+目录：~/aiproxy/Vibe-Trading
+服务：Docker Compose
+API：http://192.168.1.58:8899
+健康检查：GET /health
+```
+
+已验证服务状态：
+
+```json
+{"status":"healthy","service":"Vibe-Trading API"}
+```
+
+Hermes Agent 已部署在：
+
+```text
+主机：root@192.168.1.63
+容器：hermes
+镜像：nousresearch/hermes-agent:latest
+版本：Hermes Agent v0.12.0
+入口：飞书 gateway
+```
+
+Hermes 容器内可以访问 Vibe-Trading API：
+
+```text
+http://192.168.1.58:8899/health
+```
+
+当前 Hermes 配置中已启用插件：
+
+```yaml
+plugins:
+  enabled:
+    - tencent-news
+    - vibe-trading
+```
+
+尚未配置 `mcp_servers`。第一版集成已沿用现有插件模式，没有在 Hermes 容器内安装 Vibe-Trading 的 MCP 依赖。
+
+## 2. 推荐集成方式
+
+推荐使用 Hermes 插件封装 Vibe-Trading REST API：
+
+```text
+飞书 -> Hermes Gateway -> Hermes Agent -> vibe-trading Hermes 插件 -> Vibe-Trading API -> Hermes 总结 -> 飞书
+```
+
+理由：
+
+- Vibe-Trading 已经作为独立 Docker 服务稳定运行，不需要把它的 Python 依赖安装进 Hermes 容器。
+- Hermes v0.12.0 的插件系统已经在当前部署中使用过，`tencent-news` 插件可作为实现参考。
+- 插件可以只暴露经过筛选的金融工具，避免一次性把所有文件读写、搜索、回测和 swarm 工具暴露给模型。
+- Vibe-Trading 后续升级可以独立进行，Hermes 只需要保持 HTTP 调用兼容。
+
+备选方案是把 `vibe-trading-mcp` 配成 Hermes MCP server。该方式工具覆盖更完整，但需要在 Hermes 容器内安装 `vibe-trading-ai`，依赖更重，升级和数据目录隔离也更复杂。
+
+## 3. Vibe-Trading 已识别能力
+
+Vibe-Trading 仓库中包含：
+
+- `agent/api_server.py`：FastAPI 服务。
+- `agent/mcp_server.py`：MCP server，暴露金融研究工具。
+- `agent/SKILL.md`：说明 PyPI 包、MCP 命令和工具清单。
+- `docker-compose.yml`：当前 Docker 部署入口。
+
+已识别 REST API 路由包括：
+
+- `GET /health`
+- `GET /skills`
+- `GET /api`
+- `GET /runs`
+- `GET /runs/{run_id}`
+- `GET /runs/{run_id}/code`
+- `GET /runs/{run_id}/pine`
+- `GET /correlation`
+- `POST /sessions`
+- `GET /sessions`
+- `POST /sessions/{session_id}/messages`
+- `GET /sessions/{session_id}/messages`
+- `POST /sessions/{session_id}/cancel`
+- `GET /sessions/{session_id}/events`
+- `POST /upload`
+- `GET /shadow-reports/{shadow_id}`
+- `GET /swarm/presets`
+- `POST /swarm/runs`
+- `GET /swarm/runs`
+- `GET /swarm/runs/{run_id}`
+- `GET /swarm/runs/{run_id}/events`
+- `POST /swarm/runs/{run_id}/cancel`
+
+已识别 MCP 工具包括：
+
+- `list_skills`
+- `load_skill`
+- `backtest`
+- `factor_analysis`
+- `analyze_options`
+- `pattern_recognition`
+- `read_url`
+- `read_document`
+- `web_search`
+- `write_file`
+- `read_file`
+- `list_swarm_presets`
+- `run_swarm`
+- `get_market_data`
+- `get_swarm_status`
+- `get_run_result`
+- `list_runs`
+- `analyze_trade_journal`
+- `extract_shadow_strategy`
+- `run_shadow_backtest`
+- `render_shadow_report`
+- `scan_shadow_signals`
+
+## 4. A 股相关功能
+
+### 4.1 个股买卖建议辅助
+
+适用问题：
+
+```text
+分析 600519.SH 当前是否适合买入，给出买入、观望、减仓或卖出的倾向。
+```
+
+建议输出格式：
+
+- 结论：买入、观望、减仓或卖出。
+- 核心理由：趋势、估值、资金面、基本面、技术面、事件风险。
+- 反向风险：什么情况会推翻当前判断。
+- 入场条件：需要满足哪些价格、量能或事件条件。
+- 止损条件：跌破什么位置或出现什么风险信号应退出。
+- 观察周期：短线、中线或长期。
+- 数据限制：本次分析依赖的数据源和可能缺口。
+
+注意：该能力应定位为研究辅助，不应在飞书中表述为确定性投资指令。
+
+### 4.2 A 股行情获取
+
+Vibe-Trading 支持 A 股行情数据源：
+
+- `tushare`：适合更稳定的 A 股数据，需要 `TUSHARE_TOKEN`。
+- `akshare`：免费数据源，可作为 fallback。
+- `auto`：根据证券代码自动判断并选择数据源。
+
+适用问题：
+
+```text
+获取 000001.SZ 过去一年的日线行情，分析趋势、波动率和支撑阻力。
+```
+
+可用于：
+
+- 个股 OHLCV 行情。
+- 指数或板块相关行情。
+- 回测前的数据准备。
+- 趋势、波动率、支撑阻力和量价关系分析。
+
+### 4.3 策略生成与回测
+
+Vibe-Trading 支持通过自然语言生成策略并运行回测。A 股场景中可用于把“买入逻辑”变成可验证规则。
+
+适用问题：
+
+```text
+用 600519.SH 回测一个均线突破策略，时间从 2021-01-01 到 2025-12-31，输出收益、最大回撤、夏普和交易次数。
+```
+
+典型输出：
+
+- 策略逻辑。
+- 回测区间。
+- 数据源。
+- 总收益。
+- 年化收益。
+- 最大回撤。
+- 夏普比率。
+- 胜率。
+- 交易次数。
+- 结果局限。
+
+### 4.4 因子分析
+
+MCP 工具 `factor_analysis` 可用于 A 股横截面研究，例如估值、换手、动量或财务因子有效性检查。
+
+适用问题：
+
+```text
+对沪深 300 成分股做 pe_ttm 因子分析，时间 2023-01-01 到 2025-12-31，判断低 PE 因子是否有效。
+```
+
+可回答：
+
+- 某个因子最近是否有效。
+- 因子 IC/IR 表现如何。
+- 多头组合和空头组合收益差异。
+- 因子是否适合进入后续选股框架。
+
+### 4.5 技术分析和形态识别
+
+Vibe-Trading 的技能体系覆盖多类技术分析方法：
+
+- K 线形态。
+- 均线和常见技术指标。
+- 一目均衡。
+- Elliott wave。
+- SMC。
+- 缠论或技术基础方法。
+- 图形识别，如头肩顶、双底、三角形等。
+
+适用问题：
+
+```text
+用技术分析框架评估 601318.SH，重点看趋势、支撑阻力、量价关系和短线交易风险。
+```
+
+### 4.6 ST 和 pre-ST 风险筛查
+
+Vibe-Trading README 记录了 `ashare-pre-st-filter` 技能，用于 A 股 ST 或 pre-ST 风险筛查。
+
+适用问题：
+
+```text
+检查 002XXX.SZ 是否存在 ST 或 pre-ST 风险，关注财务异常、处罚公告、连续亏损和交易所风险提示。
+```
+
+该能力适合在买入建议前作为强制风控步骤。
+
+### 4.7 板块和行业轮动分析
+
+Vibe-Trading 的技能体系包含 sector rotation、asset allocation、macro-analysis 等能力，可用于 A 股板块比较。
+
+适用问题：
+
+```text
+分析当前 A 股新能源、半导体、白酒、银行几个板块的相对强弱，给出更适合关注的方向。
+```
+
+可输出：
+
+- 板块强弱排序。
+- 近期驱动因素。
+- 风险事件。
+- 适合关注的标的类型。
+- 不适合追涨的条件。
+
+### 4.8 多代理投资委员会
+
+Vibe-Trading 提供 29 个 swarm preset。A 股买卖建议相关场景中优先考虑：
+
+- `investment_committee`：多空辩论后给出投资建议。
+- `risk_committee`：专门审查风险。
+- `quant_strategy_desk`：偏量化和回测验证。
+- `global_equities_desk`：跨 A 股、港美股和加密市场视角。
+
+适用问题：
+
+```text
+用 Vibe-Trading 的 investment_committee 分析 600519.SH，输出买入、观望或卖出建议、核心分歧、风险点和触发条件。
+```
+
+### 4.9 交易日志和影子账户
+
+如果用户上传券商交割单，Vibe-Trading 可用于交易复盘：
+
+- 分析持仓周期。
+- 计算胜率和盈亏比。
+- 识别处置效应。
+- 识别过度交易。
+- 识别追涨杀跌。
+- 识别锚定效应。
+- 从历史盈利交易中提取规则。
+- 回测“如果严格执行这些规则会怎样”。
+
+适用问题：
+
+```text
+分析我的同花顺交割单，提取影子账户策略，并回测过去一年如果按这些规则交易会有什么差异。
+```
+
+第一版 Hermes 集成可以暂不开放文件上传，等基础查询和分析稳定后再处理飞书附件到 Vibe `/upload` 的链路。
+
+## 5. 第一版插件建议暴露的工具
+
+第一版建议只暴露高价值且可控的工具：
+
+| Hermes 工具名 | 调用目标 | 用途 |
+| --- | --- | --- |
+| `vibe_health` | `GET /health` | 检查 Vibe-Trading 服务是否可用 |
+| `vibe_list_skills` | `GET /skills` | 查看可用金融技能 |
+| `vibe_list_swarm_presets` | `GET /swarm/presets` | 查看可用多代理团队 |
+| `vibe_run_swarm` | `POST /swarm/runs` | 运行投资委员会或风控委员会分析 |
+| `vibe_get_swarm_run` | `GET /swarm/runs/{run_id}` | 查询 swarm 结果 |
+| `vibe_create_session` | `POST /sessions` | 创建 Vibe 会话 |
+| `vibe_send_message` | `POST /sessions/{session_id}/messages` | 向 Vibe 会话发送自然语言请求 |
+| `vibe_get_run_result` | `GET /runs/{run_id}` | 查询历史回测或分析结果 |
+| `vibe_list_runs` | `GET /runs` | 列出近期运行记录 |
+
+暂缓开放：
+
+- 文件写入类工具。
+- 任意网页搜索类工具。
+- 任意文件读取类工具。
+- 飞书附件上传到 Vibe 的自动处理。
+
+这些能力有用，但需要额外做路径、权限、文件大小、敏感信息和金融风险边界设计。
+
+## 6. 飞书使用示例
+
+### 个股买卖建议
+
+```text
+用 Vibe-Trading 分析 600519.SH 当前是否适合买入。
+请输出：结论、核心理由、反向风险、入场条件、止损条件、观察周期。
+```
+
+### 风险优先分析
+
+```text
+用 Vibe-Trading 的 risk_committee 分析 300750.SZ。
+重点检查下跌风险、估值风险、行业风险和需要回避的触发条件。
+```
+
+### 投资委员会分析
+
+```text
+用 Vibe-Trading 的 investment_committee 分析 601318.SH。
+请给出多方观点、空方观点、最终建议和关键验证信号。
+```
+
+### 策略回测
+
+```text
+用 Vibe-Trading 为 000001.SZ 设计一个均线突破策略，并回测 2021-01-01 到 2025-12-31。
+输出收益、最大回撤、夏普、胜率、交易次数和策略缺陷。
+```
+
+### ST 风险检查
+
+```text
+用 Vibe-Trading 检查 002XXX.SZ 是否有 ST 或 pre-ST 风险。
+请关注财务异常、监管处罚、连续亏损和公告风险。
+```
+
+## 7. 风险和边界
+
+### 金融建议边界
+
+Hermes 输出应使用“研究结论”“交易辅助判断”“风险提示”等措辞，不应承诺收益，也不应把模型输出表述为确定性投资建议。
+
+推荐固定免责声明：
+
+```text
+以下内容仅用于研究辅助，不构成投资建议。A 股交易存在本金亏损风险，请结合自己的风险承受能力和实时行情独立决策。
+```
+
+### 数据时效边界
+
+A 股买卖建议高度依赖实时或准实时数据。每次输出应说明：
+
+- 使用的数据源。
+- 数据截止日期或时间。
+- 是否成功获取最新行情。
+- 哪些结论依赖模型推断而不是实时数据。
+
+### 工具权限边界
+
+第一版插件不应开放 Vibe 的任意文件读写能力。涉及交割单、报告、附件上传时，应单独设计文件路径和权限。
+
+### 操作边界
+
+第一版只做分析和研究，不连接券商交易接口，不自动下单。
+
+## 8. 下一步实施计划
+
+第一版已完成：
+
+1. 已在 `192.168.1.63:/root/.hermes/plugins/vibe-trading/` 创建 Hermes 插件。
+2. 插件默认连接 `http://192.168.1.58:8899`，也支持通过 `VIBE_TRADING_BASE_URL` 覆盖。
+3. 已注册第一版工具：健康检查、技能列表、swarm preset、运行 swarm、查询 run、会话发送消息。
+4. 已更新 `/root/.hermes/config.yaml`：
+
+```yaml
+plugins:
+  enabled:
+    - tencent-news
+    - vibe-trading
+```
+
+5. 已重启 Hermes 容器。
+6. 已验证 `vibe_health` 到 Vibe-Trading API 的连通性。
+
+后续可以在飞书中测试：
+
+```text
+检查 Vibe-Trading 是否可用
+用 Vibe-Trading 的 investment_committee 分析 600519.SH
+```
+
+根据实际使用结果，再决定是否增加文件上传、影子账户和完整回测自动化。

--- a/docs/vibe_trading_ashare_integration.md
+++ b/docs/vibe_trading_ashare_integration.md
@@ -404,10 +404,10 @@ A 股买卖建议高度依赖实时或准实时数据。每次输出应说明：
 
 ### 响应耗时边界
 
-完整 Vibe Agent 分析通常需要几十秒到两分钟以上。插件默认等待 `180` 秒，可以通过环境变量调整：
+完整 Vibe Agent 分析通常需要几十秒到数分钟。插件默认等待 `300` 秒，并会在超时边界再读取一次结果，避免 Vibe 已完成但 Hermes 刚好错过最后一轮轮询。可以通过环境变量调整：
 
 ```text
-VIBE_TRADING_AGENT_TIMEOUT_SECONDS=180
+VIBE_TRADING_AGENT_TIMEOUT_SECONDS=300
 VIBE_TRADING_AGENT_POLL_SECONDS=3
 ```
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5488,6 +5488,7 @@ class GatewayRunner:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    current_api_key = model_cfg.get("api_key", "") or ""
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -5736,6 +5737,8 @@ class GatewayRunner:
                 model_cfg["provider"] = result.target_provider
                 if result.base_url:
                     model_cfg["base_url"] = result.base_url
+                if result.api_key:
+                    model_cfg["api_key"] = result.api_key
                 from hermes_cli.config import save_config
                 save_config(cfg)
             except Exception as e:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -859,6 +859,10 @@ def switch_model(
             if not api_key:
                 api_key = "no-key-required"
 
+    # --- Determine api_mode if not already set (must happen before validation) ---
+    if not api_mode:
+        api_mode = determine_api_mode(target_provider, base_url)
+
     # --- Normalize model name for target provider ---
     new_model = normalize_model_for_provider(new_model, target_provider)
 

--- a/plugins/vibe-trading/__init__.py
+++ b/plugins/vibe-trading/__init__.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 TOOLSET = "vibe-trading"
 DEFAULT_BASE_URL = "http://192.168.1.58:8899"
 DEFAULT_TIMEOUT_SECONDS = 20.0
-DEFAULT_AGENT_TIMEOUT_SECONDS = 180.0
+DEFAULT_AGENT_TIMEOUT_SECONDS = 300.0
 DEFAULT_AGENT_POLL_SECONDS = 3.0
 
 
@@ -123,7 +123,7 @@ def _latest_assistant_message(messages: Any) -> str | None:
 
 def _clean_agent_answer(content: str) -> str:
     text = content.strip()
-    return re.sub(r"^<think>\s*</think>\s*", "", text, flags=re.IGNORECASE).strip()
+    return re.sub(r"^(?:<think>.*?</think>\s*)+", "", text, flags=re.IGNORECASE | re.DOTALL).strip()
 
 
 def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None) -> str:
@@ -153,16 +153,21 @@ def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None
         return _json_dumps(send_payload)
     attempt_id = send_payload.get("attempt_id")
 
+    messages_path = f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages"
+
+    def read_answer() -> tuple[str | None, Any]:
+        messages_payload = json.loads(_request_json(
+            "GET",
+            messages_path,
+            query={"limit": 50},
+        ))
+        return _latest_assistant_message(messages_payload), messages_payload
+
     deadline = time.monotonic() + _agent_timeout_seconds()
     last_messages: Any = None
     while time.monotonic() < deadline:
-        messages_payload = json.loads(_request_json(
-            "GET",
-            f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages",
-            query={"limit": 50},
-        ))
+        answer, messages_payload = read_answer()
         last_messages = messages_payload
-        answer = _latest_assistant_message(messages_payload)
         if answer:
             return _json_dumps({
                 "success": True,
@@ -171,6 +176,16 @@ def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None
                 "answer": answer,
             })
         time.sleep(_agent_poll_seconds())
+
+    answer, messages_payload = read_answer()
+    last_messages = messages_payload
+    if answer:
+        return _json_dumps({
+            "success": True,
+            "session_id": session_id,
+            "attempt_id": attempt_id,
+            "answer": answer,
+        })
 
     return _json_dumps({
         "success": False,

--- a/plugins/vibe-trading/__init__.py
+++ b/plugins/vibe-trading/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -15,6 +17,8 @@ logger = logging.getLogger(__name__)
 TOOLSET = "vibe-trading"
 DEFAULT_BASE_URL = "http://192.168.1.58:8899"
 DEFAULT_TIMEOUT_SECONDS = 20.0
+DEFAULT_AGENT_TIMEOUT_SECONDS = 180.0
+DEFAULT_AGENT_POLL_SECONDS = 3.0
 
 
 def _base_url() -> str:
@@ -27,6 +31,22 @@ def _timeout_seconds() -> float:
         return max(1.0, float(raw))
     except ValueError:
         return DEFAULT_TIMEOUT_SECONDS
+
+
+def _agent_timeout_seconds() -> float:
+    raw = os.getenv("VIBE_TRADING_AGENT_TIMEOUT_SECONDS", str(DEFAULT_AGENT_TIMEOUT_SECONDS))
+    try:
+        return max(10.0, float(raw))
+    except ValueError:
+        return DEFAULT_AGENT_TIMEOUT_SECONDS
+
+
+def _agent_poll_seconds() -> float:
+    raw = os.getenv("VIBE_TRADING_AGENT_POLL_SECONDS", str(DEFAULT_AGENT_POLL_SECONDS))
+    try:
+        return max(1.0, float(raw))
+    except ValueError:
+        return DEFAULT_AGENT_POLL_SECONDS
 
 
 def _json_dumps(payload: Any) -> str:
@@ -86,6 +106,114 @@ def _request_json(
 
 def _vibe_health(args: dict[str, Any], **kwargs) -> str:
     return _request_json("GET", "/health")
+
+
+def _latest_assistant_message(messages: Any) -> str | None:
+    if not isinstance(messages, list):
+        return None
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "assistant":
+            content = _clean_agent_answer(str(message.get("content") or ""))
+            if content:
+                return content
+    return None
+
+
+def _clean_agent_answer(content: str) -> str:
+    text = content.strip()
+    return re.sub(r"^<think>\s*</think>\s*", "", text, flags=re.IGNORECASE).strip()
+
+
+def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None) -> str:
+    clean_question = question.strip()
+    if not clean_question:
+        return _json_dumps({"success": False, "error": "question is required"})
+
+    create_payload = json.loads(_request_json("POST", "/sessions", {"title": title}))
+    if create_payload.get("success") is False:
+        return _json_dumps(create_payload)
+    session_id = str(create_payload.get("session_id") or "").strip()
+    if not session_id:
+        return _json_dumps({
+            "success": False,
+            "error": "Vibe-Trading did not return session_id",
+            "response": create_payload,
+        })
+
+    content = clean_question if not instruction else f"{instruction.strip()}\n\n用户原始问题：\n{clean_question}"
+    send_payload = json.loads(_request_json(
+        "POST",
+        f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages",
+        {"content": content},
+    ))
+    if send_payload.get("success") is False:
+        send_payload.setdefault("session_id", session_id)
+        return _json_dumps(send_payload)
+    attempt_id = send_payload.get("attempt_id")
+
+    deadline = time.monotonic() + _agent_timeout_seconds()
+    last_messages: Any = None
+    while time.monotonic() < deadline:
+        messages_payload = json.loads(_request_json(
+            "GET",
+            f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages",
+            query={"limit": 50},
+        ))
+        last_messages = messages_payload
+        answer = _latest_assistant_message(messages_payload)
+        if answer:
+            return _json_dumps({
+                "success": True,
+                "session_id": session_id,
+                "attempt_id": attempt_id,
+                "answer": answer,
+            })
+        time.sleep(_agent_poll_seconds())
+
+    return _json_dumps({
+        "success": False,
+        "error": "Timed out waiting for Vibe-Trading Agent response",
+        "session_id": session_id,
+        "attempt_id": attempt_id,
+        "last_messages": last_messages,
+    })
+
+
+ASHARE_AKSHARE_INSTRUCTION = """请作为 Vibe-Trading A股投资分析 Agent 处理以下问题，并直接输出最终中文分析报告。
+
+第一阶段约束：
+- 优先使用免费 AKShare 数据源和 Vibe-Trading 内置 A股能力。
+- 不要默认调用 Tushare 或 QVeris；只有用户明确要求时才使用它们。
+- 如果无法获取实时或最新数据，请明确说明数据时效和限制。
+- 最终回答不要输出 <minimax:tool_call>、<invoke>、工具 XML 或代码块式工具调用标记。
+
+请尽量输出结构化报告，包含：
+1. 当前行情状态
+2. 技术指标和趋势判断
+3. 买入、加仓、卖出或观望条件
+4. 止损位和止盈目标
+5. 风险收益比
+6. 关键风险与反向信号
+7. 操作建议总结
+8. 免责声明：仅供研究参考，不构成投资建议
+"""
+
+
+def _vibe_ask(args: dict[str, Any], **kwargs) -> str:
+    return _vibe_agent_ask(
+        str(args.get("question", "")),
+        title=args.get("title") or "Vibe-Trading Ask",
+    )
+
+
+def _vibe_ask_ashare(args: dict[str, Any], **kwargs) -> str:
+    return _vibe_agent_ask(
+        str(args.get("question", "")),
+        title=args.get("title") or "A股自然语言分析",
+        instruction=ASHARE_AKSHARE_INSTRUCTION,
+    )
 
 
 def _vibe_list_skills(args: dict[str, Any], **kwargs) -> str:
@@ -149,6 +277,52 @@ VIBE_HEALTH_SCHEMA = {
     "name": "vibe_health",
     "description": "Check whether the Vibe-Trading API service is reachable and healthy.",
     "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+VIBE_ASK_SCHEMA = {
+    "name": "vibe_ask",
+    "description": (
+        "Forward a natural-language finance or trading question directly to the "
+        "Vibe-Trading Agent and return the final assistant report."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "User's original natural-language question.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Optional Vibe-Trading session title.",
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+VIBE_ASK_ASHARE_SCHEMA = {
+    "name": "vibe_ask_ashare",
+    "description": (
+        "Use this first for A-share or stock questions from Feishu, including buy/sell "
+        "points, stop-loss, take-profit, risk, technical analysis, sector analysis, "
+        "and strategy questions. It forwards natural language to Vibe-Trading Agent "
+        "with free AKShare-first instructions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "User's original A-share natural-language question.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Optional Vibe-Trading session title.",
+            },
+        },
+        "required": ["question"],
+    },
 }
 
 VIBE_LIST_SKILLS_SCHEMA = {
@@ -257,6 +431,8 @@ VIBE_LIST_RUNS_SCHEMA = {
 def register(ctx):
     """Register Vibe-Trading bridge tools."""
     tools = [
+        ("vibe_ask", VIBE_ASK_SCHEMA, _vibe_ask),
+        ("vibe_ask_ashare", VIBE_ASK_ASHARE_SCHEMA, _vibe_ask_ashare),
         ("vibe_health", VIBE_HEALTH_SCHEMA, _vibe_health),
         ("vibe_list_skills", VIBE_LIST_SKILLS_SCHEMA, _vibe_list_skills),
         ("vibe_list_swarm_presets", VIBE_LIST_SWARM_PRESETS_SCHEMA, _vibe_list_swarm_presets),

--- a/plugins/vibe-trading/__init__.py
+++ b/plugins/vibe-trading/__init__.py
@@ -17,8 +17,12 @@ logger = logging.getLogger(__name__)
 TOOLSET = "vibe-trading"
 DEFAULT_BASE_URL = "http://192.168.1.58:8899"
 DEFAULT_TIMEOUT_SECONDS = 20.0
-DEFAULT_AGENT_TIMEOUT_SECONDS = 300.0
+DEFAULT_AGENT_TIMEOUT_SECONDS = 600.0
 DEFAULT_AGENT_POLL_SECONDS = 3.0
+AGENT_TOOL_MARKUP_PATTERN = re.compile(
+    r"<\s*(?:minimax:tool_call|longcat_tool_call|invoke)\b|</\s*(?:minimax:tool_call|longcat_tool_call|invoke)\s*>",
+    re.IGNORECASE,
+)
 
 
 def _base_url() -> str:
@@ -111,7 +115,13 @@ def _vibe_health(args: dict[str, Any], **kwargs) -> str:
 def _latest_assistant_message(messages: Any) -> str | None:
     if not isinstance(messages, list):
         return None
-    for message in reversed(messages):
+
+    last_user_index = -1
+    for index, message in enumerate(messages):
+        if isinstance(message, dict) and message.get("role") == "user":
+            last_user_index = index
+
+    for message in reversed(messages[last_user_index + 1:]):
         if not isinstance(message, dict):
             continue
         if message.get("role") == "assistant":
@@ -124,6 +134,10 @@ def _latest_assistant_message(messages: Any) -> str | None:
 def _clean_agent_answer(content: str) -> str:
     text = content.strip()
     return re.sub(r"^(?:<think>.*?</think>\s*)+", "", text, flags=re.IGNORECASE | re.DOTALL).strip()
+
+
+def _contains_agent_tool_markup(content: str) -> bool:
+    return bool(AGENT_TOOL_MARKUP_PATTERN.search(content))
 
 
 def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None) -> str:
@@ -152,8 +166,17 @@ def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None
         send_payload.setdefault("session_id", session_id)
         return _json_dumps(send_payload)
     attempt_id = send_payload.get("attempt_id")
+    repaired_tool_markup = False
 
     messages_path = f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages"
+
+    def send_session_message(message_content: str) -> dict[str, Any]:
+        payload = json.loads(_request_json(
+            "POST",
+            f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages",
+            {"content": message_content},
+        ))
+        return payload
 
     def read_answer() -> tuple[str | None, Any]:
         messages_payload = json.loads(_request_json(
@@ -169,6 +192,20 @@ def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None
         answer, messages_payload = read_answer()
         last_messages = messages_payload
         if answer:
+            if _contains_agent_tool_markup(answer) and not repaired_tool_markup:
+                repaired_tool_markup = True
+                repair_payload = send_session_message(
+                    "上一条回答包含未执行的工具调用标记，例如 <minimax:tool_call> 或 <invoke>。"
+                    "请不要再调用任何工具，不要输出工具 XML，不要输出代码块；"
+                    "只基于你已经获取到的数据，直接重新输出一份完整、干净的中文最终投资分析报告，"
+                    "必须包含买入/观望/卖出结论、买卖点、止损止盈、风险和免责声明。"
+                )
+                if repair_payload.get("success") is False:
+                    repair_payload.setdefault("session_id", session_id)
+                    return _json_dumps(repair_payload)
+                attempt_id = repair_payload.get("attempt_id") or attempt_id
+                deadline = time.monotonic() + _agent_timeout_seconds()
+                continue
             return _json_dumps({
                 "success": True,
                 "session_id": session_id,
@@ -180,6 +217,24 @@ def _vibe_agent_ask(question: str, *, title: str, instruction: str | None = None
     answer, messages_payload = read_answer()
     last_messages = messages_payload
     if answer:
+        if _contains_agent_tool_markup(answer) and not repaired_tool_markup:
+            repair_payload = send_session_message(
+                "上一条回答包含未执行的工具调用标记，例如 <minimax:tool_call> 或 <invoke>。"
+                "请不要再调用任何工具，不要输出工具 XML，不要输出代码块；"
+                "只基于你已经获取到的数据，直接重新输出一份完整、干净的中文最终投资分析报告。"
+            )
+            if repair_payload.get("success") is False:
+                repair_payload.setdefault("session_id", session_id)
+                return _json_dumps(repair_payload)
+            attempt_id = repair_payload.get("attempt_id") or attempt_id
+            deadline = time.monotonic() + _agent_timeout_seconds()
+            while time.monotonic() < deadline:
+                answer, messages_payload = read_answer()
+                last_messages = messages_payload
+                if answer and not _contains_agent_tool_markup(answer):
+                    break
+                time.sleep(_agent_poll_seconds())
+
         return _json_dumps({
             "success": True,
             "session_id": session_id,

--- a/plugins/vibe-trading/__init__.py
+++ b/plugins/vibe-trading/__init__.py
@@ -1,0 +1,278 @@
+"""Hermes plugin that bridges to a running Vibe-Trading API service."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TOOLSET = "vibe-trading"
+DEFAULT_BASE_URL = "http://192.168.1.58:8899"
+DEFAULT_TIMEOUT_SECONDS = 20.0
+
+
+def _base_url() -> str:
+    return os.getenv("VIBE_TRADING_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def _timeout_seconds() -> float:
+    raw = os.getenv("VIBE_TRADING_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS))
+    try:
+        return max(1.0, float(raw))
+    except ValueError:
+        return DEFAULT_TIMEOUT_SECONDS
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _request_json(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    query: dict[str, Any] | None = None,
+) -> str:
+    """Call Vibe-Trading and return a JSON string for Hermes tool output."""
+    url = f"{_base_url()}/{path.lstrip('/')}"
+    if query:
+        clean_query = {k: v for k, v in query.items() if v is not None}
+        if clean_query:
+            url = f"{url}?{urllib.parse.urlencode(clean_query)}"
+
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method.upper())
+
+    try:
+        with urllib.request.urlopen(request, timeout=_timeout_seconds()) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+            if not raw.strip():
+                return _json_dumps({"success": True, "status": getattr(response, "status", 200)})
+            try:
+                return _json_dumps(json.loads(raw))
+            except json.JSONDecodeError:
+                return _json_dumps({"success": True, "text": raw})
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            detail = str(exc)
+        return _json_dumps({
+            "success": False,
+            "error_type": "HTTPError",
+            "status": exc.code,
+            "error": detail,
+            "url": url,
+        })
+    except Exception as exc:
+        return _json_dumps({
+            "success": False,
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+            "url": url,
+        })
+
+
+def _vibe_health(args: dict[str, Any], **kwargs) -> str:
+    return _request_json("GET", "/health")
+
+
+def _vibe_list_skills(args: dict[str, Any], **kwargs) -> str:
+    return _request_json("GET", "/skills")
+
+
+def _vibe_list_swarm_presets(args: dict[str, Any], **kwargs) -> str:
+    return _request_json("GET", "/swarm/presets")
+
+
+def _vibe_run_swarm(args: dict[str, Any], **kwargs) -> str:
+    payload = {
+        "preset_name": args.get("preset_name"),
+        "variables": args.get("variables") or {},
+    }
+    return _request_json("POST", "/swarm/runs", payload)
+
+
+def _vibe_get_swarm_run(args: dict[str, Any], **kwargs) -> str:
+    run_id = str(args.get("run_id", "")).strip()
+    if not run_id:
+        return _json_dumps({"success": False, "error": "run_id is required"})
+    return _request_json("GET", f"/swarm/runs/{urllib.parse.quote(run_id, safe='')}")
+
+
+def _vibe_create_session(args: dict[str, Any], **kwargs) -> str:
+    payload = {
+        "title": args.get("title") or "",
+        "config": args.get("config"),
+    }
+    return _request_json("POST", "/sessions", payload)
+
+
+def _vibe_send_message(args: dict[str, Any], **kwargs) -> str:
+    session_id = str(args.get("session_id", "")).strip()
+    content = str(args.get("content", "")).strip()
+    if not session_id:
+        return _json_dumps({"success": False, "error": "session_id is required"})
+    if not content:
+        return _json_dumps({"success": False, "error": "content is required"})
+    return _request_json(
+        "POST",
+        f"/sessions/{urllib.parse.quote(session_id, safe='')}/messages",
+        {"content": content},
+    )
+
+
+def _vibe_get_run_result(args: dict[str, Any], **kwargs) -> str:
+    run_id = str(args.get("run_id", "")).strip()
+    if not run_id:
+        return _json_dumps({"success": False, "error": "run_id is required"})
+    return _request_json("GET", f"/runs/{urllib.parse.quote(run_id, safe='')}")
+
+
+def _vibe_list_runs(args: dict[str, Any], **kwargs) -> str:
+    limit = args.get("limit", 20)
+    return _request_json("GET", "/runs", query={"limit": limit})
+
+
+VIBE_HEALTH_SCHEMA = {
+    "name": "vibe_health",
+    "description": "Check whether the Vibe-Trading API service is reachable and healthy.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+VIBE_LIST_SKILLS_SCHEMA = {
+    "name": "vibe_list_skills",
+    "description": "List Vibe-Trading finance skills, including A-share analysis skills.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+VIBE_LIST_SWARM_PRESETS_SCHEMA = {
+    "name": "vibe_list_swarm_presets",
+    "description": "List Vibe-Trading multi-agent team presets such as investment_committee and risk_committee.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+VIBE_RUN_SWARM_SCHEMA = {
+    "name": "vibe_run_swarm",
+    "description": (
+        "Run a Vibe-Trading multi-agent team. Use this for investment committee, "
+        "risk committee, quant strategy, and A-share research desk analysis."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "preset_name": {
+                "type": "string",
+                "description": "Swarm preset name, e.g. investment_committee, risk_committee, quant_strategy_desk.",
+            },
+            "variables": {
+                "type": "object",
+                "description": "Preset variables, e.g. {'target': '600519.SH', 'market': 'A股'}.",
+                "additionalProperties": {"type": "string"},
+            },
+        },
+        "required": ["preset_name", "variables"],
+    },
+}
+
+VIBE_GET_SWARM_RUN_SCHEMA = {
+    "name": "vibe_get_swarm_run",
+    "description": "Fetch a Vibe-Trading swarm run result by run_id.",
+    "parameters": {
+        "type": "object",
+        "properties": {"run_id": {"type": "string", "description": "Swarm run identifier."}},
+        "required": ["run_id"],
+    },
+}
+
+VIBE_CREATE_SESSION_SCHEMA = {
+    "name": "vibe_create_session",
+    "description": "Create a Vibe-Trading session for natural-language finance analysis.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string", "description": "Session title."},
+            "config": {"type": "object", "description": "Optional session config."},
+        },
+        "required": [],
+    },
+}
+
+VIBE_SEND_MESSAGE_SCHEMA = {
+    "name": "vibe_send_message",
+    "description": (
+        "Send a natural-language request to a Vibe-Trading session. Use this for "
+        "A-share buy/sell research, backtest requests, ST risk checks, and sector analysis."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {"type": "string", "description": "Vibe-Trading session identifier."},
+            "content": {"type": "string", "description": "Natural-language analysis request."},
+        },
+        "required": ["session_id", "content"],
+    },
+}
+
+VIBE_GET_RUN_RESULT_SCHEMA = {
+    "name": "vibe_get_run_result",
+    "description": "Fetch a Vibe-Trading run result by run_id, including backtest and analysis outputs.",
+    "parameters": {
+        "type": "object",
+        "properties": {"run_id": {"type": "string", "description": "Run identifier."}},
+        "required": ["run_id"],
+    },
+}
+
+VIBE_LIST_RUNS_SCHEMA = {
+    "name": "vibe_list_runs",
+    "description": "List recent Vibe-Trading runs with summary fields.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of runs to return.",
+                "default": 20,
+                "minimum": 1,
+                "maximum": 100,
+            }
+        },
+        "required": [],
+    },
+}
+
+
+def register(ctx):
+    """Register Vibe-Trading bridge tools."""
+    tools = [
+        ("vibe_health", VIBE_HEALTH_SCHEMA, _vibe_health),
+        ("vibe_list_skills", VIBE_LIST_SKILLS_SCHEMA, _vibe_list_skills),
+        ("vibe_list_swarm_presets", VIBE_LIST_SWARM_PRESETS_SCHEMA, _vibe_list_swarm_presets),
+        ("vibe_run_swarm", VIBE_RUN_SWARM_SCHEMA, _vibe_run_swarm),
+        ("vibe_get_swarm_run", VIBE_GET_SWARM_RUN_SCHEMA, _vibe_get_swarm_run),
+        ("vibe_create_session", VIBE_CREATE_SESSION_SCHEMA, _vibe_create_session),
+        ("vibe_send_message", VIBE_SEND_MESSAGE_SCHEMA, _vibe_send_message),
+        ("vibe_get_run_result", VIBE_GET_RUN_RESULT_SCHEMA, _vibe_get_run_result),
+        ("vibe_list_runs", VIBE_LIST_RUNS_SCHEMA, _vibe_list_runs),
+    ]
+    for name, schema, handler in tools:
+        ctx.register_tool(
+            name=name,
+            toolset=TOOLSET,
+            schema=schema,
+            handler=handler,
+            description=schema["description"],
+        )
+    logger.info("vibe-trading plugin: registered %s tools", len(tools))

--- a/plugins/vibe-trading/plugin.yaml
+++ b/plugins/vibe-trading/plugin.yaml
@@ -3,6 +3,8 @@ version: "1.0.0"
 description: Vibe-Trading API bridge for A-share research, swarm analysis, sessions, and run lookup
 author: yukun
 provides_tools:
+  - vibe_ask
+  - vibe_ask_ashare
   - vibe_health
   - vibe_list_skills
   - vibe_list_swarm_presets

--- a/plugins/vibe-trading/plugin.yaml
+++ b/plugins/vibe-trading/plugin.yaml
@@ -1,0 +1,14 @@
+name: vibe-trading
+version: "1.0.0"
+description: Vibe-Trading API bridge for A-share research, swarm analysis, sessions, and run lookup
+author: yukun
+provides_tools:
+  - vibe_health
+  - vibe_list_skills
+  - vibe_list_swarm_presets
+  - vibe_run_swarm
+  - vibe_get_swarm_run
+  - vibe_create_session
+  - vibe_send_message
+  - vibe_get_run_result
+  - vibe_list_runs

--- a/tests/plugins/test_vibe_trading_plugin.py
+++ b/tests/plugins/test_vibe_trading_plugin.py
@@ -1,0 +1,134 @@
+"""Tests for the Vibe-Trading Hermes plugin."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from urllib.error import URLError
+
+
+def _load_plugin():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "vibe-trading"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.vibe_trading",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["hermes_plugins.vibe_trading"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeResponse:
+    def __init__(self, body, status=200):
+        self.body = body.encode("utf-8")
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class FakeContext:
+    def __init__(self):
+        self.tools = {}
+
+    def register_tool(self, name, toolset, schema, handler, **kwargs):
+        self.tools[name] = {
+            "toolset": toolset,
+            "schema": schema,
+            "handler": handler,
+            "kwargs": kwargs,
+        }
+
+
+def test_request_json_uses_base_url_and_get(monkeypatch):
+    plugin = _load_plugin()
+    seen = {}
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["method"] = request.get_method()
+        seen["timeout"] = timeout
+        return FakeResponse('{"ok": true}')
+
+    monkeypatch.setenv("VIBE_TRADING_BASE_URL", "http://vibe.local:8899/")
+    monkeypatch.setattr(plugin.urllib.request, "urlopen", fake_urlopen)
+
+    result = json.loads(plugin._request_json("GET", "/health"))
+
+    assert result == {"ok": True}
+    assert seen == {
+        "url": "http://vibe.local:8899/health",
+        "method": "GET",
+        "timeout": 20.0,
+    }
+
+
+def test_request_json_posts_json_body(monkeypatch):
+    plugin = _load_plugin()
+    seen = {}
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["method"] = request.get_method()
+        seen["body"] = request.data.decode("utf-8")
+        seen["content_type"] = request.headers["Content-type"]
+        return FakeResponse('{"run_id": "r1"}')
+
+    monkeypatch.setenv("VIBE_TRADING_BASE_URL", "http://vibe.local:8899")
+    monkeypatch.setattr(plugin.urllib.request, "urlopen", fake_urlopen)
+
+    result = json.loads(plugin._request_json("POST", "/swarm/runs", {"preset_name": "risk_committee"}))
+
+    assert result == {"run_id": "r1"}
+    assert seen == {
+        "url": "http://vibe.local:8899/swarm/runs",
+        "method": "POST",
+        "body": '{"preset_name": "risk_committee"}',
+        "content_type": "application/json",
+    }
+
+
+def test_request_json_returns_error_payload_on_network_error(monkeypatch):
+    plugin = _load_plugin()
+
+    def fake_urlopen(request, timeout):
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(plugin.urllib.request, "urlopen", fake_urlopen)
+
+    result = json.loads(plugin._request_json("GET", "/health"))
+
+    assert result["success"] is False
+    assert result["error_type"] == "URLError"
+    assert "connection refused" in result["error"]
+
+
+def test_register_exposes_first_version_tools():
+    plugin = _load_plugin()
+    ctx = FakeContext()
+
+    plugin.register(ctx)
+
+    assert set(ctx.tools) == {
+        "vibe_health",
+        "vibe_list_skills",
+        "vibe_list_swarm_presets",
+        "vibe_run_swarm",
+        "vibe_get_swarm_run",
+        "vibe_create_session",
+        "vibe_send_message",
+        "vibe_get_run_result",
+        "vibe_list_runs",
+    }
+    assert ctx.tools["vibe_health"]["toolset"] == "vibe-trading"
+    assert callable(ctx.tools["vibe_run_swarm"]["handler"])
+

--- a/tests/plugins/test_vibe_trading_plugin.py
+++ b/tests/plugins/test_vibe_trading_plugin.py
@@ -237,6 +237,45 @@ def test_vibe_ask_strips_leading_think_block_with_reasoning(monkeypatch):
     assert result["answer"] == "# 最终报告"
 
 
+def test_vibe_ask_repairs_vibe_tool_call_leak_with_followup(monkeypatch):
+    plugin = _load_plugin()
+    sent_payloads = []
+    get_calls = 0
+
+    def fake_request_json(method, path, payload=None, query=None):
+        nonlocal get_calls
+        if method == "POST" and path == "/sessions":
+            return json.dumps({"session_id": "s6"})
+        if method == "POST" and path == "/sessions/s6/messages":
+            sent_payloads.append(payload)
+            return json.dumps({"message_id": f"m{len(sent_payloads)}", "attempt_id": f"a{len(sent_payloads)}"})
+        if method == "GET" and path == "/sessions/s6/messages":
+            get_calls += 1
+            if len(sent_payloads) == 1:
+                return json.dumps([
+                    {"role": "user", "content": "分析 600219.SH"},
+                    {"role": "assistant", "content": "报告前半段\n<minimax:tool_call>\n<invoke name=\"bash\">"},
+                ], ensure_ascii=False)
+            return json.dumps([
+                {"role": "user", "content": "分析 600219.SH"},
+                {"role": "assistant", "content": "报告前半段\n<minimax:tool_call>\n<invoke name=\"bash\">"},
+                {"role": "user", "content": "请重新输出最终报告"},
+                {"role": "assistant", "content": "# 干净最终报告"},
+            ], ensure_ascii=False)
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    monkeypatch.setattr(plugin, "_request_json", fake_request_json)
+
+    result = json.loads(plugin._vibe_ask({"question": "分析 600219.SH"}))
+
+    assert result["success"] is True
+    assert result["attempt_id"] == "a2"
+    assert result["answer"] == "# 干净最终报告"
+    assert len(sent_payloads) == 2
+    assert "上一条回答包含未执行的工具调用标记" in sent_payloads[1]["content"]
+    assert get_calls >= 2
+
+
 def test_vibe_ask_checks_once_more_at_timeout_boundary(monkeypatch):
     plugin = _load_plugin()
     get_calls = 0

--- a/tests/plugins/test_vibe_trading_plugin.py
+++ b/tests/plugins/test_vibe_trading_plugin.py
@@ -214,3 +214,59 @@ def test_vibe_ask_strips_empty_think_tags(monkeypatch):
     result = json.loads(plugin._vibe_ask({"question": "分析 600219.SH"}))
 
     assert result["answer"] == "最终报告"
+
+
+def test_vibe_ask_strips_leading_think_block_with_reasoning(monkeypatch):
+    plugin = _load_plugin()
+
+    def fake_request_json(method, path, payload=None, query=None):
+        if method == "POST" and path == "/sessions":
+            return json.dumps({"session_id": "s5"})
+        if method == "POST" and path == "/sessions/s5/messages":
+            return json.dumps({"message_id": "m5", "attempt_id": "a5"})
+        if method == "GET" and path == "/sessions/s5/messages":
+            return json.dumps([
+                {"role": "assistant", "content": "<think>\n内部推理\n</think>\n\n# 最终报告"},
+            ], ensure_ascii=False)
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    monkeypatch.setattr(plugin, "_request_json", fake_request_json)
+
+    result = json.loads(plugin._vibe_ask({"question": "分析 600219.SH"}))
+
+    assert result["answer"] == "# 最终报告"
+
+
+def test_vibe_ask_checks_once_more_at_timeout_boundary(monkeypatch):
+    plugin = _load_plugin()
+    get_calls = 0
+    now = {"value": 0.0}
+
+    def fake_request_json(method, path, payload=None, query=None):
+        nonlocal get_calls
+        if method == "POST" and path == "/sessions":
+            return json.dumps({"session_id": "s4"})
+        if method == "POST" and path == "/sessions/s4/messages":
+            return json.dumps({"message_id": "m4", "attempt_id": "a4"})
+        if method == "GET" and path == "/sessions/s4/messages":
+            get_calls += 1
+            if get_calls < 2:
+                return json.dumps([{"role": "user", "content": "分析 600219.SH"}])
+            return json.dumps([{"role": "assistant", "content": "边界完成报告"}], ensure_ascii=False)
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    def fake_monotonic():
+        return now["value"]
+
+    def fake_sleep(seconds):
+        now["value"] += 181.0
+
+    monkeypatch.setattr(plugin, "_request_json", fake_request_json)
+    monkeypatch.setattr(plugin.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(plugin.time, "sleep", fake_sleep)
+
+    result = json.loads(plugin._vibe_ask({"question": "分析 600219.SH"}))
+
+    assert result["success"] is True
+    assert result["answer"] == "边界完成报告"
+    assert get_calls == 2

--- a/tests/plugins/test_vibe_trading_plugin.py
+++ b/tests/plugins/test_vibe_trading_plugin.py
@@ -112,13 +112,15 @@ def test_request_json_returns_error_payload_on_network_error(monkeypatch):
     assert "connection refused" in result["error"]
 
 
-def test_register_exposes_first_version_tools():
+def test_register_exposes_phase_one_tools():
     plugin = _load_plugin()
     ctx = FakeContext()
 
     plugin.register(ctx)
 
     assert set(ctx.tools) == {
+        "vibe_ask",
+        "vibe_ask_ashare",
         "vibe_health",
         "vibe_list_skills",
         "vibe_list_swarm_presets",
@@ -132,3 +134,83 @@ def test_register_exposes_first_version_tools():
     assert ctx.tools["vibe_health"]["toolset"] == "vibe-trading"
     assert callable(ctx.tools["vibe_run_swarm"]["handler"])
 
+
+def test_vibe_ask_creates_session_sends_question_and_returns_assistant(monkeypatch):
+    plugin = _load_plugin()
+    calls = []
+
+    def fake_request_json(method, path, payload=None, query=None):
+        calls.append({"method": method, "path": path, "payload": payload, "query": query})
+        if method == "POST" and path == "/sessions":
+            return json.dumps({"session_id": "s1"})
+        if method == "POST" and path == "/sessions/s1/messages":
+            return json.dumps({"message_id": "m1", "attempt_id": "a1"})
+        if method == "GET" and path == "/sessions/s1/messages":
+            return json.dumps([
+                {"role": "user", "content": "分析 600219.SH"},
+                {"role": "assistant", "content": "南山铝业分析报告"},
+            ], ensure_ascii=False)
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    monkeypatch.setattr(plugin, "_request_json", fake_request_json)
+
+    result = json.loads(plugin._vibe_ask({"question": "分析 600219.SH"}))
+
+    assert result == {
+        "success": True,
+        "session_id": "s1",
+        "attempt_id": "a1",
+        "answer": "南山铝业分析报告",
+    }
+    assert calls[0]["payload"] == {"title": "Vibe-Trading Ask"}
+    assert calls[1]["payload"] == {"content": "分析 600219.SH"}
+    assert calls[2]["query"] == {"limit": 50}
+
+
+def test_vibe_ask_ashare_wraps_question_with_akshare_first_instruction(monkeypatch):
+    plugin = _load_plugin()
+    sent_payloads = []
+
+    def fake_request_json(method, path, payload=None, query=None):
+        if method == "POST" and path == "/sessions":
+            return json.dumps({"session_id": "s2"})
+        if method == "POST" and path == "/sessions/s2/messages":
+            sent_payloads.append(payload)
+            return json.dumps({"message_id": "m2", "attempt_id": "a2"})
+        if method == "GET" and path == "/sessions/s2/messages":
+            return json.dumps([{"role": "assistant", "content": "A股 Agent 报告"}], ensure_ascii=False)
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    monkeypatch.setattr(plugin, "_request_json", fake_request_json)
+
+    result = json.loads(plugin._vibe_ask_ashare({"question": "南山铝业600219什么位置买卖比较好"}))
+
+    assert result["success"] is True
+    assert result["answer"] == "A股 Agent 报告"
+    content = sent_payloads[0]["content"]
+    assert "南山铝业600219什么位置买卖比较好" in content
+    assert "A股" in content
+    assert "AKShare" in content
+    assert "不要默认调用 Tushare 或 QVeris" in content
+    assert "最终回答不要输出" in content
+
+
+def test_vibe_ask_strips_empty_think_tags(monkeypatch):
+    plugin = _load_plugin()
+
+    def fake_request_json(method, path, payload=None, query=None):
+        if method == "POST" and path == "/sessions":
+            return json.dumps({"session_id": "s3"})
+        if method == "POST" and path == "/sessions/s3/messages":
+            return json.dumps({"message_id": "m3", "attempt_id": "a3"})
+        if method == "GET" and path == "/sessions/s3/messages":
+            return json.dumps([
+                {"role": "assistant", "content": "<think>\n</think>\n\n最终报告"},
+            ], ensure_ascii=False)
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    monkeypatch.setattr(plugin, "_request_json", fake_request_json)
+
+    result = json.loads(plugin._vibe_ask({"question": "分析 600219.SH"}))
+
+    assert result["answer"] == "最终报告"


### PR DESCRIPTION
## Summary

This PR contains two fixes for model switching in the messaging gateway:

### 1. Determine api_mode before validation for alias model switches

When switching models via a direct alias (e.g. `/model thinking`) on the same provider (`custom`), `provider_changed` is `False` and `api_mode` retains its previous value. The alias `base_url` override cleared `api_mode` to `""` expecting re-detection, but `determine_api_mode()` ran **after** `validate_requested_model()`, causing validation to use the wrong `api_mode` and reject valid switches.

### 2. Read and persist model.api_key in gateway /model handler

The gateway `/model` handler only read `model.default/provider/base_url`, missing `model.api_key`. This caused `switch_model()` to receive an empty `current_api_key`, which resolved to `"no-key-required"` and led to 401 errors for custom endpoints with explicit API keys.

Also added `api_key` to the `--global` persistence so the key is saved when persisting model switches to config.yaml.

## Test Plan

1. Configure a custom provider with `api_mode: anthropic_messages` (e.g., `https://api.longcat.chat/anthropic`)
2. Define `model_aliases` in config.yaml pointing to the same custom endpoint
3. Switch to a model via its short alias (`/model thinking`) while already on a custom provider
4. Verify the switch succeeds with correct `api_mode` and no validation errors
5. Send a message after switching — verify no 401 error