### PR TITLE
fix(agent): route MiniMax vision to dedicated VLM endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2796,6 +2796,122 @@ def _convert_openai_images_to_anthropic(messages: list) -> list:
     return converted
 
 
+def _extract_minimax_vlm_payload(messages: list) -> Tuple[str, Optional[str]]:
+    """Extract prompt text and image data URI from OpenAI-format vision messages."""
+    prompt_parts: list[str] = []
+    image_url: Optional[str] = None
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str):
+            prompt_parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if block.get("type") == "text":
+                    prompt_parts.append(block.get("text", ""))
+                elif block.get("type") == "image_url" and image_url is None:
+                    image_url = (block.get("image_url") or {}).get("url", "")
+    return "\n".join(prompt_parts).strip(), image_url
+
+
+def _build_minimax_vlm_response(content: str) -> SimpleNamespace:
+    """Build a mock response compatible with extract_content_or_reasoning."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content)
+            )
+        ]
+    )
+
+
+def _call_minimax_vlm_endpoint(
+    provider: str,
+    messages: list,
+    client: Any,
+    timeout: float,
+) -> Any:
+    """Call MiniMax's dedicated VLM endpoint for vision tasks.
+
+    The Anthropic-compatible chat endpoint silently ignores image blocks.
+    Vision must go through /v1/coding_plan/vlm instead.
+    """
+    import httpx
+
+    prompt, image_url = _extract_minimax_vlm_payload(messages)
+    if not image_url:
+        raise RuntimeError(
+            f"MiniMax VLM ({provider}): no image found in messages"
+        )
+
+    base = str(client.base_url).rstrip("/")
+    vlm_url = base + "/coding_plan/vlm"
+    api_key = client.api_key
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {"prompt": prompt, "image_url": image_url}
+
+    logger.info("MiniMax VLM: POST %s (prompt=%d chars)", vlm_url, len(prompt))
+
+    resp = httpx.post(vlm_url, json=payload, headers=headers, timeout=timeout)
+    resp.raise_for_status()
+    data = resp.json()
+
+    base_resp = data.get("base_resp", {})
+    if base_resp.get("status_code", -1) != 0:
+        raise RuntimeError(
+            f"MiniMax VLM ({provider}): API error: "
+            f"{base_resp.get('status_msg', 'unknown')}"
+        )
+
+    return _build_minimax_vlm_response(data.get("content", ""))
+
+
+async def _async_call_minimax_vlm_endpoint(
+    provider: str,
+    messages: list,
+    client: Any,
+    timeout: float,
+) -> Any:
+    """Async variant of _call_minimax_vlm_endpoint."""
+    import httpx
+
+    prompt, image_url = _extract_minimax_vlm_payload(messages)
+    if not image_url:
+        raise RuntimeError(
+            f"MiniMax VLM ({provider}): no image found in messages"
+        )
+
+    base = str(client.base_url).rstrip("/")
+    vlm_url = base + "/coding_plan/vlm"
+    api_key = client.api_key
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {"prompt": prompt, "image_url": image_url}
+
+    logger.info("MiniMax VLM: POST %s (prompt=%d chars)", vlm_url, len(prompt))
+
+    async with httpx.AsyncClient() as http_client:
+        resp = await http_client.post(
+            vlm_url, json=payload, headers=headers, timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    base_resp = data.get("base_resp", {})
+    if base_resp.get("status_code", -1) != 0:
+        raise RuntimeError(
+            f"MiniMax VLM ({provider}): API error: "
+            f"{base_resp.get('status_msg', 'unknown')}"
+        )
+
+    return _build_minimax_vlm_response(data.get("content", ""))
+
 
 def _build_call_kwargs(
     provider: str,
@@ -2999,6 +3115,10 @@ def call_llm(
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, resolved_provider or "auto", final_model or "default",
                      f" at {_base_info}" if _base_info and "openrouter" not in _base_info else "")
+
+    if task == "vision" and resolved_provider in _ANTHROPIC_COMPAT_PROVIDERS:
+        return _call_minimax_vlm_endpoint(
+            resolved_provider, messages, client, effective_timeout)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish
@@ -3296,6 +3416,10 @@ async def async_call_llm(
                 f"Run: hermes setup")
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+
+    if task == "vision" and resolved_provider in _ANTHROPIC_COMPAT_PROVIDERS:
+        return await _async_call_minimax_vlm_endpoint(
+            resolved_provider, messages, client, effective_timeout)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish

--- a/tests/agent/test_minimax_vlm.py
+++ b/tests/agent/test_minimax_vlm.py
@@ -1,0 +1,256 @@
+"""Tests for MiniMax VLM (vision) endpoint routing.
+
+MiniMax's Anthropic-compatible chat endpoint silently ignores image blocks.
+Vision requests must be routed to the dedicated /v1/coding_plan/vlm endpoint.
+See GitHub issue #15715.
+"""
+
+import sys
+import os
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from agent.auxiliary_client import (
+    _extract_minimax_vlm_payload,
+    _build_minimax_vlm_response,
+    _call_minimax_vlm_endpoint,
+    _async_call_minimax_vlm_endpoint,
+    _ANTHROPIC_COMPAT_PROVIDERS,
+    extract_content_or_reasoning,
+)
+
+
+# -- fixtures ----------------------------------------------------------------
+
+SAMPLE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+SAMPLE_DATA_URI = f"data:image/png;base64,{SAMPLE_B64}"
+
+VISION_MESSAGES_OPENAI = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this screenshot"},
+            {"type": "image_url", "image_url": {"url": SAMPLE_DATA_URI}},
+        ],
+    }
+]
+
+VISION_MESSAGES_TEXT_ONLY = [
+    {"role": "user", "content": "What do you see?"},
+]
+
+VISION_MESSAGES_MULTI_TEXT = [
+    {"role": "system", "content": "You are a vision assistant."},
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "First, look at this."},
+            {"type": "image_url", "image_url": {"url": SAMPLE_DATA_URI}},
+            {"type": "text", "text": "Then describe it."},
+        ],
+    },
+]
+
+VLM_SUCCESS_RESPONSE = {
+    "content": "This is a 1x1 transparent PNG image.",
+    "base_resp": {"status_code": 0, "status_msg": "success"},
+}
+
+VLM_ERROR_RESPONSE = {
+    "content": "",
+    "base_resp": {"status_code": 1001, "status_msg": "invalid image"},
+}
+
+
+def _mock_client(base_url="https://api.minimax.io/v1", api_key="sk-test-123"):
+    client = MagicMock()
+    client.base_url = base_url
+    client.api_key = api_key
+    return client
+
+
+# -- _extract_minimax_vlm_payload tests -------------------------------------
+
+
+class TestExtractMiniMaxVlmPayload:
+    def test_basic_extraction(self):
+        prompt, image_url = _extract_minimax_vlm_payload(VISION_MESSAGES_OPENAI)
+        assert prompt == "Describe this screenshot"
+        assert image_url == SAMPLE_DATA_URI
+
+    def test_no_image_returns_none(self):
+        prompt, image_url = _extract_minimax_vlm_payload(VISION_MESSAGES_TEXT_ONLY)
+        assert prompt == "What do you see?"
+        assert image_url is None
+
+    def test_multi_text_blocks_joined(self):
+        prompt, image_url = _extract_minimax_vlm_payload(VISION_MESSAGES_MULTI_TEXT)
+        assert "You are a vision assistant." in prompt
+        assert "First, look at this." in prompt
+        assert "Then describe it." in prompt
+        assert image_url == SAMPLE_DATA_URI
+
+    def test_only_first_image_used(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,FIRST"}},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,SECOND"}},
+                ],
+            }
+        ]
+        _, image_url = _extract_minimax_vlm_payload(msgs)
+        assert image_url == "data:image/png;base64,FIRST"
+
+    def test_empty_messages(self):
+        prompt, image_url = _extract_minimax_vlm_payload([])
+        assert prompt == ""
+        assert image_url is None
+
+
+# -- _build_minimax_vlm_response tests --------------------------------------
+
+
+class TestBuildMiniMaxVlmResponse:
+    def test_response_shape(self):
+        resp = _build_minimax_vlm_response("hello world")
+        assert resp.choices[0].message.content == "hello world"
+
+    def test_compatible_with_extract_content(self):
+        resp = _build_minimax_vlm_response("VLM analysis result")
+        assert extract_content_or_reasoning(resp) == "VLM analysis result"
+
+    def test_empty_content(self):
+        resp = _build_minimax_vlm_response("")
+        assert resp.choices[0].message.content == ""
+
+
+# -- _call_minimax_vlm_endpoint tests ----------------------------------------
+
+
+class TestCallMiniMaxVlmEndpoint:
+    @patch("httpx.post")
+    def test_successful_call(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = VLM_SUCCESS_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = _mock_client()
+        result = _call_minimax_vlm_endpoint(
+            "minimax", VISION_MESSAGES_OPENAI, client, timeout=30.0,
+        )
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "https://api.minimax.io/v1/coding_plan/vlm"
+        payload = call_args[1]["json"]
+        assert payload["prompt"] == "Describe this screenshot"
+        assert payload["image_url"] == SAMPLE_DATA_URI
+        assert call_args[1]["headers"]["Authorization"] == "Bearer sk-test-123"
+
+        assert result.choices[0].message.content == "This is a 1x1 transparent PNG image."
+
+    @patch("httpx.post")
+    def test_cn_provider_url(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = VLM_SUCCESS_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = _mock_client(
+            base_url="https://api.minimaxi.com/v1",
+            api_key="sk-cp-test",
+        )
+        _call_minimax_vlm_endpoint(
+            "minimax-cn", VISION_MESSAGES_OPENAI, client, timeout=30.0,
+        )
+
+        call_url = mock_post.call_args[0][0]
+        assert call_url == "https://api.minimaxi.com/v1/coding_plan/vlm"
+
+    def test_no_image_raises(self):
+        client = _mock_client()
+        with pytest.raises(RuntimeError, match="no image found"):
+            _call_minimax_vlm_endpoint(
+                "minimax", VISION_MESSAGES_TEXT_ONLY, client, timeout=30.0,
+            )
+
+    @patch("httpx.post")
+    def test_api_error_raises(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = VLM_ERROR_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = _mock_client()
+        with pytest.raises(RuntimeError, match="invalid image"):
+            _call_minimax_vlm_endpoint(
+                "minimax", VISION_MESSAGES_OPENAI, client, timeout=30.0,
+            )
+
+    @patch("httpx.post")
+    def test_trailing_slash_in_base_url(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = VLM_SUCCESS_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = _mock_client(base_url="https://api.minimax.io/v1/")
+        _call_minimax_vlm_endpoint(
+            "minimax", VISION_MESSAGES_OPENAI, client, timeout=30.0,
+        )
+
+        call_url = mock_post.call_args[0][0]
+        assert call_url == "https://api.minimax.io/v1/coding_plan/vlm"
+
+
+# -- _async_call_minimax_vlm_endpoint tests ----------------------------------
+
+
+class TestAsyncCallMiniMaxVlmEndpoint:
+    @pytest.mark.asyncio
+    async def test_no_image_raises(self):
+        client = _mock_client()
+        with pytest.raises(RuntimeError, match="no image found"):
+            await _async_call_minimax_vlm_endpoint(
+                "minimax", VISION_MESSAGES_TEXT_ONLY, client, timeout=30.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_successful_call(self):
+        from unittest.mock import AsyncMock
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = VLM_SUCCESS_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_http_client = MagicMock()
+        mock_http_client.post = AsyncMock(return_value=mock_resp)
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_http_client):
+            result = await _async_call_minimax_vlm_endpoint(
+                "minimax", VISION_MESSAGES_OPENAI, _mock_client(), timeout=30.0,
+            )
+
+        assert result.choices[0].message.content == "This is a 1x1 transparent PNG image."
+
+
+# -- Provider routing tests --------------------------------------------------
+
+
+class TestMiniMaxVisionRouting:
+    def test_minimax_in_anthropic_compat_providers(self):
+        assert "minimax" in _ANTHROPIC_COMPAT_PROVIDERS
+        assert "minimax-cn" in _ANTHROPIC_COMPAT_PROVIDERS
+
+    def test_openrouter_not_in_anthropic_compat(self):
+        assert "openrouter" not in _ANTHROPIC_COMPAT_PROVIDERS


### PR DESCRIPTION
## What does this PR do?

MiniMax's Anthropic-compatible chat endpoint (`/anthropic/v1/messages`) silently ignores image content blocks, causing vision analysis to return empty/useless results. This PR routes MiniMax vision requests to the dedicated VLM endpoint (`/v1/coding_plan/vlm`) which properly handles image input.

## Related Issue

Fixes #15715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `_extract_minimax_vlm_payload()` to extract prompt text and image data URI from OpenAI-format vision messages
- Add `_build_minimax_vlm_response()` to build a mock response compatible with `extract_content_or_reasoning`
- Add `_call_minimax_vlm_endpoint()` (sync) and `_async_call_minimax_vlm_endpoint()` (async) to call the dedicated `/v1/coding_plan/vlm` endpoint via httpx
- Intercept vision tasks for `minimax`/`minimax-cn` providers in both `call_llm()` and `async_call_llm()` before the standard chat completions path

## How to Test

1. Configure `imageModel: minimax-portal/MiniMax-M2.7` in config.yaml
2. Send an image to Hermes for vision analysis — should now return meaningful visual description
3. Run the targeted test: `pytest tests/agent/test_minimax_vlm.py -v`
4. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated contributing / agents docs — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
