### PR TITLE
fix(update): clarify package-lock autostash prompts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5209,6 +5209,52 @@ def _print_stash_cleanup_guidance(
         )
 
 
+_PACKAGE_LOCK_NAME = "package-lock.json"
+
+
+def _is_package_lock_path(path: str) -> bool:
+    return path == _PACKAGE_LOCK_NAME or path.endswith(f"/{_PACKAGE_LOCK_NAME}")
+
+
+def _package_lock_only_stash_files(
+    git_cmd: list[str], cwd: Path, stash_ref: str
+) -> list[str]:
+    """Return changed package-lock files when a stash contains only lockfile churn.
+
+    `hermes update` autostashes before pulling. A very common low-risk dirty state
+    is npm rewriting tracked package-lock metadata while the matching package.json
+    remains unchanged. That should not get the same scary restore-default-yes
+    prompt as real source/config edits.
+
+    Keep this intentionally narrow: any non-package-lock tracked path, any empty
+    diff, or any untracked stash payload makes the stash a normal local-change
+    stash.
+    """
+    diff = subprocess.run(
+        git_cmd + ["diff", "--name-only", f"{stash_ref}^1", stash_ref],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if diff.returncode != 0:
+        return []
+
+    tracked_paths = [line.strip() for line in diff.stdout.splitlines() if line.strip()]
+    if not tracked_paths or not all(_is_package_lock_path(path) for path in tracked_paths):
+        return []
+
+    untracked = subprocess.run(
+        git_cmd + ["ls-tree", "-r", "--name-only", f"{stash_ref}^3"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if untracked.returncode == 0 and untracked.stdout.strip():
+        return []
+
+    return tracked_paths
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -5217,22 +5263,39 @@ def _restore_stashed_changes(
     input_fn=None,
 ) -> bool:
     if prompt_user:
+        lockfile_churn_files = _package_lock_only_stash_files(git_cmd, cwd, stash_ref)
         print()
         print("⚠ Local changes were stashed before updating.")
-        print(
-            "  Restoring them may reapply local customizations onto the updated codebase."
-        )
-        print("  Review the result afterward if Hermes behaves unexpectedly.")
-        print("Restore local changes now? [Y/n]")
-        if input_fn is not None:
-            response = input_fn("Restore local changes now? [Y/n]", "y")
+        if lockfile_churn_files:
+            print("  These look like generated package-lock churn:")
+            for path in lockfile_churn_files:
+                print(f"  • {path}")
+            print("  package.json was unchanged; restoring these is usually unnecessary.")
+            print("Restore generated lockfile changes now? [y/N]")
+            if input_fn is not None:
+                response = input_fn("Restore generated lockfile changes now? [y/N]", "n")
+            else:
+                response = input().strip().lower()
+            if response not in ("y", "yes"):
+                print("Skipped restoring generated lockfile changes.")
+                print("Your changes are still preserved in git stash.")
+                print(f"Restore manually with: git stash apply {stash_ref}")
+                return False
         else:
-            response = input().strip().lower()
-        if response not in ("", "y", "yes"):
-            print("Skipped restoring local changes.")
-            print("Your changes are still preserved in git stash.")
-            print(f"Restore manually with: git stash apply {stash_ref}")
-            return False
+            print(
+                "  Restoring them may reapply local customizations onto the updated codebase."
+            )
+            print("  Review the result afterward if Hermes behaves unexpectedly.")
+            print("Restore local changes now? [Y/n]")
+            if input_fn is not None:
+                response = input_fn("Restore local changes now? [Y/n]", "y")
+            else:
+                response = input().strip().lower()
+            if response not in ("", "y", "yes"):
+                print("Skipped restoring local changes.")
+                print("Your changes are still preserved in git stash.")
+                print(f"Restore manually with: git stash apply {stash_ref}")
+                return False
 
     print("→ Restoring local changes...")
     restore = subprocess.run(

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -85,10 +85,11 @@ def test_restore_stashed_changes_prompts_before_applying(monkeypatch, tmp_path, 
     restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
 
     assert restored is True
-    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
-    assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
-    assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
-    assert calls[3][0] == ["git", "stash", "drop", "stash@{1}"]
+    assert calls[0][0] == ["git", "diff", "--name-only", "abc123^1", "abc123"]
+    assert calls[1][0] == ["git", "stash", "apply", "abc123"]
+    assert calls[2][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
+    assert calls[3][0] == ["git", "stash", "list", "--format=%gd %H"]
+    assert calls[4][0] == ["git", "stash", "drop", "stash@{1}"]
     out = capsys.readouterr().out
     assert "Restore local changes now? [Y/n]" in out
     assert "restored on top of the updated codebase" in out
@@ -101,6 +102,8 @@ def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tm
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(stdout="hermes_cli/main.py\n", stderr="", returncode=0)
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
@@ -109,11 +112,45 @@ def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tm
     restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
 
     assert restored is False
-    assert calls == []
+    assert [cmd for cmd, _ in calls] == [
+        ["git", "diff", "--name-only", "abc123^1", "abc123"],
+    ]
     out = capsys.readouterr().out
     assert "Restore local changes now? [Y/n]" in out
     assert "Your changes are still preserved in git stash." in out
     assert "git stash apply abc123" in out
+
+
+def test_restore_stashed_changes_treats_package_lock_only_stash_as_generated_churn(
+    monkeypatch, tmp_path, capsys
+):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(
+                stdout="web/package-lock.json\nui-tui/package-lock.json\n",
+                stderr="",
+                returncode=0,
+            )
+        if cmd[1:3] == ["ls-tree", "-r"]:
+            return SimpleNamespace(stdout="", stderr="fatal: not a tree\n", returncode=128)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is False
+    out = capsys.readouterr().out
+    assert "These look like generated package-lock churn" in out
+    assert "web/package-lock.json" in out
+    assert "ui-tui/package-lock.json" in out
+    assert "Restore generated lockfile changes now? [y/N]" in out
+    assert "git stash apply abc123" in out
+    assert not any(cmd[1:3] == ["stash", "apply"] for cmd, _ in calls)
 
 
 def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Detect package-lock-only update autostashes as likely generated npm lockfile churn
- Show the exact lockfile paths in the restore prompt
- Default package-lock-only restore prompts to `n` via `[y/N]`
- Preserve the existing `[Y/n]` restore behavior for real source/config/local changes

## Why
Generated `package-lock.json` metadata churn can make `hermes update` look scarier than it is, especially for new users. This can help give more info for whether local changes are real or can be quickly discarded by hitting "n".

This PR keeps the behavior conservative: nothing is ignored, dropped, or auto-discarded.

## Test Plan
- [x] `.venv/bin/pytest tests/hermes_cli/test_update_autostash.py -q`
- [x] `.venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_autostash.py`
- [x] `git diff --check`

## Notes
This intentionally does not add `package-lock.json` to `.gitignore` and does not silently discard lockfile changes.
