### PR TITLE
fix(run_agent): prevent reasoning_content regression in DeepSeek/Kimi tool-call replay (#15812)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7851,7 +7851,17 @@ class AIAgent:
             api_msg["reasoning_content"] = existing
             return
 
-        # 2. DeepSeek / Kimi thinking mode: tool-call turns that lack
+        # 2. Healthy session: promote 'reasoning' field to 'reasoning_content'
+        # for providers that use the internal 'reasoning' key.
+        # This must happen BEFORE the DeepSeek/Kimi tool-call check so that
+        # genuine reasoning content is not overwritten by the empty-string
+        # fallback (#15812 regression in PR #15478).
+        normalized_reasoning = source_msg.get("reasoning")
+        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            api_msg["reasoning_content"] = normalized_reasoning
+            return
+
+        # 3. DeepSeek / Kimi thinking mode: tool-call turns that lack
         # reasoning_content are "poisoned history" — a prior provider (MiniMax,
         # etc.) left them empty. DeepSeek returns HTTP 400 if reasoning_content
         # is absent on replay; inject "" to satisfy the provider's requirement
@@ -7865,13 +7875,6 @@ class AIAgent:
         )
         if needs_empty_reasoning:
             api_msg["reasoning_content"] = ""
-            return
-
-        # 3. Healthy session: promote 'reasoning' field to 'reasoning_content'
-        # for providers that use the internal 'reasoning' key.
-        normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
-            api_msg["reasoning_content"] = normalized_reasoning
             return
 
         # 4. DeepSeek / Kimi thinking mode: all assistant messages need


### PR DESCRIPTION
## Problem

PR #15478 fixed missing `reasoning_content` for DeepSeek API calls, but introduced a regression in the logic order of `_copy_reasoning_content_for_api`.

### Regression Detail

When a message contains:
- `role: assistant`
- `tool_calls` (non-empty)
- `reasoning: "some genuine reasoning"` (from a prior provider that uses the internal `reasoning` key)
- No `reasoning_content`

The **old (buggy) order** was:
1. Preserve explicit `reasoning_content` → skip (not present)
2. **DeepSeek/Kimi tool-call check** → inject `""` → **return** → `reasoning` never promoted
3. Promote `reasoning` field → never reached

Result: genuine reasoning content is lost, replaced by empty string.

### Fix

Swap steps 2 and 3 so promotion happens before the empty-string fallback:

```
1. Preserve explicit reasoning_content
2. Promote 'reasoning' field (MOVED UP) ← fix
3. DeepSeek/Kimi tool-call empty-string fallback (MOVED DOWN)
4. Non-thinking provider cleanup
```

## Verification

`pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -v`: **21/21 passed**

Key regression test: `test_deepseek_reasoning_field_promoted` → PASSED

## References

- Fixes #15812
- Relates #15749, #15478

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Tests pass (21/21)
- [x] Only `run_agent.py` modified (single-file change)
- [x] Comments updated to explain ordering rationale
