### PR TITLE
feat(gateway): add Hermes voice bridge tools

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -47,6 +47,11 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from gateway.voice_hermes_bridge import (
+    HER_VOICE_SYSTEM_PROMPT,
+    HerVoiceBridge,
+    her_voice_tool_declarations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -591,6 +596,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._voice_bridge: Optional[HerVoiceBridge] = None
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -701,6 +707,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("SessionDB unavailable for API server: %s", e)
         return self._session_db
 
+    def _ensure_voice_bridge(self) -> HerVoiceBridge:
+        """Lazily initialise the function-call bridge used by realtime voice."""
+        if self._voice_bridge is None:
+            self._voice_bridge = HerVoiceBridge(
+                run_agent=self._run_agent,
+                session_db_factory=self._ensure_session_db,
+            )
+        return self._voice_bridge
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
@@ -709,6 +724,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self,
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
+        platform: str = "api_server",
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
@@ -748,7 +764,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
-            platform="api_server",
+            platform=platform,
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
@@ -1038,6 +1054,44 @@ class APIServerAdapter(BasePlatformAdapter):
         }
 
         return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
+
+    async def _handle_voice_tools(self, request: "web.Request") -> "web.Response":
+        """GET /api/voice/her/tools — Gemini Live function declarations."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        return web.json_response({
+            "tools": [{"function_declarations": her_voice_tool_declarations()}],
+            "system_prompt": HER_VOICE_SYSTEM_PROMPT,
+        })
+
+    async def _handle_voice_call(self, request: "web.Request") -> "web.Response":
+        """POST /api/voice/her/call — execute one voice function call."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+
+        name = str(body.get("name") or body.get("tool") or "").strip()
+        arguments = body.get("arguments") or body.get("args") or {}
+        if not name:
+            return web.json_response(
+                {"error": {"message": "Missing voice tool name", "type": "invalid_request_error"}},
+                status=400,
+            )
+        if not isinstance(arguments, dict):
+            return web.json_response(
+                {"error": {"message": "Voice tool arguments must be an object", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        result = await self._ensure_voice_bridge().call(name, arguments)
+        status = 200 if result.get("ok", False) else 400
+        return web.json_response(result, status=status)
 
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
@@ -2247,6 +2301,7 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation_history: List[Dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
+        platform: str = "api_server",
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
@@ -2270,6 +2325,7 @@ class APIServerAdapter(BasePlatformAdapter):
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
+                platform=platform,
                 stream_delta_callback=stream_delta_callback,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
@@ -2634,6 +2690,9 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
             self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+            # Hermes voice bridge for realtime function calls
+            self._app.router.add_get("/api/voice/her/tools", self._handle_voice_tools)
+            self._app.router.add_post("/api/voice/her/call", self._handle_voice_call)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)

--- a/gateway/voice_hermes_bridge.py
+++ b/gateway/voice_hermes_bridge.py
@@ -1,0 +1,330 @@
+"""Tool bridge for the Hermes voice channel.
+
+The bridge is intentionally transport-neutral: Gemini Live or another realtime
+audio frontend can fetch the tool declarations, then POST function calls to the
+API server.  Side effects go through existing Hermes primitives so voice remains
+one more channel over the same core, memory, and delivery tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import uuid
+from typing import Any, Awaitable, Callable, Dict, List
+
+
+HER_VOICE_SYSTEM_PROMPT = """\
+You are Hermes vocal.
+
+Tone:
+- Warm, calm, concise.
+- Never hurry the user.
+- Auto-detect French or English and answer in the same language.
+- Prefer short spoken replies. Ask one focused clarification only when needed.
+
+Continuity:
+- Treat this as the voice channel of the same Hermes workspace.
+- Important voice turns are saved in the shared session database with channel voice.
+- When recalling prior discussions, search memory before answering.
+"""
+
+
+def her_voice_tool_declarations() -> List[Dict[str, Any]]:
+    """Return Gemini-compatible function declarations for the voice bridge."""
+    return [
+        {
+            "name": "run_hermes_agent",
+            "description": "Run a task through Hermes Core with optional context.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task": {"type": "string"},
+                    "context": {"type": "string"},
+                    "session_id": {"type": "string"},
+                },
+                "required": ["task"],
+            },
+        },
+        {
+            "name": "create_issue",
+            "description": "Create a Multica issue.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                    "assignee": {"type": "string"},
+                },
+                "required": ["title"],
+            },
+        },
+        {
+            "name": "list_issues",
+            "description": "List Multica issues with an optional filter object.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "filter": {
+                        "type": "object",
+                        "properties": {
+                            "status": {"type": "string"},
+                            "priority": {"type": "string"},
+                            "assignee": {"type": "string"},
+                            "limit": {"type": "integer"},
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "name": "send_whatsapp",
+            "description": "Send a WhatsApp message through Hermes delivery.",
+            "parameters": {
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+                "required": ["message"],
+            },
+        },
+        {
+            "name": "send_discord",
+            "description": "Send a Discord message through Hermes delivery.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "message": {"type": "string"},
+                    "channel": {"type": "string"},
+                },
+                "required": ["message"],
+            },
+        },
+        {
+            "name": "get_memory",
+            "description": "Search shared Hermes conversation memory.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+                "required": ["query"],
+            },
+        },
+        {
+            "name": "get_calendar",
+            "description": "Read calendar context through configured Hermes tools.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "read_email",
+            "description": "Read email context through configured Hermes tools.",
+            "parameters": {
+                "type": "object",
+                "properties": {"filter": {"type": "string"}},
+            },
+        },
+    ]
+
+
+class HerVoiceBridge:
+    """Execute voice function calls against Hermes and local platform tools."""
+
+    def __init__(
+        self,
+        *,
+        run_agent: Callable[..., Awaitable[tuple]],
+        session_db_factory: Callable[[], Any],
+        timeout_seconds: float = 120.0,
+    ) -> None:
+        self._run_agent = run_agent
+        self._session_db_factory = session_db_factory
+        self._timeout_seconds = timeout_seconds
+
+    async def call(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(arguments, dict):
+            arguments = {}
+
+        handlers = {
+            "run_hermes_agent": self._run_hermes_agent,
+            "create_issue": self._create_issue,
+            "list_issues": self._list_issues,
+            "send_whatsapp": self._send_whatsapp,
+            "send_discord": self._send_discord,
+            "get_memory": self._get_memory,
+            "get_calendar": self._get_calendar,
+            "read_email": self._read_email,
+        }
+        handler = handlers.get(name)
+        if handler is None:
+            return {"ok": False, "error": f"Unknown voice tool: {name}"}
+
+        try:
+            return await asyncio.wait_for(handler(arguments), timeout=self._timeout_seconds)
+        except asyncio.TimeoutError:
+            return {"ok": False, "error": f"Voice tool timed out: {name}"}
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    async def _run_hermes_agent(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        task = str(arguments.get("task") or "").strip()
+        if not task:
+            return {"ok": False, "error": "task is required"}
+
+        context = str(arguments.get("context") or "").strip()
+        session_id = str(arguments.get("session_id") or "").strip() or f"voice-{uuid.uuid4().hex[:16]}"
+        user_message = task if not context else f"{task}\n\nContext:\n{context}"
+
+        result, usage = await self._run_agent(
+            user_message=user_message,
+            conversation_history=[],
+            ephemeral_system_prompt=HER_VOICE_SYSTEM_PROMPT,
+            session_id=session_id,
+            platform="voice",
+        )
+        return {
+            "ok": True,
+            "session_id": session_id,
+            "response": result.get("final_response") or result.get("error") or "",
+            "usage": usage,
+        }
+
+    async def _create_issue(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        title = str(arguments.get("title") or "").strip()
+        if not title:
+            return {"ok": False, "error": "title is required"}
+
+        cmd = ["multica", "issue", "create", "--title", title]
+        description = str(arguments.get("description") or "").strip()
+        assignee = str(arguments.get("assignee") or "").strip()
+        if description:
+            cmd.extend(["--description", description])
+        if assignee:
+            cmd.extend(["--assignee", assignee])
+        return await self._run_multica(cmd)
+
+    async def _list_issues(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        filt = arguments.get("filter") or {}
+        if not isinstance(filt, dict):
+            filt = {}
+
+        cmd = ["multica", "issue", "list", "--output", "json"]
+        for key in ("status", "priority", "assignee"):
+            value = str(filt.get(key) or "").strip()
+            if value:
+                cmd.extend([f"--{key}", value])
+        limit = filt.get("limit")
+        if isinstance(limit, int) and 0 < limit <= 100:
+            cmd.extend(["--limit", str(limit)])
+        return await self._run_multica(cmd)
+
+    async def _send_whatsapp(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        message = str(arguments.get("message") or "").strip()
+        if not message:
+            return {"ok": False, "error": "message is required"}
+        return await self._send_message("whatsapp", message)
+
+    async def _send_discord(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        message = str(arguments.get("message") or "").strip()
+        if not message:
+            return {"ok": False, "error": "message is required"}
+        channel = str(arguments.get("channel") or "").strip()
+        target = "discord" if not channel else f"discord:{channel}"
+        return await self._send_message(target, message)
+
+    async def _get_memory(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        query = str(arguments.get("query") or "").strip()
+        if not query:
+            return {"ok": False, "error": "query is required"}
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 8
+        limit = min(limit, 25)
+
+        db = self._session_db_factory()
+        if db is None:
+            return {"ok": False, "error": "Session database is unavailable"}
+
+        results = db.search_messages(query=query, limit=limit)
+        memories = [
+            {
+                "session_id": row.get("session_id"),
+                "role": row.get("role"),
+                "source": row.get("source"),
+                "channel": row.get("channel"),
+                "snippet": row.get("snippet"),
+                "content": row.get("content"),
+                "timestamp": row.get("timestamp"),
+            }
+            for row in results
+        ]
+        return {"ok": True, "count": len(memories), "memories": memories}
+
+    async def _get_calendar(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        return await self._run_context_task(
+            "Read my calendar and summarize the relevant upcoming events.",
+            arguments,
+        )
+
+    async def _read_email(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        filter_text = str(arguments.get("filter") or "").strip()
+        task = "Read my email."
+        if filter_text:
+            task = f"Read my email matching this filter: {filter_text}"
+        return await self._run_context_task(task, arguments)
+
+    async def _run_context_task(self, task: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        merged = dict(arguments)
+        merged["task"] = task
+        return await self._run_hermes_agent(merged)
+
+    async def _send_message(self, target: str, message: str) -> Dict[str, Any]:
+        def _send() -> str:
+            from tools.send_message_tool import send_message_tool
+            return send_message_tool({"action": "send", "target": target, "message": message})
+
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(None, _send)
+        return self._json_result(result)
+
+    async def _run_multica(self, cmd: List[str]) -> Dict[str, Any]:
+        env = os.environ.copy()
+        env.setdefault("NO_COLOR", "1")
+
+        def _run() -> Dict[str, Any]:
+            proc = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                timeout=30,
+                env=env,
+                check=False,
+            )
+            if proc.returncode != 0:
+                return {
+                    "ok": False,
+                    "returncode": proc.returncode,
+                    "stdout": proc.stdout.strip(),
+                    "stderr": proc.stderr.strip(),
+                }
+            payload = self._json_result(proc.stdout)
+            payload.setdefault("ok", True)
+            return payload
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _run)
+
+    @staticmethod
+    def _json_result(raw: str) -> Dict[str, Any]:
+        raw = (raw or "").strip()
+        if not raw:
+            return {"ok": True}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"ok": True, "output": raw}
+        if isinstance(parsed, dict):
+            parsed.setdefault("ok", True)
+            return parsed
+        return {"ok": True, "result": parsed}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
+    channel TEXT DEFAULT 'text',
     user_id TEXT,
     model TEXT,
     model_config TEXT,
@@ -366,6 +367,21 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 9")
+            if current_version < 10:
+                # v10: mark the conversational channel separately from source.
+                # Existing sessions are text; the voice bridge creates sessions
+                # with source=voice and channel=voice for shared recall later.
+                try:
+                    cursor.execute('ALTER TABLE sessions ADD COLUMN "channel" TEXT DEFAULT \'text\'')
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute(
+                    "UPDATE sessions SET channel = 'text' WHERE channel IS NULL OR channel = ''"
+                )
+                cursor.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_sessions_channel ON sessions(channel)"
+                )
+                cursor.execute("UPDATE schema_version SET version = 10")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -376,6 +392,13 @@ class SessionDB:
             )
         except sqlite3.OperationalError:
             pass  # Index already exists
+
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_channel ON sessions(channel)"
+            )
+        except sqlite3.OperationalError:
+            pass  # Older partially-created DBs will be handled by migrations.
 
         # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
         try:
@@ -402,12 +425,13 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
+                """INSERT OR IGNORE INTO sessions (id, source, channel, user_id, model, model_config,
                    system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
+                    "voice" if source == "voice" else "text",
                     user_id,
                     model,
                     json.dumps(model_config) if model_config else None,
@@ -564,9 +588,9 @@ class SessionDB:
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions
-                   (id, source, model, started_at)
-                   VALUES (?, ?, ?, ?)""",
-                (session_id, source, model, time.time()),
+                   (id, source, channel, model, started_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (session_id, source, "voice" if source == "voice" else "text", model, time.time()),
             )
         self._execute_write(_do)
 
@@ -1310,6 +1334,7 @@ class SessionDB:
                 m.timestamp,
                 m.tool_name,
                 s.source,
+                s.channel,
                 s.model,
                 s.started_at AS session_started
             FROM messages_fts
@@ -1353,7 +1378,7 @@ class SessionDB:
                               max(1, instr(m.content, ?) - 40),
                               120) AS snippet,
                        m.content, m.timestamp, m.tool_name,
-                       s.source, s.model, s.started_at AS session_started
+                       s.source, s.channel, s.model, s.started_at AS session_started
                 FROM messages m
                 JOIN sessions s ON s.id = m.session_id
                 WHERE {' AND '.join(like_where)}
@@ -1677,4 +1702,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/tests/gateway/test_voice_hermes_bridge.py
+++ b/tests/gateway/test_voice_hermes_bridge.py
@@ -1,0 +1,67 @@
+import pytest
+
+from gateway.voice_hermes_bridge import HerVoiceBridge, her_voice_tool_declarations
+from hermes_state import SessionDB
+
+
+def test_voice_tool_declarations_include_required_contract():
+    names = {tool["name"] for tool in her_voice_tool_declarations()}
+    assert names == {
+        "run_hermes_agent",
+        "create_issue",
+        "list_issues",
+        "send_whatsapp",
+        "send_discord",
+        "get_memory",
+        "get_calendar",
+        "read_email",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_hermes_agent_uses_voice_platform_and_session(tmp_path):
+    calls = []
+
+    async def run_agent(**kwargs):
+        calls.append(kwargs)
+        return ({"final_response": "Done"}, {"total_tokens": 3})
+
+    bridge = HerVoiceBridge(
+        run_agent=run_agent,
+        session_db_factory=lambda: SessionDB(db_path=tmp_path / "state.db"),
+    )
+
+    result = await bridge.call(
+        "run_hermes_agent",
+        {"task": "Crée une issue test", "context": "Depuis le vocal", "session_id": "voice-test"},
+    )
+
+    assert result["ok"] is True
+    assert result["session_id"] == "voice-test"
+    assert result["response"] == "Done"
+    assert calls[0]["platform"] == "voice"
+    assert calls[0]["session_id"] == "voice-test"
+    assert "Context:\nDepuis le vocal" in calls[0]["user_message"]
+
+
+@pytest.mark.asyncio
+async def test_get_memory_returns_shared_voice_and_text_results(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("text-1", source="cli")
+        db.append_message("text-1", role="user", content="factures avril à vérifier")
+        db.create_session("voice-1", source="voice")
+        db.append_message("voice-1", role="user", content="factures mai à vérifier")
+
+        async def run_agent(**kwargs):
+            raise AssertionError("run_agent should not be called")
+
+        bridge = HerVoiceBridge(run_agent=run_agent, session_db_factory=lambda: db)
+        result = await bridge.call("get_memory", {"query": "factures", "limit": 10})
+
+        assert result["ok"] is True
+        assert result["count"] == 2
+        channels = {item["channel"] for item in result["memories"]}
+        assert channels == {"text", "voice"}
+    finally:
+        db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -32,8 +32,15 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session is not None
         assert session["source"] == "cli"
+        assert session["channel"] == "text"
         assert session["model"] == "test-model"
         assert session["ended_at"] is None
+
+    def test_voice_source_sets_voice_channel(self, db):
+        db.create_session(session_id="voice-1", source="voice")
+        session = db.get_session("voice-1")
+        assert session["source"] == "voice"
+        assert session["channel"] == "voice"
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
@@ -1200,7 +1207,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 9
+        assert version == 10
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1256,17 +1263,18 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to v10
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 9
+        assert cursor.fetchone()[0] == 10
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
         assert session is not None
         assert session["title"] is None
+        assert session["channel"] == "text"
 
         # Verify api_call_count column was added with default 0
         cursor = migrated_db._conn.execute(
@@ -1938,4 +1946,3 @@ class TestAutoMaintenance:
         assert marker is not None
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
-


### PR DESCRIPTION
## Summary
- add an authenticated Hermes voice bridge endpoint for realtime function calls
- expose Gemini-compatible tool declarations for Hermes, Multica, messaging, memory, calendar, and email actions
- persist voice sessions with a shared session channel marker for later text recall

## Tests
- scripts/run_tests.sh tests/test_hermes_state.py::TestSchemaInit tests/test_hermes_state.py::TestSessionLifecycle::test_create_and_get_session tests/test_hermes_state.py::TestSessionLifecycle::test_voice_source_sets_voice_channel tests/gateway/test_voice_hermes_bridge.py tests/gateway/test_api_server.py
- .venv/bin/ruff check gateway/voice_hermes_bridge.py gateway/platforms/api_server.py hermes_state.py tests/gateway/test_voice_hermes_bridge.py

## Notes
Full scripts/run_tests.sh was attempted locally. It completed with unrelated environment and platform failures in this fresh venv, including missing acp, numpy, and fastapi. The schema failures from this branch were fixed and the focused regression set passes.