### PR TITLE
fix: guard flock(LOCK_UN) in finally blocks to prevent lock leaks

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -735,7 +735,10 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         finally:
             _auth_lock_holder.depth = 0
             if fcntl:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
             elif msvcrt:
                 try:
                     lock_file.seek(0)

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -283,7 +283,10 @@ class FileSyncManager:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
             self._sync_back_impl()
         finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
             lock_fd.close()
 
     def _sync_back_impl(self) -> None:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -167,7 +167,10 @@ class MemoryStore:
             yield
         finally:
             if fcntl:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
             elif msvcrt:
                 try:
                     fd.seek(0)


### PR DESCRIPTION
## Problem

Three locations called `fcntl.flock(fd, LOCK_UN)` inside `finally` blocks without `try/except` protection. If the unlock syscall raised (e.g. due to an already-closed file descriptor or an interrupted syscall), the exception would propagate and skip the subsequent `fd.close()`, leaving the lock held indefinitely.

This is the same anti-pattern already fixed in `gateway/status.py` (which properly wraps unlock in `except OSError: pass`).

## Fix

Wrapped each `flock(LOCK_UN)` call in `try/except OSError: pass`, matching the pattern already used for `msvcrt.locking()` in the same files.

### Files fixed:
- `tools/environments/file_sync.py` — `_sync_back_locked()`
- `tools/memory_tool.py` — `_file_lock` context manager
- `hermes_cli/auth.py` — `_scoped_auth_lock` context manager

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `flock(LOCK_UN)` raises | `close()` skipped, lock held forever | Exception swallowed, `close()` runs, lock released |

## Tests

Existing lock-related tests continue to pass. This is a defensive fix for an edge case that's hard to reproduce in tests.