### PR TITLE
fix(agent): promote reasoning field when tool_calls present for DeepSeek

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7856,8 +7856,15 @@ class AIAgent:
         # etc.) left them empty. DeepSeek returns HTTP 400 if reasoning_content
         # is absent on replay; inject "" to satisfy the provider's requirement
         # without forwarding any cross-provider reasoning content.
+        # However, if there IS actual reasoning content in the "reasoning"
+        # field, skip this guard — step 3 below will promote it.
+        has_reasoning_content = bool(
+            isinstance(source_msg.get("reasoning"), str)
+            and source_msg.get("reasoning")
+        )
         needs_empty_reasoning = (
             source_msg.get("tool_calls")
+            and not has_reasoning_content
             and (
                 self._needs_kimi_tool_reasoning()
                 or self._needs_deepseek_tool_reasoning()


### PR DESCRIPTION
## Problem

`_copy_reasoning_content_for_api` had a logic bug where step 2 (the tool-call poisoned-history guard) returned early with `reasoning_content = ""` whenever `tool_calls` were present and the provider was DeepSeek or Kimi.

This prevented step 3 from promoting the internal `'reasoning'` field to the API-facing `'reasoning_content'`, causing actual reasoning traces to be **silently dropped** on tool-call turns.

## Fix

Added a check in step 2: if the source message has actual reasoning content in the `'reasoning'` field (non-empty string), skip the empty-string guard and let step 3 promote it instead.

```python
has_reasoning_content = bool(
    isinstance(source_msg.get("reasoning"), str)
    and source_msg.get("reasoning")
)
needs_empty_reasoning = (
    source_msg.get("tool_calls")
    and not has_reasoning_content  # <-- NEW
    and (self._needs_kimi_tool_reasoning() or self._needs_deepseek_tool_reasoning())
)
```

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| DeepSeek tool-call turn with reasoning | `reasoning_content = ""` (lost!) | `reasoning_content = "thought trace"` |
| DeepSeek tool-call turn without reasoning | `reasoning_content = ""` | `reasoning_content = ""` (unchanged) |

## Tests

All 21 tests in `test_deepseek_reasoning_content_echo.py` pass.