### PR TITLE
docs(docker-backend): clarify container is shared across sessions

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -146,7 +146,9 @@ terminal:
 
 **Requirements:** Docker Desktop or Docker Engine installed and running. Hermes probes `$PATH` plus common macOS install locations (`/usr/local/bin/docker`, `/opt/homebrew/bin/docker`, Docker Desktop app bundle).
 
-**Container lifecycle:** Each session starts a long-lived container (`docker run -d ... sleep 2h`). Commands run via `docker exec` with a login shell. On cleanup, the container is stopped and removed.
+**Container lifecycle:** Hermes reuses a single long-lived container (`docker run -d ... sleep 2h`) for every terminal and file-tool call made by the top-level agent, across sessions, `/new`, and `/reset`, for the lifetime of the Hermes process. Commands run via `docker exec` with a login shell, so working-directory changes, installed packages, and files in `/workspace` all persist from one tool call to the next. The container is stopped and removed on Hermes shutdown (or when the idle-sweep reclaims it).
+
+Subagents (`delegate_task`) and RL rollouts get their own isolated containers keyed by `task_id` — only the top-level agent shares the `default` container.
 
 **Security hardening:**
 - `--cap-drop ALL` with only `DAC_OVERRIDE`, `CHOWN`, `FOWNER` added back


### PR DESCRIPTION
## Summary
The Docker terminal-backend docs implied a fresh container per chat session. In practice the top-level agent reuses one container (`task_id="default"`) across every tool call, `/new`, `/reset`, and session switch, for the whole Hermes process lifetime. Only `delegate_task` subagents and RL rollouts get isolated containers.

## Changes
- `website/docs/user-guide/configuration.md` — rewrite the **Container lifecycle** paragraph under the Docker Backend section to describe the shared-container reality and call out the subagent/RL carve-out.

## Validation
| | Before | After |
|---|---|---|
| Doc claim | 'Each session starts a long-lived container' | 'Hermes reuses a single long-lived container... across sessions, /new, and /reset, for the lifetime of the Hermes process' |
| Subagent carve-out | Not mentioned | Called out explicitly |

Behavior verified against `tools/terminal_tool.py` (`_active_environments` keyed by `effective_task_id = task_id or "default"`) and `tools/delegate_tool.py` (child gets `child_task_id = _subagent_id or subagent-N-<uuid>`).