### PR TITLE
feat(discord): auto-join new forum/text threads in watched channels

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -745,6 +745,36 @@ class DiscordAdapter(BasePlatformAdapter):
                         guild_id,
                     )
 
+            @self._client.event
+            async def on_thread_create(thread):
+                """Auto-join new forum/text threads in free-response or allowed channels.
+
+                Discord bots don't receive on_message for threads they haven't
+                joined.  This ensures the bot participates in new forum posts
+                so free_response_channels works for ForumChannel parents.
+                """
+                if not thread.parent_id:
+                    return
+                parent_id = str(thread.parent_id)
+                free_channels = adapter_self._discord_free_response_channels()
+                allowed_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+                allowed_channels = {ch.strip() for ch in allowed_raw.split(",") if ch.strip()} if allowed_raw else set()
+
+                should_join = (
+                    "*" in free_channels
+                    or parent_id in free_channels
+                    or "*" in allowed_channels
+                    or parent_id in allowed_channels
+                )
+                if not should_join:
+                    return
+                try:
+                    await thread.join()
+                    adapter_self._threads.mark(str(thread.id))
+                    logger.debug("[%s] Auto-joined thread %s (parent %s)", adapter_self.name, thread.id, parent_id)
+                except Exception as e:
+                    logger.debug("[%s] Failed to auto-join thread %s: %s", adapter_self.name, thread.id, e)
+
             # Register slash commands
             if self._slash_commands:
                 self._register_slash_commands()


### PR DESCRIPTION
## Summary
- Bots don't receive `on_message` for Discord threads they haven't joined, which means `free_response_channels` / `allowed_channels` has no effect on new forum posts — the bot is deaf to them until explicitly @mentioned
- Adds an `on_thread_create` event handler that auto-joins new threads when their parent channel is in `free_response_channels` or `DISCORD_ALLOWED_CHANNELS`
- Marks joined threads in `ThreadParticipationTracker` so the existing `in_bot_thread` logic works for follow-up messages

## Details
No new intents required — `Intents.default()` includes `guilds`, which covers `on_thread_create` events. The `guild_messages` intent (already enabled) covers receiving messages in joined threads.

## Test plan
- [ ] Configure `free_response_channels` with a ForumChannel ID
- [ ] Create a new forum post — bot should auto-join and start receiving messages without @mention
- [ ] Verify threads in non-watched channels are NOT auto-joined
- [ ] Verify `allowed_channels` wildcard (`*`) triggers auto-join for all threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)