### PR TITLE
fix(gateway): use venv/bin/hermes in launchd ProgramArguments so Login Item shows "hermes" (#15636)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2010,7 +2010,6 @@ def _launchd_domain() -> str:
 
 
 def generate_launchd_plist() -> str:
-    python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
     hermes_home = str(get_hermes_home().resolve())
     log_dir = get_hermes_home() / "logs"
@@ -2038,11 +2037,12 @@ def generate_launchd_plist() -> str:
         dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
     )
 
+    # Use the venv hermes entry-point so macOS registers the Login Item as
+    # "hermes" rather than "python" in System Settings → Login Items & Extensions.
+    hermes_bin = f"{venv_bin}/hermes"
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
+        f"<string>{hermes_bin}</string>",
     ]
     if profile_arg:
         for part in profile_arg.split():

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -147,6 +147,42 @@ class TestLaunchdPlistReplace:
         replace_idx = string_values.index("--replace")
         assert replace_idx == run_idx + 1
 
+    def test_plist_uses_hermes_binary_not_python(self):
+        """First ProgramArguments entry is the hermes entry-point, not python.
+
+        macOS names the Login Item after ProgramArguments[0]; using the hermes
+        binary instead of the Python interpreter fixes the confusing "python"
+        attribution in System Settings → Login Items & Extensions.
+        """
+        plist = gateway_cli.generate_launchd_plist()
+        # Extract only the strings inside the <array> that follows <key>ProgramArguments</key>
+        lines = [line.strip() for line in plist.splitlines()]
+        in_prog_args = False
+        prog_arg_values: list[str] = []
+        for line in lines:
+            if "<key>ProgramArguments</key>" in line:
+                in_prog_args = True
+                continue
+            if in_prog_args:
+                if "<array>" in line:
+                    continue
+                if "</array>" in line:
+                    break
+                if "<string>" in line and "</string>" in line:
+                    prog_arg_values.append(
+                        line.replace("<string>", "").replace("</string>", "")
+                    )
+        assert prog_arg_values, "ProgramArguments array is empty"
+        # First ProgramArgument must end with /hermes, not python/python3
+        first_arg = prog_arg_values[0]
+        assert first_arg.endswith("/hermes"), (
+            f"Expected first ProgramArgument to end with '/hermes', got: {first_arg!r}"
+        )
+        assert "-m" not in prog_arg_values, "'-m' flag should not appear in ProgramArguments"
+        assert "hermes_cli.main" not in prog_arg_values, (
+            "'hermes_cli.main' should not appear in ProgramArguments"
+        )
+
 
 class TestLaunchdPlistPath:
     def test_plist_contains_environment_variables(self):


### PR DESCRIPTION
## Summary
- `generate_launchd_plist()` switched from `python -m hermes_cli.main` to `venv/bin/hermes` as `ProgramArguments[0]`
- macOS now shows **hermes** (not **python**) in System Settings → Login Items & Extensions
- Removes the now-unused `python_path` local variable

## The bug

macOS derives the Login Item display name from `ProgramArguments[0]`. The old plist started with the Python interpreter path (`/path/to/venv/bin/python3`), so the notification banner and System Settings listed the agent as **python** — indistinguishable from any other Python script running as a Login Item.

## The fix

`venv/bin/hermes` is the setuptools console-script entry-point installed by `pip install -e .`. Its shebang is the same venv Python; at runtime it calls `hermes_cli.main:main()` identically to the old `-m hermes_cli.main` form. The existing `PATH`, `VIRTUAL_ENV`, and `HERMES_HOME` environment variables in the plist already ensure the correct virtualenv is active.

Existing installations with the old plist will have `launchd_plist_is_current()` return `False` on next gateway start, triggering `refresh_launchd_plist_if_needed()` to update the on-disk plist automatically.

## Test plan
- [x] **Before**: `test_plist_uses_hermes_binary_not_python` fails — old `ProgramArguments[0]` is the Python interpreter path, `endswith("/hermes")` is False; `-m` and `hermes_cli.main` appear in the array
- [x] **After**: 42/42 tests in `test_update_gateway_restart.py` pass
- [x] **Regression guard**: reverted the fix → observed `AssertionError: Expected first ProgramArgument to end with '/hermes', got: '/path/to/venv/bin/python3'`; restored → 0 failures
- [x] **Baseline verified**: `test_systemd_start_refreshes_outdated_unit` fails on clean `origin/main` (macOS: no D-Bus/systemd); unrelated to this change
- [x] Adjacent suite: `tests/hermes_cli/` — 1061 passed, 2 skipped, 1 pre-existing baseline, 0 new failures

## Related
- Fixes #15636

🤖 Generated with [Claude Code](https://claude.com/claude-code)