### PR TITLE
feat(update): run WebUI updater after agent update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5877,6 +5877,33 @@ def _finalize_update_output(state):
             pass
 
 
+def _update_webui_after_agent_update() -> None:
+    """Run the optional repo-external Hermes WebUI updater after ``hermes update``.
+
+    This is intentionally repo-external so upstream Hermes Agent remains the
+    source of truth while local service customizations live under ``~/.hermes``.
+    Failures are reported but do not make the agent update fail.
+    """
+    script = Path.home() / ".hermes" / "scripts" / "update-hermes-webui.sh"
+    if not script.exists():
+        return
+
+    print()
+    print("→ Updating Hermes WebUI...")
+    try:
+        result = subprocess.run([str(script)], cwd=PROJECT_ROOT, text=True)
+    except Exception as exc:
+        print(f"  ⚠ Hermes WebUI update skipped: {exc}")
+        return
+
+    if result.returncode != 0:
+        print(
+            "  ⚠ Hermes WebUI update failed "
+            f"(exit {result.returncode}); agent update will continue."
+        )
+        print("    Check: ~/.hermes/scripts/update-hermes-webui.sh")
+
+
 def _cmd_update_check():
     """Implement ``hermes update --check``: fetch and report without installing."""
     git_dir = PROJECT_ROOT / ".git"
@@ -6112,6 +6139,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     check=False,
                 )
             print("✓ Already up to date!")
+            _update_webui_after_agent_update()
             return
 
         print(f"→ Found {commit_count} new commit(s)")
@@ -6367,6 +6395,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print()
         print("✓ Update complete!")
+        _update_webui_after_agent_update()
 
         # Write exit code *before* the gateway restart attempt.
         # When running as ``hermes update --gateway`` (spawned by the gateway's

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.main import cmd_update, PROJECT_ROOT, _update_webui_after_agent_update
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -96,10 +96,12 @@ class TestCmdUpdateBranchFallback:
             branch="main", verify_ok=True, commit_count="0"
         )
 
-        cmd_update(mock_args)
+        with patch("hermes_cli.main._update_webui_after_agent_update") as mock_webui_update:
+            cmd_update(mock_args)
 
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
+        mock_webui_update.assert_called_once_with()
 
         # Should NOT have called pull
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
@@ -116,8 +118,10 @@ class TestCmdUpdateBranchFallback:
             branch="main", verify_ok=True, commit_count="1"
         )
 
-        cmd_update(mock_args)
+        with patch("hermes_cli.main._update_webui_after_agent_update") as mock_webui_update:
+            cmd_update(mock_args)
 
+        mock_webui_update.assert_called_once_with()
         npm_calls = [
             (call.args[0], call.kwargs.get("cwd"))
             for call in mock_run.call_args_list
@@ -163,3 +167,29 @@ class TestCmdUpdateBranchFallback:
             mock_input.assert_not_called()
             captured = capsys.readouterr()
             assert "Non-interactive session" in captured.out
+
+
+def test_update_webui_after_agent_update_runs_optional_script(tmp_path, capsys):
+    script = tmp_path / ".hermes" / "scripts" / "update-hermes-webui.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/usr/bin/env bash\n")
+    with patch("hermes_cli.main.Path.home", return_value=tmp_path), patch(
+        "hermes_cli.main.subprocess.run"
+    ) as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess([str(script)], 0)
+
+        _update_webui_after_agent_update()
+
+    mock_run.assert_called_once_with([str(script)], cwd=PROJECT_ROOT, text=True)
+    captured = capsys.readouterr()
+    assert "Updating Hermes WebUI" in captured.out
+
+
+def test_update_webui_after_agent_update_ignores_missing_script():
+    missing_home = PROJECT_ROOT / "definitely-missing-home-for-webui-test"
+    with patch("hermes_cli.main.Path.home", return_value=missing_home), patch(
+        "hermes_cli.main.subprocess.run"
+    ) as mock_run:
+        _update_webui_after_agent_update()
+
+    mock_run.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Adds an optional post-update hook that runs a local Hermes WebUI updater script after `hermes update`.

- Looks for `~/.hermes/scripts/update-hermes-webui.sh`
- Runs it after the agent is already up to date and after a successful agent update
- Treats missing scripts as a no-op
- Treats updater failures as non-fatal so Hermes Agent updates are not blocked by WebUI/service issues
- Adds regression coverage for both update paths

## Related Issue

N/A

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Tests

## Changes Made

- `hermes_cli/main.py`
  - Adds the optional WebUI updater hook.
  - Calls it from the already-up-to-date path and the successful update-complete path.
- `tests/hermes_cli/test_cmd_update.py`
  - Adds coverage that the hook is invoked on both paths.

## How to Test

Focused tests run locally on Ubuntu 24.04 under WSL2:

```bash
/home/kkjop2/.hermes/hermes-agent/venv/bin/python -m pytest -q \
  tests/hermes_cli/test_cmd_update.py \
  tests/hermes_cli/test_update_autostash.py \
  tests/hermes_cli/test_update_gateway_restart.py
```

Result:

```text
71 passed
```

Diff check:

```bash
git diff --check
```

Result: passed.

Full suite was also run locally, but it does not currently pass in this environment:

```bash
/home/kkjop2/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
```

Result:

```text
95 failed, 15831 passed, 53 skipped, 217 warnings in 161.05s
```

Because of that result, the full-suite checklist item below is intentionally left unchecked.

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits (`feat(update): ...`)
- [x] I have searched for duplicate open PRs for this change
- [x] I have added or updated tests for this change
- [x] Focused tests for this change pass locally
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] This PR only changes files related to the described feature
- [x] No documentation, config schema, or tool schema changes are required
