### PR TITLE
fix(run_agent): shut down background review memory providers (salvage #15289)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3304,10 +3304,15 @@ class AIAgent:
                 logger.warning("Background memory/skill review failed: %s", e)
                 self._emit_auxiliary_failure("background review", e)
             finally:
-                # Close all resources (httpx client, subprocesses, etc.) so
-                # GC doesn't try to clean them up on a dead asyncio event
-                # loop (which produces "Event loop is closed" errors).
+                # Background review agents can initialize memory providers
+                # (for example Hindsight) that own their own network clients.
+                # Explicitly stop those providers before closing the agent so
+                # their aiohttp sessions do not leak until GC/process exit.
                 if review_agent is not None:
+                    try:
+                        review_agent.shutdown_memory_provider()
+                    except Exception:
+                        pass
                     try:
                         review_agent.close()
                     except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3308,6 +3308,10 @@ class AIAgent:
                 # (for example Hindsight) that own their own network clients.
                 # Explicitly stop those providers before closing the agent so
                 # their aiohttp sessions do not leak until GC/process exit.
+                # Then close all remaining resources (httpx client,
+                # subprocesses, etc.) so GC doesn't try to clean them up on a
+                # dead asyncio event loop (which produces "Event loop is
+                # closed" errors).
                 if review_agent is not None:
                     try:
                         review_agent.shutdown_memory_provider()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -199,6 +199,7 @@ AUTHOR_MAP = {
     "satelerd@gmail.com": "satelerd",
     "dan@danlynn.com": "danklynn",
     "mattmaximo@hotmail.com": "MattMaximo",
+    "MatthewRHardwick@gmail.com": "mrhwick",
     "149063006+j3ffffff@users.noreply.github.com": "j3ffffff",
     "A-FdL-Prog@users.noreply.github.com": "A-FdL-Prog",
     "l0hde@users.noreply.github.com": "l0hde",

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -1,0 +1,66 @@
+"""Regression tests for background review agent cleanup."""
+
+from __future__ import annotations
+
+import run_agent as run_agent_module
+from run_agent import AIAgent
+
+
+def _bare_agent() -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.model = "fake-model"
+    agent.platform = "telegram"
+    agent.provider = "openai"
+    agent._memory_store = object()
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    agent._COMBINED_REVIEW_PROMPT = "review both"
+    agent.background_review_callback = None
+    agent._safe_print = lambda *_args, **_kwargs: None
+    return agent
+
+
+class ImmediateThread:
+    def __init__(self, *, target, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
+    events = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            events.append(("init", kwargs))
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            events.append(("run_conversation", kwargs))
+
+        def shutdown_memory_provider(self):
+            events.append(("shutdown_memory_provider", None))
+
+        def close(self):
+            events.append(("close", None))
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert [name for name, _payload in events] == [
+        "init",
+        "run_conversation",
+        "shutdown_memory_provider",
+        "close",
+    ]

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -11,6 +11,12 @@ def _bare_agent() -> AIAgent:
     agent.model = "fake-model"
     agent.platform = "telegram"
     agent.provider = "openai"
+    agent.base_url = ""
+    agent.api_key = ""
+    agent.api_mode = ""
+    agent.session_id = "test-session"
+    agent._parent_session_id = ""
+    agent._credential_pool = None
     agent._memory_store = object()
     agent._memory_enabled = True
     agent._user_profile_enabled = False
@@ -18,6 +24,7 @@ def _bare_agent() -> AIAgent:
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
     agent.background_review_callback = None
+    agent.status_callback = None
     agent._safe_print = lambda *_args, **_kwargs: None
     return agent
 


### PR DESCRIPTION
Shuts down the fork's memory provider before close so Hindsight's aiohttp session doesn't leak once per turn.

Salvage of #15289 by @mrhwick. Cherry-picked all three contributor commits onto current main; author attribution preserved via rebase merge.

## Changes
- run_agent.py `_spawn_background_review`: call `review_agent.shutdown_memory_provider()` in `finally` before `review_agent.close()`. Guarded with try/except Exception: pass.
- tests/run_agent/test_background_review.py: new regression test asserting order init → run_conversation → shutdown_memory_provider → close.
- scripts/release.py: AUTHOR_MAP entry (already in original PR).
- **Follow-up (ours):** extended the test's bare-agent helper with `session_id`, `_parent_session_id`, `_credential_pool`, `base_url/api_key/api_mode`, and `status_callback` — live-runtime attrs the review fork started touching after #16099 landed.

## Validation
| | Before | After |
|---|---|---|
| run_agent.py `finally` block | close() only | shutdown_memory_provider() then close() |
| Targeted test | — | passes (2.6s) |
| E2E method trace | init → run → close | init → run → shutdown → close |

Closes #15289 (original PR, merged via salvage).