### PR TITLE
fix(update): avoid lockfile churn during npm installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4973,14 +4973,17 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
+    has_lockfile = (web_dir / "package-lock.json").exists()
+    install_cmd = "ci" if has_lockfile else "install"
+    install_args = [install_cmd, "--silent"]
+    r1 = subprocess.run([npm, *install_args], cwd=web_dir, capture_output=True)
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
             + ("" if fatal else " (hermes web will not be available)")
         )
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            print(f"  Run manually:  cd web && npm {install_cmd} && npm run build")
         return False
     r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
     if r2.returncode != 0:
@@ -4989,7 +4992,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             + ("" if fatal else " (hermes web will not be available)")
         )
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            print(f"  Run manually:  cd web && npm {install_cmd} && npm run build")
         return False
     print("  ✓ Web UI built")
     return True
@@ -5684,8 +5687,9 @@ def _update_node_dependencies() -> None:
         if not (path / "package.json").exists():
             continue
 
+        install_args = ["ci"] if (path / "package-lock.json").exists() else ["install"]
         result = subprocess.run(
-            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+            [npm, *install_args, "--silent", "--no-fund", "--no-audit", "--progress=false"],
             cwd=path,
             capture_output=True,
             text=True,

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -127,19 +127,21 @@ class TestCmdUpdateBranchFallback:
         # cmd_update runs npm commands in three locations:
         #   1. repo root  — slash-command / TUI bridge deps
         #   2. ui-tui/    — Ink TUI deps
-        #   3. web/       — install + "npm run build" for the web frontend
-        full_flags = [
+        #   3. web/       — "npm ci" + "npm run build" for the web frontend
+        # Use npm ci when package-lock.json exists so update/build does not
+        # rewrite lockfiles as a side effect of installing dependencies.
+        ci_flags = [
             "/usr/bin/npm",
-            "install",
+            "ci",
             "--silent",
             "--no-fund",
             "--no-audit",
             "--progress=false",
         ]
         assert npm_calls == [
-            (full_flags, PROJECT_ROOT),
-            (full_flags, PROJECT_ROOT / "ui-tui"),
-            (["/usr/bin/npm", "install", "--silent"], PROJECT_ROOT / "web"),
+            (ci_flags, PROJECT_ROOT),
+            (ci_flags, PROJECT_ROOT / "ui-tui"),
+            (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
             (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
         ]
 


### PR DESCRIPTION
## What does this PR do?

Switches update-time npm installs to `npm ci` whenever a `package-lock.json` is present.

This prevents `hermes update` / web UI builds from rewriting lockfiles as a side effect of installing dependencies, while preserving `npm install` fallback behavior for directories without a lockfile.

## Related Issue

No issue filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (added/updated tests)

## Testing

- `uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_cmd_update.py -q` -> 5 passed
