### PR TITLE
hermes-agent: Scrub provider creds from ACP child env

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -83,6 +83,20 @@ def _resolve_home_dir() -> str:
 
 def _build_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
+    try:
+        from tools.environments.local import (
+            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+        )
+
+        env = {
+            key: value
+            for key, value in env.items()
+            if not key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX)
+            and key not in _HERMES_PROVIDER_ENV_BLOCKLIST
+        }
+    except Exception:
+        pass
     env["HOME"] = _resolve_home_dir()
     return env
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -201,3 +201,36 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+def test_run_prompt_strips_provider_credentials_from_child_env(monkeypatch, tmp_path):
+    from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+    monkeypatch.setenv(blocked_var, "secret_value")
+    monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    child_env = captured["kwargs"]["env"]
+    assert blocked_var not in child_env
+    assert "PATH" in child_env
+
+
+def test_run_prompt_strips_force_prefixed_env_from_child(monkeypatch, tmp_path):
+    monkeypatch.setenv("_HERMES_FORCE_OPENAI_API_KEY", "secret_value")
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    child_env = captured["kwargs"]["env"]
+    assert "_HERMES_FORCE_OPENAI_API_KEY" not in child_env


### PR DESCRIPTION
## Summary
- strip Hermes-managed provider credentials before spawning the Copilot ACP subprocess
- also drop internal force-prefixed secret injection variables from the ACP child environment
- add ACP regression tests proving blocked credentials do not reach the child process while normal environment values still do

## Security rationale
The ACP backend is an external subprocess. Before this change it inherited the parent process environment wholesale, which exposed unrelated Hermes provider credentials (OpenAI, Anthropic, messaging tokens, etc.) to the ACP child. Hermes already scrubs these secrets for execute_code and terminal subprocesses; this aligns the ACP shim with that boundary.

## Testing
- `PYTHONPYCACHEPREFIX=/tmp/hermes-pyc python3 -m py_compile agent/copilot_acp_client.py tests/agent/test_copilot_acp_client.py`
- `python3.11 -m pytest tests/agent/test_copilot_acp_client.py -q` -> `9 passed in 0.63s`
- also attempted `python3.11 -m pytest tests/tools/test_local_env_blocklist.py -q`, but that suite is not currently reliable in this local environment because optional dependencies such as `PyYAML`/`httpx` are missing and unrelated baseline failures remain
