### PR TITLE
fix(auth): resolve API keys from ~/.hermes/.env and credential_pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1273,7 +1273,12 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         def _is_source_suppressed(_p, _s):  # type: ignore[misc]
             return False
     if provider == "openrouter":
-        token = os.getenv("OPENROUTER_API_KEY", "").strip()
+        # Check both os.environ and ~/.hermes/.env file
+        try:
+            from hermes_cli.config import get_env_value
+            token = (get_env_value("OPENROUTER_API_KEY") or "").strip()
+        except Exception:
+            token = os.getenv("OPENROUTER_API_KEY", "").strip()
         if token:
             source = "env:OPENROUTER_API_KEY"
             if _is_source_suppressed(provider, source):
@@ -1299,7 +1304,11 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+        try:
+            from hermes_cli.config import get_env_value
+            env_url = (get_env_value(pconfig.base_url_env_var) or "").strip().rstrip("/")
+        except Exception:
+            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
 
     env_vars = list(pconfig.api_key_env_vars)
     if provider == "anthropic":
@@ -1310,7 +1319,12 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         ]
 
     for env_var in env_vars:
-        token = os.getenv(env_var, "").strip()
+        # Check both os.environ and ~/.hermes/.env file
+        try:
+            from hermes_cli.config import get_env_value
+            token = (get_env_value(env_var) or "").strip()
+        except Exception:
+            token = os.getenv(env_var, "").strip()
         if not token:
             continue
         source = f"env:{env_var}"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -468,9 +468,28 @@ def _resolve_api_key_provider_secret(
         return "", ""
 
     for env_var in pconfig.api_key_env_vars:
-        val = os.getenv(env_var, "").strip()
+        # Check both os.environ and ~/.hermes/.env file
+        try:
+            from hermes_cli.config import get_env_value
+            val = (get_env_value(env_var) or "").strip()
+        except Exception:
+            val = os.getenv(env_var, "").strip()
         if has_usable_secret(val):
             return val, env_var
+
+    # Fallback: try credential pool (e.g. zai key stored via auth.json)
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider_id)
+        if pool and pool.has_credentials():
+            entry = pool.peek()
+            if entry:
+                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                key = str(key).strip()
+                if has_usable_secret(key):
+                    return key, f"credential_pool:{provider_id}"
+    except Exception:
+        pass
 
     return "", ""
 

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -1,0 +1,110 @@
+"""Tests for credential_pool .env fallback and auth credential pool lookup."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def _make_pconfig(env_vars=None):
+    """Create a minimal ProviderConfig for testing."""
+    from hermes_cli.auth import ProviderConfig
+    return ProviderConfig(
+        id="openai",
+        name="OpenAI",
+        auth_type="api_key",
+        api_key_env_vars=tuple(env_vars or ["OPENAI_API_KEY"]),
+    )
+
+
+class TestCredentialPoolEnvFallback:
+    """Verify _seed_from_env resolves keys from both os.environ and .env file."""
+
+    def test_os_environ_still_works(self):
+        """Existing os.environ resolution must not break.
+        _seed_from_env only collects env var names, does not return found=True
+        for existing keys — that is _resolve's job. Just verify no crash."""
+        from agent.credential_pool import _seed_from_env
+        # Should not raise
+        found, entries = _seed_from_env("openai", [])
+
+    def test_get_env_value_import_does_not_crash(self):
+        """Importing get_env_value from hermes_cli.config should not raise."""
+        try:
+            from hermes_cli.config import get_env_value
+            assert callable(get_env_value)
+        except ImportError:
+            pytest.skip("hermes_cli.config not available in test environment")
+
+
+class TestAuthCredentialPoolFallback:
+    """Verify auth.py falls back to credential pool when env vars are empty."""
+
+    def _clear_api_keys(self):
+        """Temporarily clear API key env vars, return backup dict."""
+        backup = {}
+        for key in ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                     "ZAI_API_KEY", "DEEPSEEK_API_KEY"]:
+            if key in os.environ:
+                backup[key] = os.environ.pop(key)
+        return backup
+
+    def test_credential_pool_fallback_structure(self):
+        """When no env var is set, auth should try credential pool."""
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        
+        mock_entry = MagicMock()
+        mock_entry.access_token = "test-pool-key-12345"
+        mock_entry.runtime_api_key = ""
+        
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        mock_pool.peek.return_value = mock_entry
+        
+        backup = self._clear_api_keys()
+        try:
+            with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+                key, source = _resolve_api_key_provider_secret(
+                    provider_id="openai",
+                    pconfig=_make_pconfig(),
+                )
+                assert "test-pool-key-12345" in key
+                assert "credential_pool" in source
+        finally:
+            os.environ.update(backup)
+
+    def test_credential_pool_empty_returns_empty(self):
+        """When pool is empty, return empty string."""
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = False
+        
+        backup = self._clear_api_keys()
+        try:
+            with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+                key, source = _resolve_api_key_provider_secret(
+                    provider_id="openai",
+                    pconfig=_make_pconfig(),
+                )
+                assert key == ""
+        finally:
+            os.environ.update(backup)
+
+    def test_env_var_takes_priority_over_pool(self):
+        """Env vars should be checked before credential pool."""
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-key-first-abc123"}):
+            with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+                key, source = _resolve_api_key_provider_secret(
+                    provider_id="openai",
+                    pconfig=_make_pconfig(),
+                )
+                assert key == "sk-env-key-first-abc123"
+                # Source is the env var name itself (e.g. "OPENAI_API_KEY")
+                assert "OPENAI_API_KEY" in source
+                # Pool peek should NOT have been called — env var found first
+                mock_pool.peek.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #15914

API key provider resolution (`_resolve_api_key_provider_secret`) and credential pool seeding (`_seed_from_env`) only checked `os.environ`, ignoring keys stored in `~/.hermes/.env`. When the `.env` file has keys but they are not loaded into the process environment (ACP adapter entry point, post-session-start edits, non-CLI entry points), resolution returns empty string → HTTP 401.

This also causes `_prune_stale_seeded_entries` to delete valid credential pool entries whose env var source is absent from `os.environ`.

## Changes

**`agent/credential_pool.py`** — `_seed_from_env`:
- Replace `os.getenv()` with `get_env_value()` for env var and base_url resolution
- `get_env_value()` checks both `os.environ` and `~/.hermes/.env` file
- Prevents valid entries from being pruned when `.env` is the storage source

**`hermes_cli/auth.py`** — `_resolve_api_key_provider_secret`:
- Replace `os.getenv()` with `get_env_value()` for provider key env vars
- Add credential_pool fallback: when env resolution fails, attempt `load_pool().peek()` to retrieve a stored key

## Testing

```
# get_env_value reads from .env file
get_env_value("GLM_API_KEY") → 49-char key ✓

# resolve_api_key_provider_secret finds zai key
_resolve_api_key_provider_secret("zai", pconfig) → (key, "GLM_API_KEY") ✓

# credential_pool seeds successfully
load_pool("zai").has_credentials() → True ✓

# E2E API call with resolved credentials
POST /chat/completions → 200 OK ✓
```

## Related

- #15914 — original bug report
- #14134 — api_key drift on provider switch
- #15810 — delegate_task credential chain fallback

Closes #15932