### PR TITLE
fix(wecom): mark adapter as non-editable to prevent broken streaming/progress flows

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -142,6 +142,7 @@ class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    SUPPORTS_MESSAGE_EDITING = False
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -36,6 +36,11 @@ class TestWeComRequirements:
 
 
 class TestWeComAdapterInit:
+    def test_declares_non_editable_message_capability(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
+
     def test_reads_config_from_extra(self):
         from gateway.platforms.wecom import WeComAdapter
 


### PR DESCRIPTION
## Summary
- Set `WeComAdapter.SUPPORTS_MESSAGE_EDITING = False`.
- Prevent gateway streaming/progress paths from using edit-based message updates on WeCom.
- Add a regression test to lock this capability contract.

## Why
WeCom does not reliably support message editing semantics used by streaming and tool-progress updates.  
Without an explicit non-editable declaration, gateway behavior can produce partial or duplicate output.

## Changes
- `gateway/platforms/wecom.py`
  - Added `SUPPORTS_MESSAGE_EDITING = False` to `WeComAdapter`.
- `tests/gateway/test_wecom.py`
  - Added `test_declares_non_editable_message_capability`.

## Validation
- `scripts/run_tests.sh tests/gateway/test_wecom.py` ✅
- `git log main..HEAD --oneline` contains only this task commit ✅
- `git diff main --stat` matches planned file scope (2 files) ✅

## Regression Risk
Low.  
Change is a platform capability declaration plus a focused test; no broad behavior refactor.

## Issue
Closes #10137