### PR TITLE
fix(matrix): prevent ValueError crash on non numeric batch delay env vars

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -100,6 +100,23 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_float_env(name: str, default: float) -> float:
+    """Return the float value of env var *name*, falling back to *default* on
+    any parse error instead of raising ValueError at adapter init time."""
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Matrix: env var %s=%r is not a valid number; using default %.2f",
+            name, raw, default,
+        )
+        return default
+
+
 # Matrix message size limit (4000 chars practical, spec has no hard limit
 # but clients render poorly above this).
 MAX_MESSAGE_LENGTH = 4000
@@ -272,11 +289,11 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # Matrix clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(
-            os.getenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        self._text_batch_delay_seconds = _safe_float_env(
+            "HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", 0.6
         )
-        self._text_batch_split_delay_seconds = float(
-            os.getenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        self._text_batch_split_delay_seconds = _safe_float_env(
+            "HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1956,3 +1956,64 @@ class TestMatrixPresence:
         self.adapter._client = None
         result = await self.adapter.set_presence("online")
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _safe_float_env — batch delay env var parsing
+# ---------------------------------------------------------------------------
+
+class TestMatrixBatchDelayEnvParsing:
+    """MatrixAdapter.__init__ must not raise ValueError on malformed env vars.
+
+    HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS and
+    HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS were previously parsed with
+    a bare float() call that would raise ValueError and prevent the adapter
+    from constructing when the env var contains any non-numeric string.
+    """
+
+    def _make_adapter_with_env(self, monkeypatch, delay=None, split_delay=None):
+        if delay is not None:
+            monkeypatch.setenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", delay)
+        else:
+            monkeypatch.delenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", raising=False)
+        if split_delay is not None:
+            monkeypatch.setenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", split_delay)
+        else:
+            monkeypatch.delenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", raising=False)
+        return _make_adapter()
+
+    def test_non_numeric_delay_uses_default(self, monkeypatch):
+        """Non-numeric HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS must not crash."""
+        adapter = self._make_adapter_with_env(monkeypatch, delay="disabled")
+        assert adapter._text_batch_delay_seconds == 0.6
+
+    def test_non_numeric_split_delay_uses_default(self, monkeypatch):
+        """Non-numeric HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS must not crash."""
+        adapter = self._make_adapter_with_env(monkeypatch, split_delay="off")
+        assert adapter._text_batch_split_delay_seconds == 2.0
+
+    def test_empty_delay_uses_default(self, monkeypatch):
+        """Empty env var falls back to default without crashing."""
+        adapter = self._make_adapter_with_env(monkeypatch, delay="")
+        assert adapter._text_batch_delay_seconds == 0.6
+
+    def test_valid_numeric_delay_is_respected(self, monkeypatch):
+        """A valid numeric string is parsed correctly."""
+        adapter = self._make_adapter_with_env(monkeypatch, delay="1.5")
+        assert adapter._text_batch_delay_seconds == 1.5
+
+    def test_valid_numeric_split_delay_is_respected(self, monkeypatch):
+        """A valid numeric string for split delay is parsed correctly."""
+        adapter = self._make_adapter_with_env(monkeypatch, split_delay="3.0")
+        assert adapter._text_batch_split_delay_seconds == 3.0
+
+    def test_zero_delay_disables_batching(self, monkeypatch):
+        """Zero is a valid value (disables batching)."""
+        adapter = self._make_adapter_with_env(monkeypatch, delay="0")
+        assert adapter._text_batch_delay_seconds == 0.0
+
+    def test_unset_uses_defaults(self, monkeypatch):
+        """Unset env vars produce the documented defaults."""
+        adapter = self._make_adapter_with_env(monkeypatch)
+        assert adapter._text_batch_delay_seconds == 0.6
+        assert adapter._text_batch_split_delay_seconds == 2.0


### PR DESCRIPTION
Setting `HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS=disabled` (or any non-numeric value) crashes `MatrixAdapter.__init__` with an unhandled `ValueError` before the gateway even starts. Same risk applies to `HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS`. Both env vars were parsed with a bare `float()` call — no error handling, no fallback.

This PR introduces `_safe_float_env(name, default)` in `gateway/platforms/matrix.py` (lines 104–120), which catches `ValueError`/`TypeError`, emits a warning log, and returns the documented default. The two affected call sites are updated accordingly. Pattern is consistent with how `gateway/run.py` already handles timeout env var parsing.

**Reproduce the crash (before this patch):**

```sh
HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS=disabled \
MATRIX_ACCESS_TOKEN=x \
MATRIX_HOMESERVER=https://matrix.org \
python -c "
from gateway.config import PlatformConfig, Platform
from gateway.platforms.matrix import MatrixAdapter
MatrixAdapter(PlatformConfig(platform=Platform.MATRIX))
"
# ValueError: could not convert string to float: 'disabled'
```

**After:** adapter constructs normally, default `0.6s` is used, warning is logged.

**Tests — `TestMatrixBatchDelayEnvParsing` (7 new cases):**

| Input | Expected |
|---|---|
| `"disabled"`, `"off"` | default used |
| `""` | default used |
| unset | documented default (0.6s / 2.0s) |
| `"1.5"`, `"3.0"` | parsed correctly |
| `"0"` | valid — disables batching |

Full suite: **120 passed, 0 regressions** 

**Changed:** `gateway/platforms/matrix.py` · `tests/gateway/test_matrix.py`