### PR TITLE
fix(doctor): check global agent-browser when local install not found

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -806,6 +806,8 @@ def run_doctor(args):
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
         if agent_browser_path.exists():
             check_ok("agent-browser (Node.js)", "(browser automation)")
+        elif shutil.which("agent-browser"):
+            check_ok("agent-browser", "(browser automation)")
         else:
             if _is_termux():
                 check_info("agent-browser is not installed (expected in the tested Termux path)")


### PR DESCRIPTION
Closes #15951

When agent-browser is globally installed via 'npm install -g agent-browser' but not present in the local node_modules, doctor falsely warns that it's not installed. Add shutil.which('agent-browser') as a fallback check after the local path check.