### PR TITLE
fix(test): add skip marker for transcription tests requiring faster_whisper

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -414,6 +414,10 @@ class TestTranscribeLocalCommand:
 # _transcribe_local — additional tests
 # ============================================================================
 
+@pytest.mark.skipif(
+    not __import__("importlib").util.find_spec("faster_whisper"),
+    reason="faster_whisper not installed",
+)
 class TestTranscribeLocalExtended:
     def test_model_reuse_on_second_call(self, tmp_path):
         """Second call with same model should NOT reload the model."""


### PR DESCRIPTION
## Problem

`TestTranscribeLocalExtended` patches `faster_whisper.WhisperModel`, which triggers a `ModuleNotFoundError` when the `faster_whisper` package is not installed. This causes 8 test failures in environments without the optional dependency.

## Fix

Added a `pytest.mark.skipif` marker using `importlib.util.find_spec('faster_whisper')` so these tests are gracefully skipped instead of failing.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Without `faster_whisper` | 8 tests FAIL with ModuleNotFoundError | 8 tests SKIPPED |
| With `faster_whisper` | 8 tests pass | 8 tests pass (unchanged) |