### PR TITLE
feat(cmst): add index-first skill routing

### DIFF
--- a/tests/tools/test_cmst_tool.py
+++ b/tests/tools/test_cmst_tool.py
@@ -1,0 +1,212 @@
+import hashlib
+import json
+
+import pytest
+
+
+def test_cmst_toolset_registers_route_and_load(tmp_path, monkeypatch):
+    tree_root = tmp_path / "cmst-skill-tree"
+    module_dir = tree_root / "modules" / "debug-helper"
+    module_dir.mkdir(parents=True)
+    content = "---\nname: debug-helper\ndescription: Use when debugging tests.\n---\n\n# Debug Helper\n"
+    skill_file = module_dir / "SKILL.md"
+    skill_file.write_text(content, encoding="utf-8")
+    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    (tree_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "tree": "hermes",
+                "modules": {
+                    "debug-helper": {
+                        "status": "enabled",
+                        "path": "modules/debug-helper/SKILL.md",
+                        "sha256": sha,
+                        "keywords": ["debug", "failing", "test"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"skills": {"cmst_tree_root": str(tree_root)}})
+
+    from model_tools import get_tool_definitions, handle_function_call
+
+    tools = get_tool_definitions(enabled_toolsets=["cmst"], quiet_mode=True)
+    assert [tool["function"]["name"] for tool in tools] == ["cmst_load", "cmst_route"]
+    route_schema = tools[1]["function"]["parameters"]["properties"]
+    assert set(route_schema) == {"task", "limit"}
+
+    route_result = json.loads(handle_function_call("cmst_route", {"task": "debug a failing test"}))
+    assert route_result["mode"] == "index"
+    assert route_result["candidates"][0]["number"] == 1
+    assert set(route_result["candidates"][0]) == {"number", "description", "ref"}
+    assert route_result["candidates"][0]["description"] == "Use when debugging tests."
+    assert "debug-helper" in route_result["candidates"][0]["ref"]
+
+    load_result = json.loads(handle_function_call("cmst_load", {"ref": route_result["candidates"][0]["ref"]}))
+    assert load_result["id"] == "debug-helper"
+    assert load_result["content"] == content
+
+    auto_result = json.loads(handle_function_call("cmst_route", {"task": "debug a failing test", "mode": "auto"}))
+    assert auto_result["mode"] == "runtime"
+    assert auto_result["module"]["id"] == "debug-helper"
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        "fix pytest failure after refactor",
+        "fix a bug in session handling",
+        "investigate unexpected behavior in CLI",
+        "debug a test failure after refactor",
+    ],
+)
+def test_cmst_route_indexes_debug_tasks_with_systematic_debugging_first(tmp_path, monkeypatch, task):
+    tree_root = tmp_path / "cmst-skill-tree"
+    (tree_root / "modules" / "nano-pdf").mkdir(parents=True)
+    (tree_root / "modules" / "systematic-debugging").mkdir(parents=True)
+    (tree_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "tree": "hermes",
+                "modules": {
+                    "nano-pdf": {
+                        "status": "enabled",
+                        "path": "modules/nano-pdf/SKILL.md",
+                        "sha256": "0" * 64,
+                        "keywords": ["nano-pdf", "fix", "pdfs"],
+                    },
+                    "systematic-debugging": {
+                        "status": "enabled",
+                        "path": "modules/systematic-debugging/SKILL.md",
+                        "sha256": "1" * 64,
+                        "keywords": ["systematic-debugging", "bug", "test", "failure", "unexpected", "behavior"],
+                        "summary": "Use for bugs, test failures, unexpected behavior, and build failures.",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"skills": {"cmst_tree_root": str(tree_root)}})
+
+    from tools.cmst_tool import cmst_route
+
+    route_result = json.loads(cmst_route(task))
+    assert route_result["mode"] == "index"
+    assert route_result["candidates"][0]["number"] == 1
+    assert set(route_result["candidates"][0]) == {"number", "description", "ref"}
+    assert route_result["candidates"][0]["description"] == "Use for bugs, test failures, unexpected behavior, and build failures."
+    assert "systematic-debugging" in route_result["candidates"][0]["ref"]
+    assert "nano-pdf" not in route_result["candidates"][0]["ref"]
+
+    auto_result = json.loads(cmst_route(task, mode="auto"))
+    assert auto_result["module"]["id"] == "systematic-debugging"
+
+
+def test_cmst_route_pdf_context_ranks_pdf_skill_first(tmp_path, monkeypatch):
+    tree_root = tmp_path / "cmst-skill-tree"
+    (tree_root / "modules" / "nano-pdf").mkdir(parents=True)
+    (tree_root / "modules" / "systematic-debugging").mkdir(parents=True)
+    (tree_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "tree": "hermes",
+                "modules": {
+                    "nano-pdf": {
+                        "status": "enabled",
+                        "path": "modules/nano-pdf/SKILL.md",
+                        "sha256": "0" * 64,
+                        "keywords": ["nano-pdf", "edit", "pdfs", "fix", "typos"],
+                        "summary": "Use when editing existing PDF files.",
+                    },
+                    "systematic-debugging": {
+                        "status": "enabled",
+                        "path": "modules/systematic-debugging/SKILL.md",
+                        "sha256": "1" * 64,
+                        "keywords": ["systematic-debugging", "bug", "test", "failure", "unexpected", "behavior"],
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"skills": {"cmst_tree_root": str(tree_root)}})
+
+    from tools.cmst_tool import cmst_route
+
+    route_result = json.loads(cmst_route("fix a typo in a PDF"))
+    assert "nano-pdf" in route_result["candidates"][0]["ref"]
+    assert route_result["candidates"][0]["description"] == "Use when editing existing PDF files."
+
+
+def test_cmst_route_can_return_multiple_relevant_skill_cards(tmp_path, monkeypatch):
+    tree_root = tmp_path / "cmst-skill-tree"
+    (tree_root / "modules" / "systematic-debugging").mkdir(parents=True)
+    (tree_root / "modules" / "test-driven-development").mkdir(parents=True)
+    (tree_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "tree": "hermes",
+                "modules": {
+                    "systematic-debugging": {
+                        "status": "enabled",
+                        "path": "modules/systematic-debugging/SKILL.md",
+                        "sha256": "1" * 64,
+                        "keywords": ["systematic-debugging", "bug", "failure", "unexpected", "behavior"],
+                    },
+                    "test-driven-development": {
+                        "status": "enabled",
+                        "path": "modules/test-driven-development/SKILL.md",
+                        "sha256": "2" * 64,
+                        "keywords": ["test-driven-development", "bugfix", "test-first", "implementation"],
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"skills": {"cmst_tree_root": str(tree_root)}})
+
+    from tools.cmst_tool import cmst_route
+
+    route_result = json.loads(cmst_route("implement a bug fix with tests after diagnosis"))
+    candidate_refs = [candidate["ref"] for candidate in route_result["candidates"]]
+    assert any("systematic-debugging" in ref for ref in candidate_refs)
+    assert any("test-driven-development" in ref for ref in candidate_refs)
+
+
+def test_cmst_load_rejects_content_hash_mismatch(tmp_path, monkeypatch):
+    tree_root = tmp_path / "cmst-skill-tree"
+    module_dir = tree_root / "modules" / "debug-helper"
+    module_dir.mkdir(parents=True)
+    (module_dir / "SKILL.md").write_text("changed content", encoding="utf-8")
+    manifest_sha = "0" * 64
+    (tree_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "tree": "hermes",
+                "modules": {
+                    "debug-helper": {
+                        "status": "enabled",
+                        "path": "modules/debug-helper/SKILL.md",
+                        "sha256": manifest_sha,
+                        "keywords": ["debug"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"skills": {"cmst_tree_root": str(tree_root)}})
+
+    from tools.cmst_tool import cmst_load
+
+    result = json.loads(cmst_load(f"cmst://hermes/debug-helper@sha256:{manifest_sha}"))
+    assert result == {"error": "module content hash mismatch"}

--- a/tools/cmst_tool.py
+++ b/tools/cmst_tool.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Catmaster Skill Tree native Hermes tools."""
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+from tools.registry import registry, tool_error
+
+
+REF_RE = re.compile(r"^cmst://(?P<tree>[A-Za-z0-9_-]+)/(?P<module>[A-Za-z0-9_-]+)@sha256:(?P<sha>[a-f0-9]{64})$")
+WORD_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+FRONTMATTER_DESCRIPTION_RE = re.compile(r"^description:\s*(?P<description>.+?)\s*$", re.MULTILINE)
+STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "for",
+    "from",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "set",
+    "the",
+    "to",
+    "use",
+    "when",
+    "with",
+}
+GENERIC_TASK_WORDS = {
+    "add",
+    "build",
+    "change",
+    "create",
+    "fix",
+    "help",
+    "implement",
+    "make",
+    "modify",
+    "task",
+    "update",
+}
+DEBUG_TASK_WORDS = {
+    "bug",
+    "bugfix",
+    "bugs",
+    "debug",
+    "debugging",
+    "error",
+    "errors",
+    "exception",
+    "exceptions",
+    "fail",
+    "failed",
+    "failing",
+    "failure",
+    "failures",
+    "pytest",
+    "regression",
+    "traceback",
+    "unexpected",
+}
+DEBUG_TASK_PHRASES = {"test failure", "test failures", "unexpected behavior", "unexpected behaviour"}
+PDF_TASK_WORDS = {"document", "documents", "pdf", "pdfs"}
+PDF_ACTION_WORDS = {"edit", "fix", "modify", "typo", "typos", "update"}
+TDD_TASK_WORDS = {"bugfix", "feature", "implementation", "test", "testing", "tests"}
+TDD_ACTION_WORDS = {"add", "build", "fix", "implement", "write"}
+DEFAULT_INDEX_LIMIT = 8
+
+
+def _tree_root() -> Path:
+    from hermes_cli.config import load_config
+
+    skills_cfg = load_config().get("skills", {})
+    configured = skills_cfg.get("cmst_tree_root")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return (hermes_home / "cmst-skill-tree").resolve()
+
+
+def _read_manifest(tree_root: Path) -> dict:
+    with (tree_root / "manifest.json").open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _module_ref(tree: str, module_id: str, module: dict) -> str:
+    return f"cmst://{tree}/{module_id}@sha256:{module['sha256']}"
+
+
+def _route_match(task: str, module_id: str, module: dict) -> tuple[int, list[str]]:
+    task_text = task.lower()
+    task_words = set(WORD_RE.findall(task_text))
+    score = 0
+    signals = []
+    for keyword in module.get("keywords", []):
+        normalized = str(keyword).lower().strip()
+        if not normalized or normalized in STOPWORDS:
+            continue
+        if " " in normalized:
+            if normalized in task_text:
+                score += 3
+                signals.append(normalized)
+        elif normalized in task_words:
+            if normalized in GENERIC_TASK_WORDS:
+                score += 1
+            else:
+                score += 2
+            signals.append(normalized)
+    for part in module_id.lower().split("-"):
+        if part and part not in STOPWORDS and part in task_words:
+            score += 1
+            signals.append(part)
+    if module_id == "systematic-debugging" and (task_words & DEBUG_TASK_WORDS or any(phrase in task_text for phrase in DEBUG_TASK_PHRASES)):
+        score += 4
+        signals.append("debug-task")
+    if module_id == "test-driven-development" and (task_words & TDD_TASK_WORDS or ({"bug"} <= task_words and task_words & TDD_ACTION_WORDS)):
+        score += 3
+        signals.append("test-first-implementation")
+    if module_id == "nano-pdf" and task_words & PDF_TASK_WORDS and task_words & PDF_ACTION_WORDS:
+        score += 4
+        signals.append("pdf-edit")
+    return score, sorted(set(signals))
+
+
+def _route_score(task: str, module_id: str, module: dict) -> int:
+    score, _ = _route_match(task, module_id, module)
+    return score
+
+
+def _enabled_modules(manifest: dict) -> list[tuple[str, dict]]:
+    return [(module_id, module) for module_id, module in manifest.get("modules", {}).items() if module.get("status") == "enabled"]
+
+
+def _summary_from_skill_file(tree_root: Path, module: dict) -> str | None:
+    relative_path = module.get("path")
+    if not relative_path:
+        return None
+    try:
+        path = _safe_module_path(tree_root, relative_path)
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    match = FRONTMATTER_DESCRIPTION_RE.search(text)
+    if not match:
+        return None
+    description = match.group("description").strip().strip('"\'')
+    return description or None
+
+
+def _module_description(tree_root: Path, module_id: str, module: dict) -> str:
+    explicit = module.get("summary") or module.get("description")
+    if explicit:
+        return str(explicit).strip()
+    from_file = _summary_from_skill_file(tree_root, module)
+    if from_file:
+        return from_file
+    keywords = [str(keyword).strip() for keyword in module.get("keywords", []) if str(keyword).strip() and str(keyword).strip() != module_id]
+    if keywords:
+        return "Signals: " + ", ".join(keywords[:8])
+    return "No summary available. Inspect the skill before using it."
+
+
+def _candidate_index(task: str, tree_root: Path, manifest: dict, limit: int = DEFAULT_INDEX_LIMIT) -> list[dict]:
+    enabled = _enabled_modules(manifest)
+    scored = []
+    for module_id, module in enabled:
+        score, signals = _route_match(task, module_id, module)
+        scored.append((score, module_id, module, signals))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    positive = [item for item in scored if item[0] > 0]
+    selected = positive[:limit] if positive else scored[:limit]
+    candidates = []
+    for index, (score, module_id, module, signals) in enumerate(selected, start=1):
+        candidates.append(
+            {
+                "number": index,
+                "description": _module_description(tree_root, module_id, module),
+                "ref": _module_ref(manifest["tree"], module_id, module),
+            }
+        )
+    return candidates
+
+
+def _auto_route(task: str, manifest: dict) -> tuple[str, dict] | None:
+    enabled = _enabled_modules(manifest)
+    scored = [(_route_score(task, module_id, module), module_id, module) for module_id, module in enabled]
+    scored = [item for item in scored if item[0] > 0]
+    if scored:
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        _, module_id, module = scored[0]
+        return module_id, module
+    if enabled:
+        return enabled[0]
+    return None
+
+
+def _safe_module_path(tree_root: Path, relative_path: str) -> Path:
+    root = tree_root.resolve()
+    path = (root / relative_path).resolve()
+    if root != path and root not in path.parents:
+        raise ValueError("module path escapes tree root")
+    if path.is_symlink():
+        raise ValueError("module path is a symlink")
+    return path
+
+
+def cmst_route(task: str, mode: str = "index", limit: int = DEFAULT_INDEX_LIMIT) -> str:
+    if not task or not task.strip():
+        return tool_error("task is required")
+    if mode not in {"index", "auto"}:
+        return tool_error("mode must be 'index' or 'auto'")
+    try:
+        tree_root = _tree_root()
+        manifest = _read_manifest(tree_root)
+        if mode == "index":
+            candidates = _candidate_index(task, tree_root, manifest, max(1, int(limit)))
+            if not candidates:
+                return tool_error("no enabled modules")
+            return json.dumps(
+                {
+                    "mode": "index",
+                    "candidates": candidates,
+                    "instruction": "Choose by number using the descriptions, then call cmst_load with the chosen ref.",
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        selected = _auto_route(task, manifest)
+        if not selected:
+            return tool_error("no enabled modules")
+        module_id, module = selected
+        return json.dumps({"mode": "runtime", "module": {"id": module_id, "ref": _module_ref(manifest["tree"], module_id, module)}}, indent=2, sort_keys=True)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def cmst_load(ref: str) -> str:
+    match = REF_RE.match(ref or "")
+    if not match:
+        return tool_error("invalid cmst ref")
+    try:
+        tree_root = _tree_root()
+        manifest = _read_manifest(tree_root)
+        tree = match.group("tree")
+        module_id = match.group("module")
+        expected_sha = match.group("sha")
+        if tree != manifest.get("tree"):
+            return tool_error("tree does not match manifest")
+        module = manifest.get("modules", {}).get(module_id)
+        if module is None:
+            return tool_error("module not found")
+        if module.get("status") != "enabled":
+            return tool_error("module is not enabled")
+        if module.get("sha256") != expected_sha:
+            return tool_error("module hash mismatch")
+        path = _safe_module_path(tree_root, module["path"])
+        content = path.read_bytes()
+        actual_sha = hashlib.sha256(content).hexdigest()
+        if actual_sha != expected_sha:
+            return tool_error("module content hash mismatch")
+        return json.dumps({"id": module_id, "ref": ref, "content": content.decode("utf-8")}, indent=2, sort_keys=True)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+CMST_ROUTE_SCHEMA = {
+    "name": "cmst_route",
+    "description": "Show a numbered Catmaster Skill Tree skill index for a task. Read the descriptions, choose the appropriate candidate number, then call cmst_load with that candidate's ref.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {"type": "string", "description": "Current user task or task stage to route."},
+            "limit": {"type": "integer", "description": "Maximum number of candidate cards to return in index mode."},
+        },
+        "required": ["task"],
+    },
+}
+
+
+CMST_LOAD_SCHEMA = {
+    "name": "cmst_load",
+    "description": "Load verified content for a Catmaster Skill Tree module ref returned by cmst_route.",
+    "parameters": {
+        "type": "object",
+        "properties": {"ref": {"type": "string", "description": "cmst:// tree module ref from the selected cmst_route candidate."}},
+        "required": ["ref"],
+    },
+}
+
+
+def check_cmst_requirements() -> bool:
+    return (_tree_root() / "manifest.json").exists()
+
+
+registry.register(
+    name="cmst_route",
+    toolset="cmst",
+    schema=CMST_ROUTE_SCHEMA,
+    handler=lambda args, **kw: cmst_route(args.get("task", ""), args.get("mode", "index"), args.get("limit", DEFAULT_INDEX_LIMIT)),
+    check_fn=check_cmst_requirements,
+    emoji="🌲",
+)
+
+registry.register(
+    name="cmst_load",
+    toolset="cmst",
+    schema=CMST_LOAD_SCHEMA,
+    handler=lambda args, **kw: cmst_load(args.get("ref", "")),
+    check_fn=check_cmst_requirements,
+    emoji="🌲",
+)


### PR DESCRIPTION
## Summary
- Add native CMST route/load tools that expose a numbered index of skill candidates before loading selected skill content.
- Rank debugging, TDD, and PDF-editing tasks with targeted signals while keeping the model-facing route schema minimal.
- Add regression coverage for index-first routing, hash validation, tool registration, and compatibility auto-routing.

## Test Plan
- [x] .venv/bin/pytest tests/tools/test_cmst_tool.py -q