### PR TITLE
fix(security): restore .env/auth.json/state.db with 0600 perms

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -50,6 +50,9 @@ _EXCLUDED_NAMES = {
     "cron.pid",
 }
 
+# zipfile.open() drops Unix mode bits on extract; restore tightens these to 0600.
+_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+
 
 def _should_exclude(rel_path: Path) -> bool:
     """Return True if *rel_path* (relative to hermes root) should be skipped."""
@@ -370,6 +373,8 @@ def run_import(args) -> None:
                 target.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(member) as src, open(target, "wb") as dst:
                     dst.write(src.read())
+                if target.name in _SECRET_FILE_NAMES:
+                    os.chmod(target, 0o600)
                 restored += 1
             except (PermissionError, OSError) as exc:
                 errors.append(f"  {rel}: {exc}")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -447,6 +447,32 @@ class TestImport:
         with pytest.raises(SystemExit):
             run_import(args)
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+    def test_restores_secret_files_with_0600_perms(self, tmp_path, monkeypatch):
+        """Secret files must end up at 0600 after restore (zipfile drops mode bits)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._make_backup_zip(zip_path, {
+            "config.yaml": "model: openrouter\n",
+            ".env": "OPENROUTER_API_KEY=sk-secret\n",
+            "auth.json": '{"providers": {"nous": "token"}}',
+            "state.db": b"SQLite format 3\x00",
+            "profiles/coder/.env": "ANTHROPIC_API_KEY=sk-ant-secret\n",
+        })
+
+        args = Namespace(zipfile=str(zip_path), force=True)
+
+        from hermes_cli.backup import run_import
+        run_import(args)
+
+        for rel in (".env", "auth.json", "state.db", "profiles/coder/.env"):
+            mode = (hermes_home / rel).stat().st_mode & 0o777
+            assert mode == 0o600, f"{rel} restored with mode {oct(mode)}, expected 0o600"
+
 
 # ---------------------------------------------------------------------------
 # Round-trip test


### PR DESCRIPTION
## Summary
- `hermes import` was creating `.env`, `auth.json`, and `state.db` with the process umask (typically `0644`) instead of `0600`. `zipfile.open()` does not honor the Unix mode bits stored in the zip member's `external_attr`; the restore loop uses `open(target, "wb")` which always falls back to umask.
- **Threat:** silent privilege downgrade after a routine restore on multi-user systems (shared dev boxes, CI runners, jump hosts) — any local user could `cat ~/.hermes/.env` to lift API keys and OAuth tokens.
- The fix mirrors the convention already used at file *creation* time (`hermes_cli/auth.py:833, 1308`: `chmod(path, stat.S_IRUSR | stat.S_IWUSR)`).
- The quick-snapshot restore path (`restore_quick_snapshot`) is unaffected — it uses `shutil.copy2` which preserves perms via `copystat()`. Only `run_import` (the zip restore) was broken.

## Test plan
- [x] New unit test `test_restores_secret_files_with_0600_perms` covers `.env`, `auth.json`, `state.db`, and a profile-nested `.env` (`profiles/coder/.env`)
- [x] All 69 tests in `tests/hermes_cli/test_backup.py` pass via `scripts/run_tests.sh` (CI-parity wrapper)
- [x] **Negative control:** with the `chmod` line removed, the new test fails with `AssertionError: .env restored with mode 0o644, expected 0o600` — confirming the test catches the original bug
- [x] **Manual round-trip:** created a backup with source files at `0644`, restored into a fresh `HERMES_HOME`, verified secret files land at `0600` and `config.yaml` stays at `0644` (no scope creep)
- [x] Tested on macOS (Darwin 24.6.0). Test is gated on `os.name == "posix"` since Windows doesn't honor POSIX mode bits.

## Notes
- Why force `0600` instead of restoring the zip's `external_attr`? Zip permission preservation is unreliable cross-platform (Windows zips often have empty `external_attr`); forcing `0600` on a known set of secret-bearing files is the safe fail-closed default. We also *want* these files at `0600` even if the source was wrong — restore is the right moment to correct it.
- `os.chmod` failures flow into the existing `try/except (PermissionError, OSError)` in the loop, so they're recorded as warnings rather than crashing the restore.