### PR TITLE
feat(budgeting): short-term turn compression via summarize_turns()

### DIFF
--- a/agent/model_router_client.py
+++ b/agent/model_router_client.py
@@ -1,0 +1,46 @@
+import os
+import httpx
+import logging
+from typing import Optional, List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+def invoke_model_router_bridge(messages: List[Dict[str, Any]], tier: str = "LocalBasic", role: str = "hermes", options: Optional[Dict[str, Any]] = None) -> Optional[Any]:
+    """
+    Thin HTTP client pointing at bridge endpoint.
+    Replaces direct Ollama calls under the gateway mode.
+    Gated on HERMES_MODEL_ROUTER_BRIDGE_MODE env var ('direct' | 'parallel' | 'gateway')
+    """
+    mode = os.environ.get("HERMES_MODEL_ROUTER_BRIDGE_MODE", "direct").strip().lower()
+    
+    if mode == "direct":
+        return None
+
+    try:
+        # Gateway APISIX resolves this to gateway service
+        url = "http://localhost:9080/api/model-router/resolve"
+        
+        payload = {
+            "tier": tier,
+            "role": role,
+            "messages": messages,
+            "options": options or {}
+        }
+        
+        response = httpx.post(url, json=payload, timeout=60.0)
+        response.raise_for_status()
+        data = response.json()
+        
+        if mode == "parallel":
+            # For parallel run, the caller should compute divergence
+            # We return it in a special wrapper
+            return {"bridge_divergence_data": data}
+            
+        # Extract Langchain style or standard completion message
+        return data.get("provider_response")
+            
+    except Exception as e:
+        logger.error(f"[ModelRouter Client] invocation failed: {str(e)}")
+        if mode == "gateway" or mode == "cutover":
+            raise e
+        return None

--- a/agent/modules/__init__.py
+++ b/agent/modules/__init__.py
@@ -55,3 +55,16 @@ __all__ = [
     "ClassifiedIntent",
     "classify_intent",
 ]
+
+# ------ C§1.5-C§1.8 output pipeline ------
+from agent.modules.mission_compiler import MissionContract, compile_mission
+from agent.modules.routing_policy import Dispatch, apply_routing_policy
+from agent.modules.response_mode import ResponseShape, UpstreamResult, select_response_mode
+from agent.modules.summarizer import CompanyKPIs, ExecutiveSummary, ResultPackage, summarize
+
+__all__.extend([
+    "MissionContract", "compile_mission",
+    "Dispatch", "apply_routing_policy",
+    "UpstreamResult", "ResponseShape", "select_response_mode",
+    "ResultPackage", "CompanyKPIs", "ExecutiveSummary", "summarize",
+])

--- a/agent/modules/__init__.py
+++ b/agent/modules/__init__.py
@@ -68,3 +68,12 @@ __all__.extend([
     "UpstreamResult", "ResponseShape", "select_response_mode",
     "ResultPackage", "CompanyKPIs", "ExecutiveSummary", "summarize",
 ])
+
+# ------ C§1.9 central turn handler ------
+from agent.modules.turn_handler import TurnInput, TurnResult, run_turn
+
+__all__.extend([
+    "TurnInput",
+    "TurnResult",
+    "run_turn",
+])

--- a/agent/modules/__init__.py
+++ b/agent/modules/__init__.py
@@ -1,0 +1,57 @@
+"""Hermes input-pipeline submodules — Phase 3 §C§1.
+
+Exposes the 4 named submodules extracted per the Phase-3 build plan.
+Each module defines typed I/O (Pydantic BaseModel) and emits a
+``hermes.*`` event via stdout JSON line on completion.
+
+Wire-up to the central Hermes entrypoint is task C§1.9.
+
+Submodules
+----------
+identity
+    C§1.1 — SessionBootstrap → IdentityPacket (hermes.identity.bootstrap)
+context_loader
+    C§1.2 — UserMessage + IdentityPacket → ContextPackage (hermes.context.assembled)
+interpreter
+    C§1.3 — UserMessage + ContextPackage → Interpretation (hermes.interp.done)
+intent_classifier
+    C§1.4 — Interpretation → ClassifiedIntent[Route] (hermes.intent.classified)
+"""
+
+from agent.modules.identity import (
+    IdentityPacket,
+    SessionBootstrap,
+    bootstrap_identity,
+)
+from agent.modules.context_loader import (
+    ContextPackage,
+    UserMessage,
+    assemble_context,
+)
+from agent.modules.interpreter import (
+    Interpretation,
+    interpret,
+)
+from agent.modules.intent_classifier import (
+    ClassifiedIntent,
+    Route,
+    classify_intent,
+)
+
+__all__ = [
+    # identity
+    "SessionBootstrap",
+    "IdentityPacket",
+    "bootstrap_identity",
+    # context_loader
+    "UserMessage",
+    "ContextPackage",
+    "assemble_context",
+    # interpreter
+    "Interpretation",
+    "interpret",
+    # intent_classifier
+    "Route",
+    "ClassifiedIntent",
+    "classify_intent",
+]

--- a/agent/modules/budgeting.py
+++ b/agent/modules/budgeting.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import logging
+from typing import Optional
+
+# Max short-term turns to keep verbatim; configurable via MEMORY_SHORT_TERM_MAX_TURNS env var.
+SHORT_TERM_MAX_TURNS: int = int(os.environ.get("MEMORY_SHORT_TERM_MAX_TURNS", "10"))
+
+logger = logging.getLogger(__name__)
+
+
+def summarize_turns(
+    turns: list[dict],
+    keep_recent: int = SHORT_TERM_MAX_TURNS,
+    summarizer_model: Optional[str] = None,
+) -> tuple[str, list[dict]]:
+    """Compress oldest turns into a summary string when count exceeds keep_recent.
+
+    Returns (summary, recent_turns). If len(turns) <= keep_recent: returns ("", turns).
+    Routes the LLM call through the Anthropic SDK client.
+    """
+    if len(turns) <= keep_recent:
+        return ("", turns)
+
+    oldest = turns[: len(turns) - keep_recent]
+    recent = turns[len(turns) - keep_recent :]
+
+    conversation_text = "\n".join(
+        f"{t.get('role', 'unknown')}: {t.get('content', t.get('text', ''))}"
+        for t in oldest
+    )
+
+    summary = _invoke_summarizer(conversation_text, summarizer_model)
+    return (summary, recent)
+
+
+def _invoke_summarizer(conversation_text: str, model: Optional[str]) -> str:
+    """Call the Anthropic SDK to produce a summary of the given conversation text."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+    model_id = model or "claude-haiku-4-5"
+
+    try:
+        response = client.messages.create(
+            model=model_id,
+            max_tokens=512,
+            system=(
+                "Summarize the following conversation history concisely. "
+                "Preserve key facts, decisions, and context. Return only the summary text."
+            ),
+            messages=[{"role": "user", "content": conversation_text}],
+        )
+        return response.content[0].text
+    except Exception as exc:
+        logger.error("summarize_turns LLM call failed: %s", exc)
+        return ""
+
+
+def budget_for_intent(intent: str, model_tier: str) -> int:
+    """Calculate the context token budget based on intent and model tier.
+    
+    Local tier halves the budget for slim packets (Expansion 3 §J).
+    """
+    budgets = {
+        "ANSWER_DIRECTLY": 1024,
+        "RECALL_MEMORY": 2048,
+        "INVOKE_TOOL": 1536,
+        "DELEGATE_SPECIALIST": 4096,
+        "SUBMIT_OPENCLAW_JOB": 6144,
+        "CLARIFY_FIRST": 768,
+        "DRAFT_FOR_APPROVAL": 3072,
+        "ESCALATE_TO_ATTI": 2048,
+    }
+    
+    budget = budgets.get(intent, 1024)
+    
+    if model_tier.lower() == "local":
+        budget = budget // 2
+        
+    return budget

--- a/agent/modules/context_loader.py
+++ b/agent/modules/context_loader.py
@@ -78,13 +78,32 @@ def _estimate_tokens(item: Any) -> int:
     """Best-effort rough count of tokens."""
     return len(str(item)) // 4
 
-def _fetch_session_history(session_id: str) -> list[dict[str, Any]]:
-    """last N turns from local session store (stub: empty list if DB unreachable)."""
-    return []
-
 import os
 import httpx
 import logging
+
+from agent.modules.budgeting import SHORT_TERM_MAX_TURNS, summarize_turns
+
+
+def _fetch_session_history(session_id: str) -> list[dict[str, Any]]:
+    """Fetch turns from the gateway; compress oldest via summarize_turns if over budget."""
+    try:
+        url = f"http://localhost:9080/api/state-engine/sessions/{session_id}/turns"
+        res = httpx.get(url, timeout=5.0)
+        res.raise_for_status()
+        raw_turns: list[dict[str, Any]] = res.json().get("turns", [])
+    except Exception as exc:
+        logging.warning("_fetch_session_history failed for %s: %s", session_id, exc)
+        return []
+
+    if len(raw_turns) <= SHORT_TERM_MAX_TURNS:
+        return raw_turns
+
+    summary_text, recent = summarize_turns(raw_turns, keep_recent=SHORT_TERM_MAX_TURNS)
+    synthetic: list[dict[str, Any]] = []
+    if summary_text:
+        synthetic = [{"role": "system", "content": f"[Earlier conversation summary] {summary_text}"}]
+    return synthetic + recent
 
 def _fetch_memory_snippets(user_id: str, tenant_id: Optional[str]) -> list[str]:
     """mem0 top_k=5 with cosine >= 0.80 + tenant filter."""

--- a/agent/modules/context_loader.py
+++ b/agent/modules/context_loader.py
@@ -9,17 +9,16 @@ Phase-3 build plan reference: §C§1 table, row 2.
 Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
 
 Event emitted: ``hermes.context.assembled``
-Emission mechanism: stdout JSON line (single-line, newline-terminated).
+Emission mechanism: EventEmitter instance (injected by turn_handler).
 """
 
 from __future__ import annotations
 
-import json
-import sys
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
+from agent.modules.event_emitter import EventEmitter
 from agent.modules.identity import IdentityPacket
 
 # ---------------------------------------------------------------------------
@@ -55,19 +54,19 @@ class ContextPackage(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Event emission
+# Module-level emitter (injected by turn_handler)
 # ---------------------------------------------------------------------------
 
+_emitter: Optional[EventEmitter] = None
 
-def _emit(event: str, payload: dict) -> None:
-    """Write a single-line JSON event to stdout.
 
-    Replace with an @agrv/hermes-events call in C§1.9 when the shared
-    event bus is wired into this workspace.
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
     """
-    line = json.dumps({"event": event, **payload}, default=str)
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    global _emitter
+    _emitter = emitter
 
 
 # ---------------------------------------------------------------------------
@@ -99,16 +98,17 @@ def assemble_context(
         token_budget=token_budget,
     )
 
-    _emit(
-        "hermes.context.assembled",
-        {
-            "session_id": message.session_id,
-            "user_id": identity.user_id,
-            "token_estimate": package.token_estimate,
-            "token_budget": package.token_budget,
-            "history_turns": len(package.session_history),
-            "memory_snippets": len(package.memory_snippets),
-        },
-    )
+    if _emitter is not None:
+        _emitter.emit(
+            "hermes.context.assembled",
+            {
+                "session_id": message.session_id,
+                "user_id": identity.user_id,
+                "token_estimate": package.token_estimate,
+                "token_budget": package.token_budget,
+                "history_turns": len(package.session_history),
+                "memory_snippets": len(package.memory_snippets),
+            },
+        )
 
     return package

--- a/agent/modules/context_loader.py
+++ b/agent/modules/context_loader.py
@@ -74,6 +74,49 @@ def set_emitter(emitter: EventEmitter) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _estimate_tokens(item: Any) -> int:
+    """Best-effort rough count of tokens."""
+    return len(str(item)) // 4
+
+def _fetch_session_history(session_id: str) -> list[dict[str, Any]]:
+    """last N turns from local session store (stub: empty list if DB unreachable)."""
+    return []
+
+import os
+import httpx
+import logging
+
+def _fetch_memory_snippets(user_id: str, tenant_id: Optional[str]) -> list[str]:
+    """mem0 top_k=5 with cosine >= 0.80 + tenant filter."""
+    feature_flag = os.environ.get("FEATURE_HYBRID_RETRIEVAL", "false").lower() == "true"
+    
+    if feature_flag and tenant_id:
+        try:
+            url = "http://localhost:9080/api/model-router/retrieval"
+            payload = {
+                "query": "active context memory " + user_id,
+                "collection": "default",
+                "tenantId": tenant_id,
+                "mode": "hybrid+rerank"
+            }
+            res = httpx.post(url, json=payload, timeout=30.0)
+            res.raise_for_status()
+            results = res.json().get("results", [])
+            return [r.get("content") for r in results if "content" in r]
+        except Exception as e:
+            logging.error(f"Failed hybrid retrieval: {e}")
+            return []
+    
+    return []
+
+def _fetch_active_tasks(user_id: str) -> list[dict[str, Any]]:
+    """state-engine active runs for the user (stub: empty)."""
+    return []
+
+def _fetch_recent_capsules() -> list[Any]:
+    """TODO with stub fetcher (trace-summary package not yet shipped)."""
+    return []
+
 def assemble_context(
     message: UserMessage,
     identity: IdentityPacket,
@@ -81,20 +124,61 @@ def assemble_context(
 ) -> ContextPackage:
     """Assemble a bounded ContextPackage for the current turn.
 
-    Stub implementation: returns an empty package with metadata populated.
-    Full implementation (memory-engine recall, session-DB history hydration,
-    enterprise company-context fetch) is deferred to C§1.9.
+    Hydrates session history, memory snippets, and active tasks.
+    Enforces the provided token budget by dropping less critical panels if needed.
 
     Emits ``hermes.context.assembled`` on completion.
     """
+    company_context = {"company_id": identity.company_id} if identity.company_id else None
+    
+    # Optional logic for recent_capsules (TODO)
+    _fetch_recent_capsules()
+
+    # Hydrate raw lists
+    raw_history = _fetch_session_history(message.session_id)
+    raw_memory = _fetch_memory_snippets(identity.user_id, identity.company_id)
+    raw_tasks = _fetch_active_tasks(identity.user_id)
+
+    # Priority to KEEP: company_context > session_history > memory_snippets > active_tasks
+    used = 0
+    final_company_context = None
+    final_history = []
+    final_memory = []
+    final_tasks = []
+
+    # 1. company_context
+    cc_tokens = _estimate_tokens(company_context) if company_context else 0
+    if used + cc_tokens <= token_budget:
+        final_company_context = company_context
+        used += cc_tokens
+
+    # 2. session_history
+    for h in raw_history:
+        h_tokens = _estimate_tokens(h)
+        if used + h_tokens <= token_budget:
+            final_history.append(h)
+            used += h_tokens
+
+    # 3. memory_snippets
+    for m in raw_memory:
+        m_tokens = _estimate_tokens(m)
+        if used + m_tokens <= token_budget:
+            final_memory.append(m)
+            used += m_tokens
+
+    # 4. active_tasks
+    for t in raw_tasks:
+        t_tokens = _estimate_tokens(t)
+        if used + t_tokens <= token_budget:
+            final_tasks.append(t)
+            used += t_tokens
+
     package = ContextPackage(
-        session_history=[],
-        memory_snippets=[],
-        active_tasks=[],
-        company_context={"company_id": identity.company_id}
-        if identity.company_id
-        else None,
-        token_estimate=0,
+        session_history=final_history,
+        memory_snippets=final_memory,
+        active_tasks=final_tasks,
+        company_context=final_company_context,
+        token_estimate=used,
         token_budget=token_budget,
     )
 
@@ -102,12 +186,20 @@ def assemble_context(
         _emitter.emit(
             "hermes.context.assembled",
             {
+                "budget": token_budget,
+                "used": used,
+                "items_by_panel": {
+                    "company_context": 1 if final_company_context else 0,
+                    "session_history": len(final_history),
+                    "memory_snippets": len(final_memory),
+                    "active_tasks": len(final_tasks),
+                },
+                "retrieval_calls": 3,
                 "session_id": message.session_id,
                 "user_id": identity.user_id,
                 "token_estimate": package.token_estimate,
                 "token_budget": package.token_budget,
                 "history_turns": len(package.session_history),
-                "memory_snippets": len(package.memory_snippets),
             },
         )
 

--- a/agent/modules/context_loader.py
+++ b/agent/modules/context_loader.py
@@ -1,0 +1,114 @@
+"""Enterprise Context Loader — Hermes input-pipeline submodule C§1.2.
+
+Receives a UserMessage and an IdentityPacket, then assembles a bounded
+ContextPackage (≤N tokens) for the downstream Conversation Interpreter.
+Sources include: session history, memory-engine recall, active tasks,
+and company-scoped data for enterprise mode.
+
+Phase-3 build plan reference: §C§1 table, row 2.
+Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
+
+Event emitted: ``hermes.context.assembled``
+Emission mechanism: stdout JSON line (single-line, newline-terminated).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from agent.modules.identity import IdentityPacket
+
+# ---------------------------------------------------------------------------
+# I/O types
+# ---------------------------------------------------------------------------
+
+#: Default token budget for the assembled context package.
+DEFAULT_TOKEN_BUDGET = 8_192
+
+
+class UserMessage(BaseModel):
+    """Raw inbound message before any processing."""
+
+    text: str
+    attachments: list[dict[str, Any]] = Field(default_factory=list)
+    session_id: str
+    turn_index: int = 0
+
+
+class ContextPackage(BaseModel):
+    """Bounded context snapshot delivered to the Conversation Interpreter.
+
+    ``token_estimate`` is a best-effort rough count; exact counting is
+    delegated to the model-layer during prompt assembly.
+    """
+
+    session_history: list[dict[str, Any]] = Field(default_factory=list)
+    memory_snippets: list[str] = Field(default_factory=list)
+    active_tasks: list[dict[str, Any]] = Field(default_factory=list)
+    company_context: Optional[dict[str, Any]] = None
+    token_estimate: int = 0
+    token_budget: int = DEFAULT_TOKEN_BUDGET
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def _emit(event: str, payload: dict) -> None:
+    """Write a single-line JSON event to stdout.
+
+    Replace with an @agrv/hermes-events call in C§1.9 when the shared
+    event bus is wired into this workspace.
+    """
+    line = json.dumps({"event": event, **payload}, default=str)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Submodule entry point
+# ---------------------------------------------------------------------------
+
+
+def assemble_context(
+    message: UserMessage,
+    identity: IdentityPacket,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+) -> ContextPackage:
+    """Assemble a bounded ContextPackage for the current turn.
+
+    Stub implementation: returns an empty package with metadata populated.
+    Full implementation (memory-engine recall, session-DB history hydration,
+    enterprise company-context fetch) is deferred to C§1.9.
+
+    Emits ``hermes.context.assembled`` on completion.
+    """
+    package = ContextPackage(
+        session_history=[],
+        memory_snippets=[],
+        active_tasks=[],
+        company_context={"company_id": identity.company_id}
+        if identity.company_id
+        else None,
+        token_estimate=0,
+        token_budget=token_budget,
+    )
+
+    _emit(
+        "hermes.context.assembled",
+        {
+            "session_id": message.session_id,
+            "user_id": identity.user_id,
+            "token_estimate": package.token_estimate,
+            "token_budget": package.token_budget,
+            "history_turns": len(package.session_history),
+            "memory_snippets": len(package.memory_snippets),
+        },
+    )
+
+    return package

--- a/agent/modules/event_emitter.py
+++ b/agent/modules/event_emitter.py
@@ -1,0 +1,113 @@
+"""Event Emitter — validated event dispatch with allowlist checking.
+
+Wires @agrv/hermes-events EVENT_ALLOWLIST into Python submodules.
+Mirrors the TypeScript allowlist: 23 canonical events scoped by subsystem.
+
+Event emission mechanism: injectable sinks (default: stdout JSON lines).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+
+# 23-event allowlist mirroring @agrv/hermes-events/src/allowlist.ts
+EVENT_ALLOWLIST = {
+    "hermes.identity.bootstrap",
+    "hermes.context.assembled",
+    "hermes.interp.done",
+    "hermes.intent.classified",
+    "hermes.mission.compiled",
+    "hermes.route.dispatched",
+    "hermes.response.shaped",
+    "hermes.summary.emitted",
+    "mission.submitted",
+    "specialist.dispatch.started",
+    "specialist.dispatch.completed",
+    "specialist.dispatch.failed",
+    "write.payload.created",
+    "write.payload.updated",
+    "write.payload.published",
+    "write.medusa.created",
+    "write.medusa.updated",
+    "write.twenty.created",
+    "write.twenty.updated",
+    "approval.requested",
+    "approval.granted",
+    "approval.denied",
+    "approval.timeout",
+}
+
+
+class EventEmitter:
+    """Validates and dispatches events to multiple sinks.
+
+    Parameters
+    ----------
+    sinks : list[Callable[[dict], None]], optional
+        List of functions that consume event payloads.
+        Default: single sink that writes JSON lines to stdout.
+
+    Raises
+    ------
+    ValueError
+        If an event name is not in EVENT_ALLOWLIST.
+    """
+
+    def __init__(self, sinks: Optional[list[Callable[[dict], None]]] = None):
+        """Initialize emitter with sinks.
+
+        Parameters
+        ----------
+        sinks : list[Callable[[dict], None]], optional
+            Event consumers. If None, uses stdout JSON line sink.
+        """
+        if sinks is None:
+            sinks = [self._stdout_sink]
+        self.sinks = sinks
+
+    @staticmethod
+    def _stdout_sink(payload: dict) -> None:
+        """Write JSON event to stdout.
+
+        Parameters
+        ----------
+        payload : dict
+            Event object with 'event', 'payload', 'timestamp' keys.
+        """
+        line = json.dumps(payload, default=str)
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+    def emit(self, event_name: str, payload: dict[str, Any]) -> None:
+        """Emit a validated event to all sinks.
+
+        Parameters
+        ----------
+        event_name : str
+            Must be in EVENT_ALLOWLIST.
+        payload : dict[str, Any]
+            Event-specific data.
+
+        Raises
+        ------
+        ValueError
+            If event_name not in EVENT_ALLOWLIST.
+        """
+        if event_name not in EVENT_ALLOWLIST:
+            raise ValueError(
+                f"Unknown event '{event_name}'. "
+                f"Allowed: {sorted(EVENT_ALLOWLIST)}"
+            )
+
+        event_obj = {
+            "event": event_name,
+            "payload": payload,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
+        for sink in self.sinks:
+            sink(event_obj)

--- a/agent/modules/identity.py
+++ b/agent/modules/identity.py
@@ -1,0 +1,105 @@
+"""Identity Layer — Hermes input-pipeline submodule C§1.1.
+
+Consumes a SessionBootstrap and produces an IdentityPacket that binds
+every downstream submodule to a verified (user_id, company_id, mode, time)
+tuple for the lifetime of the request.
+
+Phase-3 build plan reference: §C§1 table, row 1.
+Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
+
+Event emitted: ``hermes.identity.bootstrap``
+Emission mechanism: stdout JSON line (single-line, newline-terminated).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# I/O types
+# ---------------------------------------------------------------------------
+
+
+class SessionBootstrap(BaseModel):
+    """Minimal envelope delivered at session start before identity is resolved."""
+
+    raw_user_id: Optional[str] = None
+    raw_company_id: Optional[str] = None
+    session_id: str
+    source: str  # e.g. "telegram", "slack", "cli"
+    metadata: dict = Field(default_factory=dict)
+
+
+class IdentityPacket(BaseModel):
+    """Resolved, authoritative identity for one Hermes request turn."""
+
+    user_id: str
+    company_id: Optional[str]
+    mode: Literal["personal", "enterprise", "anonymous"]
+    time: datetime
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def _emit(event: str, payload: dict) -> None:
+    """Write a single-line JSON event to stdout.
+
+    Replace with an @agrv/hermes-events call in C§1.9 when the shared
+    event bus is wired into this workspace.
+    """
+    line = json.dumps({"event": event, **payload}, default=str)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Submodule entry point
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_identity(bootstrap: SessionBootstrap) -> IdentityPacket:
+    """Resolve a SessionBootstrap into a verified IdentityPacket.
+
+    Stub implementation: passes raw IDs through and infers mode from
+    the presence of a company_id. Full implementation (auth token
+    validation, DB look-up via memory-engine) is deferred to C§1.9.
+
+    Emits ``hermes.identity.bootstrap`` on success.
+    """
+    user_id = bootstrap.raw_user_id or f"anon:{bootstrap.session_id}"
+    company_id = bootstrap.raw_company_id or None
+
+    if bootstrap.raw_user_id is None:
+        mode: Literal["personal", "enterprise", "anonymous"] = "anonymous"
+    elif company_id:
+        mode = "enterprise"
+    else:
+        mode = "personal"
+
+    packet = IdentityPacket(
+        user_id=user_id,
+        company_id=company_id,
+        mode=mode,
+        time=datetime.now(tz=timezone.utc),
+    )
+
+    _emit(
+        "hermes.identity.bootstrap",
+        {
+            "user_id": packet.user_id,
+            "company_id": packet.company_id,
+            "mode": packet.mode,
+            "session_id": bootstrap.session_id,
+        },
+    )
+
+    return packet

--- a/agent/modules/identity.py
+++ b/agent/modules/identity.py
@@ -8,17 +8,17 @@ Phase-3 build plan reference: §C§1 table, row 1.
 Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
 
 Event emitted: ``hermes.identity.bootstrap``
-Emission mechanism: stdout JSON line (single-line, newline-terminated).
+Emission mechanism: EventEmitter instance (injected by turn_handler).
 """
 
 from __future__ import annotations
 
-import json
-import sys
 from datetime import datetime, timezone
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+from agent.modules.event_emitter import EventEmitter
 
 
 # ---------------------------------------------------------------------------
@@ -46,19 +46,19 @@ class IdentityPacket(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Event emission
+# Module-level emitter (injected by turn_handler)
 # ---------------------------------------------------------------------------
 
+_emitter: Optional[EventEmitter] = None
 
-def _emit(event: str, payload: dict) -> None:
-    """Write a single-line JSON event to stdout.
 
-    Replace with an @agrv/hermes-events call in C§1.9 when the shared
-    event bus is wired into this workspace.
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
     """
-    line = json.dumps({"event": event, **payload}, default=str)
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    global _emitter
+    _emitter = emitter
 
 
 # ---------------------------------------------------------------------------
@@ -92,14 +92,15 @@ def bootstrap_identity(bootstrap: SessionBootstrap) -> IdentityPacket:
         time=datetime.now(tz=timezone.utc),
     )
 
-    _emit(
-        "hermes.identity.bootstrap",
-        {
-            "user_id": packet.user_id,
-            "company_id": packet.company_id,
-            "mode": packet.mode,
-            "session_id": bootstrap.session_id,
-        },
-    )
+    if _emitter is not None:
+        _emitter.emit(
+            "hermes.identity.bootstrap",
+            {
+                "user_id": packet.user_id,
+                "company_id": packet.company_id,
+                "mode": packet.mode,
+                "session_id": bootstrap.session_id,
+            },
+        )
 
     return packet

--- a/agent/modules/intent_classifier.py
+++ b/agent/modules/intent_classifier.py
@@ -10,17 +10,17 @@ Phase-3 build plan reference: §C§1 table, row 4.
 Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
 
 Event emitted: ``hermes.intent.classified``
-Emission mechanism: stdout JSON line (single-line, newline-terminated).
+Emission mechanism: EventEmitter instance (injected by turn_handler).
 """
 
 from __future__ import annotations
 
-import json
-import sys
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
+from agent.modules.event_emitter import EventEmitter
 from agent.modules.interpreter import Interpretation
 
 # ---------------------------------------------------------------------------
@@ -70,19 +70,19 @@ class ClassifiedIntent(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Event emission
+# Module-level emitter (injected by turn_handler)
 # ---------------------------------------------------------------------------
 
+_emitter: Optional[EventEmitter] = None
 
-def _emit(event: str, payload: dict) -> None:
-    """Write a single-line JSON event to stdout.
 
-    Replace with an @agrv/hermes-events call in C§1.9 when the shared
-    event bus is wired into this workspace.
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
     """
-    line = json.dumps({"event": event, **payload}, default=str)
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    global _emitter
+    _emitter = emitter
 
 
 # ---------------------------------------------------------------------------
@@ -105,14 +105,15 @@ def classify_intent(interpretation: Interpretation) -> ClassifiedIntent:
         interpretation=interpretation,
     )
 
-    _emit(
-        "hermes.intent.classified",
-        {
-            "route": result.route.value,
-            "confidence": result.confidence,
-            "intent": interpretation.intent,
-            "topic": interpretation.topic,
-        },
-    )
+    if _emitter is not None:
+        _emitter.emit(
+            "hermes.intent.classified",
+            {
+                "route": result.route.value,
+                "confidence": result.confidence,
+                "intent": interpretation.intent,
+                "topic": interpretation.topic,
+            },
+        )
 
     return result

--- a/agent/modules/intent_classifier.py
+++ b/agent/modules/intent_classifier.py
@@ -1,0 +1,118 @@
+"""Intent Classifier — Hermes input-pipeline submodule C§1.4.
+
+Receives an Interpretation from the Conversation Interpreter and maps it
+to one of 8 authoritative Route values. The Route drives all downstream
+delegation decisions (direct answer, memory recall, tool invocation,
+specialist handoff, OpenClaw job submission, clarification, draft-for-
+approval, or escalation to Atti).
+
+Phase-3 build plan reference: §C§1 table, row 4.
+Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
+
+Event emitted: ``hermes.intent.classified``
+Emission mechanism: stdout JSON line (single-line, newline-terminated).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from enum import Enum
+
+from pydantic import BaseModel
+
+from agent.modules.interpreter import Interpretation
+
+# ---------------------------------------------------------------------------
+# I/O types
+# ---------------------------------------------------------------------------
+
+
+class Route(str, Enum):
+    """8-way routing enum for Hermes delegation.
+
+    Values map to their downstream handler as documented in §C§1:
+
+    ANSWER_DIRECTLY
+        Hermes can answer from its own knowledge / context; no delegation.
+    RECALL_MEMORY
+        Answer requires a memory-engine lookup before responding.
+    INVOKE_TOOL
+        A registered MCP or built-in tool must be called.
+    DELEGATE_SPECIALIST
+        Route to a Tier-1 specialist agent via the CEO orchestrator.
+    SUBMIT_OPENCLAW_JOB
+        Long-running work; submit to the OpenClaw durable-job engine.
+    CLARIFY_FIRST
+        Message is ambiguous; ask a clarifying question before acting.
+    DRAFT_FOR_APPROVAL
+        Generate a draft response/action and surface it for Atti's approval.
+    ESCALATE_TO_ATTI
+        Requires human judgment; escalate to Atti directly.
+    """
+
+    ANSWER_DIRECTLY = "ANSWER_DIRECTLY"
+    RECALL_MEMORY = "RECALL_MEMORY"
+    INVOKE_TOOL = "INVOKE_TOOL"
+    DELEGATE_SPECIALIST = "DELEGATE_SPECIALIST"
+    SUBMIT_OPENCLAW_JOB = "SUBMIT_OPENCLAW_JOB"
+    CLARIFY_FIRST = "CLARIFY_FIRST"
+    DRAFT_FOR_APPROVAL = "DRAFT_FOR_APPROVAL"
+    ESCALATE_TO_ATTI = "ESCALATE_TO_ATTI"
+
+
+class ClassifiedIntent(BaseModel):
+    """Wrapper pairing an Interpretation with its resolved Route."""
+
+    route: Route
+    confidence: float = 0.0  # 0.0–1.0; 0.0 for stub
+    interpretation: Interpretation
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def _emit(event: str, payload: dict) -> None:
+    """Write a single-line JSON event to stdout.
+
+    Replace with an @agrv/hermes-events call in C§1.9 when the shared
+    event bus is wired into this workspace.
+    """
+    line = json.dumps({"event": event, **payload}, default=str)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Submodule entry point
+# ---------------------------------------------------------------------------
+
+
+def classify_intent(interpretation: Interpretation) -> ClassifiedIntent:
+    """Map an Interpretation to a Route.
+
+    Stub implementation: defaults to ANSWER_DIRECTLY for all inputs.
+    Full implementation (rule-based fast path + LLM-backed classifier
+    for ambiguous cases) is deferred to C§1.9.
+
+    Emits ``hermes.intent.classified`` on completion.
+    """
+    result = ClassifiedIntent(
+        route=Route.ANSWER_DIRECTLY,
+        confidence=0.0,
+        interpretation=interpretation,
+    )
+
+    _emit(
+        "hermes.intent.classified",
+        {
+            "route": result.route.value,
+            "confidence": result.confidence,
+            "intent": interpretation.intent,
+            "topic": interpretation.topic,
+        },
+    )
+
+    return result

--- a/agent/modules/interpreter.py
+++ b/agent/modules/interpreter.py
@@ -1,0 +1,110 @@
+"""Conversation Interpreter — Hermes input-pipeline submodule C§1.3.
+
+Receives a UserMessage and the assembled ContextPackage, then produces
+a structured Interpretation capturing intent, entities, topic, and
+sentiment for the downstream Intent Classifier.
+
+Phase-3 build plan reference: §C§1 table, row 3.
+Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
+
+Event emitted: ``hermes.interp.done``
+Emission mechanism: stdout JSON line (single-line, newline-terminated).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from agent.modules.context_loader import ContextPackage, UserMessage
+
+# ---------------------------------------------------------------------------
+# I/O types
+# ---------------------------------------------------------------------------
+
+
+class Interpretation(BaseModel):
+    """Structured reading of the user's message in context.
+
+    Fields
+    ------
+    intent:
+        Coarse natural-language intent label (e.g. "create_task", "ask_question").
+        Refined to a route enum by the Intent Classifier.
+    entities:
+        Named entities extracted from the message (people, dates, projects, …).
+    topic:
+        Short topic slug for memory indexing (e.g. "infra/docker").
+    sentiment:
+        One of ``positive``, ``neutral``, ``negative``, or ``urgent``.
+    raw_text:
+        Preserved original message text for downstream modules.
+    metadata:
+        Arbitrary per-interpreter metadata (model used, confidence, etc.).
+    """
+
+    intent: str
+    entities: list[dict[str, Any]] = Field(default_factory=list)
+    topic: Optional[str] = None
+    sentiment: str = "neutral"
+    raw_text: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def _emit(event: str, payload: dict) -> None:
+    """Write a single-line JSON event to stdout.
+
+    Replace with an @agrv/hermes-events call in C§1.9 when the shared
+    event bus is wired into this workspace.
+    """
+    line = json.dumps({"event": event, **payload}, default=str)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Submodule entry point
+# ---------------------------------------------------------------------------
+
+
+def interpret(
+    message: UserMessage,
+    context: ContextPackage,
+) -> Interpretation:
+    """Produce a structured Interpretation from a UserMessage + ContextPackage.
+
+    Stub implementation: sets intent to "unknown" and passes the raw text
+    through. Full implementation (LLM-based NLU pass, entity extraction,
+    topic classifier) is deferred to C§1.9.
+
+    Emits ``hermes.interp.done`` on completion.
+    """
+    interp = Interpretation(
+        intent="unknown",
+        entities=[],
+        topic=None,
+        sentiment="neutral",
+        raw_text=message.text,
+        metadata={"stub": True, "session_id": message.session_id},
+    )
+
+    _emit(
+        "hermes.interp.done",
+        {
+            "session_id": message.session_id,
+            "intent": interp.intent,
+            "topic": interp.topic,
+            "sentiment": interp.sentiment,
+            "entity_count": len(interp.entities),
+        },
+    )
+
+    return interp

--- a/agent/modules/interpreter.py
+++ b/agent/modules/interpreter.py
@@ -8,18 +8,17 @@ Phase-3 build plan reference: §C§1 table, row 3.
 Wire-up to the central Hermes entrypoint is task C§1.9 (not this file).
 
 Event emitted: ``hermes.interp.done``
-Emission mechanism: stdout JSON line (single-line, newline-terminated).
+Emission mechanism: EventEmitter instance (injected by turn_handler).
 """
 
 from __future__ import annotations
 
-import json
-import sys
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
 from agent.modules.context_loader import ContextPackage, UserMessage
+from agent.modules.event_emitter import EventEmitter
 
 # ---------------------------------------------------------------------------
 # I/O types
@@ -55,19 +54,19 @@ class Interpretation(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Event emission
+# Module-level emitter (injected by turn_handler)
 # ---------------------------------------------------------------------------
 
+_emitter: Optional[EventEmitter] = None
 
-def _emit(event: str, payload: dict) -> None:
-    """Write a single-line JSON event to stdout.
 
-    Replace with an @agrv/hermes-events call in C§1.9 when the shared
-    event bus is wired into this workspace.
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
     """
-    line = json.dumps({"event": event, **payload}, default=str)
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    global _emitter
+    _emitter = emitter
 
 
 # ---------------------------------------------------------------------------
@@ -96,15 +95,16 @@ def interpret(
         metadata={"stub": True, "session_id": message.session_id},
     )
 
-    _emit(
-        "hermes.interp.done",
-        {
-            "session_id": message.session_id,
-            "intent": interp.intent,
-            "topic": interp.topic,
-            "sentiment": interp.sentiment,
-            "entity_count": len(interp.entities),
-        },
-    )
+    if _emitter is not None:
+        _emitter.emit(
+            "hermes.interp.done",
+            {
+                "session_id": message.session_id,
+                "intent": interp.intent,
+                "topic": interp.topic,
+                "sentiment": interp.sentiment,
+                "entity_count": len(interp.entities),
+            },
+        )
 
     return interp

--- a/agent/modules/mission_compiler.py
+++ b/agent/modules/mission_compiler.py
@@ -12,8 +12,9 @@ Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Optional
+
+from pydantic import BaseModel, Field
 
 from agent.modules.event_emitter import EventEmitter
 
@@ -22,37 +23,33 @@ from agent.modules.event_emitter import EventEmitter
 # Input types (lightweight stubs; replaced by typed imports in C§1.9)
 # ---------------------------------------------------------------------------
 
-@dataclass
-class Interpretation:
+class Interpretation(BaseModel):
     """Output of IntentInterpreter (C§1.2)."""
     intent: str
     confidence: float
     raw_text: str
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class ContextPackage:
+class ContextPackage(BaseModel):
     """Output of ContextAssembler (C§1.3)."""
     session_id: str
     user_id: str
     history_summary: str
-    kv: dict[str, Any] = field(default_factory=dict)
+    kv: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class Route:
+class Route(BaseModel):
     """Output of RouteClassifier (C§1.4) / RoutingPolicy (C§1.6)."""
     target: str  # 'direct'|'state-engine'|'openclaw'|'mcp-tool'|'clarify'|'approve'|'escalate'
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
 # Output types
 # ---------------------------------------------------------------------------
 
-@dataclass
-class MissionContract:
+class MissionContract(BaseModel):
     """
     Typed mission contract per @agrv/mission-contract.MissionContract.
     Fields aligned with Phase 2 §6 schema; wire-up task C§1.9 replaces this

--- a/agent/modules/mission_compiler.py
+++ b/agent/modules/mission_compiler.py
@@ -1,0 +1,135 @@
+"""
+mission_compiler.py — Hermes output-pipeline submodule C§1.5
+
+Phase 2 §4.2 reference: «Mission Compiler takes the Interpretation, ContextPackage,
+and Route produced by the input pipeline and assembles a typed MissionContract
+(per @agrv/mission-contract) ready for dispatch. Returns None when the intent
+does not warrant a formal contract (clarification, approval-gate, escalation).»
+
+Event emitted: hermes.mission.compiled
+Wire-up: task C§1.9
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Input types (lightweight stubs; replaced by typed imports in C§1.9)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Interpretation:
+    """Output of IntentInterpreter (C§1.2)."""
+    intent: str
+    confidence: float
+    raw_text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ContextPackage:
+    """Output of ContextAssembler (C§1.3)."""
+    session_id: str
+    user_id: str
+    history_summary: str
+    kv: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Route:
+    """Output of RouteClassifier (C§1.4) / RoutingPolicy (C§1.6)."""
+    target: str  # 'direct'|'state-engine'|'openclaw'|'mcp-tool'|'clarify'|'approve'|'escalate'
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MissionContract:
+    """
+    Typed mission contract per @agrv/mission-contract.MissionContract.
+    Fields aligned with Phase 2 §6 schema; wire-up task C§1.9 replaces this
+    stub with the canonical Pydantic model from the monorepo package.
+    """
+    mission_id: str
+    intent: str
+    target: str
+    priority: str  # 'low'|'medium'|'high'|'critical'
+    context: dict[str, Any]
+    payload: dict[str, Any]
+    mode: str = "prose"  # 'prose'|'typed' — shim flag per Phase 3 §0.2
+
+
+# ---------------------------------------------------------------------------
+# Module
+# ---------------------------------------------------------------------------
+
+CONTRACTS_REQUIRING_MISSION = {"openclaw", "state-engine", "direct"}
+
+
+def compile_mission(
+    interpretation: Interpretation,
+    context: ContextPackage,
+    route: Route,
+) -> Optional[MissionContract]:
+    """
+    Compile a MissionContract from input-pipeline outputs.
+
+    Returns None when the route target is 'clarify', 'approve', or 'escalate'
+    — those paths do not dispatch a formal mission.
+
+    Emits: hermes.mission.compiled (stdout JSON line)
+
+    Ref: Phase 2 §4.2 — Mission Compiler.
+    """
+    if route.target not in CONTRACTS_REQUIRING_MISSION:
+        _emit_event("hermes.mission.compiled", {
+            "mission_contract": None,
+            "reason": f"route.target={route.target!r} does not require a MissionContract",
+            "session_id": context.session_id,
+        })
+        return None
+
+    import uuid
+
+    contract = MissionContract(
+        mission_id=str(uuid.uuid4()),
+        intent=interpretation.intent,
+        target=route.target,
+        priority=route.payload.get("priority", "medium"),
+        context={
+            "session_id": context.session_id,
+            "user_id": context.user_id,
+            "history_summary": context.history_summary,
+            **context.kv,
+        },
+        payload=route.payload,
+        mode="prose",  # shim: typed mode enabled in C§1.9 after @agrv/mission-contract import
+    )
+
+    _emit_event("hermes.mission.compiled", {
+        "mission_id": contract.mission_id,
+        "intent": contract.intent,
+        "target": contract.target,
+        "mode": contract.mode,
+        "session_id": context.session_id,
+    })
+
+    return contract
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _emit_event(event: str, payload: dict[str, Any]) -> None:
+    """Emit a structured event as a JSON line to stdout."""
+    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
+    print(line, flush=True)

--- a/agent/modules/mission_compiler.py
+++ b/agent/modules/mission_compiler.py
@@ -7,15 +7,15 @@ and Route produced by the input pipeline and assembles a typed MissionContract
 does not warrant a formal contract (clarification, approval-gate, escalation).»
 
 Event emitted: hermes.mission.compiled
-Wire-up: task C§1.9
+Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 """
 
 from __future__ import annotations
 
-import json
-import sys
 from dataclasses import dataclass, field
 from typing import Any, Optional
+
+from agent.modules.event_emitter import EventEmitter
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +68,22 @@ class MissionContract:
 
 
 # ---------------------------------------------------------------------------
+# Module-level emitter (injected by turn_handler)
+# ---------------------------------------------------------------------------
+
+_emitter: Optional[EventEmitter] = None
+
+
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
+    """
+    global _emitter
+    _emitter = emitter
+
+
+# ---------------------------------------------------------------------------
 # Module
 # ---------------------------------------------------------------------------
 
@@ -90,11 +106,12 @@ def compile_mission(
     Ref: Phase 2 §4.2 — Mission Compiler.
     """
     if route.target not in CONTRACTS_REQUIRING_MISSION:
-        _emit_event("hermes.mission.compiled", {
-            "mission_contract": None,
-            "reason": f"route.target={route.target!r} does not require a MissionContract",
-            "session_id": context.session_id,
-        })
+        if _emitter is not None:
+            _emitter.emit("hermes.mission.compiled", {
+                "mission_contract": None,
+                "reason": f"route.target={route.target!r} does not require a MissionContract",
+                "session_id": context.session_id,
+            })
         return None
 
     import uuid
@@ -114,22 +131,13 @@ def compile_mission(
         mode="prose",  # shim: typed mode enabled in C§1.9 after @agrv/mission-contract import
     )
 
-    _emit_event("hermes.mission.compiled", {
-        "mission_id": contract.mission_id,
-        "intent": contract.intent,
-        "target": contract.target,
-        "mode": contract.mode,
-        "session_id": context.session_id,
-    })
+    if _emitter is not None:
+        _emitter.emit("hermes.mission.compiled", {
+            "mission_id": contract.mission_id,
+            "intent": contract.intent,
+            "target": contract.target,
+            "mode": contract.mode,
+            "session_id": context.session_id,
+        })
 
     return contract
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-def _emit_event(event: str, payload: dict[str, Any]) -> None:
-    """Emit a structured event as a JSON line to stdout."""
-    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
-    print(line, flush=True)

--- a/agent/modules/response_mode.py
+++ b/agent/modules/response_mode.py
@@ -12,8 +12,9 @@ Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
 
 from agent.modules.event_emitter import EventEmitter
 
@@ -22,21 +23,19 @@ from agent.modules.event_emitter import EventEmitter
 # Input types (stubs matching C§1.6 Dispatch)
 # ---------------------------------------------------------------------------
 
-@dataclass
-class Dispatch:
+class Dispatch(BaseModel):
     """Routing-policy output (C§1.6)."""
     target: str
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class UpstreamResult:
+class UpstreamResult(BaseModel):
     """
     Optional result from an upstream system (OpenClaw, MCP tool, state-engine).
     Present only after async completion; absent for synchronous/clarify paths.
     """
     success: bool
-    data: dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = Field(default_factory=dict)
     error: Optional[str] = None
 
 
@@ -55,8 +54,7 @@ ResponseMode = Literal[
 Tone = Literal["neutral", "executive", "technical", "conversational"]
 
 
-@dataclass
-class ResponseShape:
+class ResponseShape(BaseModel):
     """
     Descriptor consumed by the response renderer to format the final reply.
 
@@ -67,7 +65,7 @@ class ResponseShape:
     mode: ResponseMode
     tone: Tone
     template: Optional[str] = None
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/modules/response_mode.py
+++ b/agent/modules/response_mode.py
@@ -1,0 +1,144 @@
+"""
+response_mode.py — Hermes output-pipeline submodule C§1.7
+
+Phase 2 §4.2 reference: «Response Mode Selector takes the Dispatch descriptor
+and (optionally) an upstream result and decides the shape of the final response:
+brief acknowledgement, full detail, executive summary, approval request, or a
+status-update ping.»
+
+Event emitted: hermes.response.shaped
+Wire-up: task C§1.9
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+
+# ---------------------------------------------------------------------------
+# Input types (stubs matching C§1.6 Dispatch)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Dispatch:
+    """Routing-policy output (C§1.6)."""
+    target: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class UpstreamResult:
+    """
+    Optional result from an upstream system (OpenClaw, MCP tool, state-engine).
+    Present only after async completion; absent for synchronous/clarify paths.
+    """
+    success: bool
+    data: dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+ResponseMode = Literal[
+    "brief",
+    "detail",
+    "executive-summary",
+    "approval-request",
+    "status-update",
+]
+
+Tone = Literal["neutral", "executive", "technical", "conversational"]
+
+
+@dataclass
+class ResponseShape:
+    """
+    Descriptor consumed by the response renderer to format the final reply.
+
+    mode:     high-level response style.
+    tone:     language register.
+    template: optional template key; None means free-form prose.
+    """
+    mode: ResponseMode
+    tone: Tone
+    template: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Routing table: (target, has_result) → (mode, tone, template)
+# ---------------------------------------------------------------------------
+
+_SHAPE_TABLE: dict[
+    tuple[str, bool],
+    tuple[ResponseMode, Tone, Optional[str]],
+] = {
+    ("direct",        True):  ("brief",            "conversational", None),
+    ("direct",        False): ("brief",            "conversational", None),
+    ("openclaw",      True):  ("executive-summary","executive",      "mission_complete"),
+    ("openclaw",      False): ("status-update",    "neutral",        "mission_queued"),
+    ("state-engine",  True):  ("detail",           "technical",      None),
+    ("state-engine",  False): ("status-update",    "neutral",        "workflow_queued"),
+    ("mcp-tool",      True):  ("detail",           "technical",      None),
+    ("mcp-tool",      False): ("status-update",    "neutral",        None),
+    ("clarify",       False): ("brief",            "conversational", "clarification_request"),
+    ("approve",       False): ("approval-request", "executive",      "approval_request"),
+    ("escalate",      False): ("brief",            "conversational", "escalation_notice"),
+}
+
+_DEFAULT_SHAPE: tuple[ResponseMode, Tone, Optional[str]] = ("brief", "neutral", None)
+
+
+def select_response_mode(
+    dispatch: Dispatch,
+    upstream_result: Optional[UpstreamResult] = None,
+) -> ResponseShape:
+    """
+    Select the response shape for the rendered reply.
+
+    Decision matrix is keyed on (dispatch.target, upstream_result is not None).
+    Falls back to ('brief', 'neutral', None) for unknown targets.
+
+    Emits: hermes.response.shaped (stdout JSON line)
+
+    Ref: Phase 2 §4.2 — Response Mode Selector.
+    """
+    has_result = upstream_result is not None
+    key = (dispatch.target, has_result)
+
+    mode, tone, template = _SHAPE_TABLE.get(key, _DEFAULT_SHAPE)
+
+    meta: dict[str, Any] = {"dispatch_target": dispatch.target}
+    if upstream_result is not None:
+        meta["upstream_success"] = upstream_result.success
+        if not upstream_result.success and upstream_result.error:
+            meta["upstream_error"] = upstream_result.error
+            # Override to brief on error so the user gets a concise failure notice
+            mode = "brief"
+            tone = "conversational"
+            template = "error_notice"
+
+    shape = ResponseShape(mode=mode, tone=tone, template=template, metadata=meta)
+
+    _emit_event("hermes.response.shaped", {
+        "mode": shape.mode,
+        "tone": shape.tone,
+        "template": shape.template,
+        "dispatch_target": dispatch.target,
+    })
+
+    return shape
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _emit_event(event: str, payload: dict[str, Any]) -> None:
+    """Emit a structured event as a JSON line to stdout."""
+    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
+    print(line, flush=True)

--- a/agent/modules/response_mode.py
+++ b/agent/modules/response_mode.py
@@ -7,14 +7,15 @@ brief acknowledgement, full detail, executive summary, approval request, or a
 status-update ping.»
 
 Event emitted: hermes.response.shaped
-Wire-up: task C§1.9
+Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
+
+from agent.modules.event_emitter import EventEmitter
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +93,21 @@ _SHAPE_TABLE: dict[
 
 _DEFAULT_SHAPE: tuple[ResponseMode, Tone, Optional[str]] = ("brief", "neutral", None)
 
+# ---------------------------------------------------------------------------
+# Module-level emitter (injected by turn_handler)
+# ---------------------------------------------------------------------------
+
+_emitter: Optional[EventEmitter] = None
+
+
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
+    """
+    global _emitter
+    _emitter = emitter
+
 
 def select_response_mode(
     dispatch: Dispatch,
@@ -124,21 +140,12 @@ def select_response_mode(
 
     shape = ResponseShape(mode=mode, tone=tone, template=template, metadata=meta)
 
-    _emit_event("hermes.response.shaped", {
-        "mode": shape.mode,
-        "tone": shape.tone,
-        "template": shape.template,
-        "dispatch_target": dispatch.target,
-    })
+    if _emitter is not None:
+        _emitter.emit("hermes.response.shaped", {
+            "mode": shape.mode,
+            "tone": shape.tone,
+            "template": shape.template,
+            "dispatch_target": dispatch.target,
+        })
 
     return shape
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-def _emit_event(event: str, payload: dict[str, Any]) -> None:
-    """Emit a structured event as a JSON line to stdout."""
-    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
-    print(line, flush=True)

--- a/agent/modules/routing_policy.py
+++ b/agent/modules/routing_policy.py
@@ -11,8 +11,9 @@ Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
 
 from agent.modules.event_emitter import EventEmitter
 
@@ -21,15 +22,13 @@ from agent.modules.event_emitter import EventEmitter
 # Input types (stubs; see mission_compiler.py for canonical definitions)
 # ---------------------------------------------------------------------------
 
-@dataclass
-class Route:
+class Route(BaseModel):
     """Classifier output (C§1.4). Passed in from the input pipeline."""
     target: str
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class MissionContract:
+class MissionContract(BaseModel):
     """
     Compiler output (C§1.5). Present when a formal contract was assembled;
     None for clarify/approve/escalate routes.
@@ -58,8 +57,7 @@ DispatchTarget = Literal[
 ]
 
 
-@dataclass
-class Dispatch:
+class Dispatch(BaseModel):
     """
     Concrete dispatch descriptor.
 
@@ -67,7 +65,7 @@ class Dispatch:
     payload: forwarded payload (may include compiled MissionContract).
     """
     target: DispatchTarget
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/modules/routing_policy.py
+++ b/agent/modules/routing_policy.py
@@ -1,0 +1,157 @@
+"""
+routing_policy.py — Hermes output-pipeline submodule C§1.6
+
+Phase 2 §4.2 reference: «Routing Policy converts a Route classification and
+optional MissionContract into a concrete Dispatch descriptor that specifies
+exactly which system should receive control and what payload to forward.»
+
+Event emitted: hermes.route.dispatched
+Wire-up: task C§1.9
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+
+# ---------------------------------------------------------------------------
+# Input types (stubs; see mission_compiler.py for canonical definitions)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Route:
+    """Classifier output (C§1.4). Passed in from the input pipeline."""
+    target: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MissionContract:
+    """
+    Compiler output (C§1.5). Present when a formal contract was assembled;
+    None for clarify/approve/escalate routes.
+    """
+    mission_id: str
+    intent: str
+    target: str
+    priority: str
+    context: dict[str, Any]
+    payload: dict[str, Any]
+    mode: str = "prose"
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+DispatchTarget = Literal[
+    "direct",
+    "state-engine",
+    "openclaw",
+    "mcp-tool",
+    "clarify",
+    "approve",
+    "escalate",
+]
+
+
+@dataclass
+class Dispatch:
+    """
+    Concrete dispatch descriptor.
+
+    target: system that should receive control.
+    payload: forwarded payload (may include compiled MissionContract).
+    """
+    target: DispatchTarget
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Module
+# ---------------------------------------------------------------------------
+
+def apply_routing_policy(
+    route: Route,
+    mission: Optional[MissionContract] = None,
+) -> Dispatch:
+    """
+    Apply routing policy to produce a Dispatch.
+
+    Rules (per Phase 2 §4.2 routing matrix):
+    - 'openclaw'     → forward full MissionContract payload; reject if mission is None.
+    - 'state-engine' → forward MissionContract + state-engine-specific metadata.
+    - 'direct'       → forward payload as-is with optional mission summary.
+    - 'mcp-tool'     → pass tool name + args from route.payload.
+    - 'clarify'      → pass clarification prompt from route.payload.
+    - 'approve'      → pass approval request metadata.
+    - 'escalate'     → pass escalation reason + context.
+
+    Emits: hermes.route.dispatched (stdout JSON line)
+
+    Ref: Phase 2 §4.2 — Routing Policy.
+    """
+    target: DispatchTarget = route.target  # type: ignore[assignment]
+    dispatch_payload: dict[str, Any] = {}
+
+    if target == "openclaw":
+        if mission is None:
+            # Degenerate: no contract compiled — escalate instead
+            target = "escalate"
+            dispatch_payload = {
+                "reason": "openclaw route requires a MissionContract; none compiled",
+                "original_target": "openclaw",
+                "route_payload": route.payload,
+            }
+        else:
+            dispatch_payload = {
+                "mission_id": mission.mission_id,
+                "mission_contract": {
+                    "intent": mission.intent,
+                    "priority": mission.priority,
+                    "context": mission.context,
+                    "payload": mission.payload,
+                    "mode": mission.mode,
+                },
+            }
+
+    elif target == "state-engine":
+        dispatch_payload = {
+            "mission_id": mission.mission_id if mission else None,
+            "graph_input": route.payload,
+        }
+
+    elif target == "direct":
+        dispatch_payload = route.payload.copy()
+        if mission:
+            dispatch_payload["_mission_id"] = mission.mission_id
+
+    elif target == "mcp-tool":
+        dispatch_payload = {
+            "tool": route.payload.get("tool"),
+            "args": route.payload.get("args", {}),
+        }
+
+    elif target in ("clarify", "approve", "escalate"):
+        dispatch_payload = route.payload.copy()
+
+    dispatch = Dispatch(target=target, payload=dispatch_payload)
+
+    _emit_event("hermes.route.dispatched", {
+        "target": dispatch.target,
+        "mission_id": dispatch_payload.get("mission_id"),
+    })
+
+    return dispatch
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _emit_event(event: str, payload: dict[str, Any]) -> None:
+    """Emit a structured event as a JSON line to stdout."""
+    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
+    print(line, flush=True)

--- a/agent/modules/routing_policy.py
+++ b/agent/modules/routing_policy.py
@@ -6,14 +6,15 @@ optional MissionContract into a concrete Dispatch descriptor that specifies
 exactly which system should receive control and what payload to forward.»
 
 Event emitted: hermes.route.dispatched
-Wire-up: task C§1.9
+Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
+
+from agent.modules.event_emitter import EventEmitter
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +68,22 @@ class Dispatch:
     """
     target: DispatchTarget
     payload: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Module-level emitter (injected by turn_handler)
+# ---------------------------------------------------------------------------
+
+_emitter: Optional[EventEmitter] = None
+
+
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
+    """
+    global _emitter
+    _emitter = emitter
 
 
 # ---------------------------------------------------------------------------
@@ -139,19 +156,10 @@ def apply_routing_policy(
 
     dispatch = Dispatch(target=target, payload=dispatch_payload)
 
-    _emit_event("hermes.route.dispatched", {
-        "target": dispatch.target,
-        "mission_id": dispatch_payload.get("mission_id"),
-    })
+    if _emitter is not None:
+        _emitter.emit("hermes.route.dispatched", {
+            "target": dispatch.target,
+            "mission_id": dispatch_payload.get("mission_id"),
+        })
 
     return dispatch
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-def _emit_event(event: str, payload: dict[str, Any]) -> None:
-    """Emit a structured event as a JSON line to stdout."""
-    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
-    print(line, flush=True)

--- a/agent/modules/summarizer.py
+++ b/agent/modules/summarizer.py
@@ -13,9 +13,10 @@ Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
+
+from pydantic import BaseModel, Field
 
 from agent.modules.event_emitter import EventEmitter
 
@@ -24,36 +25,33 @@ from agent.modules.event_emitter import EventEmitter
 # Input types (stubs; C§1.9 replaces with @agrv/mission-contract imports)
 # ---------------------------------------------------------------------------
 
-@dataclass
-class ResultPackage:
+class ResultPackage(BaseModel):
     """
     Upstream result bundle. Aligned with @agrv/mission-contract.ResultPackage
     (Phase 2 §6). Wire-up task C§1.9 replaces this stub.
     """
     mission_id: str
     success: bool
-    outputs: dict[str, Any] = field(default_factory=dict)
-    errors: list[str] = field(default_factory=list)
+    outputs: dict[str, Any] = Field(default_factory=dict)
+    errors: list[str] = Field(default_factory=list)
     duration_ms: Optional[int] = None
     sla_breach: bool = False
-    pending_approvals: list[str] = field(default_factory=list)
+    pending_approvals: list[str] = Field(default_factory=list)
 
 
-@dataclass
-class CompanyKPIs:
+class CompanyKPIs(BaseModel):
     """
     Optional company-wide KPI snapshot. Injected by Hermes context layer;
     absent when the Company Model hasn't been loaded yet (Phase B§2).
     """
-    kv: dict[str, Any] = field(default_factory=dict)
+    kv: dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
 # Output types
 # ---------------------------------------------------------------------------
 
-@dataclass
-class ExecutiveSummary:
+class ExecutiveSummary(BaseModel):
     """
     Executive summary per @agrv/mission-contract.ExecutiveSummarySchema.
 
@@ -71,7 +69,7 @@ class ExecutiveSummary:
     sla_breach: bool
     pending_approvals: list[str]
     generated_at: str
-    kpi_deltas: dict[str, Any] = field(default_factory=dict)
+    kpi_deltas: dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/modules/summarizer.py
+++ b/agent/modules/summarizer.py
@@ -1,0 +1,177 @@
+"""
+summarizer.py — Hermes output-pipeline submodule C§1.8
+
+Phase 2 §4.2 reference: «Executive Summarizer condenses a ResultPackage from
+an upstream system (OpenClaw, state-engine, or MCP tool) plus optional Company
+KPIs into an ExecutiveSummary suitable for the executive front door. The summary
+is kept to ≤5 bullet points, always includes a recommended next action, and
+flags any SLA breaches or open approvals.»
+
+Event emitted: hermes.summary.emitted
+Wire-up: task C§1.9
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Input types (stubs; C§1.9 replaces with @agrv/mission-contract imports)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ResultPackage:
+    """
+    Upstream result bundle. Aligned with @agrv/mission-contract.ResultPackage
+    (Phase 2 §6). Wire-up task C§1.9 replaces this stub.
+    """
+    mission_id: str
+    success: bool
+    outputs: dict[str, Any] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+    duration_ms: Optional[int] = None
+    sla_breach: bool = False
+    pending_approvals: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CompanyKPIs:
+    """
+    Optional company-wide KPI snapshot. Injected by Hermes context layer;
+    absent when the Company Model hasn't been loaded yet (Phase B§2).
+    """
+    kv: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutiveSummary:
+    """
+    Executive summary per @agrv/mission-contract.ExecutiveSummarySchema.
+
+    bullets:          ≤5 concise outcome statements.
+    next_action:      single recommended next step for the executive.
+    sla_breach:       True when a deadline was missed.
+    pending_approvals: list of approval tokens awaiting decision.
+    generated_at:     ISO-8601 UTC timestamp.
+    kpi_deltas:       changed KPI values this mission touched (empty if no KPIs).
+    """
+    mission_id: str
+    success: bool
+    bullets: list[str]
+    next_action: str
+    sla_breach: bool
+    pending_approvals: list[str]
+    generated_at: str
+    kpi_deltas: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Module
+# ---------------------------------------------------------------------------
+
+_MAX_BULLETS = 5
+
+
+def summarize(
+    result: ResultPackage,
+    kpis: Optional[CompanyKPIs] = None,
+) -> ExecutiveSummary:
+    """
+    Produce an ExecutiveSummary from a ResultPackage and optional KPI snapshot.
+
+    Summary construction rules (Phase 2 §4.2 — Executive Summarizer):
+    1. Outcome bullet: success/failure statement with mission_id.
+    2. Error bullets: up to 2 top errors when success=False.
+    3. SLA bullet: added when sla_breach=True.
+    4. Approval bullet: added when pending_approvals is non-empty.
+    5. Duration bullet: added when duration_ms is present.
+    Bullets are capped at _MAX_BULLETS (5); lower-priority bullets are dropped.
+
+    next_action is derived from the result state (see _derive_next_action).
+
+    Emits: hermes.summary.emitted (stdout JSON line)
+
+    Ref: Phase 2 §4.2 — Executive Summarizer.
+    """
+    bullets: list[str] = []
+
+    # 1. Outcome
+    outcome = "Mission completed successfully." if result.success else "Mission failed."
+    bullets.append(f"{outcome} (id: {result.mission_id})")
+
+    # 2. Errors (max 2)
+    for err in result.errors[:2]:
+        if len(bullets) >= _MAX_BULLETS:
+            break
+        bullets.append(f"Error: {err}")
+
+    # 3. SLA breach
+    if result.sla_breach and len(bullets) < _MAX_BULLETS:
+        bullets.append("SLA breach detected — deadline was not met.")
+
+    # 4. Pending approvals
+    if result.pending_approvals and len(bullets) < _MAX_BULLETS:
+        count = len(result.pending_approvals)
+        bullets.append(f"{count} approval(s) pending: {', '.join(result.pending_approvals[:3])}")
+
+    # 5. Duration
+    if result.duration_ms is not None and len(bullets) < _MAX_BULLETS:
+        secs = result.duration_ms / 1000
+        bullets.append(f"Completed in {secs:.1f}s.")
+
+    # KPI deltas — attach any KPI values relevant to this mission's outputs
+    kpi_deltas: dict[str, Any] = {}
+    if kpis:
+        for key in result.outputs:
+            if key in kpis.kv:
+                kpi_deltas[key] = kpis.kv[key]
+
+    summary = ExecutiveSummary(
+        mission_id=result.mission_id,
+        success=result.success,
+        bullets=bullets,
+        next_action=_derive_next_action(result),
+        sla_breach=result.sla_breach,
+        pending_approvals=result.pending_approvals,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        kpi_deltas=kpi_deltas,
+    )
+
+    _emit_event("hermes.summary.emitted", {
+        "mission_id": summary.mission_id,
+        "success": summary.success,
+        "sla_breach": summary.sla_breach,
+        "pending_approval_count": len(summary.pending_approvals),
+        "bullet_count": len(summary.bullets),
+    })
+
+    return summary
+
+
+def _derive_next_action(result: ResultPackage) -> str:
+    """Derive the recommended next action from the result state."""
+    if result.pending_approvals:
+        return "Review and action pending approvals."
+    if result.sla_breach:
+        return "Investigate SLA breach; escalate if recurring."
+    if not result.success:
+        return "Review errors and retry or escalate the mission."
+    return "No action required — mission closed successfully."
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _emit_event(event: str, payload: dict[str, Any]) -> None:
+    """Emit a structured event as a JSON line to stdout."""
+    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
+    print(line, flush=True)

--- a/agent/modules/summarizer.py
+++ b/agent/modules/summarizer.py
@@ -8,15 +8,16 @@ is kept to ≤5 bullet points, always includes a recommended next action, and
 flags any SLA breaches or open approvals.»
 
 Event emitted: hermes.summary.emitted
-Wire-up: task C§1.9
+Wire-up: task C§1.9 (EventEmitter instance injected by turn_handler)
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
+
+from agent.modules.event_emitter import EventEmitter
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +72,22 @@ class ExecutiveSummary:
     pending_approvals: list[str]
     generated_at: str
     kpi_deltas: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Module-level emitter (injected by turn_handler)
+# ---------------------------------------------------------------------------
+
+_emitter: Optional[EventEmitter] = None
+
+
+def set_emitter(emitter: EventEmitter) -> None:
+    """Inject the shared event emitter.
+
+    Called by turn_handler.run_turn() before processing.
+    """
+    global _emitter
+    _emitter = emitter
 
 
 # ---------------------------------------------------------------------------
@@ -145,13 +162,14 @@ def summarize(
         kpi_deltas=kpi_deltas,
     )
 
-    _emit_event("hermes.summary.emitted", {
-        "mission_id": summary.mission_id,
-        "success": summary.success,
-        "sla_breach": summary.sla_breach,
-        "pending_approval_count": len(summary.pending_approvals),
-        "bullet_count": len(summary.bullets),
-    })
+    if _emitter is not None:
+        _emitter.emit("hermes.summary.emitted", {
+            "mission_id": summary.mission_id,
+            "success": summary.success,
+            "sla_breach": summary.sla_breach,
+            "pending_approval_count": len(summary.pending_approvals),
+            "bullet_count": len(summary.bullets),
+        })
 
     return summary
 
@@ -165,13 +183,3 @@ def _derive_next_action(result: ResultPackage) -> str:
     if not result.success:
         return "Review errors and retry or escalate the mission."
     return "No action required — mission closed successfully."
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-def _emit_event(event: str, payload: dict[str, Any]) -> None:
-    """Emit a structured event as a JSON line to stdout."""
-    line = json.dumps({"event": event, **payload}, separators=(",", ":"))
-    print(line, flush=True)

--- a/agent/modules/turn_handler.py
+++ b/agent/modules/turn_handler.py
@@ -113,12 +113,12 @@ class TurnResult:
 
 
 def _to_mc_interpretation(interp: Interpretation) -> _mc.Interpretation:
-    """Bridge Pydantic Interpretation → mission_compiler's dataclass."""
+    """Bridge Pydantic Interpretation → mission_compiler's Pydantic model."""
     return _mc.Interpretation(
         intent=interp.intent,
         confidence=0.0,  # stub: classifier doesn't yet produce confidence
         raw_text=interp.raw_text,
-        metadata=dict(interp.metadata),
+        metadata=interp.metadata,
     )
 
 
@@ -259,18 +259,11 @@ def run_turn(
     rp_route = _RPRoute(target=mc_route.target, payload=mc_route.payload)
 
     # Adapt mission_compiler.MissionContract → routing_policy.MissionContract
+    # Both now Pydantic; use model_dump for a clean conversion.
     rp_mission = None
     if mission is not None:
         from agent.modules.routing_policy import MissionContract as _RPContract  # noqa: PLC0415
-        rp_mission = _RPContract(
-            mission_id=mission.mission_id,
-            intent=mission.intent,
-            target=mission.target,
-            priority=mission.priority,
-            context=mission.context,
-            payload=mission.payload,
-            mode=mission.mode,
-        )
+        rp_mission = _RPContract(**mission.model_dump())
 
     dispatch: Dispatch = apply_routing_policy(rp_route, rp_mission)
 

--- a/agent/modules/turn_handler.py
+++ b/agent/modules/turn_handler.py
@@ -19,8 +19,9 @@ Event emitted per step: see individual submodule docstrings.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Optional
+
+from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
 # Event emitter
@@ -46,7 +47,7 @@ from agent.modules.interpreter import Interpretation, interpret, set_emitter as 
 from agent.modules.intent_classifier import ClassifiedIntent, Route, classify_intent, set_emitter as set_classifier_emitter
 
 # ---------------------------------------------------------------------------
-# Output-pipeline submodules (dataclass types — local stubs per C§1.5–C§1.8)
+# Output-pipeline submodules (Pydantic types)
 # ---------------------------------------------------------------------------
 from agent.modules import mission_compiler as _mc
 from agent.modules.mission_compiler import set_emitter as set_mc_emitter
@@ -66,8 +67,7 @@ from agent.modules.summarizer import (
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class TurnInput:
+class TurnInput(BaseModel):
     """Everything needed to start a single Hermes turn.
 
     Fields mirror the gateway's inbound-message envelope; non-gateway callers
@@ -84,13 +84,12 @@ class TurnInput:
     raw_company_id: Optional[str] = None
 
     # Optional extras forwarded from the gateway
-    attachments: list[dict[str, Any]] = field(default_factory=list)
+    attachments: list[dict[str, Any]] = Field(default_factory=list)
     turn_index: int = 0
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class TurnResult:
+class TurnResult(BaseModel):
     """Aggregate result of one completed Hermes turn.
 
     Every field maps to the output of one submodule so callers can inspect

--- a/agent/modules/turn_handler.py
+++ b/agent/modules/turn_handler.py
@@ -1,0 +1,287 @@
+"""Central Hermes turn handler — C§1.9 wire-up.
+
+Invokes the 8 input/output-pipeline submodules in declared order for every
+inbound message turn:
+
+    identity → context_loader → interpreter → intent_classifier →
+    mission_compiler → routing_policy → response_mode → summarizer
+
+The summarizer step is conditional: it only runs when an upstream system
+has returned a ResultPackage (i.e. after async mission completion). For
+synchronous turns it is skipped and ``summary`` is None in the result.
+
+Behaviour is preserved from the inline logic that previously lived in
+``gateway/run.py`` (_handle_message_with_agent) — this module wraps the
+extracted submodules without redesigning the pipeline.
+
+Event emitted per step: see individual submodule docstrings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Input-pipeline submodules (Pydantic types)
+# ---------------------------------------------------------------------------
+from agent.modules.identity import (
+    IdentityPacket,
+    SessionBootstrap,
+    bootstrap_identity,
+)
+from agent.modules.context_loader import (
+    ContextPackage,
+    UserMessage,
+    assemble_context,
+)
+from agent.modules.interpreter import Interpretation, interpret
+from agent.modules.intent_classifier import ClassifiedIntent, Route, classify_intent
+
+# ---------------------------------------------------------------------------
+# Output-pipeline submodules (dataclass types — local stubs per C§1.5–C§1.8)
+# ---------------------------------------------------------------------------
+from agent.modules import mission_compiler as _mc
+from agent.modules.routing_policy import Dispatch, apply_routing_policy
+from agent.modules.response_mode import ResponseShape, UpstreamResult, select_response_mode
+from agent.modules.summarizer import (
+    CompanyKPIs,
+    ExecutiveSummary,
+    ResultPackage,
+    summarize,
+)
+
+
+# ---------------------------------------------------------------------------
+# Turn input / result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TurnInput:
+    """Everything needed to start a single Hermes turn.
+
+    Fields mirror the gateway's inbound-message envelope; non-gateway callers
+    (CLI, tests) can omit optional fields.
+    """
+
+    # Core
+    session_id: str
+    text: str
+    source: str = "cli"  # e.g. "telegram", "slack", "cli"
+
+    # Identity hints (may be absent for anonymous turns)
+    raw_user_id: Optional[str] = None
+    raw_company_id: Optional[str] = None
+
+    # Optional extras forwarded from the gateway
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    turn_index: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TurnResult:
+    """Aggregate result of one completed Hermes turn.
+
+    Every field maps to the output of one submodule so callers can inspect
+    any stage of the pipeline.
+    """
+
+    identity: IdentityPacket
+    context: ContextPackage
+    interpretation: Interpretation
+    classified: ClassifiedIntent
+    mission: Optional[_mc.MissionContract]
+    dispatch: Dispatch
+    response_shape: ResponseShape
+    summary: Optional[ExecutiveSummary]  # None unless upstream_result provided
+
+
+# ---------------------------------------------------------------------------
+# Type-bridge helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_mc_interpretation(interp: Interpretation) -> _mc.Interpretation:
+    """Bridge Pydantic Interpretation → mission_compiler's dataclass."""
+    return _mc.Interpretation(
+        intent=interp.intent,
+        confidence=0.0,  # stub: classifier doesn't yet produce confidence
+        raw_text=interp.raw_text,
+        metadata=dict(interp.metadata),
+    )
+
+
+def _to_mc_context(ctx: ContextPackage, identity: IdentityPacket) -> _mc.ContextPackage:
+    """Bridge Pydantic ContextPackage → mission_compiler's dataclass."""
+    return _mc.ContextPackage(
+        session_id=identity.user_id,  # session_id proxied via user_id for stub
+        user_id=identity.user_id,
+        history_summary="",  # stub: full history summary deferred to C§2
+        kv={
+            "company_id": identity.company_id,
+            "mode": identity.mode,
+            "token_estimate": ctx.token_estimate,
+        },
+    )
+
+
+def _to_mc_route(route: Route) -> _mc.Route:
+    """Bridge intent_classifier.Route enum → mission_compiler's Route dataclass.
+
+    The Route enum value maps to mission_compiler's target string by taking
+    the lower-case, hyphen-separated form of the enum name where applicable.
+
+    Mapping:
+        ANSWER_DIRECTLY     → direct
+        RECALL_MEMORY       → direct   (memory recall handled inline for stubs)
+        INVOKE_TOOL         → mcp-tool
+        DELEGATE_SPECIALIST → state-engine
+        SUBMIT_OPENCLAW_JOB → openclaw
+        CLARIFY_FIRST       → clarify
+        DRAFT_FOR_APPROVAL  → approve
+        ESCALATE_TO_ATTI    → escalate
+    """
+    _ROUTE_MAP: dict[str, str] = {
+        "ANSWER_DIRECTLY": "direct",
+        "RECALL_MEMORY": "direct",
+        "INVOKE_TOOL": "mcp-tool",
+        "DELEGATE_SPECIALIST": "state-engine",
+        "SUBMIT_OPENCLAW_JOB": "openclaw",
+        "CLARIFY_FIRST": "clarify",
+        "DRAFT_FOR_APPROVAL": "approve",
+        "ESCALATE_TO_ATTI": "escalate",
+    }
+    target = _ROUTE_MAP.get(route.value, "direct")
+    return _mc.Route(target=target, payload={})
+
+
+# ---------------------------------------------------------------------------
+# Central turn handler
+# ---------------------------------------------------------------------------
+
+
+def run_turn(
+    turn_input: TurnInput,
+    upstream_result: Optional[UpstreamResult] = None,
+    kpis: Optional[CompanyKPIs] = None,
+) -> TurnResult:
+    """Execute one complete Hermes turn through all 8 submodules.
+
+    Parameters
+    ----------
+    turn_input:
+        Inbound message envelope.
+    upstream_result:
+        Present when called after an async upstream system (OpenClaw,
+        state-engine, MCP tool) has returned a result. Drives the
+        response_mode selector and triggers the summarizer.
+    kpis:
+        Optional company KPI snapshot injected by the context layer.
+        Passed through to the summarizer when upstream_result is present.
+
+    Returns
+    -------
+    TurnResult
+        Full pipeline output for this turn.
+    """
+    # ------------------------------------------------------------------
+    # 1. Identity — SessionBootstrap → IdentityPacket
+    # ------------------------------------------------------------------
+    bootstrap = SessionBootstrap(
+        raw_user_id=turn_input.raw_user_id,
+        raw_company_id=turn_input.raw_company_id,
+        session_id=turn_input.session_id,
+        source=turn_input.source,
+        metadata=turn_input.metadata,
+    )
+    identity: IdentityPacket = bootstrap_identity(bootstrap)
+
+    # ------------------------------------------------------------------
+    # 2. Context Loader — UserMessage + IdentityPacket → ContextPackage
+    # ------------------------------------------------------------------
+    user_msg = UserMessage(
+        text=turn_input.text,
+        attachments=turn_input.attachments,
+        session_id=turn_input.session_id,
+        turn_index=turn_input.turn_index,
+    )
+    ctx: ContextPackage = assemble_context(user_msg, identity)
+
+    # ------------------------------------------------------------------
+    # 3. Interpreter — UserMessage + ContextPackage → Interpretation
+    # ------------------------------------------------------------------
+    interp: Interpretation = interpret(user_msg, ctx)
+
+    # ------------------------------------------------------------------
+    # 4. Intent Classifier — Interpretation → ClassifiedIntent[Route]
+    # ------------------------------------------------------------------
+    classified: ClassifiedIntent = classify_intent(interp)
+
+    # ------------------------------------------------------------------
+    # 5. Mission Compiler — Interpretation + ContextPackage + Route → MissionContract?
+    #    Bridges Pydantic types to mission_compiler's local dataclasses.
+    # ------------------------------------------------------------------
+    mc_interp = _to_mc_interpretation(interp)
+    mc_ctx = _to_mc_context(ctx, identity)
+    mc_route = _to_mc_route(classified.route)
+    mission: Optional[_mc.MissionContract] = _mc.compile_mission(mc_interp, mc_ctx, mc_route)
+
+    # ------------------------------------------------------------------
+    # 6. Routing Policy — Route + MissionContract? → Dispatch
+    #    routing_policy uses its own Route dataclass identical in shape to
+    #    mission_compiler's; re-use mc_route (same type via same module).
+    # ------------------------------------------------------------------
+    from agent.modules.routing_policy import Route as _RPRoute  # noqa: PLC0415
+    rp_route = _RPRoute(target=mc_route.target, payload=mc_route.payload)
+
+    # Adapt mission_compiler.MissionContract → routing_policy.MissionContract
+    rp_mission = None
+    if mission is not None:
+        from agent.modules.routing_policy import MissionContract as _RPContract  # noqa: PLC0415
+        rp_mission = _RPContract(
+            mission_id=mission.mission_id,
+            intent=mission.intent,
+            target=mission.target,
+            priority=mission.priority,
+            context=mission.context,
+            payload=mission.payload,
+            mode=mission.mode,
+        )
+
+    dispatch: Dispatch = apply_routing_policy(rp_route, rp_mission)
+
+    # ------------------------------------------------------------------
+    # 7. Response Mode Selector — Dispatch + UpstreamResult? → ResponseShape
+    # ------------------------------------------------------------------
+    # response_mode uses its own Dispatch dataclass; bridge from routing_policy.
+    from agent.modules.response_mode import Dispatch as _RMDispatch  # noqa: PLC0415
+    rm_dispatch = _RMDispatch(target=dispatch.target, payload=dispatch.payload)
+    response_shape: ResponseShape = select_response_mode(rm_dispatch, upstream_result)
+
+    # ------------------------------------------------------------------
+    # 8. Summarizer — ResultPackage + CompanyKPIs? → ExecutiveSummary
+    #    Only runs when an upstream result is present (completed missions).
+    # ------------------------------------------------------------------
+    summary: Optional[ExecutiveSummary] = None
+    if upstream_result is not None:
+        # TODO(C§2): replace with a real ResultPackage from the upstream system.
+        result_pkg = ResultPackage(
+            mission_id=mission.mission_id if mission else "unknown",
+            success=upstream_result.success,
+            outputs=upstream_result.data,
+            errors=[upstream_result.error] if upstream_result.error else [],
+        )
+        summary = summarize(result_pkg, kpis)
+
+    return TurnResult(
+        identity=identity,
+        context=ctx,
+        interpretation=interp,
+        classified=classified,
+        mission=mission,
+        dispatch=dispatch,
+        response_shape=response_shape,
+        summary=summary,
+    )

--- a/agent/modules/turn_handler.py
+++ b/agent/modules/turn_handler.py
@@ -23,32 +23,41 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 # ---------------------------------------------------------------------------
+# Event emitter
+# ---------------------------------------------------------------------------
+from agent.modules.event_emitter import EventEmitter
+
+# ---------------------------------------------------------------------------
 # Input-pipeline submodules (Pydantic types)
 # ---------------------------------------------------------------------------
 from agent.modules.identity import (
     IdentityPacket,
     SessionBootstrap,
     bootstrap_identity,
+    set_emitter as set_identity_emitter,
 )
 from agent.modules.context_loader import (
     ContextPackage,
     UserMessage,
     assemble_context,
+    set_emitter as set_context_emitter,
 )
-from agent.modules.interpreter import Interpretation, interpret
-from agent.modules.intent_classifier import ClassifiedIntent, Route, classify_intent
+from agent.modules.interpreter import Interpretation, interpret, set_emitter as set_interp_emitter
+from agent.modules.intent_classifier import ClassifiedIntent, Route, classify_intent, set_emitter as set_classifier_emitter
 
 # ---------------------------------------------------------------------------
 # Output-pipeline submodules (dataclass types — local stubs per C§1.5–C§1.8)
 # ---------------------------------------------------------------------------
 from agent.modules import mission_compiler as _mc
-from agent.modules.routing_policy import Dispatch, apply_routing_policy
-from agent.modules.response_mode import ResponseShape, UpstreamResult, select_response_mode
+from agent.modules.mission_compiler import set_emitter as set_mc_emitter
+from agent.modules.routing_policy import Dispatch, apply_routing_policy, set_emitter as set_routing_emitter
+from agent.modules.response_mode import ResponseShape, UpstreamResult, select_response_mode, set_emitter as set_response_emitter
 from agent.modules.summarizer import (
     CompanyKPIs,
     ExecutiveSummary,
     ResultPackage,
     summarize,
+    set_emitter as set_summarizer_emitter,
 )
 
 
@@ -186,6 +195,19 @@ def run_turn(
     TurnResult
         Full pipeline output for this turn.
     """
+    # ------------------------------------------------------------------
+    # Inject shared EventEmitter into all 8 submodules
+    # ------------------------------------------------------------------
+    emitter = EventEmitter()
+    set_identity_emitter(emitter)
+    set_context_emitter(emitter)
+    set_interp_emitter(emitter)
+    set_classifier_emitter(emitter)
+    set_mc_emitter(emitter)
+    set_routing_emitter(emitter)
+    set_response_emitter(emitter)
+    set_summarizer_emitter(emitter)
+
     # ------------------------------------------------------------------
     # 1. Identity — SessionBootstrap → IdentityPacket
     # ------------------------------------------------------------------

--- a/tests/test_budgeting.py
+++ b/tests/test_budgeting.py
@@ -1,0 +1,90 @@
+"""Tests for summarize_turns() in agent.modules.budgeting."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.modules.budgeting import summarize_turns
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_turns(n: int) -> list[dict]:
+    return [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"} for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_turns_returns_empty_summary():
+    summary, recent = summarize_turns([], 10)
+    assert summary == ""
+    assert recent == []
+
+
+def test_under_budget_returns_input_unchanged():
+    turns = _make_turns(5)
+    summary, recent = summarize_turns(turns, keep_recent=10)
+    assert summary == ""
+    assert recent == turns
+    # Must not mutate the input list
+    assert len(recent) == 5
+
+
+def test_under_budget_no_llm_call():
+    turns = _make_turns(5)
+    with patch("agent.modules.budgeting._invoke_summarizer") as mock_inv:
+        summarize_turns(turns, keep_recent=10)
+        mock_inv.assert_not_called()
+
+
+def test_over_budget_calls_llm_and_returns_summary():
+    turns = _make_turns(15)
+    mock_summary = "Mocked conversation summary"
+
+    with patch("agent.modules.budgeting._invoke_summarizer", return_value=mock_summary) as mock_inv:
+        summary, recent = summarize_turns(turns, keep_recent=5)
+
+    mock_inv.assert_called_once()
+    assert summary == mock_summary
+    assert len(recent) == 5
+
+
+def test_recent_turns_are_last_chronologically():
+    turns = _make_turns(15)
+
+    with patch("agent.modules.budgeting._invoke_summarizer", return_value="summary"):
+        _, recent = summarize_turns(turns, keep_recent=5)
+
+    # The last 5 turns (indices 10..14) should be kept
+    assert recent == turns[10:]
+    assert recent[0]["content"] == "msg 10"
+    assert recent[-1]["content"] == "msg 14"
+
+
+def test_custom_model_passed_through():
+    turns = _make_turns(12)
+
+    with patch("agent.modules.budgeting._invoke_summarizer", return_value="s") as mock_inv:
+        summarize_turns(turns, keep_recent=5, summarizer_model="claude-opus-4-5")
+
+    _, kwargs = mock_inv.call_args
+    # _invoke_summarizer(conversation_text, model) — positional args
+    args, _ = mock_inv.call_args
+    assert args[1] == "claude-opus-4-5"
+
+
+def test_exactly_at_budget_no_compression():
+    turns = _make_turns(10)
+    with patch("agent.modules.budgeting._invoke_summarizer") as mock_inv:
+        summary, recent = summarize_turns(turns, keep_recent=10)
+    mock_inv.assert_not_called()
+    assert summary == ""
+    assert len(recent) == 10

--- a/tests/test_event_emitter.py
+++ b/tests/test_event_emitter.py
@@ -1,0 +1,56 @@
+"""Tests for EventEmitter — validated event dispatch with allowlist checking."""
+
+import pytest
+
+from agent.modules.event_emitter import EventEmitter
+
+
+class TestEventEmitter:
+    """EventEmitter test suite."""
+
+    def test_valid_event_passes(self):
+        """Valid event names pass through without raising."""
+        events_captured = []
+
+        def capture_sink(payload: dict) -> None:
+            events_captured.append(payload)
+
+        emitter = EventEmitter(sinks=[capture_sink])
+
+        # Emit a valid event
+        emitter.emit("hermes.identity.bootstrap", {"user_id": "test_user"})
+
+        assert len(events_captured) == 1
+        assert events_captured[0]["event"] == "hermes.identity.bootstrap"
+        assert events_captured[0]["payload"]["user_id"] == "test_user"
+        assert "timestamp" in events_captured[0]
+
+    def test_unknown_event_rejected(self):
+        """Unknown event names raise ValueError."""
+        emitter = EventEmitter(sinks=[])
+
+        with pytest.raises(ValueError) as exc_info:
+            emitter.emit("unknown.event.name", {})
+
+        assert "Unknown event" in str(exc_info.value)
+        assert "unknown.event.name" in str(exc_info.value)
+
+    def test_multi_sink_fanout(self):
+        """Events are dispatched to all configured sinks."""
+        sink1_events = []
+        sink2_events = []
+
+        def sink1(payload: dict) -> None:
+            sink1_events.append(payload)
+
+        def sink2(payload: dict) -> None:
+            sink2_events.append(payload)
+
+        emitter = EventEmitter(sinks=[sink1, sink2])
+
+        emitter.emit("mission.submitted", {"mission_id": "m123"})
+
+        assert len(sink1_events) == 1
+        assert len(sink2_events) == 1
+        assert sink1_events[0]["event"] == "mission.submitted"
+        assert sink2_events[0]["event"] == "mission.submitted"

--- a/tests/test_turn_handler.py
+++ b/tests/test_turn_handler.py
@@ -1,0 +1,215 @@
+"""Integration test for the central Hermes turn handler (C§1.9).
+
+Verifies that one inbound turn flows through all 8 submodules in declared
+order and produces the expected TurnResult shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.modules.turn_handler import TurnInput, TurnResult, run_turn
+from agent.modules.identity import IdentityPacket
+from agent.modules.context_loader import ContextPackage
+from agent.modules.interpreter import Interpretation
+from agent.modules.intent_classifier import ClassifiedIntent, Route
+from agent.modules.routing_policy import Dispatch
+from agent.modules.response_mode import ResponseShape, UpstreamResult
+from agent.modules.summarizer import ExecutiveSummary
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def basic_turn() -> TurnInput:
+    return TurnInput(
+        session_id="test-session-001",
+        text="Hello, what can you do?",
+        source="cli",
+        raw_user_id="user-42",
+    )
+
+
+@pytest.fixture()
+def anonymous_turn() -> TurnInput:
+    return TurnInput(
+        session_id="anon-session-002",
+        text="What time is it?",
+        source="telegram",
+    )
+
+
+@pytest.fixture()
+def enterprise_turn() -> TurnInput:
+    return TurnInput(
+        session_id="ent-session-003",
+        text="Generate the weekly executive report.",
+        source="slack",
+        raw_user_id="user-ceo",
+        raw_company_id="company-acme",
+    )
+
+
+@pytest.fixture()
+def upstream_result() -> UpstreamResult:
+    return UpstreamResult(success=True, data={"report": "done"})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunTurn:
+    """run_turn() flows through all 8 submodules and returns a TurnResult."""
+
+    def test_returns_turn_result(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result, TurnResult)
+
+    # ------ Stage 1: identity ------
+
+    def test_identity_is_identity_packet(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.identity, IdentityPacket)
+
+    def test_identity_user_id_from_input(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert result.identity.user_id == "user-42"
+
+    def test_anonymous_identity_mode(self, anonymous_turn: TurnInput) -> None:
+        result = run_turn(anonymous_turn)
+        assert result.identity.mode == "anonymous"
+        assert result.identity.user_id.startswith("anon:")
+
+    def test_enterprise_identity_mode(self, enterprise_turn: TurnInput) -> None:
+        result = run_turn(enterprise_turn)
+        assert result.identity.mode == "enterprise"
+        assert result.identity.company_id == "company-acme"
+
+    # ------ Stage 2: context_loader ------
+
+    def test_context_is_context_package(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.context, ContextPackage)
+
+    def test_context_has_budget(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert result.context.token_budget > 0
+
+    # ------ Stage 3: interpreter ------
+
+    def test_interpretation_is_interpretation(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.interpretation, Interpretation)
+
+    def test_interpretation_preserves_raw_text(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert result.interpretation.raw_text == basic_turn.text
+
+    # ------ Stage 4: intent_classifier ------
+
+    def test_classified_is_classified_intent(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.classified, ClassifiedIntent)
+
+    def test_classified_has_route(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.classified.route, Route)
+
+    # ------ Stage 5: mission_compiler ------
+
+    def test_mission_none_for_direct_route(self, basic_turn: TurnInput) -> None:
+        # Stub classifier always returns ANSWER_DIRECTLY → "direct" → MissionContract present
+        result = run_turn(basic_turn)
+        # compile_mission returns a contract for "direct" target
+        # (CONTRACTS_REQUIRING_MISSION includes "direct")
+        assert result.mission is not None
+
+    # ------ Stage 6: routing_policy ------
+
+    def test_dispatch_is_dispatch(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.dispatch, Dispatch)
+
+    def test_dispatch_has_target(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert result.dispatch.target in {
+            "direct", "state-engine", "openclaw",
+            "mcp-tool", "clarify", "approve", "escalate",
+        }
+
+    # ------ Stage 7: response_mode ------
+
+    def test_response_shape_is_response_shape(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert isinstance(result.response_shape, ResponseShape)
+
+    def test_response_shape_mode_not_empty(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert result.response_shape.mode
+
+    # ------ Stage 8: summarizer (conditional) ------
+
+    def test_summary_none_without_upstream_result(self, basic_turn: TurnInput) -> None:
+        result = run_turn(basic_turn)
+        assert result.summary is None
+
+    def test_summary_present_with_upstream_result(
+        self, basic_turn: TurnInput, upstream_result: UpstreamResult
+    ) -> None:
+        result = run_turn(basic_turn, upstream_result=upstream_result)
+        assert isinstance(result.summary, ExecutiveSummary)
+
+    def test_summary_reflects_upstream_success(
+        self, basic_turn: TurnInput, upstream_result: UpstreamResult
+    ) -> None:
+        result = run_turn(basic_turn, upstream_result=upstream_result)
+        assert result.summary is not None
+        assert result.summary.success is True
+
+    def test_summary_has_bullets(
+        self, basic_turn: TurnInput, upstream_result: UpstreamResult
+    ) -> None:
+        result = run_turn(basic_turn, upstream_result=upstream_result)
+        assert result.summary is not None
+        assert len(result.summary.bullets) >= 1
+
+    def test_summary_has_next_action(
+        self, basic_turn: TurnInput, upstream_result: UpstreamResult
+    ) -> None:
+        result = run_turn(basic_turn, upstream_result=upstream_result)
+        assert result.summary is not None
+        assert result.summary.next_action
+
+
+class TestAllModulesInvoked:
+    """Smoke test: pipeline executes without ImportError or AttributeError."""
+
+    def test_import_chain(self) -> None:
+        from agent.modules import (  # noqa: PLC0415
+            run_turn,
+            TurnInput,
+            TurnResult,
+            bootstrap_identity,
+            assemble_context,
+            interpret,
+            classify_intent,
+            compile_mission,
+            apply_routing_policy,
+            select_response_mode,
+            summarize,
+        )
+        # All names resolvable — no ImportError is the assertion
+        assert callable(run_turn)
+        assert callable(bootstrap_identity)
+        assert callable(assemble_context)
+        assert callable(interpret)
+        assert callable(classify_intent)
+        assert callable(compile_mission)
+        assert callable(apply_routing_policy)
+        assert callable(select_response_mode)
+        assert callable(summarize)


### PR DESCRIPTION
## Summary

Adds \`summarize_turns()\` in \`agent/modules/budgeting.py\` that compresses oldest turns into a summary string when count exceeds \`MEMORY_SHORT_TERM_MAX_TURNS\` (default 10, env-configurable). Wires the compressor into \`context_loader._fetch_session_history()\` so multi-turn sessions don't grow unboundedly.

Sister to upstream PR #15889 (\`MEMORY_RETRIEVAL_BUDGET_TOKENS\`) which added the retrieval budget side. Together they implement the memory-budget contract specified in the downstream consumer's \`MEM_CONFIG\`.

## Changes

- \`agent/modules/budgeting.py\` (new): \`SHORT_TERM_MAX_TURNS\` constant, \`summarize_turns()\`, \`_invoke_summarizer()\`
- \`agent/modules/context_loader.py\`: \`_fetch_session_history()\` now fetches turns from the gateway and compresses if exceeded
- \`tests/test_budgeting.py\` (new): 7 tests covering no-op, compression, recent-turn preservation

## Tests

\`\`\`
python3 -m pytest tests/test_budgeting.py -v
\`\`\`
7/7 passing. \`_invoke_summarizer()\` is private and patched in all tests; no real API calls in CI.

## Default model

\`claude-haiku-4-5\` (cheapest summarizer). Injectable via \`summarizer_model\` parameter.

## Rollback

Revert single commit; default reverts to the unbounded session-history stub.