### PR TITLE
feat(cli): surface /queue, /bg, /steer in agent-running placeholder

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9841,7 +9841,7 @@ class HermesCLI:
                 status = cli_ref._command_status or "Processing command..."
                 return f"{frame} {status}"
             if cli_ref._agent_running:
-                return "type a message + Enter to interrupt, Ctrl+C to cancel"
+                return "msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel"
             if cli_ref._voice_mode:
                 return "type or Ctrl+B to record"
             return ""

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -239,7 +239,7 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
-                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel' : ''}
+                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
                   value={composer.input}
                 />
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -239,7 +239,7 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
-                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel' : ''}
                   value={composer.input}
                 />
 


### PR DESCRIPTION
## Summary
Agent-running placeholder now advertises every way to interact with the loop, not just interrupt.

## Changes
- `cli.py` `_get_placeholder`: `msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel` (was "type a message + Enter to interrupt, Ctrl+C to cancel")
- `ui-tui/src/components/appLayout.tsx` busy placeholder: same string (was "Ctrl+C to interrupt…")

Keeps it to one line so it doesn't wrap in narrow terminals.

## Why
Users ask how to do async things while the agent is working. The four options (send message to interrupt, `/queue`, `/bg`/`/btw`, `/steer`) aren't discoverable from the current placeholder — only `Ctrl+C` and new-message-interrupt are hinted. Surfacing them inline means Teknium doesn't have to keep tweeting the tip.

Ref: https://x.com/Teknium1/status/...