### PR TITLE
feat(skills): add /continue cross-channel continuation skill

### DIFF
--- a/skills/software-development/continue/SKILL.md
+++ b/skills/software-development/continue/SKILL.md
@@ -51,6 +51,7 @@ from collections import defaultdict
 
 SESSION_DIR = os.path.expanduser('~/.hermes/sessions')
 LIVE_THRESHOLD_MIN = 20
+KNOWN_PLATFORMS = ['telegram', 'discord', 'tui', 'local']
 
 def get_platform_jsonl(filepath):
     try:
@@ -104,14 +105,21 @@ for p in platforms:
     platforms[p].sort(key=lambda x: x['mtime'], reverse=True)
 
 now = datetime.now(timezone.utc)
-for p, sess_list in sorted(platforms.items()):
+for idx, p in enumerate(KNOWN_PLATFORMS, 1):
+    sess_list = platforms.get(p, [])
+    if not sess_list:
+        print(f"{idx}. {p:<10} — No recent sessions")
+        continue
+
     latest = sess_list[0]
     age_min = int((now - latest['mtime']).total_seconds() / 60)
     live = age_min < LIVE_THRESHOLD_MIN
     if live:
-        print(f"{p:<12} — Live now ({age_min}m ago) [live]")
+        print(f"{idx}. {p:<10} — Live now ({age_min}m ago) [live]")
+    elif age_min < 60:
+        print(f"{idx}. {p:<10} — Last: {age_min}m ago")
     else:
-        print(f"{p:<12} — Last: {age_min//60}h {age_min%60}m ago")
+        print(f"{idx}. {p:<10} — Last: {age_min//60}h {age_min%60}m ago")
 ```
 
 ### Display format
@@ -119,15 +127,17 @@ for p, sess_list in sorted(platforms.items()):
 ```text
 📋 Available channels:
 
-telegram     — Live now (2m ago) [live]
-tui          — Last: 0h 15m ago
-local        — No recent sessions
+1. telegram   — Live now (2m ago) [live]
+2. discord    — No recent sessions
+3. tui        — Last: 15m ago
+4. local      — No recent sessions
 
 Pick one (name or number):
 ```
 
 Notes:
 - `null` or missing platform values should be labeled as `local`.
+- Support both platform names and numeric picks from the channel list.
 - If only one platform has recent sessions, skip the picker and summarize directly.
 
 ## Summary generation
@@ -151,7 +161,12 @@ def find_latest_session(platform):
         try:
             with open(filepath, 'r') as f:
                 meta = json.loads(f.readline())
-            if meta.get('role') == 'session_meta' and (meta.get('platform') or 'local') == platform:
+            detected = None
+            if meta.get('role') == 'session_meta':
+                detected = meta.get('platform') or 'local'
+            elif 'mirror_source' in meta:
+                detected = meta.get('mirror_source') or 'local'
+            if detected == platform:
                 candidates.append((filepath, os.stat(filepath).st_mtime, 'jsonl'))
         except Exception:
             pass
@@ -232,6 +247,7 @@ Got it. What would you like to work on instead?
 | Platform requested but no matching session file exists | Fall back to `session_search` |
 | `session_search` also fails | Say `Can't find that session. Start fresh?` |
 | User picks current platform | Summarize from current context instead of searching files |
+| User replies with a number instead of a platform name | Map the number from the displayed picker to the selected platform |
 | Old sessions with `platform: null` | Treat as `local` |
 | TUI/local sessions stored as `.json` | Scan `session_*.json` and read the `messages` array |
 
@@ -239,6 +255,8 @@ Got it. What would you like to work on instead?
 
 - Parse optional platform argument from the `/continue` command.
 - If no platform is provided, scan sessions and show a channel picker.
+- Include expected platforms even when some have no recent sessions.
+- Support both platform names and numeric picks from the picker.
 - If a platform is provided, locate the latest session for that platform.
 - Support both `.jsonl` and `.json` session formats.
 - Read the last 5-6 user messages only.

--- a/skills/software-development/continue/SKILL.md
+++ b/skills/software-development/continue/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: continue
+description: Cross-channel conversation continuation. User types /continue [platform] to pull context from another channel/session and resume work.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [continuation, sessions, cross-channel, gateway, tui]
+    related_skills: [plan]
+triggers:
+  - "/continue"
+  - "/continue telegram"
+  - "/continue discord"
+  - "/continue tui"
+  - "/continue local"
+---
+
+# /continue Command
+
+Use this skill when the user wants to resume work from another Hermes channel or session.
+
+## How it works
+
+When the user types `/continue` or `/continue <platform>`:
+
+1. Detect the command.
+2. If no platform is provided, scan recent sessions and show a channel picker.
+3. If a platform is provided, skip the picker and go straight to that platform's latest session.
+4. Summarize the last 5-6 user messages in 2-3 sentences.
+5. Ask: `Pick up there? (yes/no)`
+6. On `yes`, continue with that context and inspect the session more deeply if needed.
+7. On `no`, drop the loaded context and start fresh.
+
+## Channel picker
+
+If the user only types `/continue`, scan `~/.hermes/sessions` and show the latest session for each platform.
+
+### Live session rule
+
+Treat a session file modified within the last 20 minutes as live.
+
+### Scan script
+
+Run this with `terminal`:
+
+```python
+import json, os, glob
+from datetime import datetime, timezone
+from collections import defaultdict
+
+SESSION_DIR = os.path.expanduser('~/.hermes/sessions')
+LIVE_THRESHOLD_MIN = 20
+
+def get_platform_jsonl(filepath):
+    try:
+        with open(filepath, 'r') as f:
+            first = json.loads(f.readline())
+        if first.get('role') == 'session_meta':
+            return first.get('platform') or 'local'
+        if 'mirror_source' in first:
+            return first.get('mirror_source') or 'local'
+    except Exception:
+        pass
+    return None
+
+def get_platform_json(filepath):
+    try:
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+        return data.get('platform') or 'local'
+    except Exception:
+        pass
+    return None
+
+sessions = []
+
+for filepath in glob.glob(os.path.join(SESSION_DIR, '*.jsonl')):
+    stat = os.stat(filepath)
+    platform = get_platform_jsonl(filepath)
+    if platform:
+        sessions.append({
+            'file': filepath,
+            'platform': platform,
+            'mtime': datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+            'format': 'jsonl',
+        })
+
+for filepath in glob.glob(os.path.join(SESSION_DIR, 'session_*.json')):
+    stat = os.stat(filepath)
+    platform = get_platform_json(filepath)
+    if platform:
+        sessions.append({
+            'file': filepath,
+            'platform': platform,
+            'mtime': datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+            'format': 'json',
+        })
+
+platforms = defaultdict(list)
+for s in sessions:
+    platforms[s['platform']].append(s)
+for p in platforms:
+    platforms[p].sort(key=lambda x: x['mtime'], reverse=True)
+
+now = datetime.now(timezone.utc)
+for p, sess_list in sorted(platforms.items()):
+    latest = sess_list[0]
+    age_min = int((now - latest['mtime']).total_seconds() / 60)
+    live = age_min < LIVE_THRESHOLD_MIN
+    if live:
+        print(f"{p:<12} — Live now ({age_min}m ago) [live]")
+    else:
+        print(f"{p:<12} — Last: {age_min//60}h {age_min%60}m ago")
+```
+
+### Display format
+
+```text
+📋 Available channels:
+
+telegram     — Live now (2m ago) [live]
+tui          — Last: 0h 15m ago
+local        — No recent sessions
+
+Pick one (name or number):
+```
+
+Notes:
+- `null` or missing platform values should be labeled as `local`.
+- If only one platform has recent sessions, skip the picker and summarize directly.
+
+## Summary generation
+
+Session storage differs by platform, so handle both formats:
+
+- `*.jsonl` — Telegram, Discord, and similar gateway sessions. Read line-delimited JSON and inspect the first `session_meta` line for platform.
+- `session_*.json` — TUI/local sessions. Read the top-level `platform` key and extract messages from the `messages` array.
+
+### Summary extraction script
+
+```python
+import json, os, glob
+
+SESSION_DIR = os.path.expanduser('~/.hermes/sessions')
+
+def find_latest_session(platform):
+    candidates = []
+
+    for filepath in glob.glob(os.path.join(SESSION_DIR, '*.jsonl')):
+        try:
+            with open(filepath, 'r') as f:
+                meta = json.loads(f.readline())
+            if meta.get('role') == 'session_meta' and (meta.get('platform') or 'local') == platform:
+                candidates.append((filepath, os.stat(filepath).st_mtime, 'jsonl'))
+        except Exception:
+            pass
+
+    for filepath in glob.glob(os.path.join(SESSION_DIR, 'session_*.json')):
+        try:
+            with open(filepath, 'r') as f:
+                data = json.load(f)
+            if (data.get('platform') or 'local') == platform:
+                candidates.append((filepath, os.stat(filepath).st_mtime, 'json'))
+        except Exception:
+            pass
+
+    if not candidates:
+        return None, None
+
+    candidates.sort(key=lambda x: x[1], reverse=True)
+    return candidates[0][0], candidates[0][2]
+
+def extract_recent_user_messages(filepath, file_format, limit=6):
+    user_msgs = []
+
+    if file_format == 'jsonl':
+        with open(filepath, 'r') as f:
+            for line in f:
+                try:
+                    msg = json.loads(line)
+                    if msg.get('role') == 'user' and msg.get('content', '').strip():
+                        content = msg['content'].strip()
+                        if not content.startswith('[') and not content.startswith('SYSTEM'):
+                            user_msgs.append(content)
+                except Exception:
+                    pass
+    else:
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+        for msg in data.get('messages', []):
+            if msg.get('role') == 'user' and msg.get('content', '').strip():
+                content = msg['content'].strip()
+                if not content.startswith('[') and not content.startswith('SYSTEM'):
+                    user_msgs.append(content)
+
+    return user_msgs[-limit:]
+```
+
+### Summary format
+
+```text
+📋 Last tui session (15m ago):
+
+We were debugging the /continue workflow. We found that TUI sessions are stored as .json files while Telegram sessions are stored as .jsonl files, so the session scan needed to handle both formats.
+
+Pick up there? (yes/no)
+```
+
+## Confirmation behavior
+
+### If the user says yes
+
+- Continue working from that context.
+- If needed, inspect the session file more deeply.
+- Do not dump the full transcript unless the user asks for it.
+
+### If the user says no
+
+Reply:
+
+```text
+Got it. What would you like to work on instead?
+```
+
+## Edge cases
+
+| Scenario | Handling |
+|---|---|
+| No sessions found | Say `No sessions found. Start fresh?` |
+| Only one platform has sessions | Skip picker and summarize directly |
+| Platform requested but no matching session file exists | Fall back to `session_search` |
+| `session_search` also fails | Say `Can't find that session. Start fresh?` |
+| User picks current platform | Summarize from current context instead of searching files |
+| Old sessions with `platform: null` | Treat as `local` |
+| TUI/local sessions stored as `.json` | Scan `session_*.json` and read the `messages` array |
+
+## Implementation checklist
+
+- Parse optional platform argument from the `/continue` command.
+- If no platform is provided, scan sessions and show a channel picker.
+- If a platform is provided, locate the latest session for that platform.
+- Support both `.jsonl` and `.json` session formats.
+- Read the last 5-6 user messages only.
+- Summarize in 2-3 sentences.
+- Ask `Pick up there? (yes/no)`.
+- Continue on `yes`; start fresh on `no`.
+
+## Notes
+
+- Keep the summary short.
+- Skip tool output, code blocks, and system/invoke messages when building the summary.
+- Prefer the most recent live session if multiple sessions exist for the same platform.
+- If the user typed `/continue <platform>` directly, do not ask them to pick a channel first.

--- a/skills/software-development/continue/SKILL.md
+++ b/skills/software-development/continue/SKILL.md
@@ -7,7 +7,6 @@ license: MIT
 metadata:
   hermes:
     tags: [continuation, sessions, cross-channel, gateway, tui]
-    related_skills: [plan]
 triggers:
   - "/continue"
   - "/continue telegram"
@@ -20,25 +19,26 @@ triggers:
 
 Use this skill when the user wants to resume work from another Hermes channel or session.
 
-## How it works
+## Core flow
 
 When the user types `/continue` or `/continue <platform>`:
 
 1. Detect the command.
 2. If no platform is provided, scan recent sessions and show a channel picker.
-3. If a platform is provided, skip the picker and go straight to that platform's latest session.
+3. If a platform is provided, go straight to that platform's latest session.
 4. Summarize the last 5-6 user messages in 2-3 sentences.
-5. Ask: `Pick up there? (yes/no)`
-6. On `yes`, continue with that context and inspect the session more deeply if needed.
-7. On `no`, drop the loaded context and start fresh.
+5. Ask `Pick up there? (yes/no)`.
+6. On `yes`, continue from that context.
+7. On `no`, start fresh.
 
 ## Channel picker
 
-If the user only types `/continue`, scan `~/.hermes/sessions` and show the latest session for each platform.
+If the user types `/continue` with no platform argument, scan `~/.hermes/sessions` and show the latest session for each expected platform.
 
-### Live session rule
-
-Treat a session file modified within the last 20 minutes as live.
+- Treat a session file modified within the last 20 minutes as live.
+- Label missing or `null` platform values as `local`.
+- Support both platform names and numeric picks from the list.
+- If only one platform has recent sessions, skip the picker and summarize directly.
 
 ### Scan script
 
@@ -135,16 +135,11 @@ for idx, p in enumerate(KNOWN_PLATFORMS, 1):
 Pick one (name or number):
 ```
 
-Notes:
-- `null` or missing platform values should be labeled as `local`.
-- Support both platform names and numeric picks from the channel list.
-- If only one platform has recent sessions, skip the picker and summarize directly.
-
 ## Summary generation
 
-Session storage differs by platform, so handle both formats:
+Handle both Hermes session formats:
 
-- `*.jsonl` — Telegram, Discord, and similar gateway sessions. Read line-delimited JSON and inspect the first `session_meta` line for platform.
+- `*.jsonl` — gateway sessions such as Telegram and Discord. Read line-delimited JSON and inspect the first `session_meta` line for platform.
 - `session_*.json` — TUI/local sessions. Read the top-level `platform` key and extract messages from the `messages` array.
 
 ### Summary extraction script
@@ -226,8 +221,8 @@ Pick up there? (yes/no)
 
 ### If the user says yes
 
-- Continue working from that context.
-- If needed, inspect the session file more deeply.
+- Continue from that context.
+- Inspect the session more deeply only if needed.
 - Do not dump the full transcript unless the user asks for it.
 
 ### If the user says no
@@ -253,13 +248,13 @@ Got it. What would you like to work on instead?
 
 ## Implementation checklist
 
-- Parse optional platform argument from the `/continue` command.
+- Parse the optional platform argument.
 - If no platform is provided, scan sessions and show a channel picker.
 - Include expected platforms even when some have no recent sessions.
-- Support both platform names and numeric picks from the picker.
+- Support both platform names and numeric picks.
 - If a platform is provided, locate the latest session for that platform.
 - Support both `.jsonl` and `.json` session formats.
-- Read the last 5-6 user messages only.
+- Read only the last 5-6 user messages.
 - Summarize in 2-3 sentences.
 - Ask `Pick up there? (yes/no)`.
 - Continue on `yes`; start fresh on `no`.
@@ -267,6 +262,6 @@ Got it. What would you like to work on instead?
 ## Notes
 
 - Keep the summary short.
-- Skip tool output, code blocks, and system/invoke messages when building the summary.
-- Prefer the most recent live session if multiple sessions exist for the same platform.
-- If the user typed `/continue <platform>` directly, do not ask them to pick a channel first.
+- Skip tool output, code blocks, and system/invoke messages.
+- Prefer the most recent live session when multiple sessions exist for one platform.
+- If the user typed `/continue <platform>` directly, do not show the picker first.


### PR DESCRIPTION
> **Disclaimer:** This PR was generated by Hermes Agent on behalf of the user.

## What does this PR do?

This PR adds a bundled `continue` skill that lets users resume work across Hermes channels and session formats with a simple `/continue` command.

When a user types `/continue` or `/continue <platform>`, the skill:

1. Scans recent Hermes sessions
2. Shows a channel picker when needed
3. Summarizes the last 5-6 user messages from the selected session
4. Asks `Pick up there? (yes/no)`
5. Continues from that context on confirmation

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `skills/software-development/continue/SKILL.md`
- Documented a `/continue` workflow for cross-channel conversation continuation
- Added session discovery logic for both Hermes session formats:
  - `*.jsonl` sessions that expose platform via `session_meta`
  - `session_*.json` sessions that expose platform via a top-level `platform` key and store messages in a `messages` array
- Documented a 20-minute live-session threshold
- Documented summary generation from the last 5-6 user messages only
- Documented edge cases such as missing sessions, `platform: null`, current-platform continuation, and fallback to `session_search`

## Why this change?

Hermes users often move between channels such as TUI and Telegram. Without a continuation workflow, they need to manually restate what they were doing when switching devices or interfaces.

This skill makes session handoff explicit and repeatable. It also captures an important implementation detail discovered during testing: TUI/local sessions and gateway sessions are not stored in the same file format, so a robust continuation flow must handle both.

## How to Test

1. Start a conversation in one channel, for example TUI.
2. In another channel, invoke `/continue`.
3. Confirm that the skill can:
   - list available channels
   - identify a live session with a `[live]` tag
   - summarize the latest relevant user messages
   - continue after a `yes` confirmation
4. Repeat with a TUI/local session and verify that `.json` session files are handled correctly.
5. Repeat with a gateway session and verify that `.jsonl` session files are handled correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.1 (TUI + Telegram)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the continue skill to resume a session from another channel"`

## Screenshots / Logs

N/A
