### PR TITLE
fix(delegation): classify terminal trace status by exit_code

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -476,6 +476,34 @@ class TestDelegateObservability(unittest.TestCase):
             trace = result["results"][0]["tool_trace"]
             self.assertEqual(trace[0]["status"], "error")
 
+    def test_terminal_tool_trace_uses_exit_code_not_output_substring(self):
+        """Terminal output mentioning 'error' should stay ok when exit_code is 0."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "terminal", "arguments": "{}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1", "content": '{"output": "error count: 0", "exit_code": 0, "error": null}'},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test terminal ok trace", parent_agent=parent))
+            trace = result["results"][0]["tool_trace"]
+            self.assertEqual(trace[0]["tool"], "terminal")
+            self.assertEqual(trace[0]["status"], "ok")
+
     def test_parallel_tool_calls_paired_correctly(self):
         """Parallel tool calls should each get their own result via tool_call_id matching."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -273,10 +273,11 @@ def _extract_output_tail(
 def _looks_like_error_output(content: str) -> bool:
     """Conservative stderr/error detector for tool-result previews.
 
-    The old heuristic flagged any preview containing the substring "error",
-    which painted perfectly normal terminal/json output red.  We now only
-    mark output as an error when there is stronger evidence:
-      - structured JSON with an ``error`` key
+    Terminal-style JSON that includes ``exit_code`` is judged by that exit
+    code, not by whether stdout/stderr happens to contain the word "error".
+    Other tool output is only marked as an error when there is stronger
+    evidence:
+      - structured JSON with a truthy ``error`` key
       - structured JSON with ``status`` of error/failed
       - first line starts with a classic error marker
     """
@@ -288,6 +289,8 @@ def _looks_like_error_output(content: str) -> bool:
         try:
             parsed = json.loads(content)
             if isinstance(parsed, dict):
+                if parsed.get("exit_code") is not None:
+                    return parsed.get("exit_code") != 0
                 if parsed.get("error"):
                     return True
                 status = str(parsed.get("status") or "").strip().lower()
@@ -1568,7 +1571,7 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(content and "error" in content[:80].lower())
+                    is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),
                         "status": "error" if is_error else "ok",


### PR DESCRIPTION
## Summary

Fix delegation observability so terminal tool traces are classified by structured `exit_code` when present, instead of substring matching on the word `error`.

Previously a successful terminal result such as:

```json
{"output":"error count: 0", "exit_code": 0, "error": null}
```

was marked as `status: "error"` in `tool_trace` because the serialized result contained the string `error` near the beginning.

## Changes

- Teach `_looks_like_error_output()` to treat JSON results with `exit_code` as terminal-style results.
- `exit_code == 0` => not an error.
- nonzero `exit_code` => error.
- Reuse `_looks_like_error_output()` for `_run_single_child()` `tool_trace` status.
- Add regression test for terminal output containing the word `error` with `exit_code: 0`.

## Test plan

```bash
source venv/bin/activate
pytest -q tests/tools/test_delegate.py -q
```

Result: passed.
