### PR TITLE
fix(doctor): accept aliased providers (e.g. 'copilot') without false-positive unknown-provider error

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -329,7 +329,14 @@ def run_doctor(args):
                 canonical_provider = provider_def.id if provider_def is not None else None
 
             if provider and provider != "auto":
-                if canonical_provider is None or (known_providers and canonical_provider not in known_providers):
+                # canonical_provider may be an alias-resolved id (e.g. "github-copilot"
+                # for input "copilot") that differs from the PROVIDER_REGISTRY key.
+                # Accept the provider if EITHER the original name OR the canonical id
+                # is in known_providers to avoid false-positive "unknown provider" errors.
+                if (
+                    (canonical_provider is None or (known_providers and canonical_provider not in known_providers))
+                    and provider not in known_providers
+                ):
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     check_fail(
                         f"model.provider '{provider_raw}' is not a recognised provider",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -345,6 +345,44 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+def test_run_doctor_accepts_aliased_provider(monkeypatch, tmp_path):
+    """Providers with short-name aliases (e.g. 'copilot' → 'github-copilot')
+    must not be flagged as unrecognised by the doctor."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: copilot\n"
+        "  default: gpt-4o\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'copilot' is not a recognised provider" not in out
+
+
 def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #16076

## Problem

`resolve_provider_full("copilot")` returns the canonical model.dev id `"github-copilot"`, which differs from the `PROVIDER_REGISTRY` key `"copilot"`.  The provider-validation guard in `hermes_cli/doctor.py` only checked the canonical id against `known_providers`, so six short-name aliases were always flagged as unrecognised:

```
model.provider 'copilot' is not a recognised provider
model.provider 'kimi-coding' is not a recognised provider
...
```

Even though `hermes doctor` lists those same names as valid in the Providers section — a confusing contradiction.

## Fix

The guard now accepts the provider when **either** the original input name **or** its canonical alias-resolved id is present in `known_providers`.  No change to the happy-path logic for providers that don't need alias resolution.

```python
# Before
if canonical_provider is None or (known_providers and canonical_provider not in known_providers):

# After — also accept when the original short-name is itself a known key
if (
    (canonical_provider is None or (known_providers and canonical_provider not in known_providers))
    and provider not in known_providers
):
```

## Tests

- Added `test_run_doctor_accepts_aliased_provider` in `tests/hermes_cli/test_doctor.py`
- Confirmed test **fails** on unpatched code and **passes** with the fix (regression guard verified)
- All 24 doctor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)