### PR TITLE
fix(model-picker): exclude providers with empty credential pool entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -929,11 +929,7 @@ def list_authenticated_providers(
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
                 providers_store = store.get("providers", {})
-                pool_store = store.get("credential_pool", {})
-                if store and (
-                    pid in providers_store or hermes_slug in providers_store
-                    or pid in pool_store or hermes_slug in pool_store
-                ):
+                if store and (pid in providers_store or hermes_slug in providers_store):
                     has_creds = True
             except Exception as exc:
                 logger.debug("Auth store check failed for %s: %s", pid, exc)
@@ -1016,11 +1012,7 @@ def list_authenticated_providers(
                 from hermes_cli.auth import _load_auth_store
                 _cp_store = _load_auth_store()
                 _cp_providers_store = _cp_store.get("providers", {})
-                _cp_pool_store = _cp_store.get("credential_pool", {})
-                if _cp_store and (
-                    _cp.slug in _cp_providers_store
-                    or _cp.slug in _cp_pool_store
-                ):
+                if _cp_store and _cp.slug in _cp_providers_store:
                     _cp_has_creds = True
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

- `list_authenticated_providers` checked `slug in credential_pool` (key existence) to decide a provider is authenticated, but an empty pool entry is not a credential
- `ollama-cloud` had a ghost entry in `credential_pool` with no actual key, so it appeared as authenticated in the model picker even with no `OLLAMA_API_KEY` set
- User selected `nemotron-3-super` from the Ollama Cloud section → routed to `https://ollama.com/v1` → HTTP 400 on every turn
- Fix: drop `pool_store` key-existence check from sections 2 and 2b; the `load_pool().has_credentials()` call that immediately follows already handles legitimate pooled credentials

## Test plan

- [ ] `tests/hermes_cli/test_ollama_cloud_provider.py` — 25 tests pass
- [ ] `tests/hermes_cli/test_model_switch_custom_providers.py` — 13 tests pass  
- [ ] `tests/hermes_cli/test_overlay_slug_resolution.py` — 5 tests pass
- [ ] Verified locally: `ollama-cloud` no longer appears in `list_authenticated_providers` when `OLLAMA_API_KEY` is unset (even with a ghost pool entry)
- [ ] Verified: providers with real credentials (copilot, openai-codex) still show correctly via `pool.has_credentials()`