### PR TITLE
fix(doctor): accept providers whose catalog id is None

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -372,10 +372,11 @@ def run_doctor(args):
                     provider_ids_to_accept.add(catalog_provider)
 
             if provider and provider != "auto":
-                if catalog_provider is None or (
-                    known_providers
-                    and not (provider_ids_to_accept & valid_provider_ids)
-                ):
+                # Don't reject solely because catalog_provider is None: local
+                # endpoints (ollama/vllm/llamacpp) have no catalog entry but
+                # auth.resolve_provider routes them to "custom", which is in
+                # PROVIDER_REGISTRY. Let the intersection check decide.
+                if known_providers and not (provider_ids_to_accept & valid_provider_ids):
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     check_fail(
                         f"model.provider '{provider_raw}' is not a recognised provider",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -430,6 +430,141 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
         )
 
 
+@pytest.mark.parametrize(
+    "provider_name",
+    [
+        # Local endpoint aliases: auth.resolve_provider routes them to "custom"
+        # but resolve_provider_full returns None, so the previous
+        # `catalog_provider is None` short-circuit rejected them despite the
+        # runtime-resolved id being a valid provider.
+        "ollama",
+        "vllm",
+        "llamacpp",
+        # bedrock and lmstudio are regression guards — they used to be on this
+        # list (#16085) but were fixed independently by adding a HERMES_OVERLAYS
+        # entry / a PROVIDER_REGISTRY entry, respectively.
+        "bedrock",
+        "lmstudio",
+    ],
+)
+def test_run_doctor_accepts_provider_when_catalog_resolution_returns_none(
+    monkeypatch, tmp_path, provider_name
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        f"  provider: {provider_name}\n"
+        "  default: dummy-model\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert f"model.provider '{provider_name}' is not a recognised provider" not in out
+    assert f"model.provider '{provider_name}' is unknown" not in out
+
+
+def test_run_doctor_validator_invariant_holds_for_every_known_provider():
+    # Acceptance invariant: every name doctor prints in its "Valid providers"
+    # list must also pass doctor's "is it valid" check. The two used to be
+    # built from registries (PROVIDER_REGISTRY vs HERMES_OVERLAYS) that
+    # disagreed on canonical ids, producing self-contradicting errors.
+    from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
+    from hermes_cli.providers import (
+        ALIASES,
+        HERMES_OVERLAYS,
+        normalize_provider,
+        resolve_provider_full,
+    )
+
+    known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+    acceptable_ids = (
+        known_providers
+        | set(HERMES_OVERLAYS.keys())
+        | set(ALIASES.values())
+    )
+
+    failed = []
+    for name in sorted(known_providers):
+        if name in ("auto", "custom", "openrouter"):
+            continue
+        candidates = {name, normalize_provider(name)}
+        try:
+            runtime_id = resolve_provider(name)
+            if runtime_id:
+                candidates.add(runtime_id)
+        except Exception:
+            pass
+        pdef = resolve_provider_full(name, None, [])
+        if pdef is not None and pdef.id:
+            candidates.add(pdef.id)
+        if not (candidates & acceptable_ids):
+            failed.append((name, sorted(candidates)))
+
+    assert not failed, (
+        "Provider names printed as valid by doctor that fail its own validator: "
+        f"{failed}"
+    )
+
+
+def test_run_doctor_still_flags_unknown_provider(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: completely-made-up\n"
+        "  default: foo\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'completely-made-up' is not a recognised provider" in out
+
+
 def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What & Why

#17135 (merged) fixed `hermes doctor` for providers whose Hermes runtime id differs from the models.dev catalog id: `ai-gateway`, `copilot`, `kilocode`, `kimi-coding`, `kimi-coding-cn`, `opencode-zen`. It did not cover local-endpoint aliases — `ollama`, `vllm`, `llamacpp` — which still produce a self-contradicting "unknown provider" error today.

Reproduction on current `main` (post #17135):

```yaml
# ~/.hermes/config.yaml
model:
  provider: ollama
  default: dummy-model
  base_url: http://localhost:11434/v1
```

```
✗ model.provider 'ollama' is not a recognised provider
  (known: ai-gateway, alibaba, ..., custom, ..., zai)
```

`ollama` is not in the printed "known" list, but it's a documented user-facing value — `auth.resolve_provider` routes it to `custom`, which *is* in the list.

Closes #16076 (`copilot`, fixed by #17135). Closes the still-open part of #16085. Supersedes the earlier scope of this PR; #15159 / #15361 / #15583 / #15778 stay closed.

## Root cause (what #17135 missed)

Three providers — `ollama`, `vllm`, `llamacpp` — sit in `auth.py:_PROVIDER_ALIASES` mapping to `"custom"`, but have no entry in `providers.py`. After #17135, the validator built up `provider_ids_to_accept = {raw, runtime_resolved, catalog_resolved}` correctly (including `"custom"` for these three), but the failure condition still started with:

```python
if catalog_provider is None or (
    known_providers and not (provider_ids_to_accept & valid_provider_ids)
):
```

`resolve_provider_full("ollama")` returns `None`, so `catalog_provider is None`, and the short-circuit rejects the provider before the intersection check ever runs.

| Input | `auth.resolve_provider(...)` | `resolve_provider_full(...).id` | Status before this PR |
| --- | --- | --- | --- |
| `ollama` | `custom` | `None` | rejected ❌ |
| `vllm` | `custom` | `None` | rejected ❌ |
| `llamacpp` | `custom` | `None` | rejected ❌ |
| `bedrock` | `bedrock` | `bedrock` (HERMES_OVERLAYS entry now exists) | accepted ✅ |
| `lmstudio` | `lmstudio` (now in PROVIDER_REGISTRY) | `lmstudio` | accepted ✅ |

`bedrock` and `lmstudio` were on the original #16085 list but were fixed independently — `bedrock` by adding a `HERMES_OVERLAYS` entry, `lmstudio` by promoting it to `PROVIDER_REGISTRY` (214ca943a, `feat(agent): add lmstudio integration`). Both are kept in the parametrized test as regression guards.

## Change

One behaviour change in `hermes_cli/doctor.py`: drop the `catalog_provider is None or ...` short-circuit. The intersection check below already covers the cases that matter — a `None` catalog id is not a sufficient signal that the provider is unknown when the auth-resolved runtime id lands in `PROVIDER_REGISTRY`.

## Tests

`tests/hermes_cli/test_doctor.py` adds:

- `test_run_doctor_accepts_provider_when_catalog_resolution_returns_none` — parametrized over `ollama`, `vllm`, `llamacpp` (the cases #17135 didn't fix) plus `bedrock` and `lmstudio` as regression guards.
- `test_run_doctor_validator_invariant_holds_for_every_known_provider` — invariant test asserting every name in `PROVIDER_REGISTRY` (i.e. every name doctor prints as valid) also passes its own validator. Catches forward regressions like the original `bedrock` shape if a future provider lands in `PROVIDER_REGISTRY` without a matching catalog or alias entry.
- `test_run_doctor_still_flags_unknown_provider` — negative case: `provider: completely-made-up` is still flagged.

```bash
$ scripts/run_tests.sh tests/hermes_cli/test_doctor.py
35 passed in 1.4s
```

Wider sweep on `tests/hermes_cli/`: 3471 passed, 9 unrelated failures (`test_gateway_service`, `test_gateway_wsl`, `test_setup_openclaw_migration`, `test_tools_config`) that reproduce on a clean `main` without these changes.

## Platforms tested

- macOS 14 (Apple Silicon), Python 3.11.15

## Scope

One commit, one file plus tests. Six-line diff in `doctor.py` (drop one short-circuit + a clarifying comment). No behaviour change for providers that already passed the validator.
