### PR TITLE
fix(status): add missing popular provider API keys to hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -120,6 +120,10 @@ def show_status(args):
     keys = {
         "OpenRouter": "OPENROUTER_API_KEY",
         "OpenAI": "OPENAI_API_KEY",
+        "Google/Gemini": "GOOGLE_API_KEY",
+        "DeepSeek": "DEEPSEEK_API_KEY",
+        "xAI / Grok": "XAI_API_KEY",
+        "NVIDIA NIM": "NVIDIA_API_KEY",
         "Z.AI/GLM": "GLM_API_KEY",
         "Kimi": "KIMI_API_KEY",
         "StepFun Step Plan": "STEPFUN_API_KEY",
@@ -258,6 +262,10 @@ def show_status(args):
     print(color("◆ API-Key Providers", Colors.CYAN, Colors.BOLD))
 
     apikey_providers = {
+        "Google / Gemini":  ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+        "DeepSeek":         ("DEEPSEEK_API_KEY",),
+        "xAI / Grok":       ("XAI_API_KEY",),
+        "NVIDIA NIM":       ("NVIDIA_API_KEY",),
         "Z.AI / GLM":       ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         "Kimi / Moonshot":  ("KIMI_API_KEY",),
         "StepFun Step Plan": ("STEPFUN_API_KEY",),

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -117,14 +117,15 @@ def show_status(args):
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
     
-    keys = {
+    # Values may be a single env var name (str) or a tuple of alternates (first found wins).
+    keys: dict[str, str | tuple[str, ...]] = {
         "OpenRouter": "OPENROUTER_API_KEY",
         "OpenAI": "OPENAI_API_KEY",
-        "Google/Gemini": "GOOGLE_API_KEY",
+        "Google / Gemini": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
         "DeepSeek": "DEEPSEEK_API_KEY",
         "xAI / Grok": "XAI_API_KEY",
         "NVIDIA NIM": "NVIDIA_API_KEY",
-        "Z.AI/GLM": "GLM_API_KEY",
+        "Z.AI / GLM": "GLM_API_KEY",
         "Kimi": "KIMI_API_KEY",
         "StepFun Step Plan": "STEPFUN_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
@@ -139,9 +140,12 @@ def show_status(args):
         "ElevenLabs": "ELEVENLABS_API_KEY",
         "GitHub": "GITHUB_TOKEN",
     }
-    
-    for name, env_var in keys.items():
-        value = get_env_value(env_var) or ""
+
+    for name, env_var_spec in keys.items():
+        if isinstance(env_var_spec, tuple):
+            value = next((get_env_value(ev) or "" for ev in env_var_spec if get_env_value(ev)), "")
+        else:
+            value = get_env_value(env_var_spec) or ""
         has_key = bool(value)
         display = redact_key(value) if not show_all else value
         print(f"  {name:<12}  {check_mark(has_key)} {display}")

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,6 +3,38 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
+def test_show_status_new_api_key_providers_appear(monkeypatch, capsys, tmp_path):
+    """New provider rows added in #16082 must appear in the API Keys section."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-abcdef1234567890")
+    monkeypatch.setenv("XAI_API_KEY", "xai-abcdef1234567890")
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-abcdef1234567890abcdef")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "DeepSeek" in output
+    assert "xAI / Grok" in output
+    assert "NVIDIA NIM" in output
+    # Redacted key values must appear
+    assert "sk-d" in output
+    assert "xai-" in output
+
+
+def test_show_status_gemini_api_key_fallback(monkeypatch, capsys, tmp_path):
+    """GEMINI_API_KEY should satisfy the Google/Gemini row when GOOGLE_API_KEY is absent."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy-gemini-testkey1234567890ab")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Google / Gemini" in output
+    # The key is present so the row should show a redacted value, not be blank
+    assert "AIza" in output
+
+
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")


### PR DESCRIPTION
## Summary

Closes #16082

`hermes status` was silently omitting four widely-used LLM providers from both its **API Keys** and **API-Key Providers** sections, even though all four are fully registered in `PROVIDER_REGISTRY` with `api_key_env_vars` defined:

| Provider | Env var(s) |
|---|---|
| Google / Gemini | `GOOGLE_API_KEY`, `GEMINI_API_KEY` |
| DeepSeek | `DEEPSEEK_API_KEY` |
| xAI / Grok | `XAI_API_KEY` |
| NVIDIA NIM | `NVIDIA_API_KEY` |

Each entry is added to both sections:
- **API Keys** — shows the redacted key value so users can confirm the variable is set
- **API-Key Providers** — shows configured/not-configured with the same multi-var fallback pattern used by existing entries (e.g. Z.AI/GLM checks three env vars)

> Note: PR #16143 adds only NVIDIA to the API Keys section (+1 line). This PR is a broader fix that covers all four missing providers across both display sections.

## Test plan

- [ ] Run `hermes status` with `NVIDIA_API_KEY`, `DEEPSEEK_API_KEY`, `XAI_API_KEY`, and `GOOGLE_API_KEY` set — confirm each appears with ✓ and a redacted value in both sections
- [ ] Run `hermes status` without those env vars — confirm each appears with ✗ and `(not set)` / `not configured`
- [ ] Confirm existing entries (OpenRouter, OpenAI, GLM, Kimi, MiniMax) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)