### PR TITLE
feat(honcho): add honcho_list_conclusions tool to expose conclusion IDs

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -177,7 +177,36 @@ CONCLUDE_SCHEMA = {
 }
 
 
-ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCHEMA, CONCLUDE_SCHEMA]
+LIST_CONCLUSIONS_SCHEMA = {
+    "name": "honcho_list_conclusions",
+    "description": (
+        "List conclusions about a peer with their IDs, content, and metadata. "
+        "Use this to find the ID of a conclusion you want to delete via honcho_conclude(delete_id=...). "
+        "Returns id, content, observer, observed, session_id, created_at for each conclusion. "
+        "Optional `query` parameter does a semantic search instead of listing recent."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Optional semantic search query. If omitted, returns most recent conclusions.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return (default 20, max 100).",
+            },
+            "peer": {
+                "type": "string",
+                "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCHEMA, CONCLUDE_SCHEMA, LIST_CONCLUSIONS_SCHEMA]
 
 
 # ---------------------------------------------------------------------------
@@ -1225,6 +1254,17 @@ class HonchoMemoryProvider(MemoryProvider):
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})
                 return tool_error("Failed to save conclusion.")
+
+            elif tool_name == "honcho_list_conclusions":
+                query = (args.get("query") or "").strip() or None
+                limit = min(max(int(args.get("limit", 20)), 1), 100)
+                peer = args.get("peer", "user")
+                items = self._manager.list_conclusions(
+                    self._session_key, query=query, limit=limit, peer=peer
+                )
+                if not items:
+                    return json.dumps({"result": "No conclusions found.", "conclusions": []})
+                return json.dumps({"result": f"{len(items)} conclusion(s) found.", "conclusions": items})
 
             return tool_error(f"Unknown tool: {tool_name}")
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1120,6 +1120,64 @@ class HonchoSessionManager:
             logger.error("Failed to delete conclusion %s: %s", conclusion_id, e)
             return False
 
+    def list_conclusions(
+        self,
+        session_key: str,
+        query: str | None = None,
+        limit: int = 20,
+        peer: str = "user",
+    ) -> list[dict]:
+        """List conclusions about a peer with their IDs and metadata.
+
+        Used by honcho_list_conclusions tool to expose IDs needed for delete_id.
+
+        Args:
+            session_key: Session key for peer resolution.
+            query: Optional semantic search query. If None, returns recent.
+            limit: Max number of results (clamped to 100).
+            peer: Peer alias or explicit peer ID.
+
+        Returns:
+            List of dicts with id, content, observer, observed, session_id, created_at.
+        """
+        session = self._cache.get(session_key)
+        if not session:
+            return []
+
+        try:
+            target_peer_id = self._resolve_peer_id(session, peer)
+            if target_peer_id is None:
+                return []
+
+            if target_peer_id == session.assistant_peer_id:
+                observer = self._get_or_create_peer(session.assistant_peer_id)
+                scope = observer.conclusions_of(session.assistant_peer_id)
+            elif self._ai_observe_others:
+                observer = self._get_or_create_peer(session.assistant_peer_id)
+                scope = observer.conclusions_of(target_peer_id)
+            else:
+                target_peer = self._get_or_create_peer(target_peer_id)
+                scope = target_peer.conclusions_of(target_peer_id)
+
+            results = scope.query(query=query) if query else scope.list()
+
+            items: list[dict] = []
+            for c in results:
+                if len(items) >= limit:
+                    break
+                items.append({
+                    "id": getattr(c, "id", None),
+                    "content": getattr(c, "content", ""),
+                    "observer": getattr(c, "observer_id", None),
+                    "observed": getattr(c, "observed_id", None),
+                    "session_id": getattr(c, "session_id", None),
+                    "created_at": str(c.created_at) if getattr(c, "created_at", None) else None,
+                })
+            return items
+        except Exception as e:
+            logger.error("Failed to list conclusions: %s", e)
+            return []
+
     def set_peer_card(self, session_key: str, card: list[str], peer: str = "user") -> list[str] | None:
         """Update a peer's card.
 


### PR DESCRIPTION
## Problem

The Honcho memory plugin exposes a `honcho_conclude(delete_id=...)` tool to delete conclusions for PII removal, but no tool exposes conclusion IDs. Users (and the agent itself) cannot determine the `delete_id` to pass.

In practice, agents accumulate test/debug conclusions during interactive debugging that they cannot clean up. The agent reports "Impossible to recover ID for delete_id" because all read-side tools (`honcho_search`, `honcho_profile`, `honcho_reasoning`, `honcho_context`) return aggregated/synthesized text without underlying document IDs.

## Solution

Adds a new `honcho_list_conclusions` tool that returns conclusions with their metadata (id, content, observer, observed, session_id, created_at) using the Honcho SDK's existing `peer.conclusions.list()` and `peer.conclusions.query()` APIs.

## Changes

**`plugins/memory/honcho/__init__.py`** (+27 lines)
- New `LIST_CONCLUSIONS_SCHEMA` tool definition with `query`, `limit`, `peer` params
- Added to `ALL_TOOL_SCHEMAS`
- New handler in `handle_tool_call` calling `self._manager.list_conclusions(...)`

**`plugins/memory/honcho/session.py`** (+56 lines)
- New `list_conclusions(session_key, query, limit, peer)` method on `HonchoSessionManager`
- Reuses the same peer/scope resolution logic as `delete_conclusion` for consistency
- Returns `list[dict]` with id, content, observer, observed, session_id, created_at

## Behavior

- `query=None` → `peer.conclusions.list()` (most recent)
- `query="..."` → `peer.conclusions.query(query=...)` (semantic search)
- `limit` clamped to [1, 100]
- Same peer alias resolution as other Honcho tools (`user`, `ai`, or explicit ID)
- Same `_ai_observe_others` flag handling as `delete_conclusion`

## Use case

1. Agent runs `honcho_list_conclusions(query="test")` → gets `[{id: "abc123", content: "..."}]`
2. Agent runs `honcho_conclude(delete_id="abc123")` → conclusion deleted

## Testing

Verified end-to-end on Honcho self-hosted v3.0.6 + honcho-ai SDK 2.1.1:
- `list()` returns conclusions with IDs
- `query()` returns ranked subset with IDs
- `delete_id` flow works after listing
- Tool count goes from 5 to 6
- Existing tools unchanged