### PR TITLE
fix(slack): honor reply_in_thread=false in DMs and channels

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -570,6 +570,8 @@ def load_gateway_config() -> GatewayConfig:
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
+                if "reply_in_thread" in platform_cfg:
+                    bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -450,8 +450,18 @@ class SlackAdapter(BasePlatformAdapter):
         """
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
+        # For top-level channel messages, the inbound handler sets
+        # metadata.thread_id to the message's own ts as a session-keying
+        # fallback (see the `thread_ts = event.get("thread_ts") or ts` branch),
+        # so metadata alone can't distinguish a real thread reply from a
+        # top-level message. reply_to is the incoming message's own id, so
+        # when thread_id == reply_to the "thread" is synthetic and we reply
+        # directly in the channel instead.
         if not self.config.extra.get("reply_in_thread", True):
-            existing_thread = (metadata or {}).get("thread_id") or (metadata or {}).get("thread_ts")
+            md = metadata or {}
+            existing_thread = md.get("thread_id") or md.get("thread_ts")
+            if existing_thread and reply_to and existing_thread == reply_to:
+                existing_thread = None
             return existing_thread or None
 
         if metadata:

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -310,3 +310,31 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     import os as _os
     assert _os.environ["SLACK_REQUIRE_MENTION"] == "false"
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
+
+
+def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  reply_in_thread: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+
+    assert config is not None
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.extra.get("reply_in_thread") is False
+
+    adapter = SlackAdapter(slack_config)
+    assert adapter._resolve_thread_ts(reply_to="171.000", metadata={}) is None
+    assert adapter._resolve_thread_ts(
+        reply_to="171.000",
+        metadata={"thread_id": "171.000"},
+    ) == "171.000"

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -334,7 +334,19 @@ def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
 
     adapter = SlackAdapter(slack_config)
     assert adapter._resolve_thread_ts(reply_to="171.000", metadata={}) is None
+
+    # Top-level channel messages arrive with metadata.thread_id == reply_to
+    # because the inbound handler uses event.ts as a session-keying fallback.
+    # Those must be treated as non-threaded so reply_in_thread=false takes
+    # effect in channels, not just DMs.
     assert adapter._resolve_thread_ts(
         reply_to="171.000",
+        metadata={"thread_id": "171.000"},
+    ) is None
+
+    # Real thread replies (reply_to differs from thread parent) must still
+    # resolve to the parent thread so conversation context is preserved.
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
         metadata={"thread_id": "171.000"},
     ) == "171.000"


### PR DESCRIPTION
Makes `slack.reply_in_thread: false` in config.yaml actually disable thread-anchoring for top-level messages on both DMs and channels. Previously it was silently ignored (config bridge bug) and even when bridged, channels still threaded because of a session-keying fallback.

## Changes
- `gateway/config.py`: bridge `slack.reply_in_thread` yaml → `PlatformConfig.extra` (same pattern as require_mention, allow_bots, free_response_channels)
- `gateway/platforms/slack.py`: in `_resolve_thread_ts`, treat `metadata.thread_id == reply_to` as a synthetic thread (inbound handler uses event.ts as a session-keying fallback, which is indistinguishable from a real thread parent without comparing against the incoming message id)
- `tests/gateway/test_slack_mention.py`: regression tests for DM case, top-level channel case, and real-thread-reply case

## Validation
| | Before | After |
|---|---|---|
| DM with `reply_in_thread: false` | threaded | direct reply |
| Top-level channel msg with `reply_in_thread: false` | threaded | direct reply |
| Real thread reply with `reply_in_thread: false` | threaded (correct) | threaded (preserved) |
| `test_slack*.py + test_config.py` | 193/194 | 196/196 (3x green) |

## Credits
- #10566 by @briandevans — salvaged as 7e97ea561, authorship preserved (closes #7532 — the DM case config bridge)
- Follow-up commit 2f2765b4d fixes the remaining channel case (closes #9268 by @bassboy2k)

Closes #7532
Closes #9268