### PR TITLE
fix(Slack): resolve Slack channels by raw ID and enumerate joined channels

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -57,7 +57,7 @@ def _session_entry_name(origin: Dict[str, Any]) -> str:
 # Build / refresh
 # ---------------------------------------------------------------------------
 
-def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
+async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     """
     Build a channel directory from connected platform adapters and session data.
 
@@ -72,7 +72,7 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             if platform == Platform.DISCORD:
                 platforms["discord"] = _build_discord(adapter)
             elif platform == Platform.SLACK:
-                platforms["slack"] = _build_slack(adapter)
+                platforms["slack"] = await _build_slack(adapter)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -136,21 +136,66 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
     return channels
 
 
-def _build_slack(adapter) -> List[Dict[str, str]]:
-    """List Slack channels the bot has joined."""
-    # Slack adapter may expose a web client
-    client = getattr(adapter, "_app", None) or getattr(adapter, "_client", None)
-    if not client:
+async def _build_slack(adapter) -> List[Dict[str, Any]]:
+    """List Slack channels the bot has joined across all workspaces.
+
+    Uses ``users.conversations`` against each workspace's web client. Pulls
+    public + private channels the bot is a member of, then merges in DMs
+    discovered from session history (IMs aren't useful to enumerate
+    proactively).
+    """
+    team_clients = getattr(adapter, "_team_clients", None) or {}
+    if not team_clients:
         return _build_from_sessions("slack")
 
-    try:
-        from tools.send_message_tool import _send_slack  # noqa: F401
-        # Use the Slack Web API directly if available
-    except Exception:
-        pass
+    channels: List[Dict[str, Any]] = []
+    seen_ids: set = set()
 
-    # Fallback to session data
-    return _build_from_sessions("slack")
+    for team_id, client in team_clients.items():
+        try:
+            cursor: Optional[str] = None
+            for _page in range(20):  # safety cap on pagination
+                response = await client.users_conversations(
+                    types="public_channel,private_channel",
+                    exclude_archived=True,
+                    limit=200,
+                    cursor=cursor,
+                )
+                if not response.get("ok"):
+                    logger.warning(
+                        "Channel directory: users.conversations not ok for team %s: %s",
+                        team_id,
+                        response.get("error", "unknown"),
+                    )
+                    break
+                for ch in response.get("channels", []):
+                    cid = ch.get("id")
+                    name = ch.get("name")
+                    if not cid or not name or cid in seen_ids:
+                        continue
+                    seen_ids.add(cid)
+                    channels.append({
+                        "id": cid,
+                        "name": name,
+                        "type": "private" if ch.get("is_private") else "channel",
+                    })
+                cursor = (response.get("response_metadata") or {}).get("next_cursor")
+                if not cursor:
+                    break
+        except Exception as e:
+            logger.warning(
+                "Channel directory: failed to list Slack channels for team %s: %s",
+                team_id, e,
+            )
+            continue
+
+    # Merge in DM/group entries discovered from session history.
+    for entry in _build_from_sessions("slack"):
+        if entry.get("id") not in seen_ids:
+            channels.append(entry)
+            seen_ids.add(entry.get("id"))
+
+    return channels
 
 
 def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
@@ -222,6 +267,14 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     channels = directory.get("platforms", {}).get(platform_name, [])
     if not channels:
         return None
+
+    # 0. Exact ID match — case-sensitive, no normalization. Lets callers pass
+    # raw platform IDs (e.g. Slack "C0B0QV5434G") even when the format guard
+    # in _parse_target_ref hasn't recognized them as explicit.
+    raw = name.strip()
+    for ch in channels:
+        if ch.get("id") == raw:
+            return ch["id"]
 
     query = _normalize_channel_query(name)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2182,7 +2182,7 @@ class GatewayRunner:
         # Build initial channel directory for send_message name resolution
         try:
             from gateway.channel_directory import build_channel_directory
-            directory = build_channel_directory(self.adapters)
+            directory = await build_channel_directory(self.adapters)
             ch_count = sum(len(chs) for chs in directory.get("platforms", {}).values())
             logger.info("Channel directory built: %d target(s)", ch_count)
         except Exception as e:
@@ -2466,7 +2466,7 @@ class GatewayRunner:
                         # Rebuild channel directory with the new adapter
                         try:
                             from gateway.channel_directory import build_channel_directory
-                            build_channel_directory(self.adapters)
+                            await build_channel_directory(self.adapters)
                         except Exception:
                             pass
                     else:
@@ -10886,7 +10886,15 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
         if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
             try:
                 from gateway.channel_directory import build_channel_directory
-                build_channel_directory(adapters)
+                if loop is not None:
+                    # build_channel_directory is async (Slack web calls), and
+                    # this ticker runs in a background thread. Schedule onto
+                    # the gateway event loop and wait briefly for completion
+                    # so refresh failures are still logged via the except.
+                    fut = asyncio.run_coroutine_threadsafe(
+                        build_channel_directory(adapters), loop
+                    )
+                    fut.result(timeout=30)
             except Exception as e:
                 logger.debug("Channel directory refresh error: %s", e)
 

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -1,9 +1,11 @@
 """Tests for gateway/channel_directory.py — channel resolution and display."""
 
+import asyncio
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.channel_directory import (
     build_channel_directory,
@@ -12,6 +14,7 @@ from gateway.channel_directory import (
     format_directory_for_display,
     load_directory,
     _build_from_sessions,
+    _build_slack,
     DIRECTORY_PATH,
 )
 
@@ -62,7 +65,7 @@ class TestBuildChannelDirectoryWrites:
         monkeypatch.setattr(json, "dump", broken_dump)
 
         with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
-            build_channel_directory({})
+            asyncio.run(build_channel_directory({}))
             result = load_directory()
 
         assert result == previous
@@ -141,6 +144,21 @@ class TestResolveChannelName:
         }
         with self._setup(tmp_path, platforms):
             assert resolve_channel_name("telegram", "Coaching Chat / topic 17585") == "-1001:17585"
+
+    def test_id_match_takes_precedence_over_name(self, tmp_path):
+        """A raw channel ID resolves to itself, even when a different
+        channel happens to be named the same string. Case-sensitive: Slack
+        IDs are uppercase and must not be normalized away."""
+        platforms = {
+            "slack": [
+                {"id": "C0B0QV5434G", "name": "engineering", "type": "channel"},
+                {"id": "C99", "name": "c0b0qv5434g", "type": "channel"},
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("slack", "C0B0QV5434G") == "C0B0QV5434G"
+            # Lowercase still falls through to name matching (case-insensitive)
+            assert resolve_channel_name("slack", "c0b0qv5434g") == "C99"
 
     def test_display_label_with_type_suffix_resolves(self, tmp_path):
         platforms = {
@@ -332,3 +350,135 @@ class TestLookupChannelType:
         }
         with self._setup(tmp_path, platforms):
             assert lookup_channel_type("discord", "300") is None
+
+
+def _make_slack_adapter(team_clients):
+    """Build a stand-in for SlackAdapter exposing only ``_team_clients``."""
+    return SimpleNamespace(_team_clients=team_clients)
+
+
+def _make_slack_client(pages):
+    """Build an AsyncWebClient mock whose ``users_conversations`` returns pages."""
+    client = MagicMock()
+    client.users_conversations = AsyncMock(side_effect=pages)
+    return client
+
+
+class TestBuildSlack:
+    """_build_slack actually calls users.conversations on each workspace client."""
+
+    def test_no_team_clients_falls_back_to_sessions(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {"origin": {"platform": "slack", "chat_id": "D123", "chat_name": "Alice"}},
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({})))
+
+        assert len(entries) == 1
+        assert entries[0]["id"] == "D123"
+
+    def test_lists_channels_from_users_conversations(self, tmp_path):
+        client = _make_slack_client([
+            {
+                "ok": True,
+                "channels": [
+                    {"id": "C0B0QV5434G", "name": "engineering", "is_private": False},
+                    {"id": "G123ABCDEF", "name": "secret-chat", "is_private": True},
+                ],
+                "response_metadata": {},
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+
+        ids = {e["id"] for e in entries}
+        assert ids == {"C0B0QV5434G", "G123ABCDEF"}
+        types = {e["id"]: e["type"] for e in entries}
+        assert types["C0B0QV5434G"] == "channel"
+        assert types["G123ABCDEF"] == "private"
+        client.users_conversations.assert_awaited_once()
+
+    def test_paginates_via_response_metadata_cursor(self, tmp_path):
+        client = _make_slack_client([
+            {
+                "ok": True,
+                "channels": [{"id": "C001", "name": "first", "is_private": False}],
+                "response_metadata": {"next_cursor": "cur1"},
+            },
+            {
+                "ok": True,
+                "channels": [{"id": "C002", "name": "second", "is_private": False}],
+                "response_metadata": {"next_cursor": ""},
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+
+        assert {e["id"] for e in entries} == {"C001", "C002"}
+        assert client.users_conversations.await_count == 2
+
+    def test_per_workspace_error_does_not_block_others(self, tmp_path):
+        bad = MagicMock()
+        bad.users_conversations = AsyncMock(side_effect=RuntimeError("boom"))
+        good = _make_slack_client([
+            {
+                "ok": True,
+                "channels": [{"id": "C999", "name": "ok-channel", "is_private": False}],
+                "response_metadata": {},
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({"BAD": bad, "GOOD": good})))
+
+        assert {e["id"] for e in entries} == {"C999"}
+
+    def test_session_dms_merged_when_not_in_api_results(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {"origin": {"platform": "slack", "chat_id": "D456", "chat_name": "Bob"}},
+            "dup": {"origin": {"platform": "slack", "chat_id": "C001", "chat_name": "first"}},
+        }))
+        client = _make_slack_client([
+            {
+                "ok": True,
+                "channels": [{"id": "C001", "name": "first", "is_private": False}],
+                "response_metadata": {},
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+
+        ids = {e["id"] for e in entries}
+        assert "C001" in ids and "D456" in ids
+        # Channel ID from API should not be duplicated by the session merge
+        assert sum(1 for e in entries if e["id"] == "C001") == 1
+
+    def test_skips_channels_with_no_id_or_name(self, tmp_path):
+        client = _make_slack_client([
+            {
+                "ok": True,
+                "channels": [
+                    {"id": "C001", "name": "good", "is_private": False},
+                    {"id": "", "name": "no-id"},
+                    {"id": "C002"},  # no name (e.g. IM)
+                ],
+                "response_metadata": {},
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+
+        assert {e["id"] for e in entries} == {"C001"}
+
+    def test_response_not_ok_breaks_pagination_for_that_workspace(self, tmp_path):
+        client = _make_slack_client([
+            {"ok": False, "error": "missing_scope"},
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+
+        assert entries == []

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -810,6 +810,40 @@ class TestParseTargetRefE164:
         assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
 
+class TestParseTargetRefSlack:
+    """_parse_target_ref recognizes Slack channel/user IDs as explicit."""
+
+    def test_public_channel_id_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "C0B0QV5434G")
+        assert chat_id == "C0B0QV5434G"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_private_channel_id_is_explicit(self):
+        assert _parse_target_ref("slack", "G123ABCDEF")[2] is True
+
+    def test_dm_id_is_explicit(self):
+        assert _parse_target_ref("slack", "D123ABCDEF")[2] is True
+
+    def test_user_id_is_explicit(self):
+        assert _parse_target_ref("slack", "U123ABCDEF")[2] is True
+        assert _parse_target_ref("slack", "W123ABCDEF")[2] is True
+
+    def test_whitespace_is_stripped(self):
+        chat_id, _, is_explicit = _parse_target_ref("slack", "  C0B0QV5434G  ")
+        assert chat_id == "C0B0QV5434G"
+        assert is_explicit is True
+
+    def test_lowercase_or_short_id_is_not_explicit(self):
+        assert _parse_target_ref("slack", "c0b0qv5434g")[2] is False
+        assert _parse_target_ref("slack", "C123")[2] is False
+        assert _parse_target_ref("slack", "X0B0QV5434G")[2] is False
+
+    def test_slack_id_not_explicit_for_other_platforms(self):
+        assert _parse_target_ref("discord", "C0B0QV5434G")[2] is False
+        assert _parse_target_ref("telegram", "C0B0QV5434G")[2] is False
+
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
+# Slack channel/user IDs: C (public), G (private/group), D (DM), U/W (user).
+# Always uppercase alphanumeric, 9+ chars. Without this, Slack IDs fall through
+# to channel-name resolution, which only matches by name and fails.
+_SLACK_TARGET_RE = re.compile(r"^\s*([CGDUW][A-Z0-9]{8,})\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
@@ -318,6 +322,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+    if platform_name == "slack":
+        match = _SLACK_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
  
  When asking Hermes to send a Slack message to a channel other than the                                                                                                                                 
  current one, two failure modes appeared:                                                                                                                                                               
   
  1. `send_message(target='slack:<channel_id>')` returned `Could not resolve '<channel_id>' on slack`, even though the bot was a member of the channel and the ID was valid.
  2. As a fallback, the agent would retry with the bare `target='slack'`
     form and silently post to the platform's home channel instead of
     the requested one.

  In-channel and DM conversations worked fine — the bug only surfaced
  on outbound cross-channel sends.

  ### Root cause

  Three compounding gaps in the `send_message` → `channel_directory`
  path, all specific to Slack:

  1. **`tools/send_message_tool.py::_parse_target_ref`** had explicit
     handlers for Telegram/Discord/Feishu/Weixin/Matrix/phone IDs, but
     no Slack branch. Slack's uppercase-alphanumeric IDs (`C…`, `G…`,
     `D…`, `U…`, `W…`) failed the existing `target_ref.lstrip("-").isdigit()`
     check and fell through with `is_explicit=False`, forcing the value
     into the name-resolver.
  2. **`gateway/channel_directory.py::resolve_channel_name`** only
     matched against `channel["name"]`, never `channel["id"]`. So even
     when a channel *was* in the directory, supplying its raw ID didn't
     resolve.
  3. **`gateway/channel_directory.py::_build_slack`** never actually
     called the Slack web API — it just delegated to
     `_build_from_sessions`, so the directory only knew about channels
     the bot had received inbound messages in. Channels the bot had
     joined but never been talked to in were absent from
     `action='list'` and unaddressable by name.

  The "redirected to home channel" symptom was the model's own
  fallback: after the resolver error, it retried with bare
  `target='slack'`, which the schema documents as "uses home channel"
  — compounding the visible misbehavior.

  ### Fix

  - `_parse_target_ref` recognizes Slack channel/user IDs as explicit
    targets via a precompiled regex (`[CGDUW][A-Z0-9]{8,}`), so they
    bypass name resolution entirely.
  - `resolve_channel_name` adds a case-sensitive raw-ID match step
    before the existing case-insensitive name match. Defense in depth
    for any platform: a raw ID always resolves to itself if present in
    the directory.
  - `_build_slack` now calls `users.conversations` against each
    workspace's `AsyncWebClient`, paginates via
    `response_metadata.next_cursor`, and merges in DM entries from
    session history. Per-workspace errors are isolated. Requires
    `channels:read` and `groups:read` Slack scopes for full
    enumeration; missing scopes degrade gracefully for that workspace
    alone.
  - `build_channel_directory` becomes `async` (Slack web calls require
    it). Two async-context callers in `gateway/run.py` are awaited;
    the cron-ticker thread call bridges via
    `asyncio.run_coroutine_threadsafe(...).result(timeout=30)`.

  ### Why this approach

  - **Surgical, not architectural.** The Slack ID parsing branch
    matches the pattern every other platform already uses in
    `_parse_target_ref` — it's the smallest change that brings Slack to
    parity.
  - **ID-match-before-name in `resolve_channel_name`** is platform-
    agnostic: it costs one cheap loop and prevents this entire class of
    bug from recurring on any future platform whose ID format isn't
    caught by `_parse_target_ref`.
  - **`users.conversations` over `conversations.list`** because it
    scopes to channels the bot is actually a member of, requires
    fewer permissions, and matches how Slack itself recommends bots
    enumerate their own workspace presence.
  - **Async over sync-with-`requests`** because the adapter already
    owns the typed `AsyncWebClient`s with multi-workspace tokens, proxy
    config, and retry semantics — reusing them avoids a parallel
    HTTP path and keeps token plumbing in one place.

  ### Tests

  24 new test cases:

  - `tests/tools/test_send_message_tool.py::TestParseTargetRefSlack` (7) —
    public/private/DM/user IDs, whitespace, lowercase/short rejection,
    isolation from other platforms.
  - `tests/gateway/test_channel_directory.py::TestResolveChannelName::test_id_match_takes_precedence_over_name` (1) —
    raw IDs resolve to themselves, lowercase still falls through to
    name matching.
  - `tests/gateway/test_channel_directory.py::TestBuildSlack` (7) —
    no-clients fallback, single-page list, pagination via cursor,
    per-workspace error isolation, session-DM merge with dedup,
    missing-id/name skip, `ok=False` handling.

  Existing `test_failed_write_preserves_previous_cache` updated to
  `asyncio.run(build_channel_directory({}))`.

  Full test run: 118 passed (1 pre-existing Windows `/tmp/` failure
  unrelated to this change).


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #15927

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

Three fixes:
- _parse_target_ref recognizes Slack IDs (C/G/D/U/W prefix) as explicit targets so the name-resolver is bypassed entirely.
- resolve_channel_name tries a case-sensitive raw-ID match before the existing name match, so any platform's IDs resolve cleanly.
- _build_slack now actually calls users.conversations against each workspace's AsyncWebClient (paginated), instead of only returning session-history entries. This populates the directory with public and private channels the bot has joined, so action='list' shows them and they can also be addressed by name. Errors from one workspace don't block others.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.  Add Hermes to at least two Slack channels (e.g. #general, and #social)
2.  In channel 1 (#general) ask Hermes to send a message (e.g. "hello world") in channel 2 (#social)
3.  Hermes should say hello world in channel 2, while reporting message successfully sent in channel 1.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - There is a existing PR #2897 , but that one has been closed without merging.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**

