### PR TITLE
Fix Codex auxiliary tool message conversion

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -373,23 +373,35 @@ class _CodexCompletionsAdapter:
         self._model = model
 
     def create(self, **kwargs) -> Any:
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
 
         # Separate system/instructions from conversation messages.
-        # Convert chat.completions multimodal content blocks to Responses
-        # API format (input_text / input_image instead of text / image_url).
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        non_system_messages: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
+                non_system_messages.append(msg)
+
+        canonical_roles = {"user", "assistant", "tool"}
+        if all((msg.get("role") in canonical_roles) for msg in non_system_messages):
+            input_msgs = _chat_messages_to_responses_input(non_system_messages)
+        else:
+            input_msgs = []
+            for msg in non_system_messages:
+                role = msg.get("role", "user")
+                if role in canonical_roles:
+                    input_msgs.extend(_chat_messages_to_responses_input([msg]))
+                    continue
                 input_msgs.append({
                     "role": role,
-                    "content": _convert_content_for_responses(content),
+                    "content": _convert_content_for_responses(msg.get("content") or ""),
                 })
 
         resp_kwargs: Dict[str, Any] = {

--- a/tests/agent/test_auxiliary_client_codex_adapter.py
+++ b/tests/agent/test_auxiliary_client_codex_adapter.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+from agent.auxiliary_client import _CodexCompletionsAdapter
+
+
+class _FakeResponsesStream:
+    def __init__(self, final_response):
+        self._final_response = final_response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_response(self):
+        return self._final_response
+
+
+def _final_message_response(text: str = "memory flush ok"):
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+    )
+
+
+def test_codex_auxiliary_adapter_converts_tool_history_for_responses_input():
+    captured = {}
+
+    class _ResponsesAPI:
+        def stream(self, **kwargs):
+            captured.update(kwargs)
+            return _FakeResponsesStream(_final_message_response())
+
+    client = SimpleNamespace(responses=_ResponsesAPI())
+    adapter = _CodexCompletionsAdapter(client, "gpt-5.2-codex")
+
+    response = adapter.create(
+        model="gpt-5.2-codex",
+        messages=[
+            {"role": "system", "content": "You are a memory flusher."},
+            {"role": "user", "content": "Summarize what happened."},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_search_1",
+                        "call_id": "call_search_1",
+                        "type": "function",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": '{"query":"hermes auxiliary memory flush"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_search_1",
+                "content": "Found the relevant transcript entries.",
+            },
+            {"role": "user", "content": "Now flush the memory."},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "store_memory",
+                    "description": "Persist a memory entry.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert response.choices[0].message.content == "memory flush ok"
+    assert captured["instructions"] == "You are a memory flusher."
+    assert captured["tools"] == [
+        {
+            "type": "function",
+            "name": "store_memory",
+            "description": "Persist a memory entry.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+
+    input_items = captured["input"]
+    assert any(
+        item.get("type") == "function_call"
+        and item.get("call_id") == "call_search_1"
+        and item.get("name") == "web_search"
+        for item in input_items
+    )
+    assert any(
+        item.get("type") == "function_call_output"
+        and item.get("call_id") == "call_search_1"
+        and item.get("output") == "Found the relevant transcript entries."
+        for item in input_items
+    )
+    assert not any(item.get("role") == "tool" for item in input_items)


### PR DESCRIPTION
## Summary
- reuse the canonical Codex Responses message converter in the auxiliary adapter
- ensure prior assistant tool calls and tool outputs become `function_call` / `function_call_output`
- add a regression test covering memory-flush-like tool history

## Validation
- `scripts/run_tests.sh tests/agent/test_auxiliary_client_codex_adapter.py -q`
- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -q`
- `tests/run_agent/test_flush_memories_codex.py` is not present in this checkout