### PR TITLE
feat(telegram): add interactive stop button to interrupt session processing

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -251,6 +251,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Stop-button stubs: session_key → (chat_id, message_id)
+        self._stop_stubs: Dict[str, tuple] = {}
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -1673,6 +1675,27 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
             return
 
+        # --- Stop button callbacks (st:<session_key>) ---
+        if data.startswith("st:"):
+            session_key = data[3:]
+            chat_id = str(query.message.chat_id) if query.message else None
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(caller_id):
+                await query.answer(text="⛔ You are not authorized to stop this session.")
+                return
+            stub = self._stop_stubs.pop(session_key, None)
+            if stub is None:
+                await query.answer(text="Session already stopped or finished.")
+                return
+            await query.answer(text="🛑 Stopping…")
+            try:
+                await query.edit_message_text(text="🛑 Stopped.")
+            except Exception:
+                pass
+            if chat_id:
+                await self.interrupt_session_activity(session_key, chat_id)
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return
@@ -3083,28 +3106,89 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[%s] set_message_reaction failed (%s): %s", self.name, emoji, e)
             return False
 
+    def _stop_button_enabled(self) -> bool:
+        """Return True when the ⏳ Stop button stub is enabled (opt-in via env)."""
+        return os.getenv("TELEGRAM_STOP_BUTTON", "false").lower() not in ("false", "0", "no")
+
+    def _session_key_for_event(self, event: MessageEvent) -> str:
+        """Derive the canonical session key from a MessageEvent source."""
+        from gateway.session import build_session_key
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
-        if not self._reactions_enabled():
+        """React to processing start and optionally send a ⏳ Stop button stub."""
+        if self._reactions_enabled():
+            chat_id = getattr(event.source, "chat_id", None)
+            message_id = getattr(event, "message_id", None)
+            if chat_id and message_id:
+                await self._set_reaction(chat_id, message_id, "\U0001f440")
+
+        if self._stop_button_enabled():
+            await self._send_stop_stub(event)
+
+    async def _send_stop_stub(self, event: MessageEvent) -> None:
+        """Send a ⏳ Working… message with a [🛑 Stop] inline button.
+
+        The message is stored in ``_stop_stubs`` keyed by session_key so it
+        can be cleaned up in ``on_processing_complete`` or removed immediately
+        when the user clicks the button.
+        """
+        if not self._bot:
             return
         chat_id = getattr(event.source, "chat_id", None)
-        message_id = getattr(event, "message_id", None)
-        if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+        if not chat_id:
+            return
+        session_key = self._session_key_for_event(event)
+        keyboard = InlineKeyboardMarkup([[
+            InlineKeyboardButton("🛑 Stop", callback_data=f"st:{session_key}")
+        ]])
+        thread_id = getattr(event.source, "thread_id", None)
+        kwargs: Dict[str, Any] = {
+            "chat_id": int(chat_id),
+            "text": "⏳ _Working…_",
+            "parse_mode": ParseMode.MARKDOWN,
+            "reply_markup": keyboard,
+            **self._link_preview_kwargs(),
+        }
+        message_thread_id = self._message_thread_id_for_send(thread_id)
+        if message_thread_id is not None:
+            kwargs["message_thread_id"] = message_thread_id
+        try:
+            msg = await self._bot.send_message(**kwargs)
+            self._stop_stubs[session_key] = (chat_id, str(msg.message_id))
+        except Exception as e:
+            logger.debug("[%s] Failed to send stop stub: %s", self.name, e)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction.
+        """Swap the in-progress reaction and clean up the ⏳ Stop button stub.
 
         Unlike Discord (additive reactions), Telegram's set_message_reaction
         replaces all existing reactions in one call — no remove step needed.
         """
-        if not self._reactions_enabled():
-            return
-        chat_id = getattr(event.source, "chat_id", None)
-        message_id = getattr(event, "message_id", None)
-        if chat_id and message_id and outcome != ProcessingOutcome.CANCELLED:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-            )
+        if self._reactions_enabled():
+            chat_id = getattr(event.source, "chat_id", None)
+            message_id = getattr(event, "message_id", None)
+            if chat_id and message_id and outcome != ProcessingOutcome.CANCELLED:
+                await self._set_reaction(
+                    chat_id,
+                    message_id,
+                    "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+                )
+
+        if self._stop_button_enabled():
+            await self._delete_stop_stub(event)
+
+    async def _delete_stop_stub(self, event: MessageEvent) -> None:
+        """Delete the ⏳ Working… stub message when processing finishes normally."""
+        session_key = self._session_key_for_event(event)
+        stub = self._stop_stubs.pop(session_key, None)
+        if stub and self._bot:
+            chat_id, message_id = stub
+            try:
+                await self._bot.delete_message(int(chat_id), int(message_id))
+            except Exception as e:
+                logger.debug("[%s] Failed to delete stop stub %s: %s", self.name, message_id, e)

--- a/tests/gateway/test_telegram_stop_button.py
+++ b/tests/gateway/test_telegram_stop_button.py
@@ -1,0 +1,315 @@
+"""Tests for the Telegram ⏳ Stop button (on_processing_start / _handle_callback_query)."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock (same pattern as test_telegram_approval_buttons.py)
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+
+def _make_adapter(extra=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_event(chat_id="12345", message_id="99", thread_id=None):
+    """Build a minimal MessageEvent with a SessionSource stub."""
+    source = MagicMock()
+    source.chat_id = chat_id
+    source.thread_id = thread_id
+    event = MagicMock(spec=MessageEvent)
+    event.source = source
+    event.message_id = message_id
+    return event
+
+
+# ===========================================================================
+# on_processing_start — stop stub
+# ===========================================================================
+
+class TestSendStopStub:
+    """_send_stop_stub sends the ⏳ Working… message with a [🛑 Stop] button."""
+
+    @pytest.mark.asyncio
+    async def test_sends_stop_stub_when_enabled(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true"}):
+            with patch.object(adapter, "_session_key_for_event", return_value="sk-test"):
+                event = _make_event()
+                await adapter._send_stop_stub(event)
+
+        adapter._bot.send_message.assert_called_once()
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["chat_id"] == 12345
+        assert "Working" in kwargs["text"]
+        assert kwargs["reply_markup"] is not None
+        # Stored in _stop_stubs
+        assert adapter._stop_stubs.get("sk-test") == ("12345", "77")
+
+    @pytest.mark.asyncio
+    async def test_no_stub_when_not_connected(self):
+        adapter = _make_adapter()
+        adapter._bot = None
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true"}):
+            with patch.object(adapter, "_session_key_for_event", return_value="sk-test"):
+                await adapter._send_stop_stub(_make_event())
+
+        assert "sk-test" not in adapter._stop_stubs
+
+    @pytest.mark.asyncio
+    async def test_no_stub_when_no_chat_id(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true"}):
+            with patch.object(adapter, "_session_key_for_event", return_value="sk-test"):
+                event = _make_event(chat_id=None)
+                event.source.chat_id = None
+                await adapter._send_stop_stub(event)
+
+        adapter._bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_in_thread(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true"}):
+            with patch.object(adapter, "_session_key_for_event", return_value="sk-thread"):
+                event = _make_event(thread_id="555")
+                await adapter._send_stop_stub(event)
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs.get("message_thread_id") == 555
+
+    @pytest.mark.asyncio
+    async def test_on_processing_start_calls_stub_when_enabled(self):
+        adapter = _make_adapter()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true", "TELEGRAM_REACTIONS": "false"}):
+            with patch.object(adapter, "_send_stop_stub", new_callable=AsyncMock) as mock_stub:
+                await adapter.on_processing_start(_make_event())
+
+        mock_stub.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_on_processing_start_skips_stub_when_disabled(self):
+        adapter = _make_adapter()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "false", "TELEGRAM_REACTIONS": "false"}):
+            with patch.object(adapter, "_send_stop_stub", new_callable=AsyncMock) as mock_stub:
+                await adapter.on_processing_start(_make_event())
+
+        mock_stub.assert_not_called()
+
+
+# ===========================================================================
+# on_processing_complete — stub cleanup
+# ===========================================================================
+
+class TestDeleteStopStub:
+    """_delete_stop_stub deletes the stub message on normal completion."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_stub_on_complete(self):
+        adapter = _make_adapter()
+        adapter._stop_stubs["sk-done"] = ("12345", "77")
+        adapter._bot.delete_message = AsyncMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true"}):
+            with patch.object(adapter, "_session_key_for_event", return_value="sk-done"):
+                await adapter._delete_stop_stub(_make_event())
+
+        adapter._bot.delete_message.assert_called_once_with(12345, 77)
+        assert "sk-done" not in adapter._stop_stubs
+
+    @pytest.mark.asyncio
+    async def test_no_crash_when_stub_missing(self):
+        adapter = _make_adapter()
+        adapter._bot.delete_message = AsyncMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true"}):
+            with patch.object(adapter, "_session_key_for_event", return_value="sk-gone"):
+                await adapter._delete_stop_stub(_make_event())
+
+        adapter._bot.delete_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_calls_delete_when_enabled(self):
+        adapter = _make_adapter()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "true", "TELEGRAM_REACTIONS": "false"}):
+            with patch.object(adapter, "_delete_stop_stub", new_callable=AsyncMock) as mock_del:
+                await adapter.on_processing_complete(_make_event(), ProcessingOutcome.SUCCESS)
+
+        mock_del.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_skips_delete_when_disabled(self):
+        adapter = _make_adapter()
+
+        with patch.dict(os.environ, {"TELEGRAM_STOP_BUTTON": "false", "TELEGRAM_REACTIONS": "false"}):
+            with patch.object(adapter, "_delete_stop_stub", new_callable=AsyncMock) as mock_del:
+                await adapter.on_processing_complete(_make_event(), ProcessingOutcome.SUCCESS)
+
+        mock_del.assert_not_called()
+
+
+# ===========================================================================
+# _handle_callback_query — st: stop button click
+# ===========================================================================
+
+class TestStopButtonCallback:
+    """Stop button click handler in _handle_callback_query."""
+
+    def _make_query(self, data: str, user_id: int = 123, chat_id: int = 12345):
+        query = AsyncMock()
+        query.data = data
+        query.message = MagicMock()
+        query.message.chat_id = chat_id
+        query.from_user = MagicMock()
+        query.from_user.id = user_id
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        return query
+
+    @pytest.mark.asyncio
+    async def test_stop_click_interrupts_session(self):
+        adapter = _make_adapter()
+        adapter._stop_stubs["my-session"] = ("12345", "77")
+
+        query = self._make_query("st:my-session")
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}):
+            with patch.object(adapter, "interrupt_session_activity", new_callable=AsyncMock) as mock_interrupt:
+                await adapter._handle_callback_query(update, context)
+
+        mock_interrupt.assert_called_once_with("my-session", "12345")
+        query.answer.assert_called_once()
+        assert "Stopping" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_called_once()
+        assert "Stopped" in query.edit_message_text.call_args[1]["text"]
+        assert "my-session" not in adapter._stop_stubs
+
+    @pytest.mark.asyncio
+    async def test_stop_already_finished(self):
+        """Clicking Stop after processing already ended answers gracefully."""
+        adapter = _make_adapter()
+        # No stub in _stop_stubs — processing already completed
+
+        query = self._make_query("st:expired-session")
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}):
+            with patch.object(adapter, "interrupt_session_activity", new_callable=AsyncMock) as mock_interrupt:
+                await adapter._handle_callback_query(update, context)
+
+        mock_interrupt.assert_not_called()
+        query.answer.assert_called_once()
+        assert "already" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_stop_rejects_unauthorized_user(self):
+        adapter = _make_adapter()
+        adapter._stop_stubs["sk"] = ("12345", "77")
+
+        query = self._make_query("st:sk", user_id=999)
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+            with patch.object(adapter, "interrupt_session_activity", new_callable=AsyncMock) as mock_interrupt:
+                await adapter._handle_callback_query(update, context)
+
+        mock_interrupt.assert_not_called()
+        query.answer.assert_called_once()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+        # Stub should NOT be consumed by unauthorized click
+        assert "sk" in adapter._stop_stubs
+
+    @pytest.mark.asyncio
+    async def test_stop_allows_authorized_user(self):
+        adapter = _make_adapter()
+        adapter._stop_stubs["sk"] = ("12345", "77")
+
+        query = self._make_query("st:sk", user_id=111)
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+            with patch.object(adapter, "interrupt_session_activity", new_callable=AsyncMock) as mock_interrupt:
+                await adapter._handle_callback_query(update, context)
+
+        mock_interrupt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_approval_callback_not_affected(self):
+        """Existing ea: callbacks still work after adding st: handler."""
+        adapter = _make_adapter()
+        adapter._approval_state[1] = "some-session"
+
+        query = self._make_query("ea:once:1")
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once_with("some-session", "once")


### PR DESCRIPTION
## What does this PR do?

This PR introduces an interactive "Stop" button for the Telegram integration, allowing users to cleanly interrupt an agent's processing mid-flight. 

When an agent begins processing a request, Telegram users will see a "⏳ _Working…_" stub message containing an inline "🛑 Stop" button. Clicking this button safely calls `interrupt_session_activity()` to halt the agent immediately, and updates the stub to say "🛑 Stopped.". If the task completes normally, the stub is automatically cleaned up.

To prevent visual clutter or unwanted behavior for existing users, this feature is strictly **opt-in** and must be enabled by setting `TELEGRAM_STOP_BUTTON=true` in the environment configuration.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes # <!-- Add the issue number here if you opened one, or delete this line -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`:
  - Added `_send_stop_stub()` to emit the temporary button on `on_processing_start`.
  - Added `_delete_stop_stub()` to remove it on `on_processing_complete`.
  - Added the `st:<session_key>` callback handler in `_handle_callback_query` to verify user authorization, update the UI, and trigger the session interruption.
  - Handled edge cases (e.g., clicking stop on an already finished task, unauthorized clicks) gracefully.
- `tests/gateway/test_telegram_stop_button.py`: Added comprehensive unit tests mocking the Telegram API to cover stub rendering, cleanup, and callback execution.

## How to Test

1. Add `TELEGRAM_STOP_BUTTON=true` to your `.env` or configuration.
2. Run the agent and the gateway.
3. Send a request to the bot that requires some processing time (e.g., "Write a very long essay").
4. Notice the "⏳ _Working…_" message with the "🛑 Stop" button appearing in the chat.
5. Click the "🛑 Stop" button.
6. Verify that the message updates to "🛑 Stopped." and the agent's stream is successfully interrupted in your terminal/logs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
