### PR TITLE
feat(discord): auto-rename Hermes-owned threads with a short title

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -631,6 +631,15 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                # Auto-rename of Hermes-owned threads after first reply.
+                # See gateway/platforms/discord_thread_rename.py for the
+                # supported delay modes and length cap.
+                if "auto_rename_threads" in discord_cfg and not os.getenv("DISCORD_AUTO_RENAME_THREADS"):
+                    os.environ["DISCORD_AUTO_RENAME_THREADS"] = str(discord_cfg["auto_rename_threads"]).lower()
+                if "auto_rename_max_length" in discord_cfg and not os.getenv("DISCORD_AUTO_RENAME_MAX_LENGTH"):
+                    os.environ["DISCORD_AUTO_RENAME_MAX_LENGTH"] = str(discord_cfg["auto_rename_max_length"])
+                if "auto_rename_delay" in discord_cfg and not os.getenv("DISCORD_AUTO_RENAME_DELAY"):
+                    os.environ["DISCORD_AUTO_RENAME_DELAY"] = str(discord_cfg["auto_rename_delay"])
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -44,6 +44,10 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 from gateway.config import Platform, PlatformConfig
 import re
 
+from gateway.platforms.discord_thread_rename import (
+    load_config_from_env as _load_auto_rename_config,
+    maybe_auto_rename_thread,
+)
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -529,6 +533,14 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # Auto-rename Hermes-owned threads with a short conversation-style
+        # title after the first assistant response.  Per-thread state lives
+        # on the adapter so we never rename twice or stomp on user-set
+        # names.  Per-thread user prompts are captured in _handle_message
+        # and consumed in send().
+        self._auto_rename_cfg = _load_auto_rename_config()
+        self._renamed_threads: set = set()
+        self._pending_user_messages: Dict[str, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1150,6 +1162,18 @@ class DiscordAdapter(BasePlatformAdapter):
                         raise
                 message_ids.append(str(msg.id))
 
+            # Hermes-owned thread? Schedule a one-shot auto-rename in the
+            # background so the user-facing reply isn't blocked on the
+            # auxiliary LLM round-trip or Discord PATCH.
+            thread_cls = getattr(discord, "Thread", None) if discord is not None else None
+            if (
+                self._auto_rename_cfg.enabled
+                and message_ids
+                and thread_cls is not None
+                and isinstance(channel, thread_cls)
+            ):
+                self._schedule_thread_auto_rename(channel, content)
+
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
@@ -1159,6 +1183,45 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    def _schedule_thread_auto_rename(self, thread: Any, assistant_response: str) -> None:
+        """Fire-and-forget: rename ``thread`` based on the captured user prompt.
+
+        Pops the pending user message so a second send into the same
+        thread doesn't re-trigger a rename mid-conversation; the
+        ``_renamed_threads`` set is the persistent guard.
+        """
+        thread_id = str(getattr(thread, "id", "") or "")
+        if not thread_id:
+            return
+        if thread_id in self._renamed_threads:
+            return
+        if thread_id not in self._threads:
+            return
+        user_message = self._pending_user_messages.pop(thread_id, None)
+        if not user_message:
+            return
+
+        cfg = self._auto_rename_cfg
+        renamed_threads = self._renamed_threads
+
+        async def _runner():
+            await maybe_auto_rename_thread(
+                thread,
+                user_message,
+                assistant_response,
+                cfg,
+                is_renamed=lambda: thread_id in renamed_threads,
+                on_renamed=lambda _title: renamed_threads.add(thread_id),
+            )
+
+        try:
+            asyncio.create_task(_runner())
+        except RuntimeError:
+            # No running loop (rare: send() called outside the bot loop —
+            # e.g. in unit tests).  Silently skip — auto-rename is
+            # non-essential.
+            logger.debug("[%s] No event loop available to auto-rename %s", self.name, thread_id)
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
@@ -3310,6 +3373,21 @@ class DiscordAdapter(BasePlatformAdapter):
         # For threads whose parent is a forum channel, inherit the parent's topic
         # so forum descriptions (e.g. project instructions) appear in the session context.
         chat_topic = self._get_effective_topic(message.channel, is_thread=is_thread)
+
+        # Capture the user prompt so the auto-rename hook in send() can
+        # generate a title from the same exchange.  Only stash for threads
+        # that Hermes owns (auto-created or already-participated) so we
+        # don't accidentally rename arbitrary threads someone happened to
+        # @mention us in.
+        if (
+            self._auto_rename_cfg.enabled
+            and is_thread
+            and thread_id
+            and thread_id in self._threads
+            and thread_id not in self._renamed_threads
+            and normalized_content
+        ):
+            self._pending_user_messages[thread_id] = normalized_content
 
         # Build source
         source = self.build_source(

--- a/gateway/platforms/discord_thread_rename.py
+++ b/gateway/platforms/discord_thread_rename.py
@@ -1,0 +1,241 @@
+"""Auto-rename Hermes Discord threads with a short, conversation-style title.
+
+When Hermes auto-creates a thread on @mention (or runs inside a thread it
+already participated in), the thread name starts as the raw user prompt
+truncated to 80 chars.  After the first assistant response, this module
+generates a clean 3-8 word title (Claude/ChatGPT style) and renames the
+thread once via Discord's PATCH /channels/{thread_id} endpoint.
+
+Kept deliberately platform-local: the Discord adapter owns the trigger
+and state, so no broader gateway/core change is required.  Title
+generation reuses ``agent.title_generator.generate_title`` (cheap
+auxiliary LLM path).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Discord enforces a 100-char hard limit on channel/thread names.
+DISCORD_MAX_THREAD_NAME = 100
+
+# Default cap for the generated title — keeps thread lists readable.
+DEFAULT_MAX_LENGTH = 60
+
+# Modes for when to fire the rename.  Only one mode is supported today;
+# the field exists so future delays (after_first_user_response, after_n
+# exchanges, ...) slot in without breaking config consumers.
+DELAY_AFTER_FIRST_ASSISTANT_RESPONSE = "after_first_assistant_response"
+
+_VALID_DELAYS = {DELAY_AFTER_FIRST_ASSISTANT_RESPONSE}
+
+# Characters that look noisy in a thread title.
+_TRAILING_PUNCTUATION = ".!?,;:\u2026"
+
+# Discord channel/thread names cannot contain control chars; collapse
+# any whitespace run (including newlines, tabs) into a single space.
+_WS_RUN = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class DiscordAutoRenameConfig:
+    """Resolved config for the auto-rename feature."""
+
+    enabled: bool = False
+    max_length: int = DEFAULT_MAX_LENGTH
+    delay: str = DELAY_AFTER_FIRST_ASSISTANT_RESPONSE
+
+    @property
+    def effective_max_length(self) -> int:
+        """Clamp the user-provided cap to Discord's hard limit."""
+        if self.max_length <= 0:
+            return DEFAULT_MAX_LENGTH
+        return min(self.max_length, DISCORD_MAX_THREAD_NAME)
+
+
+def load_config_from_env(env: Optional[dict] = None) -> DiscordAutoRenameConfig:
+    """Build a config from environment variables.
+
+    Env vars (all optional):
+      DISCORD_AUTO_RENAME_THREADS    bool, default ``true``
+      DISCORD_AUTO_RENAME_MAX_LENGTH int,  default ``60``
+      DISCORD_AUTO_RENAME_DELAY      str,  default ``after_first_assistant_response``
+    """
+    src = env if env is not None else os.environ
+
+    raw_enabled = src.get("DISCORD_AUTO_RENAME_THREADS", "true")
+    enabled = str(raw_enabled).strip().lower() in ("1", "true", "yes", "on")
+
+    raw_len = src.get("DISCORD_AUTO_RENAME_MAX_LENGTH", "")
+    try:
+        max_length = int(raw_len) if str(raw_len).strip() else DEFAULT_MAX_LENGTH
+    except ValueError:
+        max_length = DEFAULT_MAX_LENGTH
+
+    raw_delay = (src.get("DISCORD_AUTO_RENAME_DELAY") or DELAY_AFTER_FIRST_ASSISTANT_RESPONSE).strip()
+    delay = raw_delay if raw_delay in _VALID_DELAYS else DELAY_AFTER_FIRST_ASSISTANT_RESPONSE
+
+    return DiscordAutoRenameConfig(enabled=enabled, max_length=max_length, delay=delay)
+
+
+def sanitize_title(raw: str, max_length: int = DEFAULT_MAX_LENGTH) -> str:
+    """Clean an LLM-generated title down to a Discord-safe thread name.
+
+    - Strips surrounding quotes/whitespace and a leading "Title:" prefix.
+    - Collapses internal whitespace runs into single spaces.
+    - Trims trailing punctuation.
+    - Truncates to ``max_length`` (clamped to Discord's 100-char limit)
+      on a word boundary when possible, with a trailing ellipsis.
+    Returns ``""`` for empty / unsalvageable input — callers should treat
+    that as "skip rename".
+    """
+    if not raw:
+        return ""
+
+    title = raw.strip().strip("\"'\u201c\u201d\u2018\u2019")
+    if title.lower().startswith("title:"):
+        title = title[6:].strip().strip("\"'\u201c\u201d\u2018\u2019")
+
+    # Collapse all whitespace (incl. newlines) into single spaces.
+    title = _WS_RUN.sub(" ", title).strip()
+
+    # Strip trailing punctuation (a single pass is enough since we
+    # already collapsed whitespace).
+    title = title.rstrip(_TRAILING_PUNCTUATION).strip()
+
+    if not title:
+        return ""
+
+    cap = max(1, min(max_length, DISCORD_MAX_THREAD_NAME))
+    if len(title) <= cap:
+        return title
+
+    # Truncate; prefer a word boundary so we don't chop a word in half.
+    cut = title[: cap - 1]
+    space = cut.rfind(" ")
+    if space >= max(10, cap // 2):
+        cut = cut[:space]
+    return cut.rstrip(_TRAILING_PUNCTUATION + " ") + "\u2026"
+
+
+def looks_like_raw_prompt(current_name: str, original_prompt: str) -> bool:
+    """Heuristic: does ``current_name`` still match the raw user prompt?
+
+    The Discord adapter seeds new threads with the first ~80 chars of the
+    user's mention-stripped message (see ``DiscordAdapter._auto_create_thread``).
+    If the current name still matches that seed, no human/agent has
+    renamed it yet — safe to overwrite.
+    """
+    if not current_name or not original_prompt:
+        return False
+    cur = _WS_RUN.sub(" ", current_name).strip()
+    seed = _WS_RUN.sub(" ", original_prompt).strip()
+    if not cur or not seed:
+        return False
+    if cur == seed:
+        return True
+    # The adapter may have appended an ellipsis when truncating to 80
+    # chars (``thread_name[:77] + "..."``).  Normalise that off.
+    cur_no_ell = cur.rstrip(".\u2026").rstrip()
+    seed_prefix = seed[: len(cur_no_ell)]
+    return bool(cur_no_ell) and cur_no_ell == seed_prefix.strip()
+
+
+async def maybe_auto_rename_thread(
+    thread: Any,
+    user_message: str,
+    assistant_response: str,
+    config: DiscordAutoRenameConfig,
+    *,
+    is_renamed: Callable[[], bool] = lambda: False,
+    on_renamed: Callable[[str], None] = lambda _title: None,
+    title_generator: Optional[Callable[[str, str], Optional[str]]] = None,
+    edit_runner: Optional[Callable[[Any, str], Awaitable[None]]] = None,
+) -> Optional[str]:
+    """Generate a title and rename a Hermes-owned Discord thread.
+
+    Returns the applied title on success, ``None`` if skipped or failed.
+    All failure paths log at WARNING/DEBUG and never raise — the caller
+    (a fire-and-forget background task in the adapter) must keep the
+    user-facing reply uninterrupted.
+
+    Injection points (all optional, real defaults):
+      title_generator(user, assistant) -> Optional[str]
+        Defaults to ``agent.title_generator.generate_title``.
+      edit_runner(thread, name) -> Awaitable[None]
+        Defaults to ``await thread.edit(name=name, reason=...)``.
+    """
+    if not config.enabled:
+        return None
+    if config.delay != DELAY_AFTER_FIRST_ASSISTANT_RESPONSE:
+        # Reserved for future strategies; treat unknown delays as "skip"
+        # rather than silently firing on the wrong trigger.
+        logger.debug("Discord auto-rename: unsupported delay %r, skipping", config.delay)
+        return None
+    if thread is None:
+        return None
+    if not user_message or not assistant_response:
+        return None
+
+    try:
+        if is_renamed():
+            return None
+    except Exception:
+        # is_renamed should never raise; if it does, fail open (skip)
+        # rather than risk a duplicate rename.
+        return None
+
+    current_name = getattr(thread, "name", "") or ""
+    if not looks_like_raw_prompt(current_name, user_message):
+        # User already picked a real name OR a previous run already set
+        # one.  Don't stomp on it.
+        logger.debug(
+            "Discord auto-rename: thread name %r no longer matches raw prompt — skipping",
+            current_name,
+        )
+        return None
+
+    if title_generator is None:
+        from agent.title_generator import generate_title as title_generator  # noqa: PLC0415
+
+    try:
+        raw_title = title_generator(user_message, assistant_response)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Discord auto-rename: title generation raised %s", e)
+        return None
+
+    cleaned = sanitize_title(raw_title or "", config.effective_max_length)
+    if not cleaned:
+        logger.debug("Discord auto-rename: empty title after sanitization, skipping")
+        return None
+    if cleaned == current_name:
+        return None
+
+    if edit_runner is None:
+        async def edit_runner(t: Any, name: str) -> None:
+            await t.edit(name=name, reason="Hermes auto-rename")
+
+    try:
+        await edit_runner(thread, cleaned)
+    except Exception as e:
+        logger.warning(
+            "Discord auto-rename: failed to rename thread %s to %r: %s",
+            getattr(thread, "id", "?"), cleaned, e,
+        )
+        return None
+
+    try:
+        on_renamed(cleaned)
+    except Exception:  # pragma: no cover - defensive
+        pass
+    logger.info(
+        "Discord auto-rename: thread %s renamed to %r",
+        getattr(thread, "id", "?"), cleaned,
+    )
+    return cleaned

--- a/tests/gateway/test_discord_thread_rename.py
+++ b/tests/gateway/test_discord_thread_rename.py
@@ -1,0 +1,287 @@
+"""Tests for the Discord thread auto-rename feature.
+
+Covers:
+  * Title sanitization (quotes, punctuation, length, whitespace).
+  * Config gating (env vars, enabled/disabled).
+  * "Looks like raw prompt" detection so user-set names are not stomped.
+  * Discord API failure fallback (no exception, returns None).
+  * Repeat-rename prevention via the ``is_renamed`` callback.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.discord_thread_rename import (
+    DEFAULT_MAX_LENGTH,
+    DELAY_AFTER_FIRST_ASSISTANT_RESPONSE,
+    DISCORD_MAX_THREAD_NAME,
+    DiscordAutoRenameConfig,
+    load_config_from_env,
+    looks_like_raw_prompt,
+    maybe_auto_rename_thread,
+    sanitize_title,
+)
+
+
+# --------------------------------------------------------------------------
+# sanitize_title
+# --------------------------------------------------------------------------
+
+
+class TestSanitizeTitle:
+    def test_strips_quotes_and_punctuation(self):
+        assert sanitize_title('"Auto-renommage des threads Discord."') == \
+            "Auto-renommage des threads Discord"
+
+    def test_strips_title_prefix(self):
+        assert sanitize_title("Title: Refactor login flow") == "Refactor login flow"
+
+    def test_collapses_whitespace_and_newlines(self):
+        assert sanitize_title("Refactor   the\nlogin\tflow") == "Refactor the login flow"
+
+    def test_returns_empty_for_empty_input(self):
+        assert sanitize_title("") == ""
+        assert sanitize_title("   ") == ""
+        assert sanitize_title("...") == ""
+
+    def test_truncates_to_max_length_on_word_boundary(self):
+        title = "This is a long generated title that exceeds the limit by a lot"
+        out = sanitize_title(title, max_length=30)
+        assert len(out) <= 30
+        assert out.endswith("\u2026")
+        assert " " in out  # word boundary cut, not mid-word
+
+    def test_clamps_max_length_to_discord_limit(self):
+        # Even with a huge config cap, never exceed Discord's 100-char limit.
+        long = "x" * 200
+        out = sanitize_title(long, max_length=500)
+        assert len(out) <= DISCORD_MAX_THREAD_NAME
+
+    def test_handles_curly_quotes(self):
+        assert sanitize_title("\u201cFix login bug\u201d") == "Fix login bug"
+
+    def test_returns_short_unchanged(self):
+        assert sanitize_title("Hello world") == "Hello world"
+
+
+# --------------------------------------------------------------------------
+# load_config_from_env
+# --------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_defaults_enabled(self):
+        cfg = load_config_from_env(env={})
+        assert cfg.enabled is True
+        assert cfg.max_length == DEFAULT_MAX_LENGTH
+        assert cfg.delay == DELAY_AFTER_FIRST_ASSISTANT_RESPONSE
+
+    def test_disabled_via_env(self):
+        cfg = load_config_from_env(env={"DISCORD_AUTO_RENAME_THREADS": "false"})
+        assert cfg.enabled is False
+
+    def test_max_length_override(self):
+        cfg = load_config_from_env(env={"DISCORD_AUTO_RENAME_MAX_LENGTH": "40"})
+        assert cfg.max_length == 40
+
+    def test_invalid_max_length_falls_back(self):
+        cfg = load_config_from_env(env={"DISCORD_AUTO_RENAME_MAX_LENGTH": "abc"})
+        assert cfg.max_length == DEFAULT_MAX_LENGTH
+
+    def test_unknown_delay_falls_back_to_default(self):
+        cfg = load_config_from_env(env={"DISCORD_AUTO_RENAME_DELAY": "ater_first_yolo"})
+        assert cfg.delay == DELAY_AFTER_FIRST_ASSISTANT_RESPONSE
+
+    def test_effective_max_length_clamps_to_discord_limit(self):
+        cfg = DiscordAutoRenameConfig(enabled=True, max_length=500)
+        assert cfg.effective_max_length == DISCORD_MAX_THREAD_NAME
+
+    def test_effective_max_length_replaces_zero_with_default(self):
+        cfg = DiscordAutoRenameConfig(enabled=True, max_length=0)
+        assert cfg.effective_max_length == DEFAULT_MAX_LENGTH
+
+
+# --------------------------------------------------------------------------
+# looks_like_raw_prompt
+# --------------------------------------------------------------------------
+
+
+class TestLooksLikeRawPrompt:
+    def test_exact_match(self):
+        assert looks_like_raw_prompt("hello world", "hello world") is True
+
+    def test_truncated_with_ellipsis(self):
+        prompt = "lorsque l'agent Hermes ouvre un thread dans Discord il le renomme"
+        # adapter does prompt[:77] + "..."
+        seeded = prompt[:77] + "..."
+        assert looks_like_raw_prompt(seeded, prompt) is True
+
+    def test_user_set_name_returns_false(self):
+        assert looks_like_raw_prompt("Customer billing thread", "fix the broken login") is False
+
+    def test_empty_inputs(self):
+        assert looks_like_raw_prompt("", "anything") is False
+        assert looks_like_raw_prompt("anything", "") is False
+
+
+# --------------------------------------------------------------------------
+# maybe_auto_rename_thread
+# --------------------------------------------------------------------------
+
+
+def _fake_thread(name: str, edit: AsyncMock | None = None):
+    thread = MagicMock()
+    thread.id = 1234567
+    thread.name = name
+    thread.edit = edit if edit is not None else AsyncMock()
+    return thread
+
+
+@pytest.mark.asyncio
+async def test_renames_thread_on_happy_path():
+    cfg = DiscordAutoRenameConfig(enabled=True)
+    thread = _fake_thread("fix the login bug please")
+    on_renamed = MagicMock()
+
+    result = await maybe_auto_rename_thread(
+        thread,
+        user_message="fix the login bug please",
+        assistant_response="Sure, looking into it.",
+        config=cfg,
+        on_renamed=on_renamed,
+        title_generator=lambda u, a: "Fix the broken login flow",
+    )
+
+    assert result == "Fix the broken login flow"
+    thread.edit.assert_awaited_once()
+    kwargs = thread.edit.await_args.kwargs
+    assert kwargs["name"] == "Fix the broken login flow"
+    assert "reason" in kwargs
+    on_renamed.assert_called_once_with("Fix the broken login flow")
+
+
+@pytest.mark.asyncio
+async def test_skips_when_disabled():
+    cfg = DiscordAutoRenameConfig(enabled=False)
+    thread = _fake_thread("anything")
+
+    result = await maybe_auto_rename_thread(
+        thread, "u", "a", cfg,
+        title_generator=lambda u, a: "Generated",
+    )
+    assert result is None
+    thread.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_already_renamed():
+    cfg = DiscordAutoRenameConfig(enabled=True)
+    thread = _fake_thread("fix the login bug please")
+
+    result = await maybe_auto_rename_thread(
+        thread, "fix the login bug please", "ok", cfg,
+        is_renamed=lambda: True,
+        title_generator=lambda u, a: "Generated Title",
+    )
+    assert result is None
+    thread.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_thread_name_no_longer_matches_prompt():
+    """User (or another agent) already renamed the thread — leave it alone."""
+    cfg = DiscordAutoRenameConfig(enabled=True)
+    thread = _fake_thread("Customer billing thread")
+
+    result = await maybe_auto_rename_thread(
+        thread,
+        user_message="fix the broken login",
+        assistant_response="ok",
+        config=cfg,
+        title_generator=lambda u, a: "Generated Title",
+    )
+    assert result is None
+    thread.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_does_not_raise_when_discord_edit_fails():
+    """Forbidden / HTTPException must be swallowed and logged — never bubble."""
+    cfg = DiscordAutoRenameConfig(enabled=True)
+    edit = AsyncMock(side_effect=RuntimeError("403 Forbidden: missing perms"))
+    thread = _fake_thread("fix the login bug", edit=edit)
+    on_renamed = MagicMock()
+
+    result = await maybe_auto_rename_thread(
+        thread, "fix the login bug", "ok", cfg,
+        on_renamed=on_renamed,
+        title_generator=lambda u, a: "Fix Login Bug",
+    )
+
+    assert result is None
+    edit.assert_awaited_once()
+    on_renamed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_title_generator_returns_empty():
+    cfg = DiscordAutoRenameConfig(enabled=True)
+    thread = _fake_thread("fix the login bug")
+
+    result = await maybe_auto_rename_thread(
+        thread, "fix the login bug", "ok", cfg,
+        title_generator=lambda u, a: "",
+    )
+    assert result is None
+    thread.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_user_or_assistant_message_missing():
+    cfg = DiscordAutoRenameConfig(enabled=True)
+    thread = _fake_thread("fix the login bug")
+    result = await maybe_auto_rename_thread(
+        thread, "", "response", cfg,
+        title_generator=lambda u, a: "Title",
+    )
+    assert result is None
+    thread.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_marks_renamed_only_after_successful_edit():
+    """on_renamed must fire exactly once after a successful edit, not before."""
+    cfg = DiscordAutoRenameConfig(enabled=True)
+
+    renamed_state = {"done": False}
+
+    async def fake_edit(name, reason):
+        # Simulate edit succeeding.
+        return None
+
+    thread = _fake_thread("fix the login bug", edit=AsyncMock(side_effect=fake_edit))
+
+    def is_renamed():
+        return renamed_state["done"]
+
+    def on_renamed(_title):
+        renamed_state["done"] = True
+
+    out1 = await maybe_auto_rename_thread(
+        thread, "fix the login bug", "ok", cfg,
+        is_renamed=is_renamed, on_renamed=on_renamed,
+        title_generator=lambda u, a: "Fix Login Bug",
+    )
+    assert out1 == "Fix Login Bug"
+    assert renamed_state["done"] is True
+
+    # Second call must short-circuit on is_renamed=True.
+    out2 = await maybe_auto_rename_thread(
+        thread, "fix the login bug", "ok", cfg,
+        is_renamed=is_renamed, on_renamed=on_renamed,
+        title_generator=lambda u, a: "Different Title",
+    )
+    assert out2 is None
+    # edit was called only once across both invocations
+    assert thread.edit.await_count == 1


### PR DESCRIPTION
## Summary
- Discord adapter generates a clean 3-8 word title (Claude/ChatGPT style) after the first assistant response in a Hermes-owned thread, then renames the thread once via `discord.Thread.edit()`.
- Reuses the existing cheap auxiliary LLM path (`agent.title_generator.generate_title`).
- Scope is intentionally local to the Discord platform adapter — no core/gateway changes.

## Behavior
- Fires only for threads tracked in `DiscordAdapter._threads` (auto-created or already-participated).
- Skips if the current thread name no longer matches the raw user prompt seed (no stomping on user/agent renames).
- Renames at most once per thread (per-process `_renamed_threads` guard).
- Forbidden / HTTPException / generation errors are swallowed and logged — the user-facing reply is never blocked.

## Config
New flags (env or `discord.*` yaml):
| Key                              | Default                              |
|----------------------------------|--------------------------------------|
| `auto_rename_threads`            | `true`                               |
| `auto_rename_max_length`         | `60` (capped at 100)                 |
| `auto_rename_delay`              | `after_first_assistant_response`     |

## Files
- `gateway/platforms/discord_thread_rename.py` — new helper module.
- `gateway/platforms/discord.py` — capture user prompt in `_handle_message`, schedule background rename in `send()`.
- `gateway/config.py` — yaml -> env bridge for the three new keys.
- `tests/gateway/test_discord_thread_rename.py` — 27 tests.

## Test plan
- [x] `tests/gateway/test_discord_thread_rename.py` (27 passed)
- [x] `tests/gateway/test_discord_send.py` (15 passed)
- [x] `tests/gateway/test_discord_thread_persistence.py` (7 passed)
- [x] `tests/gateway/test_discord_system_messages.py`, `test_discord_allowed_mentions.py` (passed)