### PR TITLE
Fix Codex auxiliary tool message conversion

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -377,19 +377,36 @@ class _CodexCompletionsAdapter:
         model = kwargs.get("model", self._model)
 
         # Separate system/instructions from conversation messages.
-        # Convert chat.completions multimodal content blocks to Responses
-        # API format (input_text / input_image instead of text / image_url).
+        # Convert chat.completions history to Responses API input items.  This
+        # must translate chat ``role=tool`` messages to ``function_call_output``
+        # items; sending raw tool-role messages to Codex Responses fails with
+        # HTTP 400 ("Invalid value: 'tool'").
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        conversation_msgs: List[Dict[str, Any]] = []
         for msg in messages:
+            if not isinstance(msg, dict):
+                continue
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
+                conversation_msgs.append(msg)
+
+        try:
+            from agent.codex_responses_adapter import _chat_messages_to_responses_input
+            input_msgs = _chat_messages_to_responses_input(conversation_msgs)
+        except Exception:
+            # Conservative fallback: preserve the old behavior but drop raw
+            # tool-role messages rather than forwarding a role Codex rejects.
+            input_msgs = []
+            for msg in conversation_msgs:
+                role = msg.get("role", "user")
+                if role == "tool":
+                    continue
                 input_msgs.append({
                     "role": role,
-                    "content": _convert_content_for_responses(content),
+                    "content": _convert_content_for_responses(msg.get("content") or ""),
                 })
 
         resp_kwargs: Dict[str, Any] = {

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,7 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
+    _CodexCompletionsAdapter,
 )
 
 
@@ -53,6 +54,88 @@ def codex_auth_dir(tmp_path, monkeypatch):
         lambda: "codex-test-token-abc123",
     )
     return codex_dir
+
+
+class _FakeCodexStream:
+    def __init__(self, captured, kwargs):
+        self._captured = captured
+        self._kwargs = kwargs
+
+    def __enter__(self):
+        self._captured.append(self._kwargs)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_response(self):
+        message = MagicMock()
+        message.type = "message"
+        part = MagicMock()
+        part.type = "output_text"
+        part.text = "ok"
+        message.content = [part]
+        final = MagicMock()
+        final.output = [message]
+        final.usage = None
+        return final
+
+
+class _FakeCodexResponses:
+    def __init__(self):
+        self.captured = []
+
+    def stream(self, **kwargs):
+        return _FakeCodexStream(self.captured, kwargs)
+
+
+class _FakeCodexClient:
+    def __init__(self):
+        self.responses = _FakeCodexResponses()
+
+
+class TestCodexCompletionsAdapter:
+    def test_converts_chat_tool_messages_to_responses_items(self):
+        client = _FakeCodexClient()
+        adapter = _CodexCompletionsAdapter(client, "gpt-5.5")
+
+        adapter.create(
+            model="gpt-5.5",
+            messages=[
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "remember this"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {"name": "memory", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_abc123", "content": "saved"},
+            ],
+        )
+
+        sent = client.responses.captured[0]
+        assert sent["instructions"] == "system prompt"
+        assert {"role": "tool", "content": "saved"} not in sent["input"]
+        assert {
+            "type": "function_call",
+            "call_id": "call_abc123",
+            "name": "memory",
+            "arguments": "{}",
+        } in sent["input"]
+        assert {
+            "type": "function_call_output",
+            "call_id": "call_abc123",
+            "output": "saved",
+        } in sent["input"]
 
 
 class TestNormalizeAuxProvider:


### PR DESCRIPTION
## Summary
- convert auxiliary Codex chat histories through the Responses adapter so tool-role messages become function_call_output items
- avoid forwarding raw role=tool messages that Codex Responses rejects
- add regression coverage for auxiliary memory/tool-message histories

## Tests
- venv/bin/python -m pytest -q -o addopts='' tests/agent/test_auxiliary_client.py::TestCodexCompletionsAdapter::test_converts_chat_tool_messages_to_responses_items
- venv/bin/python -m pytest -q -o addopts='' tests/agent/test_auxiliary_client.py tests/run_agent/test_background_review_summary.py tests/run_agent/test_run_agent_codex_responses.py::test_chat_messages_to_responses_input_uses_call_id_for_function_call tests/run_agent/test_run_agent_codex_responses.py::test_chat_messages_to_responses_input_accepts_call_pipe_fc_ids
- venv/bin/python -m pytest -q -o addopts='' tests/run_agent/test_run_agent_codex_responses.py
- venv/bin/python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
- hermes config check