### PR TITLE
fix(web): make Config page deep-linkable to a specific category (#15677)

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3625,6 +3625,15 @@ class TestWebServerEndpoints:
 
 
 class TestBuildSchemaFromConfig:
+    def test_compression_section_reachable_in_config_ui(self):
+        """Regression for #15677: links can target the compression settings category."""
+        from hermes_cli.web_server import CONFIG_SCHEMA, _CATEGORY_ORDER
+
+        assert "compression" in _CATEGORY_ORDER
+        for key in ("compression.enabled", "compression.threshold"):
+            assert key in CONFIG_SCHEMA
+            assert CONFIG_SCHEMA[key]["category"] == "compression"
+
     def test_produces_expected_field_count(self):
         from hermes_cli.web_server import CONFIG_SCHEMA
         # DEFAULT_CONFIG has ~150+ leaf fields

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -406,6 +406,32 @@ class TestBuildSchemaFromConfig:
         for cat, count in cats.items():
             assert count >= 2, f"Category '{cat}' has only {count} field(s) — should be merged"
 
+    def test_compression_section_reachable_in_config_ui(self):
+        """Regression for #15677 — context-pressure warnings link users to the
+        Compression section of the Config page (e.g. /config?category=compression).
+        The schema and category-order contract must keep that section populated:
+
+          1. `compression` appears in `_CATEGORY_ORDER` (sidebar nav slot).
+          2. `compression.enabled` and `compression.threshold` are in CONFIG_SCHEMA
+             with `category == "compression"` so the deep link lands on a real,
+             editable section — not a phantom tab.
+
+        If any of these break, surfaces that point users at "Config →
+        Compression" (modals, docs, /compact warnings) become misleading.
+        """
+        from hermes_cli.web_server import CONFIG_SCHEMA, _CATEGORY_ORDER
+
+        assert "compression" in _CATEGORY_ORDER, (
+            "compression must be in _CATEGORY_ORDER so the Config sidebar "
+            "renders the section as a navigable tab"
+        )
+        for key in ("compression.enabled", "compression.threshold"):
+            assert key in CONFIG_SCHEMA, f"{key} missing from auto-derived schema"
+            assert CONFIG_SCHEMA[key]["category"] == "compression", (
+                f"{key} must resolve to category 'compression' so it renders "
+                "under the Compression tab the warning links to"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Config round-trip tests

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from "react-router-dom";
 import { useEffect, useLayoutEffect, useRef, useState, useMemo } from "react";
 import {
   Code,
@@ -113,6 +114,8 @@ export default function ConfigPage() {
   );
   const [saving, setSaving] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedCategory = searchParams.get("category") ?? "";
   const [yamlMode, setYamlMode] = useState(false);
   const [yamlText, setYamlText] = useState("");
   const [yamlLoading, setYamlLoading] = useState(false);
@@ -193,13 +196,6 @@ export default function ConfigPage() {
       .catch(() => {});
   }, []);
 
-  // Set active category when categories load
-  useEffect(() => {
-    if (categoryOrder.length > 0 && !activeCategory) {
-      setActiveCategory(categoryOrder[0]);
-    }
-  }, [categoryOrder, activeCategory]);
-
   // Load YAML when switching to YAML mode
   useEffect(() => {
     if (yamlMode) {
@@ -224,6 +220,25 @@ export default function ConfigPage() {
     const extra = allCats.filter((c) => !categoryOrder.includes(c)).sort();
     return [...ordered, ...extra];
   }, [schema, categoryOrder]);
+
+  // Set active category when categories load or when a ?category= deep link is present.
+  useEffect(() => {
+    if (categories.length === 0) return;
+    if (requestedCategory && categories.includes(requestedCategory)) {
+      setActiveCategory(requestedCategory);
+      setSearchQuery("");
+      return;
+    }
+    if (!activeCategory) {
+      setActiveCategory(categories[0]);
+    }
+  }, [categories, requestedCategory, activeCategory]);
+
+  const selectCategory = (category: string) => {
+    setSearchQuery("");
+    setActiveCategory(category);
+    setSearchParams({ category }, { replace: true });
+  };
 
   /* ---- Category field counts ---- */
   const categoryCounts = useMemo(() => {
@@ -561,10 +576,7 @@ export default function ConfigPage() {
                       <ListItem
                         key={cat}
                         active={isActive}
-                        onClick={() => {
-                          setSearchQuery("");
-                          setActiveCategory(cat);
-                        }}
+                        onClick={() => selectCategory(cat)}
                         className="rounded-none whitespace-nowrap px-2 py-1 text-xs"
                       >
                         <CategoryIcon

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   Code,
   Download,
@@ -88,6 +89,25 @@ export default function ConfigPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Deep-link target — e.g. /config?category=compression.
+  // requestedCategory is live (re-reads searchParams each render). The effect
+  // below reacts to changes so that intra-page navigation (back/forward,
+  // address-bar edits, modal links fired while Config is already mounted)
+  // updates the visible tab — not just first-mount.
+  const requestedCategory = searchParams.get("category") ?? "";
+
+  // Centralized handler keeps the URL and active tab in sync. `replace: true`
+  // means the back-button doesn't accumulate a step per category click.
+  const selectCategory = (cat: string) => {
+    setSearchQuery("");
+    setActiveCategory(cat);
+    if (searchParams.get("category") !== cat) {
+      const next = new URLSearchParams(searchParams);
+      next.set("category", cat);
+      setSearchParams(next, { replace: true });
+    }
+  };
 
   useLayoutEffect(() => {
     if (!config || !schema) {
@@ -135,12 +155,40 @@ export default function ConfigPage() {
     api.getDefaults().then(setDefaults).catch(() => {});
   }, []);
 
-  // Set active category when categories load
+  // Resolved categories = ordered list ∪ extras present only in the schema
+  // (e.g. plugin-added). Used both for nav rendering and deep-link validation
+  // so a /config?category=<plugin> URL also works.
+  const categories = useMemo(() => {
+    if (!schema) return [];
+    const allCats = [...new Set(Object.values(schema).map((s) => String(s.category ?? "general")))];
+    const ordered = categoryOrder.filter((c) => allCats.includes(c));
+    const extra = allCats.filter((c) => !categoryOrder.includes(c)).sort();
+    return [...ordered, ...extra];
+  }, [schema, categoryOrder]);
+
+  // Sync the active category with the URL on mount AND on subsequent
+  // ?category=… changes (deep-link from a warning modal, browser back/
+  // forward, address-bar paste). If the requested category is valid and
+  // differs from the current tab, switch to it. Otherwise — only when no
+  // tab has been picked yet — fall back to the first configured category.
+  //
+  // Loop safety: after setActiveCategory(requestedCategory) the effect
+  // re-runs (activeCategory is in deps), the equality branch matches, and
+  // we no-op. We deliberately do NOT call selectCategory() here because
+  // that would write back to the URL and could fight with the browser's
+  // own history machinery during back/forward navigation — the URL is
+  // already correct in this code path; we're only catching the visible
+  // tab up to it.
   useEffect(() => {
-    if (categoryOrder.length > 0 && !activeCategory) {
-      setActiveCategory(categoryOrder[0]);
+    if (categories.length === 0) return;
+    if (requestedCategory && categories.includes(requestedCategory)) {
+      if (activeCategory !== requestedCategory) {
+        setActiveCategory(requestedCategory);
+      }
+    } else if (!activeCategory) {
+      setActiveCategory(categories[0]);
     }
-  }, [categoryOrder, activeCategory]);
+  }, [categories, activeCategory, requestedCategory]);
 
   // Load YAML when switching to YAML mode
   useEffect(() => {
@@ -153,15 +201,6 @@ export default function ConfigPage() {
         .finally(() => setYamlLoading(false));
     }
   }, [yamlMode]);
-
-  /* ---- Categories ---- */
-  const categories = useMemo(() => {
-    if (!schema) return [];
-    const allCats = [...new Set(Object.values(schema).map((s) => String(s.category ?? "general")))];
-    const ordered = categoryOrder.filter((c) => allCats.includes(c));
-    const extra = allCats.filter((c) => !categoryOrder.includes(c)).sort();
-    return [...ordered, ...extra];
-  }, [schema, categoryOrder]);
 
   /* ---- Category field counts ---- */
   const categoryCounts = useMemo(() => {
@@ -425,10 +464,7 @@ export default function ConfigPage() {
                       <button
                         key={cat}
                         type="button"
-                        onClick={() => {
-                          setSearchQuery("");
-                          setActiveCategory(cat);
-                        }}
+                        onClick={() => selectCategory(cat)}
                         className={`
                           group flex items-center gap-2 px-2 py-1
                           rounded-sm text-left text-[11px] cursor-pointer whitespace-nowrap


### PR DESCRIPTION
## What does this PR do?

The web Config page schema can expose category links, but the UI did not honor category deep links. This PR wires the Config page to URL search params so a requested category is selected on load and category navigation updates the URL.

## Related Issue

Fixes #15677

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Use search params in `web/src/pages/ConfigPage.tsx` to read requested config categories.
- Update category selection to keep the URL in sync.
- Add a web-server schema regression test covering config compression/category link metadata.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_web_server.py -q`
3. Expected result: 151 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_web_server.py -q` — 151 passed
```
