### PR TITLE
fix(memory): close embedded Hindsight async client cleanly (salvage #14605)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1231,9 +1231,19 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._client is not None:
             try:
                 if self._mode == "local_embedded":
-                    # Use the public close() API. The RuntimeError from
-                    # aiohttp's "attached to a different loop" is expected
-                    # and harmless — the daemon keeps running independently.
+                    # HindsightEmbedded.close() delegates to its sync client.close().
+                    # When Hermes created/used that client on the shared async loop,
+                    # closing it from this thread can raise "attached to a different
+                    # loop" before aiohttp releases the session. Close the embedded
+                    # inner async client on the shared loop first, then let the
+                    # wrapper clean up daemon/UI bookkeeping.
+                    inner_client = getattr(self._client, "_client", None)
+                    if inner_client is not None and hasattr(inner_client, "aclose"):
+                        _run_sync(inner_client.aclose())
+                        try:
+                            self._client._client = None
+                        except Exception:
+                            pass
                     try:
                         self._client.close()
                     except RuntimeError:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "julia@alexland.us": "alexg0bot",
     "1060770+benjaminsehl@users.noreply.github.com": "benjaminsehl",
     "nerijusn76@gmail.com": "Nerijusas",
+    "maxim.smetanin@gmail.com": "maxims-oss",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1102,3 +1102,22 @@ class TestSharedEventLoopLifecycle:
 
         mock_client.aclose.assert_called_once()
         assert provider._client is None
+
+
+class TestShutdown:
+    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
+        inner_client = _make_mock_client()
+        embedded = MagicMock()
+        embedded._client = inner_client
+        embedded.close = MagicMock()
+
+        provider._mode = "local_embedded"
+        provider._client = embedded
+
+        provider.shutdown()
+
+        inner_client.aclose.assert_awaited_once()
+        embedded.close.assert_called_once()
+        assert embedded._client is None
+        assert provider._client is None
+


### PR DESCRIPTION
`HindsightEmbedded.close()` delegates to its sync `client.close()`. When Hermes created/used that client on the shared async loop, closing it from the main thread raises `attached to a different loop` before aiohttp releases the session — so the ClientSession / TCPConnector leak past provider teardown.

Fix closes the embedded inner async client on the shared loop first via `_run_sync(inner_client.aclose())`, then lets the wrapper's sync `close()` do its daemon/UI bookkeeping.

Salvage of #14605 by @maxims-oss. Original author attribution preserved via rebase merge.

## Salvage note
PR was stale on the test-file anchor: `TestSharedEventLoopLifecycle` + `TestAvailability` expansions landed on main after the PR was written (file grew 612 → 1104 lines). Rebased the new `TestShutdown` class to append cleanly after `TestSharedEventLoopLifecycle` instead of in the middle. Production hunk was clean.

## Changes
- plugins/memory/hindsight/__init__.py `shutdown()` `local_embedded` branch: close inner async client on shared loop via `_run_sync(inner_client.aclose())` then null out `self._client._client` before calling wrapper `close()`.
- tests/plugins/memory/test_hindsight_provider.py: new `TestShutdown` class with `test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop`.
- scripts/release.py: AUTHOR_MAP entry for @maxims-oss.

## Validation
| | Before | After |
|---|---|---|
| `local_embedded` shutdown | sync `close()` → RuntimeError swallowed, session leaks | inner async `aclose()` on shared loop → wrapper `close()` → clean |
| Targeted test | — | passes (0.4s) |
| Broader hindsight suite | 75 pass, 1 pre-existing uv-not-found env failure | same |

Closes #14605 (original PR, merged via salvage).
