### PR TITLE
fix(cli): reject invalid argv values from -p/--profile before resolving

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -114,6 +114,16 @@ def _apply_profile_override() -> None:
             consume = 1
             break
 
+    # 1b. Reject values that can't be valid profile names (e.g. pytest's
+    # "-p no:xdist" would be misread as profile "no:xdist" otherwise).
+    # Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never call
+    # resolve_profile_env() with a value it must reject + sys.exit on.
+    if profile_name is not None and consume == 2:
+        import re as _re
+        if not _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile_name):
+            profile_name = None
+            consume = 0
+
     # 1.5 If HERMES_HOME is already set and no explicit flag was given, trust it.
     # This lets child processes (relaunch, subprocess) inherit the parent's
     # profile choice without having to pass --profile again.


### PR DESCRIPTION
## Summary
- `_apply_profile_override()` in `hermes_cli/main.py` scans `sys.argv` for `-p`/`--profile` at module import time
- When `hermes_cli.main` is imported inside pytest with `-p no:xdist` on the command line, `'no:xdist'` is picked up as a profile name candidate, which then causes `sys.exit(1)` — aborting test collection with an `INTERNALERROR`
- Fixes 7 consistently-failing CI tests in `tests/gateway/test_update_streaming.py`

## The bug

`_apply_profile_override()` runs at module level (line 160). It scans `sys.argv` for `-p <value>` and tries to resolve it as a HERMES_HOME profile.  When pytest is invoked with `-p no:xdist` (disable xdist plugin), the function picks up `no:xdist` as a profile name, passes it to `resolve_profile_env()`, which calls `validate_profile_name()`, which raises `ValueError: Invalid profile name 'no:xdist'` — causing `sys.exit(1)` before any test runs.

The same conflict affects any process (CI runner, wrapper scripts) that uses `-p` for its own flag and then imports `hermes_cli.main`.

## The fix

Add a format-validation guard immediately after the explicit `-p` flag scan (step 1). If the candidate value doesn't match the valid profile-name pattern `[a-z0-9][a-z0-9_-]{0,63}`, discard it and fall through as if no `-p` flag was found. The file-based `active_profile` fallback (step 2) only reads files written by hermes itself and always produces valid names, so it needs no guard.

```python
# 1b. Reject values that can't be valid profile names (e.g. pytest's
# "-p no:xdist" would be misread as profile "no:xdist" otherwise).
if profile_name is not None and consume == 2:
    import re as _re
    if not _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile_name):
        profile_name = None
        consume = 0
```

## Test plan
- [x] **Before**: `tests/gateway/test_update_streaming.py` → 7 failures with `SystemExit: 1` / `INTERNALERROR`
- [x] **After**: 17/17 `test_update_streaming.py` pass; broader `tests/gateway/` unchanged
- [x] **Regression guard**: reverted guard → `SystemExit: 1` on import; restored → 0 failures
- [x] Adjacent suites unchanged (dingtalk/matrix baseline unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)