### PR TITLE
fix(agent): restrict background review agent to memory and skills toolsets

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3232,6 +3232,7 @@ class AIAgent:
                         platform=self.platform,
                         provider=self.provider,
                         parent_session_id=self.session_id,
+                        enabled_toolsets=["memory", "skills"],
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -1,0 +1,82 @@
+"""Tests that the background review agent is restricted to memory+skills toolsets.
+
+Regression coverage for issue #15204: the background skill-review agent
+inherited the full default toolset, allowing it to perform non-skill side
+effects (terminal, send_message, delegate_task, etc.).
+"""
+
+import threading
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_agent_stub():
+    """Create a minimal AIAgent-like object with just enough state for _spawn_background_review."""
+    agent = object.__new__(AIAgent)
+    agent.model = "test-model"
+    agent.platform = "test"
+    agent.provider = "openai"
+    agent.session_id = "sess-123"
+    agent.quiet_mode = True
+    agent._memory_store = None
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+    agent._memory_nudge_interval = 5
+    agent._skill_nudge_interval = 5
+    agent.background_review_callback = None
+    agent.status_callback = None
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    agent._COMBINED_REVIEW_PROMPT = "review both"
+    return agent
+
+
+class _SyncThread:
+    """Drop-in replacement for threading.Thread that runs the target inline."""
+
+    def __init__(self, *, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+def test_background_review_agent_uses_restricted_toolsets():
+    """The review agent must only have access to 'memory' and 'skills' toolsets."""
+    agent = _make_agent_stub()
+    captured = {}
+
+    def _capture_init(self, *args, **kwargs):
+        captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
+        raise RuntimeError("stop after capturing init args")
+
+    with patch.object(AIAgent, "__init__", _capture_init), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "enabled_toolsets" in captured, "AIAgent.__init__ was not called"
+    assert sorted(captured["enabled_toolsets"]) == ["memory", "skills"]
+
+
+def test_background_review_agent_tools_are_limited():
+    """Verify the resolved memory+skills toolsets only contain memory and skill tools."""
+    from toolsets import resolve_multiple_toolsets
+
+    expected_tools = set(resolve_multiple_toolsets(["memory", "skills"]))
+
+    assert "memory" in expected_tools
+    assert "skill_manage" in expected_tools
+    assert "skill_view" in expected_tools
+    assert "skills_list" in expected_tools
+
+    assert "terminal" not in expected_tools
+    assert "send_message" not in expected_tools
+    assert "delegate_task" not in expected_tools
+    assert "web_search" not in expected_tools
+    assert "execute_code" not in expected_tools


### PR DESCRIPTION
## What does this PR do?

The background skill/memory review agent was created without toolset restrictions, inheriting the full default tool set. This allowed it to use terminal, send_message, delegate_task, and other tools outside its intended scope, potentially performing unrelated side effects (e.g., sending messages to other agents via tmux, modifying unrelated files) after completing its skill creation task.

This PR restricts the review agent to only `memory` and `skills` toolsets by passing `enabled_toolsets=["memory", "skills"]` during AIAgent construction.

## Related Issue

Fixes #15204

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `enabled_toolsets=["memory", "skills"]` to the `AIAgent()` constructor call in `_spawn_background_review()` (`run_agent.py`), restricting the background review agent to only memory and skill management tools
- Add regression tests verifying the toolset restriction is applied

## How to Test

1. Start a long conversation that triggers background skill review
2. Verify the review agent can still create/update skills and memory
3. Verify the review agent cannot use terminal, send_message, or other non-skill tools
4. Run the targeted test: `pytest tests/run_agent/test_background_review_toolset_restriction.py -v`
5. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated contributing / agents docs — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
