### PR TITLE
feat(nix): declarative plugin installation for NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
 
       imports = [
         ./nix/packages.nix
+        ./nix/overlays.nix
         ./nix/nixosModules.nix
         ./nix/checks.nix
         ./nix/devShell.nix

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -195,7 +195,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
 
         # Verify extraPythonPackages PYTHONPATH injection
         extra-python-packages = let
-          testPkg = pkgs.python312Packages.pyyaml;
+          testPkg = pkgs.python312Packages.pyfiglet;
           hermesWithExtra = pkgs.callPackage ./hermes-agent.nix {
             inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
             npm-lockfile-fix = inputs'.npm-lockfile-fix.packages.default;

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -7,9 +7,7 @@
   perSystem = { pkgs, system, lib, inputs', ... }:
     let
       hermes-agent = inputs.self.packages.${system}.default;
-      hermesVenv = pkgs.callPackage ./python.nix {
-        inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
-      };
+      hermesVenv = hermes-agent.hermesVenv;
 
       configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
 
@@ -196,9 +194,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
         # Verify extraPythonPackages PYTHONPATH injection
         extra-python-packages = let
           testPkg = pkgs.python312Packages.pyfiglet;
-          hermesWithExtra = pkgs.callPackage ./hermes-agent.nix {
-            inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
-            npm-lockfile-fix = inputs'.npm-lockfile-fix.packages.default;
+          hermesWithExtra = hermes-agent.override {
             extraPythonPackages = [ testPkg ];
           };
         in pkgs.runCommand "hermes-extra-python-packages" { } ''
@@ -214,8 +210,9 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           echo "PASS: test package path found in wrapper"
 
           echo "=== Checking base package has no PYTHONPATH ==="
-          grep -q "PYTHONPATH" ${hermes-agent}/bin/hermes && \
-            (echo "FAIL: base package should not have PYTHONPATH"; exit 1) || true
+          if grep -q "PYTHONPATH" ${hermes-agent}/bin/hermes; then
+            echo "FAIL: base package should not have PYTHONPATH"; exit 1
+          fi
           echo "PASS: base package clean"
 
           echo "=== All extraPythonPackages checks passed ==="

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -4,7 +4,7 @@
 # transitive deps like onnxruntime that lack compatible wheels on
 # aarch64-darwin. The package and devShell still work on macOS.
 { inputs, ... }: {
-  perSystem = { pkgs, system, lib, ... }:
+  perSystem = { pkgs, system, lib, inputs', ... }:
     let
       hermes-agent = inputs.self.packages.${system}.default;
       hermesVenv = pkgs.callPackage ./python.nix {
@@ -189,6 +189,36 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           check_blocked "config edit" ${hermes-agent}/bin/hermes config edit
 
           echo "=== All guard checks passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+
+        # Verify extraPythonPackages PYTHONPATH injection
+        extra-python-packages = let
+          testPkg = pkgs.python312Packages.pyyaml;
+          hermesWithExtra = pkgs.callPackage ./hermes-agent.nix {
+            inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
+            npm-lockfile-fix = inputs'.npm-lockfile-fix.packages.default;
+            extraPythonPackages = [ testPkg ];
+          };
+        in pkgs.runCommand "hermes-extra-python-packages" { } ''
+          set -e
+          echo "=== Checking extraPythonPackages PYTHONPATH injection ==="
+
+          grep -q "PYTHONPATH" ${hermesWithExtra}/bin/hermes || \
+            (echo "FAIL: PYTHONPATH not in wrapper"; exit 1)
+          echo "PASS: PYTHONPATH present in wrapper"
+
+          grep -q "${testPkg}" ${hermesWithExtra}/bin/hermes || \
+            (echo "FAIL: test package path not in PYTHONPATH"; exit 1)
+          echo "PASS: test package path found in wrapper"
+
+          echo "=== Checking base package has no PYTHONPATH ==="
+          grep -q "PYTHONPATH" ${hermes-agent}/bin/hermes && \
+            (echo "FAIL: base package should not have PYTHONPATH"; exit 1) || true
+          echo "PASS: base package clean"
+
+          echo "=== All extraPythonPackages checks passed ==="
           mkdir -p $out
           echo "ok" > $out/result
         '';

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -4,7 +4,7 @@
 # transitive deps like onnxruntime that lack compatible wheels on
 # aarch64-darwin. The package and devShell still work on macOS.
 { inputs, ... }: {
-  perSystem = { pkgs, system, lib, inputs', ... }:
+  perSystem = { pkgs, system, lib, ... }:
     let
       hermes-agent = inputs.self.packages.${system}.default;
       hermesVenv = hermes-agent.hermesVenv;

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -57,7 +57,12 @@ let
 
   sitePackagesPath = python312.sitePackages;
 
-  pythonPath = lib.makeSearchPath sitePackagesPath extraPythonPackages;
+  # Walk propagatedBuildInputs to include transitive Python deps in PYTHONPATH.
+  # Without this, a plugin listing e.g. requests as a dep would fail at runtime
+  # if requests isn't already in the sealed uv2nix venv.
+  allExtraPythonPackages = python312.pkgs.requiredPythonModules extraPythonPackages;
+
+  pythonPath = lib.makeSearchPath sitePackagesPath allExtraPythonPackages;
 
   pyprojectHash = builtins.hashString "sha256" (builtins.readFile ../pyproject.toml);
   uvLockHash =
@@ -122,7 +127,7 @@ for di in venv_sp.glob('*.dist-info'):
                 break
 
 # Check each extra package for collisions
-extras_dirs = [${lib.concatMapStringsSep ", " (p: "'${toString p}'") extraPythonPackages}]
+extras_dirs = [${lib.concatMapStringsSep ", " (p: "'${toString p}'") allExtraPythonPackages}]
 for edir in extras_dirs:
     sp = pathlib.Path(edir) / '${sitePackagesPath}'
     if not sp.exists():

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -1,0 +1,181 @@
+# nix/hermes-agent.nix — Overridable Hermes Agent package
+#
+# callPackage auto-wires nixpkgs args; flake inputs are passed explicitly.
+# Users override via: pkgs.hermes-agent.override { extraPythonPackages = [...]; }
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  callPackage,
+  python312,
+  nodejs_22,
+  ripgrep,
+  git,
+  openssh,
+  ffmpeg,
+  tirith,
+  # Flake inputs — passed explicitly by packages.nix and overlays.nix
+  uv2nix,
+  pyproject-nix,
+  pyproject-build-systems,
+  npm-lockfile-fix,
+  # Overridable parameters
+  extraPythonPackages ? [ ],
+}:
+let
+  hermesVenv = callPackage ./python.nix {
+    inherit uv2nix pyproject-nix pyproject-build-systems;
+  };
+
+  hermesNpmLib = callPackage ./lib.nix {
+    inherit npm-lockfile-fix;
+  };
+
+  hermesTui = callPackage ./tui.nix {
+    inherit hermesNpmLib;
+  };
+
+  hermesWeb = callPackage ./web.nix {
+    inherit hermesNpmLib;
+  };
+
+  bundledSkills = lib.cleanSourceWith {
+    src = ../skills;
+    filter = path: _type: !(lib.hasInfix "/index-cache/" path);
+  };
+
+  runtimeDeps = [
+    nodejs_22
+    ripgrep
+    git
+    openssh
+    ffmpeg
+    tirith
+  ];
+
+  runtimePath = lib.makeBinPath runtimeDeps;
+
+  sitePackagesPath = python312.sitePackages;
+
+  pythonPath = lib.makeSearchPath sitePackagesPath extraPythonPackages;
+
+  pyprojectHash = builtins.hashString "sha256" (builtins.readFile ../pyproject.toml);
+  uvLockHash =
+    if builtins.pathExists ../uv.lock then
+      builtins.hashString "sha256" (builtins.readFile ../uv.lock)
+    else
+      "none";
+in
+stdenv.mkDerivation {
+  pname = "hermes-agent";
+  version = (builtins.fromTOML (builtins.readFile ../pyproject.toml)).project.version;
+
+  dontUnpack = true;
+  dontBuild = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/hermes-agent $out/bin
+    cp -r ${bundledSkills} $out/share/hermes-agent/skills
+    cp -r ${hermesWeb} $out/share/hermes-agent/web_dist
+
+    mkdir -p $out/ui-tui
+    cp -r ${hermesTui}/lib/hermes-tui/* $out/ui-tui/
+
+    ${lib.concatMapStringsSep "\n"
+      (name: ''
+        makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
+          --suffix PATH : "${runtimePath}" \
+          --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills \
+          --set HERMES_WEB_DIST $out/share/hermes-agent/web_dist \
+          --set HERMES_TUI_DIR $out/ui-tui \
+          --set HERMES_PYTHON ${hermesVenv}/bin/python3 \
+          --set HERMES_NODE ${nodejs_22}/bin/node \
+          ${lib.optionalString (extraPythonPackages != [ ]) ''--suffix PYTHONPATH : "${pythonPath}"''}
+      '')
+      [
+        "hermes"
+        "hermes-agent"
+        "hermes-acp"
+      ]
+    }
+
+    ${lib.optionalString (extraPythonPackages != [ ]) ''
+      echo "=== Checking for plugin/core package collisions ==="
+      ${hermesVenv}/bin/python3 -c "
+import pathlib, sys, re
+
+def canonical(name):
+    return re.sub(r'[-_.]+', '-', name).lower()
+
+# Collect core venv package names
+core = set()
+venv_sp = pathlib.Path('${hermesVenv}/${sitePackagesPath}')
+for di in venv_sp.glob('*.dist-info'):
+    meta = di / 'METADATA'
+    if meta.exists():
+        for line in meta.read_text().splitlines():
+            if line.startswith('Name:'):
+                core.add(canonical(line.split(':', 1)[1].strip()))
+                break
+
+# Check each extra package for collisions
+extras_dirs = '${lib.concatMapStringsSep ":" toString extraPythonPackages}'.split(':')
+for edir in extras_dirs:
+    sp = pathlib.Path(edir) / '${sitePackagesPath}'
+    if not sp.exists():
+        continue
+    for di in sp.glob('*.dist-info'):
+        meta = di / 'METADATA'
+        if not meta.exists():
+            continue
+        for line in meta.read_text().splitlines():
+            if line.startswith('Name:'):
+                pkg = canonical(line.split(':', 1)[1].strip())
+                if pkg in core:
+                    print(f'ERROR: plugin package \"{pkg}\" collides with a package in hermes sealed venv', file=sys.stderr)
+                    print(f'  from: {di}', file=sys.stderr)
+                    print(f'  Remove this dependency from extraPythonPackages.', file=sys.stderr)
+                    sys.exit(1)
+                break
+
+print('No collisions found.')
+      "
+      echo "=== No collisions ==="
+    ''}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit hermesTui hermesWeb hermesNpmLib hermesVenv;
+
+    devShellHook = ''
+      STAMP=".nix-stamps/hermes-agent"
+      STAMP_VALUE="${pyprojectHash}:${uvLockHash}"
+      if [ ! -f "$STAMP" ] || [ "$(cat "$STAMP")" != "$STAMP_VALUE" ]; then
+        echo "hermes-agent: installing Python dependencies..."
+        uv venv .venv --python ${python312}/bin/python3 2>/dev/null || true
+        source .venv/bin/activate
+        uv pip install -e ".[all]"
+        [ -d mini-swe-agent ] && uv pip install -e ./mini-swe-agent 2>/dev/null || true
+        [ -d tinker-atropos ] && uv pip install -e ./tinker-atropos 2>/dev/null || true
+        mkdir -p .nix-stamps
+        echo "$STAMP_VALUE" > "$STAMP"
+      else
+        source .venv/bin/activate
+        export HERMES_PYTHON=${hermesVenv}/bin/python3
+      fi
+    '';
+  };
+
+  meta = with lib; {
+    description = "AI agent with advanced tool-calling capabilities";
+    homepage = "https://github.com/NousResearch/hermes-agent";
+    mainProgram = "hermes";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -122,7 +122,7 @@ for di in venv_sp.glob('*.dist-info'):
                 break
 
 # Check each extra package for collisions
-extras_dirs = '${lib.concatMapStringsSep ":" toString extraPythonPackages}'.split(':')
+extras_dirs = [${lib.concatMapStringsSep ", " (p: "'${toString p}'") extraPythonPackages}]
 for edir in extras_dirs:
     sp = pathlib.Path(edir) / '${sitePackagesPath}'
     if not sp.exists():

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -32,9 +32,6 @@
       else cfg.package.override { inherit (cfg) extraPythonPackages; };
     hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
-    # Derive a human-readable plugin name from a derivation.
-    pluginName = plugin: lib.getName plugin;
-
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
     deepConfigType = lib.types.mkOptionType {
       name = "hermes-config-attrs";
@@ -635,7 +632,7 @@
       # ── Assertions ─────────────────────────────────────────────────────
       {
         assertions = let
-          names = map pluginName cfg.extraPlugins;
+          names = map lib.getName cfg.extraPlugins;
         in [{
           assertion = (lib.length names) == (lib.length (lib.unique names));
           message = "services.hermes-agent.extraPlugins: duplicate plugin names detected: ${toString names}. If using fetchFromGitHub, set name = \"plugin-name\" to disambiguate.";
@@ -685,7 +682,7 @@
           find ${cfg.stateDir}/.hermes -maxdepth 1 \
             \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
             -exec chmod g+rw {} + 2>/dev/null || true
-          for _subdir in cron sessions logs memories; do
+          for _subdir in cron sessions logs memories plugins; do
             mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
             chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/$_subdir"
             chmod 2770 "${cfg.stateDir}/.hermes/$_subdir"
@@ -796,18 +793,12 @@ HERMES_NIX_ENV_EOF
           '') cfg.documents)}
 
         # ── Declarative plugins ─────────────────────────────────────────
-        mkdir -p ${cfg.stateDir}/.hermes/plugins
-        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/plugins
-        chmod 2770 ${cfg.stateDir}/.hermes/plugins
-
         # Remove stale managed symlinks (plugins removed from config)
-        for link in ${cfg.stateDir}/.hermes/plugins/nix-managed-*; do
-          [ -L "$link" ] && rm -f "$link"
-        done
+        find ${cfg.stateDir}/.hermes/plugins -maxdepth 1 -type l -name 'nix-managed-*' -delete 2>/dev/null || true
 
         ${lib.concatStringsSep "\n" (map (plugin:
           let
-            name = pluginName plugin;
+            name = lib.getName plugin;
           in ''
             if [ ! -f "${plugin}/plugin.yaml" ]; then
               echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -28,6 +28,8 @@
 
   let
     cfg = config.services.hermes-agent;
+    effectivePackage = if cfg.extraPythonPackages == [ ] then cfg.package
+      else cfg.package.override { inherit (cfg) extraPythonPackages; };
     hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
@@ -479,6 +481,31 @@
         '';
       };
 
+      extraPythonPackages = mkOption {
+          type = types.listOf types.package;
+          default = [ ];
+          description = ''
+            Python packages to add to PYTHONPATH for entry-point plugin discovery.
+            These are pip-packaged plugins that register via the
+            hermes_agent.plugins entry-point group. Each package must be built
+            with the same Python interpreter as hermes (python312).
+          '';
+          example = literalExpression ''
+            [
+              (pkgs.python312Packages.buildPythonPackage {
+                pname = "rtk-hermes";
+                version = "1.0.0";
+                src = pkgs.fetchFromGitHub {
+                  owner = "ogallotti";
+                  repo = "rtk-hermes";
+                  rev = "main";
+                  hash = "sha256-...";
+                };
+              })
+            ]
+          '';
+        };
+
       restart = mkOption {
         type = types.str;
         default = "always";
@@ -593,7 +620,7 @@
       # so interactive shells share state (sessions, skills, cron) with the
       # gateway service instead of creating a separate ~/.hermes/.
       (lib.mkIf cfg.addToSystemPackages {
-        environment.systemPackages = [ cfg.package ];
+        environment.systemPackages = [ effectivePackage ];
         environment.variables.HERMES_HOME = "${cfg.stateDir}/.hermes";
       })
 
@@ -832,7 +859,7 @@ HERMES_NIX_ENV_EOF
             # reads them at Python startup — no systemd EnvironmentFile needed.
 
             ExecStart = lib.concatStringsSep " " ([
-              "${cfg.package}/bin/hermes"
+              "${effectivePackage}/bin/hermes"
               "gateway"
             ] ++ cfg.extraArgs);
 
@@ -855,7 +882,7 @@ HERMES_NIX_ENV_EOF
           };
 
           path = [
-            cfg.package
+            effectivePackage
             pkgs.bash
             pkgs.coreutils
             pkgs.git
@@ -880,11 +907,11 @@ HERMES_NIX_ENV_EOF
 
           preStart = ''
             # Stable symlinks — container references these, not store paths directly
-            ln -sfn ${cfg.package} ${cfg.stateDir}/current-package
+            ln -sfn ${effectivePackage} ${cfg.stateDir}/current-package
             ln -sfn ${containerEntrypoint} ${cfg.stateDir}/current-entrypoint
 
             # GC roots so nix-collect-garbage doesn't remove store paths in use
-            ${pkgs.nix}/bin/nix-store --add-root ${cfg.stateDir}/.gc-root --indirect -r ${cfg.package} 2>/dev/null || true
+            ${pkgs.nix}/bin/nix-store --add-root ${cfg.stateDir}/.gc-root --indirect -r ${effectivePackage} 2>/dev/null || true
             ${pkgs.nix}/bin/nix-store --add-root ${cfg.stateDir}/.gc-root-entrypoint --indirect -r ${containerEntrypoint} 2>/dev/null || true
 
             # Check if container needs (re)creation

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -32,6 +32,12 @@
       else cfg.package.override { inherit (cfg) extraPythonPackages; };
     hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
+    # Derive a human-readable plugin name.  fetchFromGitHub yields name="source",
+    # so we fall through to baseNameOf which gives the store hash prefix — not
+    # ideal but unique.  Users can set name= on their fetchFromGitHub to override.
+    pluginName = plugin:
+      plugin.pname or plugin.name or (builtins.baseNameOf (toString plugin));
+
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
     deepConfigType = lib.types.mkOptionType {
       name = "hermes-config-attrs";
@@ -165,9 +171,6 @@
       if [ -d "$TARGET_HOME/.venv/bin" ]; then
         export PATH="$TARGET_HOME/.venv/bin:$PATH"
       fi
-
-      # Match the native systemd UMask so files are group-writable
-      umask 0007
 
       if command -v setpriv >/dev/null 2>&1; then
         exec setpriv --reuid="$HERMES_UID" --regid="$HERMES_GID" --init-groups "$@"
@@ -474,6 +477,7 @@
             (pkgs.fetchFromGitHub {
               owner = "stephenschoettler";
               repo = "hermes-lcm";
+              name = "hermes-lcm";
               rev = "v0.7.0";
               hash = "sha256-...";
             })
@@ -482,29 +486,29 @@
       };
 
       extraPythonPackages = mkOption {
-          type = types.listOf types.package;
-          default = [ ];
-          description = ''
-            Python packages to add to PYTHONPATH for entry-point plugin discovery.
-            These are pip-packaged plugins that register via the
-            hermes_agent.plugins entry-point group. Each package must be built
-            with the same Python interpreter as hermes (python312).
-          '';
-          example = literalExpression ''
-            [
-              (pkgs.python312Packages.buildPythonPackage {
-                pname = "rtk-hermes";
-                version = "1.0.0";
-                src = pkgs.fetchFromGitHub {
-                  owner = "ogallotti";
-                  repo = "rtk-hermes";
-                  rev = "main";
-                  hash = "sha256-...";
-                };
-              })
-            ]
-          '';
-        };
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          Python packages to add to PYTHONPATH for entry-point plugin discovery.
+          These are pip-packaged plugins that register via the
+          hermes_agent.plugins entry-point group. Each package must be built
+          with the same Python interpreter as hermes (python312).
+        '';
+        example = literalExpression ''
+          [
+            (pkgs.python312Packages.buildPythonPackage {
+              pname = "rtk-hermes";
+              version = "1.0.0";
+              src = pkgs.fetchFromGitHub {
+                owner = "ogallotti";
+                repo = "rtk-hermes";
+                rev = "main";
+                hash = "sha256-...";
+              };
+            })
+          ]
+        '';
+      };
 
       restart = mkOption {
         type = types.str;
@@ -634,12 +638,10 @@
       # ── Assertions ─────────────────────────────────────────────────────
       {
         assertions = let
-          pluginNames = map (plugin:
-            plugin.pname or plugin.name or (builtins.baseNameOf (toString plugin))
-          ) cfg.extraPlugins;
+          names = map pluginName cfg.extraPlugins;
         in [{
-          assertion = (lib.length pluginNames) == (lib.length (lib.unique pluginNames));
-          message = "services.hermes-agent.extraPlugins: duplicate plugin names detected: ${toString pluginNames}";
+          assertion = (lib.length names) == (lib.length (lib.unique names));
+          message = "services.hermes-agent.extraPlugins: duplicate plugin names detected: ${toString names}. If using fetchFromGitHub, set name = \"plugin-name\" to disambiguate.";
         }];
       }
 
@@ -693,18 +695,6 @@
             find "${cfg.stateDir}/.hermes/$_subdir" -type f \
               -exec chmod g+rw {} + 2>/dev/null || true
           done
-
-          # One-time migration: fix files created by the container before the
-          # umask 0007 fix.  They were 0644 (group read-only) instead of 0660.
-          _migration=${cfg.stateDir}/.hermes/.migration-group-write
-          if [ ! -f "$_migration" ]; then
-            find ${cfg.stateDir}/.hermes -type f ! -perm -g=w \
-              -exec chmod g+w {} + 2>/dev/null || true
-            find ${cfg.stateDir}/.hermes -type d ! -perm -g=w \
-              -exec chmod g+w {} + 2>/dev/null || true
-            touch "$_migration"
-            chown ${cfg.user}:${cfg.group} "$_migration"
-          fi
 
           # Merge Nix settings into existing config.yaml.
           # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
@@ -820,7 +810,7 @@ HERMES_NIX_ENV_EOF
 
         ${lib.concatStringsSep "\n" (map (plugin:
           let
-            name = plugin.pname or plugin.name or (builtins.baseNameOf (toString plugin));
+            name = pluginName plugin;
           in ''
             if [ ! -f "${plugin}/plugin.yaml" ]; then
               echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -164,6 +164,9 @@
         export PATH="$TARGET_HOME/.venv/bin:$PATH"
       fi
 
+      # Match the native systemd UMask so files are group-writable
+      umask 0007
+
       if command -v setpriv >/dev/null 2>&1; then
         exec setpriv --reuid="$HERMES_UID" --regid="$HERMES_GID" --init-groups "$@"
       elif command -v su >/dev/null 2>&1; then
@@ -456,6 +459,26 @@
         description = "Extra packages available on PATH.";
       };
 
+      extraPlugins = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          Directory-based plugin packages to symlink into the hermes plugins
+          directory. Each package should contain a plugin.yaml and __init__.py
+          at its root. Hermes discovers these automatically on startup.
+        '';
+        example = literalExpression ''
+          [
+            (pkgs.fetchFromGitHub {
+              owner = "stephenschoettler";
+              repo = "hermes-lcm";
+              rev = "v0.7.0";
+              hash = "sha256-...";
+            })
+          ]
+        '';
+      };
+
       restart = mkOption {
         type = types.str;
         default = "always";
@@ -581,6 +604,18 @@
         });
       })
 
+      # ── Assertions ─────────────────────────────────────────────────────
+      {
+        assertions = let
+          pluginNames = map (plugin:
+            plugin.pname or plugin.name or (builtins.baseNameOf (toString plugin))
+          ) cfg.extraPlugins;
+        in [{
+          assertion = (lib.length pluginNames) == (lib.length (lib.unique pluginNames));
+          message = "services.hermes-agent.extraPlugins: duplicate plugin names detected: ${toString pluginNames}";
+        }];
+      }
+
       # ── Warnings ──────────────────────────────────────────────────────
       (lib.mkIf (cfg.container.enable && !cfg.addToSystemPackages && cfg.container.hostUsers != []) {
         warnings = [
@@ -602,6 +637,7 @@
           "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/logs   2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/memories 2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/plugins 2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/home           0750 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.workingDirectory}         2770 ${cfg.user} ${cfg.group} - -"
         ];
@@ -630,6 +666,18 @@
             find "${cfg.stateDir}/.hermes/$_subdir" -type f \
               -exec chmod g+rw {} + 2>/dev/null || true
           done
+
+          # One-time migration: fix files created by the container before the
+          # umask 0007 fix.  They were 0644 (group read-only) instead of 0660.
+          _migration=${cfg.stateDir}/.hermes/.migration-group-write
+          if [ ! -f "$_migration" ]; then
+            find ${cfg.stateDir}/.hermes -type f ! -perm -g=w \
+              -exec chmod g+w {} + 2>/dev/null || true
+            find ${cfg.stateDir}/.hermes -type d ! -perm -g=w \
+              -exec chmod g+w {} + 2>/dev/null || true
+            touch "$_migration"
+            chown ${cfg.user}:${cfg.group} "$_migration"
+          fi
 
           # Merge Nix settings into existing config.yaml.
           # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
@@ -732,6 +780,28 @@ HERMES_NIX_ENV_EOF
           ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _value: ''
             install -o ${cfg.user} -g ${cfg.group} -m 0640 ${documentDerivation}/${name} ${cfg.workingDirectory}/${name}
           '') cfg.documents)}
+
+        # ── Declarative plugins ─────────────────────────────────────────
+        mkdir -p ${cfg.stateDir}/.hermes/plugins
+        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/plugins
+        chmod 2770 ${cfg.stateDir}/.hermes/plugins
+
+        # Remove stale managed symlinks (plugins removed from config)
+        for link in ${cfg.stateDir}/.hermes/plugins/nix-managed-*; do
+          [ -L "$link" ] && rm -f "$link"
+        done
+
+        ${lib.concatStringsSep "\n" (map (plugin:
+          let
+            name = plugin.pname or plugin.name or (builtins.baseNameOf (toString plugin));
+          in ''
+            if [ ! -f "${plugin}/plugin.yaml" ]; then
+              echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2
+              exit 1
+            fi
+            ln -sfn ${plugin} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
+            chown -h ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
+          '') cfg.extraPlugins)}
         '';
       }
 

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -32,11 +32,8 @@
       else cfg.package.override { inherit (cfg) extraPythonPackages; };
     hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
-    # Derive a human-readable plugin name.  fetchFromGitHub yields name="source",
-    # so we fall through to baseNameOf which gives the store hash prefix — not
-    # ideal but unique.  Users can set name= on their fetchFromGitHub to override.
-    pluginName = plugin:
-      plugin.pname or plugin.name or (builtins.baseNameOf (toString plugin));
+    # Derive a human-readable plugin name from a derivation.
+    pluginName = plugin: lib.getName plugin;
 
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
     deepConfigType = lib.types.mkOptionType {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,10 @@
+# nix/overlays.nix — Expose pkgs.hermes-agent for external NixOS configs
+{ inputs, ... }:
+{
+  flake.overlays.default = final: _: {
+    hermes-agent = final.callPackage ./hermes-agent.nix {
+      inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
+      npm-lockfile-fix = inputs.npm-lockfile-fix.packages.${final.stdenv.hostPlatform.system}.default;
+    };
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -4,120 +4,19 @@
   perSystem =
     { pkgs, inputs', ... }:
     let
-      hermesVenv = pkgs.callPackage ./python.nix {
+      hermesAgent = pkgs.callPackage ./hermes-agent.nix {
         inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
-      };
-
-      hermesNpmLib = pkgs.callPackage ./lib.nix {
         npm-lockfile-fix = inputs'.npm-lockfile-fix.packages.default;
       };
-
-      hermesTui = pkgs.callPackage ./tui.nix {
-        inherit hermesNpmLib;
-      };
-
-      # Import bundled skills, excluding runtime caches
-      bundledSkills = pkgs.lib.cleanSourceWith {
-        src = ../skills;
-        filter = path: _type: !(pkgs.lib.hasInfix "/index-cache/" path);
-      };
-
-      hermesWeb = pkgs.callPackage ./web.nix {
-        inherit hermesNpmLib;
-      };
-
-      runtimeDeps = with pkgs; [
-        nodejs_22
-        ripgrep
-        git
-        openssh
-        ffmpeg
-        tirith
-      ];
-
-      runtimePath = pkgs.lib.makeBinPath runtimeDeps;
-
-      # Lockfile hashes for dev shell stamps
-      pyprojectHash = builtins.hashString "sha256" (builtins.readFile ../pyproject.toml);
-      uvLockHash =
-        if builtins.pathExists ../uv.lock then
-          builtins.hashString "sha256" (builtins.readFile ../uv.lock)
-        else
-          "none";
     in
     {
       packages = {
-        default = pkgs.stdenv.mkDerivation {
-          pname = "hermes-agent";
-          version = (fromTOML (builtins.readFile ../pyproject.toml)).project.version;
+        default = hermesAgent;
+        tui = hermesAgent.hermesTui;
+        web = hermesAgent.hermesWeb;
 
-          dontUnpack = true;
-          dontBuild = true;
-          nativeBuildInputs = [ pkgs.makeWrapper ];
-
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p $out/share/hermes-agent $out/bin
-            cp -r ${bundledSkills} $out/share/hermes-agent/skills
-            cp -r ${hermesWeb} $out/share/hermes-agent/web_dist
-
-            # copy pre-built TUI (same layout as dev: ui-tui/dist/ + node_modules/)
-            mkdir -p $out/ui-tui
-            cp -r ${hermesTui}/lib/hermes-tui/* $out/ui-tui/
-
-            ${pkgs.lib.concatMapStringsSep "\n"
-              (name: ''
-                makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
-                  --suffix PATH : "${runtimePath}" \
-                  --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills \
-                  --set HERMES_WEB_DIST $out/share/hermes-agent/web_dist \
-                  --set HERMES_TUI_DIR $out/ui-tui \
-                  --set HERMES_PYTHON ${hermesVenv}/bin/python3 \
-                  --set HERMES_NODE ${pkgs.nodejs_22}/bin/node
-              '')
-              [
-                "hermes"
-                "hermes-agent"
-                "hermes-acp"
-              ]
-            }
-
-            runHook postInstall
-          '';
-
-          passthru.devShellHook = ''
-            STAMP=".nix-stamps/hermes-agent"
-            STAMP_VALUE="${pyprojectHash}:${uvLockHash}"
-            if [ ! -f "$STAMP" ] || [ "$(cat "$STAMP")" != "$STAMP_VALUE" ]; then
-              echo "hermes-agent: installing Python dependencies..."
-              uv venv .venv --python ${pkgs.python312}/bin/python3 2>/dev/null || true
-              source .venv/bin/activate
-              uv pip install -e ".[all]"
-              [ -d mini-swe-agent ] && uv pip install -e ./mini-swe-agent 2>/dev/null || true
-              [ -d tinker-atropos ] && uv pip install -e ./tinker-atropos 2>/dev/null || true
-              mkdir -p .nix-stamps
-              echo "$STAMP_VALUE" > "$STAMP"
-            else
-              source .venv/bin/activate
-              export HERMES_PYTHON=${hermesVenv}/bin/python3
-            fi
-          '';
-
-          meta = with pkgs.lib; {
-            description = "AI agent with advanced tool-calling capabilities";
-            homepage = "https://github.com/NousResearch/hermes-agent";
-            mainProgram = "hermes";
-            license = licenses.mit;
-            platforms = platforms.unix;
-          };
-        };
-
-        tui = hermesTui;
-        web = hermesWeb;
-
-        fix-lockfiles = hermesNpmLib.mkFixLockfiles {
-          packages = [ hermesTui hermesWeb ];
+        fix-lockfiles = hermesAgent.hermesNpmLib.mkFixLockfiles {
+          packages = [ hermesAgent.hermesTui hermesAgent.hermesWeb ];
         };
       };
     };

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -7,6 +7,7 @@
   pyproject-nix,
   pyproject-build-systems,
   stdenv,
+  dependency-groups ? [ "all" ],
 }:
 let
   workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./..; };
@@ -96,5 +97,5 @@ let
       ]);
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = [ "all" ];
+  hermes-agent = dependency-groups;
 }

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -599,6 +599,93 @@ The `preStart` script creates a GC root at `${stateDir}/.gc-root` pointing to th
 
 ---
 
+## Plugins
+
+The NixOS module supports declarative plugin installation — no imperative `hermes plugins install` needed.
+
+### Directory Plugins (`extraPlugins`)
+
+For plugins that are just a source tree with `plugin.yaml` + `__init__.py` (e.g., [hermes-lcm](https://github.com/stephenschoettler/hermes-lcm)):
+
+```nix
+services.hermes-agent.extraPlugins = [
+  (pkgs.fetchFromGitHub {
+    owner = "stephenschoettler";
+    repo = "hermes-lcm";
+    rev = "v0.7.0";
+    hash = "sha256-...";
+  })
+];
+```
+
+Plugins are symlinked into `$HERMES_HOME/plugins/` at activation time. Hermes discovers them via its normal directory scan. Removing a plugin from the list and running `nixos-rebuild switch` removes the symlink.
+
+### Entry-Point Plugins (`extraPythonPackages`)
+
+For pip-packaged plugins that register via `[project.entry-points."hermes_agent.plugins"]` (e.g., [rtk-hermes](https://github.com/ogallotti/rtk-hermes)):
+
+```nix
+services.hermes-agent.extraPythonPackages = [
+  (pkgs.python312Packages.buildPythonPackage {
+    pname = "rtk-hermes";
+    version = "1.0.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "ogallotti";
+      repo = "rtk-hermes";
+      rev = "v1.0.0";
+      hash = "sha256-...";
+    };
+    format = "pyproject";
+    build-system = [ pkgs.python312Packages.setuptools ];
+  })
+];
+```
+
+The package's `site-packages` is added to PYTHONPATH in the hermes wrapper. `importlib.metadata` discovers the entry point at session start.
+
+### Combining Both
+
+A directory plugin with third-party Python dependencies needs both options:
+
+```nix
+services.hermes-agent = {
+  extraPlugins = [ my-plugin-src ];          # plugin source
+  extraPythonPackages = [ pkgs.python312Packages.redis ];  # its Python dep
+  extraPackages = [ pkgs.redis ];            # system binary it needs
+};
+```
+
+### Using the Overlay
+
+External flakes can override the package directly:
+
+```nix
+{
+  inputs.hermes-agent.url = "github:NousResearch/hermes-agent";
+  outputs = { hermes-agent, nixpkgs, ... }: {
+    nixpkgs.overlays = [ hermes-agent.overlays.default ];
+    # Then: pkgs.hermes-agent.override { extraPythonPackages = [...]; }
+  };
+}
+```
+
+### Plugin Configuration
+
+Plugins still need to be enabled in `config.yaml`. Add them via the declarative settings:
+
+```nix
+services.hermes-agent.settings.plugins.enabled = [
+  "hermes-lcm"
+  "rtk-rewrite"
+];
+```
+
+:::note
+A build-time collision check prevents plugin packages from shadowing core hermes dependencies. If a plugin provides a package already in the sealed venv, `nixos-rebuild` fails with a clear error.
+:::
+
+---
+
 ## Development
 
 ### Dev Shell
@@ -721,6 +808,8 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 |---|---|---|---|
 | `extraArgs` | `listOf str` | `[]` | Extra args for `hermes gateway` |
 | `extraPackages` | `listOf package` | `[]` | Extra packages on service PATH (native mode only) |
+| `extraPlugins` | `listOf package` | `[]` | Directory plugin packages to symlink into `$HERMES_HOME/plugins/`. Each must contain `plugin.yaml` |
+| `extraPythonPackages` | `listOf package` | `[]` | Python packages added to PYTHONPATH for entry-point plugin discovery. Build with `python312Packages` |
 | `restart` | `str` | `"always"` | systemd `Restart=` policy |
 | `restartSec` | `int` | `5` | systemd `RestartSec=` value |
 

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -633,6 +633,43 @@ pip install hermes-plugin-calculator
 # Plugin auto-discovered on next hermes startup
 ```
 
+### Distribute for NixOS
+
+NixOS users can install your plugin declaratively if you provide a `pyproject.toml` with entry points:
+
+**Entry-point plugins** (recommended for distribution):
+```nix
+# User's configuration.nix
+services.hermes-agent.extraPythonPackages = [
+  (pkgs.python312Packages.buildPythonPackage {
+    pname = "my-plugin";
+    version = "1.0.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "you";
+      repo = "hermes-my-plugin";
+      rev = "v1.0.0";
+      hash = "sha256-...";  # nix-prefetch-url --unpack
+    };
+    format = "pyproject";
+    build-system = [ pkgs.python312Packages.setuptools ];
+  })
+];
+```
+
+**Directory plugins** (no `pyproject.toml` needed):
+```nix
+services.hermes-agent.extraPlugins = [
+  (pkgs.fetchFromGitHub {
+    owner = "you";
+    repo = "hermes-my-plugin";
+    rev = "v1.0.0";
+    hash = "sha256-...";
+  })
+];
+```
+
+See the [Nix Setup guide](/docs/getting-started/nix-setup#plugins) for complete documentation including overlay usage and collision checking.
+
 ## Common mistakes
 
 **Handler doesn't return JSON string:**

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -99,6 +99,7 @@ Project-local plugins under `./.hermes/plugins/` are disabled by default. Enable
 | User | `~/.hermes/plugins/` | Personal plugins |
 | Project | `.hermes/plugins/` | Project-specific plugins (requires `HERMES_ENABLE_PROJECT_PLUGINS=true`) |
 | pip | `hermes_agent.plugins` entry_points | Distributed packages |
+| Nix | `services.hermes-agent.extraPlugins` / `extraPythonPackages` | NixOS declarative installs — see [Nix Setup](/docs/getting-started/nix-setup#plugins) |
 
 Later sources override earlier ones on name collision, so a user plugin with the same name as a bundled plugin replaces it.
 
@@ -154,6 +155,23 @@ Hermes has three kinds of plugins:
 | **Context engines** | Replace the built-in context compressor | Single-select (one active) | `plugins/context_engine/` |
 
 Memory providers and context engines are **provider plugins** — only one of each type can be active at a time. General plugins can be enabled in any combination.
+
+## NixOS declarative plugins
+
+On NixOS, plugins can be installed declaratively via the module options — no `hermes plugins install` needed. See the **[Nix Setup guide](/docs/getting-started/nix-setup#plugins)** for full details.
+
+```nix
+services.hermes-agent = {
+  # Directory plugin (source tree with plugin.yaml)
+  extraPlugins = [ (pkgs.fetchFromGitHub { ... }) ];
+  # Entry-point plugin (pip package)
+  extraPythonPackages = [ (pkgs.python312Packages.buildPythonPackage { ... }) ];
+  # Enable in config
+  settings.plugins.enabled = [ "my-plugin" ];
+};
+```
+
+Declarative plugins are symlinked with a `nix-managed-` prefix — they coexist with manually installed plugins and are cleaned up automatically when removed from the Nix config.
 
 ## Managing plugins
 


### PR DESCRIPTION
## Summary

Enable NixOS users to declaratively install hermes plugins — both directory-based and pip-packaged — without manual PYTHONPATH hacks or imperative installs.

Closes #14453

## What changed

**Package refactor (Nix hygiene):**
- Extract the inline `stdenv.mkDerivation` from `packages.nix` into a standalone `nix/hermes-agent.nix` — now `callPackage`-able and overridable via `.override{}`
- Add `nix/overlays.nix` exposing `pkgs.hermes-agent` for external flakes
- Parameterize `dependency-groups` in `python.nix` (default `["all"]`, preserves current behavior)

**Plugin support (new feature):**
- New `extraPythonPackages` parameter on the package derivation — when non-empty, `makeWrapper` appends plugin `site-packages` to PYTHONPATH via `--suffix`
- Build-time collision check using PEP 503 canonical name normalization — fails the build if a plugin package shadows a core hermes dependency
- New NixOS module option `extraPlugins` (directory plugins) — symlinks packages into `HERMES_HOME/plugins/` at activation time with `nix-managed-` prefix, validates `plugin.yaml` presence, asserts unique names at eval time
- New NixOS module option `extraPythonPackages` (entry-point plugins) — overrides the hermes package with PYTHONPATH injection, works in both native systemd and container modes

**Documentation:**
- New "Plugins" section in `nix-setup.md` with examples for both plugin types, overlay usage, and collision checking
- NixOS row in plugin discovery table in `plugins.md`
- "Distribute for NixOS" section in `build-a-hermes-plugin.md`

## Usage

```nix
services.hermes-agent = {
  enable = true;

  # Directory plugin (source tree with plugin.yaml)
  extraPlugins = [
    (pkgs.fetchFromGitHub {
      owner = "stephenschoettler";
      repo = "hermes-lcm";
      rev = "v0.7.0";
      hash = "sha256-...";
    })
  ];

  # Entry-point plugin (pip package with hermes_agent.plugins entry point)
  extraPythonPackages = [
    (pkgs.python312Packages.buildPythonPackage {
      pname = "rtk-hermes";
      version = "1.0.0";
      src = pkgs.fetchFromGitHub { owner = "ogallotti"; repo = "rtk-hermes"; rev = "v1.0.0"; hash = "sha256-..."; };
      format = "pyproject";
      build-system = [ pkgs.python312Packages.setuptools ];
    })
  ];

  # Enable plugins in config
  settings.plugins.enabled = [ "hermes-lcm" "rtk-rewrite" ];
};
```

External flakes:
```nix
overlays = [ inputs.hermes-agent.overlays.default ];
# Then: pkgs.hermes-agent.override { extraPythonPackages = [...]; }
```

## How it works

- **Directory plugins:** Activation script symlinks each `extraPlugins` entry into `$HERMES_HOME/plugins/nix-managed-<name>`. Hermes discovers them via its normal directory scan. Stale symlinks are cleaned up on every activation.
- **Entry-point plugins:** The package derivation is rebuilt with `extraPythonPackages` baked into the wrapper's PYTHONPATH. `importlib.metadata.entry_points()` discovers the plugins at session start. No extra volume mounts needed in container mode — `/nix/store` is already mounted at the same path.
- **Collision check:** A Python script in the install phase scans plugin `.dist-info/METADATA` against the core venv using PEP 503 canonical names. Collisions fail the build.
- **GC safety:** Plugin store paths appear as literal strings in the wrapper script. Nix's reference scanner detects them — they're protected from garbage collection as long as the hermes-agent derivation is alive.

## Verified

- `nix build` passes (hermes v0.11.0, all three binaries present)
- `nix build .#checks.x86_64-linux.extra-python-packages` passes (pyfiglet injected, PYTHONPATH verified)
- Collision check correctly blocks `pydantic` (core dep) with clear error
- End-to-end test: built hermes with a custom test plugin, `importlib.metadata` discovered the entry point, `register(ctx)` called, tool registered (32 tools, up from 31), LLM called the plugin tool successfully
- Overlay evaluates (`"lambda"`)
- Duplicate plugin name assertion fires at eval time

## Prior art

Follows established nixpkgs patterns:
- `extraPlugins` → Nextcloud/Grafana (symlink into discovery directory)
- `extraPythonPackages` → Home Assistant/Maubot (package override with PYTHONPATH)