### PR TITLE
fix(nix): skip av/faster-whisper build checks on aarch64-darwin

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -18,6 +18,18 @@ let
 
   isAarch64Darwin = stdenv.hostPlatform.system == "aarch64-darwin";
 
+  # Nix daemon RewritingSink corrupts Mach-O ad-hoc code signatures on
+  # ffmpeg-headless sibling outputs (aarch64-darwin), causing SIGKILL when
+  # loading av's ffmpeg dylibs during build checks.
+  # Drop once https://github.com/NixOS/nix/pull/15638 lands.
+  avDarwin = python312.pkgs.av.overrideAttrs (_: {
+    dontUsePytestCheck = true;
+    dontUsePythonImportsCheck = true;
+  });
+  fasterWhisperDarwin = (python312.pkgs.faster-whisper.override { av = avDarwin; }).overrideAttrs (_: {
+    dontUsePythonImportsCheck = true;
+  });
+
   # Keep the workspace locked through uv2nix, but supply the local voice stack
   # from nixpkgs so wheel-only transitive artifacts do not break evaluation.
   mkPrebuiltPassthru = dependencies: {
@@ -55,7 +67,7 @@ let
 
       pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
 
-      av = mkPrebuiltOverride final python312.pkgs.av { };
+      av = mkPrebuiltOverride final avDarwin { };
 
       humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
 
@@ -74,7 +86,7 @@ let
         pyyaml = [ ];
       };
 
-      faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
+      faster-whisper = mkPrebuiltOverride final fasterWhisperDarwin {
         av = [ ];
         ctranslate2 = [ ];
         huggingface-hub = [ ];


### PR DESCRIPTION
## What does this PR do?

Disables build check phases that dlopen broken ffmpeg-headless dylibs on aarch64-darwin:
- `av`: disable `pythonImportsCheck` and `pytestCheckPhase` (both load ffmpeg dylibs)
- `faster-whisper`: disable `pythonImportsCheck` (transitively imports av; pytest already off upstream)

Overrides are targeted per-package to preserve binary cache for unrelated packages.

## Related Issue

Fixes #15776

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `nix/python.nix`: introduce `avDarwin` and `fasterWhisperDarwin` — overridden nixpkgs packages with build checks disabled. Used as `from` for `mkPrebuiltOverride` in the `isAarch64Darwin` block.

## How to Test

1. `nix build .#packages.aarch64-darwin.default` on macOS ARM64
2. Build succeeds (previously failed with exit code 137 / `Killed: 9`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1 aarch64-darwin

### Documentation &amp; Housekeeping

- [x] N/A — nix packaging only, no docs impact

## Context

- Root cause: [NixOS/nix#15638](https://github.com/NixOS/nix/pull/15638)
- Upstream issue: [NixOS/nixpkgs#511265](https://github.com/NixOS/nixpkgs/issues/511265)
- Linux unaffected (no code signing enforcement on ELF)
- Drop this override once the nix daemon fix lands

_Note: replaces #15777 which was closed due to corrupted git history._