### PR TITLE
fix(gateway): reorder interrupt-recovery prompt to prevent topic drift

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10243,11 +10243,11 @@ class GatewayRunner:
                 )
             elif agent_history and agent_history[-1].get("role") == "tool":
                 message = (
-                    "[System note: Your previous turn was interrupted before you could "
-                    "process the last tool result(s). The conversation history contains "
-                    "tool outputs you haven't responded to yet. Please finish processing "
-                    "those results and summarize what was accomplished, then address the "
-                    "user's new message below.]\n\n"
+                    "[System note: Address the user's new message below as the primary task. "
+                    "An orphaned tool result from a previous interrupted turn exists in history — "
+                    "reference or summarize it ONLY if it is directly relevant to the user's new message. "
+                    "If the new message is on a different topic, treat the orphan as resolved and ignore it. "
+                    "Do NOT lead your reply with stale-topic content.]\n\n"
                     + message
                 )
 

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -19,11 +19,11 @@ def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
     message = user_message
     if agent_history and agent_history[-1].get("role") == "tool":
         message = (
-            "[System note: Your previous turn was interrupted before you could "
-            "process the last tool result(s). The conversation history contains "
-            "tool outputs you haven't responded to yet. Please finish processing "
-            "those results and summarize what was accomplished, then address the "
-            "user's new message below.]\n\n"
+            "[System note: Address the user's new message below as the primary task. "
+            "An orphaned tool result from a previous interrupted turn exists in history — "
+            "reference or summarize it ONLY if it is directly relevant to the user's new message. "
+            "If the new message is on a different topic, treat the orphan as resolved and ignore it. "
+            "Do NOT lead your reply with stale-topic content.]\n\n"
             + message
         )
     return message
@@ -92,4 +92,39 @@ class TestAutoDetection:
         # System note comes first, then user's message
         note_end = result.index("]\n\n")
         user_msg_start = result.index("now do X")
+        assert user_msg_start > note_end
+
+    def test_prompt_prioritizes_new_message_and_allows_ignoring_orphan(self):
+        """Regression: the recovery prompt must lead with the new message as
+        the primary task and explicitly allow ignoring topic-mismatched
+        orphan tool results, to prevent stale-topic drift (see fix:
+        reorder interrupt-recovery prompt to prevent topic drift).
+        """
+        history = [
+            {"role": "user", "content": "probe the weather API"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "http_get", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"temp\": 72}"},
+        ]
+        # New user message is on a totally different topic
+        result = _simulate_auto_continue(history, "what's 2+2?")
+
+        # The new message must be present and the system note must instruct
+        # the model to treat the new message as the primary task.
+        assert "what's 2+2?" in result
+        lowered = result.lower()
+        assert "primary task" in lowered
+        assert "new message" in lowered
+        # Must permit ignoring the orphan when topics differ.
+        assert "ignore" in lowered or "treat the orphan as resolved" in lowered
+        assert "different topic" in lowered
+        # Must explicitly forbid leading the reply with stale-topic content.
+        assert "stale-topic" in lowered or "do not lead" in lowered
+        # Must NOT contain the old "process old results first" framing.
+        assert "finish processing" not in lowered
+        assert "process them first" not in lowered
+        # System note still comes before the user's actual message.
+        note_end = result.index("]\n\n")
+        user_msg_start = result.index("what's 2+2?")
         assert user_msg_start > note_end

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -86,11 +86,11 @@ def _simulate_note_injection(
         )
     elif agent_history and agent_history[-1].get("role") == "tool":
         message = (
-            "[System note: Your previous turn was interrupted before you could "
-            "process the last tool result(s). The conversation history contains "
-            "tool outputs you haven't responded to yet. Please finish processing "
-            "those results and summarize what was accomplished, then address the "
-            "user's new message below.]\n\n"
+            "[System note: Address the user's new message below as the primary task. "
+            "An orphaned tool result from a previous interrupted turn exists in history — "
+            "reference or summarize it ONLY if it is directly relevant to the user's new message. "
+            "If the new message is on a different topic, treat the orphan as resolved and ignore it. "
+            "Do NOT lead your reply with stale-topic content.]\n\n"
             + message
         )
     return message


### PR DESCRIPTION
## Summary

Reduces stale-topic contamination in interrupt-recovery prompt handling. When a previous agent turn ends with an orphaned tool result and the user's next message is on a different topic, the gateway currently injects a system note instructing the model to "process the orphan first, then address the new message." This ordering causes the model to spend substantial output on stale-topic content, which can propagate wrong-topic answering across subsequent turns.

This PR reorders and reframes the prompt to prioritize the new user message and explicitly permit ignoring the orphan when topics differ. **It does not eliminate the underlying issue** — a more structural fix (orphan pruning or topic-relevance gating) is likely needed for full mitigation.

## Root Cause

`gateway/run.py:~10080` injects a recovery prompt whenever `agent_history[-1].role == "tool"`, with no relevance check between the orphan and the new user message. The prompt's "old → new" ordering primes the model to anchor on the wrong topic.

## Reproduction

In a long-running gateway session:
1. Run a tool call (e.g., an HTTP API probe)
2. Have the turn interrupted before the assistant responds to the tool result
3. Send a new user message on an unrelated topic
4. Observe: the agent emits significant stale-topic content, can mishandle the new question, and may continue drifting on subsequent turns even after explicit corrections

Observed live in a gateway session where two interrupt events caused 30+ turns of topic confusion.

## Fix

Rewrite the recovery prompt to:
- Lead with "address the user's new message as the primary task"
- Allow the model to ignore the orphan if it's on a different topic
- Explicitly instruct: do not lead the reply with stale-topic content

Minimal, low-risk change. Does not alter the trigger condition (still fires on `role == "tool"`) or modify history.

## Empirical A/B Results

5-trial A/B comparison on `qwen3.6-35b-a3b` with synthetic interrupted history (Copilot probe orphan) and an off-topic new message ("Are you able to leverage brave search api?"):

| Metric | OLD prompt | NEW prompt | Change |
|---|---|---|---|
| Lead with new-topic | 5/5 | 5/5 | — |
| Stale-topic mentions per reply | 12.0 | 6.0 | **−50%** |
| New-topic mentions per reply | 10.4 | 8.0 | −23% |
| Reply length (chars) | 2040 | 1722 | **−16%** |

**Caveats:**
- Tested only on `qwen3.6-35b-a3b`; the original drift was observed on a different (frontier-class) model.
- Synthetic 4-message history; the live failure involved ~60 turns of accumulated context, where drift compounds.
- Reasoning-trace bleed inflates the OLD-prompt mention counts; the user-facing answer portion is more focused than raw counts suggest.

The fix produces measurable reduction in stale-topic contamination but does not, on this model, change which topic the reply leads with. Treat this as a partial mitigation.

## Out of Scope (Follow-Ups)

- **Orphan pruning** — drop the orphan tool result from history when the new user message is topic-mismatched, rather than asking the model to deal with it.
- **Topic-relevance gating** — only inject the recovery note when the orphan and new message are semantically related.
- Either could be a follow-up PR.

## Related

- #13121 — describes the same symptom class but focuses on transcript persistence (JSONL vs SQLite). This PR is complementary: even with perfect transcript preservation, the prompt wording itself contributes to drift.
- #14400 — open PR for #13121's transcript-source bug.

## Testing

Updated `tests/gateway/test_auto_continue.py` and `tests/gateway/test_restart_resume_pending.py` to match the new wording. Added regression test for topic-mismatch scenario. All 38 affected tests pass.

## Draft

Marking as draft to invite discussion on:
- Whether to extend the fix to also prune orphan tool results when topic mismatch is detected
- Whether the prompt wording should be configurable
- Whether a stronger empirical eval (Opus / live gateway repro) should land before merging