### PR TITLE
fix(compressor): reset cooldown and model-fallback flag on session reset (#16067)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -297,6 +297,8 @@ class ContextCompressor(ContextEngine):
         self._last_summary_error = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._summary_failure_cooldown_until = 0.0
+        self._summary_model_fallen_back = False
 
     def update_model(
         self,

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -189,6 +189,28 @@ class TestCompressorSessionReset:
         assert c._context_probe_persistable is False
         assert c._previous_summary is None
 
+    def test_reset_clears_summary_failure_cooldown(self):
+        """_summary_failure_cooldown_until must be zeroed on reset (issue #16067).
+
+        A cooldown set during session A must not bleed into session B after /new.
+        """
+        import time
+        c = ContextCompressor(model="test", quiet_mode=True, config_context_length=200000)
+        c._summary_failure_cooldown_until = time.monotonic() + 600.0
+        c.on_session_reset()
+        assert c._summary_failure_cooldown_until == 0.0
+
+    def test_reset_clears_summary_model_fallen_back(self):
+        """_summary_model_fallen_back must be False after reset.
+
+        If the summary model fell back in session A, the fallback flag must not
+        persist into session B — the primary model should be tried first again.
+        """
+        c = ContextCompressor(model="test", quiet_mode=True, config_context_length=200000)
+        c._summary_model_fallen_back = True
+        c.on_session_reset()
+        assert c._summary_model_fallen_back is False
+
 
 # ---------------------------------------------------------------------------
 # Plugin slot (PluginManager integration)


### PR DESCRIPTION
## Summary

- Add `self._summary_failure_cooldown_until = 0.0` to `on_session_reset()`
- Add `self._summary_model_fallen_back = False` to `on_session_reset()`

## The bug

`ContextCompressor.on_session_reset()` (called on `/new` and `/reset`) was missing two attribute resets:

**1. `_summary_failure_cooldown_until`** — when compression summary fails (no aux provider, rate limit, transient error), the compressor sets a cooldown of up to 10 minutes before retrying. This attribute was initialized to `0.0` in `__init__` but was never zeroed in `on_session_reset()`. Result: a compression failure in session A causes summarization to be silently skipped at the start of session B, with the log line `"Skipping context summary during cooldown"` as the only indication.

**2. `_summary_model_fallen_back`** — set to `True` when the primary summary model fails and a fallback is selected. Also missing from `on_session_reset()`. Result: session B always skips the primary model and goes straight to the fallback, even though the failure was in a different session entirely.

Both attributes are set to their clean values in `__init__` but the reset path was incomplete.

## Test plan

- [x] **Before**: direct Python test confirms both attributes persist across `on_session_reset()` call — `_summary_failure_cooldown_until` remains `~600s` and `_summary_model_fallen_back` remains `True`
- [x] **After**: `TestCompressorSessionReset::test_reset_clears_summary_failure_cooldown` and `test_reset_clears_summary_model_fallen_back` both pass
- [x] All 3 `TestCompressorSessionReset` tests pass
- [x] Adjacent `tests/agent/test_context_engine.py` suite unchanged

## Related

- Fixes #16067

🤖 Generated with [Claude Code](https://claude.com/claude-code)