### PR TITLE
Fix config-driven context length resolution

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5356,9 +5356,57 @@ class HermesCLI:
         if result.api_mode:
             self.api_mode = result.api_mode
 
+        # Recompute the effective config override for the newly selected runtime.
+        # This mirrors AIAgent init so /model confirmation text stays aligned with
+        # the live agent when providers share a base_url but have different
+        # per-model context lengths.
+        _display_ctx = None
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            _cfg = load_config()
+            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+            if _display_ctx is None:
+                _custom_providers = get_compatible_custom_providers(_cfg)
+                _normalized_base_url = (result.base_url or self.base_url or "").rstrip("/")
+                _normalized_provider = (result.target_provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
+        self._config_context_length = _display_ctx
+
         # Apply to running agent (in-place swap)
         if self.agent is not None:
             try:
+                self.agent._config_context_length = _display_ctx
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
@@ -5394,6 +5442,7 @@ class HermesCLI:
             base_url=result.base_url or self.base_url or "",
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
+            config_context_length=_display_ctx,
         )
         if ctx:
             _cprint(f"    Context: {ctx:,} tokens")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4957,21 +4957,129 @@ class GatewayRunner:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
     
-    def _format_session_info(self) -> str:
+    def _resolve_display_context_length_for_gateway(
+        self,
+        model: str,
+        provider: str = "",
+        base_url: str = "",
+        api_key: str = "",
+        *,
+        model_info=None,
+        cfg: Optional[dict] = None,
+    ) -> tuple[Optional[int], Optional[int]]:
+        """Return (resolved_context, config_override_context) for gateway displays.
+
+        Gateway surfaces model context in three places: direct `/model`, the
+        interactive model picker callback, and `/new` session reset banners.
+        All three must prefer the same provider-aware config sources:
+
+        1. `model.context_length`
+        2. `providers.<provider>.models.<model>.context_length`
+        3. legacy/custom provider entries returned by `get_compatible_custom_providers()`
+        4. provider-aware runtime detection/fallbacks via `resolve_display_context_length()`
+        """
+        from hermes_cli.model_switch import resolve_display_context_length
+
+        _display_ctx = None
+        try:
+            _cfg = cfg if isinstance(cfg, dict) else load_config()
+        except Exception:
+            _cfg = {}
+
+        try:
+            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+
+            if _display_ctx is None and isinstance(_cfg, dict):
+                _providers = _cfg.get("providers", {}) or {}
+                if isinstance(_providers, dict):
+                    _provider_cfg = _providers.get(provider, {}) if provider else {}
+                    if isinstance(_provider_cfg, dict):
+                        _provider_models = _provider_cfg.get("models", {}) or {}
+                        if isinstance(_provider_models, dict):
+                            _provider_model_cfg = _provider_models.get(model, {}) or {}
+                            if isinstance(_provider_model_cfg, dict):
+                                _provider_ctx = _provider_model_cfg.get("context_length")
+                                if _provider_ctx is not None:
+                                    try:
+                                        _display_ctx = int(_provider_ctx)
+                                    except (TypeError, ValueError):
+                                        _display_ctx = None
+
+            if _display_ctx is None and isinstance(_cfg, dict):
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers
+                    _custom_providers = get_compatible_custom_providers(_cfg)
+                except Exception:
+                    _custom_providers = _cfg.get("custom_providers") or []
+
+                _normalized_base_url = (base_url or "").rstrip("/")
+                _normalized_provider = (provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
+
+        try:
+            ctx = resolve_display_context_length(
+                model,
+                provider,
+                base_url=base_url or "",
+                api_key=api_key or "",
+                model_info=model_info,
+                config_context_length=_display_ctx,
+            )
+        except Exception:
+            ctx = None
+
+        return ctx, _display_ctx
+
+    def _format_session_info(
+        self,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+    ) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
         """
-        from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
 
         model = _resolve_gateway_model()
-        config_context_length = None
         provider = None
         base_url = None
         api_key = None
         custom_provs = None
+        data = {}
 
         try:
             cfg_path = _hermes_home / "config.yaml"
@@ -4981,12 +5089,6 @@ class GatewayRunner:
                     data = _info_yaml.safe_load(f) or {}
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
-                    raw_ctx = model_cfg.get("context_length")
-                    if raw_ctx is not None:
-                        try:
-                            config_context_length = int(raw_ctx)
-                        except (TypeError, ValueError):
-                            pass
                     provider = model_cfg.get("provider") or None
                     base_url = model_cfg.get("base_url") or None
                 try:
@@ -4995,7 +5097,7 @@ class GatewayRunner:
                 except Exception:
                     custom_provs = data.get("custom_providers")
         except Exception:
-            pass
+            data = {}
 
         # Resolve runtime credentials for probing
         try:
@@ -5006,14 +5108,31 @@ class GatewayRunner:
         except Exception:
             pass
 
-        context_length = get_model_context_length(
-            model,
-            base_url=base_url or "",
-            api_key=api_key or "",
-            config_context_length=config_context_length,
-            provider=provider or "",
-            custom_providers=custom_provs,
+        resolved_session_key = session_key
+        if not resolved_session_key and source is not None:
+            try:
+                resolved_session_key = self._session_key_for_source(source)
+            except Exception:
+                resolved_session_key = None
+
+        override = (
+            self._session_model_overrides.get(resolved_session_key, {})
+            if resolved_session_key else {}
         )
+        if override:
+            model = override.get("model", model)
+            provider = override.get("provider", provider)
+            base_url = override.get("base_url", base_url)
+            api_key = override.get("api_key", api_key)
+
+        context_length, config_context_length = self._resolve_display_context_length_for_gateway(
+            model,
+            provider or "",
+            base_url or "",
+            api_key or "",
+            cfg=data,
+        )
+        context_length = context_length or DEFAULT_FALLBACK_CONTEXT
 
         # Format context source hint
         if config_context_length is not None:
@@ -5637,47 +5756,13 @@ class GatewayRunner:
                         if not result.success:
                             return f"Error: {result.error_message}"
 
-                        _display_ctx = None
-                        try:
-                            _cfg = load_config()
-                            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
-                            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
-                            if _raw_ctx is not None:
-                                try:
-                                    _display_ctx = int(_raw_ctx)
-                                except (TypeError, ValueError):
-                                    _display_ctx = None
-                            if _display_ctx is None:
-                                from hermes_cli.config import get_compatible_custom_providers
-                                _custom_providers = get_compatible_custom_providers(_cfg)
-                                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
-                                _normalized_provider = (result.target_provider or "").strip().lower()
-                                for _cp_entry in _custom_providers:
-                                    if not isinstance(_cp_entry, dict):
-                                        continue
-                                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
-                                    if _cp_url and _cp_url != _normalized_base_url:
-                                        continue
-                                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
-                                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
-                                        continue
-                                    _cp_models = _cp_entry.get("models", {})
-                                    if not isinstance(_cp_models, dict):
-                                        continue
-                                    _cp_model_cfg = _cp_models.get(result.new_model, {})
-                                    if not isinstance(_cp_model_cfg, dict):
-                                        continue
-                                    _cp_ctx = _cp_model_cfg.get("context_length")
-                                    if _cp_ctx is None:
-                                        continue
-                                    try:
-                                        _display_ctx = int(_cp_ctx)
-                                    except (TypeError, ValueError):
-                                        _display_ctx = None
-                                    else:
-                                        break
-                        except Exception:
-                            _display_ctx = None
+                        _, _display_ctx = _self._resolve_display_context_length_for_gateway(
+                            result.new_model,
+                            result.target_provider,
+                            result.base_url or current_base_url or "",
+                            result.api_key or current_api_key or "",
+                            cfg=cfg,
+                        )
 
                         # Update cached agent in-place
                         cached_entry = None
@@ -5725,56 +5810,13 @@ class GatewayRunner:
                         lines = [f"Model switched to `{result.new_model}`"]
                         lines.append(f"Provider: {plabel}")
                         mi = result.model_info
-                        from hermes_cli.model_switch import resolve_display_context_length
-                        _display_ctx = None
-                        try:
-                            _cfg = load_config()
-                            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
-                            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
-                            if _raw_ctx is not None:
-                                try:
-                                    _display_ctx = int(_raw_ctx)
-                                except (TypeError, ValueError):
-                                    _display_ctx = None
-                            if _display_ctx is None:
-                                from hermes_cli.config import get_compatible_custom_providers
-                                _custom_providers = get_compatible_custom_providers(_cfg)
-                                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
-                                _normalized_provider = (result.target_provider or "").strip().lower()
-                                for _cp_entry in _custom_providers:
-                                    if not isinstance(_cp_entry, dict):
-                                        continue
-                                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
-                                    if _cp_url and _cp_url != _normalized_base_url:
-                                        continue
-                                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
-                                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
-                                        continue
-                                    _cp_models = _cp_entry.get("models", {})
-                                    if not isinstance(_cp_models, dict):
-                                        continue
-                                    _cp_model_cfg = _cp_models.get(result.new_model, {})
-                                    if not isinstance(_cp_model_cfg, dict):
-                                        continue
-                                    _cp_ctx = _cp_model_cfg.get("context_length")
-                                    if _cp_ctx is None:
-                                        continue
-                                    try:
-                                        _display_ctx = int(_cp_ctx)
-                                    except (TypeError, ValueError):
-                                        _display_ctx = None
-                                    else:
-                                        break
-                        except Exception:
-                            _display_ctx = None
-                        ctx = resolve_display_context_length(
+                        ctx, _ = _self._resolve_display_context_length_for_gateway(
                             result.new_model,
                             result.target_provider,
-                            base_url=result.base_url or current_base_url or "",
-                            api_key=result.api_key or current_api_key or "",
+                            result.base_url or current_base_url or "",
+                            result.api_key or current_api_key or "",
                             model_info=mi,
-                            custom_providers=custom_provs,
-                            config_context_length=_display_ctx,
+                            cfg=cfg,
                         )
                         if ctx:
                             lines.append(f"Context: {ctx:,} tokens")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4341,8 +4341,8 @@ class GatewayRunner:
 
                 # Check custom_providers per-model context_length
                 # (same fallback as run_agent.py lines 1171-1189).
-                # Must run after runtime resolution so _hyg_base_url is set.
-                if _hyg_config_context_length is None and _hyg_base_url:
+                # Must run after runtime resolution so provider/base_url are set.
+                if _hyg_config_context_length is None:
                     try:
                         try:
                             from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
@@ -4351,19 +4351,27 @@ class GatewayRunner:
                             _hyg_custom_providers = _hyg_data.get("custom_providers")
                             if not isinstance(_hyg_custom_providers, list):
                                 _hyg_custom_providers = []
+                        _hyg_base_url_norm = (_hyg_base_url or "").rstrip("/")
+                        _hyg_provider_norm = str(_hyg_provider or "").strip().lower()
                         for _cp in _hyg_custom_providers:
                             if not isinstance(_cp, dict):
                                 continue
                             _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                            if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                _cp_models = _cp.get("models", {})
-                                if isinstance(_cp_models, dict):
-                                    _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                    if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
-                                        if _cp_ctx is not None:
-                                            _hyg_config_context_length = int(_cp_ctx)
-                                break
+                            if _cp_url and _hyg_base_url_norm and _cp_url != _hyg_base_url_norm:
+                                continue
+                            if _cp_url and not _hyg_base_url_norm:
+                                continue
+                            _cp_provider_key = str(_cp.get("provider_key", "") or "").strip().lower()
+                            if _hyg_provider_norm and _cp_provider_key and _cp_provider_key != _hyg_provider_norm:
+                                continue
+                            _cp_models = _cp.get("models", {})
+                            if isinstance(_cp_models, dict):
+                                _cp_model_cfg = _cp_models.get(_hyg_model, {})
+                                if isinstance(_cp_model_cfg, dict):
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is not None:
+                                        _hyg_config_context_length = int(_cp_ctx)
+                                        break
                     except (TypeError, ValueError):
                         pass
             except Exception:
@@ -5550,6 +5558,7 @@ class GatewayRunner:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        cfg = {}
         config_path = _hermes_home / "config.yaml"
         try:
             if config_path.exists():
@@ -5628,6 +5637,48 @@ class GatewayRunner:
                         if not result.success:
                             return f"Error: {result.error_message}"
 
+                        _display_ctx = None
+                        try:
+                            _cfg = load_config()
+                            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+                            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+                            if _raw_ctx is not None:
+                                try:
+                                    _display_ctx = int(_raw_ctx)
+                                except (TypeError, ValueError):
+                                    _display_ctx = None
+                            if _display_ctx is None:
+                                from hermes_cli.config import get_compatible_custom_providers
+                                _custom_providers = get_compatible_custom_providers(_cfg)
+                                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                                _normalized_provider = (result.target_provider or "").strip().lower()
+                                for _cp_entry in _custom_providers:
+                                    if not isinstance(_cp_entry, dict):
+                                        continue
+                                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                                    if _cp_url and _cp_url != _normalized_base_url:
+                                        continue
+                                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                                        continue
+                                    _cp_models = _cp_entry.get("models", {})
+                                    if not isinstance(_cp_models, dict):
+                                        continue
+                                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                                    if not isinstance(_cp_model_cfg, dict):
+                                        continue
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is None:
+                                        continue
+                                    try:
+                                        _display_ctx = int(_cp_ctx)
+                                    except (TypeError, ValueError):
+                                        _display_ctx = None
+                                    else:
+                                        break
+                        except Exception:
+                            _display_ctx = None
+
                         # Update cached agent in-place
                         cached_entry = None
                         _cache_lock = getattr(_self, "_agent_cache_lock", None)
@@ -5637,6 +5688,7 @@ class GatewayRunner:
                                 cached_entry = _cache.get(_session_key)
                         if cached_entry and cached_entry[0] is not None:
                             try:
+                                cached_entry[0]._config_context_length = _display_ctx
                                 cached_entry[0].switch_model(
                                     new_model=result.new_model,
                                     new_provider=result.target_provider,
@@ -5674,6 +5726,47 @@ class GatewayRunner:
                         lines.append(f"Provider: {plabel}")
                         mi = result.model_info
                         from hermes_cli.model_switch import resolve_display_context_length
+                        _display_ctx = None
+                        try:
+                            _cfg = load_config()
+                            _model_cfg = _cfg.get("model", {}) if isinstance(_cfg, dict) else {}
+                            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+                            if _raw_ctx is not None:
+                                try:
+                                    _display_ctx = int(_raw_ctx)
+                                except (TypeError, ValueError):
+                                    _display_ctx = None
+                            if _display_ctx is None:
+                                from hermes_cli.config import get_compatible_custom_providers
+                                _custom_providers = get_compatible_custom_providers(_cfg)
+                                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                                _normalized_provider = (result.target_provider or "").strip().lower()
+                                for _cp_entry in _custom_providers:
+                                    if not isinstance(_cp_entry, dict):
+                                        continue
+                                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                                    if _cp_url and _cp_url != _normalized_base_url:
+                                        continue
+                                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                                        continue
+                                    _cp_models = _cp_entry.get("models", {})
+                                    if not isinstance(_cp_models, dict):
+                                        continue
+                                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                                    if not isinstance(_cp_model_cfg, dict):
+                                        continue
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is None:
+                                        continue
+                                    try:
+                                        _display_ctx = int(_cp_ctx)
+                                    except (TypeError, ValueError):
+                                        _display_ctx = None
+                                    else:
+                                        break
+                        except Exception:
+                            _display_ctx = None
                         ctx = resolve_display_context_length(
                             result.new_model,
                             result.target_provider,
@@ -5681,6 +5774,7 @@ class GatewayRunner:
                             api_key=result.api_key or current_api_key or "",
                             model_info=mi,
                             custom_providers=custom_provs,
+                            config_context_length=_display_ctx,
                         )
                         if ctx:
                             lines.append(f"Context: {ctx:,} tokens")
@@ -5752,6 +5846,47 @@ class GatewayRunner:
         if not result.success:
             return f"Error: {result.error_message}"
 
+        _display_ctx = None
+        try:
+            _model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+            if _display_ctx is None:
+                from hermes_cli.config import get_compatible_custom_providers
+                _custom_providers = get_compatible_custom_providers(cfg)
+                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                _normalized_provider = (result.target_provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
+
         # If there's a cached agent, update it in-place
         cached_entry = None
         _cache_lock = getattr(self, "_agent_cache_lock", None)
@@ -5762,6 +5897,7 @@ class GatewayRunner:
 
         if cached_entry and cached_entry[0] is not None:
             try:
+                cached_entry[0]._config_context_length = _display_ctx
                 cached_entry[0].switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
@@ -5822,6 +5958,46 @@ class GatewayRunner:
         # Copilot, and Nous-enforced caps win over the raw models.dev entry.
         mi = result.model_info
         from hermes_cli.model_switch import resolve_display_context_length
+        _display_ctx = None
+        try:
+            _model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                try:
+                    _display_ctx = int(_raw_ctx)
+                except (TypeError, ValueError):
+                    _display_ctx = None
+            if _display_ctx is None:
+                from hermes_cli.config import get_compatible_custom_providers
+                _custom_providers = get_compatible_custom_providers(cfg)
+                _normalized_base_url = (result.base_url or current_base_url or "").rstrip("/")
+                _normalized_provider = (result.target_provider or "").strip().lower()
+                for _cp_entry in _custom_providers:
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = str(_cp_entry.get("base_url", "") or "").rstrip("/")
+                    if _cp_url and _cp_url != _normalized_base_url:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if not isinstance(_cp_models, dict):
+                        continue
+                    _cp_model_cfg = _cp_models.get(result.new_model, {})
+                    if not isinstance(_cp_model_cfg, dict):
+                        continue
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        _display_ctx = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        _display_ctx = None
+                    else:
+                        break
+        except Exception:
+            _display_ctx = None
         ctx = resolve_display_context_length(
             result.new_model,
             result.target_provider,
@@ -5829,6 +6005,7 @@ class GatewayRunner:
             api_key=result.api_key or current_api_key or "",
             model_info=mi,
             custom_providers=custom_provs,
+            config_context_length=_display_ctx,
         )
         if ctx:
             lines.append(f"Context: {ctx:,} tokens")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -534,6 +534,7 @@ def resolve_display_context_length(
     api_key: str = "",
     model_info: Optional[ModelInfo] = None,
     custom_providers: list | None = None,
+    config_context_length: Optional[int] = None,
 ) -> Optional[int]:
     """Resolve the context length to show in /model output.
 
@@ -558,6 +559,7 @@ def resolve_display_context_length(
             model,
             base_url=base_url or "",
             api_key=api_key or "",
+            config_context_length=config_context_length,
             provider=provider or None,
             custom_providers=custom_providers,
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1782,9 +1782,6 @@ class AIAgent:
                 )
                 _config_context_length = None
 
-        # Store for reuse in switch_model (so config override persists across model switches)
-        self._config_context_length = _config_context_length
-
         # Resolve custom_providers list once for reuse below (startup
         # context-length override and plugin context-engine init).
         try:
@@ -1813,36 +1810,44 @@ class AIAgent:
             # wasn't a valid positive int — the helper silently skips those.
             if _config_context_length is None:
                 _target = self.base_url.rstrip("/") if self.base_url else ""
+                _normalized_provider = (self.provider or "").strip().lower()
                 for _cp_entry in _custom_providers:
                     if not isinstance(_cp_entry, dict):
                         continue
                     _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                    if _target and _cp_url == _target:
-                        _cp_models = _cp_entry.get("models", {})
-                        if isinstance(_cp_models, dict):
-                            _cp_model_cfg = _cp_models.get(self.model, {})
-                            if isinstance(_cp_model_cfg, dict):
-                                _cp_ctx = _cp_model_cfg.get("context_length")
-                                if _cp_ctx is not None:
-                                    try:
-                                        _parsed = int(_cp_ctx)
-                                        if _parsed <= 0:
-                                            raise ValueError
-                                    except (TypeError, ValueError):
-                                        logger.warning(
-                                            "Invalid context_length for model %r in "
-                                            "custom_providers: %r — must be a positive "
-                                            "integer (e.g. 256000, not '256K'). "
-                                            "Falling back to auto-detection.",
-                                            self.model, _cp_ctx,
-                                        )
-                                        print(
-                                            f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
-                                            f"  Must be a positive integer (e.g. 256000, not '256K').\n"
-                                            f"  Falling back to auto-detected context window.\n",
-                                            file=sys.stderr,
-                                        )
-                        break
+                    if _target and _cp_url != _target:
+                        continue
+                    _cp_provider_key = str(_cp_entry.get("provider_key", "") or "").strip().lower()
+                    if _normalized_provider and _cp_provider_key and _cp_provider_key != _normalized_provider:
+                        continue
+                    _cp_models = _cp_entry.get("models", {})
+                    if isinstance(_cp_models, dict):
+                        _cp_model_cfg = _cp_models.get(self.model, {})
+                        if isinstance(_cp_model_cfg, dict):
+                            _cp_ctx = _cp_model_cfg.get("context_length")
+                            if _cp_ctx is not None:
+                                try:
+                                    _parsed = int(_cp_ctx)
+                                    if _parsed <= 0:
+                                        raise ValueError
+                                except (TypeError, ValueError):
+                                    logger.warning(
+                                        "Invalid context_length for model %r in "
+                                        "custom_providers: %r — must be a positive "
+                                        "integer (e.g. 256000, not '256K'). "
+                                        "Falling back to auto-detection.",
+                                        self.model, _cp_ctx,
+                                    )
+                                    print(
+                                        f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
+                                        f"  Must be a positive integer (e.g. 256000, not '256K').\n"
+                                        f"  Falling back to auto-detected context window.\n",
+                                        file=sys.stderr,
+                                    )
+                    break
+
+        # Store for reuse in switch_model (so config override persists across model switches)
+        self._config_context_length = _config_context_length
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -2445,12 +2450,15 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            client_provider = getattr(client, "provider", None)
+            if not isinstance(client_provider, str):
+                client_provider = ""
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
-                provider=getattr(self, "provider", ""),
+                provider=client_provider,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/gateway/test_gateway_model_context_display.py
+++ b/tests/gateway/test_gateway_model_context_display.py
@@ -1,0 +1,194 @@
+"""Regression tests for gateway model context display helpers.
+
+Covers three user-visible paths that must agree:
+- direct /model <name> --provider <slug>
+- interactive /model picker callback
+- /new session reset banner via _format_session_info()
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+AI_API_CONFIG = """
+model:
+  default: MiniMax-M2.7
+  provider: ai-api-chat
+providers:
+  ai-api-codex:
+    name: AI API Codex
+    base_url: https://ai-api.home.sadlay.cn:22843/v1
+    api_key: sk-test
+    api_mode: codex_responses
+    default_model: gpt-5.4
+    models:
+      gpt-5.4:
+        context_length: 400000
+  ai-api-chat:
+    name: AI API Chat
+    base_url: https://ai-api.home.sadlay.cn:22843/v1
+    api_key: sk-test
+    api_mode: chat_completions
+    default_model: MiniMax-M2.7
+    models:
+      MiniMax-M2.7:
+        context_length: 204800
+"""
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._clear_session_boundary_security_state = lambda _session_key: None
+    runner._invalidate_session_run_generation = lambda *_args, **_kwargs: None
+    runner._cleanup_agent_resources = lambda *_args, **_kwargs: None
+    runner._evict_cached_agent = lambda *_args, **_kwargs: None
+    runner._is_user_authorized = lambda _source: True
+
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.reset_session.return_value = session_entry
+    runner.session_store._entries = {session_key: session_entry}
+    return runner
+
+
+class _PickerAdapter:
+    def __init__(self):
+        self.last_result = None
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata=None,
+    ):
+        self.last_result = await on_model_selected(chat_id, "gpt-5.4", "ai-api-codex")
+        return SimpleNamespace(success=True, message_id="picker-msg-1")
+
+
+@pytest.mark.asyncio
+async def test_interactive_model_picker_uses_provider_model_context_length(tmp_path):
+    runner = _make_runner()
+    adapter = _PickerAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    (tmp_path / "config.yaml").write_text(AI_API_CONFIG)
+
+    fake_result = SimpleNamespace(
+        success=True,
+        new_model="gpt-5.4",
+        target_provider="ai-api-codex",
+        provider_label="ai-api-codex",
+        api_key="sk-test",
+        base_url="https://ai-api.home.sadlay.cn:22843/v1",
+        api_mode="codex_responses",
+        error_message="",
+        model_info=None,
+    )
+    fake_providers = [{"slug": "ai-api-codex", "name": "AI API Codex", "models": ["gpt-5.4"], "is_current": False, "total_models": 1}]
+
+    with patch("gateway.run._hermes_home", tmp_path), patch(
+        "hermes_cli.model_switch.list_authenticated_providers", return_value=fake_providers
+    ), patch("hermes_cli.model_switch.switch_model", return_value=fake_result):
+        response = await runner._handle_model_command(_make_event("/model"))
+
+    assert response is None
+    assert adapter.last_result is not None
+    assert "Model switched to `gpt-5.4`" in adapter.last_result
+    assert "Provider: ai-api-codex" in adapter.last_result
+    assert "Context: 400,000 tokens" in adapter.last_result
+
+
+@pytest.mark.asyncio
+async def test_new_banner_uses_provider_model_context_length_from_config(tmp_path):
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: MagicMock(send=AsyncMock())}
+
+    (tmp_path / "config.yaml").write_text(AI_API_CONFIG)
+
+    with patch("gateway.run._hermes_home", tmp_path):
+        response = await runner._handle_reset_command(_make_event("/new"))
+
+    assert "Session reset! Starting fresh." in response
+    assert "◆ Model: `MiniMax-M2.7`" in response
+    assert "◆ Provider: ai-api-chat" in response
+    assert "◆ Context: 204K tokens" in response
+
+
+def test_format_session_info_prefers_session_override_context_length(tmp_path):
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "ai-api-codex",
+        "api_key": "sk-test",
+        "base_url": "https://ai-api.home.sadlay.cn:22843/v1",
+        "api_mode": "codex_responses",
+    }
+
+    (tmp_path / "config.yaml").write_text(AI_API_CONFIG)
+
+    runtime = {
+        "provider": "ai-api-chat",
+        "base_url": "https://ai-api.home.sadlay.cn:22843/v1",
+        "api_key": "sk-test",
+    }
+
+    with patch("gateway.run._hermes_home", tmp_path), patch(
+        "gateway.run._resolve_gateway_model", return_value="MiniMax-M2.7"
+    ), patch("gateway.run._resolve_runtime_agent_kwargs", return_value=runtime):
+        info = runner._format_session_info(_make_source(), session_key)
+
+    assert "◆ Model: `gpt-5.4`" in info
+    assert "◆ Provider: ai-api-codex" in info
+    assert "◆ Context: 400K tokens" in info

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -96,6 +96,7 @@ class TestResolveDisplayContextLength:
             api_key="sk-test",
             config_context_length=204_800,
             provider="provider-b",
+            custom_providers=None,
         )
 
     def test_custom_providers_override_honored(self):

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -75,19 +75,28 @@ class TestResolveDisplayContextLength:
             )
         assert ctx == 200_000
 
-    def test_prefers_resolver_even_when_model_info_has_larger_value(self):
-        """Invariant: provider-aware resolver is authoritative, even if models.dev
-        reports a bigger window."""
-        fake_mi = _FakeModelInfo(2_000_000)
+    def test_prefers_explicit_config_context_override_for_custom_provider(self):
+        fake_mi = _FakeModelInfo(128_000)
         with patch(
-            "agent.model_metadata.get_model_context_length", return_value=128_000
-        ):
+            "agent.model_metadata.get_model_context_length",
+            return_value=204_800,
+        ) as mock_get_ctx:
             ctx = resolve_display_context_length(
-                "capped-model",
-                "capped-provider",
+                "chat-model-b",
+                "provider-b",
+                base_url="https://shared-gateway.example/v1",
+                api_key="sk-test",
                 model_info=fake_mi,
+                config_context_length=204_800,
             )
-        assert ctx == 128_000
+        assert ctx == 204_800
+        mock_get_ctx.assert_called_once_with(
+            "chat-model-b",
+            base_url="https://shared-gateway.example/v1",
+            api_key="sk-test",
+            config_context_length=204_800,
+            provider="provider-b",
+        )
 
     def test_custom_providers_override_honored(self):
         """Regression for #15779: /model switch onto a custom provider must

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -171,6 +171,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     mock_client = MagicMock()
     mock_client.base_url = "http://custom-endpoint:8080/v1"
     mock_client.api_key = "sk-custom"
+    mock_client.provider = ""
     mock_get_client.return_value = (mock_client, "custom/big-model")
 
     agent._emit_status = lambda msg: None
@@ -181,7 +182,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
-        provider="openrouter",
+        provider="",
     )
 
 
@@ -194,6 +195,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     mock_client = MagicMock()
     mock_client.base_url = "http://custom:8080/v1"
     mock_client.api_key = "sk-test"
+    mock_client.provider = ""
     mock_get_client.return_value = (mock_client, "custom/model")
 
     agent._emit_status = lambda msg: None
@@ -204,7 +206,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
-        provider="openrouter",
+        provider="",
     )
 
 
@@ -233,6 +235,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
     mock_client = MagicMock()
     mock_client.base_url = "http://custom-endpoint:8080/v1"
     mock_client.api_key = "sk-custom"
+    mock_client.provider = ""
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
@@ -259,6 +262,63 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         config_context_length=1_000_000,
         provider="",
     )
+
+
+def test_init_prefers_provider_specific_context_override_when_base_urls_match():
+    """When multiple providers share a base_url, AIAgent should use the entry
+    matching the active provider instead of the first base_url match."""
+
+    class _StubCompressor:
+        def __init__(self, *args, **kwargs):
+            self.context_length = kwargs.get("config_context_length") or 128_000
+            self.threshold_tokens = 64_000
+            self.threshold_percent = 0.50
+
+        def get_tool_schemas(self):
+            return []
+
+        def on_session_start(self, *args, **kwargs):
+            return None
+
+    cfg = {
+        "providers": {
+            "provider-a": {
+                "name": "Provider A",
+                "base_url": "https://shared-gateway.example/v1",
+                "models": {
+                    "reasoning-model-a": {"context_length": 400_000},
+                },
+            },
+            "provider-b": {
+                "name": "Provider B",
+                "base_url": "https://shared-gateway.example/v1",
+                "models": {
+                    "chat-model-b": {"context_length": 204_800},
+                },
+            },
+        },
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.ContextCompressor", new=_StubCompressor),
+        patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(None, None)),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://shared-gateway.example/v1",
+            provider="provider-b",
+            model="chat-model-b",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._config_context_length == 204_800
+    assert agent.context_compressor.context_length == 204_800
 
 
 @patch("agent.auxiliary_client.get_text_auxiliary_client")

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -34,8 +34,23 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     )
     agent.context_compressor = compressor
 
-    # For switch_model
+    # Minimal state expected by switch_model
     agent._primary_runtime = {}
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._cached_system_prompt = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = ""
+    agent._is_anthropic_oauth = False
+    agent._client_kwargs = {}
+    agent._transport_cache = {}
+    agent._vprint = lambda *args, **kwargs: None
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
 
     return agent
 


### PR DESCRIPTION
## Summary

This PR focuses on the remaining context-resolution gap **after** the upstream fixes in #15844 and #16030.

Those upstream changes already fixed:
- baseline `custom_providers[].models.<id>.context_length` propagation
- CLI `/model` picker display for provider-specific context caps

The remaining issue addressed here is narrower:

1. **provider disambiguation when multiple configured providers share the same `base_url`**
2. **gateway-side consistency across all user-visible model/context display paths**
3. **regression coverage for those gateway-visible paths**

In practice, this matters for configurations where two providers point at the same OpenAI-compatible gateway URL but expose different models or different configured `context_length` values (for example, separate chat vs codex-style provider entries sharing one gateway endpoint).

## Problem

Even after the earlier fixes, context resolution could still pick the wrong config entry when:

- multiple configured providers shared the same `base_url`
- the lookup matched only on URL, without also disambiguating by provider identity
- gateway-visible paths (`/model` picker, `/new`, session banners) needed to stay consistent with the runtime

That could lead to the wrong configured `context_length` being selected or displayed for the active provider/model pair.

## What this PR changes

### 1) Provider-aware disambiguation for shared gateways
This PR keeps the existing context-resolution flow but tightens selection so shared-gateway entries are matched by:
- normalized `base_url`
- **and** provider identity / provider key when available

This avoids accidentally selecting the first matching gateway entry when multiple providers share the same endpoint.

### 2) Gateway display consistency
This PR unifies gateway-side context resolution across:
- direct `/model <name> --provider <slug>` responses
- interactive `/model` picker confirmations
- `/new` reset/session banners
- session info derived from session overrides

The goal is simple: the runtime, the gateway picker, and gateway session/reset displays should all agree on the active context window.

### 3) Auxiliary compression feasibility correctness
This PR also keeps the auxiliary compression feasibility path aligned by ensuring the context-length resolver receives the **actual auxiliary client provider**, rather than implicitly reusing the main runtime provider.

## Files changed

- `cli.py`
- `gateway/run.py`
- `hermes_cli/model_switch.py`
- `run_agent.py`
- `tests/gateway/test_gateway_model_context_display.py`
- `tests/hermes_cli/test_model_switch_context_display.py`
- `tests/run_agent/test_compression_feasibility.py`
- `tests/run_agent/test_switch_model_context.py`

## Regression coverage

Added / updated targeted tests for:
- shared-`base_url` provider disambiguation in runtime init
- explicit config override propagation through display resolution
- auxiliary compression feasibility using the auxiliary client provider
- gateway interactive `/model` picker context display
- gateway `/new` / session banner context display
- gateway session override context display

## Testing

```bash
pytest tests/run_agent/test_compression_feasibility.py tests/hermes_cli/test_model_switch_context_display.py tests/run_agent/test_switch_model_context.py tests/gateway/test_gateway_model_context_display.py -q -o 'addopts='
```

Result on this branch:
- **29 passed**

## Relationship to previous work

- This PR **supersedes #15907**.
- This PR is **not intended to replace** the already-merged upstream fixes in **#15844** and **#16030**.
- Instead, it narrows in on the remaining shared-gateway/provider-disambiguation and gateway-consistency issues that those earlier fixes did not fully cover.

Addresses #12977.
