### PR TITLE
fix: enable fast mode for gpt-5.5

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1592,6 +1592,7 @@ def provider_label(provider: Optional[str]) -> str:
 # See https://openai.com/api-priority-processing/ for the canonical list.
 # Only the bare model slug is stored (no vendor prefix).
 _PRIORITY_PROCESSING_MODELS: frozenset[str] = frozenset({
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.2",

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
     is_nous_free_tier, partition_nous_models_by_tier,
-    check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    check_nous_free_tier, _FREE_TIER_CACHE_TTL, model_supports_fast_mode,
 )
 import hermes_cli.models as _models_mod
 
@@ -15,6 +15,14 @@ LIVE_OPENROUTER_MODELS = [
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
 ]
 
+
+
+class TestModelFastMode:
+    def test_gpt_55_supports_fast_mode(self):
+        assert model_supports_fast_mode("gpt-5.5") is True
+
+    def test_prefixed_gpt_55_supports_fast_mode(self):
+        assert model_supports_fast_mode("openai-codex/gpt-5.5") is True
 
 
 class TestModelIds:


### PR DESCRIPTION
## Summary
- add gpt-5.5 to the OpenAI Priority Processing model allowlist
- add coverage for bare and openai-codex-prefixed gpt-5.5 model IDs so /fast is exposed correctly

## Test Plan
- ~/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/models.py tests/hermes_cli/test_models.py
- ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_models.py -q