### PR TITLE
fix(gateway): deduplicate Weixin messages by content fingerprint

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1308,6 +1308,15 @@ class WeixinAdapter(BasePlatformAdapter):
         if message_id and self._dedup.is_duplicate(message_id):
             return
 
+        # Secondary content-fingerprint dedup for text messages
+        item_list = message.get("item_list") or []
+        text = _extract_text(item_list)
+        if text:
+            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+            if self._dedup.is_duplicate(content_key):
+                logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
+                return
+
         chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)
         if chat_type == "group":
             if self._group_policy == "disabled":
@@ -1322,8 +1331,6 @@ class WeixinAdapter(BasePlatformAdapter):
             self._token_store.set(self._account_id, sender_id, context_token)
         asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
 
-        item_list = message.get("item_list") or []
-        text = _extract_text(item_list)
         media_paths: List[str] = []
         media_types: List[str] = []
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -5,7 +5,7 @@ import base64
 import json
 import os
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
@@ -758,3 +758,43 @@ class TestWeixinVoiceSending:
         assert voice_item["encode_type"] == 6
         assert voice_item["sample_rate"] == 24000
         assert voice_item["bits_per_sample"] == 16
+
+
+class TestWeixinContentDedup:
+    """Regression tests for Issue #16182 — upstream API sends duplicate content
+    with different message_ids, bypassing message_id deduplication.
+    """
+
+    def test_duplicate_content_with_different_message_ids_is_dropped(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "hello world"}}],
+        }
+
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-1"}))
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-2"}))
+
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args[0][0]
+        assert event.text == "hello world"
+
+    def test_content_dedup_not_called_for_messages_without_text(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._dedup.is_duplicate = Mock(return_value=False)
+
+        empty_msg = {
+            "from_user_id": "wxid_user1",
+            "message_id": "msg-1",
+            "item_list": [],
+        }
+        asyncio.run(adapter._process_message(empty_msg))
+
+        assert adapter.handle_message.await_count == 0
+        # is_duplicate should only be called for message_id, never for content
+        assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)


### PR DESCRIPTION
## What does this PR do?

This PR resolves an issue where the Weixin (ilinkai) adapter would occasionally deliver the same logical message twice within a short window (~3 seconds). Because the upstream API assigns unique `message_id` values to these duplicate deliveries, they bypassed the existing ID-based deduplicator, causing the agent to respond twice to the same user query.

The fix implements a secondary deduplication layer in the Weixin adapter that fingerprints messages based on a hash of the `sender_id` and the `text` content. This ensures that identical text from the same sender within the deduplicator's 5-minute TTL window is only processed once.

## Related Issue

Fixes #16182

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/platforms/weixin.py`**: Updated `_process_message` to calculate an MD5 content fingerprint (`content:{sender_id}:{text_hash}`) for messages containing text. If this fingerprint is already present in the deduplicator, the message is dropped early.
- **`tests/gateway/test_weixin.py`**: Added a new `TestWeixinContentDedup` class with regression tests to verify:
    1. Duplicate content with different message IDs is correctly caught and dropped.
    2. Messages without text (media-only) bypass the content-based logic to prevent false positives on consecutive media uploads.

## How to Test

1. **Automated Tests:** Run the targeted test suite using:
   ```bash
   pytest tests/gateway/test_weixin.py -v
   
2. **Manual Verification:** Monitor gateway logs during a Weixin session. Verify that the debug log `[Weixin] Content-dedup: skipping duplicate message from ...` appears if the upstream API sends a redundant poll response.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

**Test Execution Output:**

```text
tests/gateway/test_weixin.py::TestWeixinContentDedup::test_duplicate_content_with_different_message_ids_is_dropped PASSED
tests/gateway/test_weixin.py::TestWeixinContentDedup::test_content_dedup_not_called_for_messages_without_text PASSED

======================== 44 passed, 2 warnings in 4.68s =======================