### PR TITLE
fix(gateway): honor Discord channel controls from config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -574,6 +574,14 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "auto_thread" in platform_cfg:
+                    bridged["auto_thread"] = platform_cfg["auto_thread"]
+                if plat == Platform.DISCORD and "allowed_channels" in platform_cfg:
+                    bridged["allowed_channels"] = platform_cfg["allowed_channels"]
+                if plat == Platform.DISCORD and "ignored_channels" in platform_cfg:
+                    bridged["ignored_channels"] = platform_cfg["ignored_channels"]
+                if plat == Platform.DISCORD and "no_thread_channels" in platform_cfg:
+                    bridged["no_thread_channels"] = platform_cfg["no_thread_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2709,6 +2709,44 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
 
+    def _discord_config_or_env_value(self, key: str, env_name: str, default: Any = None) -> Any:
+        """Return a Discord config value, with non-empty env vars overriding config."""
+        extra = self.config.extra if isinstance(getattr(self.config, "extra", None), dict) else {}
+        configured = extra.get(key)
+        env_value = os.getenv(env_name)
+        if env_value is not None and str(env_value).strip():
+            return env_value
+        if configured is not None:
+            return configured
+        return default
+
+    @staticmethod
+    def _discord_channel_set(raw: Any) -> set:
+        """Normalize Discord channel config from CSV, YAML sequences, or scalar IDs."""
+        if raw is None:
+            return set()
+        if isinstance(raw, str):
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        if isinstance(raw, (list, tuple, set)):
+            return {
+                str(part).strip()
+                for part in raw
+                if part is not None and str(part).strip()
+            }
+        raw_text = str(raw).strip()
+        return {raw_text} if raw_text else set()
+
+    def _discord_channel_setting(self, key: str, env_name: str) -> set:
+        """Return a normalized Discord channel-control set."""
+        return self._discord_channel_set(self._discord_config_or_env_value(key, env_name))
+
+    def _discord_auto_thread_enabled(self) -> bool:
+        """Return whether Discord auto-threading is enabled."""
+        raw = self._discord_config_or_env_value("auto_thread", "DISCORD_AUTO_THREAD", True)
+        if isinstance(raw, str):
+            return raw.strip().lower() in ("true", "1", "yes", "on")
+        return bool(raw)
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
@@ -2716,14 +2754,10 @@ class DiscordAdapter(BasePlatformAdapter):
         string) is preserved in the returned set so callers can short-circuit
         on wildcard membership, consistent with ``allowed_channels``.
         """
-        raw = self.config.extra.get("free_response_channels")
-        if raw is None:
-            raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
-        if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        if isinstance(raw, str) and raw.strip():
-            return {part.strip() for part in raw.split(",") if part.strip()}
-        return set()
+        return self._discord_channel_setting(
+            "free_response_channels",
+            "DISCORD_FREE_RESPONSE_CHANNELS",
+        )
 
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
@@ -3205,16 +3239,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel_ids.add(parent_channel_id)
 
             # Check allowed channels - if set, only respond in these channels
-            allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
-            if allowed_channels_raw:
-                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
+            allowed_channels = self._discord_channel_setting(
+                "allowed_channels",
+                "DISCORD_ALLOWED_CHANNELS",
+            )
+            if allowed_channels:
                 if "*" not in allowed_channels and not (channel_ids & allowed_channels):
                     logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
                     return
 
             # Check ignored channels - never respond even when mentioned
-            ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
-            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
+            ignored_channels = self._discord_channel_setting(
+                "ignored_channels",
+                "DISCORD_IGNORED_CHANNELS",
+            )
             if "*" in ignored_channels or (channel_ids & ignored_channels):
                 logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
                 return
@@ -3248,10 +3286,16 @@ class DiscordAdapter(BasePlatformAdapter):
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
-            no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
-            no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+            no_thread_channels = self._discord_channel_setting(
+                "no_thread_channels",
+                "DISCORD_NO_THREAD_CHANNELS",
+            )
+            skip_thread = (
+                "*" in no_thread_channels
+                or bool(channel_ids & no_thread_channels)
+                or is_free_channel
+            )
+            auto_thread = self._discord_auto_thread_enabled()
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 
 
 def _ensure_discord_mock():
@@ -59,7 +59,7 @@ class FakeTextChannel:
     def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=321, name=guild_name)
         self.topic = None
 
 
@@ -69,7 +69,7 @@ class FakeThread:
         self.name = name
         self.parent = parent
         self.parent_id = getattr(parent, "id", None)
-        self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(id=321, name=guild_name)
         self.topic = None
 
 
@@ -96,6 +96,7 @@ def make_message(*, channel, content: str, mentions=None):
         reference=None,
         created_at=datetime.now(timezone.utc),
         channel=channel,
+        guild=getattr(channel, "guild", None),
         author=author,
     )
 
@@ -200,6 +201,113 @@ async def test_dms_unaffected_by_ignored_channels(adapter, monkeypatch):
     adapter.handle_message.assert_awaited_once()
 
 
+# ── config.yaml equivalents ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_config_ignored_channels_blocks_message(adapter, monkeypatch):
+    """discord.ignored_channels from config.extra blocks matching channels."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["ignored_channels"] = [500]
+
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_env_ignored_channels_overrides_config(adapter, monkeypatch):
+    """Non-empty DISCORD_IGNORED_CHANNELS overrides discord.ignored_channels."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "600")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["ignored_channels"] = [500]
+
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_config_allowed_channels_blocks_non_matching_channel(adapter, monkeypatch):
+    """discord.allowed_channels from config.extra whitelists server channels."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["allowed_channels"] = {700}
+
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_config_allowed_channels_inherits_thread_parent(adapter, monkeypatch):
+    """Threads inherit allowed-channel status from their parent channel."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["allowed_channels"] = ["500"]
+
+    parent = FakeTextChannel(channel_id=500, name="allowed-channel")
+    thread = FakeThread(channel_id=501, name="thread-in-allowed", parent=parent)
+    message = make_message(channel=thread, content="hello from thread")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_env_allowed_channels_overrides_config(adapter, monkeypatch):
+    """Non-empty DISCORD_ALLOWED_CHANNELS overrides discord.allowed_channels."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "600")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["allowed_channels"] = ["500"]
+
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dms_unaffected_by_config_channel_controls(adapter, monkeypatch):
+    """DMs are not filtered or threaded by server channel controls."""
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra.update(
+        {
+            "allowed_channels": ["999"],
+            "ignored_channels": ["*"],
+            "no_thread_channels": ["*"],
+            "auto_thread": True,
+        }
+    )
+
+    adapter._auto_create_thread = AsyncMock()
+    message = make_message(channel=FakeDMChannel(channel_id=500), content="dm hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
 # ── no_thread_channels ───────────────────────────────────────────────
 
 
@@ -264,6 +372,44 @@ async def test_no_thread_channels_csv_parsing(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_config_no_thread_channels_skips_auto_thread(adapter, monkeypatch):
+    """discord.no_thread_channels from config.extra skips auto-threading."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = (800,)
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(channel=FakeTextChannel(channel_id=800), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_config_no_thread_channels_wildcard_skips_auto_thread(adapter, monkeypatch):
+    """The no_thread_channels wildcard applies to every server channel."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = "*"
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch):
     """no_thread_channels is a no-op when auto_thread is globally disabled."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
@@ -279,6 +425,45 @@ async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch)
 
     adapter._auto_create_thread.assert_not_awaited()
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_config_auto_thread_false_disables_thread_creation(adapter, monkeypatch):
+    """discord.auto_thread=false disables auto-threading."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["auto_thread"] = False
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_env_auto_thread_overrides_config(adapter, monkeypatch):
+    """Non-empty DISCORD_AUTO_THREAD overrides discord.auto_thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["auto_thread"] = False
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
 
 
 # ── config.py bridging ───────────────────────────────────────────────
@@ -299,10 +484,11 @@ def test_config_bridges_ignored_channels(monkeypatch, tmp_path):
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "")
 
     from gateway.config import load_gateway_config
-    load_gateway_config()
+    config = load_gateway_config()
 
     import os
     assert os.getenv("DISCORD_IGNORED_CHANNELS") == "111,222"
+    assert config.platforms[Platform.DISCORD].extra["ignored_channels"] == ["111", "222"]
 
 
 def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
@@ -318,10 +504,39 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
     monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "")
 
     from gateway.config import load_gateway_config
-    load_gateway_config()
+    config = load_gateway_config()
 
     import os
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
+    assert config.platforms[Platform.DISCORD].extra["no_thread_channels"] == ["333"]
+
+
+def test_config_bridges_discord_channel_controls_to_extra(monkeypatch, tmp_path):
+    """Top-level discord channel controls are copied into PlatformConfig.extra."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "allowed_channels": [111],
+            "ignored_channels": ["222"],
+            "no_thread_channels": ["333"],
+            "auto_thread": False,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "")
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "")
+
+    from gateway.config import load_gateway_config
+    config = load_gateway_config()
+
+    extra = config.platforms[Platform.DISCORD].extra
+    assert extra["allowed_channels"] == [111]
+    assert extra["ignored_channels"] == ["222"]
+    assert extra["no_thread_channels"] == ["333"]
+    assert extra["auto_thread"] is False
 
 
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -59,7 +59,7 @@ class FakeTextChannel:
     def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=321, name=guild_name)
         self.topic = None
 
 
@@ -67,7 +67,7 @@ class FakeForumChannel:
     def __init__(self, channel_id: int = 1, name: str = "support-forum", guild_name: str = "Hermes Server"):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=321, name=guild_name)
         self.type = 15
         self.topic = None
 
@@ -78,7 +78,7 @@ class FakeThread:
         self.name = name
         self.parent = parent
         self.parent_id = getattr(parent, "id", None)
-        self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(id=321, name=guild_name)
         self.topic = None
 
 
@@ -106,6 +106,7 @@ def make_message(*, channel, content: str, mentions=None, msg_type=None):
         reference=None,
         created_at=datetime.now(timezone.utc),
         channel=channel,
+        guild=getattr(channel, "guild", None),
         author=author,
         type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
     )


### PR DESCRIPTION
## Summary
- Honor `discord.allowed_channels`, `discord.ignored_channels`, `discord.no_thread_channels`, and `discord.auto_thread` from `config.yaml` / `PlatformConfig.extra`, not only `DISCORD_*` environment variables.
- Normalize Discord channel-control settings from CSV strings, YAML sequences/sets/tuples, numeric IDs, and wildcard `"*"`.
- Preserve environment-variable override behavior for non-empty `DISCORD_*` values.
- Add regression coverage for config-based channel controls, thread-parent inheritance, DMs being unaffected, wildcard `no_thread_channels`, and env overrides.

## Test plan
- `python -m pytest tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_allowed_channels.py tests/gateway/test_discord_free_response.py -q` — 60 passed
- `python -m py_compile gateway/platforms/discord.py gateway/config.py`
- `git diff --check origin/main...HEAD`
- Full-suite check attempted with `python -m pytest tests/ -q`; this local environment is not currently clean on upstream `origin/main` either (`115 failed, 15959 passed, 57 skipped` on `9be83728`), so full-suite failures are treated as environment/upstream baseline noise rather than this PR's validation gate.

## Platforms tested
- Linux x86_64
- Python 3.11.15
- Node.js 18.19.1 present (not exercised by this PR)

## Notes
- The fix was developed in a fresh clone of the official repository at `/root/hermes-agent-official-fix`.
- No local `~/.hermes/config.yaml` or `~/.hermes/.env` files were modified.
