### PR TITLE
fix(browser): allow explicit CDP override without local agent-browser dependency

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -209,6 +209,13 @@ class TestFindAgentBrowser:
 
 
 class TestBrowserRequirements:
+    def test_cdp_override_does_not_require_agent_browser_cli(self, monkeypatch):
+        monkeypatch.setenv("BROWSER_CDP_URL", "ws://127.0.0.1:9222/devtools/browser/test")
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: (_ for _ in ()).throw(FileNotFoundError("not found")))
+
+        assert check_browser_requirements() is True
+
     def test_termux_requires_real_agent_browser_install_not_npx_fallback(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2483,7 +2483,12 @@ def check_browser_requirements() -> bool:
     if _is_camofox_mode():
         return True
 
-    # The agent-browser CLI is always required
+    # CDP override mode can connect to an existing remote/local browser endpoint
+    # without requiring the local agent-browser binary on PATH.
+    if _get_cdp_override():
+        return True
+
+    # The agent-browser CLI is required for local launch and cloud-provider flows.
     try:
         browser_cmd = _find_agent_browser()
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- Treat explicit CDP override mode (`BROWSER_CDP_URL`) as a valid browser backend in `check_browser_requirements()`.
- Remove the false-negative availability gate that required a local `agent-browser` binary even when using direct CDP connection.
- Add a regression test to lock this behavior and prevent future regressions.

## Why
When users connect via explicit CDP endpoint, the local `agent-browser` CLI is not required for capability detection. The previous check incorrectly reported browser tools as unavailable, which blocked valid browser workflows.

## Changes
- Update `tools/browser_tool.py`:
  - `check_browser_requirements()` now returns success when CDP override is present.
- Update `tests/tools/test_browser_homebrew_paths.py`:
  - Add `test_cdp_override_does_not_require_agent_browser_cli`.

## Validation
- `git log main..HEAD --oneline` contains only this task commit.
- `git diff main --stat` includes only planned files.
- Target regression test passed:
  - `python -m pytest tests/tools/test_browser_homebrew_paths.py::TestBrowserRequirements::test_cdp_override_does_not_require_agent_browser_cli -q`

## Related Issue
- Fixes #15952