### PR TITLE
fix(agent): preserve direct image blocks and correct stale session api_mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1041,6 +1041,8 @@ class GatewayRunner:
         (provider/api_key/base_url/api_mode), prefer it directly instead of
         resolving fresh global runtime state first.
         """
+        from hermes_cli.providers import determine_api_mode
+
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
             try:
@@ -1058,6 +1060,23 @@ class GatewayRunner:
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
             }
+            override_provider = (override_runtime.get("provider") or "").strip().lower()
+            override_base_url = override_runtime.get("base_url") or ""
+            inferred_api_mode = determine_api_mode(override_provider, override_base_url)
+            if (
+                override_runtime.get("api_mode") == "anthropic_messages"
+                and inferred_api_mode != "anthropic_messages"
+            ):
+                logger.warning(
+                    "Correcting stale session override api_mode for session=%s provider=%s base_url=%s: %s -> %s",
+                    (resolved_session_key or "")[:30],
+                    override_provider,
+                    override_base_url,
+                    override_runtime.get("api_mode"),
+                    inferred_api_mode,
+                )
+                override_runtime["api_mode"] = inferred_api_mode
+                override["api_mode"] = inferred_api_mode
             if override_runtime.get("api_key"):
                 logger.debug(
                     "Session model override (fast): session=%s config_model=%s -> override_model=%s provider=%s",

--- a/run_agent.py
+++ b/run_agent.py
@@ -6709,7 +6709,7 @@ class AIAgent:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
             _transport = self._get_anthropic_transport()
-            anthropic_messages = self._prepare_anthropic_messages_for_api(api_messages)
+            anthropic_messages = api_messages
             ctx_len = getattr(self, "context_compressor", None)
             ctx_len = ctx_len.context_length if ctx_len else None
             ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -75,7 +75,7 @@ async def test_new_command_clears_session_model_override():
     runner._session_model_overrides[session_key] = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
@@ -108,14 +108,14 @@ async def test_new_command_only_clears_own_session():
     runner._session_model_overrides[session_key] = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
     runner._session_model_overrides[other_key] = {
         "model": "claude-sonnet-4-6",
         "provider": "anthropic",
-        "api_key": "sk-ant-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "anthropic",
     }
@@ -124,3 +124,28 @@ async def test_new_command_only_clears_own_session():
 
     assert session_key not in runner._session_model_overrides
     assert other_key in runner._session_model_overrides
+
+
+def test_resolve_session_runtime_recomputes_stale_override_api_mode_for_custom_openai_endpoint():
+    """A stale override api_mode must not force custom /v1 endpoints onto Anthropic path."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "custom",
+        "api_key": "***",
+        "base_url": "http://192.168.50.81:8317/v1",
+        "api_mode": "anthropic_messages",
+    }
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=_make_source(),
+        session_key=session_key,
+        user_config={},
+    )
+
+    assert model == "gpt-5.4"
+    assert runtime["provider"] == "custom"
+    assert runtime["base_url"] == "http://192.168.50.81:8317/v1"
+    assert runtime["api_mode"] == "chat_completions"
+    assert runner._session_model_overrides[session_key]["api_mode"] == "chat_completions"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3437,7 +3437,7 @@ class TestBuildApiKwargsAnthropicMaxTokens:
 
 
 class TestAnthropicImageFallback:
-    def test_build_api_kwargs_converts_multimodal_user_image_to_text(self, agent):
+    def test_build_api_kwargs_passes_multimodal_user_image_blocks_through(self, agent):
         agent.api_mode = "anthropic_messages"
         agent.reasoning_config = None
 
@@ -3450,7 +3450,7 @@ class TestAnthropicImageFallback:
         }]
 
         with (
-            patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(return_value=json.dumps({"success": True, "analysis": "A cat sitting on a chair."}))),
+            patch.object(agent, "_describe_image_for_anthropic_fallback") as mock_describe,
             patch("agent.anthropic_adapter.build_anthropic_kwargs") as mock_build,
         ):
             mock_build.return_value = {"model": "claude-sonnet-4-20250514", "messages": [], "max_tokens": 4096}
@@ -3461,12 +3461,10 @@ class TestAnthropicImageFallback:
             mock_build.call_args.args,
         ))
         transformed = kwargs["messages"]
-        assert isinstance(transformed[0]["content"], str)
-        assert "A cat sitting on a chair." in transformed[0]["content"]
-        assert "Can you see this now?" in transformed[0]["content"]
-        assert "vision_analyze with image_url: https://example.com/cat.png" in transformed[0]["content"]
+        assert transformed[0]["content"] == api_messages[0]["content"]
+        mock_describe.assert_not_called()
 
-    def test_build_api_kwargs_reuses_cached_image_analysis_for_duplicate_images(self, agent):
+    def test_build_api_kwargs_preserves_duplicate_image_blocks_without_fallback(self, agent):
         agent.api_mode = "anthropic_messages"
         agent.reasoning_config = None
         data_url = "data:image/png;base64,QUFBQQ=="
@@ -3488,15 +3486,19 @@ class TestAnthropicImageFallback:
             },
         ]
 
-        mock_vision = AsyncMock(return_value=json.dumps({"success": True, "analysis": "A small test image."}))
         with (
-            patch("tools.vision_tools.vision_analyze_tool", new=mock_vision),
+            patch.object(agent, "_describe_image_for_anthropic_fallback") as mock_describe,
             patch("agent.anthropic_adapter.build_anthropic_kwargs") as mock_build,
         ):
             mock_build.return_value = {"model": "claude-sonnet-4-20250514", "messages": [], "max_tokens": 4096}
             agent._build_api_kwargs(api_messages)
 
-        assert mock_vision.await_count == 1
+        kwargs = mock_build.call_args.kwargs or dict(zip(
+            ["model", "messages", "tools", "max_tokens", "reasoning_config"],
+            mock_build.call_args.args,
+        ))
+        assert kwargs["messages"] == api_messages
+        mock_describe.assert_not_called()
 
 
 class TestFallbackAnthropicProvider:


### PR DESCRIPTION
## Summary
- correct stale per-session override `api_mode` when a custom `/v1` runtime is no longer Anthropic
- preserve direct multimodal image blocks on the Anthropic messages path instead of forcing local vision-text fallback
- add regression coverage for both stale session override normalization and image-block passthrough

## Test Plan
- [x] `pytest -q tests/gateway/test_session_model_reset.py tests/run_agent/test_run_agent.py`

Closes #16000
