### PR TITLE
fix(run_agent): restore reasoning field promotion on DeepSeek/Kimi tool-call turns (salvage #15883)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7868,7 +7868,17 @@ class AIAgent:
             api_msg["reasoning_content"] = existing
             return
 
-        # 2. DeepSeek / Kimi thinking mode: tool-call turns that lack
+        # 2. Healthy session: promote 'reasoning' field to 'reasoning_content'
+        # for providers that use the internal 'reasoning' key.
+        # This must happen BEFORE the DeepSeek/Kimi tool-call check so that
+        # genuine reasoning content is not overwritten by the empty-string
+        # fallback (#15812 regression in PR #15478).
+        normalized_reasoning = source_msg.get("reasoning")
+        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            api_msg["reasoning_content"] = normalized_reasoning
+            return
+
+        # 3. DeepSeek / Kimi thinking mode: tool-call turns that lack
         # reasoning_content are "poisoned history" — a prior provider (MiniMax,
         # etc.) left them empty. DeepSeek returns HTTP 400 if reasoning_content
         # is absent on replay; inject "" to satisfy the provider's requirement
@@ -7882,13 +7892,6 @@ class AIAgent:
         )
         if needs_empty_reasoning:
             api_msg["reasoning_content"] = ""
-            return
-
-        # 3. Healthy session: promote 'reasoning' field to 'reasoning_content'
-        # for providers that use the internal 'reasoning' key.
-        normalized_reasoning = source_msg.get("reasoning")
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
-            api_msg["reasoning_content"] = normalized_reasoning
             return
 
         # 4. DeepSeek / Kimi thinking mode: all assistant messages need

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,7 @@ AUTHOR_MAP = {
     "teknium1@gmail.com": "teknium1",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "focusflow.app.help@gmail.com": "yes999zc",
     "343873859@qq.com": "DrStrangerUJN",
     "uzmpsk.dilekakbas@gmail.com": "dlkakbs",
     "jefferson@heimdallstrategy.com": "Mind-Dragon",


### PR DESCRIPTION
Salvage of #15883 onto current main. Fixes the regression reported in #15812.

## Summary
Promotes the internal `reasoning` field to `reasoning_content` BEFORE the DeepSeek/Kimi empty-string fallback runs, so same-provider reasoning content is preserved on tool-call replay.

## Root cause
PR #15749 reordered `_copy_reasoning_content_for_api` so the DeepSeek/Kimi tool-call empty-string guard (step 2) returned before the `reasoning`→`reasoning_content` promotion (step 3). Any assistant tool-call turn with a genuine reasoning trace got its content replaced with `""` on replay.

## Changes
- `run_agent.py`: swap steps 2 and 3 in `_copy_reasoning_content_for_api` — promote `reasoning` first, fall back to `""` only when no reasoning is present.
- `scripts/release.py`: AUTHOR_MAP entry for focusflow.app.help@gmail.com → yes999zc so release-notes CI attributes correctly.

## Validation
| | Before | After |
|---|---|---|
| `test_deepseek_reasoning_field_promoted` | FAIL (`'' == 'thought trace'`) | PASS |
| `tests/run_agent/test_deepseek_reasoning_content_echo.py` (full file) | 20/21 | 21/21 |

Cherry-picked from @yes999zc's commit (authored as FocusFlow Dev). Original PR: #15883.

Closes #15812