### PR TITLE
docs(readme): add hermes-multitenancy to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ scripts/run_tests.sh
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🌐 [hermes-multitenancy](https://github.com/eggyrooch-blip/hermes-multitenancy) — Community Feishu multi-tenant router: One Feishu bot serving N users, each routed to their own profile (independent SOUL, sessions, memories). Plugin only — zero patches to hermes-agent.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds a single bullet to the **Community** section of the README pointing to [hermes-multitenancy](https://github.com/eggyrooch-blip/hermes-multitenancy), a community plugin that uses the new `pre_gateway_dispatch` hook to route Feishu messages from N users to N independent hermes profiles (one bot serves the whole org; each user gets their own SOUL / sessions / memories).

This mirrors the existing HermesClaw entry one line above — same format, same level of detail. Happy to close if showcase entries aren't desired.

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- `README.md` — added one bullet to the Community section.

## How to Test
```
grep -A1 HermesClaw README.md
```
The new entry appears immediately after the HermesClaw line.

## Why this might be useful upstream
The plugin is a real-world stress test of `pre_gateway_dispatch` (introduced 2026-04-21 in 1ef1e4c6) plus `BasePlatformAdapter.edit_message / on_processing_start / on_processing_complete`. End-to-end verified against real Feishu; 71 unit tests + 3 live-LLM integration tests; hermes-agent itself is unmodified (`git diff` shows zero touches outside this README).

## Checklist
- [x] Read [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Conventional Commits (`docs(readme):`)
- [x] No duplicate PR
- [x] Only README change
- [x] N/A — no code, no tests, no schema, no config