### PR TITLE
fix: use live Codex models in picker

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -13,19 +13,17 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
     "gpt-5.5",
-    "gpt-5.4-mini",
     "gpt-5.4",
+    "gpt-5.4-mini",
     "gpt-5.3-codex",
-    "gpt-5.2-codex",
-    "gpt-5.1-codex-max",
-    "gpt-5.1-codex-mini",
+    "gpt-5.2",
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
-    ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
-    ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
-    ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
-    ("gpt-5.3-codex", ("gpt-5.2-codex",)),
+    ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2")),
+    ("gpt-5.4", ("gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2")),
+    ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2")),
+    ("gpt-5.3-codex", ("gpt-5.2",)),
 ]
 
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1173,7 +1173,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"copilot", "copilot-acp"}:
+        if hermes_slug in {"copilot", "copilot-acp", "openai-codex"}:
             model_ids = provider_model_ids(hermes_slug)
         else:
             # Use curated list — look up by Hermes slug, fall back to overlay key

--- a/tests/hermes_cli/test_codex_cli_model_picker.py
+++ b/tests/hermes_cli/test_codex_cli_model_picker.py
@@ -75,6 +75,29 @@ def test_normal_path_still_works(hermes_auth_only_env):
     assert "openai-codex" in slugs
 
 
+def test_codex_picker_uses_live_model_listing_when_available(hermes_auth_only_env, monkeypatch):
+    """The picker should not advertise stale fallback Codex models when live discovery works."""
+    from hermes_cli import model_switch
+
+    live_models = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"]
+    stale_models = {"gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"}
+
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider: live_models if provider == "openai-codex" else [],
+    )
+
+    providers = model_switch.list_authenticated_providers(
+        current_provider="openai-codex",
+        max_models=50,
+    )
+
+    codex = next(p for p in providers if p["slug"] == "openai-codex")
+    assert codex["models"] == live_models
+    assert codex["total_models"] == len(live_models)
+    assert stale_models.isdisjoint(codex["models"])
+
+
 @pytest.fixture()
 def claude_code_only_env(tmp_path, monkeypatch):
     """Set up an environment where Anthropic credentials only exist in

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -1,9 +1,5 @@
 import json
-import os
-import sys
 from unittest.mock import patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
 
@@ -52,20 +48,29 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
 
     models = get_codex_model_ids()
 
+    assert DEFAULT_CODEX_MODELS == [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+    ]
     assert models[: len(DEFAULT_CODEX_MODELS)] == DEFAULT_CODEX_MODELS
-    assert "gpt-5.4" in models
+    assert "gpt-5.2-codex" not in models
+    assert "gpt-5.1-codex-max" not in models
+    assert "gpt-5.1-codex-mini" not in models
     assert "gpt-5.3-codex-spark" not in models
 
 
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
-        lambda access_token: ["gpt-5.2-codex"],
+        lambda access_token: ["gpt-5.2"],
     )
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+    assert models == ["gpt-5.2", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):


### PR DESCRIPTION
## Summary
- Use live OpenAI Codex model discovery for the authenticated model picker instead of the static curated fallback list.
- Refresh Codex fallback defaults to the current live lineup: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.2.
- Add regression coverage so stale Codex slugs are not shown when live discovery is available.

## Test Plan
- venv/bin/python -m pytest tests/hermes_cli/test_codex_models.py tests/hermes_cli/test_codex_cli_model_picker.py -q
- venv/bin/python -m pytest tests/hermes_cli/test_codex_models.py tests/hermes_cli/test_codex_cli_model_picker.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py -q

## Live verification
- provider_model_ids('openai-codex', force_refresh=True) returned: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.2']
- list_authenticated_providers(..., current_provider='openai-codex') now returns the same five Codex models.