### PR TITLE
fix(tui): correct import path for unified_search in skills search

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4569,7 +4569,7 @@ def _(rid, params: dict) -> dict:
 
             return _ok(rid, {"skills": get_available_skills()})
         if action == "search":
-            from hermes_cli.skills_hub import (
+            from tools.skills_hub import (
                 unified_search,
                 GitHubAuth,
                 create_source_router,


### PR DESCRIPTION
## Problem

The TUI gateway's skills search handler was importing `unified_search`, `GitHubAuth`, and `create_source_router` from `hermes_cli.skills_hub` instead of `tools.skills_hub`. This caused `ImportError` when running `/skills search` in TUI mode:

```
cannot import name 'unified_search' from 'hermes_cli.skills_hub'
```

## Root Cause

The `unified_search` function lives in `tools/skills_hub.py`, not in `hermes_cli/skills_hub.py`. The latter only contains CLI wrapper functions (`do_search`, `do_install`, etc.) that correctly import from `tools.skills_hub` internally.

The TUI backend (`tui_gateway/server.py`) was using the wrong import path for the search action handler.

## Fix

Changed the import in `tui_gateway/server.py` line 4572:
- **Before**: `from hermes_cli.skills_hub import unified_search, GitHubAuth, create_source_router`
- **After**: `from tools.skills_hub import unified_search, GitHubAuth, create_source_router`

## Testing

- Verified fix by running `hermes --tui` and executing `/skills search kubernetes`
- CLI mode (`hermes`) was unaffected and continues to work correctly