### PR TITLE
fix(anthropic): preserve thinking blocks on DeepSeek's /anthropic endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -336,6 +336,28 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     return normalized.rstrip("/").lower().startswith("https://api.kimi.com/coding")
 
 
+def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for DeepSeek's Anthropic-compatible endpoint.
+
+    DeepSeek's ``/anthropic`` route requires that any ``thinking`` /
+    ``redacted_thinking`` blocks returned in assistant messages be replayed
+    *unchanged* (signature included) on subsequent turns when thinking mode
+    is enabled.  Stripping them — as the generic third-party path does to
+    avoid Anthropic-signature validation errors on other proxies — triggers
+    HTTP 400::
+
+        The content[].thinking in the thinking mode must be passed back to
+        the API.
+
+    The signatures are DeepSeek's own (not Anthropic's), so DeepSeek can and
+    does validate them.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    return normalized.rstrip("/").lower().startswith("https://api.deepseek.com/anthropic")
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1435,6 +1457,7 @@ def convert_messages_to_anthropic(
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
     _is_kimi = _is_kimi_coding_endpoint(base_url)
+    _is_deepseek = _is_deepseek_anthropic_endpoint(base_url)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -1464,6 +1487,14 @@ def convert_messages_to_anthropic(
                 # keep it: Kimi needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+        elif _is_deepseek:
+            # DeepSeek's /anthropic endpoint requires every thinking block
+            # — including the signature it issued — to be replayed unchanged
+            # on subsequent turns when thinking mode is enabled.  The
+            # signatures are DeepSeek's own so it can validate them; do not
+            # strip or downgrade.  See the docstring on
+            # ``_is_deepseek_anthropic_endpoint`` for the failure mode.
+            pass
         elif _is_third_party or idx != last_assistant_idx:
             # Third-party endpoint: strip ALL thinking blocks from every
             # assistant message — signatures are Anthropic-proprietary.

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -1,0 +1,260 @@
+"""Regression guard: preserve thinking blocks on DeepSeek's /anthropic endpoint.
+
+DeepSeek's ``api.deepseek.com/anthropic`` route speaks the Anthropic Messages
+protocol but, when thinking mode is enabled, requires every ``thinking`` /
+``redacted_thinking`` block returned in assistant messages to be replayed
+unchanged on subsequent turns.  The signatures are DeepSeek's own (not
+Anthropic's), so DeepSeek validates them and rejects the request with HTTP
+400 if they are missing::
+
+    The content[].thinking in the thinking mode must be passed back to the
+    API.
+
+The generic third-party path strips all thinking blocks (because Anthropic
+signatures cannot be validated by other proxies); DeepSeek needs to opt out
+of that stripping.  See :func:`agent.anthropic_adapter._is_deepseek_anthropic_endpoint`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestDeepSeekAnthropicPreservesThinking:
+    """convert_messages_to_anthropic must replay DeepSeek thinking blocks."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.deepseek.com/anthropic",
+            "https://api.deepseek.com/anthropic/",
+            "https://api.deepseek.com/anthropic/v1",
+            "https://API.DeepSeek.com/anthropic",
+        ],
+    )
+    def test_thinking_block_with_signature_is_preserved(self, base_url: str) -> None:
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "hello!",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "the user said hi",
+                        "signature": "deepseek-sig-abc",
+                    }
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url=base_url
+        )
+
+        assistant = next(m for m in anthropic_messages if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0]["thinking"] == "the user said hi"
+        assert thinking_blocks[0]["signature"] == "deepseek-sig-abc"
+
+    def test_thinking_preserved_on_non_latest_assistant_too(self) -> None:
+        """DeepSeek validates thinking on every prior assistant turn, not just the last."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "content": "a1",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "t1", "signature": "sig1"},
+                ],
+            },
+            {"role": "user", "content": "q2"},
+            {
+                "role": "assistant",
+                "content": "a2",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "t2", "signature": "sig2"},
+                ],
+            },
+            {"role": "user", "content": "q3"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url="https://api.deepseek.com/anthropic"
+        )
+
+        assistants = [m for m in anthropic_messages if m["role"] == "assistant"]
+        assert len(assistants) == 2
+        for assistant, expected_sig in zip(assistants, ("sig1", "sig2")):
+            blocks = [
+                b for b in assistant["content"]
+                if isinstance(b, dict) and b.get("type") == "thinking"
+            ]
+            assert len(blocks) == 1
+            assert blocks[0]["signature"] == expected_sig
+
+    def test_redacted_thinking_with_data_is_preserved(self) -> None:
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning_details": [
+                    {"type": "redacted_thinking", "data": "encrypted-blob"},
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url="https://api.deepseek.com/anthropic"
+        )
+
+        assistant = next(m for m in anthropic_messages if m["role"] == "assistant")
+        redacted = [
+            b for b in assistant["content"]
+            if isinstance(b, dict) and b.get("type") == "redacted_thinking"
+        ]
+        assert len(redacted) == 1
+        assert redacted[0]["data"] == "encrypted-blob"
+
+    def test_cache_control_stripped_from_thinking_block(self) -> None:
+        """cache_control must still be stripped from thinking blocks even on DeepSeek."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "t",
+                        "signature": "sig",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url="https://api.deepseek.com/anthropic"
+        )
+
+        assistant = next(m for m in anthropic_messages if m["role"] == "assistant")
+        thinking = next(
+            b for b in assistant["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        )
+        assert "cache_control" not in thinking
+        assert thinking["signature"] == "sig"
+
+
+class TestDeepSeekDoesNotAffectOtherEndpoints:
+    """The DeepSeek special case must not change behavior on other endpoints."""
+
+    def test_minimax_third_party_still_strips_signed_thinking(self) -> None:
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "hello!",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "x", "signature": "anthropic-sig"},
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url="https://api.minimax.io/anthropic"
+        )
+
+        assistant = next(m for m in anthropic_messages if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == []
+
+    def test_native_anthropic_unaffected(self) -> None:
+        """Direct Anthropic still keeps the signed block on the latest assistant only."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "content": "a1",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "t1", "signature": "sig1"},
+                ],
+            },
+            {"role": "user", "content": "q2"},
+            {
+                "role": "assistant",
+                "content": "a2",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "t2", "signature": "sig2"},
+                ],
+            },
+            {"role": "user", "content": "q3"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url=None
+        )
+
+        assistants = [m for m in anthropic_messages if m["role"] == "assistant"]
+        # First assistant: thinking stripped (not latest)
+        first_thinking = [
+            b for b in assistants[0]["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert first_thinking == []
+        # Latest assistant: signed thinking kept
+        last_thinking = [
+            b for b in assistants[1]["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(last_thinking) == 1
+        assert last_thinking[0]["signature"] == "sig2"
+
+
+class TestEndpointDetection:
+    """Boundary tests for _is_deepseek_anthropic_endpoint."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://api.deepseek.com/anthropic", True),
+            ("https://api.deepseek.com/anthropic/", True),
+            ("https://api.deepseek.com/anthropic/v1/messages", True),
+            ("HTTPS://API.DEEPSEEK.COM/anthropic", True),
+            ("https://api.deepseek.com/v1", False),  # OpenAI-compat route
+            ("https://api.deepseek.com", False),
+            ("https://api.minimax.io/anthropic", False),
+            ("https://api.kimi.com/coding", False),
+            (None, False),
+            ("", False),
+        ],
+    )
+    def test_endpoint_detection(self, url, expected: bool) -> None:
+        from agent.anthropic_adapter import _is_deepseek_anthropic_endpoint
+
+        assert _is_deepseek_anthropic_endpoint(url) is expected


### PR DESCRIPTION
## Summary

DeepSeek's anthropic-compat endpoint (`https://api.deepseek.com/anthropic`) requires that any `thinking` / `redacted_thinking` blocks returned in assistant messages be replayed **unchanged** (signature included) on subsequent turns when thinking mode is enabled.

`convert_messages_to_anthropic` currently treats DeepSeek as a generic third-party Anthropic endpoint and strips all thinking blocks, which causes DeepSeek to reject the next request with HTTP 400:

```
The content[].thinking in the thinking mode must be passed back to the API.
```

The signatures DeepSeek issues are its own — not Anthropic's — so DeepSeek can and does validate them. This PR adds an endpoint-detection helper analogous to `_is_kimi_coding_endpoint` and skips the thinking-block strip for DeepSeek. `cache_control` is still stripped from thinking blocks (unchanged from prior behavior on every endpoint).

Related: #15700 (same error text, same endpoint, complementary failure mode — that issue describes the *thinking-disabled* path which still needs an explicit `thinking: {"type": "disabled"}` to be sent; this PR fixes the *thinking-enabled* path. See [my comment there](https://github.com/NousResearch/hermes-agent/issues/15700#issuecomment-4322575041) for the breakdown.)

Note: #16135 / #16137 / #15717 surface a similar-looking 400 but the error text is `reasoning_content` (OpenAI-compat route, fixed in `_copy_reasoning_content_for_api`), not `content[].thinking` (anthropic-compat route, this PR). Different code path.

## Reproduction

Configure Hermes against DeepSeek's anthropic-compat endpoint with thinking enabled:

```yaml
model:
  default: anthropic/deepseek-v4-pro
  provider: anthropic
  base_url: https://api.deepseek.com/anthropic
agent:
  reasoning_effort: xhigh
```

Issue any prompt that triggers a multi-turn exchange (tool use, follow-up, etc.). The second turn 400s with the message above.

## Changes

- `agent/anthropic_adapter.py`: add `_is_deepseek_anthropic_endpoint(base_url)` and a corresponding branch in the thinking-block management loop that preserves `thinking` / `redacted_thinking` blocks unchanged.
- `tests/agent/test_deepseek_anthropic_thinking.py`: new regression suite covering endpoint detection (incl. casing/trailing-slash variants), preservation across multiple prior assistant turns, redacted blocks, `cache_control` stripping, and non-regression on MiniMax + native Anthropic paths.

## Test plan

- [x] `pytest tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_kimi_coding_anthropic_thinking.py tests/agent/test_anthropic_adapter.py` — 164 passed
- [x] Endpoint detection covers casing + trailing slash + path suffixes
- [x] MiniMax and native Anthropic paths confirmed unchanged
- [x] End-to-end verified by reporter against `deepseek-v4-pro` with `reasoning_effort: xhigh` — multi-turn conversations no longer 400

Closes part of #15700 (enabled-thinking path).