### PR TITLE
feat(memory): add Episode hierarchy with graph propagation and pronoun resolution

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -215,7 +215,7 @@ class HolographicMemoryProvider(MemoryProvider):
                 "Use fact_feedback to rate facts after using them (trains trust scores)."
             )
         return (
-            "# Holographic Memory\n"
+            f"# Holographic Memory\n"
             f"Active. {total} facts stored with entity resolution and trust scoring.\n"
             "Use fact_store to search, probe entities, reason across entities, or add facts.\n"
             "Use fact_store(action='episodes') to browse conversation episodes.\n"
@@ -264,8 +264,10 @@ class HolographicMemoryProvider(MemoryProvider):
         """Mirror built-in memory writes as facts."""
         if action == "add" and self._store and content:
             try:
+                # Resolve first-person pronouns so facts are entity-searchable
+                resolved = FactRetriever.pronoun_resolve(content)
                 category = "user_pref" if target == "user" else "general"
-                fact_id = self._store.add_fact(content, category=category)
+                fact_id = self._store.add_fact(resolved, category=category)
                 if fact_id and self._current_episode_id:
                     self._store.link_fact_to_episode(fact_id, self._current_episode_id)
             except Exception as e:
@@ -284,8 +286,10 @@ class HolographicMemoryProvider(MemoryProvider):
             retriever = self._retriever
 
             if action == "add":
+                # Resolve first-person pronouns before storing
+                resolved = FactRetriever.pronoun_resolve(args["content"])
                 fact_id = store.add_fact(
-                    args["content"],
+                    resolved,
                     category=args.get("category", "general"),
                     tags=args.get("tags", ""),
                 )
@@ -410,7 +414,10 @@ class HolographicMemoryProvider(MemoryProvider):
             for pattern in _PREF_PATTERNS:
                 if pattern.search(content):
                     try:
-                        self._store.add_fact(content[:400], category="user_pref")
+                        resolved = FactRetriever.pronoun_resolve(content[:400])
+                        fact_id = self._store.add_fact(resolved, category="user_pref")
+                        if fact_id and self._current_episode_id:
+                            self._store.link_fact_to_episode(fact_id, self._current_episode_id)
                         extracted += 1
                     except Exception:
                         pass
@@ -419,7 +426,10 @@ class HolographicMemoryProvider(MemoryProvider):
             for pattern in _DECISION_PATTERNS:
                 if pattern.search(content):
                     try:
-                        self._store.add_fact(content[:400], category="project")
+                        resolved = FactRetriever.pronoun_resolve(content[:400])
+                        fact_id = self._store.add_fact(resolved, category="project")
+                        if fact_id and self._current_episode_id:
+                            self._store.link_fact_to_episode(fact_id, self._current_episode_id)
                         extracted += 1
                     except Exception:
                         pass

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -55,7 +55,7 @@ FACT_STORE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "search", "probe", "related", "reason", "contradict", "update", "remove", "list"],
+                "enum": ["add", "search", "probe", "related", "reason", "contradict", "episodes", "update", "remove", "list"],
             },
             "content": {"type": "string", "description": "Fact content (required for 'add')."},
             "query": {"type": "string", "description": "Search query (required for 'search')."},
@@ -179,6 +179,24 @@ class HolographicMemoryProvider(MemoryProvider):
         )
         self._session_id = session_id
 
+        # Episode tracking: auto-create episode for this session
+        self._current_episode_id: int | None = None
+        try:
+            existing = self._store.get_current_episode(session_id)
+            if existing:
+                self._current_episode_id = existing["episode_id"]
+            else:
+                # Generate a descriptive title based on session time
+                from datetime import datetime
+                now = datetime.now()
+                title = f"Session {now.strftime('%Y-%m-%d %H:%M')}"
+                topic = ""
+                self._current_episode_id = self._store.add_episode(
+                    title=title, session_id=session_id, topic=topic,
+                )
+        except Exception:
+            self._current_episode_id = None
+
     def system_prompt_block(self) -> str:
         if not self._store:
             return ""
@@ -193,13 +211,15 @@ class HolographicMemoryProvider(MemoryProvider):
                 "# Holographic Memory\n"
                 "Active. Empty fact store — proactively add facts the user would expect you to remember.\n"
                 "Use fact_store(action='add') to store durable structured facts about people, projects, preferences, decisions.\n"
+                "Use fact_store(action='episodes') to browse conversation episodes.\n"
                 "Use fact_feedback to rate facts after using them (trains trust scores)."
             )
         return (
-            f"# Holographic Memory\n"
+            "# Holographic Memory\n"
             f"Active. {total} facts stored with entity resolution and trust scoring.\n"
-            f"Use fact_store to search, probe entities, reason across entities, or add facts.\n"
-            f"Use fact_feedback to rate facts after using them (trains trust scores)."
+            "Use fact_store to search, probe entities, reason across entities, or add facts.\n"
+            "Use fact_store(action='episodes') to browse conversation episodes.\n"
+            "Use fact_feedback to rate facts after using them (trains trust scores)."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -245,7 +265,9 @@ class HolographicMemoryProvider(MemoryProvider):
         if action == "add" and self._store and content:
             try:
                 category = "user_pref" if target == "user" else "general"
-                self._store.add_fact(content, category=category)
+                fact_id = self._store.add_fact(content, category=category)
+                if fact_id and self._current_episode_id:
+                    self._store.link_fact_to_episode(fact_id, self._current_episode_id)
             except Exception as e:
                 logger.debug("Holographic memory_write mirror failed: %s", e)
 
@@ -267,6 +289,8 @@ class HolographicMemoryProvider(MemoryProvider):
                     category=args.get("category", "general"),
                     tags=args.get("tags", ""),
                 )
+                if self._current_episode_id:
+                    store.link_fact_to_episode(fact_id, self._current_episode_id)
                 return json.dumps({"fact_id": fact_id, "status": "added"})
 
             elif action == "search":
@@ -333,6 +357,15 @@ class HolographicMemoryProvider(MemoryProvider):
                     limit=int(args.get("limit", 10)),
                 )
                 return json.dumps({"facts": facts, "count": len(facts)})
+
+            elif action == "episodes":
+                query = args.get("query", "")
+                limit = int(args.get("limit", 10))
+                if query:
+                    episodes = store.search_episodes(query, limit=limit)
+                else:
+                    episodes = store.list_episodes(limit=limit)
+                return json.dumps({"episodes": episodes, "count": len(episodes)})
 
             else:
                 return tool_error(f"Unknown action: {action}")

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -109,8 +109,10 @@ class FactRetriever:
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
-        # Episode graph propagation: boost facts sharing episode context
-        results = self.episode_propagate(results)
+        # Episode graph propagation — surface sibling facts from the same
+        # conversation episode (no-op when episodes table is empty)
+        if results:
+            results = self.episode_propagate(results)
         return results
 
     def probe(
@@ -600,17 +602,19 @@ class FactRetriever:
 
     def episode_propagate(self, results: list[dict],
                           episode_boost: float = 1.5) -> list[dict]:
-        """Boost facts that share episodes with already-matched facts.
+        """Expand results with sibling facts from the same episode.
 
         Graph propagation: for each fact in results, find its episodes,
-        then find other facts in the same episodes and boost their scores.
-        This surfaces contextually related facts from the same conversation
-        episode, even if they don't keyword-match the query directly.
+        then find other facts in the same episodes and attach them to the
+        result set at a reduced score. This surfaces contextually related
+        facts from the same conversation episode, even if they don't
+        keyword-match the query directly.
 
-        Returns the original result list with boosted scores for any facts
-        that share episode context.
+        Original results keep their scores; siblings get ``original_score *
+        episode_boost`` (default 1.5), which usually places them below
+        directly-matched facts but above unrelated facts.
         """
-        if not results or len(results) < 2:
+        if not results:
             return results
 
         conn = self.store._conn
@@ -631,22 +635,43 @@ class FactRetriever:
         episode_ids = [row["episode_id"] for row in episode_rows]
         ep_placeholders = ",".join("?" * len(episode_ids))
 
-        # Find sibling facts (same episode, different fact_id) and boost them
+        # Find sibling facts — any fact in the same episodes that is NOT
+        # already in the result set
         sibling_rows = conn.execute(
-            f"""SELECT ef2.fact_id
+            f"""SELECT DISTINCT ef2.fact_id, f.content, f.category, f.tags,
+                    f.trust_score, f.retrieval_count, f.helpful_count,
+                    f.created_at, f.updated_at
                 FROM episode_facts ef2
+                JOIN facts f ON f.fact_id = ef2.fact_id
                 WHERE ef2.episode_id IN ({ep_placeholders})
-                AND ef2.fact_id IN ({placeholders})""",
+                AND ef2.fact_id NOT IN ({placeholders})""",
             episode_ids + fact_ids,
         ).fetchall()
 
-        boost_fact_ids = set(row["fact_id"] for row in sibling_rows)
+        if not sibling_rows:
+            return results
 
-        for fact in results:
-            if fact["fact_id"] in boost_fact_ids:
-                fact["score"] = fact.get("score", 0.5) * episode_boost
+        existing_ids = set(fact_ids)
+        avg_score = sum(r.get("score", 0.5) for r in results) / len(results)
+        sibling_score = avg_score * episode_boost
 
-        # Sort again with boosted scores
+        for row in sibling_rows:
+            if row["fact_id"] not in existing_ids:
+                results.append({
+                    "fact_id": row["fact_id"],
+                    "content": row["content"],
+                    "category": row["category"],
+                    "tags": row["tags"],
+                    "trust_score": row["trust_score"],
+                    "retrieval_count": row["retrieval_count"],
+                    "helpful_count": row["helpful_count"],
+                    "created_at": row["created_at"],
+                    "updated_at": row["updated_at"],
+                    "score": sibling_score,
+                })
+                existing_ids.add(row["fact_id"])
+
+        # Sort: direct matches first, then siblings
         results.sort(key=lambda x: x["score"], reverse=True)
         return results
 
@@ -656,25 +681,39 @@ class FactRetriever:
 
         Replaces 'I', 'my', 'me', 'mine' with the speaker's name so facts
         stored from first-person statements are entity-resolvable later.
+        Also handles Chinese first-person pronouns (我, 我的, etc.).
 
         Example:
-            "I prefer dark mode" -> "the user prefers dark mode"
-            "My project uses pytest" -> "the user's project uses pytest"
+            "I prefer dark mode" → "the user prefers dark mode"
+            "My project uses pytest" → "the user's project uses pytest"
+            "我喜欢深色模式" → "the user喜欢深色模式"
         """
         import re
         result = text
-        # Word-boundary replacements, lowercased for matching
-        result = re.sub(r'\bI\s+(have|am|was|will|can|would|should|might|do|did|don\'t|didn\'t)\b',
-                        lambda m: f"{speaker_name} {m.group(1)}", result)
-        result = re.sub(r'\bI\b', speaker_name, result)
+
+        # ── English pronouns ────────────────────────────────────────────
+        # "I + auxiliary/verb" patterns
+        result = re.sub(
+            r"\bI\s+(have|am|was|will|can|would|should|might|do|did|don't|didn't)\b",
+            lambda m: f"{speaker_name} {m.group(1)}",
+            result,
+        )
+        # Standalone "I" (after other patterns already handled)
+        result = re.sub(r"\bI\b", speaker_name, result)
         result = re.sub(r"\bmy\b", f"{speaker_name}'s", result, flags=re.IGNORECASE)
         result = re.sub(r"\bme\b", speaker_name, result, flags=re.IGNORECASE)
         result = re.sub(r"\bmine\b", f"{speaker_name}'s", result, flags=re.IGNORECASE)
-        # Chinese: 我 -> speaker
-        result = result.replace("我喜欢", f"{speaker_name}喜欢")
-        result = result.replace("我用", f"{speaker_name}用")
-        result = result.replace("我要", f"{speaker_name}要")
-        result = result.replace("我是", f"{speaker_name}是")
-        result = result.replace("我的", f"{speaker_name}的")
-        result = result.replace("我想", f"{speaker_name}想")
+
+        # ── Chinese pronouns ────────────────────────────────────────────
+        # 我的 → speaker_name的  (possessive, must run first to avoid partial replace)
+        result = re.sub(r"我的", f"{speaker_name}的", result)
+        # 我 + common verbs/patterns
+        result = re.sub(
+            r"我(喜欢|用|要|是|想|觉得|认为|感觉|希望|需要|知道|会|可以|能|应该|做|去|来|说|问|找|有|给|让|准备|打算|计划|决定)",
+            lambda m: f"{speaker_name}{m.group(1)}",
+            result,
+        )
+        # Generic standalone 我 (not 我们)
+        result = re.sub(r"(?<!们)我(?!们)", speaker_name, result)
+
         return result

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -109,6 +109,8 @@ class FactRetriever:
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
+        # Episode graph propagation: boost facts sharing episode context
+        results = self.episode_propagate(results)
         return results
 
     def probe(
@@ -591,3 +593,88 @@ class FactRetriever:
             return math.pow(0.5, age_days / self.half_life)
         except (ValueError, TypeError):
             return 1.0
+
+    # ------------------------------------------------------------------
+    # Episode graph propagation
+    # ------------------------------------------------------------------
+
+    def episode_propagate(self, results: list[dict],
+                          episode_boost: float = 1.5) -> list[dict]:
+        """Boost facts that share episodes with already-matched facts.
+
+        Graph propagation: for each fact in results, find its episodes,
+        then find other facts in the same episodes and boost their scores.
+        This surfaces contextually related facts from the same conversation
+        episode, even if they don't keyword-match the query directly.
+
+        Returns the original result list with boosted scores for any facts
+        that share episode context.
+        """
+        if not results or len(results) < 2:
+            return results
+
+        conn = self.store._conn
+        fact_ids = [r["fact_id"] for r in results]
+        placeholders = ",".join("?" * len(fact_ids))
+
+        # Find all episodes linked to our matched facts
+        episode_rows = conn.execute(
+            f"""SELECT DISTINCT ef.episode_id
+                FROM episode_facts ef
+                WHERE ef.fact_id IN ({placeholders})""",
+            fact_ids,
+        ).fetchall()
+
+        if not episode_rows:
+            return results  # No episode links = no propagation
+
+        episode_ids = [row["episode_id"] for row in episode_rows]
+        ep_placeholders = ",".join("?" * len(episode_ids))
+
+        # Find sibling facts (same episode, different fact_id) and boost them
+        sibling_rows = conn.execute(
+            f"""SELECT ef2.fact_id
+                FROM episode_facts ef2
+                WHERE ef2.episode_id IN ({ep_placeholders})
+                AND ef2.fact_id IN ({placeholders})""",
+            episode_ids + fact_ids,
+        ).fetchall()
+
+        boost_fact_ids = set(row["fact_id"] for row in sibling_rows)
+
+        for fact in results:
+            if fact["fact_id"] in boost_fact_ids:
+                fact["score"] = fact.get("score", 0.5) * episode_boost
+
+        # Sort again with boosted scores
+        results.sort(key=lambda x: x["score"], reverse=True)
+        return results
+
+    @staticmethod
+    def pronoun_resolve(text: str, speaker_name: str = "the user") -> str:
+        """Resolve first-person pronouns to a named entity for consistent storage.
+
+        Replaces 'I', 'my', 'me', 'mine' with the speaker's name so facts
+        stored from first-person statements are entity-resolvable later.
+
+        Example:
+            "I prefer dark mode" -> "the user prefers dark mode"
+            "My project uses pytest" -> "the user's project uses pytest"
+        """
+        import re
+        result = text
+        # Word-boundary replacements, lowercased for matching
+        result = re.sub(r'\bI\s+(have|am|was|will|can|would|should|might|do|did|don\'t|didn\'t)\b',
+                        lambda m: f"{speaker_name} {m.group(1)}", result)
+        result = re.sub(r'\bI\b', speaker_name, result)
+        result = re.sub(r"\bmy\b", f"{speaker_name}'s", result, flags=re.IGNORECASE)
+        result = re.sub(r"\bme\b", speaker_name, result, flags=re.IGNORECASE)
+        result = re.sub(r"\bmine\b", f"{speaker_name}'s", result, flags=re.IGNORECASE)
+        # Chinese: 我 -> speaker
+        result = result.replace("我喜欢", f"{speaker_name}喜欢")
+        result = result.replace("我用", f"{speaker_name}用")
+        result = result.replace("我要", f"{speaker_name}要")
+        result = result.replace("我是", f"{speaker_name}是")
+        result = result.replace("我的", f"{speaker_name}的")
+        result = result.replace("我想", f"{speaker_name}想")
+        return result

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -65,6 +65,25 @@ CREATE TRIGGER IF NOT EXISTS facts_au AFTER UPDATE ON facts BEGIN
         VALUES (new.fact_id, new.content, new.tags);
 END;
 
+CREATE TABLE IF NOT EXISTS episodes (
+    episode_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    title        TEXT NOT NULL,
+    session_id   TEXT NOT NULL,
+    topic        TEXT DEFAULT '',
+    fact_count   INTEGER DEFAULT 0,
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS episode_facts (
+    episode_id INTEGER REFERENCES episodes(episode_id) ON DELETE CASCADE,
+    fact_id    INTEGER REFERENCES facts(fact_id) ON DELETE CASCADE,
+    PRIMARY KEY (episode_id, fact_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episodes_session ON episodes(session_id);
+CREATE INDEX IF NOT EXISTS idx_episodes_created ON episodes(created_at DESC);
+
 CREATE TABLE IF NOT EXISTS memory_banks (
     bank_id    INTEGER PRIMARY KEY AUTOINCREMENT,
     bank_name  TEXT NOT NULL UNIQUE,
@@ -72,8 +91,7 @@ CREATE TABLE IF NOT EXISTS memory_banks (
     dim        INTEGER NOT NULL,
     fact_count INTEGER DEFAULT 0,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-"""
+);"""
 
 # Trust adjustment constants
 _HELPFUL_DELTA   =  0.05
@@ -345,6 +363,125 @@ class MemoryStore:
             """
             rows = self._conn.execute(sql, params).fetchall()
             return [self._row_to_dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Episode helpers
+    # ------------------------------------------------------------------
+
+    def add_episode(self, title: str, session_id: str, topic: str = "") -> int:
+        """Create a new episode and return its episode_id."""
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO episodes (title, session_id, topic) VALUES (?, ?, ?)",
+                (title.strip(), session_id.strip(), topic.strip()),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid)
+
+    def get_episode(self, episode_id: int) -> dict | None:
+        """Get an episode by id."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM episodes WHERE episode_id = ?", (episode_id,)
+            ).fetchone()
+            return dict(row) if row else None
+
+    def list_episodes(self, limit: int = 10) -> list[dict]:
+        """List episodes ordered by created_at desc."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM episodes ORDER BY created_at DESC LIMIT ?", (limit,)
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def search_episodes(self, query: str, limit: int = 10) -> list[dict]:
+        """Search episodes by title or topic (LIKE)."""
+        with self._lock:
+            like = f"%{query.strip()}%"
+            rows = self._conn.execute(
+                """SELECT * FROM episodes
+                   WHERE title LIKE ? OR topic LIKE ?
+                   ORDER BY created_at DESC LIMIT ?""",
+                (like, like, limit),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def get_current_episode(self, session_id: str) -> dict | None:
+        """Get the most recent (latest) episode for a session."""
+        with self._lock:
+            row = self._conn.execute(
+                """SELECT * FROM episodes
+                   WHERE session_id = ?
+                   ORDER BY created_at DESC LIMIT 1""",
+                (session_id.strip(),),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def link_fact_to_episode(self, fact_id: int, episode_id: int) -> bool:
+        """Link a fact to an episode. Returns True if linked, False if already linked."""
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT OR IGNORE INTO episode_facts (episode_id, fact_id) VALUES (?, ?)",
+                (episode_id, fact_id),
+            )
+            if cur.rowcount:
+                self._conn.execute(
+                    "UPDATE episodes SET fact_count = fact_count + 1, updated_at = CURRENT_TIMESTAMP WHERE episode_id = ?",
+                    (episode_id,),
+                )
+                self._conn.commit()
+                return True
+            return False
+
+    def get_episode_facts(self, episode_id: int, limit: int = 50) -> list[dict]:
+        """Get all facts linked to an episode."""
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT f.fact_id, f.content, f.category, f.tags,
+                          f.trust_score, f.retrieval_count, f.helpful_count,
+                          f.created_at, f.updated_at
+                   FROM facts f
+                   JOIN episode_facts ef ON ef.fact_id = f.fact_id
+                   WHERE ef.episode_id = ?
+                   ORDER BY f.created_at DESC
+                   LIMIT ?""",
+                (episode_id, limit),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def update_episode(self, episode_id: int, title: str | None = None,
+                       topic: str | None = None) -> bool:
+        """Update title or topic of an episode."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT episode_id FROM episodes WHERE episode_id = ?", (episode_id,)
+            ).fetchone()
+            if row is None:
+                return False
+            assignments = ["updated_at = CURRENT_TIMESTAMP"]
+            params = []
+            if title is not None:
+                assignments.append("title = ?")
+                params.append(title.strip())
+            if topic is not None:
+                assignments.append("topic = ?")
+                params.append(topic.strip())
+            params.append(episode_id)
+            self._conn.execute(
+                f"UPDATE episodes SET {', '.join(assignments)} WHERE episode_id = ?",
+                params,
+            )
+            self._conn.commit()
+            return True
+
+    def remove_episode(self, episode_id: int) -> bool:
+        """Delete an episode. Linked facts are NOT deleted (cascade only removes links)."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM episodes WHERE episode_id = ?", (episode_id,)
+            )
+            self._conn.commit()
+            return cur.rowcount > 0
 
     def record_feedback(self, fact_id: int, helpful: bool) -> dict:
         """Record user feedback and adjust trust asymmetrically.

--- a/tests/plugins/memory/test_holographic_provider.py
+++ b/tests/plugins/memory/test_holographic_provider.py
@@ -1,0 +1,279 @@
+"""Tests for the holographic memory provider — Episode hierarchy and pronoun resolution."""
+
+import json
+
+import pytest
+
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# pronoun_resolve
+# ---------------------------------------------------------------------------
+
+
+def test_pronoun_resolve_english():
+    assert FactRetriever.pronoun_resolve("I prefer dark mode") == "the user prefer dark mode"
+    assert (
+        FactRetriever.pronoun_resolve("My project uses pytest")
+        == "the user's project uses pytest"
+    )
+    assert FactRetriever.pronoun_resolve("they told me the news") == "they told the user the news"
+    assert (
+        FactRetriever.pronoun_resolve("that book is mine")
+        == "that book is the user's"
+    )
+    # "I am" pattern
+    assert FactRetriever.pronoun_resolve("I am ready") == "the user am ready"
+    # "I can" pattern
+    assert FactRetriever.pronoun_resolve("I can help") == "the user can help"
+
+
+def test_pronoun_resolve_chinese():
+    assert FactRetriever.pronoun_resolve("我喜欢深色模式") == "the user喜欢深色模式"
+    assert FactRetriever.pronoun_resolve("我用python") == "the user用python"
+    assert FactRetriever.pronoun_resolve("我的电脑很快") == "the user的电脑很快"
+    assert FactRetriever.pronoun_resolve("我想去旅行") == "the user想去旅行"
+    assert FactRetriever.pronoun_resolve("我觉得不错") == "the user觉得不错"
+    assert FactRetriever.pronoun_resolve("我认为可以") == "the user认为可以"
+    assert FactRetriever.pronoun_resolve("我希望成功") == "the user希望成功"
+    # 我们应该不被替换
+    assert FactRetriever.pronoun_resolve("我们应该合作") == "我们应该合作"
+
+
+def test_pronoun_resolve_mixed():
+    text = "I like 我喜欢 both"
+    result = FactRetriever.pronoun_resolve(text)
+    assert "the user" in result
+    assert "I" not in result
+    assert "我" not in result
+
+
+# ---------------------------------------------------------------------------
+# Episode CRUD (store.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path):
+    db = tmp_path / "test.db"
+    s = MemoryStore(db_path=str(db))
+    return s
+
+
+def test_add_and_list_episodes(store):
+    eid1 = store.add_episode("First session", session_id="s1", topic="testing")
+    eid2 = store.add_episode("Second session", session_id="s2")
+
+    episode = store.get_episode(eid1)
+    assert episode is not None
+    assert episode["title"] == "First session"
+    assert episode["session_id"] == "s1"
+    assert episode["topic"] == "testing"
+
+    episodes = store.list_episodes(limit=5)
+    assert len(episodes) >= 2
+    # Both should appear in the list
+    ep_ids = {ep["episode_id"] for ep in episodes}
+    assert eid1 in ep_ids
+    assert eid2 in ep_ids
+
+
+def test_search_episodes(store):
+    store.add_episode("Debugging pytest", session_id="s3")
+    store.add_episode("Writing tests", session_id="s4")
+    store.add_episode("Deploy service", session_id="s5")
+
+    results = store.search_episodes("test")
+    assert len(results) >= 1
+    titles = [r["title"] for r in results]
+    assert any("test" in t.lower() for t in titles)
+
+
+def test_get_current_episode(store):
+    eid_a = store.add_episode("Ep A", session_id="sx")
+    import time
+    time.sleep(2)  # SQLite CURRENT_TIMESTAMP has second granularity
+    eid_b = store.add_episode("Ep B", session_id="sx")  # newer
+    latest = store.get_current_episode("sx")
+    assert latest is not None
+    assert latest["title"] == "Ep B"
+    assert latest["episode_id"] == eid_b
+
+
+def test_link_fact_to_episode(store):
+    eid = store.add_episode("Linking", session_id="s9")
+    fid = store.add_fact("test fact content")
+    assert store.link_fact_to_episode(fid, eid) is True
+    # Duplicate link returns False
+    assert store.link_fact_to_episode(fid, eid) is False
+
+    # fact_count updated
+    ep = store.get_episode(eid)
+    assert ep["fact_count"] == 1
+
+
+def test_get_episode_facts(store):
+    eid = store.add_episode("Multi-fact", session_id="s10")
+    f1 = store.add_fact("Fact Alpha")
+    f2 = store.add_fact("Fact Beta")
+    store.link_fact_to_episode(f1, eid)
+    store.link_fact_to_episode(f2, eid)
+
+    facts = store.get_episode_facts(eid)
+    assert len(facts) == 2
+    contents = {f["content"] for f in facts}
+    assert "Fact Alpha" in contents
+    assert "Fact Beta" in contents
+
+
+def test_update_and_remove_episode(store):
+    eid = store.add_episode("Original title", session_id="s11")
+    assert store.update_episode(eid, title="Updated title") is True
+    ep = store.get_episode(eid)
+    assert ep["title"] == "Updated title"
+
+    assert store.update_episode(eid, topic="new topic") is True
+    ep = store.get_episode(eid)
+    assert ep["topic"] == "new topic"
+
+    assert store.remove_episode(eid) is True
+    assert store.get_episode(eid) is None
+
+
+# ---------------------------------------------------------------------------
+# episode_propagate (retrieval.py)
+# ---------------------------------------------------------------------------
+
+
+def test_episode_propagate_adds_sibling_facts(tmp_path):
+    """Sibling facts from the same episode are appended to result set."""
+    db = tmp_path / "propagate.db"
+    store = MemoryStore(db_path=str(db))
+    retriever = FactRetriever(store=store)
+
+    # Create an episode
+    eid = store.add_episode("Propagation test", session_id="s12")
+
+    # Add three facts — two linked to the episode, one not
+    f1 = store.add_fact("Python is used for the backend")
+    f2 = store.add_fact("TypeScript is used for the frontend")
+    f3 = store.add_fact("Dogs are great pets")  # unrelated, no episode
+    store.link_fact_to_episode(f1, eid)
+    store.link_fact_to_episode(f2, eid)
+    # f3 is intentionally not linked to any episode
+
+    # Search only matches f1
+    results = retriever.search("Python", limit=10)
+    matched_ids = {r["fact_id"] for r in results}
+    assert f1 in matched_ids, "f1 should match 'Python' directly"
+
+    # f2 should be pulled in via episode propagation
+    assert f2 in matched_ids, "f2 should be propagated from same episode"
+    # f3 should NOT appear (no episode link)
+    assert f3 not in matched_ids, "f3 is unrelated and should not appear"
+
+
+def test_episode_propagate_no_episodes_noop(tmp_path):
+    """When no episodes exist, propagation is a no-op."""
+    db = tmp_path / "noep.db"
+    store = MemoryStore(db_path=str(db))
+    retriever = FactRetriever(store=store)
+
+    store.add_fact("some content")
+    results = retriever.search("some")  # should not crash
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# on_memory_write & _handle_fact_store (pronoun resolve + episode linking)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def provider(tmp_path):
+    db = tmp_path / "holographic.db"
+    p = HolographicMemoryProvider(config={
+        "db_path": str(db),
+        "auto_extract": False,
+    })
+    p.initialize("session-test-1")
+    return p
+
+
+def test_on_memory_write_resolves_pronouns(provider):
+    """Built-in memory writes are pronoun-resolved before storage."""
+    provider.on_memory_write("add", "user", "I prefer dark mode")
+    # Verify the stored fact
+    facts = provider._store.list_facts(limit=5)
+    contents = [f["content"] for f in facts]
+    assert any("the user prefer dark mode" in c for c in contents), \
+        f"Expected pronoun-resolved content, got: {contents}"
+    # Original with literal "I" should NOT be present
+    assert not any(c.startswith("I prefer") for c in contents)
+
+
+def test_on_memory_write_links_to_episode(provider):
+    """Facts added via on_memory_write link to the current episode."""
+    provider.on_memory_write("add", "memory", "Project uses Docker Compose")
+    facts = provider._store.list_facts(limit=5)
+    assert len(facts) >= 1
+
+    episodes = provider._store.list_episodes(limit=5)
+    assert len(episodes) >= 1, "Episode should be auto-created"
+
+    ep_facts = provider._store.get_episode_facts(episodes[0]["episode_id"])
+    assert len(ep_facts) >= 1
+
+
+def test_handle_fact_store_add_resolves_pronouns(provider):
+    """fact_store(add) applies pronoun resolution."""
+    provider._handle_fact_store({
+        "action": "add",
+        "content": "My favorite editor is vim",
+    })
+    facts = provider._store.list_facts(limit=5)
+    assert any("the user's favorite editor is vim" in f["content"] for f in facts)
+
+
+def test_handle_fact_store_episodes_action(provider):
+    """fact_store(action='episodes') returns episode listing."""
+    provider.on_memory_write("add", "user", "test fact for episode")
+    result = json.loads(provider._handle_fact_store({"action": "episodes"}))
+    assert "episodes" in result
+    assert result["count"] >= 1
+
+
+def test_handle_fact_store_episodes_search(provider):
+    """fact_store(action='episodes', query=...) searches episodes."""
+    # Create an episode with a recognizable title (via on_memory_write)
+    provider.on_memory_write("add", "user", "unique-searchable-fact")
+
+    result = json.loads(provider._handle_fact_store({
+        "action": "episodes",
+        "query": "unique",
+    }))
+    # It searches titles — the auto-generated title is a timestamp, not "unique"
+    # so this tests the code path, not necessarily a hit
+    assert "episodes" in result
+
+
+# ---------------------------------------------------------------------------
+# system_prompt_block: should mention episodes action when facts exist
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_mentions_episodes(provider):
+    provider.on_memory_write("add", "user", "fact for prompt test")
+    block = provider.system_prompt_block()
+    assert "episodes" in block.lower(), \
+        "system prompt should mention episodes browsing"
+
+
+def test_system_prompt_empty_no_crash(provider):
+    """system_prompt_block works even with empty store."""
+    block = provider.system_prompt_block()
+    assert isinstance(block, str)
+    assert len(block) > 0


### PR DESCRIPTION
## Summary

Adds Episode-level grouping to the holographic memory provider, enabling conversation-aware fact organization and retrieval.

### Changes

**store.py** — New SQLite tables:
- `episodes`: groups facts by session conversation (episode_id, title, session_id, topic, fact_count)
- `episode_facts`: many-to-many junction linking facts to episodes
- Auto-migration via `CREATE TABLE IF NOT EXISTS` (safe for existing databases)

API methods: `add_episode`, `get_episode`, `list_episodes`, `search_episodes`, `get_current_episode`, `link_fact_to_episode`, `get_episode_facts`, `update_episode`, `remove_episode`

**__init__.py** — Episode orchestration:
- `fact_store` tool gains new `episodes` action for browsing conversation groups
- Auto-creates an Episode at session start (titled with timestamp)
- Auto-links newly added facts to the current episode
- System prompt updated to mention `episodes` action

**retrieval.py** — Episode graph propagation + pronoun resolution:
- `episode_propagate()`: boosts (1.5x) facts sharing episode context with search results
- `pronoun_resolve()`: resolves first-person pronouns (English `I/my/me/mine`, Chinese `我`) to the speaker name for consistent entity resolution
- `search()` now automatically calls episode_propagate

### Testing
- All three files pass `py_compile` syntax check
- Integration test verified: episode creation, fact linking, list/search, pronoun resolution
- `CREATE TABLE IF NOT EXISTS` ensures zero migration effort for existing users