### PR TITLE
fix(dashboard): show custom theme palette swatches

### DIFF
--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Palette, Check } from "lucide-react";
 import { Typography } from "@nous-research/ui";
 import { BUILTIN_THEMES, useTheme } from "@/themes";
+import type { DashboardTheme } from "@/themes";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
 
@@ -9,8 +10,8 @@ import { cn } from "@/lib/utils";
  * Compact theme picker mounted next to the language switcher in the header.
  * Each dropdown row shows a 3-stop swatch (background / midground / warm
  * glow) so users can preview the palette before committing. User-defined
- * themes from `~/.hermes/dashboard-themes/*.yaml` that aren't in
- * `BUILTIN_THEMES` render without swatches and apply the default palette.
+ * themes from `~/.hermes/dashboard-themes/*.yaml` use their API-provided
+ * definitions so they show real palette swatches just like built-ins.
  *
  * When placed at the bottom of a container (e.g. the sidebar rail), pass
  * `dropUp` so the menu opens above the trigger instead of clipping below
@@ -94,7 +95,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
 
           {availableThemes.map((th) => {
             const isActive = th.name === themeName;
-            const preset = BUILTIN_THEMES[th.name];
+            const paletteTheme = BUILTIN_THEMES[th.name] ?? th.definition;
 
             return (
               <button
@@ -112,8 +113,8 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
                   isActive ? "text-midground" : "text-midground/60",
                 )}
               >
-                {preset ? (
-                  <ThemeSwatch theme={preset.name} />
+                {paletteTheme ? (
+                  <ThemeSwatch theme={paletteTheme} />
                 ) : (
                   <PlaceholderSwatch />
                 )}
@@ -147,10 +148,8 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
   );
 }
 
-function ThemeSwatch({ theme }: { theme: string }) {
-  const preset = BUILTIN_THEMES[theme];
-  if (!preset) return <PlaceholderSwatch />;
-  const { background, midground, warmGlow } = preset.palette;
+function ThemeSwatch({ theme }: { theme: DashboardTheme }) {
+  const { background, midground, warmGlow } = theme.palette;
   return (
     <div
       aria-hidden

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -311,9 +311,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   /** All selectable themes (shown in the picker). Starts with just the
    *  built-ins; the API call below merges in user themes. */
-  const [availableThemes, setAvailableThemes] = useState<
-    Array<{ description: string; label: string; name: string }>
-  >(() =>
+  const [availableThemes, setAvailableThemes] = useState<ThemeSummary[]>(() =>
     Object.values(BUILTIN_THEMES).map((t) => ({
       name: t.name,
       label: t.label,
@@ -360,6 +358,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
               name: t.name,
               label: t.label,
               description: t.description,
+              definition: t.definition,
             })),
           );
           // Index any definitions the server shipped (user themes).
@@ -430,8 +429,15 @@ const ThemeContext = createContext<ThemeContextValue>({
 });
 
 interface ThemeContextValue {
-  availableThemes: Array<{ description: string; label: string; name: string }>;
+  availableThemes: ThemeSummary[];
   setTheme: (name: string) => void;
   theme: DashboardTheme;
   themeName: string;
+}
+
+interface ThemeSummary {
+  description: string;
+  label: string;
+  name: string;
+  definition?: DashboardTheme;
 }


### PR DESCRIPTION
## Bug Description

Custom dashboard themes loaded from `~/.hermes/dashboard-themes/*.yaml` appeared in the theme picker, but their palette preview rendered as a blank dashed placeholder instead of the theme's actual colors.

## Root Cause

The dashboard theme API already returns full `definition` objects for user-defined themes, but the frontend dropped those definitions when mapping the API response into `availableThemes`.

`ThemeSwitcher` then only looked up preview palettes in `BUILTIN_THEMES`, so custom themes had no palette available for the swatch renderer.

## Fix

- Preserve API-provided custom theme definitions in the theme context's `availableThemes`
- Render swatches from either a built-in theme or the custom theme definition
- Keep the fallback placeholder only for themes that genuinely do not have a palette definition

## Verification

- `npm --prefix web run build`
- Opened the live dashboard at `http://127.0.0.1:9119/analytics`
- Verified the theme switcher shows real three-color swatches for `Studio Grid` and `Studio Grid Dark` custom themes

## Existing Baseline Issues

`npm --prefix web run lint` currently fails on existing unrelated dashboard lint issues, including files such as:
- `web/src/components/OAuthProvidersCard.tsx`
- `web/src/components/Toast.tsx`
- `web/src/pages/ConfigPage.tsx`
- `web/src/pages/SessionsPage.tsx`
- `web/src/plugins/PluginPage.tsx`

No new lint failures were introduced by this change.

## Risk Assessment

Low. The change only preserves custom theme metadata already returned by the API and uses it for palette previews in the theme switcher. Built-in theme behavior is unchanged.
