### PR TITLE
fix(mcp-oauth): preserve server_url path for protected-resource validation

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -491,11 +491,36 @@ def test_configure_callback_port_uses_explicit_port():
     assert cfg["_resolved_port"] == 54321
 
 
-def test_parse_base_url_strips_path():
-    """_parse_base_url drops path components for OAuth discovery."""
-    from tools.mcp_oauth import _parse_base_url
+def test_build_oauth_auth_preserves_server_url_path():
+    """server_url with path is forwarded to OAuthClientProvider unmodified.
 
-    assert _parse_base_url("https://example.com/mcp/v1") == "https://example.com"
-    assert _parse_base_url("https://example.com") == "https://example.com"
-    assert _parse_base_url("https://host.example.com:8080/api") == "https://host.example.com:8080"
+    Regression for #16015: previously ``_parse_base_url`` stripped the path,
+    collapsing ``https://mcp.notion.com/mcp`` to ``https://mcp.notion.com`` and
+    breaking RFC 9728 protected-resource validation against servers whose PRM
+    advertises a path-scoped resource (Notion). The MCP SDK strips the path
+    itself for authorization-server discovery via
+    ``OAuthContext.get_authorization_base_url``; Hermes must not pre-strip.
+    """
+    from tools import mcp_oauth
+
+    captured: dict = {}
+
+    class _FakeProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch.object(mcp_oauth, "_OAUTH_AVAILABLE", True), \
+         patch.object(mcp_oauth, "OAuthClientProvider", _FakeProvider), \
+         patch.object(mcp_oauth, "_is_interactive", return_value=True), \
+         patch.object(mcp_oauth, "_maybe_preregister_client"), \
+         patch.object(mcp_oauth, "HermesTokenStorage") as mock_storage_cls:
+        mock_storage_cls.return_value = MagicMock(has_cached_tokens=lambda: True)
+        build_oauth_auth(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            oauth_config={},
+        )
+
+    assert captured["server_url"] == "https://mcp.notion.com/mcp"
+
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -519,12 +519,6 @@ def _maybe_preregister_client(
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 
-def _parse_base_url(server_url: str) -> str:
-    """Strip path component from server URL, returning the base origin."""
-    parsed = urlparse(server_url)
-    return f"{parsed.scheme}://{parsed.netloc}"
-
-
 def build_oauth_auth(
     server_name: str,
     server_url: str,
@@ -570,7 +564,7 @@ def build_oauth_auth(
     _maybe_preregister_client(storage, cfg, client_metadata)
 
     return OAuthClientProvider(
-        server_url=_parse_base_url(server_url),
+        server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -362,7 +362,6 @@ class MCPOAuthManager:
             _configure_callback_port,
             _is_interactive,
             _maybe_preregister_client,
-            _parse_base_url,
             _redirect_handler,
             _wait_for_callback,
         )
@@ -387,7 +386,7 @@ class MCPOAuthManager:
 
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
-            server_url=_parse_base_url(entry.server_url),
+            server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
             redirect_handler=_redirect_handler,


### PR DESCRIPTION
Closes #16015.

## Summary
MCP OAuth now preserves the path component of the configured server URL so path-scoped Protected Resource Metadata (Notion MCP, `https://mcp.notion.com/mcp`) validates correctly.

## Root cause
`tools/mcp_oauth.py` defined `_parse_base_url()` and applied it to `server_url` right before constructing `OAuthClientProvider`, collapsing `https://mcp.notion.com/mcp` → `https://mcp.notion.com`. The MCP SDK then:
- used the (already stripped) `server_url` for RFC 8707 canonical resource via `resource_url_from_server_url()`
- passed it to `check_resource_allowed(requested, configured)` against Notion's PRM resource `https://mcp.notion.com/mcp`

Hierarchical match fails (requested `/` shorter than configured `/mcp/`) → `Protected resource https://mcp.notion.com/mcp does not match expected https://mcp.notion.com`.

The SDK strips the path itself where needed (for authorization-server discovery, via `OAuthContext.get_authorization_base_url()` at `mcp/client/auth/oauth2.py:320,365,426,578`). Our pre-stripping was redundant for discovery AND destructive for PRM validation.

## Changes
- `tools/mcp_oauth.py`: delete `_parse_base_url`, pass `server_url` through to `OAuthClientProvider` unmodified.
- `tools/mcp_oauth_manager.py`: drop the `_parse_base_url` import, pass `entry.server_url` directly.
- `tests/tools/test_mcp_oauth.py`: drop `test_parse_base_url_strips_path`, add `test_build_oauth_auth_preserves_server_url_path` — captures the kwargs passed to a fake `OAuthClientProvider` and asserts the full URL (including `/mcp`) is forwarded verbatim.

## Validation
| | Before | After |
|---|---|---|
| `server_url` forwarded to `OAuthClientProvider` for `https://mcp.notion.com/mcp` | `https://mcp.notion.com` | `https://mcp.notion.com/mcp` |
| `tests/tools/test_mcp_oauth.py` | 37 passed | 37 passed |
| `tests/tools/test_mcp_oauth_{manager,integration,bidirectional,cold_load_expiry}.py` | — | 23 passed |

Regression test verified by reverting the fix in-place: new test fails with `AssertionError: 'https://mcp.notion.com' == 'https://mcp.notion.com/mcp'`, which maps 1:1 to the user's reported error. Fix restored, suite re-green.