### PR TITLE
fix: ensure reasoning_content consistency for DeepSeek-compatible APIs

### DIFF
--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -319,9 +319,13 @@ class HermesAgentLoop:
 
                 # Preserve reasoning_content for multi-turn chat template handling
                 # (e.g., Kimi-K2's template renders <think> blocks differently
-                # for history vs. the latest turn based on this field)
-                if reasoning:
-                    msg_dict["reasoning_content"] = reasoning
+                # for history vs. the latest turn based on this field).
+                # Always set reasoning_content -- DeepSeek and DeepSeek-compatible
+                # APIs (Ark Coding Plan, etc.) require reasoning_content on EVERY
+                # assistant message when thinking mode is enabled, even if the
+                # message had no reasoning.  Inconsistency (some messages with,
+                # some without) triggers a 400 error.
+                msg_dict["reasoning_content"] = reasoning or ""
 
                 messages.append(msg_dict)
 
@@ -492,8 +496,10 @@ class HermesAgentLoop:
                     "role": "assistant",
                     "content": assistant_msg.content or "",
                 }
-                if reasoning:
-                    msg_dict["reasoning_content"] = reasoning
+                # Always set reasoning_content for multi-turn consistency
+                # (same rationale as tool-call path above -- DeepSeek requires
+                # reasoning_content on every assistant message in thinking mode)
+                msg_dict["reasoning_content"] = reasoning or ""
                 messages.append(msg_dict)
 
                 turn_elapsed = _time.monotonic() - turn_start

--- a/run_agent.py
+++ b/run_agent.py
@@ -7639,11 +7639,12 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
-                # DeepSeek thinking mode requires reasoning_content on every
-                # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
+            elif self._needs_deepseek_tool_reasoning() or self._needs_kimi_tool_reasoning():
+                # DeepSeek / Kimi thinking mode requires reasoning_content on EVERY
+                # assistant message (not just tool-call ones).  An inconsistent
+                # mix (some messages with, some without) triggers HTTP 400 from
+                # the API.  Include empty string as a defensive compatibility
+                # fallback (refs #15250).
                 msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
@@ -7738,8 +7739,12 @@ class AIAgent:
         """Return True when the current provider is DeepSeek thinking mode.
 
         DeepSeek V4 thinking mode requires ``reasoning_content`` on every
-        assistant tool-call turn; omitting it causes HTTP 400 when the
-        message is replayed in a subsequent API request (#15250).
+        assistant turn; omitting it causes HTTP 400 when the message is
+        replayed in a subsequent API request (#15250).
+
+        Detection covers: provider='deepseek', model name containing
+        'deepseek', api.deepseek.com host, and Ark Coding Plan endpoint
+        (ark.cn-beijing.volces.com) which follows DeepSeek API conventions.
         """
         provider = (self.provider or "").lower()
         model = (self.model or "").lower()
@@ -7747,6 +7752,7 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+            or base_url_host_matches(self.base_url, "ark.cn-beijing.volces.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
@@ -7765,10 +7771,11 @@ class AIAgent:
             return
 
         # Providers that require an echoed reasoning_content on every
-        # assistant tool-call turn. Detection logic lives in the per-provider
-        # helpers so both the creation path (_build_assistant_message) and
-        # this replay path stay in sync.
-        if source_msg.get("tool_calls") and (
+        # assistant turn (not just tool-call messages — DeepSeek validates
+        # the entire conversation history for consistency).  Detection logic
+        # lives in the per-provider helpers so both the creation path
+        # (_build_assistant_message) and this replay path stay in sync.
+        if (
             self._needs_kimi_tool_reasoning()
             or self._needs_deepseek_tool_reasoning()
         ):

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -56,6 +56,16 @@ class TestNeedsDeepSeekToolReasoning:
         )
         assert agent._needs_deepseek_tool_reasoning() is True
 
+    def test_ark_coding_plan_endpoint(self) -> None:
+        """Ark Coding Plan endpoint (ark.cn-beijing.volces.com) follows
+        DeepSeek API conventions and requires reasoning_content echo."""
+        agent = _make_agent(
+            provider="custom",
+            model="glm-5.1",
+            base_url="https://ark.cn-beijing.volces.com/api/coding/v3",
+        )
+        assert agent._needs_deepseek_tool_reasoning() is True
+
     def test_provider_case_insensitive(self) -> None:
         agent = _make_agent(provider="DeepSeek", model="")
         assert agent._needs_deepseek_tool_reasoning() is True
@@ -88,13 +98,14 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg.get("reasoning_content") == ""
 
-    def test_deepseek_assistant_no_tool_call_left_alone(self) -> None:
-        """Plain assistant turns without tool_calls don't get padded."""
+    def test_deepseek_assistant_no_tool_call_now_padded(self) -> None:
+        """Plain assistant turns without tool_calls ALSO get padded for DeepSeek
+        because the API validates the whole conversation history for consistency."""
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
         source = {"role": "assistant", "content": "hello"}
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
-        assert "reasoning_content" not in api_msg
+        assert api_msg.get("reasoning_content") == ""
 
     def test_deepseek_explicit_reasoning_content_preserved(self) -> None:
         """When reasoning_content is already set, it's copied verbatim."""


### PR DESCRIPTION
## Summary

DeepSeek V4 thinking mode (and compatible APIs like Ark Coding Plan at `ark.cn-beijing.volces.com`) requires `reasoning_content` on **every** assistant message in the conversation history. An inconsistent mix — some messages with `reasoning_content`, some without — triggers HTTP 400:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

This bug manifests on the Ark Coding Plan endpoint when models intermittently return `reasoning_content` (e.g., `glm-5.1`), producing 22 messages with it and 71 without in the same conversation.

## Changes

### `environments/agent_loop.py` (subagent loop / HermesAgentLoop)
- Always set `reasoning_content` on assistant messages (use empty string when no reasoning was returned in that turn)
- Previously only set it when `reasoning` was non-None, creating inconsistent messages

### `run_agent.py` — `_build_assistant_message()`
- Extend defensive padding to cover **all** assistant messages for DeepSeek/Kimi, not just tool-call ones
- Previously: `elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning()`
- Now: `elif self._needs_deepseek_tool_reasoning() or self._needs_kimi_tool_reasoning()`

### `run_agent.py` — `_copy_reasoning_content_for_api()` (replay path)
- Same change: pad all assistant messages during replay, not just tool-call ones

### `run_agent.py` — `_needs_deepseek_tool_reasoning()` (detection)
- Add detection for Ark Coding Plan endpoint (`ark.cn-beijing.volces.com`) which follows DeepSeek API conventions

### Tests
- Update `test_deepseek_assistant_no_tool_call_now_padded` to expect padding on non-tool-call messages
- Add `test_ark_coding_plan_endpoint` for Ark detection

## Test Plan

All 22 tests in `test_deepseek_reasoning_content_echo.py` pass. All 7 reasoning-related tests in `test_hermes_state.py` pass.

Refs #15250