### PR TITLE
fix(cron): keep homeassistant toolset enabled when HASS_TOKEN is set

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -11,6 +11,7 @@ the `platform_toolsets` key.
 
 import json as _json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
@@ -676,6 +677,15 @@ def _get_platform_tools(
         # their own platform (e.g. `discord` + `discord` should stay OFF).
         if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
             default_off.remove(platform)
+        # Home Assistant is already runtime-gated by its check_fn (requires
+        # HASS_TOKEN to register any tools). When a user has configured
+        # HASS_TOKEN, they've explicitly opted in — don't also strip it via
+        # _DEFAULT_OFF_TOOLSETS, which would silently drop HA from platforms
+        # (e.g. cron) that run through _get_platform_tools without an
+        # explicit saved toolset list. Without this, Norbert's HA cron jobs
+        # regressed after #14798 made cron honor per-platform tool config.
+        if "homeassistant" in default_off and os.getenv("HASS_TOKEN"):
+            default_off.remove("homeassistant")
         enabled_toolsets -= default_off
 
     # Recover non-configurable platform toolsets (e.g. discord, feishu_doc,

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -41,6 +41,36 @@ def test_get_platform_tools_homeassistant_platform_keeps_homeassistant_toolset()
     assert "homeassistant" in enabled
 
 
+def test_get_platform_tools_homeassistant_toolset_enabled_for_cron_when_hass_token_set(monkeypatch):
+    """HA toolset is runtime-gated by check_fn (requires HASS_TOKEN).
+
+    When HASS_TOKEN is set, the user has explicitly opted in — _DEFAULT_OFF_TOOLSETS
+    shouldn't also strip HA from platforms (like cron) that run through
+    _get_platform_tools without an explicit saved toolset list.
+
+    Regression guard for Norbert's HA cron breakage after #14798 made cron
+    honor per-platform tool config.
+    """
+    monkeypatch.setenv("HASS_TOKEN", "fake-test-token")
+
+    cron_enabled = _get_platform_tools({}, "cron")
+    assert "homeassistant" in cron_enabled
+    # moa must stay off — the original goal of #14798
+    assert "moa" not in cron_enabled
+
+    cli_enabled = _get_platform_tools({}, "cli")
+    assert "homeassistant" in cli_enabled
+
+
+def test_get_platform_tools_homeassistant_toolset_off_for_cron_when_hass_token_missing(monkeypatch):
+    """Without HASS_TOKEN, HA stays off by default — preserves #14798's behavior
+    for users who never configured HA."""
+    monkeypatch.delenv("HASS_TOKEN", raising=False)
+
+    cron_enabled = _get_platform_tools({}, "cron")
+    assert "homeassistant" not in cron_enabled
+
+
 def test_get_platform_tools_preserves_explicit_empty_selection():
     config = {"platform_toolsets": {"cli": []}}
 


### PR DESCRIPTION
## Summary
Restores Home Assistant for cron (and any other platform that relies on `_get_platform_tools()` defaults) when the user has `HASS_TOKEN` configured. Norbert's HA cron reports regressed after #14798 silently stripped `homeassistant` via `_DEFAULT_OFF_TOOLSETS`.

## Root cause
#14798 made cron honor per-platform `hermes tools` config via `_get_platform_tools(cfg, "cron")`. That resolver applies `_DEFAULT_OFF_TOOLSETS = {moa, homeassistant, rl, spotify, discord, discord_admin}` when the platform has no explicit saved toolset list. For existing HA-using cron users, that silently dropped `homeassistant` from the cron toolset — the agent never saw `ha_list_entities` / `ha_get_state` tools and fell back to bash+curl (which also fails because the env blocklist strips HASS_TOKEN from subprocess env).

Telegram kept working because the user's saved `platform_toolsets.telegram` explicitly lists `homeassistant`.

## Fix
The HA toolset's `check_fn` already gates registration on `HASS_TOKEN`. When the token is set, the user has explicitly opted in — `_DEFAULT_OFF_TOOLSETS` is redundant and harmful. When HASS_TOKEN is missing, `check_fn` keeps it off anyway.

Drop `homeassistant` from `_DEFAULT_OFF_TOOLSETS` application iff `HASS_TOKEN` is set. `moa` and `rl` stay off by default (original #14798 goal preserved).

## Changes
- `hermes_cli/tools_config.py`: conditionally remove `homeassistant` from the `default_off` set when `HASS_TOKEN` is set
- `tests/hermes_cli/test_tools_config.py`: two regression tests (token-set → HA on for cron/cli; token-missing → HA off)

## Validation
| Scenario | Before | After |
|---|---|---|
| cron, HASS_TOKEN set, no saved config | HA stripped → 401 via bash curl | HA registered ✓ |
| cron, HASS_TOKEN unset | HA off | HA off (unchanged) |
| cron, HASS_TOKEN set, moa | moa off | moa off (unchanged) |
| telegram, explicit HA in saved config | HA on | HA on (unchanged) |
| `homeassistant` gateway platform | HA on | HA on (unchanged) |

Targeted test results: `tests/hermes_cli/test_tools_config.py` 50/50 pass, `tests/cron/test_scheduler.py` 91/91 pass.