### PR TITLE
fix(cli): check updates against upstream/main for fork users

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5888,13 +5888,29 @@ def _cmd_update_check():
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
-    print("→ Fetching from origin...")
+    # Fetch both origin and upstream; prefer upstream as the canonical reference
+    print("→ Fetching from upstream...")
     fetch_result = subprocess.run(
-        git_cmd + ["fetch", "origin"],
+        git_cmd + ["fetch", "upstream"],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
     )
+    if fetch_result.returncode != 0:
+        # Fallback to origin if upstream doesn't exist
+        print("→ Fetching from origin...")
+        fetch_result = subprocess.run(
+            git_cmd + ["fetch", "origin"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        upstream_exists = False
+        compare_branch = "origin/main"
+    else:
+        upstream_exists = True
+        compare_branch = "upstream/main"
+
     if fetch_result.returncode != 0:
         stderr = fetch_result.stderr.strip()
         if "Could not resolve host" in stderr or "unable to access" in stderr:
@@ -5902,13 +5918,13 @@ def _cmd_update_check():
         elif "Authentication failed" in stderr or "could not read Username" in stderr:
             print("✗ Authentication failed — check your git credentials or SSH key.")
         else:
-            print("✗ Failed to fetch from origin.")
+            print("✗ Failed to fetch.")
             if stderr:
                 print(f"  {stderr.splitlines()[0]}")
         sys.exit(1)
 
     rev_result = subprocess.run(
-        git_cmd + ["rev-list", "HEAD..origin/main", "--count"],
+        git_cmd + ["rev-list", f"HEAD..{compare_branch}", "--count"],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -5920,7 +5936,7 @@ def _cmd_update_check():
         print("✓ Already up to date.")
     else:
         commits_word = "commit" if behind == 1 else "commits"
-        print(f"⚕ Update available: {behind} {commits_word} behind origin/main.")
+        print(f"⚕ Update available: {behind} {commits_word} behind {compare_branch}.")
         from hermes_cli.config import recommended_update_command
         print(f"  Run '{recommended_update_command()}' to install.")
 


### PR DESCRIPTION
## What

When a user runs `hermes update --check` on a fork of hermes-agent, the command currently fetches from `origin` (the fork) and compares against `origin/main`. This means it always reports "already up to date" even when the upstream NousResearch/hermes-agent has new commits.

## Why

Fork users need to compare against `upstream/main` (the canonical source of truth) rather than their own `origin/main`. The `hermes update` command itself already handles fork detection and pulls from the correct remote, but `--check` was not updated to do the same.

## How

In `_cmd_update_check()`, the code now:
1. Fetches from `upstream` first (falls back to `origin` if upstream remote does not exist)
2. Compares `HEAD..upstream/main` for the behind count
3. Reports the correct number of commits behind the canonical source

For non-fork users (using the official repo directly), behavior is unchanged — `origin` points to `NousResearch/hermes-agent`, so `upstream` and `origin` are equivalent.

## Testing

- [x] Fork user: `hermes update --check` now correctly reports commits behind `upstream/main`
- [x] Official repo user: behavior unchanged (origin == upstream)
- [x] `hermes update` still works correctly for both fork and official users

## Platforms tested

- Linux (Ubuntu)
