### PR TITLE
feat(gateway): add Feishu per-chat channel prompts

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -574,6 +574,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "free_response_chats" in platform_cfg:
+                    bridged["free_response_chats"] = platform_cfg["free_response_chats"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -669,6 +671,17 @@ def load_gateway_config() -> GatewayConfig:
                     ):
                         if yaml_key in allow_mentions_cfg and not os.getenv(env_key):
                             os.environ[env_key] = str(allow_mentions_cfg[yaml_key]).lower()
+
+            # Feishu settings → env vars (env vars take precedence)
+            feishu_cfg = yaml_cfg.get("feishu", {})
+            if isinstance(feishu_cfg, dict):
+                if "require_mention" in feishu_cfg and not os.getenv("FEISHU_REQUIRE_MENTION"):
+                    os.environ["FEISHU_REQUIRE_MENTION"] = str(feishu_cfg["require_mention"]).lower()
+                frc = feishu_cfg.get("free_response_chats")
+                if frc is not None and not os.getenv("FEISHU_FREE_RESPONSE_CHATS"):
+                    if isinstance(frc, list):
+                        frc = ",".join(str(v) for v in frc)
+                    os.environ["FEISHU_FREE_RESPONSE_CHATS"] = str(frc)
 
             # Telegram settings → env vars (env vars take precedence)
             telegram_cfg = yaml_cfg.get("telegram", {})
@@ -1126,6 +1139,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
             "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
         })
+        feishu_require_mention = os.getenv("FEISHU_REQUIRE_MENTION")
+        if feishu_require_mention is not None:
+            config.platforms[Platform.FEISHU].extra["require_mention"] = (
+                feishu_require_mention.strip().lower() in {"true", "1", "yes", "on"}
+            )
+        feishu_free_response_chats = os.getenv("FEISHU_FREE_RESPONSE_CHATS")
+        if feishu_free_response_chats is not None:
+            config.platforms[Platform.FEISHU].extra["free_response_chats"] = [
+                item.strip()
+                for item in feishu_free_response_chats.split(",")
+                if item.strip()
+            ]
         feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
             config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -132,6 +132,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     ProcessingOutcome,
+    resolve_channel_prompt,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
     cache_document_from_bytes,
@@ -364,6 +365,8 @@ class FeishuAdapterSettings:
     verification_token: str
     group_policy: str
     allowed_group_users: frozenset[str]
+    require_mention: bool
+    free_response_chats: frozenset[str]
     # Bot's own open_id (app-scoped) — returned by /bot/v3/info.  Used only for
     # @mention matching: Feishu puts this value in mentions[].id.open_id when
     # a user @-mentions the bot in a group chat.
@@ -1390,6 +1393,33 @@ class FeishuAdapter(BasePlatformAdapter):
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
 
+        require_mention_config = extra.get("require_mention")
+        if require_mention_config is None:
+            require_mention = os.getenv("FEISHU_REQUIRE_MENTION", "true").strip().lower() in (
+                "true",
+                "1",
+                "yes",
+                "on",
+            )
+        elif isinstance(require_mention_config, str):
+            require_mention = require_mention_config.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            require_mention = bool(require_mention_config)
+
+        raw_free_response_chats = extra.get("free_response_chats")
+        if raw_free_response_chats is None:
+            raw_free_response_chats = extra.get("free_response_channels")
+        if raw_free_response_chats is None:
+            raw_free_response_chats = os.getenv("FEISHU_FREE_RESPONSE_CHATS", "")
+        if isinstance(raw_free_response_chats, str):
+            free_response_chats = frozenset(
+                item.strip() for item in raw_free_response_chats.split(",") if item.strip()
+            )
+        elif isinstance(raw_free_response_chats, (list, tuple, set, frozenset)):
+            free_response_chats = frozenset(str(item).strip() for item in raw_free_response_chats if str(item).strip())
+        else:
+            free_response_chats = frozenset()
+
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
@@ -1405,6 +1435,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
+            require_mention=require_mention,
+            free_response_chats=free_response_chats,
             bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
             bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
             bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
@@ -1457,6 +1489,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._verification_token = settings.verification_token
         self._group_policy = settings.group_policy
         self._allowed_group_users = set(settings.allowed_group_users)
+        self._require_mention = settings.require_mention
+        self._free_response_chats = set(settings.free_response_chats)
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
         self._group_rules = settings.group_rules
@@ -2409,6 +2443,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         sender_profile = await self._resolve_sender_profile(user_id_obj)
         chat_info = await self.get_chat_info(chat_id)
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        channel_prompt = resolve_channel_prompt(config_extra, chat_id, None)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2424,6 +2460,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=message_id,
+            channel_prompt=channel_prompt,
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing reaction %s:%s on bot message %s as synthetic event", action, emoji_type, message_id)
@@ -2471,6 +2508,8 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
         sender_profile = await self._resolve_sender_profile(sender_id)
         chat_info = await self.get_chat_info(chat_id)
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        channel_prompt = resolve_channel_prompt(config_extra, chat_id, None)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2486,6 +2525,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=token or str(uuid.uuid4()),
+            channel_prompt=channel_prompt,
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
@@ -2717,6 +2757,8 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id)
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        channel_prompt = resolve_channel_prompt(config_extra, chat_id, None)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2736,6 +2778,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
+            channel_prompt=channel_prompt,
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)
@@ -3625,10 +3668,21 @@ class FeishuAdapter(BasePlatformAdapter):
 
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
+    def _feishu_require_mention(self) -> bool:
+        return bool(getattr(self, "_require_mention", True))
+
+    def _feishu_free_response_chats(self) -> set[str]:
+        raw = getattr(self, "_free_response_chats", set())
+        return {str(chat_id).strip() for chat_id in raw if str(chat_id).strip()}
+
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Apply Feishu group trigger rules after the group policy gate."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        if chat_id and chat_id in self._feishu_free_response_chats():
+            return True
+        if not self._feishu_require_mention():
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -833,6 +833,11 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Feishu / Lark platform settings (gateway mode)
+    "feishu": {
+        "channel_prompts": {},         # Per-chat ephemeral system prompts
+    },
+
     # Discord platform settings (gateway mode)
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -76,6 +76,50 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_xxx",
+        "FEISHU_APP_SECRET": "secret_xxx",
+        "FEISHU_REQUIRE_MENTION": "false",
+        "FEISHU_FREE_RESPONSE_CHATS": "oc_alpha, oc_beta",
+    }, clear=False)
+    def test_feishu_group_gating_loaded_from_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        extra = config.platforms[Platform.FEISHU].extra
+        self.assertFalse(extra["require_mention"])
+        self.assertEqual(extra["free_response_chats"], ["oc_alpha", "oc_beta"])
+
+
+def test_config_bridges_feishu_free_response_chats(monkeypatch, tmp_path):
+    from gateway.config import Platform, load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "feishu:\n"
+        "  require_mention: false\n"
+        "  free_response_chats:\n"
+        "    - oc_alpha\n"
+        "    - oc_beta\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("FEISHU_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("FEISHU_FREE_RESPONSE_CHATS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    feishu_extra = config.platforms[Platform.FEISHU].extra
+    assert feishu_extra.get("require_mention") is False
+    assert feishu_extra.get("free_response_chats") == ["oc_alpha", "oc_beta"]
+    assert os.environ["FEISHU_REQUIRE_MENTION"] == "false"
+    assert os.environ["FEISHU_FREE_RESPONSE_CHATS"] == "oc_alpha,oc_beta"
+
 
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):
@@ -3998,6 +4042,50 @@ class TestFeishuPostMentionsBot(unittest.TestCase):
         self.assertFalse(adapter._post_mentions_bot([]))
 
 
+class TestFeishuGroupGating(unittest.TestCase):
+    def _build_adapter(self, *, require_mention=True, free_response_chats=None):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._admins = set()
+        adapter._group_rules = {}
+        adapter._default_group_policy = "open"
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = set()
+        adapter._require_mention = require_mention
+        adapter._free_response_chats = set(free_response_chats or [])
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_user_id = ""
+        adapter._bot_name = "Hermes"
+        return adapter
+
+    def _build_message(self, text="plain hello", mentions=None):
+        return SimpleNamespace(
+            content=json.dumps({"text": text}),
+            mentions=mentions,
+            message_type="text",
+        )
+
+    def test_requires_mention_by_default(self):
+        adapter = self._build_adapter(require_mention=True)
+        message = self._build_message()
+
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_plain"))
+
+    def test_require_mention_false_allows_plain_group_message(self):
+        adapter = self._build_adapter(require_mention=False)
+        message = self._build_message()
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_plain"))
+
+    def test_free_response_chat_bypasses_mention_requirement(self):
+        adapter = self._build_adapter(require_mention=True, free_response_chats={"oc_open"})
+        message = self._build_message()
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_open"))
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id=None, chat_id="oc_other"))
+
+
 class TestFeishuExtractMessageContent(unittest.TestCase):
     def _build_adapter(self):
         from gateway.platforms.feishu import FeishuAdapter
@@ -4050,6 +4138,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = SimpleNamespace(extra={})
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
@@ -4198,6 +4287,33 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertEqual(event.text, "stop pinging @Hermes please")
 
+    def test_process_inbound_message_applies_channel_prompt(self):
+        adapter = self._build_adapter()
+        adapter.config.extra["channel_prompts"] = {"oc_chat": "You are the release bot."}
+        message = SimpleNamespace(
+            content=json.dumps({"text": "plain hello"}),
+            message_type="text",
+            message_id="m_prompt",
+            mentions=None,
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_prompt",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.channel_prompt, "You are the release bot.")
+
     def test_pure_self_mention_message_is_ignored(self):
         """A message containing only '@Bot' (no body, no media) must not dispatch.
 
@@ -4340,6 +4456,7 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = SimpleNamespace(extra={})
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
@@ -4469,6 +4586,46 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertIn("[Mentioned: Alice (open_id=ou_alice)]", event.text)
         self.assertIn("@Alice lookup this doc", event.text)
+
+
+class TestFeishuSyntheticChannelPrompt(unittest.TestCase):
+    def _build_adapter(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = SimpleNamespace(extra={"channel_prompts": {"oc_chat": "You are the ops bot."}})
+        adapter._card_action_tokens = {}
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_user_id = ""
+        adapter._bot_name = "Hermes"
+        adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
+        adapter._fetch_message_text = AsyncMock(return_value=None)
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
+        )
+        adapter.get_chat_info = AsyncMock(return_value={"name": "Ops Chat"})
+        adapter._resolve_source_chat_type = Mock(return_value="group")
+        adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
+        adapter._handle_message_with_guards = AsyncMock()
+        adapter._dispatch_inbound_event = AsyncMock()
+        return adapter
+
+    def test_card_action_event_applies_channel_prompt(self):
+        adapter = self._build_adapter()
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                token="tok_1",
+                context=SimpleNamespace(open_chat_id="oc_chat"),
+                operator=SimpleNamespace(open_id="ou_operator"),
+                action=SimpleNamespace(tag="button", value={"action": "deploy"}),
+            )
+        )
+
+        asyncio.run(adapter._handle_card_action_event(data))
+
+        event = adapter._handle_message_with_guards.call_args.args[0]
+        self.assertEqual(event.channel_prompt, "You are the ops bot.")
+        self.assertEqual(event.message_type.name, "COMMAND")
 
     def test_scenario_post_bot_plus_alice_filters_self_from_hint(self):
         """Post-type message @-ing both the bot and Alice: leading bot is

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -215,6 +215,36 @@ FEISHU_BOT_NAME=MyBot
 
 If none of these are set, the adapter will attempt to auto-discover the bot name via the Application Info API on startup. For this to work, grant the `admin:app.info:readonly` or `application:application:self_manage` permission scope.
 
+## Per-Chat Agent Descriptions
+
+You can inject different ephemeral system prompts for different Feishu / Lark chats by using `feishu.channel_prompts` in `~/.hermes/config.yaml`.
+
+These prompts:
+
+- apply on every turn in the matching chat
+- are keyed by Feishu `chat_id` (for example `oc_xxx`)
+- are **not** persisted to transcript history
+
+```yaml
+feishu:
+  channel_prompts:
+    oc_release_chat: |
+      You are a release-management assistant.
+      Focus on incidents, rollbacks, deploy health, and concise next steps.
+
+    oc_research_chat: |
+      You are a research assistant.
+      Compare options, surface tradeoffs, and cite sources when possible.
+```
+
+Behavior:
+
+- message in `oc_release_chat` → release-management prompt applied
+- message in `oc_research_chat` → research prompt applied
+- message in any other chat → no per-chat prompt applied
+
+Use this when you want one Hermes gateway instance to behave like different "agents" in different Feishu groups.
+
 ## Interactive Card Actions
 
 When users click buttons or interact with interactive cards sent by the bot, the adapter routes these as synthetic `/card` command events:


### PR DESCRIPTION
## Background
- Hermes Feishu adapter currently supports a single global agent identity, which is not enough when one bot is shared across multiple group chats with different roles.
- Different Feishu chats often need different system behavior, such as release triage, research assistance, or internal ops coordination.
- The adapter already normalizes several Feishu event paths, so per-chat prompt injection belongs in that normalization layer instead of being duplicated downstream.

## Summary
- add `feishu.channel_prompts` for per-chat agent descriptions
- apply channel prompts to normal inbound messages, reaction-routed synthetic events, and card-action synthetic commands
- document the config and cover Feishu prompt propagation with gateway tests

## Verification
- `venv/bin/python -m pytest tests/gateway/test_feishu.py -q`