### PR TITLE
fix(cli): wire approvals in background tasks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6313,6 +6313,12 @@ class HermesCLI:
         turn_route = self._resolve_turn_agent_config(prompt)
 
         def run_background():
+            set_sudo_password_callback(self._sudo_password_callback)
+            set_approval_callback(self._approval_callback)
+            try:
+                set_secret_capture_callback(self._secret_capture_callback)
+            except Exception:
+                pass
             try:
                 bg_agent = AIAgent(
                     model=turn_route["model"],
@@ -6410,6 +6416,12 @@ class HermesCLI:
                 print()
                 _cprint(f"  ❌ Background task #{task_num} failed: {e}")
             finally:
+                try:
+                    set_sudo_password_callback(None)
+                    set_approval_callback(None)
+                    set_secret_capture_callback(None)
+                except Exception:
+                    pass
                 self._background_tasks.pop(task_id, None)
                 # Clear spinner only if no foreground agent owns it
                 if not self._agent_running:

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -31,6 +31,40 @@ def _make_cli_stub():
     return cli
 
 
+def _make_background_cli_stub():
+    cli = _make_cli_stub()
+    cli._background_task_counter = 0
+    cli._background_tasks = {}
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(return_value={
+        "model": "test-model",
+        "runtime": {
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "provider": "test",
+            "api_mode": "chat_completions",
+        },
+        "request_overrides": None,
+    })
+    cli.max_turns = 90
+    cli.enabled_toolsets = []
+    cli._session_db = None
+    cli.reasoning_config = {}
+    cli.service_tier = None
+    cli._providers_only = None
+    cli._providers_ignore = None
+    cli._providers_order = None
+    cli._provider_sort = None
+    cli._provider_require_params = None
+    cli._provider_data_collection = None
+    cli._fallback_model = None
+    cli._agent_running = False
+    cli._spinner_text = ""
+    cli.bell_on_complete = False
+    cli.final_response_markdown = "strip"
+    return cli
+
+
 class TestCliApprovalUi:
     def test_sudo_prompt_restores_existing_draft_after_response(self):
         cli = _make_cli_stub()
@@ -254,6 +288,54 @@ class TestCliApprovalUi:
 
         # Command got truncated with a marker.
         assert "(command truncated" in rendered
+
+    def test_background_task_registers_thread_local_approval_callbacks(self):
+        """Background /btw tasks must use the prompt_toolkit approval UI.
+
+        The foreground chat path registers dangerous-command callbacks inside
+        its worker thread because tools.terminal_tool stores them in
+        threading.local(). /background used to skip that, so dangerous commands
+        fell back to raw input() in a background thread and timed out under
+        prompt_toolkit.
+        """
+        cli = _make_background_cli_stub()
+        seen = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **kwargs):
+                from tools.terminal_tool import (
+                    _get_approval_callback,
+                    _get_sudo_password_callback,
+                )
+
+                seen["approval"] = _get_approval_callback()
+                seen["sudo"] = _get_sudo_password_callback()
+                return {
+                    "final_response": "done",
+                    "messages": [],
+                    "completed": True,
+                    "failed": False,
+                }
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console:
+            chat_console.return_value.print = MagicMock()
+            cli._handle_background_command("/btw check weather")
+
+            deadline = time.time() + 2
+            while cli._background_tasks and time.time() < deadline:
+                time.sleep(0.01)
+
+        assert seen["approval"].__self__ is cli
+        assert seen["approval"].__func__ is HermesCLI._approval_callback
+        assert seen["sudo"].__self__ is cli
+        assert seen["sudo"].__func__ is HermesCLI._sudo_password_callback
+        assert not cli._background_tasks
 
 
 class TestApprovalCallbackThreadLocalWiring:


### PR DESCRIPTION
## What does this PR do?

Fixes background CLI tasks such as `/background` and `/btw` so dangerous-command approval, sudo password, and secret capture callbacks are registered inside the background worker thread.

The foreground chat path already does this because these callbacks are stored in thread-local state. Background tasks skipped that setup, so a dangerous command in `/btw` could fall back to the raw `input()` approval prompt while prompt_toolkit owned stdin. That made the prompt effectively unanswerable and caused it to time out.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `cli.py`: registers sudo, approval, and secret callbacks inside `run_background()`, then clears them in `finally`.
- `tests/cli/test_cli_approval_ui.py`: adds regression coverage proving background tasks can see the thread-local callbacks.

## How to Test

1. Run `pytest -n 4 tests/cli/test_cli_approval_ui.py tests/tools/test_yolo_mode.py`.
2. In the classic CLI, run a `/btw` prompt that triggers a dangerous command approval.
3. Confirm the prompt_toolkit approval UI handles the approval instead of falling back to the raw `[o]nce | [s]ession | [d]eny` input prompt.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Ubuntu on Windows Terminal

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests passed:

`pytest -n 4 tests/cli/test_cli_approval_ui.py tests/tools/test_yolo_mode.py`
