### PR TITLE
fix(slack): add strict thread reply mode

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -574,6 +574,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "thread_reply_mode" in platform_cfg:
+                    bridged["thread_reply_mode"] = platform_cfg["thread_reply_mode"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:
@@ -611,6 +613,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
                 if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
                     os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
+                if "thread_reply_mode" in slack_cfg and not os.getenv("SLACK_THREAD_REPLY_MODE"):
+                    os.environ["SLACK_THREAD_REPLY_MODE"] = str(slack_cfg["thread_reply_mode"]).lower()
                 frc = slack_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("SLACK_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1087,9 +1087,12 @@ class SlackAdapter(BasePlatformAdapter):
         #   0. Channel is in free_response_channels, OR require_mention is
         #      disabled — always process regardless of mention.
         #   1. The bot is @mentioned in this message, OR
-        #   2. The message is a reply in a thread the bot started/participated in, OR
-        #   3. The message is in a thread where the bot was previously @mentioned, OR
-        #   4. There's an existing session for this thread (survives restarts)
+        #   2. thread_reply_mode=engaged and the message is a reply in a
+        #      thread the bot started/participated in, OR
+        #   3. thread_reply_mode=engaged and the message is in a thread where
+        #      the bot was previously @mentioned, OR
+        #   4. thread_reply_mode=engaged and there's an existing session for
+        #      this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         is_mentioned = bot_uid and f"<@{bot_uid}>" in text
         event_thread_ts = event.get("thread_ts")
@@ -1101,6 +1104,8 @@ class SlackAdapter(BasePlatformAdapter):
             elif not self._slack_require_mention():
                 pass  # Mention requirement disabled globally for Slack
             elif not is_mentioned:
+                if self._slack_thread_reply_mode() == "strict":
+                    return
                 reply_to_bot_thread = (
                     is_thread_reply and event_thread_ts in self._bot_message_ts
                 )
@@ -1731,6 +1736,25 @@ class SlackAdapter(BasePlatformAdapter):
                 return configured.lower() not in ("false", "0", "no", "off")
             return bool(configured)
         return os.getenv("SLACK_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
+
+    def _slack_thread_reply_mode(self) -> str:
+        """Return Slack thread trigger behavior.
+
+        Modes:
+        - engaged: current/backward-compatible behavior. Once Hermes has
+          participated in a thread, later thread replies can trigger it without
+          a fresh @mention.
+        - strict: when require_mention is enabled, every channel/thread message
+          must explicitly mention the bot unless the channel is configured as a
+          free-response channel.
+        """
+        configured = self.config.extra.get("thread_reply_mode")
+        if configured is None:
+            configured = os.getenv("SLACK_THREAD_REPLY_MODE", "engaged")
+        mode = str(configured).strip().lower()
+        if mode in {"strict", "engaged"}:
+            return mode
+        return "engaged"
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -55,12 +55,14 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, free_response_channels=None):
+def _make_adapter(require_mention=None, free_response_channels=None, thread_reply_mode=None):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
     if free_response_channels is not None:
         extra["free_response_channels"] = free_response_channels
+    if thread_reply_mode is not None:
+        extra["thread_reply_mode"] = thread_reply_mode
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
@@ -135,6 +137,37 @@ def test_require_mention_env_var_default_true(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Tests: _slack_thread_reply_mode
+# ---------------------------------------------------------------------------
+
+def test_thread_reply_mode_defaults_to_engaged(monkeypatch):
+    monkeypatch.delenv("SLACK_THREAD_REPLY_MODE", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_thread_reply_mode() == "engaged"
+
+
+def test_thread_reply_mode_strict():
+    adapter = _make_adapter(thread_reply_mode="strict")
+    assert adapter._slack_thread_reply_mode() == "strict"
+
+
+def test_thread_reply_mode_engaged():
+    adapter = _make_adapter(thread_reply_mode="engaged")
+    assert adapter._slack_thread_reply_mode() == "engaged"
+
+
+def test_thread_reply_mode_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_THREAD_REPLY_MODE", "strict")
+    adapter = _make_adapter()
+    assert adapter._slack_thread_reply_mode() == "strict"
+
+
+def test_thread_reply_mode_malformed_falls_back_to_engaged():
+    adapter = _make_adapter(thread_reply_mode="maybe")
+    assert adapter._slack_thread_reply_mode() == "engaged"
+
+
+# ---------------------------------------------------------------------------
 # Tests: _slack_free_response_channels
 # ---------------------------------------------------------------------------
 
@@ -194,6 +227,8 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
         elif not adapter._slack_require_mention():
             return True
         elif not is_mentioned:
+            if adapter._slack_thread_reply_mode() == "strict":
+                return False
             if thread_reply and active_session:
                 return True
             else:
@@ -237,10 +272,38 @@ def test_mentioned_message_always_processed():
     assert _would_process(adapter, mentioned=True, text="what's up") is True
 
 
-def test_thread_reply_with_active_session_processed():
+def test_thread_reply_with_active_session_processed_by_default_engaged_mode():
     adapter = _make_adapter(require_mention=True)
     assert _would_process(
         adapter, text="followup",
+        thread_reply=True, active_session=True,
+    ) is True
+
+
+def test_thread_reply_with_active_session_ignored_in_strict_mode_without_mention():
+    adapter = _make_adapter(require_mention=True, thread_reply_mode="strict")
+    assert _would_process(
+        adapter, text="followup",
+        thread_reply=True, active_session=True,
+    ) is False
+
+
+def test_thread_reply_with_active_session_processed_in_strict_mode_with_mention():
+    adapter = _make_adapter(require_mention=True, thread_reply_mode="strict")
+    assert _would_process(
+        adapter, text="followup", mentioned=True,
+        thread_reply=True, active_session=True,
+    ) is True
+
+
+def test_strict_thread_reply_mode_does_not_override_free_response_channels():
+    adapter = _make_adapter(
+        require_mention=True,
+        free_response_channels=[CHANNEL_ID],
+        thread_reply_mode="strict",
+    )
+    assert _would_process(
+        adapter, channel_id=CHANNEL_ID, text="followup",
         thread_reply=True, active_session=True,
     ) is True
 
@@ -290,6 +353,7 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     (hermes_home / "config.yaml").write_text(
         "slack:\n"
         "  require_mention: false\n"
+        "  thread_reply_mode: strict\n"
         "  free_response_channels:\n"
         "    - C0AQWDLHY9M\n"
         "    - C9999999999\n",
@@ -305,8 +369,10 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     assert config is not None
     slack_extra = config.platforms[Platform.SLACK].extra
     assert slack_extra.get("require_mention") is False
+    assert slack_extra.get("thread_reply_mode") == "strict"
     assert slack_extra.get("free_response_channels") == ["C0AQWDLHY9M", "C9999999999"]
     # Verify env vars were set by config bridging
     import os as _os
     assert _os.environ["SLACK_REQUIRE_MENTION"] == "false"
+    assert _os.environ["SLACK_THREAD_REPLY_MODE"] == "strict"
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -211,10 +211,10 @@ Understanding how Hermes behaves in different contexts:
 |---------|----------|
 | **DMs** | Bot responds to every message — no @mention needed |
 | **Channels** | Bot **only responds when @mentioned** (e.g., `@Hermes Agent what time is it?`). In channels, Hermes replies in a thread attached to that message. |
-| **Threads** | If you @mention Hermes inside an existing thread, it replies in that same thread. Once the bot has an active session in a thread, **subsequent replies in that thread do not require @mention** — the bot follows the conversation naturally. |
+| **Threads** | If you @mention Hermes inside an existing thread, it replies in that same thread. By default, once the bot has an active session in a thread, **subsequent replies in that thread do not require @mention** — the bot follows the conversation naturally. Set `slack.thread_reply_mode: "strict"` to require an explicit @mention for every channel/thread reply. |
 
 :::tip
-In channels, always @mention the bot to start a conversation. Once the bot is active in a thread, you can reply in that thread without mentioning it. Outside of threads, messages without @mention are ignored to prevent noise in busy channels.
+In channels, always @mention the bot to start a conversation. With the default `thread_reply_mode: "engaged"`, once the bot is active in a thread, you can reply in that thread without mentioning it. Use `thread_reply_mode: "strict"` for shared or multi-agent channels where Hermes should only respond when explicitly mentioned again.
 :::
 
 ---
@@ -272,6 +272,15 @@ slack:
   # but you can set this explicitly for consistency with other platforms)
   require_mention: true
 
+  # Controls whether engaged Slack threads keep triggering Hermes without
+  # repeated @mentions:
+  # "engaged" — current/default behavior; after Hermes participates in a
+  #             thread, later replies in that thread can trigger it without
+  #             mentioning the bot again
+  # "strict"  — every channel/thread message must explicitly @mention Hermes
+  #             unless the channel is in free_response_channels
+  thread_reply_mode: "engaged"
+
   # Custom mention patterns that trigger the bot
   # (in addition to the default @mention detection)
   mention_patterns:
@@ -283,7 +292,7 @@ slack:
 ```
 
 :::info
-Slack supports both patterns: `@mention` required to start a conversation by default, but you can opt specific channels out via `SLACK_FREE_RESPONSE_CHANNELS` (comma-separated channel IDs) or `slack.free_response_channels` in `config.yaml`. Once the bot has an active session in a thread, subsequent thread replies do not require a mention. In DMs the bot always responds without needing a mention.
+Slack supports both patterns: `@mention` required to start a conversation by default, but you can opt specific channels out via `SLACK_FREE_RESPONSE_CHANNELS` (comma-separated channel IDs) or `slack.free_response_channels` in `config.yaml`. With `thread_reply_mode: "engaged"` (default), once the bot has an active session in a thread, subsequent thread replies do not require a mention. With `thread_reply_mode: "strict"`, every channel/thread message must explicitly mention the bot unless the channel is configured as free-response. In DMs the bot always responds without needing a mention.
 :::
 
 ### Unauthorized User Handling
@@ -324,6 +333,7 @@ stt_enabled: true
 # Slack-specific settings
 slack:
   require_mention: true
+  thread_reply_mode: "engaged"
   unauthorized_dm_behavior: "pair"
 
 # Platform config


### PR DESCRIPTION
## Summary
- add `slack.thread_reply_mode` with `engaged` (default/current behavior) and `strict` modes
- make `strict` require an explicit Slack bot mention for every channel/thread message when `require_mention` is enabled
- document the new Slack thread behavior option
- add tests covering default/backward-compatible behavior, strict mode, env/config bridging, and free-response channel interaction

Fixes #8019

## Test Plan
- `python -m pytest tests/gateway/test_slack_mention.py -q`
- `python -m py_compile gateway/platforms/slack.py gateway/config.py`
