### PR TITLE
fix: gateway restart deadlock + auxiliary custom provider + test fix

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1822,7 +1822,7 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = explicit_base_url.strip()
+            custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
@@ -1835,7 +1835,7 @@ def resolve_provider_client(
                 )
                 return None, None
             final_model = _normalize_resolved_model(
-                model or _read_main_model() or "gpt-4o-mini",
+                model or main_runtime.get("model") or "gpt-4o-mini",
                 provider,
             )
             extra = {}

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -19,10 +19,16 @@ _TITLE_PROMPT = (
 )
 
 
-def generate_title(user_message: str, assistant_response: str, timeout: float = 30.0) -> Optional[str]:
+def generate_title(
+    user_message: str,
+    assistant_response: str,
+    timeout: float = 30.0,
+    main_runtime: dict = None,
+) -> Optional[str]:
     """Generate a session title from the first exchange.
 
-    Uses the auxiliary LLM client (cheapest/fastest available model).
+    Uses the main runtime's model when available, falling back to the
+    auxiliary LLM client (cheapest/fastest available model).
     Returns the title string or None on failure.
     """
     # Truncate long messages to keep the request small
@@ -41,6 +47,7 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
             max_tokens=500,
             temperature=0.3,
             timeout=timeout,
+            main_runtime=main_runtime,
         )
         title = (response.choices[0].message.content or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
@@ -61,6 +68,7 @@ def auto_title_session(
     session_id: str,
     user_message: str,
     assistant_response: str,
+    main_runtime: dict = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -81,7 +89,7 @@ def auto_title_session(
     except Exception:
         return
 
-    title = generate_title(user_message, assistant_response)
+    title = generate_title(user_message, assistant_response, main_runtime=main_runtime)
     if not title:
         return
 
@@ -98,6 +106,7 @@ def maybe_auto_title(
     user_message: str,
     assistant_response: str,
     conversation_history: list,
+    main_runtime: dict = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -118,7 +127,7 @@ def maybe_auto_title(
 
     thread = threading.Thread(
         target=auto_title_session,
-        args=(session_db, session_id, user_message, assistant_response),
+        args=(session_db, session_id, user_message, assistant_response, main_runtime),
         daemon=True,
         name="auto-title",
     )

--- a/cli.py
+++ b/cli.py
@@ -8569,6 +8569,13 @@ class HermesCLI:
                         message,
                         response,
                         self.conversation_history,
+                        main_runtime={
+                            "model": self.model,
+                            "provider": self.provider,
+                            "base_url": self.base_url,
+                            "api_key": self.api_key,
+                            "api_mode": self.api_mode,
+                        },
                     )
                 except Exception:
                     pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -684,6 +684,7 @@ class GatewayRunner:
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._restart_caller_key: str = None  # session_key of the agent that triggered /restart
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -1664,7 +1665,7 @@ class GatewayRunner:
 
         return True
 
-    async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+    async def _drain_active_agents(self, timeout: float, exclude_key: str = None) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
         last_status_at = 0.0
@@ -1672,13 +1673,22 @@ class GatewayRunner:
         def _maybe_update_status(force: bool = False) -> None:
             nonlocal last_active_count, last_status_at
             now = asyncio.get_running_loop().time()
-            active_count = self._running_agent_count()
+            # Count agents, excluding the restart caller so it can't block drain.
+            active_count = sum(
+                1 for k in self._running_agents
+                if k != exclude_key and self._running_agents.get(k) is not _AGENT_PENDING_SENTINEL
+            )
             if force or active_count != last_active_count or (now - last_status_at) >= 1.0:
                 self._update_runtime_status("draining")
                 last_active_count = active_count
                 last_status_at = now
 
-        if not self._running_agents:
+        # Build a filtered view that excludes the restart caller.
+        filtered_agents = {
+            k: v for k, v in self._running_agents.items() if k != exclude_key
+        } if exclude_key else dict(self._running_agents)
+
+        if not filtered_agents:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -1687,15 +1697,21 @@ class GatewayRunner:
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while filtered_agents and asyncio.get_running_loop().time() < deadline:
+            # Re-filter each iteration in case agents drop out.
+            filtered_agents = {
+                k: v for k, v in self._running_agents.items() if k != exclude_key
+            }
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(filtered_agents)
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
-    def _interrupt_running_agents(self, reason: str) -> None:
+    def _interrupt_running_agents(self, reason: str, exclude_key: str = None) -> None:
         for session_key, agent in list(self._running_agents.items()):
+            if session_key == exclude_key:
+                continue
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -2653,7 +2669,9 @@ class GatewayRunner:
             await self._notify_active_sessions_of_shutdown()
 
             timeout = self._restart_drain_timeout
-            active_agents, timed_out = await self._drain_active_agents(timeout)
+            active_agents, timed_out = await self._drain_active_agents(
+                timeout, exclude_key=self._restart_caller_key
+            )
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
@@ -2695,7 +2713,8 @@ class GatewayRunner:
                             _sk, _e,
                         )
                 self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+                    exclude_key=self._restart_caller_key,
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
@@ -5387,6 +5406,10 @@ class GatewayRunner:
         # doesn't work under systemd because KillMode=mixed kills all
         # processes in the cgroup, including the detached helper.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # Record the caller's session_key so drain can exclude it — the restart
+        # triggerer's agent cannot exit until it receives the HTTP response, so
+        # excluding it prevents the drain-from-itself deadlock.
+        self._restart_caller_key = self._session_key_for_source(event.source)
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10212,12 +10212,21 @@ class GatewayRunner:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
+                    # Build main_runtime from the agent that handled this run
+                    _title_agent = agent_holder[0]
                     maybe_auto_title(
                         self._session_db,
                         effective_session_id,
                         message,
                         final_response,
                         all_msgs,
+                        main_runtime={
+                            "model": getattr(_title_agent, "model", None),
+                            "provider": getattr(_title_agent, "provider", None),
+                            "base_url": getattr(_title_agent, "base_url", None),
+                            "api_key": getattr(_title_agent, "api_key", None),
+                            "api_mode": getattr(_title_agent, "api_mode", None),
+                        } if _title_agent else None,
                     )
                 except Exception:
                     pass

--- a/run_agent.py
+++ b/run_agent.py
@@ -8055,6 +8055,203 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
+    def flush_memories(self, messages: list = None, min_turns: int = None):
+        """Give the model one turn to persist memories before context is lost.
+
+        Called before compression, session reset, or CLI exit. Injects a flush
+        message, makes one API call, executes any memory tool calls, then
+        strips all flush artifacts from the message list.
+
+        Args:
+            messages: The current conversation messages. If None, uses
+                      self._session_messages (last run_conversation state).
+            min_turns: Minimum user turns required to trigger the flush.
+                       None = use config value (flush_min_turns).
+                       0 = always flush (used for compression).
+        """
+        if self._memory_flush_min_turns == 0 and min_turns is None:
+            return
+        if "memory" not in self.valid_tool_names or not self._memory_store:
+            return
+        effective_min = min_turns if min_turns is not None else self._memory_flush_min_turns
+        if self._user_turn_count < effective_min:
+            return
+
+        if messages is None:
+            messages = getattr(self, '_session_messages', None)
+        if not messages or len(messages) < 3:
+            return
+
+        flush_content = (
+            "[System: The session is being compressed. "
+            "Save anything worth remembering — prioritize user preferences, "
+            "corrections, and recurring patterns over task-specific details.]"
+        )
+        _sentinel = f"__flush_{id(self)}_{time.monotonic()}"
+        flush_msg = {"role": "user", "content": flush_content, "_flush_sentinel": _sentinel}
+        messages.append(flush_msg)
+
+        try:
+            # Build API messages for the flush call
+            _needs_sanitize = self._should_sanitize_tool_calls()
+            api_messages = []
+            for msg in messages:
+                api_msg = msg.copy()
+                self._copy_reasoning_content_for_api(msg, api_msg)
+                api_msg.pop("reasoning", None)
+                api_msg.pop("finish_reason", None)
+                api_msg.pop("_flush_sentinel", None)
+                api_msg.pop("_thinking_prefill", None)
+                if _needs_sanitize:
+                    self._sanitize_tool_calls_for_strict_api(api_msg)
+                api_messages.append(api_msg)
+
+            if self._cached_system_prompt:
+                api_messages = [{"role": "system", "content": self._cached_system_prompt}] + api_messages
+
+            # Make one API call with only the memory tool available
+            memory_tool_def = None
+            for t in (self.tools or []):
+                if t.get("function", {}).get("name") == "memory":
+                    memory_tool_def = t
+                    break
+
+            if not memory_tool_def:
+                messages.pop()  # remove flush msg
+                return
+
+            # Use auxiliary client for the flush call when available --
+            # it's cheaper and avoids Codex Responses API incompatibility.
+            from agent.auxiliary_client import (
+                call_llm as _call_llm,
+                _fixed_temperature_for_model,
+                OMIT_TEMPERATURE,
+            )
+            _aux_available = True
+            # Kimi models manage temperature server-side — omit it entirely.
+            # Other models with a fixed contract get that value; everyone else
+            # gets the historical 0.3 default.
+            _fixed_temp = _fixed_temperature_for_model(self.model, self.base_url)
+            _omit_temperature = _fixed_temp is OMIT_TEMPERATURE
+            if _omit_temperature:
+                _flush_temperature = None
+            elif _fixed_temp is not None:
+                _flush_temperature = _fixed_temp
+            else:
+                _flush_temperature = 0.3
+            try:
+                response = _call_llm(
+                    task="flush_memories",
+                    messages=api_messages,
+                    tools=[memory_tool_def],
+                    temperature=_flush_temperature,
+                    max_tokens=5120,
+                    main_runtime={
+                        "model": self.model,
+                        "provider": self.provider,
+                        "base_url": self.base_url,
+                        "api_key": self.api_key,
+                        "api_mode": self.api_mode,
+                    },
+                    # timeout resolved from auxiliary.flush_memories.timeout config
+                )
+            except RuntimeError:
+                _aux_available = False
+                response = None
+
+            if not _aux_available and self.api_mode == "codex_responses":
+                # No auxiliary client -- use the Codex Responses path directly
+                codex_kwargs = self._build_api_kwargs(api_messages)
+                codex_kwargs["tools"] = self._get_transport().convert_tools([memory_tool_def])
+                if _flush_temperature is not None:
+                    codex_kwargs["temperature"] = _flush_temperature
+                else:
+                    codex_kwargs.pop("temperature", None)
+                if "max_output_tokens" in codex_kwargs:
+                    codex_kwargs["max_output_tokens"] = 5120
+                response = self._run_codex_stream(codex_kwargs)
+            elif not _aux_available and self.api_mode == "anthropic_messages":
+                # Native Anthropic — use the transport for kwargs
+                _tflush = self._get_transport()
+                ant_kwargs = _tflush.build_kwargs(
+                    model=self.model, messages=api_messages,
+                    tools=[memory_tool_def], max_tokens=5120,
+                    reasoning_config=None,
+                    preserve_dots=self._anthropic_preserve_dots(),
+                )
+                response = self._anthropic_messages_create(ant_kwargs)
+            elif not _aux_available:
+                api_kwargs = {
+                    "model": self.model,
+                    "messages": api_messages,
+                    "tools": [memory_tool_def],
+                    **self._max_tokens_param(5120),
+                }
+                if _flush_temperature is not None:
+                    api_kwargs["temperature"] = _flush_temperature
+                from agent.auxiliary_client import _get_task_timeout
+                response = self._ensure_primary_openai_client(reason="flush_memories").chat.completions.create(
+                    **api_kwargs, timeout=_get_task_timeout("flush_memories")
+                )
+
+            # Extract tool calls from the response, handling all API formats
+            tool_calls = []
+            if self.api_mode == "codex_responses" and not _aux_available:
+                _ct_flush = self._get_transport()
+                _cnr_flush = _ct_flush.normalize_response(response)
+                if _cnr_flush and _cnr_flush.tool_calls:
+                    tool_calls = [
+                        SimpleNamespace(
+                            id=tc.id, type="function",
+                            function=SimpleNamespace(name=tc.name, arguments=tc.arguments),
+                        ) for tc in _cnr_flush.tool_calls
+                    ]
+            elif self.api_mode == "anthropic_messages" and not _aux_available:
+                _tfn = self._get_transport()
+                _flush_nr = _tfn.normalize_response(response, strip_tool_prefix=self._is_anthropic_oauth)
+                if _flush_nr and _flush_nr.tool_calls:
+                    tool_calls = [
+                        SimpleNamespace(
+                            id=tc.id, type="function",
+                            function=SimpleNamespace(name=tc.name, arguments=tc.arguments),
+                        ) for tc in _flush_nr.tool_calls
+                    ]
+            elif hasattr(response, "choices") and response.choices:
+                # chat_completions / bedrock — normalize through transport
+                _flush_cc_nr = self._get_transport().normalize_response(response)
+                _flush_msg = self._nr_to_assistant_message(_flush_cc_nr)
+                if _flush_msg.tool_calls:
+                    tool_calls = _flush_msg.tool_calls
+
+            for tc in tool_calls:
+                if tc.function.name == "memory":
+                    try:
+                        args = json.loads(tc.function.arguments)
+                        flush_target = args.get("target", "memory")
+                        from tools.memory_tool import memory_tool as _memory_tool
+                        _memory_tool(
+                            action=args.get("action"),
+                            target=flush_target,
+                            content=args.get("content"),
+                            old_text=args.get("old_text"),
+                            store=self._memory_store,
+                        )
+                        if not self.quiet_mode:
+                            print(f"  🧠 Memory flush: saved to {args.get('target', 'memory')}")
+                    except Exception as e:
+                        logger.debug("Memory flush tool call failed: %s", e)
+        except Exception as e:
+            logger.debug("Memory flush API call failed: %s", e)
+        finally:
+            # Strip flush artifacts: remove everything from the flush message onward.
+            # Use sentinel marker instead of identity check for robustness.
+            while messages and messages[-1].get("_flush_sentinel") != _sentinel:
+                messages.pop()
+                if not messages:
+                    break
+            if messages and messages[-1].get("_flush_sentinel") == _sentinel:
+                messages.pop()
+
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -150,7 +150,7 @@ class TestMaybeAutoTitle:
             # Wait for the daemon thread to complete
             import time
             time.sleep(0.3)
-            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there")
+            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there", None)
 
     def test_skips_if_no_response(self):
         db = MagicMock()

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -62,6 +62,7 @@ def make_restart_runner(
     runner._restart_detached = False
     runner._restart_via_service = False
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._restart_caller_key = None
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -206,6 +206,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -112,6 +112,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}


### PR DESCRIPTION
## Summary

Three self-contained bug fixes extracted from PR #15632:

### 1. fix(gateway): exclude restart caller from drain to prevent 60s hang
/restart triggered a drain that waited for ALL agents including the caller agent itself, which was waiting for the HTTP response — creating a deadlock that always timed out after 60 seconds.

Files: gateway/run.py

### 2. fix(auxiliary): custom provider uses main_runtime model + URL rewrite
- : apply  to custom  — fixes /anthropic → /v1 rewrite missing for provider="custom"
- : use  instead of  so auxiliary tasks follow system default model changes

Files: agent/auxiliary_client.py, agent/title_generator.py, cli.py, gateway/run.py, run_agent.py

### 3. fix(test): add missing _restart_caller_key in test_marker_written_on_graceful_stop
配套测试修复，添加  参数。

Files: tests/gateway/test_clean_shutdown_marker.py

---

All 3 commits cherry-pick cleanly onto current upstream/main. No conflicts.