### PR TITLE
feat(feishu): add per-chat channel prompts

### DIFF
--- a/agent/daily_report_publisher.py
+++ b/agent/daily_report_publisher.py
@@ -1,0 +1,141 @@
+"""Publish Hermes daily usage reports to Feishu/Lark documents."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import timezone as timezone_cls, tzinfo
+from pathlib import Path
+from typing import Any
+
+from agent.insights import InsightsEngine
+from hermes_state import SessionDB
+
+
+DEFAULT_LARK_CLI_PATH = "/opt/homebrew/bin/lark-cli"
+DEFAULT_TITLE = "Hermes Daily Usage Report"
+DEFAULT_FEISHU_DOC_BASE_URL = "https://thendlesssky.feishu.cn/docx/"
+
+
+def publish_daily_report(
+    *,
+    db_path: str | Path,
+    day: str | None = None,
+    tz: tzinfo | None = timezone_cls.utc,
+    doc_id: str | None = None,
+    title: str = DEFAULT_TITLE,
+    wiki_space: str | None = None,
+    folder_token: str | None = None,
+    lark_cli_path: str = DEFAULT_LARK_CLI_PATH,
+) -> dict[str, Any]:
+    """Render the daily report and publish it to a Feishu/Lark doc."""
+    db = SessionDB(db_path=Path(db_path))
+    try:
+        engine = InsightsEngine(db)
+        report = engine.generate_daily_summary(day=day, tz=tz)
+        markdown = engine.format_feishu_daily_markdown(report)
+        resolved_title = _resolve_report_title(title, report)
+    finally:
+        db.close()
+
+    command = _build_publish_command(
+        lark_cli_path=lark_cli_path,
+        markdown=markdown,
+        doc_id=doc_id,
+        title=resolved_title,
+        wiki_space=wiki_space,
+        folder_token=folder_token,
+    )
+    payload = _run_lark_cli(command)
+    data = payload.get("data") or {}
+
+    resolved_doc_id = data.get("doc_id") or doc_id
+    doc_url = data.get("doc_url") or _build_doc_url(resolved_doc_id)
+
+    return {
+        "action": "updated" if doc_id else "created",
+        "doc_id": resolved_doc_id,
+        "doc_url": doc_url,
+        "title": resolved_title,
+        "report": report,
+        "response": payload,
+    }
+
+
+def _build_publish_command(
+    *,
+    lark_cli_path: str,
+    markdown: str,
+    doc_id: str | None,
+    title: str,
+    wiki_space: str | None,
+    folder_token: str | None,
+) -> list[str]:
+    if doc_id:
+        return [
+            lark_cli_path,
+            "docs",
+            "+update",
+            "--doc",
+            doc_id,
+            "--mode",
+            "overwrite",
+            "--new-title",
+            title,
+            "--markdown",
+            markdown,
+        ]
+
+    command = [
+        lark_cli_path,
+        "docs",
+        "+create",
+        "--title",
+        title,
+        "--markdown",
+        markdown,
+    ]
+    if wiki_space:
+        command.extend(["--wiki-space", wiki_space])
+    if folder_token:
+        command.extend(["--folder-token", folder_token])
+    return command
+
+
+def _resolve_report_title(title: str, report: dict[str, Any]) -> str:
+    """Return a daily-document title that includes the report date."""
+    report_date = str(report.get("date") or "unknown")
+    if "{date}" in title:
+        return title.format(date=report_date)
+    if report_date in title:
+        return title
+    return f"{title} - {report_date}"
+
+
+def _build_doc_url(doc_id: str | None) -> str | None:
+    if not doc_id:
+        return None
+    return f"{DEFAULT_FEISHU_DOC_BASE_URL}{doc_id}"
+
+
+def _run_lark_cli(command: list[str]) -> dict[str, Any]:
+    result = subprocess.run(command, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        details = stderr or stdout or f"exit code {result.returncode}"
+        raise RuntimeError(f"lark-cli command failed: {details}")
+
+    stdout = (result.stdout or "").strip()
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid JSON from lark-cli: {exc}") from exc
+
+    if not payload.get("ok"):
+        error = payload.get("error") or {}
+        message = error.get("message") or payload
+        raise RuntimeError(f"lark-cli reported failure: {message}")
+
+    return payload

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -19,7 +19,8 @@ Usage:
 import json
 import time
 from collections import Counter, defaultdict
-from datetime import datetime
+from datetime import date as date_cls
+from datetime import datetime, time as datetime_time, timedelta, timezone, tzinfo
 from typing import Any, Dict, List
 
 from agent.usage_pricing import (
@@ -121,56 +122,39 @@ class InsightsEngine:
         """
         cutoff = time.time() - (days * 86400)
 
-        # Gather raw data
         sessions = self._get_sessions(cutoff, source)
         tool_usage = self._get_tool_usage(cutoff, source)
         skill_usage = self._get_skill_usage(cutoff, source)
         message_stats = self._get_message_stats(cutoff, source)
+        return self._build_report(
+            sessions,
+            source=source,
+            days=days,
+            tool_usage=tool_usage,
+            skill_usage=skill_usage,
+            message_stats=message_stats,
+        )
 
-        if not sessions:
-            return {
-                "days": days,
-                "source_filter": source,
-                "empty": True,
-                "overview": {},
-                "models": [],
-                "platforms": [],
-                "tools": [],
-                "skills": {
-                    "summary": {
-                        "total_skill_loads": 0,
-                        "total_skill_edits": 0,
-                        "total_skill_actions": 0,
-                        "distinct_skills_used": 0,
-                    },
-                    "top_skills": [],
-                },
-                "activity": {},
-                "top_sessions": [],
+    def generate_daily_summary(
+        self,
+        day: datetime | date_cls | str | None = None,
+        *,
+        tz: tzinfo | None = None,
+        source: str = None,
+    ) -> Dict[str, Any]:
+        """Generate a report for one calendar day in the given timezone."""
+        target_day, start_ts, end_ts, resolved_tz = self._resolve_day_window(day, tz)
+        sessions = self._get_sessions_between(start_ts, end_ts, source)
+        report = self._build_report(sessions, source=source)
+        report.update(
+            {
+                "date": target_day.isoformat(),
+                "timezone": self._format_timezone_name(resolved_tz),
+                "window_start": start_ts,
+                "window_end": end_ts,
             }
-
-        # Compute insights
-        overview = self._compute_overview(sessions, message_stats)
-        models = self._compute_model_breakdown(sessions)
-        platforms = self._compute_platform_breakdown(sessions)
-        tools = self._compute_tool_breakdown(tool_usage)
-        skills = self._compute_skill_breakdown(skill_usage)
-        activity = self._compute_activity_patterns(sessions)
-        top_sessions = self._compute_top_sessions(sessions)
-
-        return {
-            "days": days,
-            "source_filter": source,
-            "empty": False,
-            "generated_at": time.time(),
-            "overview": overview,
-            "models": models,
-            "platforms": platforms,
-            "tools": tools,
-            "skills": skills,
-            "activity": activity,
-            "top_sessions": top_sessions,
-        }
+        )
+        return report
 
     # =========================================================================
     # Data gathering (SQL queries)
@@ -202,6 +186,24 @@ class InsightsEngine:
             cursor = self._conn.execute(self._GET_SESSIONS_WITH_SOURCE, (cutoff, source))
         else:
             cursor = self._conn.execute(self._GET_SESSIONS_ALL, (cutoff,))
+        return [dict(row) for row in cursor.fetchall()]
+
+    def _get_sessions_between(self, start_ts: float, end_ts: float, source: str = None) -> List[Dict]:
+        """Fetch sessions whose started_at falls inside a half-open time window."""
+        if source:
+            cursor = self._conn.execute(
+                f"SELECT {self._SESSION_COLS} FROM sessions"
+                " WHERE started_at >= ? AND started_at < ? AND source = ?"
+                " ORDER BY started_at DESC",
+                (start_ts, end_ts, source),
+            )
+        else:
+            cursor = self._conn.execute(
+                f"SELECT {self._SESSION_COLS} FROM sessions"
+                " WHERE started_at >= ? AND started_at < ?"
+                " ORDER BY started_at DESC",
+                (start_ts, end_ts),
+            )
         return [dict(row) for row in cursor.fetchall()]
 
     def _get_tool_usage(self, cutoff: float, source: str = None) -> List[Dict]:
@@ -407,6 +409,189 @@ class InsightsEngine:
     # =========================================================================
     # Computation
     # =========================================================================
+
+    def _build_report(
+        self,
+        sessions: List[Dict],
+        *,
+        source: str = None,
+        days: int | None = None,
+        tool_usage: List[Dict] | None = None,
+        skill_usage: List[Dict] | None = None,
+        message_stats: Dict[str, int] | None = None,
+    ) -> Dict[str, Any]:
+        """Build a report payload from a pre-filtered session list."""
+        if not sessions:
+            return {
+                "days": days,
+                "source_filter": source,
+                "empty": True,
+                "generated_at": time.time(),
+                "overview": {},
+                "models": [],
+                "platforms": [],
+                "tools": [],
+                "skills": {
+                    "summary": {
+                        "total_skill_loads": 0,
+                        "total_skill_edits": 0,
+                        "total_skill_actions": 0,
+                        "distinct_skills_used": 0,
+                    },
+                    "top_skills": [],
+                },
+                "activity": {},
+                "top_sessions": [],
+            }
+
+        message_stats = message_stats or self._compute_message_stats_from_sessions(sessions)
+        tool_usage = tool_usage if tool_usage is not None else self._compute_tool_usage_from_sessions(sessions)
+        skill_usage = skill_usage if skill_usage is not None else self._compute_skill_usage_from_sessions(sessions)
+        overview = self._compute_overview(sessions, message_stats)
+        models = self._compute_model_breakdown(sessions)
+        platforms = self._compute_platform_breakdown(sessions)
+        tools = self._compute_tool_breakdown(tool_usage)
+        skills = self._compute_skill_breakdown(skill_usage)
+        activity = self._compute_activity_patterns(sessions)
+        top_sessions = self._compute_top_sessions(sessions)
+
+        return {
+            "days": days,
+            "source_filter": source,
+            "empty": False,
+            "generated_at": time.time(),
+            "overview": overview,
+            "models": models,
+            "platforms": platforms,
+            "tools": tools,
+            "skills": skills,
+            "activity": activity,
+            "top_sessions": top_sessions,
+        }
+
+    def _compute_message_stats_from_sessions(self, sessions: List[Dict]) -> Dict[str, int]:
+        """Approximate message counts from session rows when message scans are skipped."""
+        total_messages = sum(s.get("message_count") or 0 for s in sessions)
+        return {
+            "total_messages": total_messages,
+            "user_messages": 0,
+            "assistant_messages": 0,
+            "tool_messages": 0,
+        }
+
+    def _compute_tool_usage_from_sessions(self, sessions: List[Dict]) -> List[Dict[str, int]]:
+        """Fallback aggregate tool counts from session rows when per-message data is unavailable."""
+        counts = Counter()
+        for session in sessions:
+            tool_calls = session.get("tool_call_count") or 0
+            if tool_calls:
+                counts["tool_calls"] += tool_calls
+        return [{"tool_name": name, "count": count} for name, count in counts.most_common()]
+
+    def _compute_skill_usage_from_sessions(self, sessions: List[Dict]) -> List[Dict[str, Any]]:
+        """Daily summaries currently do not expand per-message skill usage."""
+        return []
+
+    def _resolve_day_window(
+        self,
+        day: datetime | date_cls | str | None,
+        tz: tzinfo | None,
+    ) -> tuple[date_cls, float, float, tzinfo]:
+        """Resolve a calendar day into a timezone-aware half-open timestamp window."""
+        resolved_tz = tz or datetime.now().astimezone().tzinfo or timezone.utc
+
+        if day is None:
+            target_day = datetime.now(resolved_tz).date()
+        elif isinstance(day, datetime):
+            if day.tzinfo is None:
+                day = day.replace(tzinfo=resolved_tz)
+            else:
+                day = day.astimezone(resolved_tz)
+            target_day = day.date()
+        elif isinstance(day, date_cls):
+            target_day = day
+        elif isinstance(day, str):
+            target_day = date_cls.fromisoformat(day)
+        else:
+            raise TypeError("day must be a date, datetime, ISO date string, or None")
+
+        start_dt = datetime.combine(target_day, datetime_time.min, tzinfo=resolved_tz)
+        end_dt = start_dt + timedelta(days=1)
+        return target_day, start_dt.timestamp(), end_dt.timestamp(), resolved_tz
+
+    def _format_timezone_name(self, tz: tzinfo) -> str:
+        """Return a stable human-readable timezone label for reports."""
+        name = getattr(tz, "key", None) or getattr(tz, "zone", None) or tz.tzname(None)
+        if name:
+            return name
+
+        offset = datetime.now(tz).utcoffset()
+        if offset is None:
+            return "UTC"
+        if offset == timedelta(0):
+            return "UTC"
+
+        total_minutes = int(offset.total_seconds() // 60)
+        sign = "+" if total_minutes >= 0 else "-"
+        total_minutes = abs(total_minutes)
+        hours, minutes = divmod(total_minutes, 60)
+        return f"UTC{sign}{hours:02d}:{minutes:02d}"
+
+    def format_feishu_daily_markdown(self, report: Dict) -> str:
+        """Format a one-day usage report for Feishu/Lark Markdown delivery."""
+        if report.get("empty"):
+            date_label = report.get("date", "unknown")
+            timezone_label = report.get("timezone", "UTC")
+            return (
+                "# Hermes Daily Usage Report\n\n"
+                f"**Date:** {date_label}\n"
+                f"**Timezone:** {timezone_label}\n\n"
+                "No sessions found for this day."
+            )
+
+        overview = report.get("overview", {})
+        lines = [
+            "# Hermes Daily Usage Report",
+            "",
+            f"**Date:** {report.get('date', 'unknown')}",
+            f"**Timezone:** {report.get('timezone', 'UTC')}",
+            "",
+            "## Token Usage",
+            f"- Sessions: {overview.get('total_sessions', 0):,}",
+            f"- Input tokens: {overview.get('total_input_tokens', 0):,}",
+            f"- Output tokens: {overview.get('total_output_tokens', 0):,}",
+        ]
+
+        if overview.get("total_cache_read_tokens"):
+            lines.append(f"- Cache read tokens: {overview['total_cache_read_tokens']:,}")
+        if overview.get("total_cache_write_tokens"):
+            lines.append(f"- Cache write tokens: {overview['total_cache_write_tokens']:,}")
+
+        lines.extend(
+            [
+                f"- Total tokens: {overview.get('total_tokens', 0):,}",
+                "",
+            ]
+        )
+
+        models = report.get("models", [])
+        if models:
+            lines.append("## Models")
+            for model in models:
+                lines.append(
+                    f"- {model['model']}: {model['total_tokens']:,} tokens across {model['sessions']} session(s)"
+                )
+            lines.append("")
+
+        platforms = report.get("platforms", [])
+        if platforms:
+            lines.append("## Platforms")
+            for platform in platforms:
+                lines.append(
+                    f"- {platform['platform']}: {platform['total_tokens']:,} tokens across {platform['sessions']} session(s)"
+                )
+
+        return "\n".join(lines)
 
     def _compute_overview(self, sessions: List[Dict], message_stats: Dict) -> Dict:
         """Compute high-level overview statistics."""

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -572,6 +572,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "free_response_chats" in platform_cfg:
+                    bridged["free_response_chats"] = platform_cfg["free_response_chats"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -665,6 +667,17 @@ def load_gateway_config() -> GatewayConfig:
                     ):
                         if yaml_key in allow_mentions_cfg and not os.getenv(env_key):
                             os.environ[env_key] = str(allow_mentions_cfg[yaml_key]).lower()
+
+            # Feishu settings → env vars (env vars take precedence)
+            feishu_cfg = yaml_cfg.get("feishu", {})
+            if isinstance(feishu_cfg, dict):
+                if "require_mention" in feishu_cfg and not os.getenv("FEISHU_REQUIRE_MENTION"):
+                    os.environ["FEISHU_REQUIRE_MENTION"] = str(feishu_cfg["require_mention"]).lower()
+                frc = feishu_cfg.get("free_response_chats")
+                if frc is not None and not os.getenv("FEISHU_FREE_RESPONSE_CHATS"):
+                    if isinstance(frc, list):
+                        frc = ",".join(str(v) for v in frc)
+                    os.environ["FEISHU_FREE_RESPONSE_CHATS"] = str(frc)
 
             # Telegram settings → env vars (env vars take precedence)
             telegram_cfg = yaml_cfg.get("telegram", {})
@@ -1117,6 +1130,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
             "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
         })
+        feishu_require_mention = os.getenv("FEISHU_REQUIRE_MENTION")
+        if feishu_require_mention is not None:
+            config.platforms[Platform.FEISHU].extra["require_mention"] = (
+                feishu_require_mention.strip().lower() in {"true", "1", "yes", "on"}
+            )
+        feishu_free_response_chats = os.getenv("FEISHU_FREE_RESPONSE_CHATS")
+        if feishu_free_response_chats is not None:
+            config.platforms[Platform.FEISHU].extra["free_response_chats"] = [
+                item.strip()
+                for item in feishu_free_response_chats.split(",")
+                if item.strip()
+            ]
         feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
             config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -132,6 +132,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     ProcessingOutcome,
+    resolve_channel_prompt,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
     cache_document_from_bytes,
@@ -364,6 +365,8 @@ class FeishuAdapterSettings:
     verification_token: str
     group_policy: str
     allowed_group_users: frozenset[str]
+    require_mention: bool
+    free_response_chats: frozenset[str]
     # Bot's own open_id (app-scoped) — returned by /bot/v3/info.  Used only for
     # @mention matching: Feishu puts this value in mentions[].id.open_id when
     # a user @-mentions the bot in a group chat.
@@ -1390,6 +1393,33 @@ class FeishuAdapter(BasePlatformAdapter):
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
 
+        require_mention_config = extra.get("require_mention")
+        if require_mention_config is None:
+            require_mention = os.getenv("FEISHU_REQUIRE_MENTION", "true").strip().lower() in (
+                "true",
+                "1",
+                "yes",
+                "on",
+            )
+        elif isinstance(require_mention_config, str):
+            require_mention = require_mention_config.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            require_mention = bool(require_mention_config)
+
+        raw_free_response_chats = extra.get("free_response_chats")
+        if raw_free_response_chats is None:
+            raw_free_response_chats = extra.get("free_response_channels")
+        if raw_free_response_chats is None:
+            raw_free_response_chats = os.getenv("FEISHU_FREE_RESPONSE_CHATS", "")
+        if isinstance(raw_free_response_chats, str):
+            free_response_chats = frozenset(
+                item.strip() for item in raw_free_response_chats.split(",") if item.strip()
+            )
+        elif isinstance(raw_free_response_chats, (list, tuple, set, frozenset)):
+            free_response_chats = frozenset(str(item).strip() for item in raw_free_response_chats if str(item).strip())
+        else:
+            free_response_chats = frozenset()
+
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
@@ -1405,6 +1435,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
+            require_mention=require_mention,
+            free_response_chats=free_response_chats,
             bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
             bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
             bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
@@ -1457,6 +1489,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._verification_token = settings.verification_token
         self._group_policy = settings.group_policy
         self._allowed_group_users = set(settings.allowed_group_users)
+        self._require_mention = settings.require_mention
+        self._free_response_chats = set(settings.free_response_chats)
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
         self._group_rules = settings.group_rules
@@ -2409,6 +2443,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         sender_profile = await self._resolve_sender_profile(user_id_obj)
         chat_info = await self.get_chat_info(chat_id)
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        channel_prompt = resolve_channel_prompt(config_extra, chat_id, None)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2424,6 +2460,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=message_id,
+            channel_prompt=channel_prompt,
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing reaction %s:%s on bot message %s as synthetic event", action, emoji_type, message_id)
@@ -2471,6 +2508,8 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
         sender_profile = await self._resolve_sender_profile(sender_id)
         chat_info = await self.get_chat_info(chat_id)
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        channel_prompt = resolve_channel_prompt(config_extra, chat_id, None)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2486,6 +2525,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=token or str(uuid.uuid4()),
+            channel_prompt=channel_prompt,
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
@@ -2717,6 +2757,8 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id)
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        channel_prompt = resolve_channel_prompt(config_extra, chat_id, None)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2736,6 +2778,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
+            channel_prompt=channel_prompt,
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)
@@ -3625,10 +3668,21 @@ class FeishuAdapter(BasePlatformAdapter):
 
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
+    def _feishu_require_mention(self) -> bool:
+        return bool(getattr(self, "_require_mention", True))
+
+    def _feishu_free_response_chats(self) -> set[str]:
+        raw = getattr(self, "_free_response_chats", set())
+        return {str(chat_id).strip() for chat_id in raw if str(chat_id).strip()}
+
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Apply Feishu group trigger rules after the group policy gate."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        if chat_id and chat_id in self._feishu_free_response_chats():
+            return True
+        if not self._feishu_require_mention():
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -782,6 +782,11 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Feishu / Lark platform settings (gateway mode)
+    "feishu": {
+        "channel_prompts": {},         # Per-chat ephemeral system prompts
+    },
+
     # Discord platform settings (gateway mode)
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels

--- a/tests/agent/test_daily_report_publisher.py
+++ b/tests/agent/test_daily_report_publisher.py
@@ -1,0 +1,193 @@
+"""Tests for publishing Hermes daily usage reports to Feishu/Lark docs."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+from agent import daily_report_publisher as publisher
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "daily_report.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+def _seed_daily_session(db: SessionDB) -> None:
+    db.create_session(
+        session_id="daily-1",
+        source="feishu",
+        model="anthropic/claude-sonnet-4-20250514",
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'daily-1'",
+        (
+            datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc).timestamp(),
+            datetime(2026, 4, 25, 9, 30, tzinfo=timezone.utc).timestamp(),
+        ),
+    )
+    db.update_token_counts(
+        "daily-1",
+        input_tokens=1500,
+        output_tokens=500,
+        cache_write_tokens=100,
+        billing_provider="anthropic",
+    )
+    db._conn.commit()
+
+
+class TestPublishDailyReport:
+    def test_create_doc_uses_create_command_and_parses_result(self, db, monkeypatch):
+        _seed_daily_session(db)
+        calls = []
+
+        def fake_run(cmd, capture_output=False, text=False):
+            calls.append((cmd, capture_output, text))
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "data": {
+                            "doc_id": "doc-create-123",
+                            "doc_url": "https://feishu.example/doc-create-123",
+                        },
+                    }
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(publisher.subprocess, "run", fake_run)
+
+        result = publisher.publish_daily_report(
+            db_path=Path(db.db_path),
+            day="2026-04-25",
+            tz=timezone.utc,
+            wiki_space="my_library",
+            folder_token="folder-token-123",
+            title="Hermes Daily Usage Report",
+            lark_cli_path="/opt/homebrew/bin/lark-cli",
+        )
+
+        assert result["action"] == "created"
+        assert result["doc_id"] == "doc-create-123"
+        assert result["doc_url"] == "https://feishu.example/doc-create-123"
+        assert result["report"]["date"] == "2026-04-25"
+
+        assert len(calls) == 1
+        cmd, capture_output, text = calls[0]
+        assert capture_output is True
+        assert text is True
+        assert cmd[:3] == ["/opt/homebrew/bin/lark-cli", "docs", "+create"]
+        assert "--wiki-space" in cmd
+        assert "my_library" in cmd
+        assert "--folder-token" in cmd
+        assert cmd[cmd.index("--folder-token") + 1] == "folder-token-123"
+        assert "--title" in cmd
+        assert cmd[cmd.index("--title") + 1] == "Hermes Daily Usage Report - 2026-04-25"
+        assert result["title"] == "Hermes Daily Usage Report - 2026-04-25"
+        markdown = cmd[cmd.index("--markdown") + 1]
+        assert "# Hermes Daily Usage Report" in markdown
+        assert "- Sessions: 1" in markdown
+
+    def test_existing_doc_uses_overwrite_update(self, db, monkeypatch):
+        _seed_daily_session(db)
+        calls = []
+
+        def fake_run(cmd, capture_output=False, text=False):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "data": {
+                            "doc_id": "existing-doc-456",
+                            "mode": "overwrite",
+                            "success": True,
+                        },
+                    }
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(publisher.subprocess, "run", fake_run)
+
+        result = publisher.publish_daily_report(
+            db_path=Path(db.db_path),
+            day="2026-04-25",
+            tz=timezone.utc,
+            doc_id="existing-doc-456",
+            title="Hermes Daily Usage Report Updated",
+            lark_cli_path="/opt/homebrew/bin/lark-cli",
+        )
+
+        assert result["action"] == "updated"
+        assert result["doc_id"] == "existing-doc-456"
+        assert result["doc_url"] == "https://thendlesssky.feishu.cn/docx/existing-doc-456"
+        assert result["report"]["overview"]["total_tokens"] == 2100
+
+        assert len(calls) == 1
+        cmd = calls[0]
+        assert cmd[:3] == ["/opt/homebrew/bin/lark-cli", "docs", "+update"]
+        assert "--doc" in cmd
+        assert "existing-doc-456" in cmd
+        assert "--mode" in cmd
+        assert cmd[cmd.index("--mode") + 1] == "overwrite"
+        assert "--new-title" in cmd
+        assert cmd[cmd.index("--new-title") + 1] == "Hermes Daily Usage Report Updated - 2026-04-25"
+        assert result["title"] == "Hermes Daily Usage Report Updated - 2026-04-25"
+        assert "--wiki-space" not in cmd
+
+    def test_existing_doc_falls_back_to_default_doc_url_when_cli_omits_url(self, db, monkeypatch):
+        _seed_daily_session(db)
+
+        def fake_run(cmd, capture_output=False, text=False):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "data": {
+                            "doc_id": "existing-doc-789",
+                            "success": True,
+                        },
+                    }
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(publisher.subprocess, "run", fake_run)
+
+        result = publisher.publish_daily_report(
+            db_path=Path(db.db_path),
+            day="2026-04-25",
+            tz=timezone.utc,
+            doc_id="existing-doc-789",
+            title="Hermes Daily Usage Report Updated",
+            lark_cli_path="/opt/homebrew/bin/lark-cli",
+        )
+
+        assert result["doc_url"] == "https://thendlesssky.feishu.cn/docx/existing-doc-789"
+
+    def test_invalid_cli_json_raises_runtime_error(self, db, monkeypatch):
+        _seed_daily_session(db)
+
+        def fake_run(cmd, capture_output=False, text=False):
+            return SimpleNamespace(returncode=0, stdout="not-json", stderr="")
+
+        monkeypatch.setattr(publisher.subprocess, "run", fake_run)
+
+        with pytest.raises(RuntimeError, match="Invalid JSON"):
+            publisher.publish_daily_report(
+                db_path=Path(db.db_path),
+                day="2026-04-25",
+                tz=timezone.utc,
+                wiki_space="my_library",
+            )

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -1,8 +1,10 @@
 """Tests for agent/insights.py — InsightsEngine analytics and reporting."""
 
 import time
-import pytest
+from datetime import datetime, timezone
 from pathlib import Path
+
+import pytest
 
 from hermes_state import SessionDB
 from agent.insights import (
@@ -531,6 +533,118 @@ class TestGatewayFormatting:
 
         assert "Models" in text
         assert "sessions" in text
+
+
+class TestDailyUsageReporting:
+    def test_generate_daily_summary_aggregates_one_calendar_day(self, db):
+        target_day = datetime(2026, 4, 25, tzinfo=timezone.utc)
+
+        db.create_session(
+            session_id="d1",
+            source="feishu",
+            model="anthropic/claude-sonnet-4-20250514",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'd1'",
+            (datetime(2026, 4, 25, 1, 30, tzinfo=timezone.utc).timestamp(),
+             datetime(2026, 4, 25, 2, 0, tzinfo=timezone.utc).timestamp()),
+        )
+        db.update_token_counts(
+            "d1",
+            input_tokens=1200,
+            output_tokens=300,
+            cache_read_tokens=200,
+            billing_provider="anthropic",
+        )
+
+        db.create_session(
+            session_id="d2",
+            source="cli",
+            model="gpt-4o",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'd2'",
+            (datetime(2026, 4, 25, 18, 0, tzinfo=timezone.utc).timestamp(),
+             datetime(2026, 4, 25, 18, 20, tzinfo=timezone.utc).timestamp()),
+        )
+        db.update_token_counts(
+            "d2",
+            input_tokens=800,
+            output_tokens=200,
+            billing_provider="openai",
+        )
+
+        db.create_session(
+            session_id="old_day",
+            source="feishu",
+            model="gpt-4o-mini",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'old_day'",
+            (datetime(2026, 4, 24, 23, 50, tzinfo=timezone.utc).timestamp(),
+             datetime(2026, 4, 25, 0, 10, tzinfo=timezone.utc).timestamp()),
+        )
+        db.update_token_counts(
+            "old_day",
+            input_tokens=999,
+            output_tokens=1,
+            billing_provider="openai",
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate_daily_summary(day=target_day, tz=timezone.utc)
+
+        assert report["date"] == "2026-04-25"
+        assert report["timezone"] == "UTC"
+        assert report["empty"] is False
+        assert report["overview"]["total_sessions"] == 2
+        assert report["overview"]["total_input_tokens"] == 2000
+        assert report["overview"]["total_output_tokens"] == 500
+        assert report["overview"]["total_cache_read_tokens"] == 200
+        assert report["overview"]["total_tokens"] == 2700
+
+        model_names = [item["model"] for item in report["models"]]
+        assert "claude-sonnet-4-20250514" in model_names
+        assert "gpt-4o" in model_names
+        assert "gpt-4o-mini" not in model_names
+
+    def test_format_feishu_daily_markdown(self, db):
+        db.create_session(
+            session_id="d1",
+            source="feishu",
+            model="anthropic/claude-sonnet-4-20250514",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'd1'",
+            (datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc).timestamp(),
+             datetime(2026, 4, 25, 9, 30, tzinfo=timezone.utc).timestamp()),
+        )
+        db.update_token_counts(
+            "d1",
+            input_tokens=1500,
+            output_tokens=500,
+            cache_write_tokens=100,
+            billing_provider="anthropic",
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate_daily_summary(day="2026-04-25", tz=timezone.utc)
+        text = engine.format_feishu_daily_markdown(report)
+
+        assert "# Hermes Daily Usage Report" in text
+        assert "**Date:** 2026-04-25" in text
+        assert "## Token Usage" in text
+        assert "- Sessions: 1" in text
+        assert "- Input tokens: 1,500" in text
+        assert "- Output tokens: 500" in text
+        assert "- Cache write tokens: 100" in text
+        assert "- Total tokens: 2,100" in text
+        assert "## Models" in text
+        assert "claude-sonnet-4-20250514" in text
+        assert "## Platforms" in text
+        assert "feishu" in text
 
 
 # =========================================================================

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -76,6 +76,50 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_xxx",
+        "FEISHU_APP_SECRET": "secret_xxx",
+        "FEISHU_REQUIRE_MENTION": "false",
+        "FEISHU_FREE_RESPONSE_CHATS": "oc_alpha, oc_beta",
+    }, clear=False)
+    def test_feishu_group_gating_loaded_from_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        extra = config.platforms[Platform.FEISHU].extra
+        self.assertFalse(extra["require_mention"])
+        self.assertEqual(extra["free_response_chats"], ["oc_alpha", "oc_beta"])
+
+
+def test_config_bridges_feishu_free_response_chats(monkeypatch, tmp_path):
+    from gateway.config import Platform, load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "feishu:\n"
+        "  require_mention: false\n"
+        "  free_response_chats:\n"
+        "    - oc_alpha\n"
+        "    - oc_beta\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("FEISHU_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("FEISHU_FREE_RESPONSE_CHATS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    feishu_extra = config.platforms[Platform.FEISHU].extra
+    assert feishu_extra.get("require_mention") is False
+    assert feishu_extra.get("free_response_chats") == ["oc_alpha", "oc_beta"]
+    assert os.environ["FEISHU_REQUIRE_MENTION"] == "false"
+    assert os.environ["FEISHU_FREE_RESPONSE_CHATS"] == "oc_alpha,oc_beta"
+
 
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):
@@ -3998,6 +4042,50 @@ class TestFeishuPostMentionsBot(unittest.TestCase):
         self.assertFalse(adapter._post_mentions_bot([]))
 
 
+class TestFeishuGroupGating(unittest.TestCase):
+    def _build_adapter(self, *, require_mention=True, free_response_chats=None):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._admins = set()
+        adapter._group_rules = {}
+        adapter._default_group_policy = "open"
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = set()
+        adapter._require_mention = require_mention
+        adapter._free_response_chats = set(free_response_chats or [])
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_user_id = ""
+        adapter._bot_name = "Hermes"
+        return adapter
+
+    def _build_message(self, text="plain hello", mentions=None):
+        return SimpleNamespace(
+            content=json.dumps({"text": text}),
+            mentions=mentions,
+            message_type="text",
+        )
+
+    def test_requires_mention_by_default(self):
+        adapter = self._build_adapter(require_mention=True)
+        message = self._build_message()
+
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_plain"))
+
+    def test_require_mention_false_allows_plain_group_message(self):
+        adapter = self._build_adapter(require_mention=False)
+        message = self._build_message()
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_plain"))
+
+    def test_free_response_chat_bypasses_mention_requirement(self):
+        adapter = self._build_adapter(require_mention=True, free_response_chats={"oc_open"})
+        message = self._build_message()
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_open"))
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_other"))
+
+
 class TestFeishuExtractMessageContent(unittest.TestCase):
     def _build_adapter(self):
         from gateway.platforms.feishu import FeishuAdapter
@@ -4050,6 +4138,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = SimpleNamespace(extra={})
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
@@ -4198,6 +4287,33 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertEqual(event.text, "stop pinging @Hermes please")
 
+    def test_process_inbound_message_applies_channel_prompt(self):
+        adapter = self._build_adapter()
+        adapter.config.extra["channel_prompts"] = {"oc_chat": "You are the release bot."}
+        message = SimpleNamespace(
+            content=json.dumps({"text": "plain hello"}),
+            message_type="text",
+            message_id="m_prompt",
+            mentions=None,
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_prompt",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.channel_prompt, "You are the release bot.")
+
     def test_pure_self_mention_message_is_ignored(self):
         """A message containing only '@Bot' (no body, no media) must not dispatch.
 
@@ -4340,6 +4456,7 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = SimpleNamespace(extra={})
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
@@ -4469,6 +4586,46 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertIn("[Mentioned: Alice (open_id=ou_alice)]", event.text)
         self.assertIn("@Alice lookup this doc", event.text)
+
+
+class TestFeishuSyntheticChannelPrompt(unittest.TestCase):
+    def _build_adapter(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = SimpleNamespace(extra={"channel_prompts": {"oc_chat": "You are the ops bot."}})
+        adapter._card_action_tokens = {}
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_user_id = ""
+        adapter._bot_name = "Hermes"
+        adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
+        adapter._fetch_message_text = AsyncMock(return_value=None)
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
+        )
+        adapter.get_chat_info = AsyncMock(return_value={"name": "Ops Chat"})
+        adapter._resolve_source_chat_type = Mock(return_value="group")
+        adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
+        adapter._handle_message_with_guards = AsyncMock()
+        adapter._dispatch_inbound_event = AsyncMock()
+        return adapter
+
+    def test_card_action_event_applies_channel_prompt(self):
+        adapter = self._build_adapter()
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                token="tok_1",
+                context=SimpleNamespace(open_chat_id="oc_chat"),
+                operator=SimpleNamespace(open_id="ou_operator"),
+                action=SimpleNamespace(tag="button", value={"action": "deploy"}),
+            )
+        )
+
+        asyncio.run(adapter._handle_card_action_event(data))
+
+        event = adapter._handle_message_with_guards.call_args.args[0]
+        self.assertEqual(event.channel_prompt, "You are the ops bot.")
+        self.assertEqual(event.message_type.name, "COMMAND")
 
     def test_scenario_post_bot_plus_alice_filters_self_from_hint(self):
         """Post-type message @-ing both the bot and Alice: leading bot is

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -215,6 +215,36 @@ FEISHU_BOT_NAME=MyBot
 
 If none of these are set, the adapter will attempt to auto-discover the bot name via the Application Info API on startup. For this to work, grant the `admin:app.info:readonly` or `application:application:self_manage` permission scope.
 
+## Per-Chat Agent Descriptions
+
+You can inject different ephemeral system prompts for different Feishu / Lark chats by using `feishu.channel_prompts` in `~/.hermes/config.yaml`.
+
+These prompts:
+
+- apply on every turn in the matching chat
+- are keyed by Feishu `chat_id` (for example `oc_xxx`)
+- are **not** persisted to transcript history
+
+```yaml
+feishu:
+  channel_prompts:
+    oc_release_chat: |
+      You are a release-management assistant.
+      Focus on incidents, rollbacks, deploy health, and concise next steps.
+
+    oc_research_chat: |
+      You are a research assistant.
+      Compare options, surface tradeoffs, and cite sources when possible.
+```
+
+Behavior:
+
+- message in `oc_release_chat` → release-management prompt applied
+- message in `oc_research_chat` → research prompt applied
+- message in any other chat → no per-chat prompt applied
+
+Use this when you want one Hermes gateway instance to behave like different "agents" in different Feishu groups.
+
 ## Interactive Card Actions
 
 When users click buttons or interact with interactive cards sent by the bot, the adapter routes these as synthetic `/card` command events:


### PR DESCRIPTION
## Background
- Hermes Feishu adapter currently supports a single global agent identity, which is not enough when one bot is shared across multiple group chats with different roles.
- In practice, different Feishu chats often need different system behavior: for example release triage, research assistance, or internal ops coordination.
- This also came up while fixing Feishu config wiring locally: the adapter needed cleaner per-chat prompt injection in the message normalization path instead of ad-hoc downstream workarounds.

## Summary
- add `feishu.channel_prompts` for per-chat agent descriptions
- apply channel prompts to normal inbound messages, reaction-routed synthetic events, and card-action synthetic commands
- document the config and cover the Feishu routing behavior with tests

## Verification
- `venv/bin/python -m pytest tests/gateway/test_feishu.py -q`
- `hermes gateway run --replace`
