### PR TITLE
fix: append cron activity diagnostics to output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -986,7 +986,22 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
-        
+
+        _memory_diag = None
+        if hasattr(agent, "get_activity_summary"):
+            try:
+                _candidate_diag = agent.get_activity_summary()
+                if isinstance(_candidate_diag, dict):
+                    _memory_diag = _candidate_diag
+                elif _candidate_diag is not None:
+                    logger.debug(
+                        "Job '%s': skipping non-dict activity summary of type %s",
+                        job_id,
+                        type(_candidate_diag).__name__,
+                    )
+            except Exception as diag_exc:
+                logger.debug("Job '%s': failed to capture activity summary: %s", job_id, diag_exc)
+
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
@@ -1000,6 +1015,16 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 ## Response
 
 {logged_response}
+"""
+        if _memory_diag:
+            _diag_json = json.dumps(_memory_diag, ensure_ascii=False, indent=2, sort_keys=True)
+            output += f"""
+
+## Memory Diagnostics
+
+```json
+{_diag_json}
+```
 """
         
         logger.info("Job '%s' completed successfully", job_name)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -805,6 +805,86 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         fake_db.close.assert_called_once()
 
+    def test_run_job_appends_memory_diagnostics_to_output(self, tmp_path):
+        job = {
+            "id": "diag-job",
+            "name": "diag test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        activity = {
+            "last_activity_desc": "tool_call:read_file",
+            "seconds_since_activity": 0.2,
+            "current_tool": "read_file",
+            "api_call_count": 3,
+            "max_iterations": 90,
+            "budget_used": 12,
+            "budget_max": 200,
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent.get_activity_summary.return_value = activity
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "## Memory Diagnostics" in output
+        assert '"current_tool": "read_file"' in output
+        assert '"budget_used": 12' in output
+
+    def test_run_job_skips_memory_diagnostics_when_summary_unavailable(self, tmp_path):
+        job = {
+            "id": "diag-missing",
+            "name": "diag missing",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent.get_activity_summary.side_effect = RuntimeError("summary unavailable")
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "## Memory Diagnostics" not in output
+
 
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""


### PR DESCRIPTION
## Summary
- append optional cron activity diagnostics to the saved cron output
- only include diagnostics when `get_activity_summary()` returns a dict
- add tests for both available and unavailable summary paths

## Test Plan
- [x] `pytest -q tests/cron/test_scheduler.py -k "memory_diagnostics or session_persistence"`