### PR TITLE
test(gateway): stub shutil.which and _preflight_user_systemd in systemd/WSL fixtures

### DIFF
--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -253,6 +253,8 @@ class TestDoctorCommandInstallation:
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
         monkeypatch.setattr(sys, "platform", "win32")
+        # shutil.which uses _winapi on win32 which is None on non-Windows hosts
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: None)
 
         fake_model_tools = types.SimpleNamespace(
             check_tool_availability=lambda *a, **kw: ([], []),

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -44,6 +44,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
 
         calls = []
 
@@ -67,6 +68,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
 
         calls = []
 
@@ -465,6 +467,7 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -519,6 +522,7 @@ class TestGatewaySystemServiceRouting:
 
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -142,7 +142,7 @@ class TestSupportsSystemdServicesWSL:
         assert gateway.supports_systemd_services() is False
 
     def test_native_linux(self, monkeypatch):
-        """Native Linux (not WSL) → True without checking systemd."""
+        """Native Linux (not WSL, not container) → True when systemctl is found on PATH."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -130,6 +130,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
         assert gateway.supports_systemd_services() is True
 
     def test_wsl_without_systemd(self, monkeypatch):
@@ -145,6 +146,8 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):


### PR DESCRIPTION
## Problem

Two recent commits introduced production-correct guards that broke 7 tests on macOS CI hosts:

- **e89b9d97** added `shutil.which("systemctl")` guard in `supports_systemd_services()` — returns `None` on macOS, so `test_wsl_with_systemd` and `test_native_linux` now return `False` before reaching the mocked branches.
- **d45c738a** added `_preflight_user_systemd()` call in `systemd_start()` / `systemd_restart()` — raises `UserSystemdUnavailableError` on macOS (no D-Bus session), breaking 4 `TestSystemdServiceRefresh` and `TestGatewaySystemServiceRouting` tests.
- `test_windows_skips_check` patches `sys.platform = "win32"`, which causes `shutil.which` to call `_winapi.NeedCurrentDirectoryForExePath` — `_winapi` is `None` on non-Windows hosts → `AttributeError`.

All 7 failures are pure test-isolation gaps; the production code changes are correct and intentional.

## Fix

Add targeted monkeypatches to each affected test fixture:

| File | Tests fixed | Patch added |
|------|-------------|-------------|
| `test_gateway_wsl.py` | `test_wsl_with_systemd`, `test_native_linux` | `gateway.shutil.which → "/usr/bin/<cmd>"` |
| `test_gateway_service.py` | `test_systemd_{start,restart}_refreshes_outdated_unit`, 2 `TestGatewaySystemServiceRouting` restart tests | `gateway_cli._preflight_user_systemd → no-op` |
| `test_doctor_command_install.py` | `test_windows_skips_check` | `doctor_mod.shutil.which → None` |

## Verification

```
python3 -m pytest \
  tests/hermes_cli/test_gateway_wsl.py \
  tests/hermes_cli/test_gateway_service.py \
  tests/hermes_cli/test_doctor_command_install.py \
  --override-ini="addopts=-p no:xdist"
# 135 passed, 1 warning
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)