### PR TITLE
fix: normalize Kimi coding Anthropic base URL

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -769,6 +769,21 @@ def _routermint_headers() -> dict:
     }
 
 
+def _anthropic_sdk_base_url(base_url: str | None) -> str | None:
+    """Return the base URL shape expected by the Anthropic SDK."""
+    if not base_url:
+        return base_url
+
+    stripped = base_url.rstrip("/")
+    if (
+        base_url_host_matches(stripped, "api.kimi.com")
+        and "/coding" in stripped.lower()
+        and stripped.endswith("/v1")
+    ):
+        return stripped[:-3]
+    return base_url
+
+
 def _pool_may_recover_from_rate_limit(pool) -> bool:
     """Decide whether to wait for credential-pool rotation instead of falling back.
 
@@ -1269,7 +1284,7 @@ class AIAgent:
                 effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
                 self.api_key = effective_key
                 self._anthropic_api_key = effective_key
-                self._anthropic_base_url = base_url
+                self._anthropic_base_url = _anthropic_sdk_base_url(base_url)
                 # Only mark the session as OAuth-authenticated when the token
                 # genuinely belongs to native Anthropic.  Third-party providers
                 # (MiniMax, Kimi, GLM, LiteLLM proxies) that accept the
@@ -1279,7 +1294,9 @@ class AIAgent:
                 # the third-party identity-injection bug.
                 from agent.anthropic_adapter import _is_oauth_token as _is_oat
                 self._is_anthropic_oauth = _is_oat(effective_key) if _is_native_anthropic else False
-                self._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+                self._anthropic_client = build_anthropic_client(
+                    effective_key, self._anthropic_base_url, timeout=_provider_timeout
+                )
                 # No OpenAI client needed for Anthropic mode
                 self.client = None
                 self._client_kwargs = {}
@@ -2144,7 +2161,7 @@ class AIAgent:
             effective_key = (api_key or self.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or self.api_key or "")
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
-            self._anthropic_base_url = base_url or getattr(self, "_anthropic_base_url", None)
+            self._anthropic_base_url = _anthropic_sdk_base_url(base_url or getattr(self, "_anthropic_base_url", None))
             self._anthropic_client = build_anthropic_client(
                 effective_key, self._anthropic_base_url,
                 timeout=get_provider_request_timeout(self.provider, self.model),
@@ -5621,9 +5638,9 @@ class AIAgent:
                 pass
 
             self._anthropic_api_key = runtime_key
-            self._anthropic_base_url = runtime_base
+            self._anthropic_base_url = _anthropic_sdk_base_url(runtime_base)
             self._anthropic_client = build_anthropic_client(
-                runtime_key, runtime_base,
+                runtime_key, self._anthropic_base_url,
                 timeout=get_provider_request_timeout(self.provider, self.model),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
@@ -6945,7 +6962,7 @@ class AIAgent:
                 effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
                 self.api_key = effective_key
                 self._anthropic_api_key = effective_key
-                self._anthropic_base_url = fb_base_url
+                self._anthropic_base_url = _anthropic_sdk_base_url(fb_base_url)
                 self._anthropic_client = build_anthropic_client(
                     effective_key, self._anthropic_base_url, timeout=_fb_timeout,
                 )
@@ -7066,9 +7083,9 @@ class AIAgent:
             if self.api_mode == "anthropic_messages":
                 from agent.anthropic_adapter import build_anthropic_client
                 self._anthropic_api_key = rt["anthropic_api_key"]
-                self._anthropic_base_url = rt["anthropic_base_url"]
+                self._anthropic_base_url = _anthropic_sdk_base_url(rt["anthropic_base_url"])
                 self._anthropic_client = build_anthropic_client(
-                    rt["anthropic_api_key"], rt["anthropic_base_url"],
+                    rt["anthropic_api_key"], self._anthropic_base_url,
                     timeout=get_provider_request_timeout(self.provider, self.model),
                 )
                 self._is_anthropic_oauth = rt["is_anthropic_oauth"]
@@ -7165,9 +7182,9 @@ class AIAgent:
             if self.api_mode == "anthropic_messages":
                 from agent.anthropic_adapter import build_anthropic_client
                 self._anthropic_api_key = rt["anthropic_api_key"]
-                self._anthropic_base_url = rt["anthropic_base_url"]
+                self._anthropic_base_url = _anthropic_sdk_base_url(rt["anthropic_base_url"])
                 self._anthropic_client = build_anthropic_client(
-                    rt["anthropic_api_key"], rt["anthropic_base_url"],
+                    rt["anthropic_api_key"], self._anthropic_base_url,
                     timeout=get_provider_request_timeout(self.provider, self.model),
                 )
                 self._is_anthropic_oauth = rt["is_anthropic_oauth"]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3954,6 +3954,28 @@ class TestAnthropicBaseUrlPassthrough:
             passed_url = call_args[0][1]
             assert not passed_url or passed_url is None
 
+    def test_kimi_coding_v1_base_url_normalized_for_anthropic_sdk(self):
+        """Kimi's /coding/v1 endpoint is Anthropic-compatible, but the
+        Anthropic SDK appends /v1/messages itself.
+        """
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client") as mock_build,
+        ):
+            mock_build.return_value = MagicMock()
+            AIAgent(
+                api_key="sk-kimi-test1234567890",
+                base_url="https://api.kimi.com/coding/v1",
+                provider="kimi-coding",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            assert mock_build.call_args[0][1] == "https://api.kimi.com/coding"
+
 
 class TestAnthropicCredentialRefresh:
     def test_try_refresh_anthropic_client_credentials_rebuilds_client(self):


### PR DESCRIPTION
## Summary

- normalize `https://api.kimi.com/coding/v1` before passing it to the Anthropic SDK
- apply the normalization to the main Anthropic client construction and rebuild paths
- add a regression test for Kimi Coding's Anthropic-compatible endpoint

## Why

Kimi Coding exposes its Anthropic-compatible messages endpoint at `/coding/v1/messages`. The Anthropic SDK appends `/v1/messages` to the configured base URL, so passing `https://api.kimi.com/coding/v1` causes requests to land on `/coding/v1/v1/messages`, which returns 404.

## Test plan

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestAnthropicBaseUrlPassthrough::test_kimi_coding_v1_base_url_normalized_for_anthropic_sdk -q`
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestAnthropicBaseUrlPassthrough -q`
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestBuildApiKwargs -q`
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q` (`304 passed`)
