### PR TITLE
refactor: drop persist_session plumbing + fix broken /btw mid-turn bypass

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3498,16 +3498,10 @@ class GatewayRunner:
 
             # /background must bypass the running-agent guard — it starts a
             # parallel task and must never interrupt the active conversation.
+            # /btw is an alias of /background and resolves to the same canonical
+            # name, so this branch handles both commands.
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
-
-            # /btw must bypass the running-agent guard for the same reason
-            # as /background: it spawns a parallel ephemeral side-question
-            # task (see _handle_btw_command) that doesn't interrupt the
-            # active conversation and self-guards against concurrent /btw
-            # on the same chat.
-            if _cmd_def_inner and _cmd_def_inner.name == "btw":
-                return await self._handle_btw_command(event)
 
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles

--- a/run_agent.py
+++ b/run_agent.py
@@ -892,7 +892,6 @@ class AIAgent:
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
-        persist_session: bool = True,
     ):
         """
         Initialize the AI Agent.
@@ -964,7 +963,6 @@ class AIAgent:
         self.background_review_callback = None  # Optional sync callback for gateway delivery
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
-        self.persist_session = persist_session
         self._credential_pool = credential_pool
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
@@ -3353,10 +3351,7 @@ class AIAgent:
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
-        Skipped when ``persist_session=False`` (ephemeral helper flows).
         """
-        if not self.persist_session:
-            return
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -169,23 +169,22 @@ async def test_reasoning_rejected_mid_run():
 
 @pytest.mark.asyncio
 async def test_btw_dispatches_mid_run():
-    """/btw mid-run must dispatch to its handler, not hit the catch-all.
+    """/btw mid-run must dispatch to /background's handler, not hit the catch-all.
 
-    /btw spawns a parallel ephemeral side-question task that does NOT
-    interrupt the active conversation (see _handle_btw_command). It's the
-    whole point of the command — asking a side question while the main
-    turn is still working. Before the mid-turn bypass was added, /btw
-    fell through to the "Agent is running — wait or /stop first" catch-all,
-    making it useless in exactly the scenario it was designed for.
+    /btw is an alias of /background (see hermes_cli/commands.py). Typing
+    /btw mid-turn must spawn a parallel background task — that's the whole
+    point of the command. Before the mid-turn bypass was added for
+    /background, /btw fell through to the "Agent is running — wait or
+    /stop first" catch-all, making it useless in exactly the scenario it
+    was designed for. The alias and the bypass together make it work.
     """
     runner = _make_runner()
-    runner._handle_btw_command = AsyncMock(
-        return_value='💬 /btw: "what module owns titles?"\nReply will appear here shortly.'
+    runner._handle_background_command = AsyncMock(
+        return_value='🚀 Background task started: "what module owns titles?"'
     )
 
     result = await runner._handle_message(_make_event("/btw what module owns titles?"))
 
-    runner._handle_btw_command.assert_awaited_once()
+    runner._handle_background_command.assert_awaited_once()
     assert result is not None
-    assert "💬 /btw" in result
     assert "can't run mid-turn" not in result


### PR DESCRIPTION
## Summary
Follow-up cleanup to PR #16053 (/btw as /background alias). Removes the \`persist_session\` kwarg that only existed for the old ephemeral /btw handler, and fixes a broken /btw mid-turn bypass (PR #16059) that called a method the refactor deleted.

## Changes
- \`run_agent.py\`: remove \`persist_session: bool = True\` kwarg, \`self.persist_session\` attr, and the \`if not self.persist_session: return\` short-circuit in \`_persist_session\`. Only the removed /btw handlers ever passed \`False\`; no other callers in production or tests.
- \`gateway/run.py\`: remove the unreachable \`if _cmd_def_inner.name == \"btw\"\` block. Canonical name after alias resolution is always \`background\`, so the comparison could never match. It also called \`_handle_btw_command\`, which PR #16053 deleted. The existing \`name == \"background\"\` branch above it already dispatches /btw correctly (via alias).
- \`tests/gateway/test_running_agent_session_toggles.py\`: rewrite \`test_btw_dispatches_mid_run\` to mock \`_handle_background_command\` (the real dispatch target) instead of the deleted \`_handle_btw_command\`. Test still covers the same regression — /btw must not hit the "can't run mid-turn" catch-all — but against the current architecture.

## Kept on purpose
- \`model_tools.py\` \`if enabled_toolsets is not None\` (vs the previous truthy check) stays. PR #16053 removed the only in-repo caller that passed \`[]\`, but the semantic is correct behavior and documented by a regression test (\`test_no_tools_never_injects\`). Reverting it would re-introduce the footgun where \`enabled_toolsets=[]\` silently means "all tools" instead of "no tools."

## Validation
\`scripts/run_tests.sh tests/gateway/test_running_agent_session_toggles.py tests/run_agent/test_run_agent.py tests/run_agent/test_413_compression.py tests/run_agent/test_860_dedup.py tests/tools/test_interrupt.py tests/cron/test_codex_execution_paths.py\` — **339 passed**.

Net: **-25 / +13** lines.