### PR TITLE
fix: always include reasoning_content on assistant messages for DeepSeek

### DIFF
--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -320,8 +320,9 @@ class HermesAgentLoop:
                 # Preserve reasoning_content for multi-turn chat template handling
                 # (e.g., Kimi-K2's template renders <think> blocks differently
                 # for history vs. the latest turn based on this field)
-                if reasoning:
-                    msg_dict["reasoning_content"] = reasoning
+                # Always include the field — DeepSeek thinking mode requires
+                # reasoning_content on every assistant turn (#15250, #15430).
+                msg_dict["reasoning_content"] = reasoning or ""
 
                 messages.append(msg_dict)
 
@@ -492,8 +493,9 @@ class HermesAgentLoop:
                     "role": "assistant",
                     "content": assistant_msg.content or "",
                 }
-                if reasoning:
-                    msg_dict["reasoning_content"] = reasoning
+                # Always include reasoning_content — DeepSeek thinking mode
+                # requires it on every assistant turn (#15250, #15430).
+                msg_dict["reasoning_content"] = reasoning or ""
                 messages.append(msg_dict)
 
                 turn_elapsed = _time.monotonic() - turn_start

--- a/run_agent.py
+++ b/run_agent.py
@@ -7851,11 +7851,20 @@ class AIAgent:
             api_msg["reasoning_content"] = existing
             return
 
-        # 2. DeepSeek / Kimi thinking mode: tool-call turns that lack
-        # reasoning_content are "poisoned history" — a prior provider (MiniMax,
-        # etc.) left them empty. DeepSeek returns HTTP 400 if reasoning_content
-        # is absent on replay; inject "" to satisfy the provider's requirement
-        # without forwarding any cross-provider reasoning content.
+        # 2. Healthy session: promote 'reasoning' field to 'reasoning_content'
+        # for providers that use the internal 'reasoning' key.
+        # Must come BEFORE the poisoned-history empty-string fallback so
+        # valid reasoning traces are preserved (#15430).
+        normalized_reasoning = source_msg.get("reasoning")
+        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            api_msg["reasoning_content"] = normalized_reasoning
+            return
+
+        # 3. DeepSeek / Kimi thinking mode: tool-call turns that lack both
+        # reasoning_content and reasoning are "poisoned history" — a prior
+        # provider (MiniMax, etc.) left them empty. DeepSeek returns HTTP 400
+        # if reasoning_content is absent on replay; inject "" to satisfy the
+        # provider's requirement without forwarding cross-provider content.
         needs_empty_reasoning = (
             source_msg.get("tool_calls")
             and (
@@ -7867,16 +7876,11 @@ class AIAgent:
             api_msg["reasoning_content"] = ""
             return
 
-        # 3. Healthy session: promote 'reasoning' field to 'reasoning_content'
-        # for providers that use the internal 'reasoning' key.
-        normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
-            api_msg["reasoning_content"] = normalized_reasoning
-            return
-
         # 4. DeepSeek / Kimi thinking mode: all assistant messages need
         # reasoning_content. Inject "" to satisfy the provider's requirement
-        # when no explicit reasoning content is present.
+        # when no explicit reasoning content is present. Covers text-only
+        # messages from sessions that were recorded before the
+        # unconditional-reasoning_content write was landed (#15430).
         if (
             self._needs_kimi_tool_reasoning()
             or self._needs_deepseek_tool_reasoning()


### PR DESCRIPTION
## Summary

DeepSeek thinking mode requires `reasoning_content` on **every** assistant turn — not just tool-call messages but also text-only responses. When a text-only assistant message lacks this field, DeepSeek returns HTTP 400:
> "The reasoning_content in the thinking mode must be passed back to the API"

This PR applies three defenses:

### 1. `environments/agent_loop.py` — unconditional write at creation time
Both the tool-call path (L324) and the text-response path (L496) now write `reasoning_content = reasoning or ""` unconditionally, replacing the old `if reasoning:` guard.

### 2. `run_agent.py` — reorder reasoning promotion before empty-string fallback
The `_copy_reasoning_content_for_api` function had steps 2 and 3 in the wrong order: the poisoned-history `""` injection ran *before* the `reasoning` → `reasoning_content` promotion, causing valid reasoning traces to be overwritten. Swapped them.

### 3. `run_agent.py` — step 4 catch-all now covers text-only messages
The final safety net (step 4) already covers all assistant messages, but its comment didn't mention text-only messages specifically. Clarified.

## Test Plan

- [x] `tests/run_agent/test_deepseek_reasoning_content_echo.py` — 21/21 pass
- [ ] Manual verification with DeepSeek v4 on long conversations

## References

- #15250 (original report)
- #15430 (text-only message case)

Closes #15430
