### PR TITLE
fix: reorder reasoning_content promotion before poisoned-history fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7851,11 +7851,19 @@ class AIAgent:
             api_msg["reasoning_content"] = existing
             return
 
-        # 2. DeepSeek / Kimi thinking mode: tool-call turns that lack
-        # reasoning_content are "poisoned history" — a prior provider (MiniMax,
-        # etc.) left them empty. DeepSeek returns HTTP 400 if reasoning_content
-        # is absent on replay; inject "" to satisfy the provider's requirement
-        # without forwarding any cross-provider reasoning content.
+        # 2. Promote 'reasoning' field to 'reasoning_content' FIRST — before
+        # the poisoned-history / empty-string fallback below.  This ensures
+        # cross-provider reasoning (e.g. Xiaomi → DeepSeek fallback) is not
+        # silently dropped on tool-call turns.
+        normalized_reasoning = source_msg.get("reasoning")
+        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            api_msg["reasoning_content"] = normalized_reasoning
+            return
+
+        # 3. DeepSeek / Kimi thinking mode: tool-call turns that still lack
+        # reasoning_content at this point are "poisoned history" — a prior
+        # provider left them empty.  Inject "" to satisfy the provider's
+        # requirement (avoids HTTP 400 on replay).
         needs_empty_reasoning = (
             source_msg.get("tool_calls")
             and (
@@ -7867,15 +7875,8 @@ class AIAgent:
             api_msg["reasoning_content"] = ""
             return
 
-        # 3. Healthy session: promote 'reasoning' field to 'reasoning_content'
-        # for providers that use the internal 'reasoning' key.
-        normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
-            api_msg["reasoning_content"] = normalized_reasoning
-            return
-
         # 4. DeepSeek / Kimi thinking mode: all assistant messages need
-        # reasoning_content. Inject "" to satisfy the provider's requirement
+        # reasoning_content.  Inject "" to satisfy the provider's requirement
         # when no explicit reasoning content is present.
         if (
             self._needs_kimi_tool_reasoning()


### PR DESCRIPTION
## Summary

When a non-DeepSeek provider (e.g. Xiaomi/MiMo) returns a tool-call message with `reasoning`, and the fallback switches to DeepSeek, the original code in `_copy_reasoning_content_for_api()` injects an empty `reasoning_content=""` before trying to promote the existing `reasoning` field. This silently drops cross-provider reasoning content.

## Root Cause

In `_copy_reasoning_content_for_api()`, the original step order was:

1. Preserve explicit `reasoning_content` string
2. Tool-calls + DeepSeek/Kimi → inject `""` ← **short-circuits here**
3. Promote `reasoning` → `reasoning_content` ← **never reached for tool-call messages**
4. DeepSeek/Kimi fallback → inject `""`
5. Pop null `reasoning_content`

When replaying a tool-call message from a prior provider (Xiaomi) with valid `reasoning` text under the current DeepSeek provider, step 2 fires first and injects `""`, causing the actual reasoning to be discarded.

## Fix

Rearrange the order: promote `reasoning` → `reasoning_content` (new step 2) **before** the poisoned-history empty-string fallback (new step 3). Valid reasoning from prior providers is now preserved across provider switches, while the empty-string safety net still applies when no reasoning exists.

```
Steps after fix:
1. Preserve explicit reasoning_content string
2. Promote reasoning → reasoning_content ← MOVED UP
3. Tool-calls + DeepSeek/Kimi → inject ""  
4. DeepSeek/Kimi fallback → inject ""
5. Pop null reasoning_content
```

## Testing

- Existing `test_deepseek_reasoning_content_echo.py` tests still pass (same empty-string behavior when no reasoning present)
- Manual repro: Xiaomi primary → DeepSeek fallback on tool-call turns no longer drops reasoning content

Fixes: HTTP 400 "The `reasoning_content` in the thinking mode must be passed back to the API."