### PR TITLE
feat(models): add GPT-5.5 support across providers and docs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -85,7 +85,8 @@ VERCEL_AI_GATEWAY_MODELS: list[tuple[str, str]] = [
     ("anthropic/claude-opus-4.7",            ""),
     ("anthropic/claude-opus-4.6",            ""),
     ("anthropic/claude-haiku-4.5",           ""),
-    ("openai/gpt-5.4",                       ""),
+    ("openai/gpt-5.5",                  ""),
+    ("openai/gpt-5.4",                  ""),
     ("openai/gpt-5.4-mini",                  ""),
     ("openai/gpt-5.3-codex",                 ""),
     ("google/gemini-3.1-pro-preview",        ""),
@@ -145,6 +146,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.
     "openai": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -159,6 +161,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -284,6 +287,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "opencode-zen": [
         "kimi-k2.5",
+        "gpt-5.5",
         "gpt-5.4-pro",
         "gpt-5.4",
         "gpt-5.3-codex",
@@ -336,6 +340,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
@@ -1619,6 +1624,7 @@ def provider_label(provider: Optional[str]) -> str:
 # See https://openai.com/api-priority-processing/ for the canonical list.
 # Only the bare model slug is stored (no vendor prefix).
 _PRIORITY_PROCESSING_MODELS: frozenset[str] = frozenset({
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.2",

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -72,7 +72,7 @@ _SIZES = {
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
 # done by ``API_MODEL``.
-_CODEX_CHAT_MODEL = "gpt-5.4"
+_CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -127,7 +127,7 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
 
     response = await runner._handle_fast_command(_make_event("/fast fast"))
 
@@ -148,7 +148,7 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -181,7 +181,7 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="portrait")
         assert result["success"] is True
 
-        assert captured["model"] == "gpt-5.4"
+        assert captured["model"] == "gpt-5.5"
         assert captured["store"] is False
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -192,7 +192,7 @@ Hermes supports GitHub Copilot as a first-class provider with two modes:
 **`copilot` — Direct Copilot API** (recommended). Uses your GitHub Copilot subscription to access GPT-5.x, Claude, Gemini, and other models through the Copilot API.
 
 ```bash
-hermes chat --provider copilot --model gpt-5.4
+hermes chat --provider copilot --model gpt-5.5
 ```
 
 **Authentication options** (checked in this order):
@@ -241,7 +241,7 @@ hermes chat --provider copilot-acp --model copilot-acp
 ```yaml
 model:
   provider: "copilot"
-  default: "gpt-5.4"
+  default: "gpt-5.5"
 ```
 
 | Environment variable | Description |

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -644,7 +644,7 @@ For one-off model switches without delegation, use `/model` in the CLI:
 ```bash
 /model google/gemini-3-flash-preview    # switch for this session
 # ... write your content ...
-/model openai/gpt-5.4                   # switch back
+/model openai/gpt-5.5                   # switch back
 ```
 
 See [Subagent Delegation](../user-guide/features/delegation.md) for more on how delegation works.


### PR DESCRIPTION
## Summary

Adds GPT-5.5 support only across the model catalog, Codex image-gen default, focused tests, and documentation.

Closes #16161

## Problem

GPT-5.5 is missing from the provider catalog and priority-processing set, while Codex image generation and docs/tests still reference GPT-5.4.

## Changes

- Add `gpt-5.5` to Vercel AI gateway models and relevant provider lists.
- Add `gpt-5.5` to `_PRIORITY_PROCESSING_MODELS`.
- Bump the OpenAI Codex image-gen chat model from `gpt-5.4` to `gpt-5.5`.
- Update focused gateway and image-gen tests.
- Update provider and FAQ docs examples.

## Scope control

This PR intentionally contains only the six files named in #16161:

- `hermes_cli/models.py`
- `plugins/image_gen/openai-codex/__init__.py`
- `tests/gateway/test_fast_command.py`
- `tests/plugins/image_gen/test_openai_codex_provider.py`
- `website/docs/integrations/providers.md`
- `website/docs/reference/faq.md`

The previous PR #16180 was opened from `dpaluy:main` and accidentally included unrelated commits/files; this clean branch replaces it.

## Test Plan

- [x] `scripts/run_tests.sh tests/gateway/test_fast_command.py tests/plugins/image_gen/test_openai_codex_provider.py` — 22 passed
