### PR TITLE
fix(agent): preserve dots in model names for Xiaomi MiMo provider

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7357,6 +7357,7 @@ class AIAgent:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
+        Xiaomi MiMo keeps dots (e.g. mimo-v2.5, mimo-v2.5-pro).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
         AWS Bedrock uses dotted inference-profile IDs
@@ -7370,6 +7371,7 @@ class AIAgent:
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",
             "zai", "bedrock",
+            "xiaomi",
         }:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
@@ -7379,6 +7381,7 @@ class AIAgent:
             or "minimax" in base
             or "opencode.ai/zen/" in base
             or "bigmodel.cn" in base
+            or "xiaomimimo.com" in base
             # AWS Bedrock runtime endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
             or "bedrock-runtime." in base


### PR DESCRIPTION
## What

Add `"xiaomi"` to the `_anthropic_preserve_dots()` provider whitelist and `"xiaomimimo.com"` to the URL-based fallback check in `run_agent.py`.

## Why

Without this fix, `normalize_model_name()` in `agent/anthropic_adapter.py` converts `mimo-v2.5` → `mimo-v2-5` (dots to hyphens). The Xiaomi MiMo API rejects the hyphenated name with HTTP 400: `Not supported model mimo-v2-5`.

This follows the same pattern as the existing whitelist entries for Alibaba/DashScope, MiniMax, OpenCode, ZAI, and Bedrock.

Fixes #16156

## How to test

1. Configure Hermes with Xiaomi MiMo:
   ```yaml
   model: xiaomi/mimo-v2.5-pro
   provider: xiaomi
   base_url: https://token-plan-cn.xiaomimimo.com/anthropic
   ```
2. Set `XIAOMI_API_KEY` in `.env`
3. Send any message — should work without HTTP 400

## Platform tested

- WSL2 Ubuntu on Windows
