### PR TITLE
fix(docker): don't chown config.yaml after gosu drop (#15865)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,6 +41,15 @@ if [ "$(id -u)" = "0" ]; then
             echo "Warning: chown failed (rootless container?) — continuing anyway"
     fi
 
+    # Ensure config.yaml is readable by the hermes runtime user even if it was
+    # edited on the host after initial ownership setup. Must run here (as root)
+    # rather than after the gosu drop, otherwise a non-root caller like
+    # `docker run -u $(id -u):$(id -g)` hits "Operation not permitted" (#15865).
+    if [ -f "$HERMES_HOME/config.yaml" ]; then
+        chown hermes:hermes "$HERMES_HOME/config.yaml" 2>/dev/null || true
+        chmod 640 "$HERMES_HOME/config.yaml" 2>/dev/null || true
+    fi
+
     echo "Dropping root privileges"
     exec gosu hermes "$0" "$@"
 fi
@@ -65,13 +74,6 @@ fi
 # config.yaml
 if [ ! -f "$HERMES_HOME/config.yaml" ]; then
     cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
-fi
-
-# Ensure the main config file remains accessible to the hermes runtime user
-# even if it was edited on the host after initial ownership setup.
-if [ -f "$HERMES_HOME/config.yaml" ]; then
-    chown hermes:hermes "$HERMES_HOME/config.yaml"
-    chmod 640 "$HERMES_HOME/config.yaml"
 fi
 
 # SOUL.md


### PR DESCRIPTION
## Summary
Fixes `chown: changing ownership of '/opt/data/config.yaml': Operation not permitted` when running the docker image with `-u $(id -u):$(id -g)`. Regression from b24d239ce (Apr 15, v2026.4.23).

## Root cause
The chown/chmod block for `config.yaml` lives in the entrypoint's post-gosu 'running as hermes' section, not the root section. When the container is started with an explicit `-u` flag, the root block (lines 12-46) is skipped entirely, execution falls through to line 72 as the caller's UID (non-root, not `hermes`), and `chown hermes:hermes` fails. Under `set -e` this aborts the whole startup.

## Changes
- `docker/entrypoint.sh`: move the config.yaml chown/chmod into the root block (before the gosu exec), add `2>/dev/null || true` guards to match the `-R` chown on HERMES_HOME for rootless Podman compatibility.

## Validation
| Scenario | Before | After |
|---|---|---|
| `docker run <image> setup` (default, root start) | works | works |
| `docker run -u $(id -u):$(id -g) <image> setup` | **"Operation not permitted", aborts** | works |
| Rootless Podman (root-in-container but no host chown privilege) | works | works (silent failure) |

Local E2E harness confirms `chown <other-user>` under `set -e` with the `|| true` guard does not abort the script.

Closes #15865