### PR TITLE
fix(telegram): skip fallback IPs when proxy is detected to prevent connection deadlock

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -715,6 +715,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
             proxy_targets = ["api.telegram.org", *fallback_ips]
             proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
+            if proxy_url:
+                fallback_ips = []
+                proxy_targets = ["api.telegram.org"]
             if fallback_ips and not proxy_url and not disable_fallback:
                 logger.info(
                     "[%s] Telegram fallback IPs active: %s",


### PR DESCRIPTION
Fixes #8761. When proxy_url is correctly resolved via `resolve_proxy_url`, `telegram.py` does not pass it to `HTTPXRequest` if `fallback_ips` is non-empty. It constructed `TelegramFallbackTransport(fallback_ips)` instead, which ignores the proxy and causes DoH/SNI deadlocks in proxy environments. This generic fix checks if `proxy_url` is valid and if so, clears `fallback_ips` and `proxy_targets`, prioritizing the explicit proxy configuration.