### PR TITLE
fix(model-switch): soft-accept unlisted openai-codex models (gpt-5.3-codex-spark for example) in /model flow

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2707,11 +2707,12 @@ def validate_requested_model(
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
             return {
-                "accepted": False,
-                "persist": False,
+                "accepted": True,
+                "persist": True,
                 "recognized": False,
                 "message": (
-                    f"Model `{requested}` was not found in the OpenAI Codex model listing."
+                    f"Note: `{requested}` was not found in the OpenAI Codex model listing. "
+                    "It may still work if your ChatGPT/Codex account has access to a newer or hidden model ID."
                     f"{suggestion_text}"
                 ),
             }

--- a/tests/hermes_cli/test_openai_codex_model_validation_fallback.py
+++ b/tests/hermes_cli/test_openai_codex_model_validation_fallback.py
@@ -1,0 +1,55 @@
+"""Regression tests for OpenAI Codex model validation when the listing lags behind
+actually usable backend model IDs.
+
+The bug: `/model` and `switch_model()` reject `gpt-5.3-codex-spark` because the
+OpenAI Codex listing omits it, even though direct runtime calls with
+`--provider openai-codex -m gpt-5.3-codex-spark` succeed.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+from hermes_cli.models import validate_requested_model
+
+
+def test_openai_codex_unknown_but_plausible_model_is_accepted_with_warning():
+    """If the Codex listing is incomplete, `/model` should soft-accept the model
+    with a warning instead of hard-rejecting it.
+    """
+    with patch(
+        "hermes_cli.models.provider_model_ids",
+        return_value=["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+    ):
+        result = validate_requested_model("gpt-5.3-codex-spark", "openai-codex")
+
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is False
+    assert "gpt-5.3-codex-spark" in result["message"]
+    assert "OpenAI Codex model listing" in result["message"]
+    assert "Similar models" in result["message"]
+    assert "gpt-5.3-codex" in result["message"]
+
+
+def test_switch_model_allows_openai_codex_model_missing_from_listing():
+    """switch_model() should succeed for Codex models that the runtime accepts
+    even when the listing has not caught up yet.
+    """
+    with patch(
+        "hermes_cli.models.provider_model_ids",
+        return_value=["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+    ):
+        result = switch_model(
+            "gpt-5.3-codex-spark",
+            current_provider="openai-codex",
+            current_model="gpt-5.4",
+            current_base_url="",
+            current_api_key="",
+            user_providers=None,
+        )
+
+    assert result.success is True
+    assert result.new_model == "gpt-5.3-codex-spark"
+    assert result.target_provider == "openai-codex"
+    assert result.warning_message
+    assert "OpenAI Codex model listing" in result.warning_message


### PR DESCRIPTION
This fix is done by Hermes Agent + gpt-5.3-codex-spark, including this PR body. I only did a quick manual check on the changed files.

## What does this PR do?

This PR fixes a hard-reject behavior in the `openai-codex` model validation path when the provider’s model listing is stale or incomplete.

When a user requests a valid Codex model ID that is not currently present in the returned listing (for example a newer or hidden deployment), Hermes currently rejects the model at `/model` time, even though direct runtime usage can still work. This creates a false negative and blocks model switching for users.

The change is to keep the existing direct model switch flow but switch this case to soft-accept semantics:
- accept and persist the requested model,
- mark it as not recognized (because it is not present in the listing),
- return a warning with nearby model suggestions.

This aligns `/model` behavior with existing permissive behavior used for other provider paths that can validly accept unknown models while still warning users.

## Related Issue

Fixes # https://github.com/NousResearch/hermes-agent/issues/16172

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`
  - Update `validate_requested_model()` for `openai-codex`.
  - If the requested model is not in the Codex listing, return `accepted=True` and `persist=True` with `recognized=False` instead of rejecting.
  - Keep warning message and similar model suggestion behavior so users get feedback without being blocked.

- `tests/hermes_cli/test_openai_codex_model_validation_fallback.py`
  - Add regression coverage (2 tests) to verify:
    - unknown but plausible `openai-codex` models are accepted with warning;
    - `switch_model(...)` succeeds for a model missing from listing and preserves provider/model switching behavior.

## How to Test

1. Run focused fallback regression
   - `python3 -m pytest tests/hermes_cli/test_openai_codex_model_validation_fallback.py -q`
   - Expected: 2 passed

2. Run related validation regression group
   - `python3 -m pytest tests/test_minimax_model_validation.py tests/hermes_cli/test_opencode_go_validation_fallback.py tests/hermes_cli/test_openai_codex_model_validation_fallback.py -q`
   - Expected: 16 passed

3. Sanity check function behavior
   - Call validation with a model not in mocked Codex listing and confirm:
     - `accepted is True`
     - `persist is True`
     - `recognized is False`
     - warning message is present with listing/similar-model context

## Checklist

### Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Note: full suite status in this environment is affected by unrelated pre-existing failures; targeted regression set is passing.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

### For New Skills

- [ ] This skill is broadly useful to most users (if bundled) — see Contributing Guide — or N/A
- [ ] SKILL.md follows the standard format — or N/A
- [ ] No external dependencies that aren't already available — or N/A
- [ ] I've tested the skill end-to-end — or N/A

## Screenshots / Logs

Not applicable (logic + unit tests only).  
Regression logs: 2/2 and 16/16 for the above targeted test commands.