### PR TITLE
fix(qqbot): honor proxy env vars for websocket

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -393,13 +393,24 @@ class QQAdapter(BasePlatformAdapter):
             await self._session.close()
         self._session = None
 
-        self._session = aiohttp.ClientSession()
+        # Honor WSL proxy env for QQ WebSocket. Hermes upgrades overwrite this
+        # local patch, so QQ can regress to direct-connect timeouts after update.
+        self._session = aiohttp.ClientSession(trust_env=True)
+        ws_proxy = (
+            os.getenv("WSS_PROXY")
+            or os.getenv("wss_proxy")
+            or os.getenv("HTTPS_PROXY")
+            or os.getenv("https_proxy")
+            or os.getenv("ALL_PROXY")
+            or os.getenv("all_proxy")
+        )
         self._ws = await self._session.ws_connect(
             gateway_url,
             headers={
                 "User-Agent": build_user_agent(),
             },
             timeout=CONNECT_TIMEOUT_SECONDS,
+            proxy=ws_proxy,
         )
         logger.info("[%s] WebSocket connected to %s", self._log_tag, gateway_url)
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -191,6 +191,50 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy handling
+# ---------------------------------------------------------------------------
+
+class TestQQWebSocketProxy:
+    @pytest.mark.asyncio
+    async def test_open_ws_honors_proxy_env(self, monkeypatch):
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in (
+            "WSS_PROXY",
+            "wss_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+        seen_session_kwargs = {}
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                seen_session_kwargs.update(kwargs)
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_session_kwargs.get("trust_env") is True
+        assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- honor proxy env vars when opening the QQBot websocket
- keep aiohttp aligned with environments where REST calls already work through a proxy
- add a regression test covering proxy propagation into ws_connect

## Problem
On WSL and other restricted network setups, QQBot could regress after upgrade because the websocket path in  did not reliably honor proxy env vars. In practice this showed up as REST/token requests succeeding while  timed out, leaving QQ disconnected while other platforms could still work.

This is in the same family of proxy regressions discussed in #11609, but on the QQBot websocket adapter path rather than the general provider HTTP client path.

## Testing
- bringing up nodes...
bringing up nodes...

........................................................................ [100%]
=============================== warnings summary ===============================
tests/gateway/test_qqbot.py::TestDispatchPayload::test_op10_updates_heartbeat_interval
  /home/openclaw/.hermes/hermes-agent/gateway/platforms/qqbot/adapter.py:741: RuntimeWarning: coroutine 'QQAdapter._send_identify' was never awaited
    self._create_task(self._send_identify())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
72 passed, 1 warning in 2.98s
