### PR TITLE
Fix config-driven context length resolution

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5347,9 +5347,57 @@ class HermesCLI:
         if result.api_mode:
             self.api_mode = result.api_mode
 
+        # Recompute the effective config override for the newly selected runtime.
+        # This mirrors AIAgent init so /model confirmation text stays aligned with
+        # the live agent when providers share a base_url but have different
+        # per-model context lengths.
+        _display_ctx = None
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            _cfg = load_config()
+            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+            if _display_ctx is None:
+                _custom_providers = get_compatible_custom_providers(_cfg)
+                _normalized_base_url = (result.base_url or self.base_url or "").rstrip("/")
+                _normalized_provider = (result.target_provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
+        self._config_context_length = _display_ctx
+
         # Apply to running agent (in-place swap)
         if self.agent is not None:
             try:
+                self.agent._config_context_length = _display_ctx
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
@@ -5385,6 +5433,7 @@ class HermesCLI:
             base_url=result.base_url or self.base_url or "",
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
+            config_context_length=_display_ctx,
         )
         if ctx:
             _cprint(f"    Context: {ctx:,} tokens")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4328,8 +4328,8 @@ class GatewayRunner:
 
                 # Check custom_providers per-model context_length
                 # (same fallback as run_agent.py lines 1171-1189).
-                # Must run after runtime resolution so _hyg_base_url is set.
-                if _hyg_config_context_length is None and _hyg_base_url:
+                # Must run after runtime resolution so provider/base_url are set.
+                if _hyg_config_context_length is None:
                     try:
                         try:
                             from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
@@ -4338,19 +4338,27 @@ class GatewayRunner:
                             _hyg_custom_providers = _hyg_data.get("custom_providers")
                             if not isinstance(_hyg_custom_providers, list):
                                 _hyg_custom_providers = []
+                        _hyg_base_url_norm = (_hyg_base_url or "").rstrip("/")
+                        _hyg_provider_norm = str(_hyg_provider or "").strip().lower()
                         for _cp in _hyg_custom_providers:
                             if not isinstance(_cp, dict):
                                 continue
                             _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                            if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                _cp_models = _cp.get("models", {})
-                                if isinstance(_cp_models, dict):
-                                    _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                    if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
-                                        if _cp_ctx is not None:
-                                            _hyg_config_context_length = int(_cp_ctx)
-                                break
+                            if _cp_url and _hyg_base_url_norm and _cp_url != _hyg_base_url_norm:
+                                continue
+                            if _cp_url and not _hyg_base_url_norm:
+                                continue
+                            _cp_provider_key = str(_cp.get("provider_key", "") or "").strip().lower()
+                            if _hyg_provider_norm and _cp_provider_key and _cp_provider_key != _hyg_provider_norm:
+                                continue
+                            _cp_models = _cp.get("models", {})
+                            if isinstance(_cp_models, dict):
+                                _cp_model_cfg = _cp_models.get(_hyg_model, {})
+                                if isinstance(_cp_model_cfg, dict):
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is not None:
+                                        _hyg_config_context_length = int(_cp_ctx)
+                                        break
                     except (TypeError, ValueError):
                         pass
             except Exception:
@@ -5536,6 +5544,7 @@ class GatewayRunner:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        cfg = {}
         config_path = _hermes_home / "config.yaml"
         try:
             if config_path.exists():
@@ -5614,6 +5623,48 @@ class GatewayRunner:
                         if not result.success:
                             return f"Error: {result.error_message}"
 
+                        _display_ctx = None
+                        try:
+                            _cfg = load_config()
+                            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+                            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+                            if _raw_ctx is not None:
+                                try:
+                                    _display_ctx = int(_raw_ctx)
+                                except (TypeError, ValueError):
+                                    _display_ctx = None
+                            if _display_ctx is None:
+                                from hermes_cli.config import get_compatible_custom_providers
+                                _custom_providers = get_compatible_custom_providers(_cfg)
+                                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                                _normalized_provider = (result.target_provider or "").strip().lower()
+                                for _cp_entry in _custom_providers:
+                                    if not isinstance(_cp_entry, dict):
+                                        continue
+                                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                                    if _cp_url and _cp_url != _normalized_base_url:
+                                        continue
+                                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                                        continue
+                                    _cp_models = _cp_entry.get("models", {})
+                                    if not isinstance(_cp_models, dict):
+                                        continue
+                                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                                    if not isinstance(_cp_model_cfg, dict):
+                                        continue
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is None:
+                                        continue
+                                    try:
+                                        _display_ctx = int(_cp_ctx)
+                                    except (TypeError, ValueError):
+                                        _display_ctx = None
+                                    else:
+                                        break
+                        except Exception:
+                            _display_ctx = None
+
                         # Update cached agent in-place
                         cached_entry = None
                         _cache_lock = getattr(_self, "_agent_cache_lock", None)
@@ -5623,6 +5674,7 @@ class GatewayRunner:
                                 cached_entry = _cache.get(_session_key)
                         if cached_entry and cached_entry[0] is not None:
                             try:
+                                cached_entry[0]._config_context_length = _display_ctx
                                 cached_entry[0].switch_model(
                                     new_model=result.new_model,
                                     new_provider=result.target_provider,
@@ -5660,12 +5712,54 @@ class GatewayRunner:
                         lines.append(f"Provider: {plabel}")
                         mi = result.model_info
                         from hermes_cli.model_switch import resolve_display_context_length
+                        _display_ctx = None
+                        try:
+                            _cfg = load_config()
+                            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+                            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+                            if _raw_ctx is not None:
+                                try:
+                                    _display_ctx = int(_raw_ctx)
+                                except (TypeError, ValueError):
+                                    _display_ctx = None
+                            if _display_ctx is None:
+                                from hermes_cli.config import get_compatible_custom_providers
+                                _custom_providers = get_compatible_custom_providers(_cfg)
+                                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                                _normalized_provider = (result.target_provider or "").strip().lower()
+                                for _cp_entry in _custom_providers:
+                                    if not isinstance(_cp_entry, dict):
+                                        continue
+                                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                                    if _cp_url and _cp_url != _normalized_base_url:
+                                        continue
+                                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                                        continue
+                                    _cp_models = _cp_entry.get("models", {})
+                                    if not isinstance(_cp_models, dict):
+                                        continue
+                                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                                    if not isinstance(_cp_model_cfg, dict):
+                                        continue
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is None:
+                                        continue
+                                    try:
+                                        _display_ctx = int(_cp_ctx)
+                                    except (TypeError, ValueError):
+                                        _display_ctx = None
+                                    else:
+                                        break
+                        except Exception:
+                            _display_ctx = None
                         ctx = resolve_display_context_length(
                             result.new_model,
                             result.target_provider,
                             base_url=result.base_url or current_base_url or "",
                             api_key=result.api_key or current_api_key or "",
                             model_info=mi,
+                            config_context_length=_display_ctx,
                         )
                         if ctx:
                             lines.append(f"Context: {ctx:,} tokens")
@@ -5737,6 +5831,47 @@ class GatewayRunner:
         if not result.success:
             return f"Error: {result.error_message}"
 
+        _display_ctx = None
+        try:
+            _model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+            if _display_ctx is None:
+                from hermes_cli.config import get_compatible_custom_providers
+                _custom_providers = get_compatible_custom_providers(cfg)
+                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                _normalized_provider = (result.target_provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
+
         # If there's a cached agent, update it in-place
         cached_entry = None
         _cache_lock = getattr(self, "_agent_cache_lock", None)
@@ -5747,6 +5882,7 @@ class GatewayRunner:
 
         if cached_entry and cached_entry[0] is not None:
             try:
+                cached_entry[0]._config_context_length = _display_ctx
                 cached_entry[0].switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
@@ -5807,12 +5943,53 @@ class GatewayRunner:
         # Copilot, and Nous-enforced caps win over the raw models.dev entry.
         mi = result.model_info
         from hermes_cli.model_switch import resolve_display_context_length
+        _display_ctx = None
+        try:
+            _model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+            if _display_ctx is None:
+                from hermes_cli.config import get_compatible_custom_providers
+                _custom_providers = get_compatible_custom_providers(cfg)
+                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                _normalized_provider = (result.target_provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
         ctx = resolve_display_context_length(
             result.new_model,
             result.target_provider,
             base_url=result.base_url or current_base_url or "",
             api_key=result.api_key or current_api_key or "",
             model_info=mi,
+            config_context_length=_display_ctx,
         )
         if ctx:
             lines.append(f"Context: {ctx:,} tokens")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -533,6 +533,7 @@ def resolve_display_context_length(
     base_url: str = "",
     api_key: str = "",
     model_info: Optional[ModelInfo] = None,
+    config_context_length: Optional[int] = None,
 ) -> Optional[int]:
     """Resolve the context length to show in /model output.
 
@@ -552,6 +553,7 @@ def resolve_display_context_length(
             model,
             base_url=base_url or "",
             api_key=api_key or "",
+            config_context_length=config_context_length,
             provider=provider or None,
         )
         if ctx:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1764,10 +1764,7 @@ class AIAgent:
                 )
                 _config_context_length = None
 
-        # Store for reuse in switch_model (so config override persists across model switches)
-        self._config_context_length = _config_context_length
-
-        # Check custom_providers per-model context_length
+        # Check custom_providers / providers per-model context_length
         if _config_context_length is None:
             try:
                 from hermes_cli.config import get_compatible_custom_providers
@@ -1776,34 +1773,44 @@ class AIAgent:
                 _custom_providers = _agent_cfg.get("custom_providers")
                 if not isinstance(_custom_providers, list):
                     _custom_providers = []
+            _normalized_base_url = self.base_url.rstrip("/")
+            _normalized_provider = (self.provider or "").strip().lower()
             for _cp_entry in _custom_providers:
                 if not isinstance(_cp_entry, dict):
                     continue
                 _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                if _cp_url and _cp_url == self.base_url.rstrip("/"):
-                    _cp_models = _cp_entry.get("models", {})
-                    if isinstance(_cp_models, dict):
-                        _cp_model_cfg = _cp_models.get(self.model, {})
-                        if isinstance(_cp_model_cfg, dict):
-                            _cp_ctx = _cp_model_cfg.get("context_length")
-                            if _cp_ctx is not None:
-                                try:
-                                    _config_context_length = int(_cp_ctx)
-                                except (TypeError, ValueError):
-                                    logger.warning(
-                                        "Invalid context_length for model %r in "
-                                        "custom_providers: %r — must be a plain "
-                                        "integer (e.g. 256000, not '256K'). "
-                                        "Falling back to auto-detection.",
-                                        self.model, _cp_ctx,
-                                    )
-                                    print(
-                                        f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
-                                        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                                        f"  Falling back to auto-detected context window.\n",
-                                        file=sys.stderr,
-                                    )
-                    break
+                if _cp_url and _cp_url != _normalized_base_url:
+                    continue
+                _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                    continue
+                _cp_models = _cp_entry.get("models", {})
+                if isinstance(_cp_models, dict):
+                    _cp_model_cfg = _cp_models.get(self.model, {})
+                    if isinstance(_cp_model_cfg, dict):
+                        _cp_ctx = _cp_model_cfg.get("context_length")
+                        if _cp_ctx is not None:
+                            try:
+                                _config_context_length = int(_cp_ctx)
+                            except (TypeError, ValueError):
+                                logger.warning(
+                                    "Invalid context_length for model %r in "
+                                    "custom_providers: %r — must be a plain "
+                                    "integer (e.g. 256000, not '256K'). "
+                                    "Falling back to auto-detection.",
+                                    self.model, _cp_ctx,
+                                )
+                                print(
+                                    f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
+                                    f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+                                    f"  Falling back to auto-detected context window.\n",
+                                    file=sys.stderr,
+                                )
+                            else:
+                                break
+
+        # Store for reuse in switch_model (so config override persists across model switches)
+        self._config_context_length = _config_context_length
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -2394,11 +2401,15 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            client_provider = getattr(client, "provider", None)
+            if not isinstance(client_provider, str):
+                client_provider = ""
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                provider=client_provider,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -75,16 +75,26 @@ class TestResolveDisplayContextLength:
             )
         assert ctx == 200_000
 
-    def test_prefers_resolver_even_when_model_info_has_larger_value(self):
-        """Invariant: provider-aware resolver is authoritative, even if models.dev
-        reports a bigger window."""
-        fake_mi = _FakeModelInfo(2_000_000)
+    def test_prefers_explicit_config_context_override_for_custom_provider(self):
+        fake_mi = _FakeModelInfo(128_000)
         with patch(
-            "agent.model_metadata.get_model_context_length", return_value=128_000
-        ):
+            "agent.model_metadata.get_model_context_length",
+            return_value=204_800,
+        ) as mock_get_ctx:
             ctx = resolve_display_context_length(
-                "capped-model",
-                "capped-provider",
+                "MiniMax-M2.7",
+                "ai-api-chat",
+                base_url="https://ai-api.home.sadlay.cn:22843/v1",
+                api_key="sk-test",
                 model_info=fake_mi,
+                config_context_length=204_800,
             )
-        assert ctx == 128_000
+        assert ctx == 204_800
+        mock_get_ctx.assert_called_once_with(
+            "MiniMax-M2.7",
+            base_url="https://ai-api.home.sadlay.cn:22843/v1",
+            api_key="sk-test",
+            config_context_length=204_800,
+            provider="ai-api-chat",
+        )
+

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -170,6 +170,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     mock_client = MagicMock()
     mock_client.base_url = "http://custom-endpoint:8080/v1"
     mock_client.api_key = "sk-custom"
+    mock_client.provider = ""
     mock_get_client.return_value = (mock_client, "custom/big-model")
 
     agent._emit_status = lambda msg: None
@@ -180,6 +181,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        provider="",
     )
 
 
@@ -192,6 +194,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     mock_client = MagicMock()
     mock_client.base_url = "http://custom:8080/v1"
     mock_client.api_key = "sk-test"
+    mock_client.provider = ""
     mock_get_client.return_value = (mock_client, "custom/model")
 
     agent._emit_status = lambda msg: None
@@ -202,6 +205,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
+        provider="",
     )
 
 
@@ -230,6 +234,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
     mock_client = MagicMock()
     mock_client.base_url = "http://custom-endpoint:8080/v1"
     mock_client.api_key = "sk-custom"
+    mock_client.provider = ""
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
@@ -254,7 +259,65 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        provider="",
     )
+
+
+def test_init_prefers_provider_specific_context_override_when_base_urls_match():
+    """When multiple providers share a base_url, AIAgent should use the entry
+    matching the active provider instead of the first base_url match."""
+
+    class _StubCompressor:
+        def __init__(self, *args, **kwargs):
+            self.context_length = kwargs.get("config_context_length") or 128_000
+            self.threshold_tokens = 64_000
+            self.threshold_percent = 0.50
+
+        def get_tool_schemas(self):
+            return []
+
+        def on_session_start(self, *args, **kwargs):
+            return None
+
+    cfg = {
+        "providers": {
+            "ai-api-codex": {
+                "name": "AI API Codex",
+                "base_url": "https://ai-api.home.sadlay.cn:22843/v1",
+                "models": {
+                    "gpt-5.4": {"context_length": 400_000},
+                },
+            },
+            "ai-api-chat": {
+                "name": "AI API Chat",
+                "base_url": "https://ai-api.home.sadlay.cn:22843/v1",
+                "models": {
+                    "MiniMax-M2.7": {"context_length": 204_800},
+                },
+            },
+        },
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.ContextCompressor", new=_StubCompressor),
+        patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(None, None)),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://ai-api.home.sadlay.cn:22843/v1",
+            provider="ai-api-chat",
+            model="MiniMax-M2.7",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._config_context_length == 204_800
+    assert agent.context_compressor.context_length == 204_800
 
 
 @patch("agent.auxiliary_client.get_text_auxiliary_client")

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -34,8 +34,23 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     )
     agent.context_compressor = compressor
 
-    # For switch_model
+    # Minimal state expected by switch_model
     agent._primary_runtime = {}
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._cached_system_prompt = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = ""
+    agent._is_anthropic_oauth = False
+    agent._client_kwargs = {}
+    agent._transport_cache = {}
+    agent._vprint = lambda *args, **kwargs: None
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
 
     return agent
 


### PR DESCRIPTION
## Summary
- prefer configured `context_length` when resolving auxiliary compression feasibility and model switch display metadata
- disambiguate shared `base_url` providers with provider-key aware matching and carry the resolved override through CLI/gateway model switches
- add regression coverage for compression feasibility, context display, and switch-model propagation

## Testing
- pytest tests/run_agent/test_compression_feasibility.py tests/hermes_cli/test_model_switch_context_display.py tests/run_agent/test_switch_model_context.py -q -o 'addopts='
