### PR TITLE
test(auth): stub macOS Keychain and skip botocore soft-dep tests

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -117,6 +117,15 @@ class TestBuildAnthropicClient:
 
 
 class TestReadClaudeCodeCredentials:
+    @pytest.fixture(autouse=True)
+    def _stub_keychain(self, monkeypatch):
+        # Keychain is checked before the file path on macOS; suppress it so
+        # tests exercise the file-based credential path exclusively.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
@@ -128,12 +137,6 @@ class TestReadClaudeCodeCredentials:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        # Keychain is checked before the file path on macOS; suppress it so
-        # the test exercises the file-based credential path exclusively.
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
         creds = read_claude_code_credentials()
         assert creds is not None
         assert creds["accessToken"] == "sk-ant-oat01-token"
@@ -144,20 +147,11 @@ class TestReadClaudeCodeCredentials:
         claude_json = tmp_path / ".claude.json"
         claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
-
         creds = read_claude_code_credentials()
         assert creds is None
 
     def test_returns_none_for_missing_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
         assert read_claude_code_credentials() is None
 
     def test_returns_none_for_missing_oauth_key(self, tmp_path, monkeypatch):
@@ -165,10 +159,6 @@ class TestReadClaudeCodeCredentials:
         cred_file.parent.mkdir(parents=True)
         cred_file.write_text(json.dumps({"someOtherKey": {}}))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
         assert read_claude_code_credentials() is None
 
     def test_returns_none_for_empty_access_token(self, tmp_path, monkeypatch):
@@ -178,10 +168,6 @@ class TestReadClaudeCodeCredentials:
             "claudeAiOauth": {"accessToken": "", "refreshToken": "x"}
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
         assert read_claude_code_credentials() is None
 
 
@@ -200,6 +186,13 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    @pytest.fixture(autouse=True)
+    def _stub_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
@@ -258,10 +251,6 @@ class TestResolveAnthropicToken:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
         assert resolve_anthropic_token() == "cc-auto-token"
 
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
@@ -278,11 +267,6 @@ class TestResolveAnthropicToken:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
-
         assert resolve_anthropic_token() == "cc-auto-token"
 
     def test_keeps_static_anthropic_token_when_only_non_refreshable_claude_key_exists(self, monkeypatch, tmp_path):
@@ -416,6 +400,13 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def _stub_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):
@@ -426,14 +417,6 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
-        # Suppress the macOS Keychain path so the file-based lookup is
-        # exercised. Without this, subprocess.run is globally patched with a
-        # MagicMock whose .stdout.strip() is also a MagicMock, causing
-        # json.loads to raise TypeError inside _read_claude_code_credentials_from_keychain.
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
 
         # Pre-create credential files that will be found after subprocess
         cred_file = tmp_path / ".claude" / ".credentials.json"
@@ -464,10 +447,6 @@ class TestRunOauthSetupToken:
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "from-env-var")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
@@ -481,10 +460,6 @@ class TestRunOauthSetupToken:
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -128,6 +128,12 @@ class TestReadClaudeCodeCredentials:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        # Keychain is checked before the file path on macOS; suppress it so
+        # the test exercises the file-based credential path exclusively.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
         creds = read_claude_code_credentials()
         assert creds is not None
         assert creds["accessToken"] == "sk-ant-oat01-token"
@@ -138,12 +144,20 @@ class TestReadClaudeCodeCredentials:
         claude_json = tmp_path / ".claude.json"
         claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         creds = read_claude_code_credentials()
         assert creds is None
 
     def test_returns_none_for_missing_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
         assert read_claude_code_credentials() is None
 
     def test_returns_none_for_missing_oauth_key(self, tmp_path, monkeypatch):
@@ -151,6 +165,10 @@ class TestReadClaudeCodeCredentials:
         cred_file.parent.mkdir(parents=True)
         cred_file.write_text(json.dumps({"someOtherKey": {}}))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
         assert read_claude_code_credentials() is None
 
     def test_returns_none_for_empty_access_token(self, tmp_path, monkeypatch):
@@ -160,6 +178,10 @@ class TestReadClaudeCodeCredentials:
             "claudeAiOauth": {"accessToken": "", "refreshToken": "x"}
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
         assert read_claude_code_credentials() is None
 
 
@@ -236,6 +258,10 @@ class TestResolveAnthropicToken:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
         assert resolve_anthropic_token() == "cc-auto-token"
 
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
@@ -252,6 +278,10 @@ class TestResolveAnthropicToken:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         assert resolve_anthropic_token() == "cc-auto-token"
 
@@ -396,6 +426,14 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        # Suppress the macOS Keychain path so the file-based lookup is
+        # exercised. Without this, subprocess.run is globally patched with a
+        # MagicMock whose .stdout.strip() is also a MagicMock, causing
+        # json.loads to raise TypeError inside _read_claude_code_credentials_from_keychain.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         # Pre-create credential files that will be found after subprocess
         cred_file = tmp_path / ".claude" / ".credentials.json"
@@ -426,6 +464,10 @@ class TestRunOauthSetupToken:
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "from-env-var")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
@@ -439,6 +481,10 @@ class TestRunOauthSetupToken:
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1264,22 +1264,23 @@ class TestInvalidateRuntimeClient:
 class TestIsStaleConnectionError:
     """Classifier that decides whether an exception warrants client eviction."""
 
-    def test_detects_botocore_connection_closed_error(self):
-        pytest.importorskip("botocore")
+    @pytest.fixture
+    def requires_botocore(self):
+        pytest.importorskip("botocore", reason="botocore is required for botocore-specific stale connection tests")
+
+    def test_detects_botocore_connection_closed_error(self, requires_botocore):
         from agent.bedrock_adapter import is_stale_connection_error
         from botocore.exceptions import ConnectionClosedError
         exc = ConnectionClosedError(endpoint_url="https://bedrock.example")
         assert is_stale_connection_error(exc) is True
 
-    def test_detects_botocore_endpoint_connection_error(self):
-        pytest.importorskip("botocore")
+    def test_detects_botocore_endpoint_connection_error(self, requires_botocore):
         from agent.bedrock_adapter import is_stale_connection_error
         from botocore.exceptions import EndpointConnectionError
         exc = EndpointConnectionError(endpoint_url="https://bedrock.example")
         assert is_stale_connection_error(exc) is True
 
-    def test_detects_botocore_read_timeout(self):
-        pytest.importorskip("botocore")
+    def test_detects_botocore_read_timeout(self, requires_botocore):
         from agent.bedrock_adapter import is_stale_connection_error
         from botocore.exceptions import ReadTimeoutError
         exc = ReadTimeoutError(endpoint_url="https://bedrock.example")

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1265,18 +1265,21 @@ class TestIsStaleConnectionError:
     """Classifier that decides whether an exception warrants client eviction."""
 
     def test_detects_botocore_connection_closed_error(self):
+        pytest.importorskip("botocore")
         from agent.bedrock_adapter import is_stale_connection_error
         from botocore.exceptions import ConnectionClosedError
         exc = ConnectionClosedError(endpoint_url="https://bedrock.example")
         assert is_stale_connection_error(exc) is True
 
     def test_detects_botocore_endpoint_connection_error(self):
+        pytest.importorskip("botocore")
         from agent.bedrock_adapter import is_stale_connection_error
         from botocore.exceptions import EndpointConnectionError
         exc = EndpointConnectionError(endpoint_url="https://bedrock.example")
         assert is_stale_connection_error(exc) is True
 
     def test_detects_botocore_read_timeout(self):
+        pytest.importorskip("botocore")
         from agent.bedrock_adapter import is_stale_connection_error
         from botocore.exceptions import ReadTimeoutError
         exc = ReadTimeoutError(endpoint_url="https://bedrock.example")
@@ -1337,6 +1340,7 @@ class TestCallConverseInvalidatesOnStaleError:
     reconnects instead of reusing the dead socket."""
 
     def test_converse_evicts_client_on_stale_error(self):
+        pytest.importorskip("botocore")
         from agent.bedrock_adapter import (
             _bedrock_runtime_client_cache,
             call_converse,
@@ -1363,6 +1367,7 @@ class TestCallConverseInvalidatesOnStaleError:
         )
 
     def test_converse_stream_evicts_client_on_stale_error(self):
+        pytest.importorskip("botocore")
         from agent.bedrock_adapter import (
             _bedrock_runtime_client_cache,
             call_converse_stream,
@@ -1388,6 +1393,7 @@ class TestCallConverseInvalidatesOnStaleError:
 
     def test_converse_does_not_evict_on_non_stale_error(self):
         """Non-stale errors (e.g. ValidationException) leave the client cache alone."""
+        pytest.importorskip("botocore")
         from agent.bedrock_adapter import (
             _bedrock_runtime_client_cache,
             call_converse,


### PR DESCRIPTION
## Summary
- Fixes 10 `test_anthropic_adapter.py` tests that broke on developer machines with real Claude Code credentials in the macOS Keychain
- Fixes 6 `test_bedrock_adapter.py` tests that fail with `ModuleNotFoundError: No module named 'botocore'` when botocore isn't installed

## The bug

**Anthropic adapter (10 tests):** Commit `e1106772` added `_read_claude_code_credentials_from_keychain()` as the first credential source, checked before the JSON file path. The existing tests only mock `Path.home()` to a `tmp_path`, leaving the Keychain path unsuppressed. On any machine with Claude Code installed and an active Keychain entry, the Keychain wins and every file-based assertion fails (wrong token, or `None` instead of the expected value, or `TypeError: the JSON object must be str, bytes or bytearray` when `subprocess.run` is globally patched but its `.stdout.strip()` returns a `MagicMock`).

**Bedrock adapter (6 tests):** The production code in `is_stale_connection_error` already guards `from botocore.exceptions import ...` with `try/except ImportError` (comment: `# pragma: no cover — botocore always present with boto3`). The test functions import from `botocore.exceptions` directly at function scope without a guard, so they fail with `ModuleNotFoundError` in environments (CI, contributor machines) without botocore installed.

## The fix

1. Add `monkeypatch.setattr("agent.anthropic_adapter._read_claude_code_credentials_from_keychain", lambda: None)` to each of the 10 tests that exercise file-based credential paths — this isolates the test to the file path only, which is what the test intends.

2. Add `pytest.importorskip("botocore")` at the top of each of the 6 bedrock tests that require botocore exceptions — they skip cleanly when botocore isn't installed (matching the production code's defensive posture), and still run and pass in boto3-equipped environments.

## Test plan
- [x] **Before**: 16 additional failures beyond the 7-dingtalk/1-matrix baseline on clean `main`
- [x] **After**: 0 additional failures; 6 botocore tests skip cleanly instead of erroring
- [x] **Regression guard**: stashed fix → observed 7 failures; restored → 0 failures, 6 skips
- [x] All other tests in both files unchanged: `247 passed, 6 skipped`

## Related

Fixes the unreported test-isolation regressions introduced by:
- `e1106772` (macOS Keychain credential path added without updating test stubs)
- `a9ccb03c` (bedrock stale-connection tests added without `importorskip` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)