### PR TITLE
fix(auxiliary): normalize Codex transcript roles

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -381,16 +381,42 @@ class _CodexCompletionsAdapter:
         # API format (input_text / input_image instead of text / image_url).
         instructions = "You are a helpful assistant."
         input_msgs: List[Dict[str, Any]] = []
+        allowed_input_roles = {"user", "assistant", "developer"}
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
-            else:
-                input_msgs.append({
-                    "role": role,
-                    "content": _convert_content_for_responses(content),
-                })
+                continue
+
+            if role == "tool":
+                # The Codex Responses endpoint used for auxiliary tasks does
+                # not accept chat-completions ``tool`` messages in ``input``
+                # (HTTP 400: supported roles are assistant/system/developer/user).
+                # Preserve the useful transcript content for summarisation /
+                # memory flush, but present it as a user-readable transcript
+                # note instead of an invalid role.
+                tool_name = msg.get("name") or msg.get("tool_name") or "tool"
+                tool_call_id = msg.get("tool_call_id")
+                if not isinstance(content, str):
+                    try:
+                        content = json.dumps(content, ensure_ascii=False)
+                    except Exception:
+                        content = str(content)
+                label = f"Tool result from {tool_name}"
+                if tool_call_id:
+                    label += f" ({tool_call_id})"
+                role = "user"
+                content = f"[{label}:\n{content}]"
+            elif role not in allowed_input_roles:
+                # Be conservative for transcript-only auxiliary calls: keep
+                # unknown-role content, but remap it to a legal user message.
+                role = "user"
+
+            input_msgs.append({
+                "role": role,
+                "content": _convert_content_for_responses(content),
+            })
 
         resp_kwargs: Dict[str, Any] = {
             "model": model,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -517,6 +517,72 @@ class TestGetTextAuxiliaryClient:
         assert model == "gpt-5.2-codex"
 
 
+class TestCodexAuxiliaryAdapterRoleNormalization:
+    def test_tool_messages_are_remapped_before_responses_call(self):
+        """Codex auxiliary calls use Responses API, which rejects role='tool'.
+
+        Memory flush passes full chat transcripts that can include tool-result
+        messages. The adapter should preserve those results as transcript text
+        while sending only roles accepted by the backend.
+        """
+        captured = {}
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([])
+
+            def get_final_response(self):
+                return MagicMock(
+                    output=[
+                        MagicMock(
+                            type="message",
+                            content=[MagicMock(type="output_text", text="ok")],
+                        )
+                    ],
+                    usage=None,
+                )
+
+        class _FakeResponses:
+            def stream(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeStream()
+
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        adapter = _CodexCompletionsAdapter(
+            MagicMock(responses=_FakeResponses()),
+            "gpt-5.2-codex",
+        )
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "I will call a tool"},
+                {
+                    "role": "tool",
+                    "tool_name": "browser_console",
+                    "tool_call_id": "call_1",
+                    "content": {"result": 42},
+                },
+                {"role": "narrator", "content": "custom role text"},
+            ],
+        )
+
+        assert captured["instructions"] == "sys"
+        roles = [msg["role"] for msg in captured["input"]]
+        assert roles == ["user", "assistant", "user", "user"]
+        assert "tool" not in roles
+        assert "Tool result from browser_console (call_1)" in captured["input"][2]["content"]
+        assert '"result": 42' in captured["input"][2]["content"]
+        assert "custom role text" == captured["input"][3]["content"]
+
+
 class TestNousAuxiliaryRefresh:
     def test_try_nous_prefers_runtime_credentials(self):
         fresh_base = "https://inference-api.nousresearch.com/v1"


### PR DESCRIPTION
## Summary
- Remap `tool` transcript messages before sending auxiliary chat-completions calls through the Codex Responses adapter.
- Preserve tool outputs as labeled transcript text instead of dropping them.
- Conservatively remap unknown transcript roles to `user` so Responses API role validation cannot fail memory flushes.
- Add regression coverage for tool-role, unknown-role, and non-string tool-result content.

## Test Plan
- `python -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='`
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
- `git diff --check -- agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- Added-line security scan: no findings

## Notes
This fixes Telegram/Gateway auxiliary memory flush failures like:
`HTTP 400: Invalid value: 'tool'. Supported values are: 'assistant', 'system', 'developer', and 'user'.`
