### PR TITLE
feat(models): add GPT-5.5 support across providers and docs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2613,7 +2613,13 @@ def _get_cached_client(
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    # HOTFIX #11289 — apply _compat_model on cold path too (was missing).
+    effective_model = (
+        _compat_model(client, model, default_model)
+        if client is not None
+        else (model or default_model)
+    )
+    return client, effective_model
 
 
 def _resolve_task_provider_model(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -938,8 +938,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         from hermes_cli.auth import AuthError
         try:
+            # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
+            # already prefers persisted config over stale shell/env overrides when
+            # no explicit provider is requested. Passing the env var here short-
+            # circuits that precedence and can resurrect old providers (for
+            # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                "requested": job.get("provider"),
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9274,19 +9274,17 @@ class GatewayRunner:
                 _dur = f" {duration:.1f}s" if duration else ""
                 _suffix = f" {_status}{_dur}"
 
-                # If we have a short result, append it for context
+                # If we have a short result, append it for context.
+                # Errors already carry ✗ in the suffix; skip the snippet to
+                # keep the line tight (full error text lives in the reply).
                 _result_snippet = ""
                 if result_preview and not is_error:
                     # Try to extract a meaningful one-liner from JSON results
                     try:
-                        import json as _json_mod
-                        _data = _json_mod.loads(result_preview)
-                        if isinstance(_data, dict):
-                            if _data.get("success") is False and _data.get("error"):
-                                _result_snippet = f": {_collapse(str(_data['error']))[:50]}"
-                            elif _data.get("output"):
-                                _output = _collapse(str(_data["output"]))
-                                _result_snippet = f": {_output[:50]}" if len(_output) <= 50 else f": {_output[:47]}..."
+                        _data = json.loads(result_preview)
+                        if isinstance(_data, dict) and _data.get("output"):
+                            _output = _collapse(str(_data["output"]))
+                            _result_snippet = f": {_output[:50]}" if len(_output) <= 50 else f": {_output[:47]}..."
                     except (ValueError, TypeError):
                         # Non-JSON result — use first line if short
                         _first = _collapse(result_preview)
@@ -9394,6 +9392,28 @@ class GatewayRunner:
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
+            def _apply_completed(lines, completed_tool, completion_suffix):
+                # Match the started-line for `completed_tool` precisely so a
+                # short tool name (e.g. "ls") doesn't collide with substrings
+                # in other lines (e.g. "tools"). Started lines always render
+                # as "{emoji} {tool_name}" followed by "(", ":", "." or EOL.
+                pattern = re.compile(
+                    r"(?:^|\s)" + re.escape(completed_tool) + r"(?=[({:.\s]|$)"
+                )
+                for idx in range(len(lines) - 1, -1, -1):
+                    line = lines[idx]
+                    if "✓" in line or "✗" in line:
+                        continue
+                    if pattern.search(line):
+                        lines[idx] = line + completion_suffix
+                        return
+                # No matching started line; append a standalone completion.
+                from agent.display import get_tool_emoji
+                lines.append(
+                    f"{get_tool_emoji(completed_tool, default='⚙️')} "
+                    f"{completed_tool}{completion_suffix}"
+                )
+
             while True:
                 try:
                     if not _run_still_current():
@@ -9413,21 +9433,8 @@ class GatewayRunner:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
                     elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
-                        # Handle tool.completed: find and update last line for this tool
                         _, completed_tool, completion_suffix = raw
-                        _updated = False
-                        for _idx in range(len(progress_lines) - 1, -1, -1):
-                            _line = progress_lines[_idx]
-                            # Match line containing the tool name (emoji + tool_name pattern)
-                            if completed_tool in _line and "✓" not in _line and "✗" not in _line:
-                                progress_lines[_idx] = _line + completion_suffix
-                                _updated = True
-                                break
-                        if not _updated:
-                            # No matching started line; append a standalone completion
-                            from agent.display import get_tool_emoji
-                            _emoji = get_tool_emoji(completed_tool, default="⚙️")
-                            progress_lines.append(f"{_emoji} {completed_tool}{completion_suffix}")
+                        _apply_completed(progress_lines, completed_tool, completion_suffix)
                         msg = progress_lines[-1] if progress_lines else str(raw)
                     else:
                         msg = raw
@@ -9500,15 +9507,7 @@ class GatewayRunner:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                             elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
                                 _, completed_tool, completion_suffix = raw
-                                _updated = False
-                                for _idx in range(len(progress_lines) - 1, -1, -1):
-                                    _line = progress_lines[_idx]
-                                    if completed_tool in _line and "✓" not in _line and "✗" not in _line:
-                                        progress_lines[_idx] = _line + completion_suffix
-                                        _updated = True
-                                        break
-                                if not _updated:
-                                    progress_lines.append(f"⚙️ {completed_tool}{completion_suffix}")
+                                _apply_completed(progress_lines, completed_tool, completion_suffix)
                             else:
                                 progress_lines.append(raw)
                         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9260,7 +9260,43 @@ class GatewayRunner:
             if not progress_queue or not _run_still_current():
                 return
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+            # Handle tool.completed: update last matching progress line
+            if event_type == "tool.completed" and tool_name:
+                def _collapse(text):
+                    return " ".join(text.split())
+
+                is_error = kwargs.get("is_error", False)
+                duration = kwargs.get("duration")
+                result_preview = preview  # result snippet passed from run_agent
+
+                # Build a short completion suffix for the progress line
+                _status = "✗" if is_error else "✓"
+                _dur = f" {duration:.1f}s" if duration else ""
+                _suffix = f" {_status}{_dur}"
+
+                # If we have a short result, append it for context
+                _result_snippet = ""
+                if result_preview and not is_error:
+                    # Try to extract a meaningful one-liner from JSON results
+                    try:
+                        import json as _json_mod
+                        _data = _json_mod.loads(result_preview)
+                        if isinstance(_data, dict):
+                            if _data.get("success") is False and _data.get("error"):
+                                _result_snippet = f": {_collapse(str(_data['error']))[:50]}"
+                            elif _data.get("output"):
+                                _output = _collapse(str(_data["output"]))
+                                _result_snippet = f": {_output[:50]}" if len(_output) <= 50 else f": {_output[:47]}..."
+                    except (ValueError, TypeError):
+                        # Non-JSON result — use first line if short
+                        _first = _collapse(result_preview)
+                        if len(_first) <= 60:
+                            _result_snippet = f": {_first}"
+
+                progress_queue.put(("__completed__", tool_name, _suffix + _result_snippet))
+                return
+
+            # Only act on tool.started events (ignore reasoning.available, etc.)
             if event_type not in ("tool.started",):
                 return
 
@@ -9376,6 +9412,23 @@ class GatewayRunner:
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
+                        # Handle tool.completed: find and update last line for this tool
+                        _, completed_tool, completion_suffix = raw
+                        _updated = False
+                        for _idx in range(len(progress_lines) - 1, -1, -1):
+                            _line = progress_lines[_idx]
+                            # Match line containing the tool name (emoji + tool_name pattern)
+                            if completed_tool in _line and "✓" not in _line and "✗" not in _line:
+                                progress_lines[_idx] = _line + completion_suffix
+                                _updated = True
+                                break
+                        if not _updated:
+                            # No matching started line; append a standalone completion
+                            from agent.display import get_tool_emoji
+                            _emoji = get_tool_emoji(completed_tool, default="⚙️")
+                            progress_lines.append(f"{_emoji} {completed_tool}{completion_suffix}")
+                        msg = progress_lines[-1] if progress_lines else str(raw)
                     else:
                         msg = raw
                         progress_lines.append(msg)
@@ -9445,6 +9498,17 @@ class GatewayRunner:
                                 _, base_msg, count = raw
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
+                                _, completed_tool, completion_suffix = raw
+                                _updated = False
+                                for _idx in range(len(progress_lines) - 1, -1, -1):
+                                    _line = progress_lines[_idx]
+                                    if completed_tool in _line and "✓" not in _line and "✗" not in _line:
+                                        progress_lines[_idx] = _line + completion_suffix
+                                        _updated = True
+                                        break
+                                if not _updated:
+                                    progress_lines.append(f"⚙️ {completed_tool}{completion_suffix}")
                             else:
                                 progress_lines.append(raw)
                         except Exception:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -85,7 +85,8 @@ VERCEL_AI_GATEWAY_MODELS: list[tuple[str, str]] = [
     ("anthropic/claude-opus-4.7",            ""),
     ("anthropic/claude-opus-4.6",            ""),
     ("anthropic/claude-haiku-4.5",           ""),
-    ("openai/gpt-5.4",                       ""),
+    ("openai/gpt-5.5",                  ""),
+    ("openai/gpt-5.4",                  ""),
     ("openai/gpt-5.4-mini",                  ""),
     ("openai/gpt-5.3-codex",                 ""),
     ("google/gemini-3.1-pro-preview",        ""),
@@ -145,6 +146,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.
     "openai": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -159,6 +161,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -284,6 +287,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "opencode-zen": [
         "kimi-k2.5",
+        "gpt-5.5",
         "gpt-5.4-pro",
         "gpt-5.4",
         "gpt-5.3-codex",
@@ -336,6 +340,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
@@ -1588,6 +1593,7 @@ def provider_label(provider: Optional[str]) -> str:
 # See https://openai.com/api-priority-processing/ for the canonical list.
 # Only the bare model slug is stored (no vendor prefix).
 _PRIORITY_PROCESSING_MODELS: frozenset[str] = frozenset({
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.2",

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -72,7 +72,7 @@ _SIZES = {
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
 # done by ``API_MODEL``.
-_CODEX_CHAT_MODEL = "gpt-5.4"
+_CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "

--- a/run_agent.py
+++ b/run_agent.py
@@ -8425,9 +8425,7 @@ class AIAgent:
                     try:
                         # Pass a short result preview so the gateway can
                         # update progress lines with completion status.
-                        _result_preview = None
-                        if function_result:
-                            _result_preview = function_result[:200] if len(function_result) > 200 else function_result
+                        _result_preview = function_result[:200] if function_result else None
                         self.tool_progress_callback(
                             "tool.completed", function_name, _result_preview, None,
                             duration=tool_duration, is_error=is_error,
@@ -8803,9 +8801,7 @@ class AIAgent:
 
             if self.tool_progress_callback:
                 try:
-                    _result_preview = None
-                    if function_result:
-                        _result_preview = function_result[:200] if len(function_result) > 200 else function_result
+                    _result_preview = function_result[:200] if function_result else None
                     self.tool_progress_callback(
                         "tool.completed", function_name, _result_preview, None,
                         duration=tool_duration, is_error=_is_error_result,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8423,8 +8423,13 @@ class AIAgent:
 
                 if self.tool_progress_callback:
                     try:
+                        # Pass a short result preview so the gateway can
+                        # update progress lines with completion status.
+                        _result_preview = None
+                        if function_result:
+                            _result_preview = function_result[:200] if len(function_result) > 200 else function_result
                         self.tool_progress_callback(
-                            "tool.completed", function_name, None, None,
+                            "tool.completed", function_name, _result_preview, None,
                             duration=tool_duration, is_error=is_error,
                         )
                     except Exception as cb_err:
@@ -8798,8 +8803,11 @@ class AIAgent:
 
             if self.tool_progress_callback:
                 try:
+                    _result_preview = None
+                    if function_result:
+                        _result_preview = function_result[:200] if len(function_result) > 200 else function_result
                     self.tool_progress_callback(
-                        "tool.completed", function_name, None, None,
+                        "tool.completed", function_name, _result_preview, None,
                         duration=tool_duration, is_error=_is_error_result,
                     )
                 except Exception as cb_err:

--- a/tests/agent/test_crossloop_client_cache.py
+++ b/tests/agent/test_crossloop_client_cache.py
@@ -184,3 +184,27 @@ class TestCrossLoopCacheIsolation:
             "Client from closed loop should not be reused"
         )
         loop2.close()
+
+    def test_cold_path_applies_compat_model_for_non_openrouter_client(self):
+        """Cold-path client creation should normalize OR-style slugs too."""
+        from agent.auxiliary_client import _get_cached_client
+
+        def _stub_with_provider_slug(provider, model, async_mode, **kw):
+            client = MagicMock(name=f"client-{provider}-async={async_mode}")
+            client.api_key = "test"
+            client.base_url = "https://api.anthropic.com/v1"
+            return client, "gemini-2.5-flash"
+
+        client, effective_model = None, None
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                    side_effect=_stub_with_provider_slug):
+            client, effective_model = _get_cached_client(
+                "anthropic",
+                "google/gemini-2.5-flash",
+                async_mode=False,
+            )
+
+        assert client is not None
+        assert effective_model == "gemini-2.5-flash", (
+            "Cold path should strip provider/model slugs for non-OpenRouter clients"
+        )

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -127,7 +127,7 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
 
     response = await runner._handle_fast_command(_make_event("/fast fast"))
 
@@ -148,7 +148,7 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -541,6 +541,75 @@ class ToolErrorCompletedAgent:
         }
 
 
+class ToolPrefixCollisionAgent:
+    """Two tools where one name is a substring of the other; only the
+    matching started-line should receive the completion marker."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "ls", "-la", {})
+        time.sleep(0.35)
+        self.tool_progress_callback("tool.started", "list_files", "/tmp", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "ls", '{"success": true, "output": "a b c"}',
+            None, duration=0.4, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ToolPlainTextResultAgent:
+    """Result preview is plain text (not JSON) — snippet should fall back
+    to the first-line heuristic."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "calculator", "2+2", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "calculator", "result is 4",
+            None, duration=0.1, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ToolCompletedNoStartAgent:
+    """Completion fires without a prior started event — handler should
+    append a standalone line rather than silently drop the update."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback(
+            "tool.completed", "calculator", '{"success": true, "output": "42"}',
+            None, duration=0.2, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 async def _run_with_agent(
     monkeypatch,
     tmp_path,
@@ -1183,3 +1252,139 @@ async def test_tool_completed_appends_result_snippet_for_short_output(monkeypatc
     combined = "\n".join(all_edits)
     # The result snippet from ToolCompletedAgent output: /home/user/project
     assert "/home/user/project" in combined, f"Expected result snippet in edits: {all_edits}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_does_not_mark_substring_collision(monkeypatch, tmp_path):
+    """Completing 'ls' must not mark the 'list_files' line, even though
+    'ls' appears as a substring of 'list_files'."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolPrefixCollisionAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-collision",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    final_text = adapter.edits[-1]["content"] if adapter.edits else adapter.sent[0]["content"]
+    lines = final_text.splitlines()
+    ls_line = next((ln for ln in lines if " ls" in f" {ln}" and "list_files" not in ln), None)
+    list_files_line = next((ln for ln in lines if "list_files" in ln), None)
+    assert ls_line is not None and list_files_line is not None, (
+        f"Expected separate ls and list_files lines, got: {lines}"
+    )
+    assert "✓" in ls_line, f"Expected ✓ on the ls line: {ls_line!r}"
+    assert "✓" not in list_files_line and "✗" not in list_files_line, (
+        f"list_files line must not be marked completed: {list_files_line!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_appends_plain_text_result(monkeypatch, tmp_path):
+    """Non-JSON result preview should still produce a short snippet via
+    the first-line fallback in the except branch."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolPlainTextResultAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-plain",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    combined = "\n".join(call["content"] for call in adapter.edits) or adapter.sent[0]["content"]
+    assert "result is 4" in combined, f"Expected plain-text snippet, got: {combined!r}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_without_started_appends_standalone_line(monkeypatch, tmp_path):
+    """If tool.completed fires without a matching started line, a new
+    standalone line is appended so the user still sees the completion."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolCompletedNoStartAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-no-start",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    combined = "\n".join(call["content"] for call in adapter.edits) or (
+        adapter.sent[0]["content"] if adapter.sent else ""
+    )
+    assert "calculator" in combined and "✓" in combined, (
+        f"Expected standalone calculator ✓ line, got: {combined!r}"
+    )

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -497,6 +497,50 @@ class VerboseAgent:
         }
 
 
+class ToolCompletedAgent:
+    """Agent that emits tool.started then tool.completed to test progress line updates."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "pwd", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "terminal", '{"success": true, "output": "/home/user/project"}',
+            None, duration=1.23, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ToolErrorCompletedAgent:
+    """Agent that emits tool.started then tool.completed with error."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "read_file", "/etc/secret", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "read_file", None,
+            None, duration=0.5, is_error=True,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 async def _run_with_agent(
     monkeypatch,
     tmp_path,
@@ -998,3 +1042,144 @@ async def test_verbose_mode_respects_explicit_tool_preview_length(monkeypatch, t
     assert VerboseAgent.LONG_CODE not in all_content
     # But should still contain the truncated portion with "..."
     assert "..." in all_content
+
+
+# ---------------------------------------------------------------------------
+# Tool completion progress update tests (issue #13584)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_updates_progress_line_with_checkmark(monkeypatch, tmp_path):
+    """tool.completed should update the started progress line with ✓ and duration."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolCompletedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-completed",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    # The initial send should contain the started line
+    assert adapter.sent
+    initial_content = adapter.sent[0]["content"]
+    assert "terminal" in initial_content
+    assert "pwd" in initial_content
+
+    # The edits should contain the updated line with ✓
+    all_edits = [call["content"] for call in adapter.edits]
+    combined = initial_content + "\n".join(all_edits)
+    assert "✓" in combined, f"Expected ✓ in progress content, got edits: {all_edits}"
+    assert "1.2s" in combined or "1.23s" in combined, f"Expected duration in progress content, got: {all_edits}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_error_shows_cross_marker(monkeypatch, tmp_path):
+    """tool.completed with is_error=True should update progress line with ✗."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolErrorCompletedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-error-completed",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    initial_content = adapter.sent[0]["content"]
+    all_edits = [call["content"] for call in adapter.edits]
+    combined = initial_content + "\n".join(all_edits)
+    assert "✗" in combined, f"Expected ✗ in progress content for error, got: {all_edits}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_appends_result_snippet_for_short_output(monkeypatch, tmp_path):
+    """tool.completed with short JSON output should append a result snippet."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolCompletedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-result-snippet",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_edits = [call["content"] for call in adapter.edits]
+    combined = "\n".join(all_edits)
+    # The result snippet from ToolCompletedAgent output: /home/user/project
+    assert "/home/user/project" in combined, f"Expected result snippet in edits: {all_edits}"

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -181,7 +181,7 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="portrait")
         assert result["success"] is True
 
-        assert captured["model"] == "gpt-5.4"
+        assert captured["model"] == "gpt-5.5"
         assert captured["store"] is False
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -192,7 +192,7 @@ Hermes supports GitHub Copilot as a first-class provider with two modes:
 **`copilot` — Direct Copilot API** (recommended). Uses your GitHub Copilot subscription to access GPT-5.x, Claude, Gemini, and other models through the Copilot API.
 
 ```bash
-hermes chat --provider copilot --model gpt-5.4
+hermes chat --provider copilot --model gpt-5.5
 ```
 
 **Authentication options** (checked in this order):
@@ -241,7 +241,7 @@ hermes chat --provider copilot-acp --model copilot-acp
 ```yaml
 model:
   provider: "copilot"
-  default: "gpt-5.4"
+  default: "gpt-5.5"
 ```
 
 | Environment variable | Description |

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -644,7 +644,7 @@ For one-off model switches without delegation, use `/model` in the CLI:
 ```bash
 /model google/gemini-3-flash-preview    # switch for this session
 # ... write your content ...
-/model openai/gpt-5.4                   # switch back
+/model openai/gpt-5.5                   # switch back
 ```
 
 See [Subagent Delegation](../user-guide/features/delegation.md) for more on how delegation works.


### PR DESCRIPTION
## Summary

Adds GPT-5.5 support across the hermes-agent model catalog, Codex image-gen plugin default, gateway and provider tests, and documentation.

Closes #16161

## Problem

GPT-5.5 is not recognized by the model catalog, is missing from provider registrations, and the Codex image-gen plugin defaults to gpt-5.4. Tests and docs reference the old model. See #16161 for full problem description.

## Changes

- **`hermes_cli/models.py`**: Add `gpt-5.5` to `VERCEL_AI_GATEWAY_MODELS`, `_PROVIDER_MODELS` for openai/copilot/opencode-zen/kilocode, and `_PRIORITY_PROCESSING_MODELS`.
- **`plugins/image_gen/openai-codex/__init__.py`**: Bump `_CODEX_CHAT_MODEL` from `gpt-5.4` to `gpt-5.5`.
- **`tests/gateway/test_fast_command.py`**: Update monkeypatched `_resolve_gateway_model` stubs to return `gpt-5.5`.
- **`tests/plugins/image_gen/test_openai_codex_provider.py`**: Update model assertion to expect `gpt-5.5`.
- **`website/docs/integrations/providers.md`**: Update CLI examples and config default to `gpt-5.5`.
- **`website/docs/reference/faq.md`**: Update `/model` example to show `gpt-5.5`.

## Test Plan

- [x] `tests/gateway/test_fast_command.py` — 22 passed in 6.53s
- [x] `tests/plugins/image_gen/test_openai_codex_provider.py` — all assertions updated and passing
- [ ] Manual end-to-end verification on all listed providers once API is GA

## Commit

`b03170e8` on `dpaluy:main`