### PR TITLE
test(matrix): stub mautrix in encrypted-upload test so it runs without the package

### DIFF
--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1231,28 +1231,30 @@ class TestMatrixUploadAndSend:
     @pytest.mark.asyncio
     async def test_upload_encrypted_room_uses_file_payload(self):
         """Encrypted rooms should use 'file' key with crypto metadata."""
-        adapter = _make_adapter()
-        adapter._encryption = True
-        mock_client = MagicMock()
-        mock_client.crypto = object()
-        mock_client.state_store = MagicMock()
-        mock_client.state_store.is_encrypted = AsyncMock(return_value=True)
-        mock_client.upload_media = AsyncMock(return_value="mxc://example.org/enc")
-        mock_client.send_message_event = AsyncMock(return_value="$event")
-        adapter._client = mock_client
+        fake_mautrix_mods = _make_fake_mautrix()
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            adapter = _make_adapter()
+            adapter._encryption = True
+            mock_client = MagicMock()
+            mock_client.crypto = object()
+            mock_client.state_store = MagicMock()
+            mock_client.state_store.is_encrypted = AsyncMock(return_value=True)
+            mock_client.upload_media = AsyncMock(return_value="mxc://example.org/enc")
+            mock_client.send_message_event = AsyncMock(return_value="$event")
+            adapter._client = mock_client
 
-        result = await adapter._upload_and_send(
-            "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
-        )
+            result = await adapter._upload_and_send(
+                "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
+            )
 
-        assert result.success is True
-        # Should have uploaded ciphertext, not plaintext
-        uploaded_data = mock_client.upload_media.await_args.args[0]
-        assert uploaded_data != b"secret"
-        sent = mock_client.send_message_event.await_args.args[2]
-        assert "url" not in sent
-        assert "file" in sent
-        assert sent["file"]["url"] == "mxc://example.org/enc"
+            assert result.success is True
+            # Should have uploaded ciphertext, not plaintext
+            uploaded_data = mock_client.upload_media.await_args.args[0]
+            assert uploaded_data != b"secret"
+            sent = mock_client.send_message_event.await_args.args[2]
+            assert "url" not in sent
+            assert "file" in sent
+            assert sent["file"]["url"] == "mxc://example.org/enc"
 
 
 class TestMatrixEncryptedSendFallback:


### PR DESCRIPTION
## Summary
- Fixes a consistently failing CI baseline test: `TestMatrixUploadAndSend::test_upload_encrypted_room_uses_file_payload`
- Adds `patch.dict("sys.modules", _make_fake_mautrix())` wrapper — the same pattern every other mautrix-dependent test in this file already uses

## The bug
`test_upload_encrypted_room_uses_file_payload` exercises the encrypted-room branch of `_upload_and_send()`, which does `from mautrix.crypto.attachments import encrypt_attachment` at call time.  Without mautrix installed (the CI baseline), that import raises `ModuleNotFoundError`.  The adapter catches it and returns `SendResult(success=False)`, so the `assert result.success is True` assertion fails.

## The fix
Wrap the test body in `patch.dict("sys.modules", _make_fake_mautrix())`.  `_make_fake_mautrix()` (already defined at line 14 of this file) provides a deterministic `encrypt_attachment` stub that returns `b"ciphertext_" + data`, so the test now covers the full upload → encrypt → send path end-to-end without requiring the real mautrix package.

## Test plan
- [x] **Before**: `test_upload_encrypted_room_uses_file_payload` → `assert False is True` (ModuleNotFoundError on mautrix import)
- [x] **After**: 2/2 `TestMatrixUploadAndSend` tests pass; 114/114 `tests/gateway/test_matrix.py` pass
- [x] **Regression guard**: reverted `patch.dict` wrapper → observed `assert False is True`; restored → 0 failures
- [x] Adjacent suites unchanged (dingtalk baseline still 7 failures, same root cause as before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)