### PR TITLE
feat: add Google Tasks support to workspace CLI

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -44,6 +44,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents.readonly",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 
@@ -165,6 +166,21 @@ def _datetime_with_timezone(value: str) -> str:
     if "+" in tail or "-" in tail:
         return value
     return value + "Z"
+
+
+def _compact_task(task: dict) -> dict:
+    return {
+        "id": task.get("id", ""),
+        "title": task.get("title", ""),
+        "notes": task.get("notes", ""),
+        "status": task.get("status", "needsAction"),
+        "due": task.get("due", ""),
+        "completed": task.get("completed", ""),
+        "updated": task.get("updated", ""),
+        "parent": task.get("parent", ""),
+        "position": task.get("position", ""),
+        "selfLink": task.get("selfLink", ""),
+    }
 
 
 def get_credentials():
@@ -728,6 +744,119 @@ def docs_get(args):
 
 
 # =========================================================================
+# Tasks
+# =========================================================================
+
+
+def tasks_lists(args):
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasklists", "list"], params={"maxResults": args.max})
+        output = [
+            {
+                "id": item.get("id", ""),
+                "title": item.get("title", ""),
+                "updated": item.get("updated", ""),
+            }
+            for item in result.get("items", [])
+        ]
+        print(json.dumps(output, indent=2, ensure_ascii=False))
+        return
+
+    service = build_service("tasks", "v1")
+    result = service.tasklists().list(maxResults=args.max).execute()
+    output = [
+        {
+            "id": item.get("id", ""),
+            "title": item.get("title", ""),
+            "updated": item.get("updated", ""),
+        }
+        for item in result.get("items", [])
+    ]
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+def tasks_list(args):
+    params = {
+        "tasklist": args.tasklist,
+        "maxResults": args.max,
+        "showCompleted": args.show_completed,
+        "showDeleted": args.show_deleted,
+        "showHidden": args.show_hidden,
+    }
+    if args.due_min:
+        params["dueMin"] = _datetime_with_timezone(args.due_min)
+    if args.due_max:
+        params["dueMax"] = _datetime_with_timezone(args.due_max)
+
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "list"], params=params)
+        print(json.dumps([_compact_task(item) for item in result.get("items", [])], indent=2, ensure_ascii=False))
+        return
+
+    service = build_service("tasks", "v1")
+    result = service.tasks().list(**params).execute()
+    print(json.dumps([_compact_task(item) for item in result.get("items", [])], indent=2, ensure_ascii=False))
+
+
+def tasks_create(args):
+    body = {"title": args.title}
+    if args.notes:
+        body["notes"] = args.notes
+    if args.due:
+        body["due"] = _datetime_with_timezone(args.due)
+
+    params = {"tasklist": args.tasklist}
+    if args.parent:
+        params["parent"] = args.parent
+    if args.previous:
+        params["previous"] = args.previous
+
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "insert"], params=params, body=body)
+        print(json.dumps({
+            "status": "created",
+            "id": result.get("id", ""),
+            "title": result.get("title", ""),
+            "selfLink": result.get("selfLink", ""),
+        }, indent=2, ensure_ascii=False))
+        return
+
+    service = build_service("tasks", "v1")
+    result = service.tasks().insert(**params, body=body).execute()
+    print(json.dumps({
+        "status": "created",
+        "id": result.get("id", ""),
+        "title": result.get("title", ""),
+        "selfLink": result.get("selfLink", ""),
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_complete(args):
+    completed_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    body = {"status": "completed", "completed": completed_at}
+
+    if _gws_binary():
+        _run_gws(["tasks", "tasks", "patch"], params={"tasklist": args.tasklist, "task": args.task_id}, body=body)
+        print(json.dumps({"status": "completed", "id": args.task_id}, indent=2))
+        return
+
+    service = build_service("tasks", "v1")
+    service.tasks().patch(tasklist=args.tasklist, task=args.task_id, body=body).execute()
+    print(json.dumps({"status": "completed", "id": args.task_id}, indent=2))
+
+
+def tasks_delete(args):
+    if _gws_binary():
+        _run_gws(["tasks", "tasks", "delete"], params={"tasklist": args.tasklist, "task": args.task_id})
+        print(json.dumps({"status": "deleted", "id": args.task_id}, indent=2))
+        return
+
+    service = build_service("tasks", "v1")
+    service.tasks().delete(tasklist=args.tasklist, task=args.task_id).execute()
+    print(json.dumps({"status": "deleted", "id": args.task_id}, indent=2))
+
+
+# =========================================================================
 # CLI parser
 # =========================================================================
 
@@ -846,6 +975,43 @@ def main():
     p = docs_sub.add_parser("get")
     p.add_argument("doc_id")
     p.set_defaults(func=docs_get)
+
+    # --- Tasks ---
+    tasks = sub.add_parser("tasks")
+    tasks_sub = tasks.add_subparsers(dest="action", required=True)
+
+    p = tasks_sub.add_parser("lists")
+    p.add_argument("--max", type=int, default=20)
+    p.set_defaults(func=tasks_lists)
+
+    p = tasks_sub.add_parser("list")
+    p.add_argument("tasklist", help="Task list ID")
+    p.add_argument("--max", type=int, default=50)
+    p.add_argument("--show-completed", action="store_true")
+    p.add_argument("--show-deleted", action="store_true")
+    p.add_argument("--show-hidden", action="store_true")
+    p.add_argument("--due-min", default="", help="Minimum due date/time (ISO 8601)")
+    p.add_argument("--due-max", default="", help="Maximum due date/time (ISO 8601)")
+    p.set_defaults(func=tasks_list)
+
+    p = tasks_sub.add_parser("create")
+    p.add_argument("tasklist", help="Task list ID")
+    p.add_argument("--title", required=True)
+    p.add_argument("--notes", default="")
+    p.add_argument("--due", default="", help="Due date/time (ISO 8601)")
+    p.add_argument("--parent", default="", help="Parent task ID")
+    p.add_argument("--previous", default="", help="Previous sibling task ID")
+    p.set_defaults(func=tasks_create)
+
+    p = tasks_sub.add_parser("complete")
+    p.add_argument("tasklist", help="Task list ID")
+    p.add_argument("task_id", help="Task ID")
+    p.set_defaults(func=tasks_complete)
+
+    p = tasks_sub.add_parser("delete")
+    p.add_argument("tasklist", help="Task list ID")
+    p.add_argument("task_id", help="Task ID")
+    p.set_defaults(func=tasks_delete)
 
     args = parser.parse_args()
     args.func(args)

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -50,6 +50,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents.readonly",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -240,3 +240,7 @@ class TestExchangeAuthCode:
         assert setup_module.TOKEN_PATH.exists()
         # Pending auth is cleaned up
         assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+def test_google_workspace_scopes_include_tasks(setup_module):
+    assert "https://www.googleapis.com/auth/tasks" in setup_module.SCOPES

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -234,3 +234,88 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_api_tasks_lists_returns_tasklists(api_module, capsys):
+    api_module._gws_binary = lambda: None
+
+    service = MagicMock()
+    service.tasklists.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {"id": "tl_1", "title": "Personal", "updated": "2026-04-21T10:00:00.000Z"}
+        ]
+    }
+
+    args = api_module.argparse.Namespace(max=20, func=api_module.tasks_lists)
+
+    with patch.object(api_module, "build_service", return_value=service):
+        api_module.tasks_lists(args)
+
+    service.tasklists.return_value.list.assert_called_once_with(maxResults=20)
+    assert json.loads(capsys.readouterr().out) == [
+        {"id": "tl_1", "title": "Personal", "updated": "2026-04-21T10:00:00.000Z"}
+    ]
+
+
+def test_api_tasks_create_passes_insert_params_and_body(api_module, capsys):
+    api_module._gws_binary = lambda: None
+
+    service = MagicMock()
+    service.tasks.return_value.insert.return_value.execute.return_value = {
+        "id": "task_1",
+        "title": "Buy milk",
+        "selfLink": "https://tasks.google.com/task_1",
+    }
+
+    args = api_module.argparse.Namespace(
+        tasklist="tl_1",
+        title="Buy milk",
+        notes="2L whole",
+        due="2026-04-21T12:00:00",
+        parent="parent_1",
+        previous="prev_1",
+        func=api_module.tasks_create,
+    )
+
+    with patch.object(api_module, "build_service", return_value=service):
+        api_module.tasks_create(args)
+
+    service.tasks.return_value.insert.assert_called_once_with(
+        tasklist="tl_1",
+        parent="parent_1",
+        previous="prev_1",
+        body={
+            "title": "Buy milk",
+            "notes": "2L whole",
+            "due": "2026-04-21T12:00:00Z",
+        },
+    )
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "created",
+        "id": "task_1",
+        "title": "Buy milk",
+        "selfLink": "https://tasks.google.com/task_1",
+    }
+
+
+def test_api_tasks_complete_marks_task_completed(api_module, capsys):
+    api_module._gws_binary = lambda: None
+
+    service = MagicMock()
+    service.tasks.return_value.patch.return_value.execute.return_value = {"id": "task_1"}
+
+    args = api_module.argparse.Namespace(
+        tasklist="tl_1",
+        task_id="task_1",
+        func=api_module.tasks_complete,
+    )
+
+    with patch.object(api_module, "build_service", return_value=service):
+        api_module.tasks_complete(args)
+
+    patch_kwargs = service.tasks.return_value.patch.call_args.kwargs
+    assert patch_kwargs["tasklist"] == "tl_1"
+    assert patch_kwargs["task"] == "task_1"
+    assert patch_kwargs["body"]["status"] == "completed"
+    assert patch_kwargs["body"]["completed"].endswith("Z")
+    assert json.loads(capsys.readouterr().out) == {"status": "completed", "id": "task_1"}


### PR DESCRIPTION
## Summary
- add Google Tasks scope to Google Workspace OAuth and CLI auth handling
- add `tasks` subcommands for listing task lists, listing tasks, creating tasks, completing tasks, and deleting tasks
- add regression tests for new scope handling and core Tasks operations

## Root cause
The Google Workspace skill only exposed Gmail, Calendar, Drive, Contacts, Sheets, and Docs behavior. The CLI and OAuth scope set did not include Google Tasks, so Hermes could not manage Google Tasks through the existing workspace integration.

## Verification
- `pytest -q tests/skills/test_google_workspace_api.py tests/skills/test_google_oauth_setup.py`
- `pytest -q tests/skills`
- independent pre-commit review passed with no blocking security or logic issues

## Notes
- current tests cover scope inclusion plus list/create/complete flows
- follow-up coverage could be added for `tasks list`, `tasks delete`, and explicit `gws` subprocess paths
