### PR TITLE
docs(config): clarify busy_input_mode applies to gateway too

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -840,10 +840,10 @@ display:
   # messages. This is independent of tool_progress and gateway streaming.
   interim_assistant_messages: true
 
-  # What Enter does when Hermes is already busy in the CLI.
+  # What Enter does when Hermes is already busy (CLI and gateway platforms).
   #   interrupt: Interrupt the current run and redirect Hermes (default)
   #   queue:     Queue your message for the next turn
-  # Ctrl+C always interrupts regardless of this setting.
+  # Ctrl+C (or /stop in gateway) always interrupts regardless of this setting.
   busy_input_mode: interrupt
 
   # Background process notifications (gateway/messaging only).


### PR DESCRIPTION
## Summary
The `busy_input_mode` comment in `cli-config.yaml.example` said 'in the CLI' but the setting also controls Enter-while-busy behavior on gateway platforms (Telegram/Discord/Slack/etc.). New installs get this file copied to ~/.hermes/config.yaml.

## Changes
- cli-config.yaml.example: 'in the CLI' → 'CLI and gateway platforms'; noted `/stop` as the gateway equivalent of Ctrl+C.

## Validation
Comment-only change to the example config.