### PR TITLE
feat(providers): add Google Vertex AI as a first-class inference provider

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2471,9 +2471,10 @@ class HermesCLI:
             if resolved_provider not in _AGGREGATOR_PROVIDERS:
                 normalized_model = normalize_model_for_provider(current_model, resolved_provider)
                 if normalized_model and normalized_model != current_model:
-                    # --- PR Fix: Suppress warning for Vertex's mandatory publisher prefix ---
-                    _is_vertex_prefix_fix = (resolved_provider == "vertex" and normalized_model == f"google/{current_model}")
-                    if not self._model_is_default and not _is_vertex_prefix_fix:
+                    # Vertex's OpenAPI endpoint requires a publisher prefix (google/*)
+                    # — adding it silently is correct behaviour, not a user error.
+                    _silent_prefix = (resolved_provider == "vertex" and normalized_model == f"google/{current_model}")
+                    if not self._model_is_default and not _silent_prefix:
                         self._console_print(
                             f"[yellow]⚠️  Normalized model '{current_model}' to '{normalized_model}' for {resolved_provider}.[/]"
                         )

--- a/cli.py
+++ b/cli.py
@@ -2471,7 +2471,9 @@ class HermesCLI:
             if resolved_provider not in _AGGREGATOR_PROVIDERS:
                 normalized_model = normalize_model_for_provider(current_model, resolved_provider)
                 if normalized_model and normalized_model != current_model:
-                    if not self._model_is_default:
+                    # --- PR Fix: Suppress warning for Vertex's mandatory publisher prefix ---
+                    _is_vertex_prefix_fix = (resolved_provider == "vertex" and normalized_model == f"google/{current_model}")
+                    if not self._model_is_default and not _is_vertex_prefix_fix:
                         self._console_print(
                             f"[yellow]⚠️  Normalized model '{current_model}' to '{normalized_model}' for {resolved_provider}.[/]"
                         )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -361,8 +361,8 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Google Vertex AI",
         auth_type="api_key",
         inference_base_url="",
-        api_key_env_vars=("GOOGLE_APPLICATION_CREDENTIALS",),
-        base_url_env_var="VERTEX_LOCATION"
+        api_key_env_vars=("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS"),
+        base_url_env_var="VERTEX_REGION",
     )
 }
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -356,6 +356,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
+    "vertex": ProviderConfig(
+        id="vertex",
+        name="Google Vertex AI",
+        auth_type="api_key",
+        inference_base_url="",
+        api_key_env_vars=("GOOGLE_APPLICATION_CREDENTIALS",),
+        base_url_env_var="VERTEX_LOCATION"
+    )
 }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1624,9 +1624,10 @@ def select_provider_and_model(args=None):
         _model_flow_stepfun(config, current_model)
     elif selected_provider == "bedrock":
         _model_flow_bedrock(config, current_model)
+    elif selected_provider == "vertex":
+        _model_flow_vertex(config, current_model)
     elif selected_provider in (
         "gemini",
-        "vertex",
         "deepseek",
         "xai",
         "zai",
@@ -3964,6 +3965,81 @@ def _model_flow_bedrock(config, current_model=""):
         print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
     else:
         print("  No change.")
+
+
+def _model_flow_vertex(config, current_model=""):
+    """Google Vertex AI provider flow.
+
+    Credentials come from a service account JSON file or ADC — no API key
+    prompt. Region is the only optional override.
+    """
+    from hermes_cli.auth import (
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.vertex_adapter import get_vertex_config, DEFAULT_REGION
+
+    # 1. Resolve credentials (SA file or ADC) — just show status, don't prompt
+    creds_path = (
+        get_env_value("VERTEX_CREDENTIALS_PATH")
+        or os.getenv("VERTEX_CREDENTIALS_PATH", "")
+        or get_env_value("GOOGLE_APPLICATION_CREDENTIALS")
+        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+    )
+    if creds_path:
+        short = creds_path if len(creds_path) <= 40 else f"...{creds_path[-37:]}"
+        print(f"  Credentials: {short} ✓")
+    else:
+        print("  Credentials: Application Default Credentials (ADC)")
+        print("  (Set VERTEX_CREDENTIALS_PATH or GOOGLE_APPLICATION_CREDENTIALS")
+        print("   to a service account JSON file, or run")
+        print("   `gcloud auth application-default login`.)")
+    print()
+
+    # Quick probe to catch missing google-auth or invalid creds early
+    token, _ = get_vertex_config(credentials_path=creds_path or None)
+    if not token:
+        print("  ✗ Could not obtain a Vertex AI access token.")
+        print("    Check that google-auth is installed and credentials are valid.")
+        return
+
+    # 2. Optional region override
+    current_region = (
+        get_env_value("VERTEX_REGION")
+        or os.getenv("VERTEX_REGION", "")
+        or get_env_value("VERTEX_LOCATION")
+        or os.getenv("VERTEX_LOCATION", "")
+        or DEFAULT_REGION
+    )
+    try:
+        region_input = input(f"  Region [{current_region}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    region = region_input or current_region
+    if region != current_region:
+        save_env_value("VERTEX_REGION", region)
+        print(f"  Region saved: {region}")
+        print()
+
+    # 3. Model selection
+    model_list = _PROVIDER_MODELS.get("vertex", [])
+    if not model_list:
+        model_list = ["gemini-2.5-pro", "gemini-2.5-flash"]
+
+    selected = _prompt_model_selection(model_list, current_model, provider_id="vertex")
+    if not selected:
+        print("  No change.")
+        return
+
+    cfg = load_config()
+    _save_model_choice(cfg, "vertex", selected)
+    save_config(cfg)
+    deactivate_provider()
+    print(f"  Default model set to: {selected} (via Google Vertex AI, {region})")
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1626,6 +1626,7 @@ def select_provider_and_model(args=None):
         _model_flow_bedrock(config, current_model)
     elif selected_provider in (
         "gemini",
+        "vertex",
         "deepseek",
         "xai",
         "zai",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4030,13 +4030,21 @@ def _model_flow_vertex(config, current_model=""):
     if not model_list:
         model_list = ["gemini-2.5-pro", "gemini-2.5-flash"]
 
-    selected = _prompt_model_selection(model_list, current_model, provider_id="vertex")
+    selected = _prompt_model_selection(model_list, current_model)
     if not selected:
         print("  No change.")
         return
 
+    _save_model_choice(selected)
+
     cfg = load_config()
-    _save_model_choice(cfg, "vertex", selected)
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = "vertex"
+    model.pop("base_url", None)
+    model.pop("api_mode", None)
     save_config(cfg)
     deactivate_provider()
     print(f"  Default model set to: {selected} (via Google Vertex AI, {region})")

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -391,6 +391,13 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
         return _prepend_vendor(name)
+    
+    # --- Vertex AI: OpenAPI endpoint strictly requires publisher prefix ---
+    if provider == "vertex":
+        bare = _strip_matching_provider_prefix(name, provider)
+        if not bare.startswith("google/"):
+            return f"google/{bare}"
+        return bare
 
     # --- OpenCode Zen: Claude stays hyphenated; other models keep dots ---
     if provider == "opencode-zen":

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -385,11 +385,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     # Google vertex available models supported by the ChatCompletions API
     "vertex": [
+        "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro",
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",
-        "gemini-2.0-flash-001",
-        "gemini-2.0-flash-lite-001",
     ]
 }
 
@@ -2519,6 +2521,8 @@ def validate_requested_model(
             requested,
             api_key=api_key,
         ) or requested
+    elif normalized == "vertex" and requested_for_lookup.startswith("google/"):
+        requested_for_lookup = requested_for_lookup[len("google/"):]
 
     if not requested:
         return {

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -385,13 +385,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     # Google vertex available models supported by the ChatCompletions API
     "vertex": [
-        "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
-        "gemini-3-flash-preview",
-        "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro",
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",
+        "gemini-2.0-flash-001",
+        "gemini-2.0-flash-lite-001",
     ]
 }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -383,6 +383,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "us.meta.llama4-maverick-17b-instruct-v1:0",
         "us.meta.llama4-scout-17b-instruct-v1:0",
     ],
+    # Google vertex available models supported by the ChatCompletions API
+    "vertex": [
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-2.0-flash-001",
+        "gemini-2.0-flash-lite-001",
+    ]
 }
 
 # Vercel AI Gateway: derive the bare-model-id catalog from the curated
@@ -740,6 +748,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)"),
+    ProviderEntry("vertex",         "Vertex AI",                "Google Vertex AI (GCP Service Account JSON)"),
 ]
 
 # Derived dicts — used throughout the codebase

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -74,8 +74,8 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "vertex": HermesOverlay(
         transport="openai_chat",
         auth_type="api_key",
-        extra_env_vars=("GOOGLE_APPLICATION_CREDENTIALS",),
-        base_url_env_var="VERTEX_LOCATION",
+        extra_env_vars=("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS"),
+        base_url_env_var="VERTEX_REGION",
     ),
     "copilot-acp": HermesOverlay(
         transport="codex_responses",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -71,6 +71,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         auth_type="oauth_external",
         base_url_override="cloudcode-pa://google",
     ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        extra_env_vars=("GOOGLE_APPLICATION_CREDENTIALS",),
+        base_url_env_var="VERTEX_LOCATION",
+    ),
     "copilot-acp": HermesOverlay(
         transport="codex_responses",
         auth_type="external_process",
@@ -270,6 +276,10 @@ ALIASES: Dict[str, str] = {
     # google-gemini-cli (OAuth + Code Assist)
     "gemini-cli": "google-gemini-cli",
     "gemini-oauth": "google-gemini-cli",
+
+    # google vertex
+    "vertex-ai": "vertex",
+    "google-vertex": "vertex",
 
 
     # huggingface

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -214,35 +214,17 @@ def _resolve_runtime_from_pool_entry(
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "vertex":
         api_mode = "chat_completions"
-        creds_path = api_key or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        
-        if not creds_path or not __import__("os").path.exists(creds_path):
-            raise ValueError("Vertex AI credentials not found. Please set GOOGLE_APPLICATION_CREDENTIALS to a valid JSON key file path.")
-        
-        try:
-            from google.oauth2 import service_account
-            from google.auth.transport.requests import Request
-        except ImportError:
-            raise ImportError(
-                "Missing Google Auth dependencies for Vertex AI. "
-                "Please install them via: pip install hermes-agent[vertex]"
+        from hermes_cli.vertex_adapter import get_vertex_config
+        region = base_url or None  # base_url slot carries the region when set explicitly
+        token, resolved_url = get_vertex_config(credentials_path=api_key or None, region=region)
+        if not token or not resolved_url:
+            raise ValueError(
+                "Vertex AI credentials not found. Set VERTEX_CREDENTIALS_PATH or "
+                "GOOGLE_APPLICATION_CREDENTIALS to a service account JSON file, "
+                "or run `gcloud auth application-default login`."
             )
-        import json
-
-        with open(creds_path, 'r') as f:
-            sa_info = json.load(f)
-        project_id = sa_info.get("project_id")
-        
-        if not project_id:
-            raise ValueError("Invalid Vertex AI credential file: missing 'project_id' field.")
-            
-        location = base_url if base_url else __import__("os").environ.get("VERTEX_LOCATION", "us-central1")
-        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-        creds = service_account.Credentials.from_service_account_file(creds_path, scopes=scopes)
-        creds.refresh(Request())
-        
-        api_key = creds.token
-        base_url = f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project_id}/locations/{location}/endpoints/openapi"
+        api_key = token
+        base_url = resolved_url
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
     elif provider == "xai":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -212,6 +212,37 @@ def _resolve_runtime_from_pool_entry(
         if cfg_provider == "anthropic":
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
+    elif provider == "vertex":
+        api_mode = "chat_completions"
+        creds_path = api_key or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        
+        if not creds_path or not __import__("os").path.exists(creds_path):
+            raise ValueError("Vertex AI credentials not found. Please set GOOGLE_APPLICATION_CREDENTIALS to a valid JSON key file path.")
+        
+        try:
+            from google.oauth2 import service_account
+            from google.auth.transport.requests import Request
+        except ImportError:
+            raise ImportError(
+                "Missing Google Auth dependencies for Vertex AI. "
+                "Please install them via: pip install hermes-agent[vertex]"
+            )
+        import json
+
+        with open(creds_path, 'r') as f:
+            sa_info = json.load(f)
+        project_id = sa_info.get("project_id")
+        
+        if not project_id:
+            raise ValueError("Invalid Vertex AI credential file: missing 'project_id' field.")
+            
+        location = base_url if base_url else __import__("os").environ.get("VERTEX_LOCATION", "us-central1")
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+        creds = service_account.Credentials.from_service_account_file(creds_path, scopes=scopes)
+        creds.refresh(Request())
+        
+        api_key = creds.token
+        base_url = f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project_id}/locations/{location}/endpoints/openapi"
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
     elif provider == "xai":

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -93,6 +93,11 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-3.1-pro-preview", "gemini-3-pro-preview",
         "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
     ],
+    "vertex": [
+        "gemini-3.1-pro-preview", "gemini-3-pro-preview",
+        "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
+        "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+    ],
     "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -94,9 +94,8 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
     ],
     "vertex": [
-        "gemini-3.1-pro-preview", "gemini-3-pro-preview",
-        "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+        "gemini-2.0-flash-001", "gemini-2.0-flash-lite-001",
     ],
     "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],

--- a/hermes_cli/vertex_adapter.py
+++ b/hermes_cli/vertex_adapter.py
@@ -1,0 +1,137 @@
+"""Vertex AI (Google Cloud) adapter for Hermes CLI.
+
+Provides authentication and configuration for Vertex AI's OpenAI-compatible
+endpoint, allowing Hermes to use Gemini models via Google Cloud with
+enterprise-grade rate limits and quotas.
+
+Requires: pip install google-auth
+
+Environment variables honored (all optional — ADC is used as a fallback):
+  VERTEX_CREDENTIALS_PATH        — path to a service account JSON file (takes precedence).
+  GOOGLE_APPLICATION_CREDENTIALS — standard GCP credential path.
+  VERTEX_PROJECT_ID              — override the project_id embedded in creds.
+  VERTEX_REGION / VERTEX_LOCATION — override default region ("us-central1" unless set).
+"""
+
+import logging
+import os
+import time
+from typing import Optional, Tuple
+
+try:
+    import google.auth
+    import google.auth.transport.requests
+    from google.oauth2 import service_account
+except ImportError:
+    google = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REGION = "us-central1"
+_creds_cache: dict = {}
+
+
+def _resolve_credentials_path(explicit: Optional[str]) -> Optional[str]:
+    if explicit and os.path.exists(explicit):
+        return explicit
+    for env_var in ("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS"):
+        path = os.environ.get(env_var)
+        if path and os.path.exists(path):
+            return path
+    return None
+
+
+def _refresh_credentials(creds) -> None:
+    auth_req = google.auth.transport.requests.Request()
+    creds.refresh(auth_req)
+
+
+def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Optional[str], Optional[str]]:
+    """Return a (fresh access_token, project_id) pair or (None, None) on failure.
+
+    Caches the underlying Credentials object and refreshes it when within
+    5 minutes of expiry, so repeated calls don't thrash the token endpoint.
+    Supports both service account files and Application Default Credentials.
+    """
+    if google is None:
+        logger.warning(
+            "google-auth package not installed. "
+            "Install it via: pip install hermes-agent[vertex]"
+        )
+        return None, None
+
+    resolved_path = _resolve_credentials_path(credentials_path)
+    cache_key = resolved_path or "__adc__"
+
+    try:
+        cached = _creds_cache.get(cache_key)
+        if cached is None:
+            if resolved_path:
+                creds = service_account.Credentials.from_service_account_file(
+                    resolved_path,
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                )
+                project_id = creds.project_id
+            else:
+                creds, project_id = google.auth.default(
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                )
+            _creds_cache[cache_key] = (creds, project_id)
+        else:
+            creds, project_id = cached
+
+        needs_refresh = (
+            not getattr(creds, "token", None)
+            or getattr(creds, "expired", False)
+            or (
+                getattr(creds, "expiry", None) is not None
+                and (creds.expiry.timestamp() - time.time()) < 300
+            )
+        )
+        if needs_refresh:
+            _refresh_credentials(creds)
+
+        override_project = os.environ.get("VERTEX_PROJECT_ID")
+        if override_project:
+            project_id = override_project
+
+        return creds.token, project_id
+
+    except Exception as e:
+        logger.error("Failed to resolve Vertex AI credentials: %s", e)
+        _creds_cache.pop(cache_key, None)
+        # If ADC failed, retry with a service account file that may have been
+        # added after initial startup.
+        if cache_key == "__adc__":
+            sa_path = _resolve_credentials_path(credentials_path)
+            if sa_path:
+                logger.info("ADC failed, retrying with service account: %s", sa_path)
+                return get_vertex_credentials(sa_path)
+        return None, None
+
+
+def build_vertex_base_url(project_id: str, region: str = DEFAULT_REGION) -> str:
+    """Build the OpenAI-compatible base URL for Vertex AI."""
+    return (
+        f"https://{region}-aiplatform.googleapis.com"
+        f"/v1beta1/projects/{project_id}/locations/{region}/endpoints/openapi"
+    )
+
+
+def get_vertex_config(
+    credentials_path: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve (access_token, base_url) for Vertex AI, or (None, None) on failure."""
+    token, project_id = get_vertex_credentials(credentials_path)
+    if not token or not project_id:
+        return None, None
+
+    effective_region = (
+        region
+        or os.environ.get("VERTEX_REGION")
+        or os.environ.get("VERTEX_LOCATION")
+        or DEFAULT_REGION
+    )
+    base_url = build_vertex_base_url(project_id, effective_region)
+    return token, base_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ google = [
   "google-auth-oauthlib>=1.0,<2",
   "google-auth-httplib2>=0.2,<1",
 ]
+vertex = ["google-auth>=2.0.0,<3", "requests>=2.0.0,<3"]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 web = ["fastapi>=0.104.0,<1", "uvicorn[standard]>=0.24.0,<1"]
 rl = [

--- a/run_agent.py
+++ b/run_agent.py
@@ -1362,7 +1362,7 @@ class AIAgent:
                     # but no credentials were found, fail fast with a clear
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                    if _explicit and _explicit not in ("auto", "openrouter", "custom", "vertex"):
                         # Look up the actual env var name from the provider
                         # config — some providers use non-standard names
                         # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-17T16:49:45.944715922Z"
+exclude-newer = "2026-04-19T09:42:25.003522Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1760,6 +1760,77 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.194.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/ab/e83af0eb043e4ccc49571ca7a6a49984e9d00f4e9e6e6f1238d60bc84dce/google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023", size = 14443469, upload-time = "2026-04-08T23:07:35.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/34/5a624e49f179aa5b0cb87b2ce8093960299030ff40423bfbde09360eb908/google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717", size = 15016514, upload-time = "2026-04-08T23:07:33.093Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1912,6 +1983,9 @@ all = [
     { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "faster-whisper" },
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
     { name = "markdown", marker = "sys_platform == 'linux'" },
@@ -1964,6 +2038,11 @@ dingtalk = [
 feishu = [
     { name = "lark-oapi" },
     { name = "qrcode" },
+]
+google = [
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
 ]
 homeassistant = [
     { name = "aiohttp" },
@@ -2025,6 +2104,10 @@ termux = [
 tts-premium = [
     { name = "elevenlabs" },
 ]
+vertex = [
+    { name = "google-auth" },
+    { name = "requests" },
+]
 voice = [
     { name = "faster-whisper" },
     { name = "numpy" },
@@ -2064,6 +2147,10 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
+    { name = "google-api-python-client", marker = "extra == 'google'", specifier = ">=2.100,<3" },
+    { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0,<3" },
+    { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = ">=0.2,<1" },
+    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.0,<2" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
@@ -2075,6 +2162,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["dev"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["dingtalk"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["google"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
@@ -2120,6 +2208,7 @@ requires-dist = [
     { name = "qrcode", marker = "extra == 'feishu'", specifier = ">=7.0,<8" },
     { name = "qrcode", marker = "extra == 'messaging'", specifier = ">=7.0,<8" },
     { name = "requests", specifier = ">=2.33.0,<3" },
+    { name = "requests", marker = "extra == 'vertex'", specifier = ">=2.0.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
@@ -2136,7 +2225,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "google", "vertex", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2236,6 +2325,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -3278,6 +3379,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "obstore"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3856,6 +3966,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3927,6 +4049,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -4527,6 +4670,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -5266,6 +5422,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f8/114266b21a7a9e3d09b352bb63c9d61d918bb7aa35d08c722793bfbfd28f/unpaddedbase64-2.1.0.tar.gz", hash = "sha256:7273c60c089de39d90f5d6d4a7883a79e319dc9d9b1c8924a7fab96178a5f005", size = 5621, upload-time = "2021-03-09T11:35:47.729Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a7/563b2d8fb7edc07320bf69ac6a7eedcd7a1a9d663a6bb90a4d9bd2eda5f7/unpaddedbase64-2.1.0-py3-none-any.whl", hash = "sha256:485eff129c30175d2cd6f0cd8d2310dff51e666f7f36175f738d75dfdbd0b1c6", size = 6083, upload-time = "2021-03-09T11:35:46.7Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Adds Google Vertex AI as a first-class inference provider for Gemini models, using GCP's OpenAI-compatible endpoint with dynamic OAuth2 token resolution. This is similar in intent to #8427 but addresses several correctness and UX issues found during implementation and testing.

**Issues corrected vs #8427:**
- Adds `hermes_cli/vertex_adapter.py` (not just `agent/vertex_adapter.py`) so the CLI credential path is fully decoupled from the agent subsystem
- Adds a dedicated `_model_flow_vertex()` in `main.py` — the generic `_model_flow_api_key_provider()` was misidentifying the service account JSON path as an "API key" and unconditionally prompting for a "Base URL" that is dynamically computed and should not be manually entered
- Fixes `validate_requested_model()` to strip the mandatory `google/` publisher prefix before catalog lookup, preventing a false "model not found in curated catalog" warning on every session start
- Model catalog restricted to official stable chat models only (gemini-2.5-pro/flash/flash-lite, gemini-2.0-flash-001/flash-lite-001) — no preview/audio/image/embedding models

## Related Issue

See also: #8427, #4375, #6491, #3569

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**New files:**
- `hermes_cli/vertex_adapter.py` — credential resolution (SA JSON or ADC), token caching with 5-min refresh window, base URL construction. Falls back from ADC to SA file if ADC refresh fails.

**Provider registration:**
- `hermes_cli/auth.py` — register `vertex` in `PROVIDER_REGISTRY` with `VERTEX_CREDENTIALS_PATH` / `GOOGLE_APPLICATION_CREDENTIALS` env var priority
- `hermes_cli/providers.py` — register `vertex` in `HERMES_OVERLAYS` (`openai_chat` transport); add aliases `vertex-ai`, `google-vertex`
- `hermes_cli/models.py` — add vertex to `_PROVIDER_MODELS` and `CANONICAL_PROVIDERS`; fix `validate_requested_model` to strip `google/` prefix for catalog lookup
- `hermes_cli/model_normalize.py` — inject mandatory `google/` publisher prefix for Vertex requests transparently
- `hermes_cli/setup.py` — add vertex to setup model picker catalog

**Runtime:**
- `hermes_cli/runtime_provider.py` — replace 30-line inline credential block with a 5-line `get_vertex_config()` call; supports both SA file and ADC; token cached and auto-refreshed
- `hermes_cli/main.py` — dedicated `_model_flow_vertex()` flow: shows credential status without prompting, prompts for region only, suppresses spurious normalization warning for the mandatory `google/` prefix
- `run_agent.py` — exclude `vertex` from the generic "API key not found" fail-fast check (vertex uses file-based credentials, not a key env var)

**Dependencies:**
- `pyproject.toml` — lightweight `[vertex]` optional dependency group (`google-auth`)

## How to Test

1. Install the optional dependency: `pip install hermes-agent[vertex]`
2. Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json` (or run `gcloud auth application-default login`)
3. Run `hermes model`, select **Vertex AI** — should show credential path with ✓, prompt for region only, then show model picker
4. Select a model (e.g. `gemini-2.5-pro`) and start a session — no "model not found in catalog" warning should appear

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — this addresses correctness issues in #8427 which covers the same feature
- [x] My PR contains only changes related to this feature
- [x] I've tested on macOS 15

### Documentation & Housekeeping

- [x] N/A — no new config keys beyond what's described above
- [x] Cross-platform impact considered (credential path handling uses `os.path.exists`, works on Windows/macOS/Linux)

## Screenshots / Logs

```
$ hermes model
  Current model:    gemini-2.5-pro
  Active provider:  Vertex AI

  Credentials: ...service-account-key.json ✓

  Region [us-central1]:
Select default model:
-> gemini-2.5-pro  ← currently in use
   gemini-2.5-flash
   gemini-2.5-flash-lite
   gemini-2.0-flash-001
   gemini-2.0-flash-lite-001
   Enter custom model name
   Skip (keep current)

  Default model set to: gemini-2.5-pro (via Google Vertex AI, us-central1)
```