### PR TITLE
fix: strip unsupported Codex backend sampling params

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2749,6 +2749,23 @@ def _is_anthropic_compat_endpoint(provider: str, base_url: str) -> bool:
     return "/anthropic" in url_lower
 
 
+def _is_chatgpt_codex_backend(provider: str, base_url: Optional[str] = None) -> bool:
+    """Return True for ChatGPT's Codex backend.
+
+    ``https://chatgpt.com/backend-api/codex`` speaks a restricted Responses
+    API surface.  It rejects client-side sampling and output-token controls
+    such as ``temperature`` and ``max_output_tokens``.  Auxiliary callers often
+    set those knobs by default, so sanitize them before the request reaches the
+    OpenAI SDK or a fallback path.
+    """
+    normalized_provider = _normalize_aux_provider(provider)
+    url_lower = (base_url or "").strip().lower().rstrip("/")
+    return normalized_provider == "openai-codex" or (
+        base_url_host_matches(url_lower, "chatgpt.com")
+        and "/backend-api/codex" in url_lower
+    )
+
+
 def _convert_openai_images_to_anthropic(messages: list) -> list:
     """Convert OpenAI ``image_url`` content blocks to Anthropic ``image`` blocks.
 
@@ -2815,8 +2832,12 @@ def _build_call_kwargs(
         "timeout": timeout,
     }
 
+    codex_backend = _is_chatgpt_codex_backend(provider, base_url)
+
     fixed_temperature = _fixed_temperature_for_model(model, base_url)
-    if fixed_temperature is OMIT_TEMPERATURE:
+    if codex_backend:
+        temperature = None
+    elif fixed_temperature is OMIT_TEMPERATURE:
         temperature = None  # strip — let server choose
     elif fixed_temperature is not None:
         temperature = fixed_temperature
@@ -2833,7 +2854,7 @@ def _build_call_kwargs(
     if temperature is not None:
         kwargs["temperature"] = temperature
 
-    if max_tokens is not None:
+    if max_tokens is not None and not codex_backend:
         # Codex adapter handles max_tokens internally; OpenRouter/Nous use max_tokens.
         # Direct OpenAI api.openai.com with newer models needs max_completion_tokens.
         if provider == "custom":

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -121,6 +121,12 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.update(request_overrides)
 
         if is_codex_backend:
+            # ChatGPT's Codex backend rejects client-side sampling and output
+            # caps.  Keep this after request_overrides so config-level knobs
+            # cannot reintroduce unsupported parameters.
+            kwargs.pop("temperature", None)
+            kwargs.pop("max_output_tokens", None)
+
             prompt_cache_key = kwargs.get("prompt_cache_key")
             cache_scope_id = str(prompt_cache_key or session_id or "").strip()
             if cache_scope_id:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,7 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
+    _build_call_kwargs,
 )
 
 
@@ -486,6 +487,36 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+
+
+class TestBuildCallKwargs:
+    def test_chatgpt_codex_backend_omits_temperature_and_token_cap(self):
+        kwargs = _build_call_kwargs(
+            "openai-codex",
+            "gpt-5.5",
+            [{"role": "user", "content": "hi"}],
+            temperature=0.3,
+            max_tokens=512,
+            base_url="https://chatgpt.com/backend-api/codex/",
+        )
+
+        assert "temperature" not in kwargs
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    def test_non_codex_backend_keeps_temperature_and_token_cap(self):
+        kwargs = _build_call_kwargs(
+            "openrouter",
+            "google/gemini-3-flash-preview",
+            [{"role": "user", "content": "hi"}],
+            temperature=0.3,
+            max_tokens=512,
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == 512
+
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -117,6 +117,26 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
+    def test_codex_backend_strips_sampling_overrides(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            max_tokens=4096,
+            request_overrides={"temperature": 0.3, "max_output_tokens": 1024},
+            is_codex_backend=True,
+        )
+        assert "temperature" not in kw
+        assert "max_output_tokens" not in kw
+
+    def test_non_codex_responses_backend_keeps_sampling_overrides(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            request_overrides={"temperature": 0.3},
+            is_codex_backend=False,
+        )
+        assert kw["temperature"] == 0.3
+
     def test_xai_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
- omit temperature and token-cap kwargs for ChatGPT Codex auxiliary calls
- strip request override sampling/output caps in the Codex Responses transport for the ChatGPT backend
- add regression tests for auxiliary kwargs and Codex transport overrides

## Test Plan
- python -m pytest tests/agent/test_auxiliary_client.py tests/agent/transports/test_codex_transport.py -q