### PR TITLE
fix(test): correct _coerce_number inf/nan test assertions

### DIFF
--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -64,10 +64,23 @@ class TestCoerceNumber:
     def test_scientific_notation(self):
         assert _coerce_number("1e5") == 100000
 
-    def test_inf_stays_string_for_integer_only(self):
-        """Infinity should not be converted to int."""
+    def test_inf_stays_string(self):
+        """Infinity is not JSON-serializable, so it should stay as string."""
         result = _coerce_number("inf")
-        assert result == float("inf")
+        assert result == "inf"
+        assert isinstance(result, str)
+
+    def test_negative_inf_stays_string(self):
+        """Negative infinity should also stay as string."""
+        result = _coerce_number("-inf")
+        assert result == "-inf"
+        assert isinstance(result, str)
+
+    def test_nan_stays_string(self):
+        """NaN is not JSON-serializable, so it should stay as string."""
+        result = _coerce_number("nan")
+        assert result == "nan"
+        assert isinstance(result, str)
 
     def test_negative_float(self):
         assert _coerce_number("-2.5") == -2.5


### PR DESCRIPTION
## Problem

The test `test_inf_stays_string_for_integer_only` incorrectly asserted that `_coerce_number('inf')` returns `float('inf')`. However, the function correctly returns the original string `'inf'` because infinity is not JSON-serializable.

The test name said "stays string" but the assertion expected a float — a clear contradiction.

## Fix

- Corrected the assertion to expect the string `'inf'`
- Renamed test to `test_inf_stays_string` for clarity
- Added `test_negative_inf_stays_string` for `-inf` edge case
- Added `test_nan_stays_string` for `nan` edge case

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `_coerce_number("inf")` | Test incorrectly expected `float('inf')` | Test correctly expects `"inf"` |
| `_coerce_number("-inf")` | No test coverage | New test added |
| `_coerce_number("nan")` | No test coverage | New test added |

## Tests

All 53 tests in `test_tool_arg_coercion.py` pass, including 3 new/updated tests.