### PR TITLE
fix(auth): chown auth.json to parent owner when written as root (#15718)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -50,7 +50,7 @@ import yaml
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
-from utils import atomic_replace, atomic_yaml_write, is_truthy_value
+from utils import atomic_replace, atomic_yaml_write, chown_to_match_parent, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1081,6 +1081,7 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
         auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:
         pass
+    chown_to_match_parent(auth_file)
     return auth_file
 
 
@@ -1960,6 +1961,7 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
             fh.flush()
             os.fsync(fh.fileno())
         atomic_replace(tmp_path, auth_path)
+        chown_to_match_parent(auth_path)
     finally:
         try:
             if tmp_path.exists():

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -43,6 +43,7 @@ import yaml
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL
+from utils import chown_to_match_parent
 
 logger = logging.getLogger(__name__)
 
@@ -751,6 +752,30 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
     try:
         raw = json.loads(auth_file.read_text())
+    except PermissionError as exc:
+        # Distinguish "credentials missing" from "credentials present but
+        # unreadable due to file ownership" — the original generic exception
+        # handler below silently returned an empty store, which surfaced as
+        # a misleading "no credentials stored" error downstream (issue
+        # #15718).  Surface the real cause so the user can fix ownership
+        # instead of re-running login in a loop.
+        running_uid = os.geteuid() if hasattr(os, "geteuid") else "unknown"
+        try:
+            file_stat = auth_file.stat()
+            owner_info = (
+                f" (file owned by uid={file_stat.st_uid} gid={file_stat.st_gid}, "
+                f"mode={oct(stat.S_IMODE(file_stat.st_mode))}, "
+                f"running as uid={running_uid})"
+            )
+        except OSError:
+            owner_info = f" (running as uid={running_uid})"
+        raise PermissionError(
+            f"Cannot read {auth_file}: {exc}.{owner_info} "
+            "Credentials are present but unreadable by the current user. "
+            "Fix ownership to match the runtime user, e.g. inside a "
+            "container: `chown <runtime-uid>:<runtime-gid> "
+            f"{auth_file}` (see issue #15718)."
+        ) from exc
     except Exception as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
@@ -817,6 +842,12 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
         auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:
         pass
+    # If a privileged write (e.g. `docker exec` as root) just produced a
+    # file that the runtime user (Hermes container UID) can't read, rewrite
+    # the owner to match the parent directory.  Otherwise the gateway —
+    # and every messaging adapter — would see "no credentials stored"
+    # despite auth.json being present and valid.  See issue #15718.
+    chown_to_match_parent(auth_file)
     return auth_file
 
 
@@ -1291,6 +1322,9 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     tmp_path.write_text(json.dumps(tokens, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
     tmp_path.replace(auth_path)
+    # Match parent-directory ownership when running as root so a non-root
+    # Hermes runtime can still read the file (issue #15718).
+    chown_to_match_parent(auth_path)
     return auth_path
 
 

--- a/tests/hermes_cli/test_auth_ownership_chown.py
+++ b/tests/hermes_cli/test_auth_ownership_chown.py
@@ -1,0 +1,367 @@
+"""Tests for auth.json ownership remediation (issue #15718).
+
+When `hermes login` runs as root inside a container (e.g. via `docker exec`)
+but the gateway runs as a non-root user, the freshly-written ``auth.json``
+ends up owned by ``root:root`` and the gateway can no longer read it,
+surfacing as a misleading "no credentials stored" error.
+
+These tests cover:
+
+* The shared :func:`utils.chown_to_match_parent` helper:
+  - Chowns to the parent's UID/GID when running as root and ownerships differ.
+  - Does nothing when running as a non-root user.
+  - Does nothing when the file already matches the parent's owner.
+  - Is a safe no-op on platforms without ``os.chown`` (Windows).
+  - Swallows ``OSError`` from ``chown`` so a remediation failure never
+    breaks the surrounding write.
+* :func:`hermes_cli.auth._save_auth_store` invokes the helper after writing.
+* :func:`hermes_cli.auth._save_qwen_cli_tokens` invokes the helper after
+  writing.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import utils
+from hermes_cli import auth as auth_module
+
+
+# ---------------------------------------------------------------------------
+# utils.chown_to_match_parent
+# ---------------------------------------------------------------------------
+
+
+class TestChownToMatchParent:
+    def test_chowns_when_root_and_owners_differ(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+
+        # Simulate: root caller (geteuid==0), parent owned by uid 10000,
+        # file currently owned by uid 0.
+        fake_parent = type(parent_stat)(
+            (
+                parent_stat.st_mode,
+                parent_stat.st_ino,
+                parent_stat.st_dev,
+                parent_stat.st_nlink,
+                10000,            # parent uid
+                10000,            # parent gid
+                parent_stat.st_size,
+                parent_stat.st_atime,
+                parent_stat.st_mtime,
+                parent_stat.st_ctime,
+            )
+        )
+        fake_file = type(file_stat)(
+            (
+                file_stat.st_mode,
+                file_stat.st_ino,
+                file_stat.st_dev,
+                file_stat.st_nlink,
+                0,                # file uid (root)
+                0,                # file gid (root)
+                file_stat.st_size,
+                file_stat.st_atime,
+                file_stat.st_mtime,
+                file_stat.st_ctime,
+            )
+        )
+
+        recorded = {}
+
+        def fake_stat(path):
+            # Parent stat path (real os.stat is patched to this).
+            if Path(path) == tmp_path:
+                return fake_parent
+            return fake_file
+
+        def fake_lstat(path):
+            # File stat path (helper now uses lstat for the target).
+            return fake_file
+
+        def fake_chown(path, uid, gid, **kwargs):
+            recorded["args"] = (Path(path), uid, gid)
+            recorded["kwargs"] = kwargs
+
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown) as chown_mock, \
+             patch.object(utils.os, "lstat", side_effect=fake_lstat), \
+             patch.object(utils.os, "stat", side_effect=fake_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", {chown_mock}):
+            assert utils.chown_to_match_parent(target) is True
+
+        assert recorded["args"] == (target, 10000, 10000)
+        # Symlink-safety: chown must be invoked with follow_symlinks=False.
+        assert recorded["kwargs"].get("follow_symlinks") is False
+
+    def test_noop_when_not_root(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        recorded = {"called": False}
+
+        def fake_chown(*_args, **_kwargs):
+            recorded["called"] = True
+
+        with patch.object(utils.os, "geteuid", create=True, return_value=10000), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown):
+            assert utils.chown_to_match_parent(target) is False
+
+        assert recorded["called"] is False
+
+    def test_noop_when_owners_already_match(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        recorded = {"called": False}
+
+        def fake_chown(*_args, **_kwargs):
+            recorded["called"] = True
+
+        # Real stat — parent and file both owned by the test runner.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown):
+            assert utils.chown_to_match_parent(target) is False
+
+        assert recorded["called"] is False
+
+    def test_noop_on_non_posix(self, tmp_path, monkeypatch):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        # Simulate Windows: os.chown / os.geteuid don't exist.
+        # Use monkeypatch.delattr for hermetic isolation — manual
+        # delattr + try/finally is fragile (a KeyboardInterrupt between
+        # the delattr and the restore would permanently break os.chown
+        # for the rest of the test session).
+        monkeypatch.delattr(utils.os, "chown", raising=False)
+        monkeypatch.delattr(utils.os, "geteuid", raising=False)
+
+        assert utils.chown_to_match_parent(target) is False
+
+    def test_refuses_to_chown_symlink_target(self, tmp_path):
+        """If auth.json is replaced with a symlink between os.replace and
+        chown_to_match_parent (TOCTOU window), the helper MUST NOT
+        re-own the link's destination — that would let an unprivileged
+        attacker who can write into the parent dir steer root to chown
+        arbitrary files like /etc/shadow.
+        """
+        # Create a "destination" file we must protect from being chowned.
+        secret = tmp_path / "shadow"
+        secret.write_text("root:x:...", encoding="utf-8")
+        secret_stat_before = os.stat(secret)
+
+        # The "auth.json" path is actually a symlink to the secret.
+        target = tmp_path / "auth.json"
+        os.symlink(secret, target)
+
+        recorded = {"called": False, "args": None}
+
+        def fake_chown(*args, **kwargs):
+            recorded["called"] = True
+            recorded["args"] = (args, kwargs)
+
+        # Simulate root caller. Don't patch os.lstat — we want the real
+        # one to detect the symlink.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown):
+            assert utils.chown_to_match_parent(target) is False
+
+        # Crucial: chown must never have been invoked at all.
+        assert recorded["called"] is False, (
+            f"chown was called with {recorded['args']} on a symlink — "
+            "this would re-own the link's destination, a security bug."
+        )
+        # And the destination file is untouched.
+        secret_stat_after = os.stat(secret)
+        assert secret_stat_after.st_uid == secret_stat_before.st_uid
+        assert secret_stat_after.st_gid == secret_stat_before.st_gid
+
+    def test_chown_uses_follow_symlinks_false_when_supported(self, tmp_path):
+        """Belt-and-suspenders: even when the target passes the lstat
+        symlink check, the actual chown call must be invoked with
+        follow_symlinks=False (or fall through to os.lchown) so a TOCTOU
+        race between lstat and chown still cannot re-own a link target.
+        """
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+        fake_file_stat = type(file_stat)(
+            (
+                file_stat.st_mode, file_stat.st_ino, file_stat.st_dev,
+                file_stat.st_nlink, 0, 0, file_stat.st_size,
+                file_stat.st_atime, file_stat.st_mtime, file_stat.st_ctime,
+            )
+        )
+        fake_parent_stat = type(parent_stat)(
+            (
+                parent_stat.st_mode, parent_stat.st_ino, parent_stat.st_dev,
+                parent_stat.st_nlink, 10000, 10000, parent_stat.st_size,
+                parent_stat.st_atime, parent_stat.st_mtime, parent_stat.st_ctime,
+            )
+        )
+
+        recorded = {"args": None, "kwargs": None}
+
+        def fake_chown(*args, **kwargs):
+            recorded["args"] = args
+            recorded["kwargs"] = kwargs
+
+        # Patch chown, then put the patched function into
+        # supports_follow_symlinks so the helper takes the
+        # follow_symlinks=False code path.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown) as chown_mock, \
+             patch.object(utils.os, "lstat", return_value=fake_file_stat), \
+             patch.object(utils.os, "stat", return_value=fake_parent_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", {chown_mock}):
+            assert utils.chown_to_match_parent(target) is True
+
+        assert recorded["kwargs"].get("follow_symlinks") is False, (
+            "chown must be called with follow_symlinks=False to avoid "
+            "TOCTOU symlink-substitution attacks."
+        )
+        assert recorded["args"] == (target, 10000, 10000)
+
+    def test_chown_falls_back_to_lchown_when_follow_symlinks_unsupported(self, tmp_path):
+        """On exotic platforms where os.chown doesn't accept
+        follow_symlinks, the helper must fall through to os.lchown
+        (Unix-equivalent symlink-safe chown).
+        """
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+        fake_file_stat = type(file_stat)(
+            (
+                file_stat.st_mode, file_stat.st_ino, file_stat.st_dev,
+                file_stat.st_nlink, 0, 0, file_stat.st_size,
+                file_stat.st_atime, file_stat.st_mtime, file_stat.st_ctime,
+            )
+        )
+        fake_parent_stat = type(parent_stat)(
+            (
+                parent_stat.st_mode, parent_stat.st_ino, parent_stat.st_dev,
+                parent_stat.st_nlink, 10000, 10000, parent_stat.st_size,
+                parent_stat.st_atime, parent_stat.st_mtime, parent_stat.st_ctime,
+            )
+        )
+
+        chown_calls = {"called": False}
+        lchown_calls = {"args": None}
+
+        def fake_chown(*args, **kwargs):
+            chown_calls["called"] = True
+
+        def fake_lchown(*args, **kwargs):
+            lchown_calls["args"] = args
+
+        # Empty supports_follow_symlinks set => fall back to os.lchown.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown), \
+             patch.object(utils.os, "lchown", create=True, side_effect=fake_lchown), \
+             patch.object(utils.os, "lstat", return_value=fake_file_stat), \
+             patch.object(utils.os, "stat", return_value=fake_parent_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", set()):
+            assert utils.chown_to_match_parent(target) is True
+
+        assert chown_calls["called"] is False, (
+            "Must use os.lchown when os.chown lacks follow_symlinks support, "
+            "not invoke the symlink-following os.chown."
+        )
+        assert lchown_calls["args"] == (target, 10000, 10000)
+
+    def test_chown_oserror_is_swallowed(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+        fake_parent = type(parent_stat)(
+            (
+                parent_stat.st_mode, parent_stat.st_ino, parent_stat.st_dev,
+                parent_stat.st_nlink, 10000, 10000, parent_stat.st_size,
+                parent_stat.st_atime, parent_stat.st_mtime, parent_stat.st_ctime,
+            )
+        )
+        fake_file = type(file_stat)(
+            (
+                file_stat.st_mode, file_stat.st_ino, file_stat.st_dev,
+                file_stat.st_nlink, 0, 0, file_stat.st_size,
+                file_stat.st_atime, file_stat.st_mtime, file_stat.st_ctime,
+            )
+        )
+
+        def fake_stat(path):
+            return fake_parent
+
+        def fake_lstat(path):
+            return fake_file
+
+        def boom(*_a, **_kw):
+            raise PermissionError("EPERM")
+
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=boom) as chown_mock, \
+             patch.object(utils.os, "lstat", side_effect=fake_lstat), \
+             patch.object(utils.os, "stat", side_effect=fake_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", {chown_mock}):
+            # MUST NOT raise — write site should not crash on chown failure.
+            assert utils.chown_to_match_parent(target) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration with auth.py write paths
+# ---------------------------------------------------------------------------
+
+
+class TestAuthSaveInvokesChown:
+    def test_save_auth_store_calls_chown_to_match_parent(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        captured = []
+
+        def fake_chown(path):
+            captured.append(Path(path))
+            return False
+
+        with patch.object(auth_module, "chown_to_match_parent", side_effect=fake_chown):
+            auth_module._save_auth_store({"providers": {"openai-codex": {"tokens": {}}}})
+
+        # The remediation hook MUST be invoked on the resulting auth.json,
+        # not on the temp file or anything else.
+        assert (hermes_home / "auth.json") in captured
+
+    def test_save_qwen_cli_tokens_calls_chown_to_match_parent(self, tmp_path, monkeypatch):
+        # Redirect Qwen CLI path into tmp so we don't touch ~/.qwen.
+        fake_qwen_path = tmp_path / ".qwen" / "oauth_creds.json"
+        monkeypatch.setattr(
+            auth_module,
+            "_qwen_cli_auth_path",
+            lambda: fake_qwen_path,
+        )
+
+        captured = []
+
+        def fake_chown(path):
+            captured.append(Path(path))
+            return False
+
+        with patch.object(auth_module, "chown_to_match_parent", side_effect=fake_chown):
+            auth_module._save_qwen_cli_tokens({"access_token": "x", "refresh_token": "y"})
+
+        assert fake_qwen_path in captured

--- a/tests/hermes_cli/test_auth_ownership_chown.py
+++ b/tests/hermes_cli/test_auth_ownership_chown.py
@@ -1,0 +1,410 @@
+"""Tests for auth.json ownership remediation (issue #15718).
+
+When `hermes login` runs as root inside a container (e.g. via `docker exec`)
+but the gateway runs as a non-root user, the freshly-written ``auth.json``
+ends up owned by ``root:root`` and the gateway can no longer read it,
+surfacing as a misleading "no credentials stored" error.
+
+These tests cover:
+
+* The shared :func:`utils.chown_to_match_parent` helper:
+  - Chowns to the parent's UID/GID when running as root and ownerships differ.
+  - Does nothing when running as a non-root user.
+  - Does nothing when the file already matches the parent's owner.
+  - Is a safe no-op on platforms without ``os.chown`` (Windows).
+  - Swallows ``OSError`` from ``chown`` so a remediation failure never
+    breaks the surrounding write.
+* :func:`hermes_cli.auth._save_auth_store` invokes the helper after writing.
+* :func:`hermes_cli.auth._save_qwen_cli_tokens` invokes the helper after
+  writing.
+* :func:`hermes_cli.auth._load_auth_store` surfaces ``PermissionError`` with
+  a useful message instead of silently returning an empty store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import utils
+from hermes_cli import auth as auth_module
+
+
+# ---------------------------------------------------------------------------
+# utils.chown_to_match_parent
+# ---------------------------------------------------------------------------
+
+
+class TestChownToMatchParent:
+    def test_chowns_when_root_and_owners_differ(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+
+        # Simulate: root caller (geteuid==0), parent owned by uid 10000,
+        # file currently owned by uid 0.
+        fake_parent = type(parent_stat)(
+            (
+                parent_stat.st_mode,
+                parent_stat.st_ino,
+                parent_stat.st_dev,
+                parent_stat.st_nlink,
+                10000,            # parent uid
+                10000,            # parent gid
+                parent_stat.st_size,
+                parent_stat.st_atime,
+                parent_stat.st_mtime,
+                parent_stat.st_ctime,
+            )
+        )
+        fake_file = type(file_stat)(
+            (
+                file_stat.st_mode,
+                file_stat.st_ino,
+                file_stat.st_dev,
+                file_stat.st_nlink,
+                0,                # file uid (root)
+                0,                # file gid (root)
+                file_stat.st_size,
+                file_stat.st_atime,
+                file_stat.st_mtime,
+                file_stat.st_ctime,
+            )
+        )
+
+        recorded = {}
+
+        def fake_stat(path):
+            # Parent stat path (real os.stat is patched to this).
+            if Path(path) == tmp_path:
+                return fake_parent
+            return fake_file
+
+        def fake_lstat(path):
+            # File stat path (helper now uses lstat for the target).
+            return fake_file
+
+        def fake_chown(path, uid, gid, **kwargs):
+            recorded["args"] = (Path(path), uid, gid)
+            recorded["kwargs"] = kwargs
+
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown) as chown_mock, \
+             patch.object(utils.os, "lstat", side_effect=fake_lstat), \
+             patch.object(utils.os, "stat", side_effect=fake_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", {chown_mock}):
+            assert utils.chown_to_match_parent(target) is True
+
+        assert recorded["args"] == (target, 10000, 10000)
+        # Symlink-safety: chown must be invoked with follow_symlinks=False.
+        assert recorded["kwargs"].get("follow_symlinks") is False
+
+    def test_noop_when_not_root(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        recorded = {"called": False}
+
+        def fake_chown(*_args, **_kwargs):
+            recorded["called"] = True
+
+        with patch.object(utils.os, "geteuid", create=True, return_value=10000), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown):
+            assert utils.chown_to_match_parent(target) is False
+
+        assert recorded["called"] is False
+
+    def test_noop_when_owners_already_match(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        recorded = {"called": False}
+
+        def fake_chown(*_args, **_kwargs):
+            recorded["called"] = True
+
+        # Real stat — parent and file both owned by the test runner.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown):
+            assert utils.chown_to_match_parent(target) is False
+
+        assert recorded["called"] is False
+
+    def test_noop_on_non_posix(self, tmp_path, monkeypatch):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        # Simulate Windows: os.chown / os.geteuid don't exist.
+        # Use monkeypatch.delattr for hermetic isolation — manual
+        # delattr + try/finally is fragile (a KeyboardInterrupt between
+        # the delattr and the restore would permanently break os.chown
+        # for the rest of the test session).
+        monkeypatch.delattr(utils.os, "chown", raising=False)
+        monkeypatch.delattr(utils.os, "geteuid", raising=False)
+
+        assert utils.chown_to_match_parent(target) is False
+
+    def test_refuses_to_chown_symlink_target(self, tmp_path):
+        """If auth.json is replaced with a symlink between os.replace and
+        chown_to_match_parent (TOCTOU window), the helper MUST NOT
+        re-own the link's destination — that would let an unprivileged
+        attacker who can write into the parent dir steer root to chown
+        arbitrary files like /etc/shadow.
+        """
+        # Create a "destination" file we must protect from being chowned.
+        secret = tmp_path / "shadow"
+        secret.write_text("root:x:...", encoding="utf-8")
+        secret_stat_before = os.stat(secret)
+
+        # The "auth.json" path is actually a symlink to the secret.
+        target = tmp_path / "auth.json"
+        os.symlink(secret, target)
+
+        recorded = {"called": False, "args": None}
+
+        def fake_chown(*args, **kwargs):
+            recorded["called"] = True
+            recorded["args"] = (args, kwargs)
+
+        # Simulate root caller. Don't patch os.lstat — we want the real
+        # one to detect the symlink.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown):
+            assert utils.chown_to_match_parent(target) is False
+
+        # Crucial: chown must never have been invoked at all.
+        assert recorded["called"] is False, (
+            f"chown was called with {recorded['args']} on a symlink — "
+            "this would re-own the link's destination, a security bug."
+        )
+        # And the destination file is untouched.
+        secret_stat_after = os.stat(secret)
+        assert secret_stat_after.st_uid == secret_stat_before.st_uid
+        assert secret_stat_after.st_gid == secret_stat_before.st_gid
+
+    def test_chown_uses_follow_symlinks_false_when_supported(self, tmp_path):
+        """Belt-and-suspenders: even when the target passes the lstat
+        symlink check, the actual chown call must be invoked with
+        follow_symlinks=False (or fall through to os.lchown) so a TOCTOU
+        race between lstat and chown still cannot re-own a link target.
+        """
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+        fake_file_stat = type(file_stat)(
+            (
+                file_stat.st_mode, file_stat.st_ino, file_stat.st_dev,
+                file_stat.st_nlink, 0, 0, file_stat.st_size,
+                file_stat.st_atime, file_stat.st_mtime, file_stat.st_ctime,
+            )
+        )
+        fake_parent_stat = type(parent_stat)(
+            (
+                parent_stat.st_mode, parent_stat.st_ino, parent_stat.st_dev,
+                parent_stat.st_nlink, 10000, 10000, parent_stat.st_size,
+                parent_stat.st_atime, parent_stat.st_mtime, parent_stat.st_ctime,
+            )
+        )
+
+        recorded = {"args": None, "kwargs": None}
+
+        def fake_chown(*args, **kwargs):
+            recorded["args"] = args
+            recorded["kwargs"] = kwargs
+
+        # Patch chown, then put the patched function into
+        # supports_follow_symlinks so the helper takes the
+        # follow_symlinks=False code path.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown) as chown_mock, \
+             patch.object(utils.os, "lstat", return_value=fake_file_stat), \
+             patch.object(utils.os, "stat", return_value=fake_parent_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", {chown_mock}):
+            assert utils.chown_to_match_parent(target) is True
+
+        assert recorded["kwargs"].get("follow_symlinks") is False, (
+            "chown must be called with follow_symlinks=False to avoid "
+            "TOCTOU symlink-substitution attacks."
+        )
+        assert recorded["args"] == (target, 10000, 10000)
+
+    def test_chown_falls_back_to_lchown_when_follow_symlinks_unsupported(self, tmp_path):
+        """On exotic platforms where os.chown doesn't accept
+        follow_symlinks, the helper must fall through to os.lchown
+        (Unix-equivalent symlink-safe chown).
+        """
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+        fake_file_stat = type(file_stat)(
+            (
+                file_stat.st_mode, file_stat.st_ino, file_stat.st_dev,
+                file_stat.st_nlink, 0, 0, file_stat.st_size,
+                file_stat.st_atime, file_stat.st_mtime, file_stat.st_ctime,
+            )
+        )
+        fake_parent_stat = type(parent_stat)(
+            (
+                parent_stat.st_mode, parent_stat.st_ino, parent_stat.st_dev,
+                parent_stat.st_nlink, 10000, 10000, parent_stat.st_size,
+                parent_stat.st_atime, parent_stat.st_mtime, parent_stat.st_ctime,
+            )
+        )
+
+        chown_calls = {"called": False}
+        lchown_calls = {"args": None}
+
+        def fake_chown(*args, **kwargs):
+            chown_calls["called"] = True
+
+        def fake_lchown(*args, **kwargs):
+            lchown_calls["args"] = args
+
+        # Empty supports_follow_symlinks set => fall back to os.lchown.
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=fake_chown), \
+             patch.object(utils.os, "lchown", create=True, side_effect=fake_lchown), \
+             patch.object(utils.os, "lstat", return_value=fake_file_stat), \
+             patch.object(utils.os, "stat", return_value=fake_parent_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", set()):
+            assert utils.chown_to_match_parent(target) is True
+
+        assert chown_calls["called"] is False, (
+            "Must use os.lchown when os.chown lacks follow_symlinks support, "
+            "not invoke the symlink-following os.chown."
+        )
+        assert lchown_calls["args"] == (target, 10000, 10000)
+
+    def test_chown_oserror_is_swallowed(self, tmp_path):
+        target = tmp_path / "auth.json"
+        target.write_text("{}", encoding="utf-8")
+
+        parent_stat = os.stat(tmp_path)
+        file_stat = os.stat(target)
+        fake_parent = type(parent_stat)(
+            (
+                parent_stat.st_mode, parent_stat.st_ino, parent_stat.st_dev,
+                parent_stat.st_nlink, 10000, 10000, parent_stat.st_size,
+                parent_stat.st_atime, parent_stat.st_mtime, parent_stat.st_ctime,
+            )
+        )
+        fake_file = type(file_stat)(
+            (
+                file_stat.st_mode, file_stat.st_ino, file_stat.st_dev,
+                file_stat.st_nlink, 0, 0, file_stat.st_size,
+                file_stat.st_atime, file_stat.st_mtime, file_stat.st_ctime,
+            )
+        )
+
+        def fake_stat(path):
+            return fake_parent
+
+        def fake_lstat(path):
+            return fake_file
+
+        def boom(*_a, **_kw):
+            raise PermissionError("EPERM")
+
+        with patch.object(utils.os, "geteuid", create=True, return_value=0), \
+             patch.object(utils.os, "chown", create=True, side_effect=boom) as chown_mock, \
+             patch.object(utils.os, "lstat", side_effect=fake_lstat), \
+             patch.object(utils.os, "stat", side_effect=fake_stat), \
+             patch.object(utils.os, "supports_follow_symlinks", {chown_mock}):
+            # MUST NOT raise — write site should not crash on chown failure.
+            assert utils.chown_to_match_parent(target) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration with auth.py write paths
+# ---------------------------------------------------------------------------
+
+
+class TestAuthSaveInvokesChown:
+    def test_save_auth_store_calls_chown_to_match_parent(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        captured = []
+
+        def fake_chown(path):
+            captured.append(Path(path))
+            return False
+
+        with patch.object(auth_module, "chown_to_match_parent", side_effect=fake_chown):
+            auth_module._save_auth_store({"providers": {"openai-codex": {"tokens": {}}}})
+
+        # The remediation hook MUST be invoked on the resulting auth.json,
+        # not on the temp file or anything else.
+        assert (hermes_home / "auth.json") in captured
+
+    def test_save_qwen_cli_tokens_calls_chown_to_match_parent(self, tmp_path, monkeypatch):
+        # Redirect Qwen CLI path into tmp so we don't touch ~/.qwen.
+        fake_qwen_path = tmp_path / ".qwen" / "oauth_creds.json"
+        monkeypatch.setattr(
+            auth_module,
+            "_qwen_cli_auth_path",
+            lambda: fake_qwen_path,
+        )
+
+        captured = []
+
+        def fake_chown(path):
+            captured.append(Path(path))
+            return False
+
+        with patch.object(auth_module, "chown_to_match_parent", side_effect=fake_chown):
+            auth_module._save_qwen_cli_tokens({"access_token": "x", "refresh_token": "y"})
+
+        assert fake_qwen_path in captured
+
+
+# ---------------------------------------------------------------------------
+# Read-side: misleading error fix
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAuthStoreSurfacesPermissionError:
+    def test_permission_error_surfaces_clearly(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        auth_path = hermes_home / "auth.json"
+        auth_path.write_text(json.dumps({"providers": {}}), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        # Force the read path to raise PermissionError, mimicking a
+        # root-owned 0o600 file being read as a non-root UID.
+        original_read_text = Path.read_text
+
+        def boom(self, *args, **kwargs):
+            if Path(self) == auth_path:
+                raise PermissionError(13, "Permission denied")
+            return original_read_text(self, *args, **kwargs)
+
+        with patch.object(Path, "read_text", boom):
+            with pytest.raises(PermissionError) as excinfo:
+                auth_module._load_auth_store()
+
+        message = str(excinfo.value)
+        # Operator must learn:
+        #   1. that the credentials are PRESENT (not "no credentials stored"),
+        #   2. WHICH file to fix,
+        #   3. HOW to fix it (chown),
+        #   4. WHICH UID is doing the reading (vs. the file's owner UID),
+        #      so a container operator immediately sees the mismatch
+        #      e.g. "file owned by uid=0 ... running as uid=10000".
+        assert "auth.json" in message
+        assert "ownership" in message.lower() or "chown" in message.lower()
+        assert "15718" in message
+        assert "running as uid=" in message

--- a/utils.py
+++ b/utils.py
@@ -359,3 +359,117 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+def chown_to_match_parent(path: Union[str, Path]) -> bool:
+    """Chown *path* to match its parent directory's owner when running as root.
+
+    Fixes a class of ownership bug seen with `docker exec` against containers
+    where Hermes runs as a non-root user (default UID 10000): the privileged
+    `docker exec` writes a state file (e.g. ``auth.json``) as ``root:root``,
+    which the runtime user can no longer read.  By rewriting the file owner
+    to match the parent directory immediately after the write, the runtime
+    user keeps access regardless of which UID called ``hermes login``.
+
+    No-op when:
+      * Not running on POSIX (Windows ``os.chown`` does not exist).
+      * Effective UID is not 0 (root) — non-root processes can only chown
+        files they already own to themselves, which buys nothing.
+      * The target itself is a symlink — see security note below.
+      * The parent directory's owner already matches the file's owner.
+
+    **Symlink safety (TOCTOU on auth.json).** ``os.stat`` and the default
+    ``os.chown`` both follow symlinks. If an attacker replaces the target
+    with a symlink to e.g. ``/etc/shadow`` between the atomic write and
+    this call, a naive implementation would re-own the symlink's
+    destination as root.  We defend in two layers:
+
+      1. Use ``os.lstat`` (not ``os.stat``) on the target to read its
+         on-disk metadata without following symlinks. If the target IS
+         a symlink, return False without touching it — the helper only
+         exists to reconcile a regular state file's ownership.
+      2. Pass ``follow_symlinks=False`` to ``os.chown`` (or fall back to
+         ``os.lchown`` on platforms where ``os.chown`` doesn't accept the
+         keyword) so that even in the impossible-but-let's-be-paranoid
+         case where a symlink slips through the lstat check, we still
+         never re-own the link's destination.
+
+    The parent-directory ``stat`` follows symlinks intentionally — root
+    controls the parent, and resolving a parent-dir symlink mirrors the
+    behavior of the surrounding write that just landed in the same
+    directory.
+
+    Errors are swallowed (and logged at debug) so a chown failure never
+    breaks the surrounding write — the file mode is still 0o600, so the
+    worst case is the pre-fix bug.
+
+    Returns True when a chown was actually performed, False otherwise.
+    """
+    chown = getattr(os, "chown", None)
+    geteuid = getattr(os, "geteuid", None)
+    if chown is None or geteuid is None:  # Windows / non-POSIX
+        return False
+    try:
+        if geteuid() != 0:
+            return False
+    except OSError:
+        return False
+
+    target = Path(path)
+    try:
+        # lstat: do NOT follow symlinks when inspecting the target.
+        # If an attacker swapped auth.json for a symlink between the
+        # atomic write and this call, st_mode tells us so.
+        file_stat = os.lstat(target)
+    except OSError:
+        return False
+    if stat.S_ISLNK(file_stat.st_mode):
+        # Refuse to operate on symlinks. The caller wrote a regular file;
+        # if a link is here now, something else is going on and we should
+        # not chown either the link or its destination.
+        logger.warning(
+            "chown_to_match_parent: %s is a symlink, refusing to chown "
+            "(possible TOCTOU substitution; see issue #15718).",
+            target,
+        )
+        return False
+
+    try:
+        # Parent stat may follow symlinks: root controls the parent dir
+        # and we want the same UID/GID that owns it on disk.
+        parent_stat = os.stat(target.parent)
+    except OSError:
+        return False
+
+    target_uid = parent_stat.st_uid
+    target_gid = parent_stat.st_gid
+    if file_stat.st_uid == target_uid and file_stat.st_gid == target_gid:
+        return False
+
+    try:
+        # Belt-and-suspenders: even though we lstat-checked above, pass
+        # follow_symlinks=False so a TOCTOU race between the lstat and
+        # the chown still cannot re-own a link destination.  Fall back
+        # to os.lchown when the platform's os.chown doesn't accept the
+        # keyword (rare on modern Linux/macOS but possible elsewhere).
+        if chown in os.supports_follow_symlinks:
+            chown(target, target_uid, target_gid, follow_symlinks=False)
+        elif hasattr(os, "lchown"):
+            os.lchown(target, target_uid, target_gid)
+        else:
+            # No safe primitive available — refuse rather than risk
+            # following a symlink.
+            logger.debug(
+                "chown_to_match_parent: no symlink-safe chown on this "
+                "platform, skipping %s",
+                target,
+            )
+            return False
+    except OSError as exc:
+        logger.debug("chown_to_match_parent: failed to chown %s: %s", target, exc)
+        return False
+    logger.warning(
+        "Adjusted ownership of %s to %d:%d to match parent directory "
+        "(file was written as root, but parent is owned by a non-root user). "
+        "Run 'hermes login' as the runtime user to avoid this remediation.",
+        target, target_uid, target_gid,
+    )
+    return True

--- a/utils.py
+++ b/utils.py
@@ -41,6 +41,122 @@ def _preserve_file_mode(path: Path) -> "int | None":
         return None
 
 
+def chown_to_match_parent(path: Union[str, Path]) -> bool:
+    """Chown *path* to match its parent directory's owner when running as root.
+
+    Fixes a class of ownership bug seen with `docker exec` against containers
+    where Hermes runs as a non-root user (default UID 10000): the privileged
+    `docker exec` writes a state file (e.g. ``auth.json``) as ``root:root``,
+    which the runtime user can no longer read.  By rewriting the file owner
+    to match the parent directory immediately after the write, the runtime
+    user keeps access regardless of which UID called ``hermes login``.
+
+    No-op when:
+      * Not running on POSIX (Windows ``os.chown`` does not exist).
+      * Effective UID is not 0 (root) — non-root processes can only chown
+        files they already own to themselves, which buys nothing.
+      * The target itself is a symlink — see security note below.
+      * The parent directory's owner already matches the file's owner.
+
+    **Symlink safety (TOCTOU on auth.json).** ``os.stat`` and the default
+    ``os.chown`` both follow symlinks. If an attacker replaces the target
+    with a symlink to e.g. ``/etc/shadow`` between the atomic write and
+    this call, a naive implementation would re-own the symlink's
+    destination as root.  We defend in two layers:
+
+      1. Use ``os.lstat`` (not ``os.stat``) on the target to read its
+         on-disk metadata without following symlinks. If the target IS
+         a symlink, return False without touching it — the helper only
+         exists to reconcile a regular state file's ownership.
+      2. Pass ``follow_symlinks=False`` to ``os.chown`` (or fall back to
+         ``os.lchown`` on platforms where ``os.chown`` doesn't accept the
+         keyword) so that even in the impossible-but-let's-be-paranoid
+         case where a symlink slips through the lstat check, we still
+         never re-own the link's destination.
+
+    The parent-directory ``stat`` follows symlinks intentionally — root
+    controls the parent, and resolving a parent-dir symlink mirrors the
+    behavior of the surrounding write that just landed in the same
+    directory.
+
+    Errors are swallowed (and logged at debug) so a chown failure never
+    breaks the surrounding write — the file mode is still 0o600, so the
+    worst case is the pre-fix bug.
+
+    Returns True when a chown was actually performed, False otherwise.
+    """
+    chown = getattr(os, "chown", None)
+    geteuid = getattr(os, "geteuid", None)
+    if chown is None or geteuid is None:  # Windows / non-POSIX
+        return False
+    try:
+        if geteuid() != 0:
+            return False
+    except OSError:
+        return False
+
+    target = Path(path)
+    try:
+        # lstat: do NOT follow symlinks when inspecting the target.
+        # If an attacker swapped auth.json for a symlink between the
+        # atomic write and this call, st_mode tells us so.
+        file_stat = os.lstat(target)
+    except OSError:
+        return False
+    if stat.S_ISLNK(file_stat.st_mode):
+        # Refuse to operate on symlinks. The caller wrote a regular file;
+        # if a link is here now, something else is going on and we should
+        # not chown either the link or its destination.
+        logger.warning(
+            "chown_to_match_parent: %s is a symlink, refusing to chown "
+            "(possible TOCTOU substitution; see issue #15718).",
+            target,
+        )
+        return False
+
+    try:
+        # Parent stat may follow symlinks: root controls the parent dir
+        # and we want the same UID/GID that owns it on disk.
+        parent_stat = os.stat(target.parent)
+    except OSError:
+        return False
+
+    target_uid = parent_stat.st_uid
+    target_gid = parent_stat.st_gid
+    if file_stat.st_uid == target_uid and file_stat.st_gid == target_gid:
+        return False
+
+    try:
+        # Belt-and-suspenders: even though we lstat-checked above, pass
+        # follow_symlinks=False so a TOCTOU race between the lstat and
+        # the chown still cannot re-own a link destination.  Fall back
+        # to os.lchown when the platform's os.chown doesn't accept the
+        # keyword (rare on modern Linux/macOS but possible elsewhere).
+        if chown in os.supports_follow_symlinks:
+            chown(target, target_uid, target_gid, follow_symlinks=False)
+        elif hasattr(os, "lchown"):
+            os.lchown(target, target_uid, target_gid)
+        else:
+            # No safe primitive available — refuse rather than risk
+            # following a symlink.
+            logger.debug(
+                "chown_to_match_parent: no symlink-safe chown on this "
+                "platform, skipping %s",
+                target,
+            )
+            return False
+    except OSError as exc:
+        logger.debug("chown_to_match_parent: failed to chown %s: %s", target, exc)
+        return False
+    logger.warning(
+        "Adjusted ownership of %s to %d:%d to match parent directory "
+        "(file was written as root, but parent is owned by a non-root user). "
+        "Run 'hermes login' as the runtime user to avoid this remediation.",
+        target, target_uid, target_gid,
+    )
+    return True
+
+
 def _restore_file_mode(path: Path, mode: "int | None") -> None:
     """Re-apply *mode* to *path* after an atomic replace.
 


### PR DESCRIPTION
## What does this PR do?

When `hermes login` writes auth files from a root-owned container context, `auth.json` and Qwen CLI token files can become unreadable by the non-root gateway user. This PR adds a shared ownership-remediation helper and invokes it after the relevant auth writes so generated credential files match their parent directory owner when safe.

## Related Issue

Fixes #15718

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `utils.chown_to_match_parent()` as a best-effort root-only ownership remediation helper.
- Call the helper after `hermes_cli/auth.py` writes `auth.json`.
- Call the helper after Qwen CLI token writes.
- Add regression coverage for root/non-root/no-op/error-safe helper behavior and both auth write integration points.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_auth_ownership_chown.py -q`
3. Expected result: 10 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_auth_ownership_chown.py -q` — 10 passed
```
