### PR TITLE
fix(gateway): resume sessions after restart notification

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5207,8 +5207,12 @@ class GatewayRunner:
             notify_data = {
                 "platform": event.source.platform.value if event.source.platform else None,
                 "chat_id": event.source.chat_id,
+                "chat_type": event.source.chat_type,
+                "session_key": self._session_key_for_source(event.source),
             }
-            if event.source.thread_id:
+            if event.source.user_id:
+                notify_data["user_id"] = event.source.user_id
+            if event.source.thread_id is not None:
                 notify_data["thread_id"] = event.source.thread_id
             (_hermes_home / ".restart_notify.json").write_text(
                 json.dumps(notify_data)
@@ -8039,6 +8043,7 @@ class GatewayRunner:
             platform_str = data.get("platform")
             chat_id = data.get("chat_id")
             thread_id = data.get("thread_id")
+            session_key = data.get("session_key")
 
             if not platform_str or not chat_id:
                 return
@@ -8052,10 +8057,16 @@ class GatewayRunner:
                 )
                 return
 
-            metadata = {"thread_id": thread_id} if thread_id else None
+            metadata = {"thread_id": thread_id} if thread_id is not None else None
+            continuity_entry = self._find_restart_continuity_entry(
+                platform=platform,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                session_key=session_key,
+            )
             await adapter.send(
                 chat_id,
-                "♻ Gateway restarted successfully. Your session continues.",
+                self._build_restart_notification_message(continuity_entry),
                 metadata=metadata,
             )
             logger.info(
@@ -8067,6 +8078,77 @@ class GatewayRunner:
             logger.warning("Restart notification failed: %s", e)
         finally:
             notify_path.unlink(missing_ok=True)
+
+    def _find_restart_continuity_entry(
+        self,
+        *,
+        platform: Platform,
+        chat_id: str,
+        thread_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ):
+        """Return the newest session entry for the restarted chat, if any.
+
+        This keeps restart notifications channel-scoped: a Telegram DM restart
+        only mentions that same Telegram DM's session, and threaded chats must
+        match the same thread/topic.  If session storage is unavailable, fall
+        back silently to the plain restart notification.  Session-key matching
+        is required before surfacing continuity so non-thread group/channel
+        restarts cannot mention another participant's per-user session.
+        """
+        if not session_key:
+            return None
+
+        try:
+            entries = self.session_store.list_sessions()
+        except Exception as exc:
+            logger.debug("Restart continuity session lookup failed: %s", exc)
+            return None
+
+        requested_chat_id = str(chat_id)
+        requested_thread_id = str(thread_id) if thread_id is not None else None
+        matching_entries = []
+        for entry in entries:
+            if getattr(entry, "suspended", False):
+                continue
+            origin = getattr(entry, "origin", None)
+            if origin is None:
+                continue
+            if getattr(entry, "session_key", None) != session_key:
+                continue
+            if getattr(origin, "platform", None) != platform:
+                continue
+            if str(getattr(origin, "chat_id", "")) != requested_chat_id:
+                continue
+            origin_thread_id = getattr(origin, "thread_id", None)
+            origin_thread_id = str(origin_thread_id) if origin_thread_id is not None else None
+            if origin_thread_id != requested_thread_id:
+                continue
+            matching_entries.append(entry)
+
+        if not matching_entries:
+            return None
+        return max(matching_entries, key=lambda entry: getattr(entry, "updated_at", datetime.min))
+
+    def _build_restart_notification_message(self, continuity_entry=None) -> str:
+        """Build the gateway comeback message with an optional continuity prompt."""
+        message = "♻ Gateway restarted successfully. Your session continues."
+        if continuity_entry is None:
+            return message
+
+        raw_session_id = getattr(continuity_entry, "session_id", "") or "current session"
+        session_id = str(raw_session_id).replace("`", "ʼ")
+        if getattr(continuity_entry, "resume_pending", False):
+            return (
+                f"{message}\n\n"
+                "I found an interrupted conversation in this chat and kept the transcript intact. "
+                f"Session: `{session_id}`. Reply `continue` and I’ll pick it back up from there."
+            )
+        return (
+            f"{message}\n\n"
+            "I found the last conversation in this chat. "
+            f"Session: `{session_id}`. Reply `continue` if you want me to pick it back up."
+        )
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,8 +1,7 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
-import asyncio
 import json
-from pathlib import Path
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,11 +9,25 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
-from gateway.session import build_session_key
+from gateway.session import SessionEntry, build_session_key
 from tests.gateway.restart_test_helpers import (
     make_restart_runner,
     make_restart_source,
 )
+
+
+def make_restart_notify_payload(source):
+    payload = {
+        "platform": source.platform.value if source.platform else None,
+        "chat_id": source.chat_id,
+        "chat_type": source.chat_type,
+        "session_key": build_session_key(source),
+    }
+    if source.user_id:
+        payload["user_id"] = source.user_id
+    if source.thread_id is not None:
+        payload["thread_id"] = source.thread_id
+    return payload
 
 
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
@@ -44,6 +57,9 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     data = json.loads(notify_path.read_text())
     assert data["platform"] == "telegram"
     assert data["chat_id"] == "42"
+    assert data["chat_type"] == source.chat_type
+    assert data["user_id"] == source.user_id
+    assert data["session_key"] == build_session_key(source)
     assert "thread_id" not in data  # no thread → omitted
 
 
@@ -111,6 +127,7 @@ async def test_restart_command_preserves_thread_id(tmp_path, monkeypatch):
 
     data = json.loads((tmp_path / ".restart_notify.json").read_text())
     assert data["thread_id"] == "topic_7"
+    assert data["session_key"] == build_session_key(source)
 
 
 # ── _send_restart_notification ───────────────────────────────────────────
@@ -159,6 +176,284 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
 
     call_args = adapter.send.call_args
     assert call_args[1]["metadata"] == {"thread_id": "topic_7"}
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_prompts_to_continue_same_chat_session(
+    tmp_path, monkeypatch
+):
+    """Restart comeback message should proactively surface the latest same-channel session."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = make_restart_source(chat_id="42")
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="20260426_010203_abcdef12",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.list_sessions.return_value = [entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "restarted" in sent.lower()
+    assert "last conversation in this chat" in sent
+    assert "Reply `continue`" in sent
+    assert "20260426_010203_abcdef12" in sent
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_uses_newest_same_chat_session(
+    tmp_path, monkeypatch
+):
+    """When multiple same-chat sessions exist, mention the most recently updated one."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = make_restart_source(chat_id="42")
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    older = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="older_session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    newer = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="newer_session",
+        created_at=datetime(2026, 4, 26, 2, 2, 3),
+        updated_at=datetime(2026, 4, 26, 2, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.list_sessions.return_value = [older, newer]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "newer_session" in sent
+    assert "older_session" not in sent
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_sanitizes_session_id_backticks(
+    tmp_path, monkeypatch
+):
+    """Unexpected backticks in session IDs should not break Markdown code spans."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = make_restart_source(chat_id="42")
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="bad`session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.list_sessions.return_value = [entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "bad`session" not in sent
+    assert "badʼsession" in sent
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_resume_pending_session_says_transcript_intact(
+    tmp_path, monkeypatch
+):
+    """If restart interrupted the session, tell the user the transcript is intact."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = make_restart_source(chat_id="42")
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="interrupted_session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+    )
+    runner.session_store.list_sessions.return_value = [entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "interrupted conversation in this chat" in sent
+    assert "kept the transcript intact" in sent
+    assert "interrupted_session" in sent
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_ignores_other_chat_sessions(tmp_path, monkeypatch):
+    """Continuity prompt must not leak or suggest a different chat's session."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    other_source = make_restart_source(chat_id="99")
+    other_entry = SessionEntry(
+        session_key=build_session_key(other_source),
+        session_id="other_session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=other_source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.list_sessions.return_value = [other_entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "restarted" in sent.lower()
+    assert "last conversation in this chat" not in sent
+    assert "other_session" not in sent
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_ignores_same_chat_different_group_user_session(
+    tmp_path, monkeypatch
+):
+    """Same group chat alone is insufficient; restart continuity must match the full session key."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_source = make_restart_source(chat_id="42", chat_type="group")
+    notify_source.user_id = "u1"
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(notify_source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    other_user_source = make_restart_source(chat_id="42", chat_type="group")
+    other_user_source.user_id = "u2"
+    entry = SessionEntry(
+        session_key=build_session_key(other_user_source),
+        session_id="other_user_session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=other_user_source,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.list_sessions.return_value = [entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "last conversation in this chat" not in sent
+    assert "other_user_session" not in sent
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_ignores_non_matching_thread_sessions(
+    tmp_path, monkeypatch
+):
+    """Forum-topic/thread restarts only surface sessions from the same thread."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_source = make_restart_source(chat_id="42")
+    notify_source.thread_id = "topic_7"
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(notify_source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    source = make_restart_source(chat_id="42")
+    source.thread_id = "topic_9"
+    entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="wrong_thread_session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.list_sessions.return_value = [entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "last conversation in this chat" not in sent
+    assert "wrong_thread_session" not in sent
+    assert adapter.send.call_args[1]["metadata"] == {"thread_id": "topic_7"}
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_ignores_suspended_sessions(tmp_path, monkeypatch):
+    """Suspended sessions are forced-wipe candidates, not restart-continuity candidates."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = make_restart_source(chat_id="42")
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps(make_restart_notify_payload(source)))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="suspended_session",
+        created_at=datetime(2026, 4, 26, 1, 2, 3),
+        updated_at=datetime(2026, 4, 26, 1, 5, 0),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        suspended=True,
+    )
+    runner.session_store.list_sessions.return_value = [entry]
+
+    await runner._send_restart_notification()
+
+    sent = adapter.send.call_args[0][1]
+    assert "last conversation in this chat" not in sent
+    assert "suspended_session" not in sent
     assert not notify_path.exists()
 
 
@@ -213,3 +508,22 @@ async def test_send_restart_notification_cleans_up_on_send_failure(
     await runner._send_restart_notification()
 
     assert not notify_path.exists()  # cleaned up despite error
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cleans_up_malformed_notify_file(
+    tmp_path, monkeypatch
+):
+    """Corrupt restart-notification state should not crash startup or persist forever."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text("{not-json")
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+
+    await runner._send_restart_notification()
+
+    adapter.send.assert_not_called()
+    assert not notify_path.exists()


### PR DESCRIPTION
## Summary
- persist restart requester session routing, including session key, before gateway restart
- send comeback notification that can safely offer `continue` for the same stored session
- guard against cross-chat/user/thread leakage by requiring platform, chat, thread, session key, and non-suspended session match

## Verification
- `python -m pytest tests/gateway/test_restart_notification.py tests/gateway/test_restart_resume_pending.py -q` → 49 passed
- `python -m ruff check tests/gateway/test_restart_notification.py` → passed
- `python -m py_compile gateway/run.py tests/gateway/test_restart_notification.py` → passed
- staged diff security scan: 0 hardcoded secrets, 0 shell-injection patterns, 0 eval/exec patterns

## Notes
- Full `python -m pytest tests/gateway -q` currently fails outside this patch area: 47 failed, 3643 passed, 1 skipped. Failures cluster in Discord/Matrix/WhatsApp tests and appear unrelated to the staged restart-notification diff.
- Direct push to NousResearch/hermes-agent was denied for this account, so this PR is opened from the fork.