### PR TITLE
chore(skills): remove empty feeds category

### DIFF
--- a/skills/feeds/DESCRIPTION.md
+++ b/skills/feeds/DESCRIPTION.md
@@ -1,3 +1,0 @@
----
-description: Skills for monitoring, aggregating, and processing RSS feeds, blogs, and web content sources.
----

--- a/website/scripts/extract-skills.py
+++ b/website/scripts/extract-skills.py
@@ -26,7 +26,6 @@ CATEGORY_LABELS = {
     "dogfood": "Dogfood",
     "domain": "Domain",
     "email": "Email",
-    "feeds": "Feeds",
     "gaming": "Gaming",
     "gifs": "GIFs",
     "github": "GitHub",


### PR DESCRIPTION
`skills/feeds/` only contained a category-marker `DESCRIPTION.md` with no actual skills in it — dead directory. Also removes the `"feeds": "Feeds"` entry in `website/scripts/extract-skills.py` (the only other repo reference).

## Changes
- Delete `skills/feeds/DESCRIPTION.md` (the whole directory)
- Drop `feeds" -> "Feeds"` label from docs skill extractor

## Validation
- `search_files feeds` — no remaining references in the repo
- `git rm` clean, docs extractor still parses