### PR TITLE
fix(tui): use --outdir instead of --outfile in hermes-ink build script

### DIFF
--- a/ui-tui/packages/hermes-ink/index.js
+++ b/ui-tui/packages/hermes-ink/index.js
@@ -1,1 +1,1 @@
-export * from './dist/ink-bundle.js'
+export * from './dist/entry-exports.js'

--- a/ui-tui/packages/hermes-ink/package.json
+++ b/ui-tui/packages/hermes-ink/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "esbuild src/entry-exports.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/ink-bundle.js"
+    "build": "esbuild src/entry-exports.ts --bundle --platform=node --format=esm --packages=external --outdir=dist"
   },
   "sideEffects": true,
   "main": "./index.js",


### PR DESCRIPTION
## Problem

On Android/Termux ARM64 with esbuild >=0.25, the `hermes-ink` build script fails with:

```
[ERROR] Must use "outdir" when there are multiple input files
```

This causes `hermes dashboard --tui` to fail silently — the dashboard starts but the Chat tab is blank.

## Fix

- Change `--outfile=dist/ink-bundle.js` to `--outdir=dist` in the build script
- Update `index.js` to import from `./dist/entry-exports.js` (esbuild names output files after input files when using `--outdir`)

Fixes #16072