### PR TITLE
fix(gateway): clear stale pending model note on session reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5006,6 +5006,8 @@ class GatewayRunner:
         # picks up configured defaults instead of previous session switches.
         self._session_model_overrides.pop(session_key, None)
         self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
 
         # Clear session-scoped dangerous-command approvals and /yolo state.
         # /new is a conversation-boundary operation — approval state from the

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -81,11 +81,13 @@ async def test_new_command_clears_session_model_override():
         "api_mode": "openai",
     }
     runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
+    runner._pending_model_notes[session_key] = "[Note: switched to gpt-4o.]"
 
     await runner._handle_reset_command(_make_event("/new"))
 
     assert session_key not in runner._session_model_overrides
     assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
 
 
 @pytest.mark.asyncio
@@ -126,6 +128,8 @@ async def test_new_command_only_clears_own_session():
     }
     runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
     runner._session_reasoning_overrides[other_key] = {"enabled": True, "effort": "low"}
+    runner._pending_model_notes[session_key] = "[Note: switched to gpt-4o.]"
+    runner._pending_model_notes[other_key] = "[Note: switched to claude-sonnet-4-6.]"
 
     await runner._handle_reset_command(_make_event("/new"))
 
@@ -133,3 +137,5 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_model_overrides
     assert session_key not in runner._session_reasoning_overrides
     assert other_key in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
+    assert other_key in runner._pending_model_notes


### PR DESCRIPTION

`/model` and the picker flow leave a `_pending_model_notes[session_key]` entry that gets prepended to the next user message. The `/new` reset path cleared model and reasoning overrides but skipped this transient note — so the first message of a fresh session could silently inherit a "model just changed" annotation from the previous conversation.

**Root cause:** `_pending_model_notes` is ephemeral prompt state but was excluded from the session teardown sweep in `gateway/run.py`.

**Fix:** Added `_pending_model_notes[session_key]` cleanup inside the `/new` reset path (line 5007).

**Regression coverage** (`tests/gateway/test_session_model_reset.py`, line 75):
- asserts the pending note is cleared after reset
- asserts sibling session notes are not touched

---

**Testing**

```
pytest tests/gateway/test_session_model_reset.py tests/gateway/test_session_boundary_hooks.py
9 passed in 12.33s  
```

**Changed files:** `gateway/run.py` · `tests/gateway/test_session_model_reset.py` 