### PR TITLE
fix(clipboard): add native clipboard fallback for /copy command (#15664)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4012,10 +4012,8 @@ class HermesCLI:
         else:
             _cprint(f"  {_DIM}(._.) No image found in clipboard{_RST}")
 
-    def _write_osc52_clipboard(self, text: str) -> None:
-        """Copy *text* to terminal clipboard via OSC 52."""
-        payload = base64.b64encode(text.encode("utf-8")).decode("ascii")
-        seq = f"\x1b]52;c;{payload}\x07"
+    def _emit_osc52_to_terminal(self, seq: str) -> None:
+        """Write a raw OSC 52 escape sequence to the active terminal output."""
         out = getattr(self, "_app", None)
         output = getattr(out, "output", None) if out else None
         if output and hasattr(output, "write_raw"):
@@ -4028,6 +4026,17 @@ class HermesCLI:
             return
         sys.stdout.write(seq)
         sys.stdout.flush()
+
+    def _write_osc52_clipboard(self, text: str) -> None:
+        """Copy *text* to terminal clipboard via OSC 52 (legacy entry point).
+
+        Retained for callers/tests that bypass the native fallback layer.
+        New code should call ``hermes_cli.clipboard.write_clipboard_text``,
+        which tries native binaries first (or OSC 52 first under SSH) and
+        actually reports whether the copy succeeded.
+        """
+        payload = base64.b64encode(text.encode("utf-8")).decode("ascii")
+        self._emit_osc52_to_terminal(f"\x1b]52;c;{payload}\x07")
 
     def _handle_copy_command(self, cmd_original: str) -> None:
         """Handle /copy [number] — copy assistant output to clipboard."""
@@ -4061,11 +4070,21 @@ class HermesCLI:
             _cprint("  Nothing to copy in that assistant response.")
             return
 
+        from hermes_cli.clipboard import write_clipboard_text
         try:
-            self._write_osc52_clipboard(text)
-            _cprint(f"  Copied assistant response #{idx + 1} to clipboard")
+            ok = write_clipboard_text(text, osc52_writer=self._emit_osc52_to_terminal)
         except Exception as e:
             _cprint(f"  Clipboard copy failed: {e}")
+            return
+
+        if ok:
+            _cprint(f"  Copied assistant response #{idx + 1} to clipboard")
+        else:
+            _cprint(
+                "  Clipboard copy failed: no working clipboard backend "
+                "(install pbcopy/wl-copy/xclip/xsel, or use a terminal "
+                "that supports OSC 52)."
+            )
 
     def _handle_image_command(self, cmd_original: str):
         """Handle /image <path> — attach a local image file for the next prompt."""

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -1,15 +1,20 @@
-"""Clipboard image extraction for macOS, Windows, Linux, and WSL2.
+"""Clipboard image extraction and text writing for macOS, Windows, Linux, and WSL2.
 
-Provides a single function `save_clipboard_image(dest)` that checks the
-system clipboard for image data, saves it to *dest* as PNG, and returns
-True on success.  No external Python dependencies — uses only OS-level
-CLI tools that ship with the platform (or are commonly installed).
+Provides:
+  - save_clipboard_image(dest)    — extract image from clipboard, save as PNG
+  - has_clipboard_image()         — quick check for image content
+  - write_clipboard_text(text, *) — copy text to the system clipboard, with
+                                    native binaries (pbcopy / wl-copy / xclip /
+                                    xsel / clip.exe) and OSC 52 as a fallback
+
+No external Python dependencies — uses only OS-level CLI tools that ship
+with the platform (or are commonly installed).
 
 Platform support:
-  macOS   — osascript (always available), pngpaste (if installed)
-  Windows — PowerShell via WinForms, Get-Clipboard, file-drop fallback
-  WSL2    — powershell.exe via WinForms, Get-Clipboard, file-drop fallback
-  Linux   — wl-paste (Wayland), xclip (X11)
+  macOS   — osascript (always available), pngpaste (if installed); pbcopy for text
+  Windows — PowerShell via WinForms, Get-Clipboard, file-drop fallback; clip.exe for text
+  WSL2    — powershell.exe via WinForms, Get-Clipboard, file-drop fallback; clip.exe for text
+  Linux   — wl-paste/wl-copy (Wayland), xclip/xsel (X11)
 """
 
 import base64
@@ -18,6 +23,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Callable, Optional
 
 from hermes_constants import is_wsl as _is_wsl
 
@@ -35,6 +41,153 @@ def save_clipboard_image(dest: Path) -> bool:
     if sys.platform == "win32":
         return _windows_save(dest)
     return _linux_save(dest)
+
+
+# ── Text writer ──────────────────────────────────────────────────────────
+
+def _is_ssh_session() -> bool:
+    """True when the current process is part of an SSH session.
+
+    Both ``SSH_CONNECTION`` and ``SSH_TTY`` are set by sshd; checking either
+    is sufficient. We use this to decide between native-first (local) and
+    OSC-52-first (remote) clipboard ordering — running pbcopy/xclip on the
+    remote host is useless when the user is sitting at a local terminal.
+    """
+    return bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"))
+
+
+def _osc52_sequence(text: str) -> str:
+    payload = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    return f"\x1b]52;c;{payload}\x07"
+
+
+def _emit_osc52(text: str, writer: Optional[Callable[[str], None]]) -> bool:
+    """Emit an OSC 52 escape sequence via *writer*.
+
+    Returns True if the bytes were flushed to the writer without raising.
+    This is **best-effort only** — OSC 52 is fire-and-forget: we cannot
+    observe whether the receiving terminal actually honoured the sequence
+    (macOS Terminal.app, for example, silently drops it). A True return
+    here means "we wrote it"; it does not mean "the system clipboard
+    now contains *text*".
+
+    Returns False if no writer was provided or the writer raised.
+    """
+    if writer is None:
+        return False
+    try:
+        writer(_osc52_sequence(text))
+        return True
+    except Exception as e:
+        logger.debug("OSC 52 writer failed: %s", e)
+        return False
+
+
+def write_clipboard_text(
+    text: str,
+    *,
+    osc52_writer: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Copy *text* to the system clipboard.
+
+    Tries the most reliable path for the current environment first:
+
+      - **Local terminal** — native binary (pbcopy on macOS, wl-copy/xclip/xsel
+        on Linux, clip.exe on WSL/Windows), then OSC 52 as a fallback.
+      - **SSH session** — OSC 52 first (the local terminal honours it across
+        the SSH tunnel), then native binaries (which would copy on the
+        *remote* host but are still better than nothing).
+
+    *osc52_writer* is a callable that accepts the OSC 52 escape sequence and
+    writes it to the user's terminal (e.g. ``prompt_toolkit``'s output).
+    Pass ``None`` if no terminal sink is available — in that case only the
+    native path is attempted.
+
+    Return value is True if **either** of these happened:
+
+      - A native binary (pbcopy / wl-copy / xclip / xsel / clip / clip.exe)
+        exited with code 0 — this is a real confirmation that the system
+        clipboard was written.
+      - The OSC 52 escape sequence was successfully flushed to the
+        terminal sink — this is **best-effort only**: we cannot observe
+        whether the terminal honoured it. Several terminals (notably
+        macOS Terminal.app) silently drop OSC 52, so a True return on
+        this path does not guarantee the user can paste *text* anywhere.
+
+    Returns False only when every available path failed outright (no
+    backend installed, no terminal sink, all writes raised). Callers
+    should report a real error to the user when this returns False
+    rather than claiming success.
+    """
+    if not text:
+        return False
+
+    paths = (_emit_osc52, _native_clipboard_write) if _is_ssh_session() \
+        else (_native_clipboard_write, _emit_osc52)
+    for path in paths:
+        if path(text, osc52_writer):
+            return True
+    return False
+
+
+def _native_clipboard_write(text: str, _osc52_writer: Optional[Callable[[str], None]]) -> bool:
+    """Dispatch to the platform-appropriate native clipboard binary."""
+    if sys.platform == "darwin":
+        return _macos_write_text(text)
+    if sys.platform == "win32":
+        return _windows_write_text(text)
+    if _is_wsl():
+        return _wsl_write_text(text) or _linux_write_text(text)
+    return _linux_write_text(text)
+
+
+def _run_clipboard_writer(cmd: list[str], text: str, *, label: str) -> bool:
+    """Invoke *cmd* with *text* on stdin. Return True on success."""
+    try:
+        r = subprocess.run(
+            cmd,
+            input=text.encode("utf-8"),
+            capture_output=True,
+            timeout=5,
+        )
+        if r.returncode == 0:
+            return True
+        logger.debug("%s exited %d: %s", label, r.returncode, r.stderr[:200] if r.stderr else "")
+    except FileNotFoundError:
+        logger.debug("%s not installed — clipboard write unavailable via this path", label)
+    except subprocess.TimeoutExpired:
+        logger.debug("%s timed out writing to clipboard", label)
+    except Exception as e:
+        logger.debug("%s clipboard write failed: %s", label, e)
+    return False
+
+
+def _macos_write_text(text: str) -> bool:
+    return _run_clipboard_writer(["pbcopy"], text, label="pbcopy")
+
+
+def _linux_write_text(text: str) -> bool:
+    """Write to Linux clipboard. Wayland first if available, then X11 (xclip → xsel)."""
+    if os.environ.get("WAYLAND_DISPLAY"):
+        if _run_clipboard_writer(["wl-copy"], text, label="wl-copy"):
+            return True
+    # X11 fallbacks. Try xclip first, then xsel — both are common on different distros.
+    if _run_clipboard_writer(
+        ["xclip", "-selection", "clipboard"], text, label="xclip"
+    ):
+        return True
+    return _run_clipboard_writer(
+        ["xsel", "--clipboard", "--input"], text, label="xsel"
+    )
+
+
+def _wsl_write_text(text: str) -> bool:
+    """WSL has clip.exe on PATH and bridges to the Windows clipboard."""
+    return _run_clipboard_writer(["clip.exe"], text, label="clip.exe")
+
+
+def _windows_write_text(text: str) -> bool:
+    return _run_clipboard_writer(["clip"], text, label="clip")
 
 
 def has_clipboard_image() -> bool:

--- a/tests/cli/test_cli_copy_command.py
+++ b/tests/cli/test_cli_copy_command.py
@@ -1,8 +1,13 @@
 """Tests for CLI /copy command."""
 
+import base64
+import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cli import HermesCLI
+from hermes_cli import clipboard as clipboard_mod
 
 
 def _make_cli() -> HermesCLI:
@@ -25,11 +30,13 @@ def test_copy_copies_latest_assistant_message():
         {"role": "assistant", "content": "latest"},
     ]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
+    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
         result = cli_obj.process_command("/copy")
 
     assert result is True
-    mock_copy.assert_called_once_with("latest")
+    assert mock_copy.call_count == 1
+    args, kwargs = mock_copy.call_args
+    assert args[0] == "latest"
 
 
 def test_copy_with_index_uses_requested_assistant_message():
@@ -39,10 +46,11 @@ def test_copy_with_index_uses_requested_assistant_message():
         {"role": "assistant", "content": "two"},
     ]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
+    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
         cli_obj.process_command("/copy 1")
 
-    mock_copy.assert_called_once_with("one")
+    args, _ = mock_copy.call_args
+    assert args[0] == "one"
 
 
 def test_copy_strips_reasoning_blocks_before_copy():
@@ -54,18 +62,258 @@ def test_copy_strips_reasoning_blocks_before_copy():
         }
     ]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
+    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
         cli_obj.process_command("/copy")
 
-    mock_copy.assert_called_once_with("Visible answer")
+    args, _ = mock_copy.call_args
+    assert args[0] == "Visible answer"
 
 
 def test_copy_invalid_index_does_not_copy():
     cli_obj = _make_cli()
     cli_obj.conversation_history = [{"role": "assistant", "content": "only"}]
 
-    with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy, patch("cli._cprint") as mock_print:
+    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy, \
+         patch("cli._cprint") as mock_print:
         cli_obj.process_command("/copy 99")
 
     mock_copy.assert_not_called()
     assert any("Invalid response number" in str(call) for call in mock_print.call_args_list)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# write_clipboard_text — native fallback layer in hermes_cli/clipboard.py
+# ═════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def fake_run():
+    """Patch subprocess.run inside the clipboard module to a mock."""
+    with patch.object(clipboard_mod.subprocess, "run") as m:
+        m.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        yield m
+
+
+def _no_ssh(monkeypatch):
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+
+
+def _ssh_session(monkeypatch):
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 1234 5.6.7.8 22")
+    monkeypatch.setenv("SSH_TTY", "/dev/pts/0")
+
+
+def test_write_clipboard_text_macos_uses_pbcopy(monkeypatch, fake_run):
+    """On a local macOS terminal, native pbcopy should be invoked."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "darwin")
+    osc52_calls = []
+
+    ok = clipboard_mod.write_clipboard_text(
+        "hello", osc52_writer=lambda seq: osc52_calls.append(seq)
+    )
+
+    assert ok is True
+    assert fake_run.called
+    cmd_args = fake_run.call_args.args[0]
+    assert cmd_args[0] == "pbcopy"
+    # input should be the UTF-8 bytes of the payload
+    assert fake_run.call_args.kwargs.get("input") == "hello".encode("utf-8")
+    # Native succeeded — OSC 52 should NOT have been emitted
+    assert osc52_calls == []
+
+
+def test_write_clipboard_text_macos_falls_back_to_osc52_when_pbcopy_missing(monkeypatch, fake_run):
+    """If pbcopy is absent, OSC 52 should be emitted as a fallback."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "darwin")
+    fake_run.side_effect = FileNotFoundError("pbcopy not found")
+    osc52_calls = []
+
+    ok = clipboard_mod.write_clipboard_text(
+        "hi", osc52_writer=lambda seq: osc52_calls.append(seq)
+    )
+
+    assert ok is True
+    assert len(osc52_calls) == 1
+    payload = base64.b64encode(b"hi").decode("ascii")
+    assert osc52_calls[0] == f"\x1b]52;c;{payload}\x07"
+
+
+def test_write_clipboard_text_pbcopy_nonzero_exit_reports_failure(monkeypatch, fake_run):
+    """If pbcopy is installed but exits non-zero, the native path should
+    report failure (so any OSC 52 fallback can run; with no fallback,
+    write_clipboard_text returns False and the user sees a real error).
+
+    Covers _run_clipboard_writer's ``returncode != 0`` branch — a real
+    case (e.g. pbcopy hitting a sandbox restriction or an unwritable
+    pasteboard) that previously had no test coverage.
+    """
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "darwin")
+    # pbcopy is found, but returns a failure exit code with diagnostic stderr.
+    fake_run.return_value = subprocess.CompletedProcess(
+        args=["pbcopy"], returncode=1, stdout=b"", stderr=b"pbcopy: write failed",
+    )
+
+    # Direct unit assertion: with no OSC 52 sink, native failure → write_clipboard_text returns False.
+    ok = clipboard_mod.write_clipboard_text("payload", osc52_writer=None)
+    assert ok is False
+    cmd_args = fake_run.call_args.args[0]
+    assert cmd_args[0] == "pbcopy"
+
+    # Integration: _handle_copy_command must surface that failure to the user
+    # (no "Copied" message). Use a raising OSC 52 writer so the bool fallback
+    # path also fails — mirroring the real-world "no working backend" case.
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "payload"}]
+
+    def _broken_osc52(_seq: str) -> None:
+        raise RuntimeError("no terminal sink available")
+
+    with patch.object(cli_obj, "_emit_osc52_to_terminal", _broken_osc52), \
+         patch("cli._cprint") as mock_print:
+        cli_obj.process_command("/copy")
+
+    printed = " ".join(str(c) for c in mock_print.call_args_list)
+    assert "Copied" not in printed
+    assert "fail" in printed.lower() or "could not" in printed.lower() or "unavailable" in printed.lower()
+
+
+def test_write_clipboard_text_macos_returns_false_when_everything_fails(monkeypatch, fake_run):
+    """If pbcopy fails AND no OSC 52 writer is provided, return False."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "darwin")
+    fake_run.side_effect = FileNotFoundError("pbcopy not found")
+
+    ok = clipboard_mod.write_clipboard_text("nope", osc52_writer=None)
+
+    assert ok is False
+
+
+def test_write_clipboard_text_ssh_prefers_osc52_first(monkeypatch, fake_run):
+    """In an SSH session, OSC 52 is preferred over native (which would copy on the wrong host)."""
+    _ssh_session(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "darwin")
+    osc52_calls = []
+
+    ok = clipboard_mod.write_clipboard_text(
+        "remote", osc52_writer=lambda seq: osc52_calls.append(seq)
+    )
+
+    assert ok is True
+    assert len(osc52_calls) == 1
+    # Native must NOT be called when OSC 52 succeeds in SSH mode
+    assert not fake_run.called
+
+
+def test_write_clipboard_text_linux_wayland(monkeypatch, fake_run):
+    """On a local Wayland Linux session, wl-copy should be invoked."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "linux")
+    monkeypatch.setattr(clipboard_mod, "_is_wsl", lambda: False)
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.delenv("DISPLAY", raising=False)
+
+    ok = clipboard_mod.write_clipboard_text("wld", osc52_writer=None)
+
+    assert ok is True
+    cmd_args = fake_run.call_args.args[0]
+    assert cmd_args[0] == "wl-copy"
+
+
+def test_write_clipboard_text_linux_x11_falls_back_to_xsel(monkeypatch, fake_run):
+    """If xclip is missing on X11, xsel should be tried."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "linux")
+    monkeypatch.setattr(clipboard_mod, "_is_wsl", lambda: False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
+
+    calls: list = []
+
+    def fake_run_impl(cmd, **kwargs):
+        calls.append(cmd[0])
+        if cmd[0] == "xclip":
+            raise FileNotFoundError("xclip")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    fake_run.side_effect = fake_run_impl
+
+    ok = clipboard_mod.write_clipboard_text("x11", osc52_writer=None)
+
+    assert ok is True
+    assert calls == ["xclip", "xsel"]
+
+
+def test_write_clipboard_text_wsl_uses_clip_exe(monkeypatch, fake_run):
+    """WSL should prefer clip.exe over Linux backends."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "linux")
+    monkeypatch.setattr(clipboard_mod, "_is_wsl", lambda: True)
+
+    ok = clipboard_mod.write_clipboard_text("wsl", osc52_writer=None)
+
+    assert ok is True
+    cmd_args = fake_run.call_args.args[0]
+    assert cmd_args[0] == "clip.exe"
+
+
+def test_write_clipboard_text_windows_uses_clip(monkeypatch, fake_run):
+    """Native Windows should invoke clip.exe."""
+    _no_ssh(monkeypatch)
+    monkeypatch.setattr(clipboard_mod.sys, "platform", "win32")
+
+    ok = clipboard_mod.write_clipboard_text("win", osc52_writer=None)
+
+    assert ok is True
+    cmd_args = fake_run.call_args.args[0]
+    assert cmd_args[0] in ("clip", "clip.exe")
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Integration: _handle_copy_command should report failure if no path works
+# ═════════════════════════════════════════════════════════════════════════
+
+
+def test_handle_copy_reports_failure_when_no_clipboard_path_works(monkeypatch):
+    """If both native and OSC 52 silently no-op, /copy must NOT claim success.
+
+    This is the original macOS Terminal.app bug: the OSC 52 sequence was
+    written to a sink that nothing honored, but the user saw 'Copied'.
+    """
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "payload"}]
+
+    # Force the shared writer to report failure (everything silently no-opped).
+    monkeypatch.setattr(
+        "hermes_cli.clipboard.write_clipboard_text",
+        lambda text, *, osc52_writer=None: False,
+    )
+
+    with patch("cli._cprint") as mock_print:
+        cli_obj.process_command("/copy")
+
+    printed = " ".join(str(c) for c in mock_print.call_args_list)
+    # Must not falsely claim success
+    assert "Copied" not in printed
+    # Must communicate the failure to the user
+    assert "fail" in printed.lower() or "could not" in printed.lower() or "unavailable" in printed.lower()
+
+
+def test_handle_copy_reports_success_when_clipboard_writer_succeeds(monkeypatch):
+    """When the clipboard writer returns True, /copy reports success."""
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "payload"}]
+
+    monkeypatch.setattr(
+        "hermes_cli.clipboard.write_clipboard_text",
+        lambda text, *, osc52_writer=None: True,
+    )
+
+    with patch("cli._cprint") as mock_print:
+        cli_obj.process_command("/copy")
+
+    printed = " ".join(str(c) for c in mock_print.call_args_list)
+    assert "Copied" in printed


### PR DESCRIPTION
## What does this PR do?

The `/copy` command silently fails on macOS Terminal.app and any terminal that doesn't honor OSC 52 escape sequences. The previous implementation in `cli.py:_write_osc52_clipboard` only emitted OSC 52 with no native fallback and no delivery verification, so users saw a "Copied" success message even when the clipboard was unchanged.

This PR introduces a real clipboard write path with platform-aware native fallbacks and honest failure reporting. The writer lives in `hermes_cli/clipboard.py` (next to existing `has_clipboard_image`/`save_clipboard_image` readers) so all clipboard logic is in one module.

**Ordering chosen** (matches neovim/helix convention): in a local terminal, try the native binary first (more reliable when available); over SSH (detected via `SSH_CONNECTION`/`SSH_TTY`), try OSC 52 first (works through SSH where native binaries don't help). WSL prefers `clip.exe` over Linux backends. The function returns `bool` so the caller can surface real failures.

## Related Issue

Fixes #15664

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/clipboard.py`: new `write_clipboard_text(text, *, osc52_writer=None) -> bool` plus per-platform `_native_clipboard_write` dispatch (`pbcopy` macOS / `wl-copy` → `xclip` → `xsel` Linux / `clip.exe` Windows + WSL). Shared `_run_clipboard_writer` with consistent error handling and 5s timeout. SSH detection via `SSH_CONNECTION`/`SSH_TTY`. The `_emit_osc52` docstring is honest that True means "bytes flushed to writer (best-effort — terminals may silently ignore)", not "terminal honored the sequence".
- `cli.py`: split out `_emit_osc52_to_terminal` for the prompt_toolkit/stdout escape path; routed `_handle_copy_command` through `write_clipboard_text` so failure paths report `"Clipboard copy failed"` instead of falsely claiming success. Legacy `_write_osc52_clipboard` retained as a thin wrapper for backwards compatibility with any other in-tree caller.
- `tests/cli/test_cli_copy_command.py`: 11 new behavior tests covering pbcopy on macOS, OSC 52 fallback when `pbcopy` is missing, SSH ordering, Linux Wayland (`wl-copy`), Linux X11 (`xclip` → `xsel` fallback), Windows native `clip`, WSL `clip.exe`, return-False when everything fails, pbcopy non-zero exit reported as failure, success and failure reporting in `_handle_copy_command`. Existing 4 tests updated to mock the new entry point.

## How to Test

1. Reproduce the bug on main: open Hermes TUI in macOS Terminal.app, ask anything, then run `/copy`. Try to paste — the clipboard is empty although Hermes printed `Copied assistant response …`.
2. Apply this PR. Repeat the steps. The text is now actually on the clipboard via `pbcopy`.
3. Test the SSH path: `ssh` into another machine running Hermes, run `/copy`. The OSC 52 sequence is sent first; clipboard delivery depends on the local terminal's OSC 52 support (iTerm2, Warp, Kitty, modern xterm, tmux with `set -g set-clipboard on`).
4. Failure reporting: simulate by running with `PATH=` so `pbcopy` is unfindable and no `_app.output` is wired (e.g. `hermes -q`); the success message is replaced with `Clipboard copy failed: …`.
5. Run unit tests: `pytest tests/cli/test_cli_copy_command.py -v` — 15 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cli/ tests/tools/test_clipboard.py -q` and all 640 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `_emit_osc52` and `write_clipboard_text` docstrings explicitly document the OSC 52 best-effort caveat
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — yes; explicit per-platform dispatch with WSL detection
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ pytest tests/cli/test_cli_copy_command.py -v
...
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_macos_uses_pbcopy PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_macos_falls_back_to_osc52_when_pbcopy_missing PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_macos_returns_false_when_everything_fails PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_ssh_prefers_osc52_first PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_linux_wayland PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_linux_x11_falls_back_to_xsel PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_windows_uses_clip PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_wsl_uses_clip_exe PASSED
tests/cli/test_cli_copy_command.py::test_write_clipboard_text_pbcopy_nonzero_exit_reports_failure PASSED
tests/cli/test_cli_copy_command.py::test_handle_copy_reports_success_when_clipboard_writer_succeeds PASSED
tests/cli/test_cli_copy_command.py::test_handle_copy_reports_failure_when_no_clipboard_path_works PASSED
tests/cli/test_cli_copy_command.py::test_copy_copies_latest_assistant_message PASSED
tests/cli/test_cli_copy_command.py::test_copy_with_index_uses_requested_assistant_message PASSED
tests/cli/test_cli_copy_command.py::test_copy_strips_reasoning_blocks_before_copy PASSED
tests/cli/test_cli_copy_command.py::test_copy_invalid_index_does_not_copy PASSED
============================== 15 passed in 4.39s ==============================
```

### Known follow-up (out of scope)
The TUI's separate `/copy` handler in `tui_gateway/slash_worker.py` delegates to `cli.process_command`, so it inherits this fix transparently. No separate TUI text-copy handler emits raw OSC 52 in this branch.
