### PR TITLE
feat(discord): log resolved channel names and types at startup

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -802,6 +802,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """Finish non-critical startup work after Discord is connected."""
         if not self._client:
             return
+
+        self._log_watched_channels()
+
         try:
             sync_policy = self._get_discord_command_sync_policy()
             if sync_policy == "off":
@@ -2729,6 +2732,35 @@ class DiscordAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _log_watched_channels(self) -> None:
+        """Log resolved free-response and allowed channels at startup for debugging."""
+        if not self._client:
+            return
+        free_channels = self._discord_free_response_channels()
+        allowed_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+        allowed_channels = {ch.strip() for ch in allowed_raw.split(",") if ch.strip()} if allowed_raw else set()
+        for label, ch_ids in [("free-response", free_channels), ("allowed", allowed_channels)]:
+            if not ch_ids or "*" in ch_ids:
+                continue
+            for ch_id in sorted(ch_ids):
+                try:
+                    channel = self._client.get_channel(int(ch_id))
+                except (ValueError, TypeError):
+                    channel = None
+                if channel:
+                    logger.info(
+                        "[%s] %s channel: %s (type: %s, name: %s)",
+                        self.name, label, ch_id,
+                        type(channel).__name__,
+                        getattr(channel, "name", "?"),
+                    )
+                else:
+                    logger.warning(
+                        "[%s] %s channel %s not found — check the ID is correct "
+                        "and the bot has access",
+                        self.name, label, ch_id,
+                    )
 
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""


### PR DESCRIPTION
## Summary
- ForumChannel IDs aren't visible in typical Discord channel listings, making misconfiguration of `free_response_channels` hard to diagnose
- Adds startup logging that resolves each configured channel ID to its name and type (e.g., `ForumChannel`, `TextChannel`, `VoiceChannel`)
- Warns when a configured channel ID can't be found, helping catch typos or permission issues early

## Details
Logging runs in `_run_post_connect_initialization` after the guild cache is populated, so `get_channel()` lookups are reliable. Covers both `free_response_channels` and `DISCORD_ALLOWED_CHANNELS`. Wildcard (`*`) entries are skipped since they don't map to specific channels.

Example output:
```
[my-bot] free-response channel: 123456789 (type: ForumChannel, name: support-forum)
[my-bot] allowed channel: 987654321 not found — check the ID is correct and the bot has access
```

## Test plan
- [ ] Configure `free_response_channels` with valid and invalid channel IDs
- [ ] Verify startup logs show channel names and types for valid IDs
- [ ] Verify a warning is logged for invalid/inaccessible channel IDs
- [ ] Verify wildcard `*` config doesn't trigger per-channel logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)