### PR TITLE
feat(delegation): support subagent model overrides

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8220,6 +8220,7 @@ class AIAgent:
             context=function_args.get("context"),
             toolsets=function_args.get("toolsets"),
             tasks=function_args.get("tasks"),
+            model=function_args.get("model"),
             max_iterations=function_args.get("max_iterations"),
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1913,6 +1913,24 @@ class TestConcurrentToolExecution:
         assert {entry[0] for entry in completes} == {"c1", "c2"}
         assert {entry[3] for entry in completes} == {'{"id":1}', '{"id":2}'}
 
+    def test_invoke_tool_forwards_delegate_model_override(self, agent):
+        """delegate_task dispatch should pass model override through the central helper."""
+        args = {
+            "goal": "model override smoke",
+            "model": {"provider": "openai-codex", "model": "gpt-5.4"},
+            "acp_command": "codex",
+            "acp_args": ["--acp", "--stdio", "--model", "gpt-5.4"],
+        }
+        with patch("tools.delegate_tool.delegate_task", return_value='{"results":[]}') as mock_delegate:
+            result = agent._invoke_tool("delegate_task", args, "task-1")
+
+        assert result == '{"results":[]}'
+        _, kwargs = mock_delegate.call_args
+        assert kwargs["model"] == args["model"]
+        assert kwargs["acp_command"] == "codex"
+        assert kwargs["acp_args"] == ["--acp", "--stdio", "--model", "gpt-5.4"]
+        assert kwargs["parent_agent"] is agent
+
     def test_invoke_tool_handles_agent_level_tools(self, agent):
         """_invoke_tool should handle todo tool directly."""
         with patch("tools.todo_tool.todo_tool", return_value='{"ok":true}') as mock_todo:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,6 +69,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("model", props)
+        self.assertIn("model", props["tasks"]["items"]["properties"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -611,6 +613,49 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_model_override_beats_configured_model_and_provider(self, mock_resolve):
+        """Explicit override object should replace delegation config model/provider."""
+        mock_resolve.return_value = {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "google/gemini-3-flash-preview", "provider": "openrouter"}
+
+        creds = _resolve_delegation_credentials(
+            cfg,
+            parent,
+            {"model": "gpt-5.4", "provider": "openai-codex"},
+        )
+
+        self.assertEqual(creds["model"], "gpt-5.4")
+        self.assertEqual(creds["provider"], "openai-codex")
+        self.assertEqual(creds["base_url"], "https://chatgpt.com/backend-api/codex")
+        self.assertEqual(creds["api_mode"], "codex_responses")
+        mock_resolve.assert_called_once_with(requested="openai-codex")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_string_model_override_keeps_configured_provider(self, mock_resolve):
+        """Bare string override should replace only the model and preserve config provider."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "google/gemini-3-flash-preview", "provider": "openrouter"}
+
+        creds = _resolve_delegation_credentials(cfg, parent, "gpt-5.4")
+
+        self.assertEqual(creds["model"], "gpt-5.4")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        mock_resolve.assert_called_once_with(requested="openrouter")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_full_credentials(self, mock_resolve):
         """When delegation.provider is set, full credentials are resolved."""
         mock_resolve.return_value = {
@@ -955,6 +1000,91 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs.get("override_api_mode"), "chat_completions")
             self.assertEqual(kwargs.get("override_acp_command"), "custom-copilot")
             self.assertEqual(kwargs.get("override_acp_args"), ["--stdio-custom"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_override_is_passed_to_credential_resolution(self, mock_creds, mock_cfg):
+        """Top-level delegate model override should be passed through unchanged."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": ""}
+        mock_creds.return_value = {
+            "model": "gpt-5.4",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+            }
+
+            delegate_task(
+                goal="Top-level override",
+                model={"model": "gpt-5.4", "provider": "openai-codex"},
+                parent_agent=parent,
+            )
+
+            mock_creds.assert_called_once_with(
+                mock_cfg.return_value,
+                parent,
+                {"model": "gpt-5.4", "provider": "openai-codex"},
+            )
+            self.assertEqual(mock_build.call_args.kwargs.get("model"), "gpt-5.4")
+            self.assertEqual(mock_build.call_args.kwargs.get("override_provider"), "openai-codex")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_override_beats_top_level_override(self, mock_creds, mock_cfg):
+        """Per-task model override should take precedence over top-level override."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": ""}
+        mock_creds.side_effect = [
+            {
+                "model": "gpt-5.5",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "***",
+                "api_mode": "codex_responses",
+            },
+            {
+                "model": "gpt-5.4",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "***",
+                "api_mode": "codex_responses",
+            },
+        ]
+        parent = _make_mock_parent(depth=0)
+        tasks = [
+            {"goal": "Task A", "model": {"model": "gpt-5.5", "provider": "openai-codex"}},
+            {"goal": "Task B"},
+        ]
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+            }
+
+            delegate_task(
+                tasks=tasks,
+                model={"model": "gpt-5.4", "provider": "openai-codex"},
+                parent_agent=parent,
+            )
+
+            self.assertEqual(mock_creds.call_args_list[0].args[2], tasks[0]["model"])
+            self.assertEqual(
+                mock_creds.call_args_list[1].args[2],
+                {"model": "gpt-5.4", "provider": "openai-codex"},
+            )
+            self.assertEqual(mock_build.call_args_list[0].kwargs.get("model"), "gpt-5.5")
+            self.assertEqual(mock_build.call_args_list[1].kwargs.get("model"), "gpt-5.4")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1794,6 +1794,7 @@ def delegate_task(
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    model: Optional[Dict[str, Any] | str] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -1866,11 +1867,6 @@ def delegate_task(
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     if tasks and isinstance(tasks, list):
@@ -1918,6 +1914,11 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            try:
+                # Per-task model override > top-level model override > delegation config > parent.
+                creds = _resolve_delegation_credentials(cfg, parent_agent, t.get("model") or model)
+            except ValueError as exc:
+                return tool_error(str(exc))
             task_acp_args = t.get("acp_args") if "acp_args" in t else None
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
@@ -2172,7 +2173,29 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _normalize_model_override(model_override: Optional[Dict[str, Any] | str]) -> tuple[Optional[str], Optional[str]]:
+    """Return (model, provider) from a per-call delegate model override.
+
+    The public tool schema accepts a structured object like
+    {"provider": "openai-codex", "model": "gpt-5.5"}. Internal callers may
+    also pass a bare model string to override only the model while preserving
+    the configured/inherited provider.
+    """
+    if isinstance(model_override, str):
+        value = model_override.strip()
+        return (value or None), None
+    if isinstance(model_override, dict):
+        model = str(model_override.get("model") or "").strip() or None
+        provider = str(model_override.get("provider") or "").strip() or None
+        return model, provider
+    return None, None
+
+
+def _resolve_delegation_credentials(
+    cfg: dict,
+    parent_agent,
+    model_override: Optional[Dict[str, Any] | str] = None,
+) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
@@ -2187,8 +2210,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
     Raises ValueError with a user-friendly message on credential failure.
     """
-    configured_model = str(cfg.get("model") or "").strip() or None
-    configured_provider = str(cfg.get("provider") or "").strip() or None
+    override_model, override_provider = _normalize_model_override(model_override)
+    configured_model = override_model or str(cfg.get("model") or "").strip() or None
+    configured_provider = override_provider or str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
@@ -2373,6 +2397,15 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
                         },
+                        "model": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {"type": "string", "description": "Provider name (e.g. openai-codex, openrouter, anthropic)."},
+                                "model": {"type": "string", "description": "Model name/ID for this task (e.g. gpt-5.5)."},
+                            },
+                            "required": ["model"],
+                            "description": "Per-task model/provider override. Overrides top-level model and delegation config.",
+                        },
                         "acp_command": {
                             "type": "string",
                             "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
@@ -2397,6 +2430,18 @@ DELEGATE_TASK_SCHEMA = {
                     "Batch mode: tasks to run in parallel (limit configurable via delegation.max_concurrent_children, default 3). Each gets "
                     "its own subagent with isolated context and terminal session. "
                     "When provided, top-level goal/context/toolsets are ignored."
+                ),
+            },
+            "model": {
+                "type": "object",
+                "properties": {
+                    "provider": {"type": "string", "description": "Provider name (e.g. openai-codex, openrouter, anthropic). Omit to inherit the parent/configured provider."},
+                    "model": {"type": "string", "description": "Model name/ID for child agents (e.g. gpt-5.5)."},
+                },
+                "required": ["model"],
+                "description": (
+                    "Model/provider override for child agents. This is independent of the "
+                    "parent/default model; per-task model overrides take precedence in batch mode."
                 ),
             },
             "role": {
@@ -2447,6 +2492,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        model=args.get("model"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),


### PR DESCRIPTION
## Summary

Add explicit model/provider overrides to `delegate_task`, including per-task overrides for parallel subagent batches.

This enables heterogeneous subagent runs where each child can use a different model/provider while keeping current default behavior unchanged when no override is provided.

Precedence:

1. per-task `model`
2. top-level `model`
3. delegation config
4. parent/default inheritance

## Changes

- Add top-level `model` argument to `delegate_task`.
- Add per-task `model` field to the tool schema.
- Normalize model overrides from either:
  - structured object: `{"provider": "openai-codex", "model": "gpt-5.4"}`
  - internal bare string: `"gpt-5.4"`
- Resolve delegation credentials per child task so different tasks can use different models/providers.
- Forward `model` through `AIAgent._dispatch_delegate_task()`.
- Add tests for:
  - schema exposure
  - model/provider override credential resolution
  - string model override preserving configured provider
  - top-level override forwarding
  - per-task override precedence
  - run_agent delegate dispatch forwarding

## Test plan

```bash
source venv/bin/activate
pytest -q tests/tools/test_delegate.py tests/run_agent/test_run_agent.py -q
```

Result: passed.

Live smoke test performed locally after applying the combined patch:

- `gpt-5.5` subagent completed
- `gpt-5.4` subagent completed
- `gpt-5.3-codex-spark` subagent completed
- each child reported the expected model and successful terminal tool trace
