### PR TITLE
fix(docker-env): bridge `terminal.docker_env` from config.yaml to container

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -560,6 +560,7 @@ def load_cli_config() -> Dict[str, Any]:
         "container_disk": "TERMINAL_CONTAINER_DISK",
         "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+        "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
@@ -577,7 +578,7 @@ def load_cli_config() -> Dict[str, Any]:
         if config_key in terminal_config:
             if _file_has_terminal_config or env_var not in os.environ:
                 val = terminal_config[config_key]
-                if isinstance(val, list):
+                if isinstance(val, (list, dict)):
                     os.environ[env_var] = json.dumps(val)
                 else:
                     os.environ[env_var] = str(val)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -141,6 +141,7 @@ if _config_path.exists():
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+                "docker_env": "TERMINAL_DOCKER_ENV",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }
@@ -153,7 +154,7 @@ if _config_path.exists():
                     # Only bridge explicit absolute paths from config.yaml.
                     if _cfg_key == "cwd" and str(_val) in (".", "auto", "cwd"):
                         continue
-                    if isinstance(_val, list):
+                    if isinstance(_val, (list, dict)):
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -488,6 +488,9 @@ def _get_or_create_env(task_id: str):
                 "container_disk": config.get("container_disk", 51200),
                 "container_persistent": config.get("container_persistent", True),
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_env": config.get("docker_env", {}),
             }
 
         ssh_config = None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -381,6 +381,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                 }
 
             ssh_config = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -922,6 +922,7 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
     }
 
 


### PR DESCRIPTION
Closes #16214.

## Summary

`terminal.docker_env` is defined in the schema (`hermes_cli/config.py` ships `"docker_env": {}` with a doc-comment that calls out the systemd-service use case) and consumed in `tools/terminal_tool.py:1607`, but the runtime bridge between `config.yaml` and the spawned container is broken in **five** places so the value never actually reaches the container.

Originally filed as a one-line parity fix to `tools/file_tools.py` (#16214). On follow-up testing it became clear the bridge itself is the root cause; the `file_tools.py`/`code_execution_tool.py` parity gaps just happen to make the failure non-deterministic.

## Root cause

| # | File | Bug |
|---|---|---|
| 1 | `cli.py` (`env_mappings`) | does not promote `terminal.docker_env` → `TERMINAL_DOCKER_ENV` |
| 2 | `gateway/run.py` (`_terminal_env_map`) | likewise omits `docker_env` |
| 3 | `cli.py` and `gateway/run.py` serialization | only `isinstance(val, list)` is `json.dumps`-ed; a `dict` value falls through to `str(val)` and is written as Python repr — which `json.loads` later rejects |
| 4 | `tools/terminal_tool.py:_get_env_config()` | never reads `TERMINAL_DOCKER_ENV`, so the returned config is missing the key even when the env var is set out-of-band |
| 5 | `tools/file_tools.py` and `tools/code_execution_tool.py` | build their own `container_config` dicts without `docker_env` (and `code_execution_tool.py` is also missing `docker_forward_env` and `docker_mount_cwd_to_workspace`) — whichever tool spawns the per-task environment first decides whether the env vars make it in |

## Reproduction

Setup matches the doc-comment in `hermes_cli/config.py:433`:

```yaml
# ~/.hermes/config.yaml
terminal:
  backend: docker
  docker_env:
    SSH_AUTH_SOCK: /run/ssh-agent.sock
  docker_volumes:
    - /run/user/1000/ssh-agent.socket:/run/ssh-agent.sock
```

Run `hermes` (or systemd-managed gateway), open a session, trigger any sandboxed tool call, then:

```bash
$ podman inspect <container-id> --format '{{.Config.Env}}'
[PATH=… HOME=/home/agent …]                # SSH_AUTH_SOCK absent → ssh-agent forwarding broken
```

With this patch:

```bash
[PATH=… HOME=/home/agent SSH_AUTH_SOCK=/run/ssh-agent.sock …]
```

## Diff

5 files, 9 insertions, 2 changes:

```diff
--- a/cli.py
+++ b/cli.py
@@ env_mappings @@
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+        "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
@@ serialization @@
-                if isinstance(val, list):
+                if isinstance(val, (list, dict)):
                     os.environ[env_var] = json.dumps(val)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ _terminal_env_map @@
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+                "docker_env": "TERMINAL_DOCKER_ENV",
@@ serialization @@
-                    if isinstance(_val, list):
+                    if isinstance(_val, (list, dict)):
                         os.environ[_env_var] = json.dumps(_val)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ _get_env_config return dict @@
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
     }

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ container_config @@
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                 }

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ container_config @@
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_env": config.get("docker_env", {}),
             }
```

After this patch the pipeline closes end-to-end: `config.yaml` → JSON-encoded `TERMINAL_DOCKER_ENV` env var → `_get_env_config()["docker_env"]` → all three tool callsites → `DockerEnvironment(env=…)` → container `-e KEY=VALUE` flags.

## Test plan

- [x] Set `terminal.docker_env: {SSH_AUTH_SOCK: …}` in `config.yaml`. Without this patch, the env var is absent in `podman inspect` regardless of which tool runs first; with it, present in every spawned container.
- [x] `python -c "import gateway.run; print(os.environ['TERMINAL_DOCKER_ENV'])"` returns the JSON-encoded dict.
- [x] `python -c "from tools.terminal_tool import _get_env_config; print(_get_env_config()['docker_env'])"` returns the parsed dict.
- [x] Sessions whose first tool call is `read_file` / `execute_code` / `terminal` all produce containers with the same env.
- [ ] Maintainer to re-run any unit tests covering session-environment construction.

## Notes

No behaviour change for users who don't set `terminal.docker_env`: the default is still `{}`, the bridge serializes that to `"{}"`, and `_parse_env_var` returns `{}`. Pure additive.