### PR TITLE
fix(credential_pool): guard against redacted/truncated API keys in credential pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -134,6 +134,18 @@ class PooledCredential:
         data.setdefault("priority", 0)
         data.setdefault("source", SOURCE_MANUAL)
         data.setdefault("access_token", "")
+        # Guard: reject access tokens that contain literal '...' (redaction artifact).
+        # file_tools.py applies redact_sensitive_text() to read/search output, so
+        # if an agent tool reads and then writes a key, it would persist the
+        # truncated version. This guard catches that at write time.
+        token = data.get("access_token", "")
+        if isinstance(token, str) and "..." in token and len(token) < 35:
+            logger.warning(
+                "⚠️ Rejecting poisoned access_token (len=%d, has literal '...') "
+                "for %s/%s — refusing to persist redacted artifact",
+                len(token), provider, data.get("source", "?"),
+            )
+            data["access_token"] = ""
         return cls(provider=provider, **data)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -1373,10 +1385,21 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     # Seed from the custom_providers config entry's api_key field
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
-        api_key = str(cp_config.get("api_key") or "").strip()
+        api_key_raw = str(cp_config.get("api_key") or "").strip()
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
-        if api_key:
+
+        # Reject truncated keys (redact_secrets artifact from file_tools.py)
+        if api_key_raw and "..." in api_key_raw and len(api_key_raw) < 35:
+            logger.warning(
+                "⚠️ Config entry '%s' has truncated api_key (len=%d, has literal '...') — "
+                "skipping. Full key exists in model.api_key (source=model_config). "
+                "Fix: remove or correct this custom_providers entry.",
+                name or pool_key, len(api_key_raw),
+            )
+            api_key_raw = ""
+
+        if api_key_raw:
             source = f"config:{name}"
             if not _is_suppressed(pool_key, source):
                 active_sources.add(source)
@@ -1387,7 +1410,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                     {
                         "source": source,
                         "auth_type": AUTH_TYPE_API_KEY,
-                        "access_token": api_key,
+                        "access_token": api_key_raw,
                         "base_url": base_url,
                         "label": name or source,
                     },


### PR DESCRIPTION
## Problem

When `security.redact_secrets: true` is set (default), Hermes agent tools (`read_file`/`search_files` in `file_tools.py`) apply `redact_sensitive_text()` to all output. API keys like `sk-c25b3bd5a67d461790ecdc575fa2edd4` get truncated to `sk-c25...edd4` (first 6 + literal `...` + last 4 chars) at the output layer via `_mask_token()`.

If an agent reads a config file via `read_file()`, sees the truncated key, and writes it to the credential pool, `auth.json` stores a literally truncated 13-char key with actual `...` bytes (`0x2e 0x2e 0x2e`). On credential restore, this causes 401 auth failures that look identical to the `reasoning_content` 400 fallback loop.

## Fix

Two guards in `agent/credential_pool.py`:

### 1. `PooledCredential.from_dict()`

Detects `access_token` with literal `...` + len < 35 (the redaction marker) and clears it:

```python
token = data.get("access_token", "")
if isinstance(token, str) and "..." in token and len(token) < 35:
    logger.warning("Rejecting poisoned access_token ...")
    data["access_token"] = ""
```

### 2. `_seed_custom_pool()`

Detects truncated keys in custom_providers config entries and skips them with a warning.

Both guards are non-destructive: clearing the poisoned token causes the pool to fall through to the next source (typically `model_config`), which reads directly from `config.yaml` via YAML parsing (no output-layer redaction).

## Root Cause Chain

```
Agent reads config.yaml via read_file()
  -> file_tools.py:482 applies redact_sensitive_text()
  -> _mask_token() truncates to "sk-c25...edd4"
  -> Agent writes truncated value to credential pool
  -> auth.json has literal "sk-c25...edd4" (13 chars)
  -> On restore: 401 auth failure -> fallback loop
```

## Diagnostic

Users can check for poisoned entries:

```bash
python3 -c "
import json
auth = json.load(open('$HOME/.hermes/auth.json'))
for pid, entries in auth.get('credential_pool', {}).items():
    for e in entries:
        tok = e.get('access_token', '')
        if '...' in tok and len(tok) < 35:
            print(f'POISONED: {pid}/{e[\"source\"]}  len={len(tok)}')
"
```
