### PR TITLE
chore(models): drop deepseek from OpenRouter + Nous Portal picker lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -33,8 +33,6 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("moonshotai/kimi-k2.6",            "recommended"),
-    ("deepseek/deepseek-v4-pro",        ""),
-    ("deepseek/deepseek-v4-flash",      ""),
     ("anthropic/claude-opus-4.7",       ""),
     ("anthropic/claude-opus-4.6",       ""),
     ("anthropic/claude-sonnet-4.6",     ""),
@@ -111,8 +109,6 @@ def _codex_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "moonshotai/kimi-k2.6",
-        "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-v4-flash",
         "xiaomi/mimo-v2.5-pro",
         "xiaomi/mimo-v2.5",
         "anthropic/claude-opus-4.7",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-04-26T12:34:42Z",
+  "updated_at": "2026-04-26T19:27:12Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -15,14 +15,6 @@
         {
           "id": "moonshotai/kimi-k2.6",
           "description": "recommended"
-        },
-        {
-          "id": "deepseek/deepseek-v4-pro",
-          "description": ""
-        },
-        {
-          "id": "deepseek/deepseek-v4-flash",
-          "description": ""
         },
         {
           "id": "anthropic/claude-opus-4.7",
@@ -162,12 +154,6 @@
       "models": [
         {
           "id": "moonshotai/kimi-k2.6"
-        },
-        {
-          "id": "deepseek/deepseek-v4-pro"
-        },
-        {
-          "id": "deepseek/deepseek-v4-flash"
         },
         {
           "id": "xiaomi/mimo-v2.5-pro"


### PR DESCRIPTION
## Summary
Removes deepseek/deepseek-v4-pro and deepseek/deepseek-v4-flash from the OpenRouter and Nous Portal curated picker lists, and regenerates the hosted model-catalog.json so the live picker drops them too.

## Changes
- hermes_cli/models.py: 2 entries removed from OPENROUTER_MODELS, 2 from _PROVIDER_MODELS['nous']
- website/static/api/model-catalog.json: regenerated via scripts/build_model_catalog.py

## Scope
Direct-API deepseek provider entries (_PROVIDER_MODELS['deepseek'], PROVIDER_REGISTRY, normalization) are untouched — this only affects the curated picker lists for the two aggregators.