### PR TITLE
fix(status): show NVIDIA NIM api key status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -134,6 +134,7 @@ def show_status(args):
         "WandB": "WANDB_API_KEY",
         "ElevenLabs": "ELEVENLABS_API_KEY",
         "GitHub": "GITHUB_TOKEN",
+        "NVIDIA NIM":      "NVIDIA_API_KEY",
     }
     
     for name, env_var in keys.items():


### PR DESCRIPTION
## Summary

┌─────────────────────────────────────────────────────────┐
│                 ⚕ Hermes Agent Status                  │
└─────────────────────────────────────────────────────────┘

◆ Environment
  Project:      /Users/joe/.hermes/hermes-agent
  Python:       3.11.15
  .env file:    ✓ exists
  Model:        zhipu/glm-5-turbo
  Provider:     Z.AI / GLM

◆ API Keys
  OpenRouter    ✗ (not set)
  OpenAI        ✗ (not set)
  Z.AI/GLM      ✓ be9a...nLmJ
  Kimi          ✗ (not set)
  MiniMax       ✓ sk-c...KKFk
  MiniMax-CN    ✓ sk-c...KKFk
  Firecrawl     ✗ (not set)
  Tavily        ✗ (not set)
  Browser Use   ✗ (not set)
  Browserbase   ✗ (not set)
  FAL           ✗ (not set)
  Tinker        ✗ (not set)
  WandB         ✗ (not set)
  ElevenLabs    ✗ (not set)
  GitHub        ✗ (not set)
  Anthropic     ✗ (not set)

◆ Auth Providers
  Nous Portal   ✗ not logged in (run: hermes model)
  OpenAI Codex  ✓ logged in
    Auth file:  /Users/joe/.hermes/auth.json
    Refreshed:  2026-04-18 14:19:07 CST
  Qwen OAuth    ✗ not logged in (run: qwen auth qwen-oauth)
    Auth file:  /Users/joe/.qwen/oauth_creds.json
    Error:      Qwen CLI credentials not found. Run 'qwen auth qwen-oauth' first.

◆ API-Key Providers
  Z.AI / GLM       ✓ configured
  Kimi / Moonshot  ✗ not configured (run: hermes model)
  MiniMax          ✓ configured
  MiniMax (China)  ✓ configured

◆ Terminal Backend
  Backend:      local
  Sudo:         ✗ disabled

◆ Messaging Platforms
  Telegram      ✗ not configured
  Discord       ✗ not configured
  WhatsApp      ✗ not configured
  Signal        ✗ not configured
  Slack         ✗ not configured
  Email         ✗ not configured
  SMS           ✗ not configured
  DingTalk      ✗ not configured
  Feishu        ✓ configured
  WeCom         ✗ not configured
  WeCom Callback  ✗ not configured
  Weixin        ✗ not configured
  BlueBubbles   ✗ not configured
  QQBot         ✗ not configured

◆ Gateway Service
  Status:       ✓ running
  Manager:      launchd
  PID(s):       92391

◆ Scheduled Jobs
  Jobs:         0

◆ Sessions
  Active:       1 session(s)

────────────────────────────────────────────────────────────
  Run 'hermes doctor' for detailed diagnostics
  Run 'hermes setup' to configure was missing the NVIDIA NIM API key from its API keys display (the list only had GitHub at the end but skipped NVIDIA).

Now shows  with the redacted key hash like all other providers.

## Test
- 
┌─────────────────────────────────────────────────────────┐
│                 ⚕ Hermes Agent Status                  │
└─────────────────────────────────────────────────────────┘

◆ Environment
  Project:      /Users/joe/.hermes/hermes-agent
  Python:       3.11.15
  .env file:    ✓ exists
  Model:        zhipu/glm-5-turbo
  Provider:     Z.AI / GLM

◆ API Keys
  OpenRouter    ✗ (not set)
  OpenAI        ✗ (not set)
  Z.AI/GLM      ✓ be9a...nLmJ
  Kimi          ✗ (not set)
  MiniMax       ✓ sk-c...KKFk
  MiniMax-CN    ✓ sk-c...KKFk
  Firecrawl     ✗ (not set)
  Tavily        ✗ (not set)
  Browser Use   ✗ (not set)
  Browserbase   ✗ (not set)
  FAL           ✗ (not set)
  Tinker        ✗ (not set)
  WandB         ✗ (not set)
  ElevenLabs    ✗ (not set)
  GitHub        ✗ (not set)
  Anthropic     ✗ (not set)

◆ Auth Providers
  Nous Portal   ✗ not logged in (run: hermes model)
  OpenAI Codex  ✓ logged in
    Auth file:  /Users/joe/.hermes/auth.json
    Refreshed:  2026-04-18 14:19:07 CST
  Qwen OAuth    ✗ not logged in (run: qwen auth qwen-oauth)
    Auth file:  /Users/joe/.qwen/oauth_creds.json
    Error:      Qwen CLI credentials not found. Run 'qwen auth qwen-oauth' first.

◆ API-Key Providers
  Z.AI / GLM       ✓ configured
  Kimi / Moonshot  ✗ not configured (run: hermes model)
  MiniMax          ✓ configured
  MiniMax (China)  ✓ configured

◆ Terminal Backend
  Backend:      local
  Sudo:         ✗ disabled

◆ Messaging Platforms
  Telegram      ✗ not configured
  Discord       ✗ not configured
  WhatsApp      ✗ not configured
  Signal        ✗ not configured
  Slack         ✗ not configured
  Email         ✗ not configured
  SMS           ✗ not configured
  DingTalk      ✗ not configured
  Feishu        ✓ configured
  WeCom         ✗ not configured
  WeCom Callback  ✗ not configured
  Weixin        ✗ not configured
  BlueBubbles   ✗ not configured
  QQBot         ✗ not configured

◆ Gateway Service
  Status:       ✓ running
  Manager:      launchd
  PID(s):       92391

◆ Scheduled Jobs
  Jobs:         0

◆ Sessions
  Active:       1 session(s)

────────────────────────────────────────────────────────────
  Run 'hermes doctor' for detailed diagnostics
  Run 'hermes setup' to configure now includes NVIDIA NIM in the API Keys section
- The key is shown as  when  is set,  when absent

Fixes #16082