### PR TITLE
feat: land repo-context metadata and MCP workflow guidance

### DIFF
--- a/agent/capability_catalog.py
+++ b/agent/capability_catalog.py
@@ -1,0 +1,357 @@
+"""Capability metadata catalog for Hermes.
+
+Phase 1A: normalize tool + skill capability metadata into a single in-memory
+catalog. This is intentionally read-only and lightweight so `status` / `doctor`
+can gradually migrate off scattered heuristics without a large framework rewrite.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from tools.registry import ToolRegistry, registry as global_registry
+
+
+def _normalize_check(name: str, status: str, detail: str) -> Dict[str, str]:
+    return {"name": name, "status": status, "detail": detail}
+
+
+def _tool_record(tool_name: str, tool_registry: ToolRegistry) -> Dict[str, Any]:
+    entry = tool_registry.get_entry(tool_name)
+    if entry is None:
+        raise KeyError(f"Unknown tool: {tool_name}")
+
+    toolset_ready = tool_registry.is_toolset_available(entry.toolset)
+    readiness_status = "ready" if toolset_ready else "setup_needed"
+    readiness_reason = (
+        "toolset requirements satisfied"
+        if toolset_ready
+        else "toolset requirements are not currently satisfied"
+    )
+
+    return {
+        "id": f"tool:{entry.name}",
+        "kind": "tool",
+        "name": entry.name,
+        "canonical_name": entry.name,
+        "source": {
+            "type": "registry",
+            "path": "tools/registry.py",
+            "origin": entry.toolset,
+        },
+        "description": entry.description or entry.schema.get("description", ""),
+        "group": entry.toolset,
+        "platform_scope": ["all"],
+        "runtime_dependencies": list(entry.runtime_dependencies),
+        "required_env": list(entry.requires_env),
+        "required_commands": [],
+        "execution_tags": list(entry.execution_tags),
+        "readiness": {
+            "status": readiness_status,
+            "reason": readiness_reason,
+            "checks": [
+                _normalize_check(
+                    "toolset_available",
+                    "pass" if toolset_ready else "fail",
+                    f"toolset={entry.toolset}",
+                )
+            ],
+        },
+        "relationships": {
+            "depends_on": [f"toolset:{entry.toolset}"],
+            "provides_to": [],
+            "owned_by": [],
+        },
+        "display": {
+            "summary_surface": ["status", "doctor"],
+            "priority": 50,
+            "emoji": entry.emoji or None,
+        },
+    }
+
+
+def _normalize_skill_env_requirements(raw_values: List[Any]) -> List[str]:
+    normalized: List[str] = []
+    for item in raw_values or []:
+        if isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            if name:
+                normalized.append(name)
+        else:
+            text = str(item).strip()
+            if text:
+                normalized.append(text)
+    return normalized
+
+
+def _iter_skill_metadata(skill_roots: List[Path]) -> Iterable[Dict[str, Any]]:
+    from tools.skills_tool import (
+        _EXCLUDED_SKILL_DIRS,
+        _collect_prerequisite_values,
+        _get_category_from_path,
+        _get_required_environment_variables,
+        _is_env_var_persisted,
+        _parse_frontmatter,
+        MAX_DESCRIPTION_LENGTH,
+    )
+
+    seen_names: set[str] = set()
+    for root in skill_roots:
+        if not root.exists():
+            continue
+        for skill_md in root.rglob("SKILL.md"):
+            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+                continue
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                frontmatter, body = _parse_frontmatter(content)
+            except Exception:
+                continue
+
+            skill_name = str(frontmatter.get("name") or skill_md.parent.name).strip()
+            if not skill_name or skill_name in seen_names:
+                continue
+            seen_names.add(skill_name)
+
+            description = str(frontmatter.get("description") or "").strip()
+            if not description:
+                for line in body.strip().split("\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        description = line
+                        break
+            if len(description) > MAX_DESCRIPTION_LENGTH:
+                description = description[: MAX_DESCRIPTION_LENGTH - 3] + "..."
+
+            legacy_env_vars, legacy_commands = _collect_prerequisite_values(frontmatter)
+            required_env_entries = _get_required_environment_variables(frontmatter, legacy_env_vars)
+            missing_env = [
+                entry["name"]
+                for entry in required_env_entries
+                if not entry.get("optional") and not _is_env_var_persisted(entry["name"])
+            ]
+            required_cred_files_raw = frontmatter.get("required_credential_files", [])
+            if not isinstance(required_cred_files_raw, list):
+                required_cred_files_raw = []
+            missing_cred_files = [
+                str(path)
+                for path in required_cred_files_raw
+                if not Path(os.path.expanduser(str(path))).exists()
+            ]
+
+            platforms = frontmatter.get("platforms")
+            if isinstance(platforms, str):
+                platforms = [platforms]
+            if not isinstance(platforms, list) or not platforms:
+                platform_scope = ["all"]
+                supported = True
+            else:
+                platform_scope = [str(p).strip() for p in platforms if str(p).strip()]
+                current_platform = __import__("sys").platform
+                supported = any(
+                    (p == "macos" and current_platform == "darwin")
+                    or (p == "linux" and current_platform.startswith("linux"))
+                    or (p == "windows" and current_platform == "win32")
+                    for p in platform_scope
+                )
+
+            if not supported:
+                readiness_status = "unsupported"
+                readiness_reason = "skill is unsupported on this platform"
+            elif missing_env or missing_cred_files:
+                readiness_status = "setup_needed"
+                missing = missing_env or missing_cred_files
+                readiness_reason = f"missing prerequisites: {', '.join(missing)}"
+            else:
+                readiness_status = "ready"
+                readiness_reason = "skill is available"
+
+            checks: List[Dict[str, str]] = []
+            required_env = _normalize_skill_env_requirements(required_env_entries)
+            if required_env:
+                checks.append(
+                    _normalize_check(
+                        "required_environment_variables",
+                        "pass" if not missing_env else "fail",
+                        ", ".join(required_env),
+                    )
+                )
+            if legacy_commands:
+                checks.append(
+                    _normalize_check(
+                        "required_commands",
+                        "pass",
+                        ", ".join(legacy_commands),
+                    )
+                )
+            if missing_cred_files:
+                checks.append(
+                    _normalize_check(
+                        "required_credential_files",
+                        "fail",
+                        ", ".join(missing_cred_files),
+                    )
+                )
+            if not checks:
+                checks.append(_normalize_check("skill_metadata", "pass", "skill metadata loaded"))
+
+            yield {
+                "id": f"skill:{skill_name}",
+                "kind": "skill",
+                "name": skill_name,
+                "canonical_name": skill_name,
+                "source": {
+                    "type": "skill_frontmatter",
+                    "path": str(skill_md),
+                    "origin": str(skill_md.parent),
+                },
+                "description": description,
+                "group": "skill",
+                "platform_scope": platform_scope,
+                "runtime_dependencies": [],
+                "required_env": required_env,
+                "required_commands": list(legacy_commands),
+                "execution_tags": [],
+                "readiness": {
+                    "status": readiness_status,
+                    "reason": readiness_reason,
+                    "checks": checks,
+                },
+                "relationships": {
+                    "depends_on": [],
+                    "provides_to": [],
+                    "owned_by": [f"category:{_get_category_from_path(skill_md) or 'none'}"],
+                },
+                "display": {
+                    "summary_surface": ["status", "doctor", "skills_hub"],
+                    "priority": 40,
+                    "emoji": None,
+                },
+            }
+
+
+def _skill_record(skill: Dict[str, Any], task_id: str | None = None) -> Dict[str, Any]:
+    raise NotImplementedError("Use _iter_skill_metadata() for read-only skill catalog ingestion")
+
+
+def build_capability_catalog(
+    *,
+    tool_registry: ToolRegistry | None = None,
+    skills_dir: Path | None = None,
+    task_id: str | None = None,
+) -> Dict[str, Any]:
+    """Build an in-memory capability catalog.
+
+    Phase 1A intentionally limits scope to tools and skills, but the returned
+    object shape leaves room for MCP/auth/automation surfaces later.
+    """
+    tool_registry = tool_registry or global_registry
+
+    records: List[Dict[str, Any]] = []
+    for tool_name in tool_registry.get_all_tool_names():
+        records.append(_tool_record(tool_name, tool_registry))
+
+    skill_roots = [Path(skills_dir)] if skills_dir is not None else []
+    if not skill_roots:
+        from tools.skills_tool import SKILLS_DIR
+        from agent.skill_utils import get_external_skills_dirs
+
+        skill_roots = [SKILLS_DIR, *get_external_skills_dirs()]
+
+    records.extend(_iter_skill_metadata(skill_roots))
+
+    by_kind = dict(sorted(Counter(record["kind"] for record in records).items()))
+
+    return {
+        "records": sorted(records, key=lambda item: (item["kind"], item["canonical_name"])),
+        "counts": by_kind,
+    }
+
+
+def list_capabilities(*, kind: str | None = None, catalog: Dict[str, Any] | None = None) -> List[Dict[str, Any]]:
+    catalog = catalog or build_capability_catalog()
+    records = catalog.get("records", [])
+    if kind is None:
+        return records
+    return [record for record in records if record.get("kind") == kind]
+
+
+def get_capability(capability_id: str, *, catalog: Dict[str, Any] | None = None) -> Optional[Dict[str, Any]]:
+    catalog = catalog or build_capability_catalog()
+    for record in catalog.get("records", []):
+        if record.get("id") == capability_id:
+            return record
+    return None
+
+
+def summarize_capability_health(catalog: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    catalog = catalog or build_capability_catalog()
+    records = catalog.get("records", [])
+    return {
+        "total": len(records),
+        "by_kind": dict(sorted(Counter(record["kind"] for record in records).items())),
+        "by_status": dict(sorted(Counter(record["readiness"]["status"] for record in records).items())),
+    }
+
+
+def summarize_repo_context_capabilities(catalog: Dict[str, Any] | None = None) -> List[Dict[str, str]]:
+    """Return repo-context/indexing capability summaries for status/doctor surfaces."""
+    catalog = catalog or build_capability_catalog()
+    records = catalog.get("records", [])
+    summaries: List[Dict[str, str]] = []
+    seen_keys: set[tuple[str, str]] = set()
+
+    for record in records:
+        if record.get("kind") != "tool":
+            continue
+        execution_tags = set(record.get("execution_tags") or [])
+        if "indexing_workflow" not in execution_tags:
+            continue
+
+        name = str(record.get("canonical_name") or record.get("name") or "")
+        summary = {
+            "name": name,
+            "group": str(record.get("group") or ""),
+            "readiness_status": str((record.get("readiness") or {}).get("status") or "unknown"),
+            "identity_scope": "absolute_path" if name.startswith("mcp_claude_context_") else "tool_defined",
+            "workflow": "index/status/search/clear",
+            "result_mode": "partial_or_complete",
+        }
+        summaries.append(summary)
+        seen_keys.add((summary["group"], summary["name"]))
+
+    try:
+        from tools.mcp_tool import _KNOWN_MCP_RUNTIME_PROFILES, _load_mcp_config
+
+        configured_servers = _load_mcp_config()
+        for server_name in configured_servers:
+            server_profile = _KNOWN_MCP_RUNTIME_PROFILES.get(server_name, {})
+            if not any("indexing_workflow" in (meta.get("execution_tags") or []) for meta in server_profile.values()):
+                continue
+            for tool_name, meta in server_profile.items():
+                if "indexing_workflow" not in (meta.get("execution_tags") or []):
+                    continue
+                group = f"mcp-{server_name}"
+                canonical_name = f"mcp_{server_name.replace('-', '_')}_{tool_name}"
+                key = (group, canonical_name)
+                if key in seen_keys:
+                    continue
+                summaries.append(
+                    {
+                        "name": canonical_name,
+                        "group": group,
+                        "readiness_status": "configured",
+                        "identity_scope": "absolute_path" if server_name == "claude-context" else "tool_defined",
+                        "workflow": "index/status/search/clear",
+                        "result_mode": "partial_or_complete",
+                    }
+                )
+                seen_keys.add(key)
+    except Exception:
+        pass
+
+    return sorted(summaries, key=lambda item: (item["group"], item["name"]))

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -176,6 +176,54 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+EXECUTION_BOUNDARY_GUIDANCE = (
+    "When tools can affect external state, keep execution boundaries explicit. "
+    "Distinguish the local machine from a remote service or cloud sandbox before acting. "
+    "Distinguish logged-in browser/app state from public web content before assuming access. "
+    "Say clearly whether an action happens on the local machine, inside a remote service, "
+    "through a logged-in session, or by sending data out to another platform. "
+    "Treat messaging, browser clicks, file edits, and shell commands as real side effects; "
+    "for risky or destructive changes, follow the approval boundary instead of blurring ahead."
+)
+
+CLAUDE_CONTEXT_WORKFLOW_GUIDANCE = (
+    "When the claude-context MCP repo-retrieval tools are available, use them with an explicit "
+    "repo-index workflow instead of assuming code search is instant or complete. "
+    "Start with get_indexing_status for the target repo path, trigger index_codebase when the "
+    "repo is missing or stale, treat search_code results as partial while indexing is still in "
+    "progress, re-check get_indexing_status before relying on final retrieval, reserve "
+    "clear_index for explicit reset or recovery flows, and keep index/status/search/clear calls on the same absolute path."
+)
+
+SCRAPLING_WORKFLOW_GUIDANCE = (
+    "When the Scrapling MCP scraping tools are available, use them with an explicit scrape escalation ladder instead of "
+    "treating every page fetch as the same operation. Prefer get for public or static pages, escalate to fetch when the "
+    "page needs browser rendering or stateful interaction, and use stealthy_fetch only when lighter routes fail or the "
+    "site clearly needs stealth. Open sessions only for multi-step or stateful scraping, preserve selector/session/provenance "
+    "details in the result, and treat selector-targeted or main-content-only extraction as potentially partial output."
+)
+
+_MCP_WORKFLOW_GUIDANCE_BY_PREFIX = OrderedDict(
+    [
+        ("mcp_claude_context_", CLAUDE_CONTEXT_WORKFLOW_GUIDANCE),
+        ("mcp_scrapling_", SCRAPLING_WORKFLOW_GUIDANCE),
+    ]
+)
+
+
+def build_mcp_workflow_guidance(valid_tool_names: "set[str] | None" = None) -> str:
+    """Return applicable MCP workflow guidance blocks for the loaded tool names."""
+    valid_names = set(valid_tool_names or set())
+    if not valid_names:
+        return ""
+
+    selected = [
+        guidance
+        for prefix, guidance in _MCP_WORKFLOW_GUIDANCE_BY_PREFIX.items()
+        if any(name.startswith(prefix) for name in valid_names)
+    ]
+    return " ".join(selected)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -34,6 +34,18 @@ from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
 
+def _get_repo_context_capability_summary() -> list[dict[str, str]]:
+    """Return read-only repo-context capability summaries for doctor output."""
+    try:
+        from tools.registry import discover_builtin_tools
+        discover_builtin_tools()
+        from agent.capability_catalog import summarize_repo_context_capabilities
+
+        return summarize_repo_context_capabilities()
+    except Exception:
+        return []
+
+
 _PROVIDER_ENV_HINTS = (
     "OPENROUTER_API_KEY",
     "OPENAI_API_KEY",
@@ -130,6 +142,120 @@ def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
 
 
+def _count_doctor_active_jobs() -> tuple[int, int]:
+    jobs_file = HERMES_HOME / "cron" / "jobs.json"
+    if not jobs_file.exists():
+        return 0, 0
+    try:
+        import json
+        with open(jobs_file, encoding="utf-8") as f:
+            data = json.load(f)
+        jobs = data.get("jobs", [])
+        enabled_jobs = [j for j in jobs if j.get("enabled", True)]
+        return len(enabled_jobs), len(jobs)
+    except Exception:
+        return 0, 0
+
+
+def _doctor_health_grade_style(grade: str) -> tuple[str, str, str]:
+    mapping = {
+        "healthy": ("✓", "Healthy", Colors.GREEN),
+        "degraded": ("⚠", "Degraded", Colors.YELLOW),
+        "blocked": ("⛔", "Blocked", Colors.RED),
+        "needs_setup": ("✗", "Needs setup", Colors.RED),
+    }
+    return mapping.get(grade, ("⚠", grade, Colors.YELLOW))
+
+
+def _overall_doctor_health_grade(*, inference_ready: bool, inference_blocked: bool, config_ready: bool, jobs_ok: bool) -> str:
+    if inference_ready and config_ready and jobs_ok:
+        return "healthy"
+    if inference_blocked:
+        return "blocked"
+    if inference_ready or config_ready or jobs_ok:
+        return "degraded"
+    return "needs_setup"
+
+
+def _doctor_health_reason(*, grade: str, inference_ready: bool, inference_blocked: bool, config_ready: bool, jobs_ok: bool) -> str:
+    if grade == "healthy":
+        return "runtime auth available, config present, and automation running"
+    if grade == "blocked":
+        return "configured inference path exists, but auth/runtime access is unavailable"
+    if grade == "degraded":
+        reasons = []
+        if inference_ready:
+            reasons.append("runtime auth available")
+        if not config_ready:
+            reasons.append("config files incomplete")
+        if not jobs_ok:
+            reasons.append("no active automation")
+        return ", ".join(reasons[:3]) if reasons else "partial health only"
+    return "missing usable inference setup and no active automation"
+
+
+def _print_doctor_health_summary() -> None:
+    env_path = HERMES_HOME / '.env'
+    config_path = HERMES_HOME / 'config.yaml'
+    active_jobs, total_jobs = _count_doctor_active_jobs()
+
+    try:
+        from hermes_cli.auth import get_codex_auth_status
+        codex_ready = bool(get_codex_auth_status().get("logged_in"))
+    except Exception:
+        codex_ready = False
+
+    has_provider_env = False
+    if env_path.exists():
+        try:
+            has_provider_env = _has_provider_env_config(env_path.read_text())
+        except Exception:
+            has_provider_env = False
+
+    configured_model = False
+    try:
+        import yaml as _yaml
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                raw_cfg = _yaml.safe_load(f) or {}
+            model_cfg = raw_cfg.get("model")
+            if isinstance(model_cfg, dict):
+                configured_model = bool((model_cfg.get("default") or model_cfg.get("name") or "").strip())
+            elif isinstance(model_cfg, str):
+                configured_model = bool(model_cfg.strip())
+    except Exception:
+        configured_model = False
+
+    print()
+    print(color("◆ Health Summary", Colors.CYAN, Colors.BOLD))
+    inference_ready = codex_ready or has_provider_env
+    inference_blocked = bool(configured_model and not inference_ready)
+    inference_label = "runtime auth available" if inference_ready else ("configured but auth unavailable" if inference_blocked else "needs provider setup")
+    config_ready = env_path.exists() and config_path.exists()
+    jobs_label = f"{active_jobs} active / {total_jobs} total" if total_jobs else "0 scheduled jobs"
+    jobs_ok = active_jobs > 0
+    overall_grade = _overall_doctor_health_grade(
+        inference_ready=inference_ready,
+        inference_blocked=inference_blocked,
+        config_ready=config_ready,
+        jobs_ok=jobs_ok,
+    )
+    overall_reason = _doctor_health_reason(
+        grade=overall_grade,
+        inference_ready=inference_ready,
+        inference_blocked=inference_blocked,
+        config_ready=config_ready,
+        jobs_ok=jobs_ok,
+    )
+    grade_icon, grade_label, grade_color = _doctor_health_grade_style(overall_grade)
+    print(f"  Health:       {color(grade_icon, grade_color)} {color(grade_label, grade_color)}")
+    print(f"  Reason:       {overall_reason}")
+    print(f"  Inference:    {color('✓' if inference_ready else ('⛔' if inference_blocked else '⚠'), Colors.GREEN if inference_ready else (Colors.RED if inference_blocked else Colors.YELLOW))} {inference_label}")
+    config_label = "config + env present" if config_ready else "config files incomplete"
+    print(f"  Config:       {color('✓' if config_ready else '⚠', Colors.GREEN if config_ready else Colors.YELLOW)} {config_label}")
+    print(f"  Automation:   {color('✓' if jobs_ok else '⚠', Colors.GREEN if jobs_ok else Colors.YELLOW)} {jobs_label}")
+
+
 def _check_gateway_service_linger(issues: list[str]) -> None:
     """Warn when a systemd user gateway service will stop after logout."""
     try:
@@ -170,6 +296,7 @@ def run_doctor(args):
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
     # checks (like cronjob management) should see the same context as `hermes`.
     os.environ.setdefault("HERMES_INTERACTIVE", "1")
+    os.environ.setdefault("HERMES_SKIP_MCP_DISCOVERY", "1")
     
     issues = []
     manual_issues = []  # issues that can't be auto-fixed
@@ -179,6 +306,18 @@ def run_doctor(args):
     print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
     print(color("│                 🩺 Hermes Doctor                        │", Colors.CYAN))
     print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+
+    _print_doctor_health_summary()
+
+    repo_context_capabilities = _get_repo_context_capability_summary()
+    if repo_context_capabilities:
+        print()
+        print(color("◆ Repo Context", Colors.CYAN, Colors.BOLD))
+        for item in repo_context_capabilities[:4]:
+            check_ok(f"{item['name']}", f"({item['group']} · {item['readiness_status']})")
+            check_info(
+                f"identity={item['identity_scope']} · workflow={item['workflow']} · results={item['result_mode']}"
+            )
     
     # =========================================================================
     # Check: Python version

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -20,6 +20,19 @@ from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
+
+def _get_repo_context_capability_summary() -> list[dict[str, str]]:
+    """Return read-only repo-context capability summaries for status output."""
+    try:
+        from tools.registry import discover_builtin_tools
+        discover_builtin_tools()
+        from agent.capability_catalog import summarize_repo_context_capabilities
+
+        return summarize_repo_context_capabilities()
+    except Exception:
+        return []
+
+
 def check_mark(ok: bool) -> str:
     if ok:
         return color("✓", Colors.GREEN)
@@ -65,18 +78,161 @@ def _configured_model_label(config: dict) -> str:
     return model or "(not set)"
 
 
-def _effective_provider_label() -> str:
-    """Return the provider label matching current CLI runtime resolution."""
+def _effective_provider_state() -> tuple[str, bool, bool]:
+    """Return provider label plus readiness/blocking flags."""
     requested = resolve_requested_provider()
     try:
         effective = resolve_provider(requested)
+        blocked = False
+        ready = True
     except AuthError:
         effective = requested or "auto"
+        blocked = bool(requested and requested != "auto")
+        ready = False
 
     if effective == "openrouter" and get_env_value("OPENAI_BASE_URL"):
         effective = "custom"
 
-    return provider_label(effective)
+    return provider_label(effective), ready, blocked
+
+
+def _count_configured_api_keys() -> int:
+    env_vars = [
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "GLM_API_KEY",
+        "KIMI_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "TAVILY_API_KEY",
+        "BROWSER_USE_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "FAL_KEY",
+        "TINKER_API_KEY",
+        "WANDB_API_KEY",
+        "ELEVENLABS_API_KEY",
+        "GITHUB_TOKEN",
+    ]
+    count = sum(1 for env_var in env_vars if get_env_value(env_var))
+    from hermes_cli.auth import get_anthropic_key
+    if get_anthropic_key():
+        count += 1
+    return count
+
+
+def _count_configured_platforms() -> int:
+    platform_envs = [
+        "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
+        "WHATSAPP_ENABLED",
+        "SIGNAL_HTTP_URL",
+        "SLACK_BOT_TOKEN",
+        "EMAIL_ADDRESS",
+        "TWILIO_ACCOUNT_SID",
+        "DINGTALK_CLIENT_ID",
+        "FEISHU_APP_ID",
+        "WECOM_BOT_ID",
+        "WECOM_CALLBACK_CORP_ID",
+        "WEIXIN_ACCOUNT_ID",
+        "BLUEBUBBLES_SERVER_URL",
+        "QQ_APP_ID",
+    ]
+    return sum(1 for env_var in platform_envs if os.getenv(env_var, ""))
+
+
+def _count_active_jobs() -> tuple[int, int]:
+    jobs_file = get_hermes_home() / "cron" / "jobs.json"
+    if not jobs_file.exists():
+        return 0, 0
+    import json
+    try:
+        with open(jobs_file, encoding="utf-8") as f:
+            data = json.load(f)
+        jobs = data.get("jobs", [])
+        enabled_jobs = [j for j in jobs if j.get("enabled", True)]
+        return len(enabled_jobs), len(jobs)
+    except Exception:
+        return 0, 0
+
+
+def _health_grade_style(grade: str) -> tuple[str, str, str]:
+    mapping = {
+        "healthy": ("✓", "Healthy", Colors.GREEN),
+        "degraded": ("⚠", "Degraded", Colors.YELLOW),
+        "blocked": ("⛔", "Blocked", Colors.RED),
+        "needs_setup": ("✗", "Needs setup", Colors.RED),
+    }
+    return mapping.get(grade, ("⚠", grade, Colors.YELLOW))
+
+
+def _overall_health_grade(*, inference_ready: bool, inference_blocked: bool, api_key_count: int, platform_count: int, active_jobs: int) -> str:
+    if inference_ready and (platform_count > 0 or active_jobs > 0):
+        return "healthy"
+    if inference_blocked:
+        return "blocked"
+    if inference_ready or api_key_count > 0 or platform_count > 0 or active_jobs > 0:
+        return "degraded"
+    return "needs_setup"
+
+
+def _health_reason(*, grade: str, inference_ready: bool, inference_blocked: bool, api_key_count: int, platform_count: int, active_jobs: int) -> str:
+    if grade == "healthy":
+        if active_jobs > 0 and platform_count > 0:
+            return "inference OK, messaging configured, and automation running"
+        if active_jobs > 0:
+            return "inference OK and automation running"
+        return "inference OK and at least one delivery surface is configured"
+    if grade == "blocked":
+        return "configured inference path exists, but auth/runtime access is unavailable"
+    if grade == "degraded":
+        reasons = []
+        if inference_ready:
+            reasons.append("inference OK")
+        if api_key_count == 0:
+            reasons.append("no API keys configured")
+        if platform_count == 0:
+            reasons.append("no messaging platforms configured")
+        if active_jobs == 0:
+            reasons.append("no active automation")
+        return ", ".join(reasons[:3]) if reasons else "partial capability only"
+    return "missing usable inference setup and no active delivery/automation surfaces"
+
+
+def _print_quick_summary(config: dict) -> None:
+    model_label = _configured_model_label(config)
+    provider_label_text, provider_ready, provider_blocked = _effective_provider_state()
+    api_key_count = _count_configured_api_keys()
+    platform_count = _count_configured_platforms()
+    active_jobs, total_jobs = _count_active_jobs()
+    inference_ready = bool(model_label != "(not set)" and provider_ready)
+    inference_blocked = bool(model_label != "(not set)" and provider_blocked)
+    overall_grade = _overall_health_grade(
+        inference_ready=inference_ready,
+        inference_blocked=inference_blocked,
+        api_key_count=api_key_count,
+        platform_count=platform_count,
+        active_jobs=active_jobs,
+    )
+    overall_reason = _health_reason(
+        grade=overall_grade,
+        inference_ready=inference_ready,
+        inference_blocked=inference_blocked,
+        api_key_count=api_key_count,
+        platform_count=platform_count,
+        active_jobs=active_jobs,
+    )
+    grade_icon, grade_label, grade_color = _health_grade_style(overall_grade)
+
+    print()
+    print(color("◆ Quick Summary", Colors.CYAN, Colors.BOLD))
+    print(f"  Health:       {color(grade_icon, grade_color)} {color(grade_label, grade_color)}")
+    print(f"  Reason:       {overall_reason}")
+    print(f"  Inference:    {check_mark(inference_ready)} {provider_label_text} · {model_label}")
+    print(f"  API Access:   {check_mark(api_key_count > 0)} {api_key_count} API key source(s) configured")
+    print(f"  Messaging:    {check_mark(platform_count > 0)} {platform_count} platform(s) configured")
+    jobs_text = f"{active_jobs} active / {total_jobs} total" if total_jobs else "0 active"
+    print(f"  Automation:   {check_mark(active_jobs > 0)} {jobs_text}")
 
 
 from hermes_constants import is_termux as _is_termux
@@ -91,6 +247,27 @@ def show_status(args):
     print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
     print(color("│                 ⚕ Hermes Agent Status                  │", Colors.CYAN))
     print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+
+    try:
+        config = load_config()
+    except Exception:
+        config = {}
+
+    _print_quick_summary(config)
+
+    repo_context_capabilities = _get_repo_context_capability_summary()
+    if repo_context_capabilities:
+        print()
+        print(color("◆ Repo Context", Colors.CYAN, Colors.BOLD))
+        for item in repo_context_capabilities[:4]:
+            print(
+                "  "
+                f"{item['name']} · {item['group']} · {item['readiness_status']}"
+            )
+            print(
+                "    "
+                f"identity={item['identity_scope']} · workflow={item['workflow']} · results={item['result_mode']}"
+            )
     
     # =========================================================================
     # Environment
@@ -103,13 +280,9 @@ def show_status(args):
     env_path = get_env_path()
     print(f"  .env file:    {check_mark(env_path.exists())} {'exists' if env_path.exists() else 'not found'}")
 
-    try:
-        config = load_config()
-    except Exception:
-        config = {}
-
     print(f"  Model:        {_configured_model_label(config)}")
-    print(f"  Provider:     {_effective_provider_label()}")
+    provider_label_text, _, _ = _effective_provider_state()
+    print(f"  Provider:     {provider_label_text}")
     
     # =========================================================================
     # API Keys
@@ -388,17 +561,9 @@ def show_status(args):
     print()
     print(color("◆ Scheduled Jobs", Colors.CYAN, Colors.BOLD))
     
-    jobs_file = get_hermes_home() / "cron" / "jobs.json"
-    if jobs_file.exists():
-        import json
-        try:
-            with open(jobs_file, encoding="utf-8") as f:
-                data = json.load(f)
-                jobs = data.get("jobs", [])
-                enabled_jobs = [j for j in jobs if j.get("enabled", True)]
-                print(f"  Jobs:         {len(enabled_jobs)} active, {len(jobs)} total")
-        except Exception:
-            print("  Jobs:         (error reading jobs file)")
+    active_jobs, total_jobs = _count_active_jobs()
+    if total_jobs:
+        print(f"  Jobs:         {active_jobs} active, {total_jobs} total")
     else:
         print("  Jobs:         0")
     

--- a/model_tools.py
+++ b/model_tools.py
@@ -23,6 +23,7 @@ Public API (signatures preserved from the original 2,400-line version):
 import json
 import asyncio
 import logging
+import os
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
@@ -139,11 +140,14 @@ def _run_async(coro):
 discover_builtin_tools()
 
 # MCP tool discovery (external MCP servers from config)
-try:
-    from tools.mcp_tool import discover_mcp_tools
-    discover_mcp_tools()
-except Exception as e:
-    logger.debug("MCP tool discovery failed: %s", e)
+if os.environ.get("HERMES_SKIP_MCP_DISCOVERY") == "1":
+    logger.debug("Skipping MCP tool discovery because HERMES_SKIP_MCP_DISCOVERY=1")
+else:
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+        discover_mcp_tools()
+    except Exception as e:
+        logger.debug("MCP tool discovery failed: %s", e)
 
 # Plugin tool discovery (user/project/pip plugins)
 try:
@@ -337,6 +341,41 @@ def get_tool_definitions(
                         "function": {**td["function"], "description": desc},
                     }
                     break
+
+    scrapling_available = {
+        "mcp_scrapling_get",
+        "mcp_scrapling_fetch",
+        "mcp_scrapling_stealthy_fetch",
+    } & available_tool_names
+    scrapling_session_available = {"mcp_scrapling_open_session", "mcp_scrapling_screenshot"} <= available_tool_names
+    if scrapling_available:
+        for i, td in enumerate(filtered_tools):
+            name = td.get("function", {}).get("name")
+            desc = td.get("function", {}).get("description", "")
+            if name == "browser_navigate" and "mcp_scrapling_get" not in desc:
+                desc += (
+                    " For scraping or page extraction, prefer mcp_scrapling_get for public/static pages, "
+                    "escalate to mcp_scrapling_fetch when browser rendering or stateful page context is needed, "
+                    "and reserve mcp_scrapling_stealthy_fetch for sites that clearly require stealth."
+                )
+                if scrapling_session_available:
+                    desc += (
+                        " For multi-step scraping that needs the same page state, open mcp_scrapling_open_session and pair it with "
+                        "mcp_scrapling_screenshot when you need evidence from that same state."
+                    )
+                filtered_tools[i] = {
+                    "type": "function",
+                    "function": {**td["function"], "description": desc},
+                }
+            elif name == "web_extract" and "mcp_scrapling_fetch" not in desc:
+                desc += (
+                    " For page-specific DOM extraction, stateful browsing, or stealth-needed sites, "
+                    "prefer mcp_scrapling_fetch or mcp_scrapling_stealthy_fetch before escalating to full browser control."
+                )
+                filtered_tools[i] = {
+                    "type": "function",
+                    "function": {**td["function"], "description": desc},
+                }
 
     if not quiet_mode:
         if filtered_tools:
@@ -653,6 +692,11 @@ def get_all_tool_names() -> List[str]:
 def get_toolset_for_tool(tool_name: str) -> Optional[str]:
     """Return the toolset a tool belongs to."""
     return registry.get_toolset_for_tool(tool_name)
+
+
+def get_tool_runtime_metadata(tool_name: str) -> Dict[str, object]:
+    """Return structured runtime metadata for a tool."""
+    return registry.get_tool_runtime_metadata(tool_name)
 
 
 def get_available_toolsets() -> Dict[str, dict]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -70,6 +70,7 @@ else:
 from model_tools import (
     get_tool_definitions,
     get_toolset_for_tool,
+    get_tool_runtime_metadata,
     handle_function_call,
     check_toolset_requirements,
 )
@@ -86,6 +87,8 @@ from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    EXECUTION_BOUNDARY_GUIDANCE, CLAUDE_CONTEXT_WORKFLOW_GUIDANCE,
+    SCRAPLING_WORKFLOW_GUIDANCE, build_mcp_workflow_guidance,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -279,6 +282,84 @@ _PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 _MAX_TOOL_WORKERS = 8
+_EXECUTION_SIDE_EFFECT_TOOLS = frozenset({
+    "terminal",
+    "write_file",
+    "patch",
+    "browser_navigate",
+    "browser_click",
+    "browser_type",
+    "browser_press",
+    "send_message",
+    "cronjob",
+})
+
+
+def _tool_has_execution_tag(tool_name: str, tag: str) -> bool:
+    """Return True when a tool advertises *tag* in its runtime metadata.
+
+    Falls back to False when metadata is absent or malformed; callers can still
+    use the legacy hard-coded side-effect set as a compatibility safety net.
+    """
+    try:
+        metadata = get_tool_runtime_metadata(tool_name)
+    except Exception:
+        return False
+    tags = metadata.get("execution_tags") or []
+    return isinstance(tags, list) and tag in tags
+
+
+def _collect_execution_tags_for_tools(tool_names: List[str]) -> List[str]:
+    """Return stable execution tags aggregated across the given tools."""
+    ordered: List[str] = []
+    seen: set[str] = set()
+    for tool_name in tool_names or []:
+        try:
+            metadata = get_tool_runtime_metadata(tool_name)
+        except Exception:
+            metadata = {}
+        for tag in metadata.get("execution_tags") or []:
+            clean = str(tag or "").strip()
+            if not clean or clean in seen:
+                continue
+            ordered.append(clean)
+            seen.add(clean)
+    return ordered
+
+
+def _build_execution_checkpoint(stage: str, tool_names: List[str]) -> str:
+    """Build a concise review/checkpoint instruction from execution tags.
+
+    This is a first execution-policy landing: tool metadata affects the
+    checkpoint guidance the model sees after side-effect work.
+    """
+    tags = set(_collect_execution_tags_for_tools(tool_names))
+    base = {
+        "checkpoint": "run the tool work, then inspect results and verify before finalizing",
+        "review": "inspect changed files/results and verify before finalizing",
+    }.get(stage, "inspect results and verify before finalizing")
+
+    notes: List[str] = []
+    if "filesystem" in tags:
+        notes.append("check changed files/paths carefully")
+    if "process" in tags:
+        notes.append("confirm process/session state is healthy")
+    if "network" in tags:
+        notes.append("verify remote/API effects and returned state")
+    if "messaging" in tags:
+        notes.append("confirm the target boundary and message delivery result")
+    if "browser" in tags:
+        notes.append("re-check page/browser state before continuing")
+    if "scraping" in tags:
+        notes.append("verify scrape route/session provenance and note partial extraction caveats")
+    if "indexing_workflow" in tags:
+        notes.append("treat indexing/search results as partial until status confirms completion")
+    if "shell" in tags:
+        notes.append("review command output before trusting success")
+
+    if notes:
+        return f"{base}; {'; '.join(notes)}"
+    return base
 
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
@@ -1581,6 +1662,11 @@ class AIAgent:
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
         self._todo_store = TodoStore()
+        self._execution_state = {
+            "stage": None,
+            "tools": [],
+            "checkpoint": "",
+        }
         
         # Load config once for memory, skills, and compression sections
         try:
@@ -4415,6 +4501,75 @@ class AIAgent:
             if not self.quiet_mode:
                 self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
         _set_interrupt(False)
+
+    def _set_execution_state(self, stage: Optional[str], tools: List[str], checkpoint: str) -> None:
+        unique_tools = []
+        seen = set()
+        for tool in tools:
+            clean = str(tool or "").strip()
+            if not clean or clean in seen:
+                continue
+            unique_tools.append(clean)
+            seen.add(clean)
+        self._execution_state = {
+            "stage": stage,
+            "tools": unique_tools,
+            "checkpoint": str(checkpoint or "").strip(),
+        }
+
+    def _hydrate_execution_state(self, history: List[Dict[str, Any]]) -> None:
+        """Recover preserved execution-stage state from compressed history."""
+        marker = "[Execution state preserved across context compression]"
+        for msg in reversed(history):
+            if msg.get("role") != "user":
+                continue
+            content = str(msg.get("content", "") or "")
+            if marker not in content:
+                continue
+            stage_match = re.search(r"-\s*stage:\s*(.+)", content)
+            tools_match = re.search(r"-\s*tools:\s*(.+)", content)
+            next_match = re.search(r"-\s*next:\s*(.+)", content)
+            tools = []
+            if tools_match:
+                tools = [t.strip() for t in tools_match.group(1).split(",") if t.strip()]
+            self._set_execution_state(
+                stage_match.group(1).strip() if stage_match else None,
+                tools,
+                next_match.group(1).strip() if next_match else "",
+            )
+            break
+
+    def _format_execution_state_for_injection(self) -> Optional[str]:
+        stage = self._execution_state.get("stage")
+        tools = self._execution_state.get("tools") or []
+        checkpoint = self._execution_state.get("checkpoint", "")
+        if not stage or not tools:
+            return None
+        tool_list = ", ".join(tools)
+        lines = [
+            "[Execution state preserved across context compression]",
+            f"- stage: {stage}",
+            f"- tools: {tool_list}",
+        ]
+        if checkpoint:
+            lines.append(f"- next: {checkpoint}")
+        return "\n".join(lines)
+
+    def _side_effect_tools_in_batch(self, tool_calls) -> List[str]:
+        names = []
+        for tool_call in tool_calls or []:
+            name = getattr(getattr(tool_call, "function", None), "name", "")
+            if not name:
+                continue
+            if _tool_has_execution_tag(name, "side_effect") or name in _EXECUTION_SIDE_EFFECT_TOOLS:
+                names.append(name)
+        deduped = []
+        seen = set()
+        for name in names:
+            if name not in seen:
+                deduped.append(name)
+                seen.add(name)
+        return deduped
     
     @property
     def is_interrupted(self) -> bool:
@@ -4467,6 +4622,11 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
+        if self.valid_tool_names.intersection({"terminal", "browser_navigate", "send_message", "browser_click", "write_file", "patch"}):
+            tool_guidance.append(EXECUTION_BOUNDARY_GUIDANCE)
+        mcp_workflow_guidance = build_mcp_workflow_guidance(self.valid_tool_names)
+        if mcp_workflow_guidance:
+            tool_guidance.append(mcp_workflow_guidance)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
 
@@ -8084,6 +8244,10 @@ class AIAgent:
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
 
+        execution_snapshot = self._format_execution_state_for_injection()
+        if execution_snapshot:
+            compressed.append({"role": "user", "content": execution_snapshot})
+
         self._invalidate_system_prompt()
         new_system_prompt = self._build_system_prompt(system_message)
         self._cached_system_prompt = new_system_prompt
@@ -8160,6 +8324,13 @@ class AIAgent:
         file reads/writes may do so only when their target paths do not overlap.
         """
         tool_calls = assistant_message.tool_calls
+        execution_tools = self._side_effect_tools_in_batch(tool_calls)
+        if execution_tools:
+            self._set_execution_state(
+                "checkpoint",
+                execution_tools,
+                _build_execution_checkpoint("checkpoint", execution_tools),
+            )
 
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
@@ -8173,6 +8344,12 @@ class AIAgent:
                 assistant_message, messages, effective_task_id, api_call_count
             )
         finally:
+            if execution_tools:
+                self._set_execution_state(
+                    "review",
+                    execution_tools,
+                    _build_execution_checkpoint("review", execution_tools),
+                )
             self._executing_tools = False
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:
@@ -9287,6 +9464,8 @@ class AIAgent:
         # recover the todo state from the most recent todo tool response in history)
         if conversation_history and not self._todo_store.has_items():
             self._hydrate_todo_store(conversation_history)
+        if conversation_history and not self._execution_state.get("stage"):
+            self._hydrate_execution_state(conversation_history)
         
         # Prefill messages (few-shot priming) are injected at API-call time only,
         # never stored in the messages list. This keeps them ephemeral: they won't

--- a/tests/agent/test_capability_catalog.py
+++ b/tests/agent/test_capability_catalog.py
@@ -1,0 +1,181 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.registry import ToolRegistry
+
+
+def _dummy_handler(args, **kwargs):
+    return json.dumps({"ok": True})
+
+
+def _make_schema(name="test_tool"):
+    return {
+        "name": name,
+        "description": f"A {name}",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _write_skill(skill_root: Path, name: str, description: str, extra_frontmatter: str = "") -> None:
+    skill_dir = skill_root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"{extra_frontmatter}"
+        "---\n\n"
+        f"# {name}\n\n"
+        "Skill body.\n",
+        encoding="utf-8",
+    )
+
+
+class TestCapabilityCatalog:
+    def test_builds_tool_and_skill_records(self, tmp_path):
+        reg = ToolRegistry()
+        reg.register(
+            name="alpha",
+            toolset="core",
+            schema=_make_schema("alpha"),
+            handler=_dummy_handler,
+            requires_env=["ALPHA_KEY"],
+            runtime_dependencies=["filesystem"],
+            execution_tags=["side_effect"],
+        )
+
+        skills_dir = tmp_path / "skills"
+        _write_skill(skills_dir, "demo-skill", "Demo skill for catalog")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            from agent.capability_catalog import build_capability_catalog, get_capability
+
+            catalog = build_capability_catalog(tool_registry=reg, skills_dir=skills_dir)
+
+        assert catalog["counts"]["tool"] == 1
+        assert catalog["counts"]["skill"] == 1
+
+        tool_record = get_capability("tool:alpha", catalog=catalog)
+        assert tool_record is not None
+        assert tool_record["canonical_name"] == "alpha"
+        assert tool_record["group"] == "core"
+        assert tool_record["required_env"] == ["ALPHA_KEY"]
+        assert tool_record["runtime_dependencies"] == ["filesystem"]
+        assert tool_record["execution_tags"] == ["side_effect"]
+        assert tool_record["readiness"]["status"] == "ready"
+
+        skill_record = get_capability("skill:demo-skill", catalog=catalog)
+        assert skill_record is not None
+        assert skill_record["canonical_name"] == "demo-skill"
+        assert skill_record["group"] == "skill"
+        assert skill_record["readiness"]["status"] == "ready"
+        assert skill_record["source"]["type"] == "skill_frontmatter"
+
+    def test_summarizes_repo_context_capabilities(self, tmp_path):
+        reg = ToolRegistry()
+        reg.register(
+            name="mcp_claude_context_index_codebase",
+            toolset="mcp-claude-context",
+            schema=_make_schema("mcp_claude_context_index_codebase"),
+            handler=_dummy_handler,
+            runtime_dependencies=["filesystem", "mcp_server", "vector_store"],
+            execution_tags=["filesystem", "network", "side_effect", "indexing_workflow"],
+        )
+
+        skills_dir = tmp_path / "skills"
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            from agent.capability_catalog import build_capability_catalog, summarize_repo_context_capabilities
+
+            catalog = build_capability_catalog(tool_registry=reg, skills_dir=skills_dir)
+            summary = summarize_repo_context_capabilities(catalog)
+
+        assert summary == [
+            {
+                "name": "mcp_claude_context_index_codebase",
+                "group": "mcp-claude-context",
+                "readiness_status": "ready",
+                "identity_scope": "absolute_path",
+                "workflow": "index/status/search/clear",
+                "result_mode": "partial_or_complete",
+            }
+        ]
+
+    def test_summarizes_repo_context_capabilities_from_configured_mcp_profiles(self, tmp_path):
+        reg = ToolRegistry()
+        skills_dir = tmp_path / "skills"
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir), patch(
+            "tools.mcp_tool._load_mcp_config",
+            return_value={"claude-context": {"command": "npx"}},
+        ):
+            from agent.capability_catalog import build_capability_catalog, summarize_repo_context_capabilities
+
+            catalog = build_capability_catalog(tool_registry=reg, skills_dir=skills_dir)
+            summary = summarize_repo_context_capabilities(catalog)
+
+        assert any(item["group"] == "mcp-claude-context" for item in summary)
+        assert any(item["identity_scope"] == "absolute_path" for item in summary)
+        assert any(item["workflow"] == "index/status/search/clear" for item in summary)
+
+    def test_tracks_skill_setup_needed_and_health_summary(self, tmp_path):
+        reg = ToolRegistry()
+        reg.register(
+            name="beta",
+            toolset="core",
+            schema=_make_schema("beta"),
+            handler=_dummy_handler,
+        )
+
+        skills_dir = tmp_path / "skills"
+        _write_skill(
+            skills_dir,
+            "needs-secret",
+            "Skill that requires setup",
+            extra_frontmatter="required_environment_variables:\n  - SECRET_TOKEN\n",
+        )
+
+        with (
+            patch.dict(os.environ, {"SECRET_TOKEN": ""}, clear=False),
+        ):
+            from agent.capability_catalog import build_capability_catalog, summarize_capability_health
+
+            catalog = build_capability_catalog(tool_registry=reg, skills_dir=skills_dir)
+            summary = summarize_capability_health(catalog)
+
+        skill_record = next(r for r in catalog["records"] if r["id"] == "skill:needs-secret")
+        assert skill_record["readiness"]["status"] == "setup_needed"
+        assert skill_record["required_env"] == ["SECRET_TOKEN"]
+        assert skill_record["readiness"]["checks"][0]["name"] == "required_environment_variables"
+        assert summary == {
+            "total": 2,
+            "by_kind": {"skill": 1, "tool": 1},
+            "by_status": {"ready": 1, "setup_needed": 1},
+        }
+
+    def test_includes_unsupported_skills_and_command_prerequisites(self, tmp_path):
+        reg = ToolRegistry()
+        reg.register(
+            name="gamma",
+            toolset="core",
+            schema=_make_schema("gamma"),
+            handler=_dummy_handler,
+        )
+
+        skills_dir = tmp_path / "skills"
+        _write_skill(
+            skills_dir,
+            "linux-only",
+            "Linux only skill",
+            extra_frontmatter="platforms:\n  - linux\nprerequisites:\n  commands:\n    - jq\n",
+        )
+
+        from agent.capability_catalog import build_capability_catalog
+
+        catalog = build_capability_catalog(tool_registry=reg, skills_dir=skills_dir)
+        skill_record = next(r for r in catalog["records"] if r["id"] == "skill:linux-only")
+
+        assert skill_record["platform_scope"] == ["linux"]
+        assert skill_record["required_commands"] == ["jq"]
+        assert skill_record["readiness"]["status"] == "unsupported"
+        assert any(check["name"] == "required_commands" for check in skill_record["readiness"]["checks"])

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -13,7 +13,7 @@ import pytest
 import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
-from hermes_cli.doctor import _has_provider_env_config
+from hermes_cli.doctor import _doctor_health_reason, _has_provider_env_config, _overall_doctor_health_grade
 
 
 class TestDoctorPlatformHints:
@@ -52,6 +52,16 @@ class TestProviderEnvDetection:
 
 
 class TestDoctorToolAvailabilityOverrides:
+    def test_doctor_overall_health_grade_levels(self):
+        assert _overall_doctor_health_grade(inference_ready=True, inference_blocked=False, config_ready=True, jobs_ok=True) == "healthy"
+        assert _overall_doctor_health_grade(inference_ready=False, inference_blocked=True, config_ready=True, jobs_ok=False) == "blocked"
+        assert _overall_doctor_health_grade(inference_ready=True, inference_blocked=False, config_ready=False, jobs_ok=False) == "degraded"
+        assert _overall_doctor_health_grade(inference_ready=False, inference_blocked=False, config_ready=False, jobs_ok=False) == "needs_setup"
+
+    def test_doctor_health_reason_levels(self):
+        assert _doctor_health_reason(grade="healthy", inference_ready=True, inference_blocked=False, config_ready=True, jobs_ok=True) == "runtime auth available, config present, and automation running"
+        assert _doctor_health_reason(grade="blocked", inference_ready=False, inference_blocked=True, config_ready=True, jobs_ok=False) == "configured inference path exists, but auth/runtime access is unavailable"
+
     def test_marks_honcho_available_when_configured(self, monkeypatch):
         monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: True)
 
@@ -125,6 +135,84 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
         doctor_mod.run_doctor(Namespace(fix=False))
 
     assert seen["interactive"] == "1"
+
+
+def test_run_doctor_sets_skip_mcp_discovery_env_for_tool_checks(monkeypatch, tmp_path):
+    project_root = tmp_path / "project"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+    monkeypatch.delenv("HERMES_SKIP_MCP_DISCOVERY", raising=False)
+
+    seen = {}
+
+    def fake_check_tool_availability(*args, **kwargs):
+        seen["skip_mcp"] = os.getenv("HERMES_SKIP_MCP_DISCOVERY")
+        raise SystemExit(0)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=fake_check_tool_availability,
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    with pytest.raises(SystemExit):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert seen["skip_mcp"] == "1"
+
+
+def test_doctor_surfaces_repo_context_capability(monkeypatch, tmp_path):
+    project_root = tmp_path / "project"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(hermes_home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "_get_repo_context_capability_summary",
+        lambda: [
+            {
+                "name": "mcp_claude_context_index_codebase",
+                "group": "mcp-claude-context",
+                "readiness_status": "ready",
+                "identity_scope": "absolute_path",
+                "workflow": "index/status/search/clear",
+                "result_mode": "partial_or_complete",
+            }
+        ],
+    )
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "Repo Context" in out
+    assert "mcp_claude_context_index_codebase" in out
+    assert "absolute_path" in out
+    assert "index/status/search/clear" in out
 
 
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):
@@ -207,6 +295,11 @@ class TestDoctorMemoryProviderSection:
 
     def test_no_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+        assert "Health Summary" in out
+        assert "Health:" in out
+        assert "Reason:" in out
+        assert "Inference:" in out
+        assert "Automation:" in out
         assert "Memory Provider" in out
         assert "Built-in memory active" in out
         # Should NOT mention Honcho or Mem0 errors

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,17 +1,60 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from hermes_cli.status import show_status
+from hermes_cli.status import _health_reason, _overall_health_grade, show_status
+
+
+def test_overall_health_grade_levels():
+    assert _overall_health_grade(inference_ready=True, inference_blocked=False, api_key_count=0, platform_count=1, active_jobs=0) == "healthy"
+    assert _overall_health_grade(inference_ready=False, inference_blocked=True, api_key_count=0, platform_count=0, active_jobs=0) == "blocked"
+    assert _overall_health_grade(inference_ready=True, inference_blocked=False, api_key_count=0, platform_count=0, active_jobs=0) == "degraded"
+    assert _overall_health_grade(inference_ready=False, inference_blocked=False, api_key_count=0, platform_count=0, active_jobs=0) == "needs_setup"
+
+
+def test_health_reason_levels():
+    assert _health_reason(grade="healthy", inference_ready=True, inference_blocked=False, api_key_count=0, platform_count=1, active_jobs=1) == "inference OK, messaging configured, and automation running"
+    assert _health_reason(grade="blocked", inference_ready=False, inference_blocked=True, api_key_count=0, platform_count=0, active_jobs=0) == "configured inference path exists, but auth/runtime access is unavailable"
 
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
+    assert "Quick Summary" in output
+    assert "Health:" in output
+    assert "Reason:" in output
+    assert "Degraded" in output
+    assert "API Access:" in output
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_surfaces_repo_context_capability(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with patch(
+        "hermes_cli.status._get_repo_context_capability_summary",
+        return_value=[
+            {
+                "name": "mcp_claude_context_index_codebase",
+                "group": "mcp-claude-context",
+                "readiness_status": "ready",
+                "identity_scope": "absolute_path",
+                "workflow": "index/status/search/clear",
+                "result_mode": "partial_or_complete",
+            }
+        ],
+    ):
+        show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Repo Context" in output
+    assert "mcp_claude_context_index_codebase" in output
+    assert "absolute_path" in output
+    assert "index/status/search/clear" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -21,7 +21,12 @@ from agent.codex_responses_adapter import _chat_messages_to_responses_input, _no
 import run_agent
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.prompt_builder import (
+    DEFAULT_AGENT_IDENTITY,
+    EXECUTION_BOUNDARY_GUIDANCE,
+    CLAUDE_CONTEXT_WORKFLOW_GUIDANCE,
+    SCRAPLING_WORKFLOW_GUIDANCE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -857,6 +862,109 @@ class TestHydrateTodoStore:
         assert not agent._todo_store.has_items()
 
 
+class TestExecutionState:
+    def test_hydrates_from_preserved_history_marker(self, agent):
+        history = [
+            {
+                "role": "user",
+                "content": "[Execution state preserved across context compression]\n- stage: review\n- tools: terminal, write_file\n- next: inspect changed files and verify before finalizing",
+            }
+        ]
+
+        agent._hydrate_execution_state(history)
+
+        assert agent._execution_state["stage"] == "review"
+        assert agent._execution_state["tools"] == ["terminal", "write_file"]
+        assert "verify" in agent._execution_state["checkpoint"]
+
+    def test_build_execution_checkpoint_uses_runtime_tags(self, monkeypatch):
+        metadata_map = {
+            "terminal": {"execution_tags": ["shell", "filesystem", "process", "side_effect"]},
+            "send_message": {"execution_tags": ["messaging", "network", "side_effect"]},
+        }
+        monkeypatch.setattr(run_agent, "get_tool_runtime_metadata", lambda name: metadata_map.get(name, {}))
+
+        checkpoint = run_agent._build_execution_checkpoint("review", ["terminal", "send_message"])
+
+        assert checkpoint.startswith("inspect changed files/results and verify before finalizing")
+        assert "check changed files/paths carefully" in checkpoint
+        assert "confirm process/session state is healthy" in checkpoint
+        assert "verify remote/API effects and returned state" in checkpoint
+        assert "confirm the target boundary and message delivery result" in checkpoint
+        assert "review command output before trusting success" in checkpoint
+
+    def test_build_execution_checkpoint_mentions_scrape_provenance_for_scraping_tools(self, monkeypatch):
+        metadata_map = {
+            "mcp_scrapling_fetch": {"execution_tags": ["network", "browser", "scraping", "side_effect"]},
+        }
+        monkeypatch.setattr(run_agent, "get_tool_runtime_metadata", lambda name: metadata_map.get(name, {}))
+
+        checkpoint = run_agent._build_execution_checkpoint("review", ["mcp_scrapling_fetch"])
+
+        assert "verify remote/API effects and returned state" in checkpoint
+        assert "verify scrape route/session provenance and note partial extraction caveats" in checkpoint
+
+    def test_side_effect_tool_execution_updates_review_state(self, agent):
+        agent.valid_tool_names.add("terminal")
+        tc = _mock_tool_call(name="terminal", arguments='{"command":"pwd"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value="/tmp"):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert agent._execution_state["stage"] == "review"
+        assert agent._execution_state["tools"] == ["terminal"]
+        snapshot = agent._format_execution_state_for_injection()
+        assert snapshot is not None
+        assert "Execution state preserved across context compression" in snapshot
+        assert "stage: review" in snapshot
+        assert "review command output before trusting success" in agent._execution_state["checkpoint"]
+        assert "check changed files/paths carefully" in agent._execution_state["checkpoint"]
+
+    def test_runtime_metadata_side_effect_tool_updates_review_state(self, agent, monkeypatch):
+        agent.valid_tool_names.add("custom_effect")
+        tc = _mock_tool_call(name="custom_effect", arguments='{}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        monkeypatch.setattr(run_agent, "_tool_has_execution_tag", lambda name, tag: name == "custom_effect" and tag == "side_effect")
+        monkeypatch.setattr(run_agent, "get_tool_runtime_metadata", lambda name: {"execution_tags": ["network", "messaging", "side_effect"]} if name == "custom_effect" else {})
+
+        with patch("run_agent.handle_function_call", return_value='{"ok": true}'):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert agent._execution_state["stage"] == "review"
+        assert agent._execution_state["tools"] == ["custom_effect"]
+        assert "verify remote/API effects and returned state" in agent._execution_state["checkpoint"]
+        assert "confirm the target boundary and message delivery result" in agent._execution_state["checkpoint"]
+
+    def test_claude_context_mcp_tool_updates_review_state_from_runtime_metadata(self, agent, monkeypatch):
+        tool_name = "mcp_claude_context_index_codebase"
+        agent.valid_tool_names.add(tool_name)
+        tc = _mock_tool_call(name=tool_name, arguments='{"path":"."}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        monkeypatch.setattr(
+            run_agent,
+            "get_tool_runtime_metadata",
+            lambda name: {
+                "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+                "execution_tags": ["filesystem", "network", "side_effect", "indexing_workflow"],
+            } if name == tool_name else {},
+        )
+
+        with patch("run_agent.handle_function_call", return_value='{"status": "indexing"}'):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert agent._execution_state["stage"] == "review"
+        assert agent._execution_state["tools"] == [tool_name]
+        assert "check changed files/paths carefully" in agent._execution_state["checkpoint"]
+        assert "verify remote/API effects and returned state" in agent._execution_state["checkpoint"]
+        assert "treat indexing/search results as partial until status confirms completion" in agent._execution_state["checkpoint"]
+
+
 class TestBuildSystemPrompt:
     def test_always_has_identity(self, agent):
         prompt = agent._build_system_prompt()
@@ -920,6 +1028,103 @@ class TestBuildSystemPrompt:
         assert "SKILLS_PROMPT" in prompt
         assert mock_skills.call_args.kwargs["available_tools"] == set(toolset_map)
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
+
+    def test_includes_execution_boundary_guidance_when_side_effect_tools_loaded(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "browser_navigate", "send_message"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            prompt = agent._build_system_prompt()
+
+        assert EXECUTION_BOUNDARY_GUIDANCE in prompt
+
+    def test_includes_claude_context_workflow_guidance_when_tools_loaded(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs(
+                    "mcp_claude_context_get_indexing_status",
+                    "mcp_claude_context_index_codebase",
+                    "mcp_claude_context_search_code",
+                ),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            prompt = agent._build_system_prompt()
+
+        assert CLAUDE_CONTEXT_WORKFLOW_GUIDANCE in prompt
+        assert "same absolute path" in prompt
+
+    def test_build_mcp_workflow_guidance_returns_claude_context_and_scrapling_blocks(self):
+        from agent.prompt_builder import build_mcp_workflow_guidance
+
+        guidance = build_mcp_workflow_guidance(
+            {
+                "mcp_claude_context_get_indexing_status",
+                "mcp_scrapling_fetch",
+                "terminal",
+            }
+        )
+
+        assert CLAUDE_CONTEXT_WORKFLOW_GUIDANCE in guidance
+        assert SCRAPLING_WORKFLOW_GUIDANCE in guidance
+        assert guidance.count(CLAUDE_CONTEXT_WORKFLOW_GUIDANCE) == 1
+        assert guidance.count(SCRAPLING_WORKFLOW_GUIDANCE) == 1
+
+    def test_build_mcp_workflow_guidance_empty_without_known_mcp_tools(self):
+        from agent.prompt_builder import build_mcp_workflow_guidance
+
+        assert build_mcp_workflow_guidance({"terminal", "send_message"}) == ""
+
+    def test_includes_scrapling_workflow_guidance_when_tools_loaded(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs(
+                    "mcp_scrapling_get",
+                    "mcp_scrapling_fetch",
+                    "mcp_scrapling_stealthy_fetch",
+                    "mcp_scrapling_open_session",
+                ),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            prompt = agent._build_system_prompt()
+
+        assert SCRAPLING_WORKFLOW_GUIDANCE in prompt
+
+
+class TestExecutionBoundaryGuidance:
+    def test_mentions_local_remote_and_logged_in_boundaries(self):
+        lowered = EXECUTION_BOUNDARY_GUIDANCE.lower()
+        assert "local machine" in lowered
+        assert "remote service" in lowered
+        assert "logged-in" in lowered
+        assert "approval" in lowered
 
 
 class TestToolUseEnforcementConfig:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1040,6 +1040,7 @@ class TestBuildSystemPrompt:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -1063,6 +1064,7 @@ class TestBuildSystemPrompt:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -1109,6 +1111,7 @@ class TestBuildSystemPrompt:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,5 +1,6 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
+import importlib
 import json
 from unittest.mock import ANY, call, patch
 
@@ -8,6 +9,7 @@ import pytest
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -257,6 +259,14 @@ class TestBackwardCompat:
         result = get_toolset_for_tool("totally_nonexistent_tool")
         assert result is None
 
+
+class TestImportSideEffects:
+    def test_skip_mcp_discovery_env_prevents_mcp_connection_attempts(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SKIP_MCP_DISCOVERY", "1")
+        with patch("tools.mcp_tool.discover_mcp_tools", side_effect=AssertionError("should not be called")):
+            import model_tools as model_tools_module
+            importlib.reload(model_tools_module)
+
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
@@ -303,3 +313,132 @@ class TestCoerceNumberInfNan:
         assert _coerce_number("42") == 42
         assert _coerce_number("3.14") == 3.14
         assert _coerce_number("1e3") == 1000
+
+
+class TestDynamicToolDescriptions:
+    def test_browser_navigate_mentions_scrapling_ladder_when_available(self):
+        browser_schema = {
+            "type": "function",
+            "function": {
+                "name": "browser_navigate",
+                "description": (
+                    "Navigate to a URL in the browser. Must be called before other browser tools. "
+                    "For simple information retrieval, prefer web_search or web_extract (faster, cheaper)."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_get = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_get",
+                "description": "Static Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_fetch = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_fetch",
+                "description": "Browser Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_stealth = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_stealthy_fetch",
+                "description": "Stealth Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        with patch("model_tools.registry.get_definitions", return_value=[browser_schema, scrapling_get, scrapling_fetch, scrapling_stealth]):
+            tools = get_tool_definitions(enabled_toolsets=["browser", "mcp"], quiet_mode=True)
+
+        desc = next(t["function"]["description"] for t in tools if t["function"]["name"] == "browser_navigate")
+        assert "mcp_scrapling_get" in desc
+        assert "mcp_scrapling_fetch" in desc
+        assert "mcp_scrapling_stealthy_fetch" in desc
+
+    def test_web_extract_mentions_scrapling_for_stateful_or_stealth_routes(self):
+        web_extract_schema = {
+            "type": "function",
+            "function": {
+                "name": "web_extract",
+                "description": "Extract content from web page URLs. If a URL fails or times out, use the browser tool to access it instead.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_fetch = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_fetch",
+                "description": "Browser Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_stealth = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_stealthy_fetch",
+                "description": "Stealth Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        with patch("model_tools.registry.get_definitions", return_value=[web_extract_schema, scrapling_fetch, scrapling_stealth]):
+            tools = get_tool_definitions(enabled_toolsets=["web", "mcp"], quiet_mode=True)
+
+        desc = next(t["function"]["description"] for t in tools if t["function"]["name"] == "web_extract")
+        assert "mcp_scrapling_fetch" in desc
+        assert "mcp_scrapling_stealthy_fetch" in desc
+
+    def test_browser_navigate_mentions_open_session_for_stateful_scraping(self):
+        browser_schema = {
+            "type": "function",
+            "function": {
+                "name": "browser_navigate",
+                "description": "Navigate to a URL in the browser.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_get = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_get",
+                "description": "Static Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_fetch = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_fetch",
+                "description": "Browser Scrapling fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_session = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_open_session",
+                "description": "Open Scrapling browser session",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        scrapling_shot = {
+            "type": "function",
+            "function": {
+                "name": "mcp_scrapling_screenshot",
+                "description": "Capture Scrapling screenshot",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        with patch("model_tools.registry.get_definitions", return_value=[browser_schema, scrapling_get, scrapling_fetch, scrapling_session, scrapling_shot]):
+            tools = get_tool_definitions(enabled_toolsets=["browser", "mcp"], quiet_mode=True)
+
+        desc = next(t["function"]["description"] for t in tools if t["function"]["name"] == "browser_navigate")
+        assert "mcp_scrapling_open_session" in desc
+        assert "mcp_scrapling_screenshot" in desc

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -88,6 +88,88 @@ class TestLoadMCPConfig:
 # ---------------------------------------------------------------------------
 
 class TestSchemaConversion:
+    def test_known_claude_context_runtime_metadata_exposes_indexing_workflow(self):
+        from tools.mcp_tool import _get_known_mcp_runtime_metadata
+
+        metadata = _get_known_mcp_runtime_metadata("claude-context", "index_codebase")
+
+        assert "filesystem" in metadata["runtime_dependencies"]
+        assert "vector_store" in metadata["runtime_dependencies"]
+        assert "indexing_workflow" in metadata["execution_tags"]
+        assert "side_effect" in metadata["execution_tags"]
+
+    def test_normalizes_claude_context_indexing_status_to_partial(self):
+        from tools.mcp_tool import _normalize_known_mcp_success_payload
+
+        payload = {
+            "result": "ok",
+            "structuredContent": {
+                "status": "indexing",
+                "progress": 42,
+            },
+        }
+
+        normalized = _normalize_known_mcp_success_payload(
+            "claude-context",
+            "get_indexing_status",
+            payload,
+            {"path": "/tmp/repo"},
+        )
+
+        assert normalized["repo_context_result"] == {
+            "codebase_path": "/tmp/repo",
+            "workflow": "index/status/search/clear",
+            "identity_scope": "absolute_path",
+            "state": "indexing",
+            "retrieval_status": "partial",
+        }
+
+    def test_normalizes_claude_context_indexing_status_to_complete(self):
+        from tools.mcp_tool import _normalize_known_mcp_success_payload
+
+        payload = {
+            "result": "ok",
+            "structuredContent": {
+                "status": "indexed",
+            },
+        }
+
+        normalized = _normalize_known_mcp_success_payload(
+            "claude-context",
+            "get_indexing_status",
+            payload,
+            {"path": "/tmp/repo"},
+        )
+
+        assert normalized["repo_context_result"]["retrieval_status"] == "complete"
+
+    def test_make_tool_handler_preserves_structured_content_for_structured_only_results(self):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=SimpleNamespace(
+                content=[],
+                isError=False,
+                structuredContent={"status": "indexing"},
+            )
+        )
+        server = _make_mock_server("claude-context", session=mock_session)
+        _servers["claude-context"] = server
+
+        def fake_run(coro, timeout=30):
+            return asyncio.run(coro)
+
+        try:
+            handler = _make_tool_handler("claude-context", "get_indexing_status", 120)
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=fake_run):
+                result = json.loads(handler({"path": "/tmp/repo"}))
+        finally:
+            _servers.pop("claude-context", None)
+
+        assert result["structuredContent"] == {"status": "indexing"}
+        assert result["repo_context_result"]["retrieval_status"] == "partial"
+
     def test_converts_mcp_tool_to_hermes_schema(self):
         from tools.mcp_tool import _convert_mcp_schema
 
@@ -590,6 +672,168 @@ class TestDiscoverAndRegister:
         assert entry.toolset == "mcp-srv"
 
         _servers.pop("srv", None)
+
+    def test_registers_claude_context_runtime_metadata(self):
+        """Known claude-context MCP tools get Hermes runtime metadata."""
+        from tools.mcp_tool import _register_server_tools
+        from tools.registry import ToolRegistry
+
+        mock_registry = ToolRegistry()
+        server = _make_mock_server(
+            "claude-context",
+            session=MagicMock(),
+            tools=[
+                _make_mcp_tool("index_codebase", "Index codebase"),
+                _make_mcp_tool("search_code", "Search code"),
+                _make_mcp_tool("get_indexing_status", "Get indexing status"),
+                _make_mcp_tool("clear_index", "Clear index"),
+            ],
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            registered = _register_server_tools("claude-context", server, {"command": "npx"})
+
+        assert "mcp_claude_context_index_codebase" in registered
+        assert mock_registry.get_tool_runtime_metadata("mcp_claude_context_index_codebase") == {
+            "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+            "execution_tags": ["filesystem", "network", "side_effect", "indexing_workflow"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_claude_context_search_code") == {
+            "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+            "execution_tags": ["filesystem", "network", "indexing_workflow"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_claude_context_get_indexing_status") == {
+            "runtime_dependencies": ["filesystem", "mcp_server"],
+            "execution_tags": ["filesystem", "indexing_workflow"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_claude_context_clear_index") == {
+            "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+            "execution_tags": ["filesystem", "network", "side_effect", "destructive", "indexing_workflow"],
+        }
+
+    def test_registers_scrapling_runtime_metadata(self):
+        """Known Scrapling MCP tools get Hermes runtime metadata."""
+        from tools.mcp_tool import _register_server_tools
+        from tools.registry import ToolRegistry
+
+        mock_registry = ToolRegistry()
+        server = _make_mock_server(
+            "scrapling",
+            session=MagicMock(),
+            tools=[
+                _make_mcp_tool("get", "Static fetch"),
+                _make_mcp_tool("fetch", "Browser fetch"),
+                _make_mcp_tool("stealthy_fetch", "Stealth browser fetch"),
+                _make_mcp_tool("open_session", "Open browser session"),
+                _make_mcp_tool("list_sessions", "List sessions"),
+                _make_mcp_tool("close_session", "Close session"),
+                _make_mcp_tool("screenshot", "Capture screenshot"),
+            ],
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            registered = _register_server_tools("scrapling", server, {"command": "scrapling"})
+
+        assert "mcp_scrapling_get" in registered
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_get") == {
+            "runtime_dependencies": ["mcp_server", "network"],
+            "execution_tags": ["network", "scraping"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_fetch") == {
+            "runtime_dependencies": ["mcp_server", "network", "browser_session"],
+            "execution_tags": ["network", "browser", "scraping", "side_effect"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_stealthy_fetch") == {
+            "runtime_dependencies": ["mcp_server", "network", "browser_session"],
+            "execution_tags": ["network", "browser", "scraping", "side_effect"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_open_session") == {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping", "side_effect"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_list_sessions") == {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_close_session") == {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping", "side_effect"],
+        }
+        assert mock_registry.get_tool_runtime_metadata("mcp_scrapling_screenshot") == {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping"],
+        }
+
+    def test_normalizes_scrapling_fetch_result(self):
+        from tools.mcp_tool import _normalize_known_mcp_success_payload
+
+        payload = {
+            "result": "# Example title\n\nBody text",
+            "structuredContent": {
+                "status": 200,
+                "content": ["# Example title", "Body text"],
+                "url": "https://example.com/page",
+            },
+        }
+
+        normalized = _normalize_known_mcp_success_payload(
+            "scrapling",
+            "fetch",
+            payload,
+            {"session_id": "sess-1", "css_selector": "main", "main_content_only": True},
+        )
+
+        assert normalized["scrape_result"]["source_url"] == "https://example.com/page"
+        assert normalized["scrape_result"]["route_used"] == "fetch"
+        assert normalized["scrape_result"]["session_id"] == "sess-1"
+        assert normalized["scrape_result"]["selector_used"] == "main"
+        assert normalized["scrape_result"]["is_partial"] is True
+        assert "selector-targeted extraction" in normalized["scrape_result"]["caveats"]
+
+    def test_normalizes_scrapling_open_session_result(self):
+        from tools.mcp_tool import _normalize_known_mcp_success_payload
+
+        payload = {
+            "result": "Session opened",
+            "structuredContent": {
+                "session_id": "sess-42",
+                "url": "https://example.com/login",
+            },
+        }
+
+        normalized = _normalize_known_mcp_success_payload(
+            "scrapling",
+            "open_session",
+            payload,
+            {"url": "https://example.com/login"},
+        )
+
+        assert normalized["session_result"]["action"] == "open_session"
+        assert normalized["session_result"]["session_id"] == "sess-42"
+        assert normalized["session_result"]["source_url"] == "https://example.com/login"
+        assert normalized["session_result"]["is_active"] is True
+
+    def test_normalizes_scrapling_screenshot_result(self):
+        from tools.mcp_tool import _normalize_known_mcp_success_payload
+
+        payload = {
+            "result": "/tmp/example.png",
+            "structuredContent": {
+                "path": "/tmp/example.png",
+                "url": "https://example.com/page",
+            },
+        }
+
+        normalized = _normalize_known_mcp_success_payload(
+            "scrapling",
+            "screenshot",
+            payload,
+            {"session_id": "sess-9", "url": "https://example.com/page"},
+        )
+
+        assert normalized["screenshot_result"]["session_id"] == "sess-9"
+        assert normalized["screenshot_result"]["source_url"] == "https://example.com/page"
+        assert normalized["screenshot_result"]["screenshot_path"] == "/tmp/example.png"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -5,7 +5,7 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
-from tools.registry import ToolRegistry, discover_builtin_tools
+from tools.registry import ToolRegistry, discover_builtin_tools, registry
 
 
 def _dummy_handler(args, **kwargs):
@@ -31,6 +31,40 @@ class TestRegisterAndDispatch:
         )
         result = json.loads(reg.dispatch("alpha", {}))
         assert result == {"ok": True}
+
+    def test_register_preserves_runtime_metadata(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="alpha",
+            toolset="core",
+            schema=_make_schema("alpha"),
+            handler=_dummy_handler,
+            runtime_dependencies=["browser_session", "filesystem"],
+            execution_tags=["network", "side_effect"],
+        )
+
+        entry = reg.get_entry("alpha")
+        assert entry is not None
+        assert entry.runtime_dependencies == ["browser_session", "filesystem"]
+        assert entry.execution_tags == ["network", "side_effect"]
+
+        metadata = reg.get_tool_runtime_metadata("alpha")
+        assert metadata == {
+            "runtime_dependencies": ["browser_session", "filesystem"],
+            "execution_tags": ["network", "side_effect"],
+        }
+
+    def test_runtime_metadata_defaults_to_empty_lists(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="alpha",
+            toolset="core",
+            schema=_make_schema("alpha"),
+            handler=_dummy_handler,
+        )
+
+        metadata = reg.get_tool_runtime_metadata("alpha")
+        assert metadata == {"runtime_dependencies": [], "execution_tags": []}
 
     def test_dispatch_passes_args(self):
         reg = ToolRegistry()
@@ -118,6 +152,41 @@ class TestUnknownToolDispatch:
         result = json.loads(reg.dispatch("nonexistent", {}))
         assert "error" in result
         assert "Unknown tool" in result["error"]
+
+
+class TestBuiltInRuntimeMetadata:
+    def test_terminal_runtime_metadata_registered(self):
+        discover_builtin_tools()
+        metadata = registry.get_tool_runtime_metadata("terminal")
+        assert "shell_session" in metadata["runtime_dependencies"]
+        assert "shell" in metadata["execution_tags"]
+        assert "side_effect" in metadata["execution_tags"]
+
+    def test_process_runtime_metadata_registered(self):
+        discover_builtin_tools()
+        metadata = registry.get_tool_runtime_metadata("process")
+        assert "shell_session" in metadata["runtime_dependencies"]
+        assert "background_process_registry" in metadata["runtime_dependencies"]
+        assert "process" in metadata["execution_tags"]
+        assert "background_process" in metadata["execution_tags"]
+        assert "long_running" in metadata["execution_tags"]
+        assert "side_effect" in metadata["execution_tags"]
+
+    def test_browser_runtime_metadata_registered(self):
+        discover_builtin_tools()
+        metadata = registry.get_tool_runtime_metadata("browser_navigate")
+        assert metadata["runtime_dependencies"] == ["browser_session"]
+        assert "browser" in metadata["execution_tags"]
+        assert "network" in metadata["execution_tags"]
+
+    def test_send_message_runtime_metadata_registered(self):
+        discover_builtin_tools()
+        metadata = registry.get_tool_runtime_metadata("send_message")
+        assert "messaging_gateway" in metadata["runtime_dependencies"]
+        assert "messaging" in metadata["execution_tags"]
+        assert "network" in metadata["execution_tags"]
+        assert "external_delivery" in metadata["execution_tags"]
+        assert "side_effect" in metadata["execution_tags"]
 
 
 class TestToolsetAvailability:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2552,6 +2552,9 @@ if __name__ == "__main__":
 from tools.registry import registry, tool_error
 
 _BROWSER_SCHEMA_MAP = {s["name"]: s for s in BROWSER_TOOL_SCHEMAS}
+_BROWSER_RUNTIME_DEPENDENCIES = ["browser_session"]
+_BROWSER_ACTION_TAGS = ["browser", "side_effect"]
+_BROWSER_OBSERVATION_TAGS = ["browser", "observation"]
 
 registry.register(
     name="browser_navigate",
@@ -2560,6 +2563,8 @@ registry.register(
     handler=lambda args, **kw: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🌐",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_ACTION_TAGS + ["network"],
 )
 registry.register(
     name="browser_snapshot",
@@ -2569,6 +2574,8 @@ registry.register(
         full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
     check_fn=check_browser_requirements,
     emoji="📸",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_OBSERVATION_TAGS,
 )
 registry.register(
     name="browser_click",
@@ -2577,6 +2584,8 @@ registry.register(
     handler=lambda args, **kw: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👆",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_ACTION_TAGS,
 )
 registry.register(
     name="browser_type",
@@ -2585,6 +2594,8 @@ registry.register(
     handler=lambda args, **kw: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="⌨️",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_ACTION_TAGS,
 )
 registry.register(
     name="browser_scroll",
@@ -2593,6 +2604,8 @@ registry.register(
     handler=lambda args, **kw: browser_scroll(direction=args.get("direction", "down"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="📜",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_ACTION_TAGS,
 )
 registry.register(
     name="browser_back",
@@ -2601,6 +2614,8 @@ registry.register(
     handler=lambda args, **kw: browser_back(task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="◀️",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_ACTION_TAGS,
 )
 registry.register(
     name="browser_press",
@@ -2609,6 +2624,8 @@ registry.register(
     handler=lambda args, **kw: browser_press(key=args.get("key", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="⌨️",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_ACTION_TAGS,
 )
 
 registry.register(
@@ -2618,6 +2635,8 @@ registry.register(
     handler=lambda args, **kw: browser_get_images(task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖼️",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_OBSERVATION_TAGS,
 )
 registry.register(
     name="browser_vision",
@@ -2626,6 +2645,8 @@ registry.register(
     handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👁️",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_OBSERVATION_TAGS,
 )
 registry.register(
     name="browser_console",
@@ -2634,4 +2655,6 @@ registry.register(
     handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖥️",
+    runtime_dependencies=_BROWSER_RUNTIME_DEPENDENCIES,
+    execution_tags=_BROWSER_OBSERVATION_TAGS,
 )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -248,6 +248,153 @@ _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
 
+_KNOWN_MCP_RUNTIME_PROFILES = {
+    "claude-context": {
+        "index_codebase": {
+            "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+            "execution_tags": ["filesystem", "network", "side_effect", "indexing_workflow"],
+        },
+        "search_code": {
+            "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+            "execution_tags": ["filesystem", "network", "indexing_workflow"],
+        },
+        "get_indexing_status": {
+            "runtime_dependencies": ["filesystem", "mcp_server"],
+            "execution_tags": ["filesystem", "indexing_workflow"],
+        },
+        "clear_index": {
+            "runtime_dependencies": ["filesystem", "mcp_server", "vector_store"],
+            "execution_tags": ["filesystem", "network", "side_effect", "destructive", "indexing_workflow"],
+        },
+    },
+    "scrapling": {
+        "get": {
+            "runtime_dependencies": ["mcp_server", "network"],
+            "execution_tags": ["network", "scraping"],
+        },
+        "fetch": {
+            "runtime_dependencies": ["mcp_server", "network", "browser_session"],
+            "execution_tags": ["network", "browser", "scraping", "side_effect"],
+        },
+        "stealthy_fetch": {
+            "runtime_dependencies": ["mcp_server", "network", "browser_session"],
+            "execution_tags": ["network", "browser", "scraping", "side_effect"],
+        },
+        "open_session": {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping", "side_effect"],
+        },
+        "list_sessions": {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping"],
+        },
+        "close_session": {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping", "side_effect"],
+        },
+        "screenshot": {
+            "runtime_dependencies": ["mcp_server", "browser_session"],
+            "execution_tags": ["browser", "scraping"],
+        },
+    },
+}
+
+
+def _get_known_mcp_runtime_metadata(server_name: str, tool_name: str) -> dict:
+    """Return Hermes-side runtime metadata for known MCP server/tool pairs."""
+    server_profile = _KNOWN_MCP_RUNTIME_PROFILES.get(server_name, {})
+    return dict(server_profile.get(tool_name, {}))
+
+
+def _normalize_known_mcp_success_payload(server_name: str, tool_name: str, payload: dict, args: dict | None = None) -> dict:
+    """Return a normalized success payload for known MCP integrations.
+
+    Keeps the original MCP result intact and adds Hermes-side structured helpers
+    when a server/tool pair has a stable higher-level result shape.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    if payload.get("error") is not None:
+        return payload
+    args = args or {}
+
+    if server_name == "claude-context" and tool_name == "get_indexing_status":
+        structured = payload.get("structuredContent")
+        if isinstance(structured, dict):
+            state = str(structured.get("status") or structured.get("state") or "unknown").strip() or "unknown"
+            retrieval_status = "unknown"
+            if state == "indexing":
+                retrieval_status = "partial"
+            elif state == "indexed":
+                retrieval_status = "complete"
+            normalized = {
+                "codebase_path": args.get("path") or structured.get("path"),
+                "workflow": "index/status/search/clear",
+                "identity_scope": "absolute_path",
+                "state": state,
+                "retrieval_status": retrieval_status,
+            }
+            new_payload = dict(payload)
+            new_payload["repo_context_result"] = normalized
+            return new_payload
+
+    if server_name == "scrapling" and tool_name in {"get", "fetch", "stealthy_fetch"}:
+        structured = payload.get("structuredContent")
+        if isinstance(structured, dict):
+            content = structured.get("content")
+            joined = "\n\n".join(str(item) for item in content) if isinstance(content, list) else str(payload.get("result", "") or "")
+            caveats: list[str] = []
+            if args.get("css_selector"):
+                caveats.append("selector-targeted extraction")
+            if args.get("main_content_only"):
+                caveats.append("main-content-only extraction")
+            if tool_name == "stealthy_fetch":
+                caveats.append("stealth route used")
+            normalized = {
+                "source_url": structured.get("url") or args.get("url"),
+                "route_used": tool_name,
+                "title": None,
+                "content_text": joined,
+                "content_markdown": joined,
+                "selector_used": args.get("css_selector"),
+                "session_id": args.get("session_id"),
+                "screenshot_path": None,
+                "is_partial": bool(args.get("css_selector") or args.get("main_content_only")),
+                "caveats": caveats,
+            }
+            new_payload = dict(payload)
+            new_payload["scrape_result"] = normalized
+            return new_payload
+
+    if server_name == "scrapling" and tool_name in {"open_session", "close_session"}:
+        structured = payload.get("structuredContent")
+        if isinstance(structured, dict):
+            session_id = structured.get("session_id") or args.get("session_id")
+            normalized = {
+                "action": tool_name,
+                "session_id": session_id,
+                "source_url": structured.get("url") or args.get("url"),
+                "is_active": tool_name == "open_session",
+            }
+            new_payload = dict(payload)
+            new_payload["session_result"] = normalized
+            return new_payload
+
+    if server_name == "scrapling" and tool_name == "screenshot":
+        structured = payload.get("structuredContent")
+        if isinstance(structured, dict):
+            screenshot_path = structured.get("path") or structured.get("screenshot_path") or payload.get("result")
+            normalized = {
+                "session_id": args.get("session_id") or structured.get("session_id"),
+                "source_url": structured.get("url") or args.get("url"),
+                "screenshot_path": screenshot_path,
+            }
+            new_payload = dict(payload)
+            new_payload["screenshot_result"] = normalized
+            return new_payload
+
+    return payload
+
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
     "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR",
@@ -1956,12 +2103,20 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
                 if text_result:
-                    return json.dumps({
+                    payload = {
                         "result": text_result,
                         "structuredContent": structured,
-                    }, ensure_ascii=False)
-                return json.dumps({"result": structured}, ensure_ascii=False)
-            return json.dumps({"result": text_result}, ensure_ascii=False)
+                    }
+                else:
+                    payload = {
+                        "result": structured,
+                        "structuredContent": structured,
+                    }
+                payload = _normalize_known_mcp_success_payload(server_name, tool_name, payload, args)
+                return json.dumps(payload, ensure_ascii=False)
+            payload = {"result": text_result}
+            payload = _normalize_known_mcp_success_payload(server_name, tool_name, payload, args)
+            return json.dumps(payload, ensure_ascii=False)
 
         def _call_once():
             return _run_on_mcp_loop(_call(), timeout=tool_timeout)
@@ -2594,6 +2749,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
         schema = _convert_mcp_schema(name, mcp_tool)
         tool_name_prefixed = schema["name"]
+        runtime_metadata = _get_known_mcp_runtime_metadata(name, mcp_tool.name)
 
         # Guard against collisions with built-in (non-MCP) tools.
         existing_toolset = registry.get_toolset_for_tool(tool_name_prefixed)
@@ -2613,6 +2769,8 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=_make_check_fn(name),
             is_async=False,
             description=schema["description"],
+            runtime_dependencies=runtime_metadata.get("runtime_dependencies"),
+            execution_tags=runtime_metadata.get("execution_tags"),
         )
         registered_names.append(tool_name_prefixed)
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1351,4 +1351,6 @@ registry.register(
     schema=PROCESS_SCHEMA,
     handler=_handle_process,
     emoji="⚙️",
+    runtime_dependencies=["shell_session", "background_process_registry"],
+    execution_tags=["process", "background_process", "long_running", "side_effect"],
 )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -74,17 +74,24 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
 
 
 class ToolEntry:
-    """Metadata for a single registered tool."""
+    """Metadata for a single registered tool.
+
+    ``runtime_dependencies`` and ``execution_tags`` are a first landing step
+    toward a more typed action/runtime model inspired by browser-use and other
+    agent runtimes. They let tools describe the runtime capabilities and guard
+    surfaces they rely on without changing the OpenAI tool schema itself.
+    """
 
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars",
+        "max_result_size_chars", "runtime_dependencies", "execution_tags",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None):
+                 max_result_size_chars=None, runtime_dependencies=None,
+                 execution_tags=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -95,6 +102,8 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.runtime_dependencies = list(runtime_dependencies or [])
+        self.execution_tags = list(execution_tags or [])
 
 
 class ToolRegistry:
@@ -185,8 +194,17 @@ class ToolRegistry:
         description: str = "",
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
+        runtime_dependencies: list[str] | None = None,
+        execution_tags: list[str] | None = None,
     ):
-        """Register a tool.  Called at module-import time by each tool file."""
+        """Register a tool.  Called at module-import time by each tool file.
+
+        ``runtime_dependencies`` is for runtime capabilities the handler expects
+        (for example ``browser_session`` or ``filesystem``). ``execution_tags``
+        marks side-effect surfaces or guard domains (for example ``network`` or
+        ``destructive``) so future runtime/watchdog layers can reason about them
+        without scraping prose descriptions.
+        """
         with self._lock:
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
@@ -222,6 +240,8 @@ class ToolRegistry:
                 description=description or schema.get("description", ""),
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
+                runtime_dependencies=runtime_dependencies,
+                execution_tags=execution_tags,
             )
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
@@ -311,6 +331,21 @@ class ToolRegistry:
     # ------------------------------------------------------------------
     # Query helpers  (replace redundant dicts in model_tools.py)
     # ------------------------------------------------------------------
+
+    def get_tool_runtime_metadata(self, name: str) -> Dict[str, object]:
+        """Return structured runtime metadata for a tool.
+
+        This keeps execution-surface hints out of the OpenAI-facing schema while
+        making them queryable for future dependency injection, watchdog, and
+        policy layers.
+        """
+        entry = self.get_entry(name)
+        if not entry:
+            return {}
+        return {
+            "runtime_dependencies": list(entry.runtime_dependencies),
+            "execution_tags": list(entry.execution_tags),
+        }
 
     def get_max_result_size(self, name: str, default: int | float | None = None) -> int | float:
         """Return per-tool max result size, or *default* (or global default)."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1520,4 +1520,6 @@ registry.register(
     handler=send_message_tool,
     check_fn=_check_send_message,
     emoji="📨",
+    runtime_dependencies=["messaging_gateway"],
+    execution_tags=["messaging", "network", "external_delivery", "side_effect"],
 )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2117,4 +2117,6 @@ registry.register(
     check_fn=check_terminal_requirements,
     emoji="💻",
     max_result_size_chars=100_000,
+    runtime_dependencies=["shell_session"],
+    execution_tags=["shell", "filesystem", "process", "side_effect"],
 )


### PR DESCRIPTION
## Summary
- add repo-context capability catalog and surface it in status/doctor
- add MCP runtime metadata + workflow guidance for claude-context and scrapling
- preserve structured-only MCP results and normalize indexing workflow states/checkpoints
- add regression coverage for runtime metadata, prompt guidance, and normalization

## Test Plan
- pytest tests/tools/test_mcp_tool.py tests/run_agent/test_run_agent.py tests/hermes_cli/test_status.py tests/hermes_cli/test_doctor.py tests/agent/test_capability_catalog.py tests/tools/test_registry.py tests/test_model_tools.py -q