### PR TITLE
fix(gateway): load full session history in /v1/runs via X-Hermes-Session-Id header

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2415,6 +2415,46 @@ class APIServerAdapter(BasePlatformAdapter):
                 if instructions is None:
                     instructions = stored.get("instructions")
 
+        # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
+        # When provided, the FULL history (including tool messages) is loaded from
+        # state.db instead of from the request body.  This mirrors the behavior of
+        # the /v1/chat/completions endpoint and fixes the issue where web-ui clients
+        # that only send user/assistant messages lose tool-calling context across turns.
+        #
+        # Security: same gate as /v1/chat/completions — requires API key auth.
+        provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        if provided_session_id:
+            if not self._api_key:
+                logger.warning(
+                    "Session continuation via X-Hermes-Session-Id rejected on /v1/runs: "
+                    "no API key configured.  Set API_SERVER_KEY to enable "
+                    "session continuity."
+                )
+                return web.json_response(
+                    _openai_error(
+                        "Session continuation requires API key authentication. "
+                        "Configure API_SERVER_KEY to enable this feature."
+                    ),
+                    status=403,
+                )
+            # Sanitize: reject control characters that could enable header injection.
+            if re.search(r'[\r\n\x00]', provided_session_id):
+                return web.json_response(
+                    _openai_error("Invalid session ID"), status=400,
+                )
+            session_id = provided_session_id
+            stored_session_id = session_id
+            try:
+                db = self._ensure_session_db()
+                if db is not None:
+                    conversation_history = db.get_messages_as_conversation(session_id)
+                    logger.debug(
+                        "Loaded %d messages from session %s via X-Hermes-Session-Id",
+                        len(conversation_history), session_id,
+                    )
+            except Exception as e:
+                logger.warning("Failed to load session history for %s: %s", session_id, e)
+
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
@@ -2430,7 +2470,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id or run_id
+        session_id = session_id if provided_session_id else (body.get("session_id") or stored_session_id or run_id)
         ephemeral_system_prompt = instructions
 
         async def _run_and_close():

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -318,6 +318,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
     return app
 
 
@@ -2315,3 +2316,144 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+# ---------------------------------------------------------------------------
+# /v1/runs — session header tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunsSessionHeader:
+    """Test that /v1/runs supports X-Hermes-Session-Id for session continuity."""
+
+    @pytest.mark.asyncio
+    async def test_runs_loads_history_from_db_when_session_header_provided(self, auth_adapter):
+        """When X-Hermes-Session-Id is provided to /v1/runs, full history (including
+        tool messages) is loaded from SessionDB instead of from the request body."""
+        db_history = [
+            {"role": "user", "content": "search for cats"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "tc_1", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "found cats"},
+            {"role": "assistant", "content": "Cats are cute!"},
+            {"role": "user", "content": "tell me more"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = db_history
+        auth_adapter._session_db = mock_db
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "More cats!", "messages": []}
+        mock_agent.session_prompt_tokens = 10
+        mock_agent.session_completion_tokens = 5
+        mock_agent.session_total_tokens = 15
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={"X-Hermes-Session-Id": "runs-session-42", "Authorization": "Bearer sk-secret"},
+                    json={
+                        "input": "even more cats",
+                        "conversation_history": [
+                            # This should be overridden by DB history
+                            {"role": "user", "content": "old from client"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 202
+            body = await resp.json()
+            assert "run_id" in body
+            # Verify agent was created with DB history, not client history
+            call_kwargs = mock_agent.run_conversation.call_args.kwargs
+            assert call_kwargs["conversation_history"] == db_history
+            assert call_kwargs["user_message"] == "even more cats"
+
+    @pytest.mark.asyncio
+    async def test_runs_without_session_header_uses_body_history(self, auth_adapter):
+        """Without X-Hermes-Session-Id, /v1/runs uses conversation_history from request body."""
+        body_history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "Hey!", "messages": []}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "input": "what's up",
+                        "conversation_history": body_history,
+                    },
+                )
+
+            assert resp.status == 202
+            # Wait for the background run to complete
+            for _ in range(50):
+                if mock_agent.run_conversation.called:
+                    break
+                await asyncio.sleep(0.1)
+            assert mock_agent.run_conversation.called
+            call_kwargs = mock_agent.run_conversation.call_args.kwargs
+            assert call_kwargs["conversation_history"] == body_history
+
+    @pytest.mark.asyncio
+    async def test_runs_session_header_requires_api_key(self, adapter):
+        """Without API key configured, X-Hermes-Session-Id is rejected with 403."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                headers={"X-Hermes-Session-Id": "some-session"},
+                json={"input": "hello"},
+            )
+
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_runs_session_header_rejects_control_characters(self, auth_adapter):
+        """Session IDs with control characters are rejected (400)."""
+        # aiohttp's test client rejects \r\n in headers at the client level,
+        # so we test the server-side validation directly.
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-Session-Id": "bad\r\nsession", "Authorization": "Bearer sk-secret"}
+        mock_request.json = AsyncMock(return_value={"input": "hello"})
+        mock_request.__getitem__ = lambda self, key: mock_request.headers.get(key, "")
+
+        app = _create_app(auth_adapter)
+        resp = await auth_adapter._handle_runs(mock_request)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_runs_db_failure_falls_back_gracefully(self, auth_adapter):
+        """If SessionDB fails, runs still proceeds with empty history."""
+        auth_adapter._session_db = None
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "OK", "messages": []}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", return_value=mock_agent), \
+                 patch("gateway.platforms.api_server.APIServerAdapter._ensure_session_db", return_value=None):
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={"X-Hermes-Session-Id": "some-session", "Authorization": "Bearer sk-secret"},
+                    json={"input": "hello"},
+                )
+
+            assert resp.status == 202
+            await asyncio.sleep(0.1)
+            call_kwargs = mock_agent.run_conversation.call_args.kwargs
+            assert call_kwargs["conversation_history"] == []
+            assert call_kwargs["user_message"] == "hello"


### PR DESCRIPTION
## Summary

The `/v1/runs` endpoint (used by hermes-web-ui) did not read the `X-Hermes-Session-Id` header, unlike `/v1/chat/completions` which already supports it.

This caused hermes-web-ui to **lose tool-calling context across turns**: the client only sends `user`/`assistant` messages in `conversation_history`, so the agent cannot see prior tool calls and results, leading to degraded behavior ("lazy responses") in long conversations.

## Fix

Mirror the `/v1/chat/completions` logic in `_handle_runs`:

- Read `X-Hermes-Session-Id` header (with same security checks)
- When present, load full history from `SessionDB` (including tool messages) instead of using the partial request body history
- Same auth gate: requires `API_SERVER_KEY` to be configured
- Control character sanitization to prevent header injection

## Tests

5 new tests in `TestRunsSessionHeader`:

1. **DB history loaded** — header triggers SessionDB load with tool messages
2. **No header fallback** — body history used when no header present
3. **Auth required** — 403 without API key configured
4. **Control char rejection** — 400 for `\r\n` in session ID
5. **DB failure fallback** — graceful degradation when SessionDB unavailable

All 124 tests pass (119 existing + 5 new).

## Context

Related: [EKKOLearnAI/hermes-web-ui#237](https://github.com/EKKOLearnAI/hermes-web-ui/issues/237) — web-ui issue reporting agent stops using tools in long conversations.

The web-ui client-side fix ([PR #240](https://github.com/EKKOLearnAI/hermes-web-ui/pull/240)) already sends the header, but the gateway endpoint didn't read it — this PR completes the fix on the server side.
