### PR TITLE
fix(browser-cdp): remove agent-browser requirement from _browser_cdp_check (#15952)

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -379,33 +379,28 @@ def test_dispatch_through_registry(cdp_server):
 
 
 def test_check_fn_false_when_no_cdp_url(monkeypatch):
-    """Gate closes when no CDP URL is set — even if the browser toolset is
-    otherwise configured."""
+    """Gate closes when no CDP URL is configured."""
     import tools.browser_tool as bt
 
-    monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
     monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
     assert browser_cdp_tool._browser_cdp_check() is False
 
 
 def test_check_fn_true_when_cdp_url_set(monkeypatch):
-    """Gate opens as soon as a CDP URL is resolvable."""
+    """Gate opens as soon as a CDP URL is resolvable, regardless of agent-browser."""
     import tools.browser_tool as bt
 
-    monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
     monkeypatch.setattr(
         bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
     )
     assert browser_cdp_tool._browser_cdp_check() is True
 
 
-def test_check_fn_false_when_browser_requirements_fail(monkeypatch):
-    """Even with a CDP URL, gate closes if the overall browser toolset is
-    unavailable (e.g. agent-browser not installed)."""
+def test_check_fn_true_when_cdp_url_set_but_agent_browser_missing(monkeypatch):
+    """CDP URL alone is sufficient — agent-browser CLI is not required."""
     import tools.browser_tool as bt
 
-    monkeypatch.setattr(bt, "check_browser_requirements", lambda: False)
     monkeypatch.setattr(
         bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
     )
-    assert browser_cdp_tool._browser_cdp_check() is False
+    assert browser_cdp_tool._browser_cdp_check() is True

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -403,4 +403,11 @@ def test_check_fn_true_when_cdp_url_set_but_agent_browser_missing(monkeypatch):
     monkeypatch.setattr(
         bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
     )
+
+    def _unexpected_browser_check():
+        raise AssertionError(
+            "check_browser_requirements should not be needed when CDP URL is set"
+        )
+
+    monkeypatch.setattr(bt, "check_browser_requirements", _unexpected_browser_check)
     assert browser_cdp_tool._browser_cdp_check() is True

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -535,14 +535,9 @@ def _browser_cdp_check() -> bool:
     ``registry.register(...)`` calls).
     """
     try:
-        from tools.browser_tool import (  # type: ignore[import-not-found]
-            _get_cdp_override,
-            check_browser_requirements,
-        )
+        from tools.browser_tool import _get_cdp_override  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover — defensive
         logger.debug("browser_cdp check: browser_tool import failed: %s", exc)
-        return False
-    if not check_browser_requirements():
         return False
     return bool(_get_cdp_override())
 


### PR DESCRIPTION
## Summary
- `_browser_cdp_check()` called `check_browser_requirements()` which requires the agent-browser CLI binary
- `browser_cdp` is a pure WebSocket CDP client that never invokes agent-browser at runtime
- Users with Chrome on `--remote-debugging-port` and `browser.cdp_url` in config could not use the tool

## The bug
`_browser_cdp_check()` imported and called `check_browser_requirements()` from `browser_tool.py`. That function looks for the agent-browser binary — returning `False` (and gating the tool out) when it isn't found. But `browser_cdp` is entirely self-contained: it only needs a WebSocket URL and the `websockets` package, which is already a transitive dependency. The agent-browser binary is not invoked anywhere in `browser_cdp_tool.py`.

## The fix
Remove the `check_browser_requirements()` call and its import from `_browser_cdp_check()`. The only gate needed is whether `_get_cdp_override()` returns a non-empty endpoint URL. Update the test that verified the old (incorrect) behavior.

## Test plan
- [x] **Before**: `test_check_fn_false_when_browser_requirements_fail` passed — old code gated on agent-browser
- [x] **After**: `test_check_fn_true_when_cdp_url_set_but_agent_browser_missing` passes — CDP URL alone opens the gate
- [x] **Regression guard**: reverted fix → new test failed; restored → passes
- [x] Adjacent browser-cdp and camofox suites unchanged (49 passed)

## Related
- Fixes #15952

🤖 Generated with [Claude Code](https://claude.com/claude-code)