### PR TITLE
fix(tui-gateway): call maybe_auto_title after each completed turn (#15949)

### DIFF
--- a/tests/tui_gateway/test_auto_title.py
+++ b/tests/tui_gateway/test_auto_title.py
@@ -1,0 +1,63 @@
+"""Tests for auto-title generation in tui_gateway (#15949).
+
+maybe_auto_title() was called in cli.py and gateway/run.py but was missing
+from tui_gateway/server.py, leaving TUI sessions with no auto-generated titles.
+"""
+
+import inspect
+import textwrap
+
+
+def _get_prompt_submit_source() -> str:
+    """Return the source of the prompt.submit dispatch block as a string."""
+    import tui_gateway.server as srv
+
+    # The prompt.submit handler is registered via the @method("prompt.submit")
+    # decorator.  Locate the inner `run` function via the method registry so
+    # this test doesn't hard-code line numbers.
+    handler = srv._methods.get("prompt.submit")
+    if handler is None:
+        # Fallback: scan the module source for the block we care about.
+        return inspect.getsource(srv)
+    return inspect.getsource(handler)
+
+
+class TestAutoTitleInTuiGateway:
+    """Source-level checks that maybe_auto_title is wired into tui_gateway/server."""
+
+    def test_maybe_auto_title_imported_in_server(self):
+        """tui_gateway/server.py must reference maybe_auto_title."""
+        import tui_gateway.server as srv
+
+        src = inspect.getsource(srv)
+        assert "maybe_auto_title" in src, (
+            "maybe_auto_title not found in tui_gateway/server.py — "
+            "TUI sessions will never receive auto-generated titles (#15949)"
+        )
+
+    def test_auto_title_guarded_on_complete_status(self):
+        """The maybe_auto_title call must be inside a 'status == complete' guard."""
+        import tui_gateway.server as srv
+
+        src = inspect.getsource(srv)
+        # Confirm the guard appears before the import — crude but reliable.
+        complete_idx = src.find('status == "complete"')
+        title_idx = src.find("maybe_auto_title")
+        assert complete_idx != -1, "No 'status == \"complete\"' guard found"
+        assert title_idx != -1, "maybe_auto_title not found"
+        # The guard should appear before the call (it wraps the try block).
+        assert complete_idx < title_idx, (
+            "status == 'complete' guard must appear before the maybe_auto_title call"
+        )
+
+    def test_auto_title_uses_get_db_and_session_key(self):
+        """The call must pass _get_db() and session['session_key'] to maybe_auto_title."""
+        import tui_gateway.server as srv
+
+        src = inspect.getsource(srv)
+        assert "_get_db()" in src
+        assert 'session["session_key"]' in src or "session['session_key']" in src
+
+    def test_title_generator_module_importable(self):
+        """agent.title_generator must be importable so the lazy import won't fail."""
+        from agent.title_generator import maybe_auto_title  # noqa: F401

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2342,6 +2342,24 @@ def _(rid, params: dict) -> dict:
                     logger.warning("voice TTS skipped: hermes_cli.voice unavailable")
                 except Exception as e:
                     logger.warning("voice TTS dispatch failed: %s", e)
+
+            # CLI/gateway parity: auto-generate a session title after the first
+            # exchange (#15949 — tui_gateway/server.py was the only entry point
+            # that didn't call maybe_auto_title).
+            if status == "complete" and raw and text:
+                try:
+                    from agent.title_generator import maybe_auto_title
+                    all_msgs = result.get("messages", []) if isinstance(result, dict) else []
+                    maybe_auto_title(
+                        _get_db(),
+                        session["session_key"],
+                        text,
+                        raw,
+                        all_msgs,
+                    )
+                except Exception:
+                    pass
+
         except Exception as e:
             import traceback
 


### PR DESCRIPTION
## Summary

- `tui_gateway/server.py` was the only agent entry point that never called `maybe_auto_title()` after a completed turn
- TUI sessions got a 0% auto-title rate while CLI sessions got ~23.8% (verified by the reporter against 537 live sessions)
- The fix mirrors the existing pattern in `cli.py` and `gateway/run.py`

## The bug

In commit `e5fc9168` (implementing #1426), `maybe_auto_title()` was added to `cli.py` and `gateway/run.py` but `tui_gateway/server.py` was overlooked. The TUI's `prompt.submit` handler emits `message.complete` but never generates a session title, leaving every TUI session permanently untitled in the database.

## The fix

After the `message.complete` emission in the `run()` closure, when `status == "complete"` and both the user prompt and agent reply are non-empty, call `maybe_auto_title(_get_db(), session["session_key"], text, raw, all_msgs)`. The call is identical in structure to the gateway pattern and is wrapped in a bare `except` so any title-generator failure cannot affect the primary response path.

## Test plan

- [x] **Before**: `test_maybe_auto_title_imported_in_server` and `test_auto_title_guarded_on_complete_status` fail (confirmed — `maybe_auto_title` absent from source)
- [x] **After**: all 4 tests in `tests/tui_gateway/test_auto_title.py` pass
- [x] **Regression guard**: stashed fix → 2 test failures; restored → 0 failures
- [x] **Broader suite** (`tests/tui_gateway/ tests/test_tui_gateway_server.py`): 119 passed, 2 pre-existing baseline failures identical to clean `origin/main`

**Pre-existing baselines (both reproduce on `192e7eb2` with identical error text):**

| Test | Symptom | Root cause (on main) |
| --- | --- | --- |
| `test_make_agent_passes_resolved_provider` | Expected `resolve_runtime_provider(requested=None)`, actual also passes `target_model=` | Signature changed upstream since test was written |
| `test_setup_status_reports_provider_config` | `SystemExit: 1` — `hermes_cli.main` sees `no:xdist` as a profile name | Module-level side-effect in `main.py:160` fires on import during test |

## Related

- Fixes #15949

🤖 Generated with [Claude Code](https://claude.com/claude-code)