### PR TITLE
fix(gateway): use /hermes sethome in Slack onboarding hint

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4520,12 +4520,20 @@ class GatewayRunner:
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
+                    # Slack dispatches all Hermes commands through a single
+                    # parent slash command `/hermes`; bare `/sethome` is not
+                    # registered and would fail with "app did not respond".
+                    sethome_cmd = (
+                        "/hermes sethome"
+                        if source.platform == Platform.SLACK
+                        else "/sethome"
+                    )
                     await adapter.send(
                         source.chat_id,
                         f"📬 No home channel is set for {platform_name.title()}. "
                         f"A home channel is where Hermes delivers cron job results "
                         f"and cross-platform messages.\n\n"
-                        f"Type /sethome to make this chat your home channel, "
+                        f"Type {sethome_cmd} to make this chat your home channel, "
                         f"or ignore to skip."
                     )
         

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "Mibayy@users.noreply.github.com": "Mibayy",
     "mibayy@users.noreply.github.com": "Mibayy",
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
+    "lzy.dev@gmail.com": "zhiyanliu",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -12,9 +12,9 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
-def _make_source() -> SessionSource:
+def _make_source(platform: Platform = Platform.TELEGRAM) -> SessionSource:
     return SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=platform,
         user_id="u1",
         chat_id="c1",
         user_name="tester",
@@ -22,24 +22,24 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str) -> MessageEvent:
+def _make_event(text: str, *, platform: Platform = Platform.TELEGRAM) -> MessageEvent:
     return MessageEvent(
         text=text,
-        source=_make_source(),
+        source=_make_source(platform),
         message_id="m1",
     )
 
 
-def _make_runner(session_entry: SessionEntry):
+def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.TELEGRAM):
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        platforms={platform: PlatformConfig(enabled=True, token="***")}
     )
     adapter = MagicMock()
     adapter.send = AsyncMock()
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
@@ -222,6 +222,93 @@ async def test_handle_message_persists_agent_token_counts(monkeypatch):
         session_entry.session_key,
         last_prompt_tokens=80,
     )
+
+
+@pytest.mark.asyncio
+async def test_first_run_slack_home_channel_onboarding_uses_parent_command(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source(Platform.SLACK)),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry, platform=Platform.SLACK)
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = False
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": "openai/test-model",
+        }
+    )
+
+    monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello", platform=Platform.SLACK))
+
+    assert result == "ok"
+    runner.adapters[Platform.SLACK].send.assert_awaited_once()
+    onboarding = runner.adapters[Platform.SLACK].send.await_args.args[1]
+    assert "/hermes sethome" in onboarding
+    assert "Type /sethome" not in onboarding
+
+
+@pytest.mark.asyncio
+async def test_first_run_non_slack_home_channel_onboarding_keeps_direct_command(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source(Platform.TELEGRAM)),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry, platform=Platform.TELEGRAM)
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = False
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": "openai/test-model",
+        }
+    )
+
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello", platform=Platform.TELEGRAM))
+
+    assert result == "ok"
+    runner.adapters[Platform.TELEGRAM].send.assert_awaited_once()
+    onboarding = runner.adapters[Platform.TELEGRAM].send.await_args.args[1]
+    assert "Type /sethome" in onboarding
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Slack onboarding hint now tells users to type `/hermes sethome` instead of `/sethome`, which would fail with "app did not respond" on Slack (all Hermes commands dispatch through the parent `/hermes` slash). Other platforms keep `/sethome`.

## Changes
- `gateway/run.py`: branch the onboarding string on `Platform.SLACK`
- `tests/gateway/test_status_command.py`: parameterize helpers + two regression tests (Slack path, non-Slack path)

## Validation
| | Before | After |
|---|---|---|
| Slack DM (no home) | "Type /sethome..." → fails, `slack_bolt` Unhandled request | "Type /hermes sethome..." → succeeds |
| Telegram DM (no home) | "Type /sethome..." | "Type /sethome..." (unchanged) |
| `test_status_command.py` | 9 passed | 11 passed |

## Credits
- #14633 by @zhiyanliu (original issue reporter #14632 + cleanest fix with explanatory comment) — salvaged as commit c93adb08b
- #14645 by @sgaofen (regression tests) — salvaged as commit f62737b5f
- #14865 by @LeonSGP43 (duplicate fix) — will be closed with credit

Closes #14632.