### PR TITLE
docs(config): show options in comments for display settings

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -824,7 +824,9 @@ delegation:
 # Display
 # =============================================================================
 display:
-  # Use compact banner mode
+  # Use compact banner mode (hides the ASCII-art banner, shows a single line).
+  #   true:  Compact single-line banner
+  #   false: Full ASCII banner with tool/skill summary (default)
   compact: false
 
   # Tool progress display level (CLI and gateway)
@@ -838,12 +840,15 @@ display:
   # Gateway-only natural mid-turn assistant updates.
   # When true, completed assistant status messages are sent as separate chat
   # messages. This is independent of tool_progress and gateway streaming.
+  #   true:  Send mid-turn assistant updates as separate messages (default)
+  #   false: Only send the final response
   interim_assistant_messages: true
 
-  # What Enter does when Hermes is already busy in the CLI.
+  # What Enter does when Hermes is already busy (CLI and gateway platforms).
   #   interrupt: Interrupt the current run and redirect Hermes (default)
   #   queue:     Queue your message for the next turn
-  # Ctrl+C always interrupts regardless of this setting.
+  # Ctrl+C (or /stop in gateway) always interrupts regardless of this setting.
+  # Toggle at runtime with /busy_input_mode <interrupt|queue>.
   busy_input_mode: interrupt
 
   # Background process notifications (gateway/messaging only).
@@ -859,17 +864,22 @@ display:
   # Play terminal bell when agent finishes a response.
   # Useful for long-running tasks — your terminal will ding when the agent is done.
   # Works over SSH. Most terminals can be configured to flash the taskbar or play a sound.
+  #   true:  Ring the terminal bell on each response
+  #   false: Silent (default)
   bell_on_complete: false
 
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.
+  #   true:  Show the reasoning box
+  #   false: Hide reasoning (default)
   show_reasoning: false
 
   # Stream tokens to the terminal as they arrive instead of waiting for the
   # full response. The response box opens on first token and text appears
   # line-by-line. Tool calls are still captured silently.
-  # Stream tokens to the terminal in real-time. Disable to wait for full responses.
+  #   true:  Stream tokens as they arrive (default)
+  #   false: Wait for the full response before rendering
   streaming: true
 
   # ───────────────────────────────────────────────────────────────────────────
@@ -879,10 +889,15 @@ display:
   # response box label, and branding text. Change at runtime with /skin <name>.
   #
   # Built-in skins:
-  #   default  — Classic Hermes gold/kawaii
-  #   ares     — Crimson/bronze war-god theme with spinner wings
-  #   mono     — Clean grayscale monochrome
-  #   slate    — Cool blue developer-focused
+  #   default        — Classic Hermes gold/kawaii
+  #   ares           — Crimson/bronze war-god theme with spinner wings
+  #   mono           — Clean grayscale monochrome
+  #   slate          — Cool blue developer-focused
+  #   daylight       — Bright light-mode theme
+  #   warm-lightmode — Warm paper-tone light-mode theme
+  #   poseidon       — Sea-green/teal Olympian theme
+  #   sisyphus       — Earthy stone-and-moss theme
+  #   charizard      — Fiery orange dragon theme
   #
   # Custom skins: drop a YAML file in ~/.hermes/skins/<name>.yaml
   # Schema (all fields optional, missing values inherit from default):


### PR DESCRIPTION
## Summary
New installs copy `cli-config.yaml.example` verbatim (comments included) to `~/.hermes/config.yaml` via install.sh, docker/entrypoint.sh, install.ps1, and doctor. So the comments IN the example are the comments users actually see in their live config — making them the right place to document valid options.

Several display settings had thin comments that didn't enumerate valid values, so users reading their own config couldn't tell what to change them to.

## Changes
- `busy_input_mode`: widen from 'in the CLI' to 'CLI and gateway platforms'; note `/stop` as the gateway equivalent of Ctrl+C; add `/busy_input_mode` runtime hint
- `compact`, `interim_assistant_messages`, `bell_on_complete`, `show_reasoning`, `streaming`: add `true`/`false` option lines showing the effect of each value
- `skin`: refresh the built-in skin list (was missing 5 of 9: daylight, warm-lightmode, poseidon, sisyphus, charizard)

## Validation
- `python3 -c 'import yaml; yaml.safe_load(open("cli-config.yaml.example"))'` parses clean
- `display` section keys unchanged; only comments + skin list expanded
- Built-in skin list verified against `_BUILTIN_SKINS` in `hermes_cli/skin_engine.py`

Comments-only — no behavioral change. Existing user configs unaffected (they only see new comments on fresh installs).