### PR TITLE
Add configurable response style guard

### DIFF
--- a/agent/response_style.py
+++ b/agent/response_style.py
@@ -140,8 +140,9 @@ def apply_response_style_guard(
     """
     if not response or not is_response_style_enabled(config, platform):
         return response
-    if response in _DELIVERY_CONTROL_MARKERS:
-        return response
+    stripped_response = response.strip()
+    if stripped_response in _DELIVERY_CONTROL_MARKERS:
+        return stripped_response
     if "MEDIA:" in response or "![" in response or _MEDIA_ONLY_RE.match(response):
         return response
     if user_message and _DETAIL_REQUEST_RE.search(user_message):

--- a/agent/response_style.py
+++ b/agent/response_style.py
@@ -1,0 +1,173 @@
+"""Configurable response style prompts and lightweight output guardrails."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_DETAIL_REQUEST_RE = re.compile(
+    r"(详细|展开|复盘|查日志|日志|证据|完整|具体|细节|路径|代码|脚本|命令|配置|测试|报错|错误|diff|patch|debug|details?|verbose)",
+    re.IGNORECASE,
+)
+
+_SECTION_PATTERNS = {
+    "result": re.compile(r"(?:^|\n)\s*(?:Result|结果|结论)\s*[:：]\s*(.*?)(?=\n\s*(?:Blocker|阻塞|卡点|Next step|下一步)\s*[:：]|\Z)", re.IGNORECASE | re.DOTALL),
+    "blocker": re.compile(r"(?:^|\n)\s*(?:Blocker|阻塞|卡点)\s*[:：]\s*(.*?)(?=\n\s*(?:Result|结果|结论|Next step|下一步)\s*[:：]|\Z)", re.IGNORECASE | re.DOTALL),
+    "next": re.compile(r"(?:^|\n)\s*(?:Next step|下一步)\s*[:：]\s*(.*?)(?=\n\s*(?:Result|结果|结论|Blocker|阻塞|卡点)\s*[:：]|\Z)", re.IGNORECASE | re.DOTALL),
+}
+
+_BLOCKER_RE = re.compile(r"(blocker|阻塞|卡点|失败|不能|无法|没有|待|pending|error|failed|stale)", re.IGNORECASE)
+_NEXT_RE = re.compile(r"(next step|下一步|建议|后面|之后|我会|继续|接下来)", re.IGNORECASE)
+_MEDIA_ONLY_RE = re.compile(r"^\s*(?:MEDIA:\S+\s*)+$")
+
+
+def _truthy(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _style_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(config, dict):
+        return {}
+    raw = config.get("response_style") or config.get("communication_style") or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _platform_enabled(style: dict[str, Any], platform: str | None) -> bool:
+    platforms = style.get("platforms") or []
+    if not platforms:
+        return True
+    platform_key = (platform or "").strip().lower()
+    return any(str(p).strip().lower() == platform_key for p in platforms)
+
+
+def is_response_style_enabled(config: dict[str, Any] | None, platform: str | None = None) -> bool:
+    style = _style_config(config)
+    if not _truthy(style.get("enabled"), False):
+        return False
+    return _platform_enabled(style, platform)
+
+
+def build_response_style_prompt(config: dict[str, Any] | None, platform: str | None = None) -> str:
+    """Return an extra system-prompt block for the configured response style."""
+    if not is_response_style_enabled(config, platform):
+        return ""
+    style = _style_config(config)
+    profile = str(style.get("profile") or "secretary").strip().lower()
+    if profile not in {"secretary", "executive_secretary"}:
+        return ""
+
+    return (
+        "# User-facing communication style — secretary mode\n"
+        "Treat the user-facing reply like a capable human secretary/assistant would.\n"
+        "Default front-channel replies must be short, plain-language, and decision-oriented.\n"
+        "Use this visible structure unless the user explicitly asks for detail:\n"
+        "Result:\n"
+        "<one short conclusion; include only the practical impact>\n\n"
+        "Blocker:\n"
+        "<none, or the single blocker that matters>\n\n"
+        "Next step:\n"
+        "<the next useful action>\n\n"
+        "Do not dump paths, logs, PIDs, stack traces, tool names, model/router details, or long evidence lists "
+        "unless the user asks for them. If verification matters, say briefly that it was verified; keep the raw proof internal. "
+        "专业词或英文缩写只有在必要时才出现，并立刻用中文解释。"
+    )
+
+
+def _clean(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = _clean(text)
+    if len(text) <= limit:
+        return text
+    cut = text[: max(0, limit - 1)].rstrip()
+    # Prefer ending on a sentence or line boundary when possible.
+    boundary = max(cut.rfind("。"), cut.rfind("."), cut.rfind("\n"), cut.rfind("；"), cut.rfind(";"))
+    if boundary >= max(40, int(limit * 0.55)):
+        cut = cut[: boundary + 1].rstrip()
+    return cut + "…"
+
+
+def _first_content_line(text: str) -> str:
+    for line in _clean(text).splitlines():
+        stripped = line.strip(" -•*\t")
+        if not stripped:
+            continue
+        if stripped.lower().startswith(("fresh evidence", "evidence", "next step", "blocker")):
+            continue
+        return stripped
+    return _clean(text)
+
+
+def _find_line(text: str, pattern: re.Pattern[str]) -> str:
+    for line in _clean(text).splitlines():
+        stripped = line.strip(" -•*\t")
+        if stripped and pattern.search(stripped):
+            return stripped
+    return ""
+
+
+def _extract_section(text: str, key: str) -> str:
+    match = _SECTION_PATTERNS[key].search(text)
+    return _clean(match.group(1)) if match else ""
+
+
+def apply_response_style_guard(
+    response: str,
+    config: dict[str, Any] | None,
+    platform: str | None = None,
+    user_message: str | None = None,
+) -> str:
+    """Lightweight deterministic guard for concise secretary-style gateway replies.
+
+    This is intentionally local and conservative: it does not invent evidence, and
+    it skips media-only replies or explicit user requests for details.
+    """
+    if not response or not is_response_style_enabled(config, platform):
+        return response
+    if "MEDIA:" in response or "![" in response or _MEDIA_ONLY_RE.match(response):
+        return response
+    if user_message and _DETAIL_REQUEST_RE.search(user_message):
+        return response
+
+    style = _style_config(config)
+    if str(style.get("profile") or "secretary").strip().lower() not in {"secretary", "executive_secretary"}:
+        return response
+
+    max_chars = int(style.get("max_chars") or 700)
+    require_labels = _truthy(style.get("require_labels"), True)
+    result_limit = int(style.get("result_chars") or 220)
+    blocker_limit = int(style.get("blocker_chars") or 180)
+    next_limit = int(style.get("next_chars") or 180)
+
+    cleaned = _clean(response)
+    already_labeled = all(_extract_section(cleaned, key) for key in ("result", "blocker", "next"))
+    if not require_labels and len(cleaned) <= max_chars:
+        return cleaned
+    if already_labeled and len(cleaned) <= max_chars:
+        return cleaned
+
+    result = _extract_section(cleaned, "result") or _first_content_line(cleaned)
+    blocker = _extract_section(cleaned, "blocker") or _find_line(cleaned, _BLOCKER_RE) or "未单独说明。"
+    next_step = _extract_section(cleaned, "next") or _find_line(cleaned, _NEXT_RE) or "按当前方向继续推进。"
+
+    guarded = (
+        f"Result:\n{_truncate(result, result_limit)}\n\n"
+        f"Blocker:\n{_truncate(blocker, blocker_limit)}\n\n"
+        f"Next step:\n{_truncate(next_step, next_limit)}"
+    )
+    return _truncate(guarded, max_chars)

--- a/agent/response_style.py
+++ b/agent/response_style.py
@@ -19,6 +19,7 @@ _SECTION_PATTERNS = {
 _BLOCKER_RE = re.compile(r"(blocker|阻塞|卡点|失败|不能|无法|没有|待|pending|error|failed|stale)", re.IGNORECASE)
 _NEXT_RE = re.compile(r"(next step|下一步|建议|后面|之后|我会|继续|接下来)", re.IGNORECASE)
 _MEDIA_ONLY_RE = re.compile(r"^\s*(?:MEDIA:\S+\s*)+$")
+_DELIVERY_CONTROL_MARKERS = {"[SILENT]"}
 
 
 def _truthy(value: Any, default: bool = False) -> bool:
@@ -138,6 +139,8 @@ def apply_response_style_guard(
     it skips media-only replies or explicit user requests for details.
     """
     if not response or not is_response_style_enabled(config, platform):
+        return response
+    if response in _DELIVERY_CONTROL_MARKERS:
         return response
     if "MEDIA:" in response or "![" in response or _MEDIA_ONLY_RE.match(response):
         return response

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -89,6 +89,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
+from agent.response_style import apply_response_style_guard
 from utils import atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -4631,6 +4632,13 @@ class GatewayRunner:
                     "results. This can happen with some models — try again or "
                     "rephrase your question."
                 )
+            response_style_config = _load_gateway_config()
+            response = apply_response_style_guard(
+                response,
+                response_style_config,
+                platform=source.platform.value if source.platform else None,
+                user_message=message_text,
+            )
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -651,6 +651,16 @@ DEFAULT_CONFIG = {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
     },
 
+    # User-facing response style guardrails. Disabled by default; when enabled,
+    # Hermes injects a style prompt and can lightly reformat gateway replies.
+    "response_style": {
+        "enabled": False,
+        "profile": "secretary",
+        "platforms": ["telegram"],
+        "require_labels": True,
+        "max_chars": 700,
+    },
+
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
@@ -1025,7 +1035,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 22,
+    "_config_version": 23,
 }
 
 # =============================================================================
@@ -2336,7 +2346,7 @@ _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
-    "auxiliary", "custom_providers", "context", "memory", "gateway",
+    "response_style", "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",
 }
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -100,6 +100,7 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.response_style import build_response_style_prompt
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -4624,6 +4625,10 @@ class AIAgent:
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
+
+        response_style_prompt = build_response_style_prompt(self._agent_config, platform_key)
+        if response_style_prompt:
+            prompt_parts.append(response_style_prompt)
 
         return "\n\n".join(p.strip() for p in prompt_parts if p.strip())
 

--- a/tests/agent/test_response_style.py
+++ b/tests/agent/test_response_style.py
@@ -64,3 +64,20 @@ def test_guard_preserves_exact_silent_marker():
     guarded = apply_response_style_guard(response, _cfg(), "telegram", "继续")
 
     assert guarded == "[SILENT]"
+
+
+def test_guard_preserves_silent_marker_with_boundary_whitespace():
+    response = "\n  [SILENT]\t\n"
+
+    guarded = apply_response_style_guard(response, _cfg(), "telegram", "继续")
+
+    assert guarded == "[SILENT]"
+
+
+def test_guard_does_not_treat_mixed_silent_content_as_control_marker():
+    response = "[SILENT]\nResult: PR state changed"
+
+    guarded = apply_response_style_guard(response, _cfg(), "telegram", "继续")
+
+    assert guarded != "[SILENT]"
+    assert "PR state changed" in guarded

--- a/tests/agent/test_response_style.py
+++ b/tests/agent/test_response_style.py
@@ -1,0 +1,58 @@
+from agent.response_style import (
+    apply_response_style_guard,
+    build_response_style_prompt,
+    is_response_style_enabled,
+)
+
+
+def _cfg(**overrides):
+    base = {
+        "enabled": True,
+        "profile": "secretary",
+        "platforms": ["telegram"],
+        "require_labels": True,
+        "max_chars": 700,
+    }
+    base.update(overrides)
+    return {"response_style": base}
+
+
+def test_secretary_prompt_injected_for_enabled_platform():
+    prompt = build_response_style_prompt(_cfg(), "telegram")
+
+    assert "secretary mode" in prompt
+    assert "Result:" in prompt
+    assert "Blocker:" in prompt
+    assert "Next step:" in prompt
+
+
+def test_style_disabled_for_other_platform():
+    assert not is_response_style_enabled(_cfg(), "discord")
+    assert build_response_style_prompt(_cfg(), "discord") == ""
+
+
+def test_guard_reformats_long_unlabeled_gateway_response():
+    response = "已完成配置和代码修改。\n- 文件 A 已修改\n- 文件 B 已修改\n下一步：等待静默窗口热加载。"
+
+    guarded = apply_response_style_guard(response, _cfg(), "telegram", "继续")
+
+    assert guarded.startswith("Result:\n")
+    assert "\n\nBlocker:\n" in guarded
+    assert "\n\nNext step:\n" in guarded
+    assert len(guarded) <= 700
+
+
+def test_guard_preserves_explicit_detail_requests():
+    response = "第一行\n第二行\n第三行"
+
+    guarded = apply_response_style_guard(response, _cfg(), "telegram", "详细展开")
+
+    assert guarded == response
+
+
+def test_guard_preserves_media_responses():
+    response = "MEDIA:/tmp/example.png\n这是图片"
+
+    guarded = apply_response_style_guard(response, _cfg(), "telegram", "发图")
+
+    assert guarded == response

--- a/tests/agent/test_response_style.py
+++ b/tests/agent/test_response_style.py
@@ -56,3 +56,11 @@ def test_guard_preserves_media_responses():
     guarded = apply_response_style_guard(response, _cfg(), "telegram", "发图")
 
     assert guarded == response
+
+
+def test_guard_preserves_exact_silent_marker():
+    response = "[SILENT]"
+
+    guarded = apply_response_style_guard(response, _cfg(), "telegram", "继续")
+
+    assert guarded == "[SILENT]"

--- a/tests/gateway/test_response_style_gateway.py
+++ b/tests/gateway/test_response_style_gateway.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakeAdapter:
+    async def send(self, chat_id, text, **kwargs):
+        return None
+
+    async def stop_typing(self, chat_id):
+        return None
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="test-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.session_store = MagicMock()
+    runner.session_store.config = MagicMock()
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.get_or_create_session.return_value = SimpleNamespace(
+        session_id="session-1",
+        session_key="telegram:dm:chat-1",
+        created_at="2026-01-01T00:00:00",
+        updated_at="2026-01-01T00:00:01",
+        was_auto_reset=False,
+        auto_reset_reason=None,
+    )
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._session_db = None
+    runner._set_session_env = MagicMock()
+    runner._clear_session_env = MagicMock()
+    runner._should_send_voice_reply = MagicMock(return_value=False)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_gateway_response_style_guard_loads_config_without_name_error():
+    """Regression: gateway post-processing must not reference an undefined user_config."""
+    runner = _make_runner()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", chat_type="dm")
+    event = MessageEvent(
+        text="继续",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "已完成配置和代码修改。\n下一步：继续验证。",
+            "messages": [],
+            "api_calls": 1,
+            "tools": [],
+            "last_prompt_tokens": 0,
+        }
+    )
+    cfg = {
+        "response_style": {
+            "enabled": True,
+            "platforms": ["telegram"],
+            "profile": "secretary",
+            "require_labels": True,
+        }
+    }
+
+    run_generation = runner._begin_session_run_generation("telegram:dm:chat-1")
+
+    with patch("gateway.run._load_gateway_config", return_value=cfg), \
+         patch("gateway.run._resolve_gateway_model", return_value="test-model"), \
+         patch("gateway.run.build_session_context", return_value={}), \
+         patch("gateway.run.build_session_context_prompt", return_value="context"):
+        response = await runner._handle_message_with_agent(event, source, "telegram:dm:chat-1", run_generation)
+
+    assert response.startswith("Result:\n")
+    assert "Next step:" in response


### PR DESCRIPTION
## Summary
- add a configurable response_style prompt block for platform-specific secretary-style replies
- add a lightweight gateway post-processing guard for Result / Blocker / Next step formatting
- cover prompt injection, guard behavior, media/detail-request bypasses, and gateway integration

## Test Plan
- python -m pytest --rootdir=. tests/agent/test_response_style.py tests/gateway/test_response_style_gateway.py tests/gateway/test_runner_startup_failures.py -q
- python -m pytest tests/agent/test_response_style.py tests/gateway/test_response_style_gateway.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_pairing.py tests/gateway/test_status.py -q