### PR TITLE
fix(run_agent): background review fork inherits parent's live runtime

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3154,12 +3154,25 @@ class AIAgent:
                 with open(os.devnull, "w") as _devnull, \
                      contextlib.redirect_stdout(_devnull), \
                      contextlib.redirect_stderr(_devnull):
+                    # Inherit the parent agent's live runtime (provider, model,
+                    # base_url, api_key, api_mode) so the fork uses the exact
+                    # same credentials the main turn is using.  Without this,
+                    # AIAgent.__init__ re-runs auto-resolution from env vars,
+                    # which fails for OAuth-only providers, session-scoped
+                    # creds, or credential-pool setups where the resolver can't
+                    # reconstruct auth from scratch -- producing the spurious
+                    # "No LLM provider configured" warning at end of turn.
+                    _parent_runtime = self._current_main_runtime()
                     review_agent = AIAgent(
                         model=self.model,
                         max_iterations=8,
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        api_mode=_parent_runtime.get("api_mode") or None,
+                        base_url=_parent_runtime.get("base_url") or None,
+                        api_key=_parent_runtime.get("api_key") or None,
+                        credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
                     )
                     review_agent._memory_write_origin = "background_review"


### PR DESCRIPTION
## Summary
Background review now uses the parent agent's live credentials instead of re-resolving from env vars — fixes the `⚠ Auxiliary background review failed: No LLM provider configured` warning for users whose main-agent auth isn't reconstructable from environment alone (OAuth-only providers, credential pools, session-scoped creds).

Root cause is old (commit 470d89c6d, Mar 20). It was invisible until #PR 8a2506af4 (Apr 24) promoted auxiliary failure logging from `logger.debug` to a user-visible warning.

## Changes
- `run_agent.py` `_spawn_background_review`: pass `api_key`, `base_url`, `api_mode`, and `credential_pool` from `_current_main_runtime()` into the forked AIAgent. Every other auxiliary path (compression, memory flush, vision, session search) already does this.

## Validation
| | Before | After |
|---|---|---|
| Fork receives parent api_key / base_url / api_mode | No | Yes |
| `_current_main_runtime()` plumbed to fork | No | Yes |
| Targeted tests (`test_background_review_summary.py`, `test_run_progress_topics.py`) | 32 pass | 32 pass |
| E2E: parent with live creds + empty env → fork inherits creds | Fails, warning | Passes, no warning |
