### PR TITLE
fix(discord): enforce user/role allowlist on slash commands

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2162,6 +2162,16 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             pass  # logging must never block command dispatch
 
+        user_id = str(interaction.user.id) if interaction.user else None
+        if not user_id or not self._is_allowed_user(user_id, interaction.user):
+            try:
+                await interaction.response.send_message(
+                    "You don't have permission to use this command.", ephemeral=True,
+                )
+            except Exception:
+                pass
+            return
+
         await interaction.response.defer(ephemeral=True)
         event = self._build_slash_event(interaction, command_text)
         await self.handle_message(event)


### PR DESCRIPTION
## Summary
- Slash commands (`/reset`, `/model`, `/personality`, `/steer`, `/stop`, etc.) bypass the `_is_allowed_user` check that protects the `on_message` path, allowing any server member to invoke them
- Adds the same user/role allowlist gate to `_run_simple_slash` before deferring the interaction
- Unauthorized users receive an ephemeral "You don't have permission" message

## Details
The `on_message` handler calls `_is_allowed_user` at line 681, but the slash command path (`_run_simple_slash`) goes straight from logging to `defer()` → `handle_message()` with no auth check. This is a security issue for any deployment using `DISCORD_ALLOWED_USERS` or `DISCORD_ALLOWED_ROLES` — the allowlist is only enforced on regular messages, not slash commands.

The fix places the check before `interaction.response.defer()` so we can respond with an ephemeral error directly rather than needing to edit the deferred response.

## Test plan
- [ ] Configure `DISCORD_ALLOWED_USERS` with a specific user ID
- [ ] Verify that user can invoke slash commands normally
- [ ] Verify a non-allowed user gets an ephemeral "no permission" response
- [ ] Verify role-based allowlist (`DISCORD_ALLOWED_ROLES`) also works for slash commands
- [ ] Verify with no allowlist configured, all users can still use slash commands (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)