### PR TITLE
fix: ensure reasoning_content on all assistant messages for DeepSeek/Kimi thinking mode

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -34,30 +34,39 @@ class ChatCompletionsTransport(ProviderTransport):
         Strips Codex Responses API fields (``codex_reasoning_items`` on the
         message, ``call_id``/``response_item_id`` on tool_calls) that strict
         chat-completions providers reject with 400/422.
+
+        Also ensures every assistant message has ``reasoning_content`` field
+        for providers (DeepSeek thinking mode, Kimi K2, etc.) that require it
+        on all assistant turns, not just tool-call turns.
         """
-        needs_sanitize = False
+        _need_rc_fix = False
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
+            if msg.get("role") == "assistant" and "reasoning_content" not in msg:
+                _need_rc_fix = True
             if "codex_reasoning_items" in msg:
-                needs_sanitize = True
+                _need_rc_fix = True
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
                     if isinstance(tc, dict) and ("call_id" in tc or "response_item_id" in tc):
-                        needs_sanitize = True
+                        _need_rc_fix = True
                         break
-                if needs_sanitize:
+                if _need_rc_fix:
                     break
 
-        if not needs_sanitize:
+        if not _need_rc_fix:
             return messages
 
         sanitized = copy.deepcopy(messages)
         for msg in sanitized:
             if not isinstance(msg, dict):
                 continue
+            # Ensure reasoning_content on all assistant messages
+            if msg.get("role") == "assistant" and "reasoning_content" not in msg:
+                msg["reasoning_content"] = ""
             msg.pop("codex_reasoning_items", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -320,8 +320,7 @@ class HermesAgentLoop:
                 # Preserve reasoning_content for multi-turn chat template handling
                 # (e.g., Kimi-K2's template renders <think> blocks differently
                 # for history vs. the latest turn based on this field)
-                if reasoning:
-                    msg_dict["reasoning_content"] = reasoning
+                msg_dict["reasoning_content"] = reasoning or ""
 
                 messages.append(msg_dict)
 
@@ -492,8 +491,7 @@ class HermesAgentLoop:
                     "role": "assistant",
                     "content": assistant_msg.content or "",
                 }
-                if reasoning:
-                    msg_dict["reasoning_content"] = reasoning
+                msg_dict["reasoning_content"] = reasoning or ""
                 messages.append(msg_dict)
 
                 turn_elapsed = _time.monotonic() - turn_start

--- a/run_agent.py
+++ b/run_agent.py
@@ -7765,14 +7765,14 @@ class AIAgent:
             return
 
         # Providers that require an echoed reasoning_content on every
-        # assistant tool-call turn. Detection logic lives in the per-provider
-        # helpers so both the creation path (_build_assistant_message) and
-        # this replay path stay in sync.
-        if source_msg.get("tool_calls") and (
+        # assistant turn (tool-call and text-only alike). Detection logic
+        # lives in the per-provider helpers so both the creation path
+        # (_build_assistant_message) and this replay path stay in sync.
+        if (
             self._needs_kimi_tool_reasoning()
             or self._needs_deepseek_tool_reasoning()
         ):
-            api_msg["reasoning_content"] = ""
+            api_msg["reasoning_content"] = source_msg.get("reasoning_content") or ""
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:


### PR DESCRIPTION
## Problem
DeepSeek and Volc Ark thinking mode requires every assistant message (including plain text replies) to carry a `reasoning_content` field. When this field is missing, the API returns HTTP 400:
```
{"error":{"message":"The reasoning_content in the thinking mode must be passed back to the API.","type":"invalid_request_error"}}
```

## Root Cause
Three places where `reasoning_content` could be dropped:
1. **agent_loop.py**: conditionally added `reasoning_content` only when non-empty (`if reasoning:`)
2. **run_agent.py**: `_copy_reasoning_content_for_api` only covered tool-call assistant turns
3. **chat_completions.py**: `convert_messages` returned messages as-is when no Codex sanitization was needed — no field normalization

## Fix (3 changes)
- `environments/agent_loop.py` L323 & L494: changed `if reasoning: msg_dict["reasoning_content"] = reasoning` → `msg_dict["reasoning_content"] = reasoning or ""` (unconditional)
- `run_agent.py` `_copy_reasoning_content_for_api`: expanded scope from tool-call-only to all assistant turns for DeepSeek/Kimi providers
- `agent/transports/chat_completions.py` `convert_messages`: added defense-in-depth normalization — ensures every `role=="assistant"` message has `reasoning_content`

## Testing
Verified in production (Feishu bot with DeepSeek V4 Pro thinking mode). Previously failing conversations now work correctly. Three-layer defense ensures future changes won't re-introduce the issue.
