### PR TITLE
fix(auxiliary): chase fallback_providers when compression hits 429 (#15714)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1328,6 +1328,144 @@ def _is_payment_error(exc: Exception) -> bool:
     return False
 
 
+def _is_usage_limit_error(exc: Exception) -> bool:
+    """Detect rate-limit / usage-cap errors that aren't about billing.
+
+    Returns True for HTTP 429 responses whose message indicates the provider
+    rejected the request because of a rate limit, usage cap, or quota — i.e.
+    the provider is reachable and authenticated, but cannot serve the request
+    *right now*.  Distinct from :func:`_is_payment_error` which fires only on
+    402 / credit-exhaustion bodies.
+
+    Used by ``call_llm`` for ``task="compression"`` so that when the active
+    main model is rate-limited, compression can fall through to the user's
+    configured ``fallback_providers`` list instead of dropping the summary.
+    See issue #15714.
+    """
+    status = getattr(exc, "status_code", None)
+    err_lower = str(exc).lower()
+    rate_keywords = (
+        "usage_limit",
+        "usage_limit_reached",
+        "rate limit",
+        "rate_limit",
+        "rate-limit",
+        "quota",
+        "too many requests",
+        "tpm",
+        "rpm",
+        "tokens per minute",
+        "requests per minute",
+    )
+    if status == 429:
+        return True
+    if any(kw in err_lower for kw in rate_keywords):
+        return True
+    return False
+
+
+def _load_fallback_providers() -> List[Dict[str, Any]]:
+    """Read ``fallback_providers`` (or legacy ``fallback_model``) from config.yaml.
+
+    Returns a normalized list of ``{provider, model, base_url?, api_key?, key_env?}``
+    dicts.  Empty list when no fallback chain is configured.
+
+    Mirrors the loading logic in ``cli.py`` (``CLI_CONFIG.get('fallback_providers')
+    or CLI_CONFIG.get('fallback_model')``) so auxiliary callers see the same
+    chain the main agent uses.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return []
+    if not isinstance(cfg, dict):
+        return []
+    fb = cfg.get("fallback_providers")
+    if not fb:
+        fb = cfg.get("fallback_model")
+    if isinstance(fb, dict):
+        if fb.get("provider") and fb.get("model"):
+            return [fb]
+        return []
+    if not isinstance(fb, list):
+        return []
+    return [
+        entry for entry in fb
+        if isinstance(entry, dict) and entry.get("provider") and entry.get("model")
+    ]
+
+
+def _build_compression_fallback_attempts(
+    failed_provider: str,
+    messages: list,
+    *,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    timeout: float,
+    extra_body: Optional[dict],
+    async_mode: bool = False,
+) -> List[Tuple[Any, Dict[str, Any], str]]:
+    """Build (client, call_kwargs, label) attempts from ``fallback_providers``.
+
+    Used by compression's ``call_llm`` when the active main model returns a
+    usage-limit / rate-limit 429.  This is the auxiliary-side mirror of the
+    main agent's ``_try_activate_fallback`` chain — when the main model is
+    rate-limited, compression should fall through to the same configured
+    backups instead of giving up.  Returning a list lets the caller try each
+    entry in order, so a fallback that itself 429s rolls forward to the next.
+    """
+    chain = _load_fallback_providers()
+    if not chain:
+        return []
+    skip = (failed_provider or "").strip().lower()
+    attempts: List[Tuple[Any, Dict[str, Any], str]] = []
+    for entry in chain:
+        fb_provider = (entry.get("provider") or "").strip().lower()
+        fb_model = (entry.get("model") or "").strip()
+        if not fb_provider or not fb_model:
+            continue
+        # Don't loop back to the same provider that just failed.
+        if fb_provider == skip:
+            continue
+        fb_base_url = (entry.get("base_url") or "").strip() or None
+        fb_api_key = (entry.get("api_key") or "").strip() or None
+        if not fb_api_key:
+            fb_key_env = (entry.get("key_env") or "").strip()
+            if fb_key_env:
+                fb_api_key = os.getenv(fb_key_env, "").strip() or None
+        try:
+            fb_client, fb_resolved_model = resolve_provider_client(
+                fb_provider,
+                model=fb_model,
+                async_mode=async_mode,
+                explicit_base_url=fb_base_url,
+                explicit_api_key=fb_api_key,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Compression fallback: could not build client for %s/%s: %s",
+                fb_provider, fb_model, exc,
+            )
+            continue
+        if fb_client is None:
+            continue
+        fb_kwargs = _build_call_kwargs(
+            fb_provider,
+            fb_resolved_model or fb_model,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            timeout=timeout,
+            extra_body=extra_body,
+            base_url=str(getattr(fb_client, "base_url", "") or ""),
+        )
+        attempts.append((fb_client, fb_kwargs, fb_provider))
+    return attempts
+
+
 def _is_connection_error(exc: Exception) -> bool:
     """Detect connection/network errors that warrant provider fallback.
 
@@ -3163,6 +3301,55 @@ def call_llm(
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
                 return _validate_llm_response(
                     fb_client.chat.completions.create(**fb_kwargs), task)
+
+        # ── Compression usage-limit fallback to config.fallback_providers ──
+        # When the active main model is rate-limited (429 / usage_limit_reached)
+        # and the user has configured fallback_providers, retry compression
+        # against the same chain the main agent uses.  Limited to compression
+        # to keep blast radius small — vision / web_extract / summarization
+        # still need their own auto-resolution.  See issue #15714.
+        #
+        # Gated on ``is_auto`` so an explicit ``auxiliary.compression.provider``
+        # pin is honored even on failure — mirrors the payment-fallback guard
+        # above (#7559).  Explicit provider = hard constraint; auto = best-effort.
+        if (
+            task == "compression"
+            and is_auto
+            and _is_usage_limit_error(first_err)
+            and not _is_payment_error(first_err)
+        ):
+            attempts = _build_compression_fallback_attempts(
+                resolved_provider or "",
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                timeout=effective_timeout,
+                extra_body=effective_extra_body,
+                async_mode=False,
+            )
+            last_err: Optional[Exception] = first_err
+            for fb_client, fb_kwargs, fb_label in attempts:
+                logger.info(
+                    "Auxiliary compression: usage limit on %s, retrying via "
+                    "fallback_providers entry %s",
+                    resolved_provider or "main",
+                    fb_label,
+                )
+                try:
+                    return _validate_llm_response(
+                        fb_client.chat.completions.create(**fb_kwargs), task)
+                except Exception as fb_err:
+                    if not _is_usage_limit_error(fb_err):
+                        # Non-rate-limit error from the fallback — stop trying
+                        # further fallbacks and surface this fresh failure.
+                        raise
+                    last_err = fb_err
+            # Exhausted the configured fallback_providers chain — re-raise
+            # the original (or last) error so the compressor inserts its
+            # static fallback marker as before.
+            if last_err is not first_err:
+                raise last_err
         raise
 
 
@@ -3442,4 +3629,43 @@ async def async_call_llm(
                     fb_kwargs["model"] = async_fb_model
                 return _validate_llm_response(
                     await async_fb.chat.completions.create(**fb_kwargs), task)
+
+        # ── Compression usage-limit fallback to config.fallback_providers ──
+        # Mirrors the sync call_llm path so async consumers (gateway,
+        # session_search, etc.) get the same compression fallback when the
+        # main model is rate-limited.  ``is_auto`` gate honors explicit
+        # ``auxiliary.compression.provider`` pins.  See issue #15714.
+        if (
+            task == "compression"
+            and is_auto
+            and _is_usage_limit_error(first_err)
+            and not _is_payment_error(first_err)
+        ):
+            attempts = _build_compression_fallback_attempts(
+                resolved_provider or "",
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                timeout=effective_timeout,
+                extra_body=effective_extra_body,
+                async_mode=True,
+            )
+            last_err: Optional[Exception] = first_err
+            for fb_client, fb_kwargs, fb_label in attempts:
+                logger.info(
+                    "Auxiliary compression (async): usage limit on %s, retrying via "
+                    "fallback_providers entry %s",
+                    resolved_provider or "main",
+                    fb_label,
+                )
+                try:
+                    return _validate_llm_response(
+                        await fb_client.chat.completions.create(**fb_kwargs), task)
+                except Exception as fb_err:
+                    if not _is_usage_limit_error(fb_err):
+                        raise
+                    last_err = fb_err
+            if last_err is not first_err:
+                raise last_err
         raise

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -775,6 +775,472 @@ class TestCallLlmPaymentFallback:
                     messages=[{"role": "user", "content": "hello"}],
                 )
 
+
+# ---------------------------------------------------------------------------
+# Compression usage_limit fallback to config.fallback_providers — #15714
+# ---------------------------------------------------------------------------
+
+
+class TestIsUsageLimitError:
+    """_is_usage_limit_error catches usage_limit_reached / quota / rate-limit 429s."""
+
+    def test_429_usage_limit_reached(self):
+        from agent.auxiliary_client import _is_usage_limit_error
+        exc = Exception(
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached'}}"
+        )
+        exc.status_code = 429
+        assert _is_usage_limit_error(exc) is True
+
+    def test_429_plain_rate_limit(self):
+        from agent.auxiliary_client import _is_usage_limit_error
+        exc = Exception("Rate limit exceeded")
+        exc.status_code = 429
+        assert _is_usage_limit_error(exc) is True
+
+    def test_429_quota_exceeded(self):
+        from agent.auxiliary_client import _is_usage_limit_error
+        exc = Exception("quota exceeded for this minute")
+        exc.status_code = 429
+        assert _is_usage_limit_error(exc) is True
+
+    def test_500_is_not_usage_limit(self):
+        from agent.auxiliary_client import _is_usage_limit_error
+        exc = Exception("Internal Server Error")
+        exc.status_code = 500
+        assert _is_usage_limit_error(exc) is False
+
+    def test_no_status_with_usage_limit_message(self):
+        """Some providers wrap 429 inside a generic exception body."""
+        from agent.auxiliary_client import _is_usage_limit_error
+        exc = Exception("usage_limit_reached: please wait")
+        assert _is_usage_limit_error(exc) is True
+
+
+class TestCompressionFallbackProviders:
+    """call_llm(task='compression') retries against config.fallback_providers on 429/usage_limit.
+
+    Regression for #15714: when the main model 429s during compression and the
+    user has fallback_providers configured, the compression call must retry
+    against the fallback chain — not just give up and lose the summary.
+    """
+
+    def _make_429(self, msg="usage_limit_reached"):
+        exc = Exception(
+            f"Error code: 429 - {{'error': {{'type': 'usage_limit_reached', "
+            f"'message': '{msg}'}}}}"
+        )
+        exc.status_code = 429
+        return exc
+
+    def test_compression_retries_against_fallback_providers_on_usage_limit(self, monkeypatch):
+        """Main provider 429s during compression → retry against configured fallback_providers."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429()
+        primary_client.base_url = "https://chatgpt.com/backend-api/codex"
+
+        fb_client = MagicMock()
+        fb_response = MagicMock()
+        fb_response.choices = [MagicMock(message=MagicMock(content="summary text"))]
+        fb_client.chat.completions.create.return_value = fb_response
+        fb_client.base_url = "https://api.deepseek.example/v1"
+
+        fallback_providers = [
+            {"provider": "deepseek-v4", "model": "deepseek-v4-flash"},
+        ]
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=fallback_providers), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    return_value=(fb_client, "deepseek-v4-flash")):
+            response = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert response is fb_response
+        # Primary was tried once; fallback was tried once.
+        assert primary_client.chat.completions.create.call_count == 1
+        assert fb_client.chat.completions.create.call_count == 1
+
+    def test_compression_with_no_fallback_providers_re_raises(self, monkeypatch):
+        """Without fallback_providers configured, compression 429 should still raise."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429()
+        primary_client.base_url = "https://api.example/v1"
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=[]):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+            assert "usage_limit_reached" in str(excinfo.value) or "429" in str(excinfo.value)
+
+    def test_non_compression_task_skips_fallback_providers(self, monkeypatch):
+        """Only compression triggers fallback_providers retry — other tasks are unchanged."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429()
+        primary_client.base_url = "https://api.example/v1"
+
+        fb_client = MagicMock()  # would be used if fallback fired
+
+        load_called = []
+
+        def fake_load_fbp():
+            load_called.append(True)
+            return [{"provider": "deepseek-v4", "model": "deepseek-v4-flash"}]
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    side_effect=fake_load_fbp), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    return_value=(fb_client, "deepseek-v4-flash")):
+            with pytest.raises(Exception):
+                call_llm(
+                    task="web_extract",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+        # _load_fallback_providers should not be called for non-compression tasks.
+        assert load_called == []
+        assert fb_client.chat.completions.create.call_count == 0
+
+    def test_compression_falls_through_to_second_fallback_provider(self, monkeypatch):
+        """If the first fallback also 429s, try the next entry in fallback_providers."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429()
+        primary_client.base_url = "https://api.primary/v1"
+
+        fb1_client = MagicMock()
+        fb1_client.chat.completions.create.side_effect = self._make_429("rate limit on fb1")
+        fb1_client.base_url = "https://api.fb1/v1"
+
+        fb2_client = MagicMock()
+        fb2_response = MagicMock()
+        fb2_response.choices = [MagicMock(message=MagicMock(content="summary"))]
+        fb2_client.chat.completions.create.return_value = fb2_response
+        fb2_client.base_url = "https://api.fb2/v1"
+
+        fallback_providers = [
+            {"provider": "fb1-prov", "model": "fb1-model"},
+            {"provider": "fb2-prov", "model": "fb2-model"},
+        ]
+
+        def fake_resolve(provider, **kwargs):
+            if provider == "fb1-prov":
+                return fb1_client, "fb1-model"
+            if provider == "fb2-prov":
+                return fb2_client, "fb2-model"
+            return None, None
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=fallback_providers), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    side_effect=fake_resolve):
+            response = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+            )
+
+        assert response is fb2_response
+        assert fb1_client.chat.completions.create.call_count == 1
+        assert fb2_client.chat.completions.create.call_count == 1
+
+    def test_compression_happy_path_unaffected(self, monkeypatch):
+        """When primary succeeds, fallback_providers should not be touched."""
+        primary_client = MagicMock()
+        primary_response = MagicMock()
+        primary_response.choices = [MagicMock(message=MagicMock(content="summary"))]
+        primary_client.chat.completions.create.return_value = primary_response
+        primary_client.base_url = "https://api.primary/v1"
+
+        load_called = []
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    side_effect=lambda: load_called.append(True) or []):
+            response = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+            )
+
+        assert response is primary_response
+        assert load_called == []  # Never loaded — happy path
+
+    def test_compression_explicit_provider_pin_skips_fallback_chain(self, monkeypatch):
+        """Explicit ``auxiliary.compression.provider`` pin must be honored on 429.
+
+        When the user pins a specific provider (non-auto), a 429 from that
+        provider should NOT silently reroute to fallback_providers — that would
+        violate the explicit override.  Mirrors the payment-fallback gate (#7559).
+        """
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429()
+        primary_client.base_url = "https://api.deepseek.example/v1"
+
+        fb_client = MagicMock()  # would be used if fallback erroneously fired
+
+        load_called = []
+
+        def fake_load_fbp():
+            load_called.append(True)
+            return [{"provider": "openrouter", "model": "openai/gpt-5.5"}]
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "deepseek-v4-flash")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("deepseek", "deepseek-v4-flash", None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    side_effect=fake_load_fbp), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    return_value=(fb_client, "openai/gpt-5.5")):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "x"}],
+                )
+            # Original 429 must surface, not a fallback result or fallback error.
+            assert "usage_limit_reached" in str(excinfo.value) or "429" in str(excinfo.value)
+
+        # Fallback chain must not have been loaded or invoked.
+        assert load_called == [], "Explicit provider pin must skip fallback chain"
+        assert fb_client.chat.completions.create.call_count == 0
+
+    def test_compression_re_raises_when_all_fallbacks_also_usage_limit(self, monkeypatch):
+        """If every fallback_providers entry also 429s, re-raise the LAST 429 (not the first).
+
+        Exercises the ``last_err is not first_err: raise last_err`` path —
+        the sync code at auxiliary_client.py ~line 3349.
+        """
+        primary_client = MagicMock()
+        first_err = self._make_429("primary 429")
+        primary_client.chat.completions.create.side_effect = first_err
+        primary_client.base_url = "https://api.primary/v1"
+
+        fb1_err = self._make_429("fb1 429")
+        fb1_client = MagicMock()
+        fb1_client.chat.completions.create.side_effect = fb1_err
+        fb1_client.base_url = "https://api.fb1/v1"
+
+        fb2_err = self._make_429("fb2 429")
+        fb2_client = MagicMock()
+        fb2_client.chat.completions.create.side_effect = fb2_err
+        fb2_client.base_url = "https://api.fb2/v1"
+
+        fallback_providers = [
+            {"provider": "fb1-prov", "model": "fb1-model"},
+            {"provider": "fb2-prov", "model": "fb2-model"},
+        ]
+
+        def fake_resolve(provider, **kwargs):
+            if provider == "fb1-prov":
+                return fb1_client, "fb1-model"
+            if provider == "fb2-prov":
+                return fb2_client, "fb2-model"
+            return None, None
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=fallback_providers), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    side_effect=fake_resolve):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "x"}],
+                )
+
+        # Both fallbacks were attempted before re-raising.
+        assert fb1_client.chat.completions.create.call_count == 1
+        assert fb2_client.chat.completions.create.call_count == 1
+        # The re-raised error is the LAST 429 (fb2_err), not the original
+        # first_err — proving the ``raise last_err`` branch fired.
+        assert excinfo.value is fb2_err
+        assert excinfo.value is not first_err
+
+
+class TestAsyncCompressionFallbackProviders:
+    """async_call_llm(task='compression') mirrors the sync fallback behavior — #15714."""
+
+    def _make_429(self, msg="usage_limit_reached"):
+        exc = Exception(f"Error code: 429 - {msg}")
+        exc.status_code = 429
+        return exc
+
+    @pytest.mark.asyncio
+    async def test_async_compression_retries_against_fallback_providers(self, monkeypatch):
+        """Async path: primary 429 → retry against configured fallback_providers.
+
+        ``_build_compression_fallback_attempts(async_mode=True)`` calls
+        ``resolve_provider_client`` which itself produces an async client —
+        so the test patches ``resolve_provider_client`` to return an async-mock
+        client and verifies it was awaited.  No outer ``_to_async_client`` patch
+        (that helper isn't called on this code path).
+        """
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(side_effect=self._make_429())
+        primary_client.base_url = "https://api.primary/v1"
+
+        fb_client = MagicMock()
+        fb_response = MagicMock()
+        fb_response.choices = [MagicMock(message=MagicMock(content="summary"))]
+        fb_create = AsyncMock(return_value=fb_response)
+        fb_client.chat.completions.create = fb_create
+        fb_client.base_url = "https://api.fb/v1"
+
+        fallback_providers = [
+            {"provider": "fb-prov", "model": "fb-model"},
+        ]
+
+        resolve_calls = []
+
+        def fake_resolve(provider, **kwargs):
+            resolve_calls.append((provider, kwargs.get("async_mode")))
+            return fb_client, "fb-model"
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=fallback_providers), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    side_effect=fake_resolve):
+            response = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+            )
+
+        assert response is fb_response
+        # Critical: resolve_provider_client must be invoked with async_mode=True
+        # so the returned client is genuinely async — not sync-wrapped post-hoc.
+        assert resolve_calls == [("fb-prov", True)], \
+            f"Expected async_mode=True on resolve, got {resolve_calls}"
+        # And the async create was actually awaited.
+        fb_create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_compression_with_no_fallback_providers_re_raises(self, monkeypatch):
+        """Async parity for sync no-fallback re-raise."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(side_effect=self._make_429())
+        primary_client.base_url = "https://api.example/v1"
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=[]):
+            with pytest.raises(Exception) as excinfo:
+                await async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "x"}],
+                )
+            assert "usage_limit_reached" in str(excinfo.value) or "429" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_async_non_compression_task_skips_fallback_providers(self, monkeypatch):
+        """Async parity: non-compression tasks must not hit the fallback chain."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(side_effect=self._make_429())
+        primary_client.base_url = "https://api.example/v1"
+
+        fb_client = MagicMock()
+        fb_client.chat.completions.create = AsyncMock()
+
+        load_called = []
+
+        def fake_load_fbp():
+            load_called.append(True)
+            return [{"provider": "fb-prov", "model": "fb-model"}]
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    side_effect=fake_load_fbp), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    return_value=(fb_client, "fb-model")):
+            with pytest.raises(Exception):
+                await async_call_llm(
+                    task="web_extract",
+                    messages=[{"role": "user", "content": "x"}],
+                )
+        assert load_called == []
+        fb_client.chat.completions.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_async_compression_falls_through_to_second_fallback(self, monkeypatch):
+        """Async parity for two-entry roll-through: fb1 429s → fb2 succeeds."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(side_effect=self._make_429("primary"))
+        primary_client.base_url = "https://api.primary/v1"
+
+        fb1_client = MagicMock()
+        fb1_client.chat.completions.create = AsyncMock(side_effect=self._make_429("fb1"))
+        fb1_client.base_url = "https://api.fb1/v1"
+
+        fb2_client = MagicMock()
+        fb2_response = MagicMock()
+        fb2_response.choices = [MagicMock(message=MagicMock(content="summary"))]
+        fb2_client.chat.completions.create = AsyncMock(return_value=fb2_response)
+        fb2_client.base_url = "https://api.fb2/v1"
+
+        fallback_providers = [
+            {"provider": "fb1-prov", "model": "fb1-model"},
+            {"provider": "fb2-prov", "model": "fb2-model"},
+        ]
+
+        def fake_resolve(provider, **kwargs):
+            if provider == "fb1-prov":
+                return fb1_client, "fb1-model"
+            if provider == "fb2-prov":
+                return fb2_client, "fb2-model"
+            return None, None
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._load_fallback_providers",
+                    return_value=fallback_providers), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                    side_effect=fake_resolve):
+            response = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+            )
+
+        assert response is fb2_response
+        fb1_client.chat.completions.create.assert_awaited_once()
+        fb2_client.chat.completions.create.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

When the main chat model hits a 429 / `usage_limit_reached` and Hermes correctly switches the conversation to a configured `fallback_providers` entry, the auxiliary compression task (with `auxiliary.compression.provider: auto`) still resolves back to the **main** provider/model and 429s again. Compression silently inserts a static "fallback context marker" and the long-running session loses real summarization — exactly when the fallback path matters most.

Root cause: `_restore_primary_runtime` (called at the top of every new turn) restores the compressor to the just-recovered primary, but the agent's local 60s rate-limit cooldown is shorter than the provider's actual `resets_in_seconds` (e.g. 1657s in the issue example). So the very first preflight compression of the new turn lands back on an externally-still-rate-limited endpoint.

The fix is a **compression-task auxiliary fallback chase** that mirrors the existing `_try_payment_fallback` pattern in `agent/auxiliary_client.py`. When `auxiliary.compression.provider: auto` (or unset) AND a compression call hits a usage-limit / 429 error, the auxiliary client tries each entry in the user's configured `fallback_providers` chain. Limited to `task == "compression"` for blast-radius control — vision/web_extract/title_gen share the same vulnerability but are out of scope here (filed below as follow-ups).

## Related Issue

Fixes #15714

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: three new helpers + sync/async wiring.
  - `_load_fallback_providers()` reads the configured `fallback_providers` from `load_config()`.
  - `_build_compression_fallback_attempts(..., async_mode)` materializes one `(client, model, label)` tuple per fallback entry, applying `_to_async_client` internally via `resolve_provider_client(async_mode=True)` so the async path returns properly-async clients.
  - In `call_llm` (sync, lines ~3311) and `async_call_llm` (lines ~3635), after `_try_payment_fallback` exhausts and only when `task == "compression"` AND `is_auto = resolved_provider in ("auto", "", None)`, walk the fallback chain. Crucially, both sync and async paths now have the `is_auto` guard — without it, a user who pinned `auxiliary.compression.provider: deepseek` would have their explicit choice silently overridden on 429.
- `tests/agent/test_auxiliary_client.py`: 11 new tests across two classes.
  - `TestCompressionFallbackProviders` (sync): retries against fallback on usage_limit; falls through to second fallback if first also fails; no-op when no fallbacks configured (re-raises original 429); skipped when task is not compression; happy path unaffected; explicit-provider-pin skips fallback chain (preserves user's explicit choice); re-raises when ALL fallbacks 429.
  - `TestAsyncCompressionFallbackProviders`: full async parity — retries against fallback (verifying `resolve_provider_client` was called with `async_mode=True`); no-fallback re-raise; non-compression task skip; two-entry roll-through.

## How to Test

1. Reproduce the bug: configure a main provider that produces `usage_limit_reached` (e.g. an `openai-codex` plus account at the limit) and a working fallback_providers entry. Start a long session, fill enough context to trigger compression. Observe `Compression summary failed: Error code: 429 …` warnings and a `[fallback context marker]` sentinel inserted into the context.
2. Apply this PR. Repeat with the same setup. Compression now succeeds against the fallback provider; real summaries are inserted; agent continues with intact context.
3. Honor explicit pins: set `auxiliary.compression.provider: deepseek` (any non-`auto`). With deepseek 429, the call re-raises — fallback chain is NOT silently used. The user's explicit choice is honored.
4. Run unit tests: `pytest tests/agent/test_auxiliary_client.py -k "fallback or compression or 429 or usage_limit or auto" -v` — 30 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_auxiliary_client.py -q` — 108 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — helpers and call-site comments document the `is_auto` guard and the compression-only scope
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys; uses existing `fallback_providers` and `auxiliary.compression`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_auxiliary_client.py -k "fallback or compression or 429 or usage_limit or auto" -v
...
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_compression_retries_against_fallback_providers_on_usage_limit PASSED
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_compression_falls_through_to_second_fallback_provider PASSED
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_compression_with_no_fallback_providers_re_raises PASSED
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_non_compression_task_skips_fallback_providers PASSED
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_compression_happy_path_unaffected PASSED
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_compression_explicit_provider_pin_skips_fallback_chain PASSED
tests/agent/test_auxiliary_client.py::TestCompressionFallbackProviders::test_compression_re_raises_when_all_fallbacks_also_usage_limit PASSED
tests/agent/test_auxiliary_client.py::TestAsyncCompressionFallbackProviders::test_async_compression_retries_against_fallback_providers PASSED
tests/agent/test_auxiliary_client.py::TestAsyncCompressionFallbackProviders::test_async_compression_with_no_fallback_providers_re_raises PASSED
tests/agent/test_auxiliary_client.py::TestAsyncCompressionFallbackProviders::test_async_non_compression_task_skips_fallback_providers PASSED
tests/agent/test_auxiliary_client.py::TestAsyncCompressionFallbackProviders::test_async_compression_falls_through_to_second_fallback PASSED
============================== 30 passed in 3.16s ==============================
```

### Known follow-ups (out of scope)
- Vision (`tools/vision_tools.py`), web_extract (`tools/web_tools.py`), title_generation, and session_search summarization share the same structural vulnerability — they all go through `call_llm` → `_resolve_auto`. A follow-up could either widen the gate to all aux tasks or expose `fallback_providers` as a generic auxiliary-resolver fallback chain.
- A deeper fix for `_restore_primary_runtime` would honor the provider's `resets_in_seconds` from the 429 response body and thread it into `_rate_limited_until` so the primary isn't restored prematurely. Larger scope, separate concern.
