### PR TITLE
fix(models): strip :cloud/-cloud suffix from models.dev Ollama Cloud IDs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2896,6 +2896,19 @@ def fetch_api_models(
 _OLLAMA_CLOUD_CACHE_TTL = 3600  # 1 hour
 
 
+def _strip_ollama_cloud_suffix(model_id: str) -> str:
+    """Strip :cloud / -cloud suffixes that models.dev appends to Ollama Cloud IDs.
+
+    The live API uses clean IDs (e.g. 'kimi-k2.6') while models.dev sometimes
+    returns them as 'kimi-k2.6:cloud'. Normalising before the dedup merge
+    prevents duplicate entries in the merged model list.
+    """
+    for suffix in (":cloud", "-cloud"):
+        if model_id.endswith(suffix):
+            return model_id[: -len(suffix)]
+    return model_id
+
+
 def _ollama_cloud_cache_path() -> Path:
     """Return the path for the Ollama Cloud model cache."""
     from hermes_constants import get_hermes_home
@@ -2991,9 +3004,10 @@ def fetch_ollama_cloud_models(
                 seen.add(m)
                 merged.append(m)
         for m in mdev_models:
-            if m and m not in seen:
-                seen.add(m)
-                merged.append(m)
+            normalized = _strip_ollama_cloud_suffix(m)
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                merged.append(normalized)
         if merged:
             _save_ollama_cloud_cache(merged)
             return merged

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -401,6 +401,103 @@ class TestOllamaCloudProvidersNew:
         assert pdef.transport == "openai_chat"
 
 
+# ── Cloud Suffix Stripping ──
+
+class TestOllamaCloudSuffixStripping:
+    """models.dev appends :cloud / -cloud suffixes that the live API omits.
+
+    fetch_ollama_cloud_models() must normalise these before the dedup merge so
+    users never see broken IDs like 'kimi-k2.6:cloud' in the model picker.
+    """
+
+    def test_strips_colon_cloud_suffix(self, tmp_path, monkeypatch):
+        """:cloud suffix from models.dev is stripped before merge."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {"kimi-k2.6:cloud": {"tool_call": True}}
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert "kimi-k2.6" in result
+        assert "kimi-k2.6:cloud" not in result
+
+    def test_strips_dash_cloud_suffix(self, tmp_path, monkeypatch):
+        """-cloud suffix from models.dev is stripped before merge."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {"qwen3-coder:480b-cloud": {"tool_call": True}}
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert "qwen3-coder:480b" in result
+        assert "qwen3-coder:480b-cloud" not in result
+
+    def test_no_duplicate_when_live_clean_and_mdev_suffixed(self, tmp_path, monkeypatch):
+        """Live API returns clean ID; mdev has :cloud variant — result has exactly one entry."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "kimi-k2.6:cloud": {"tool_call": True},
+                    "glm-5.1:cloud": {"tool_call": True},
+                }
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["kimi-k2.6", "glm-5.1"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert result.count("kimi-k2.6") == 1
+        assert result.count("glm-5.1") == 1
+        assert "kimi-k2.6:cloud" not in result
+        assert "glm-5.1:cloud" not in result
+
+    def test_unsuffixed_model_id_unchanged(self, tmp_path, monkeypatch):
+        """Model IDs without :cloud / -cloud suffix are passed through unchanged."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {"nemotron-3-nano:30b": {"tool_call": True}}
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert "nemotron-3-nano:30b" in result
+
+    def test_strip_suffix_helper(self):
+        """Unit test for the _strip_ollama_cloud_suffix helper."""
+        from hermes_cli.models import _strip_ollama_cloud_suffix
+
+        assert _strip_ollama_cloud_suffix("kimi-k2.6:cloud") == "kimi-k2.6"
+        assert _strip_ollama_cloud_suffix("glm-5.1:cloud") == "glm-5.1"
+        assert _strip_ollama_cloud_suffix("qwen3-coder:480b-cloud") == "qwen3-coder:480b"
+        assert _strip_ollama_cloud_suffix("nemotron-3-nano:30b") == "nemotron-3-nano:30b"
+        assert _strip_ollama_cloud_suffix("") == ""
+
+
 # ── Auxiliary Model ──
 
 class TestOllamaCloudAuxiliary:


### PR DESCRIPTION
## Summary
- `fetch_ollama_cloud_models()` merges live API results with models.dev additions
- models.dev appends `:cloud` / `-cloud` suffixes to Ollama Cloud IDs (e.g. `kimi-k2.6:cloud`, `qwen3-coder:480b-cloud`) that the live API does not use
- Without normalisation, these suffixed IDs bypass the dedup check and appear alongside the correct clean IDs in `/model` and `hermes model`

## The bug

`models.dev` lists Ollama Cloud model IDs with appended `:cloud` / `-cloud` suffixes. The live Ollama Cloud API (`https://ollama.com/v1/models`) returns the same models without those suffixes. In the merge loop:

```python
for m in mdev_models:
    if m and m not in seen:   # "kimi-k2.6:cloud" ≠ "kimi-k2.6" → bypasses dedup
        seen.add(m)
        merged.append(m)       # broken ID added to cache
```

Users end up with entries like `kimi-k2.6:cloud` in the model picker. Selecting one triggers a 400/404 from the Ollama API because that ID does not exist.

## The fix

Added `_strip_ollama_cloud_suffix(model_id)` that removes `:cloud` and `-cloud` tail suffixes, and applies it to each mdev model ID before the dedup check:

```python
for m in mdev_models:
    normalized = _strip_ollama_cloud_suffix(m)
    if normalized and normalized not in seen:
        seen.add(normalized)
        merged.append(normalized)
```

Applies to both the case where live API models are available (prevents suffixed duplicates) and the no-API-key fallback (strips suffixes from mdev-only results).

## Test plan
- [x] **Before**: old merge code produces `['kimi-k2.6', 'glm-5.1', 'kimi-k2.6:cloud', 'glm-5.1:cloud', 'qwen3-coder:480b-cloud']` — confirmed locally
- [x] **After**: `test_no_duplicate_when_live_clean_and_mdev_suffixed` — exactly one `kimi-k2.6`, no `:cloud` entries
- [x] `:cloud` suffix stripping: `test_strips_colon_cloud_suffix`
- [x] `-cloud` suffix stripping: `test_strips_dash_cloud_suffix`
- [x] Unsuffixed IDs unchanged: `test_unsuffixed_model_id_unchanged`
- [x] Helper unit test: `test_strip_suffix_helper`
- [x] All 45 existing + new `test_ollama_cloud_provider.py` tests pass

## Related
- Fixes #16179

🤖 Generated with [Claude Code](https://claude.com/claude-code)