### PR TITLE
fix: pass base_url and api_key to background review AIAgent

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3231,6 +3231,8 @@ class AIAgent:
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        base_url=self.base_url,
+                        api_key=self.api_key,
                         parent_session_id=self.session_id,
                     )
                     review_agent._memory_write_origin = "background_review"


### PR DESCRIPTION
## Problem

`_spawn_background_review()` creates a background review `AIAgent` without passing `base_url` or `api_key`. When the main agent uses a custom or fallback provider (e.g. OpenRouter, Cerebras, SiliconFlow), the review agent cannot:

1. Look up per-model context overrides from `custom_providers` (which requires `base_url` to match)
2. Query custom endpoint `/models` APIs for context length detection

This causes the review agent to fall through to live API detection, which may return the model's real context window and trigger the `MINIMUM_CONTEXT_LENGTH` (64K) guard — silently killing the review thread.

## Fix

Pass `base_url` and `api_key` through to the review `AIAgent` constructor so it inherits the same provider configuration as the main agent.

## Testing

- `python3 -m py_compile run_agent.py` — passes
- `python3 -m pytest tests/run_agent/test_background_review_summary.py -v` — 8/8 passed
- Verified the fix is present via `inspect.getsource(AIAgent._spawn_background_review)`

Closes #15882