### PR TITLE
fix(gateway): let /btw dispatch mid-turn instead of being rejected

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3501,6 +3501,14 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
+            # /btw must bypass the running-agent guard for the same reason
+            # as /background: it spawns a parallel ephemeral side-question
+            # task (see _handle_btw_command) that doesn't interrupt the
+            # active conversation and self-guards against concurrent /btw
+            # on the same chat.
+            if _cmd_def_inner and _cmd_def_inner.name == "btw":
+                return await self._handle_btw_command(event)
+
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
             # the tool-progress display mode for the ongoing stream.

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -165,3 +165,27 @@ async def test_reasoning_rejected_mid_run():
     assert result is not None
     assert "can't run mid-turn" in result
     assert "/reasoning" in result
+
+
+@pytest.mark.asyncio
+async def test_btw_dispatches_mid_run():
+    """/btw mid-run must dispatch to its handler, not hit the catch-all.
+
+    /btw spawns a parallel ephemeral side-question task that does NOT
+    interrupt the active conversation (see _handle_btw_command). It's the
+    whole point of the command — asking a side question while the main
+    turn is still working. Before the mid-turn bypass was added, /btw
+    fell through to the "Agent is running — wait or /stop first" catch-all,
+    making it useless in exactly the scenario it was designed for.
+    """
+    runner = _make_runner()
+    runner._handle_btw_command = AsyncMock(
+        return_value='💬 /btw: "what module owns titles?"\nReply will appear here shortly.'
+    )
+
+    result = await runner._handle_message(_make_event("/btw what module owns titles?"))
+
+    runner._handle_btw_command.assert_awaited_once()
+    assert result is not None
+    assert "💬 /btw" in result
+    assert "can't run mid-turn" not in result


### PR DESCRIPTION
## Summary
/btw now runs while the agent is busy — which is the entire point of the command.

## Root cause
`_handle_message()` in `gateway/run.py` had a bypass list for commands that must dispatch while an agent is actively running (/steer, /approve, /deny, /agents, /background, /yolo, /verbose, /help, etc.). /btw was missing, so it fell through to the catch-all at L3403 and returned:

> ⏳ Agent is running — `/btw` can't run mid-turn. Wait for the current response or `/stop` first.

That's the opposite of what /btw is designed for — asking an ephemeral side question while the main turn is still working. `_handle_btw_command` already spawns its own task and self-guards against concurrent /btw on the same chat, so it's safe to run alongside an active agent (same reasoning as /background).

## Changes
- `gateway/run.py`: add /btw to the running-agent bypass block, right next to /background.
- `tests/gateway/test_running_agent_session_toggles.py`: regression test locking in mid-turn dispatch.

## Validation
| | Before | After |
|---|---|---|
| `/btw <q>` while agent running | "Agent is running — can't run mid-turn" | dispatches, prints '💬 /btw: "..."' |
| Existing bypass + reject tests | pass | pass (5/5 in file) |

## Reporter
Reported by @IuriiTiunov on Telegram.