### PR TITLE
fix(dashboard): keep chat alive across sidebar navigation

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1548,9 +1548,6 @@ def _(rid, params: dict) -> dict:
             finally:
                 _clear_session_context(tokens)
 
-            db = _get_db()
-            if db is not None:
-                db.create_session(key, source="tui", model=_resolve_model())
             session["agent"] = agent
 
             try:
@@ -2225,6 +2222,16 @@ def _(rid, params: dict) -> dict:
 
             approval_token = set_current_session_key(session["session_key"])
             session_tokens = _set_session_context(session["session_key"])
+
+            # Create DB session record lazily on first user message.
+            db = _get_db()
+            if db is not None and not db.get_session(session["session_key"]):
+                db.create_session(
+                    session["session_key"],
+                    source="tui",
+                    model=_resolve_model(),
+                )
+
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import {
   Menu,
   MessageSquare,
   Package,
+  Plus,
   Puzzle,
   RotateCw,
   Settings,
@@ -249,6 +250,7 @@ function buildRoutes(
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const { manifests } = usePlugins();
   const { theme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -435,7 +437,7 @@ export default function App() {
                     ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
                     : label;
                   return (
-                    <li key={path}>
+                    <li key={path} className={cn(path === "/chat" && "flex items-center")}>
                       <NavLink
                         to={path}
                         end={path === "/sessions"}
@@ -444,6 +446,7 @@ export default function App() {
                           cn(
                             "group relative flex items-center gap-3",
                             "px-5 py-2.5",
+                            path === "/chat" && "flex-1 min-w-0",
                             "font-mondwest text-[0.8rem] tracking-[0.12em]",
                             "whitespace-nowrap transition-colors cursor-pointer",
                             "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
@@ -476,6 +479,27 @@ export default function App() {
                           </>
                         )}
                       </NavLink>
+                      {embeddedChat && path === "/chat" && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            navigate("/chat?new=1");
+                            closeMobile();
+                          }}
+                          title="New session"
+                          aria-label="Start a new session"
+                          className={cn(
+                            "flex items-center justify-center px-3 py-2.5",
+                            "text-midground/60 hover:text-midground",
+                            "opacity-0 group-hover:opacity-100",
+                            "transition-opacity duration-150 cursor-pointer",
+                            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
+                          )}
+                        >
+                          <Plus className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                     </li>
                   );
                 })}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -437,14 +437,19 @@ export default function App() {
                     ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
                     : label;
                   return (
-                    <li key={path} className={cn(path === "/chat" && "flex items-center")}>
+                    <li key={path} className={cn("group relative", path === "/chat" && "flex items-center")}>
+                      {/* Row background overlay — covers both NavLink and + button */}
+                      <span
+                        aria-hidden
+                        className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
+                      />
                       <NavLink
                         to={path}
                         end={path === "/sessions"}
                         onClick={closeMobile}
                         className={({ isActive }) =>
                           cn(
-                            "group relative flex items-center gap-3",
+                            "relative flex items-center gap-3",
                             "px-5 py-2.5",
                             path === "/chat" && "flex-1 min-w-0",
                             "font-mondwest text-[0.8rem] tracking-[0.12em]",
@@ -463,11 +468,6 @@ export default function App() {
                           <>
                             <Icon className="h-3.5 w-3.5 shrink-0" />
                             <span className="truncate">{navLabel}</span>
-
-                            <span
-                              aria-hidden
-                              className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
-                            />
 
                             {isActive && (
                               <span
@@ -490,7 +490,7 @@ export default function App() {
                           title="New session"
                           aria-label="Start a new session"
                           className={cn(
-                            "flex items-center justify-center px-3 py-2.5",
+                            "relative z-10 flex items-center justify-center px-3 py-2.5",
                             "text-midground/40 hover:text-midground",
                             "opacity-40 group-hover:opacity-100",
                             "transition-opacity duration-150 cursor-pointer",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -491,8 +491,8 @@ export default function App() {
                           aria-label="Start a new session"
                           className={cn(
                             "flex items-center justify-center px-3 py-2.5",
-                            "text-midground/60 hover:text-midground",
-                            "opacity-0 group-hover:opacity-100",
+                            "text-midground/40 hover:text-midground",
+                            "opacity-40 group-hover:opacity-100",
                             "transition-opacity duration-150 cursor-pointer",
                             "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
                           )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -437,19 +437,14 @@ export default function App() {
                     ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
                     : label;
                   return (
-                    <li key={path} className={cn("group relative", path === "/chat" && "flex items-center")}>
-                      {/* Row background overlay — covers both NavLink and + button */}
-                      <span
-                        aria-hidden
-                        className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
-                      />
+                    <li key={path} className={cn(path === "/chat" && "flex items-center")}>
                       <NavLink
                         to={path}
                         end={path === "/sessions"}
                         onClick={closeMobile}
                         className={({ isActive }) =>
                           cn(
-                            "relative flex items-center gap-3",
+                            "group relative flex items-center gap-3",
                             "px-5 py-2.5",
                             path === "/chat" && "flex-1 min-w-0",
                             "font-mondwest text-[0.8rem] tracking-[0.12em]",
@@ -469,6 +464,11 @@ export default function App() {
                             <Icon className="h-3.5 w-3.5 shrink-0" />
                             <span className="truncate">{navLabel}</span>
 
+                            <span
+                              aria-hidden
+                              className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
+                            />
+
                             {isActive && (
                               <span
                                 aria-hidden
@@ -480,25 +480,31 @@ export default function App() {
                         )}
                       </NavLink>
                       {embeddedChat && path === "/chat" && (
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            navigate("/chat?new=1");
-                            closeMobile();
-                          }}
-                          title="New session"
-                          aria-label="Start a new session"
-                          className={cn(
-                            "relative z-10 flex items-center justify-center px-3 py-2.5",
-                            "text-midground/40 hover:text-midground",
-                            "opacity-40 group-hover:opacity-100",
-                            "transition-opacity duration-150 cursor-pointer",
-                            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
-                          )}
-                        >
-                          <Plus className="h-3.5 w-3.5" />
-                        </button>
+                        <div className="group relative flex items-center">
+                          <span
+                            aria-hidden
+                            className="absolute inset-y-0.5 left-0 right-0 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
+                          />
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              navigate("/chat?new=1");
+                              closeMobile();
+                            }}
+                            title="New session"
+                            aria-label="Start a new session"
+                            className={cn(
+                              "relative z-10 flex items-center justify-center px-3 py-2.5",
+                              "text-midground/40 hover:text-midground",
+                              "opacity-40 group-hover:opacity-100",
+                              "transition-opacity duration-150 cursor-pointer",
+                              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
+                            )}
+                          >
+                            <Plus className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
                       )}
                     </li>
                   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,15 @@ function RootRedirect() {
   return <Navigate to="/sessions" replace />;
 }
 
+/**
+ * Stand-in for the /chat route inside <Routes>.
+ * ChatPage is rendered separately, always mounted (see App body),
+ * so this just claims the URL slot to prevent the catch-all redirect.
+ */
+function ChatSlot() {
+  return null;
+}
+
 const CHAT_NAV_ITEM: NavItem = {
   path: "/chat",
   labelKey: "chat",
@@ -252,7 +261,7 @@ export default function App() {
   const builtinRoutes = useMemo(
     () => ({
       ...BUILTIN_ROUTES_CORE,
-      ...(embeddedChat ? { "/chat": ChatPage } : {}),
+      ...(embeddedChat ? { "/chat": ChatSlot } : {}),
     }),
     [embeddedChat],
   );
@@ -510,6 +519,17 @@ export default function App() {
                   (isDocsRoute || isChatRoute) && "min-h-0 flex flex-1 flex-col",
                 )}
               >
+                {embeddedChat && (
+                  <div
+                    className={
+                      isChatRoute
+                        ? "min-h-0 flex flex-1 flex-col"
+                        : "hidden"
+                    }
+                  >
+                    <ChatPage />
+                  </div>
+                )}
                 <Routes>
                   {routes.map(({ key, path, element }) => (
                     <Route key={key} path={path} element={element} />

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -24,7 +24,7 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Typography } from "@nous-research/ui";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, X } from "lucide-react";
+import { Copy, PanelRight, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -209,6 +209,17 @@ export default function ChatPage() {
     setCopyState("copied");
     if (copyResetRef.current) clearTimeout(copyResetRef.current);
     copyResetRef.current = setTimeout(() => setCopyState("idle"), 1500);
+    termRef.current?.focus();
+  };
+
+  const handleNewSession = () => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send("/new");
+    setTimeout(() => {
+      const s = wsRef.current;
+      if (s && s.readyState === WebSocket.OPEN) s.send("\r");
+    }, 100);
     termRef.current?.focus();
   };
 
@@ -717,6 +728,30 @@ export default function ChatPage() {
             <Copy className="h-3 w-3 shrink-0" />
             <span className="hidden min-[400px]:inline tracking-wide">
               {copyState === "copied" ? "copied" : "copy last response"}
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={handleNewSession}
+            title="Start a new session"
+            aria-label="Start a new session"
+            className={cn(
+              "absolute z-10 flex items-center gap-1.5",
+              "rounded border border-current/30",
+              "bg-black/20 backdrop-blur-sm",
+              "opacity-60 hover:opacity-100 hover:border-current/60",
+              "transition-opacity duration-150",
+              "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current",
+              "cursor-pointer",
+              "bottom-2 left-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:left-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
+              "lg:bottom-4 lg:left-4",
+            )}
+            style={{ color: TERMINAL_THEME.foreground }}
+          >
+            <Plus className="h-3 w-3 shrink-0" />
+            <span className="hidden min-[400px]:inline tracking-wide">
+              new session
             </span>
           </button>
         </div>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -24,7 +24,7 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Typography } from "@nous-research/ui";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, Plus, X } from "lucide-react";
+import { Copy, PanelRight, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -212,16 +212,31 @@ export default function ChatPage() {
     termRef.current?.focus();
   };
 
-  const handleNewSession = () => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send("/new");
-    setTimeout(() => {
-      const s = wsRef.current;
-      if (s && s.readyState === WebSocket.OPEN) s.send("\r");
-    }, 100);
-    termRef.current?.focus();
-  };
+  // When navigated to /chat?new=1, send /new through the PTY to start a fresh session.
+  const newSessionTriggeredRef = useRef<string | null>(null);
+  useEffect(() => {
+    const newParam = searchParams.get("new");
+    if (!newParam || newParam === newSessionTriggeredRef.current) return;
+    newSessionTriggeredRef.current = newParam;
+
+    const sendNew = () => {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send("/new");
+        setTimeout(() => {
+          const s = wsRef.current;
+          if (s?.readyState === WebSocket.OPEN) s.send("\r");
+        }, 100);
+      }
+    };
+    // If WS isn't open yet (PTY still booting), retry after a short delay.
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      sendNew();
+    } else {
+      const timer = setTimeout(sendNew, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -728,30 +743,6 @@ export default function ChatPage() {
             <Copy className="h-3 w-3 shrink-0" />
             <span className="hidden min-[400px]:inline tracking-wide">
               {copyState === "copied" ? "copied" : "copy last response"}
-            </span>
-          </button>
-
-          <button
-            type="button"
-            onClick={handleNewSession}
-            title="Start a new session"
-            aria-label="Start a new session"
-            className={cn(
-              "absolute z-10 flex items-center gap-1.5",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-60 hover:opacity-100 hover:border-current/60",
-              "transition-opacity duration-150",
-              "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current",
-              "cursor-pointer",
-              "bottom-2 left-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:left-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
-              "lg:bottom-4 lg:left-4",
-            )}
-            style={{ color: TERMINAL_THEME.foreground }}
-          >
-            <Plus className="h-3 w-3 shrink-0" />
-            <span className="hidden min-[400px]:inline tracking-wide">
-              new session
             </span>
           </button>
         </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard web UI (`hermes dashboard --tui`) losing chat state when switching between sidebar tabs. The `ChatPage` component is now always mounted but hidden with CSS when not on `/chat`, preserving the WebSocket connection, PTY process, and session across navigation.

Also defers DB session record creation until the first user message (no more blank sessions in the list), and adds a "+" button on the Chat sidebar nav item to intentionally start a new session.

## Related Issue

Fixes #15915

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/App.tsx` — Move `ChatPage` out of React Router, always mounted but visibility-toggled. Add "+" new-session button on the Chat sidebar nav item.
- `web/src/pages/ChatPage.tsx` — Listen for `?new=1` URL param to send `/new` through PTY WebSocket.
- `tui_gateway/server.py` — Defer `db.create_session()` from boot to first user message in `prompt.submit`.

## How to Test

1. Run `hermes dashboard --tui` and open the browser
2. Click **Chat**, type a message, then switch to **Sessions/Config/etc.**
3. Click **Chat** again — conversation should be intact
4. Hover over the **Chat** sidebar item and click the **"+"** button — starts a fresh session
5. Check the **Sessions** page — no blank sessions created without messages

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs