### PR TITLE
fix(update): sync bundled skills to all profiles, including active (#16176)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6842,20 +6842,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception as e:
             logger.debug("Skills sync during update failed: %s", e)
 
-        # Sync bundled skills to all other profiles
+        # Sync bundled skills to all profiles (including the active one).
+        # seed_profile_skills() uses subprocess with an explicit HERMES_HOME so
+        # it is not affected by sync_skills()'s module-level HERMES_HOME cache,
+        # which means the active profile is reliably synced regardless of whether
+        # the caller's HERMES_HOME env var points at the default or a named profile.
         try:
             from hermes_cli.profiles import (
                 list_profiles,
-                get_active_profile_name,
                 seed_profile_skills,
             )
 
-            active = get_active_profile_name()
-            other_profiles = [p for p in list_profiles() if p.name != active]
-            if other_profiles:
+            all_profiles = list_profiles()
+            if all_profiles:
                 print()
-                print("→ Syncing bundled skills to other profiles...")
-                for p in other_profiles:
+                print("→ Syncing bundled skills to all profiles...")
+                for p in all_profiles:
                     try:
                         r = seed_profile_skills(p.path, quiet=True)
                         if r:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -163,3 +163,78 @@ class TestCmdUpdateBranchFallback:
             mock_input.assert_not_called()
             captured = capsys.readouterr()
             assert "Non-interactive session" in captured.out
+
+
+class TestCmdUpdateProfileSkillSync:
+    """cmd_update syncs bundled skills to all profiles, including the active one.
+
+    Regression guard for #16176: previously the active profile was excluded
+    from the seed_profile_skills loop, leaving it on stale skill content.
+    """
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_active_profile_included_in_skill_sync(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        from pathlib import Path
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        default_p = SimpleNamespace(name="default", path=Path("/fake/.hermes"))
+        active_p = SimpleNamespace(name="bit", path=Path("/fake/.hermes/profiles/bit"))
+        other_p = SimpleNamespace(name="work", path=Path("/fake/.hermes/profiles/work"))
+        all_profiles = [default_p, active_p, other_p]
+
+        synced_paths = []
+
+        def fake_seed(path, quiet=False):
+            synced_paths.append(path)
+            return {"copied": [], "updated": [], "user_modified": []}
+
+        empty_sync = {"copied": [], "updated": [], "user_modified": [], "cleaned": []}
+
+        with (
+            patch("hermes_cli.profiles.list_profiles", return_value=all_profiles),
+            patch("hermes_cli.profiles.seed_profile_skills", side_effect=fake_seed),
+            patch("tools.skills_sync.sync_skills", return_value=empty_sync),
+        ):
+            cmd_update(mock_args)
+
+        assert active_p.path in synced_paths, (
+            f"Active profile 'bit' must be included in skill sync; got: {synced_paths}"
+        )
+        assert set(synced_paths) == {p.path for p in all_profiles}, (
+            f"All profiles must be synced; got: {synced_paths}"
+        )
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_single_profile_default_is_synced(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        from pathlib import Path
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        default_p = SimpleNamespace(name="default", path=Path("/fake/.hermes"))
+        synced_paths = []
+
+        def fake_seed(path, quiet=False):
+            synced_paths.append(path)
+            return {"copied": [], "updated": [], "user_modified": []}
+
+        empty_sync = {"copied": [], "updated": [], "user_modified": [], "cleaned": []}
+
+        with (
+            patch("hermes_cli.profiles.list_profiles", return_value=[default_p]),
+            patch("hermes_cli.profiles.seed_profile_skills", side_effect=fake_seed),
+            patch("tools.skills_sync.sync_skills", return_value=empty_sync),
+        ):
+            cmd_update(mock_args)
+
+        assert default_p.path in synced_paths


### PR DESCRIPTION
## Summary
- `hermes update` was silently skipping the active named profile when seeding bundled skills
- Every other profile received fresh skill content; the active profile drifted without any warning
- Drop the `p.name != active` filter so `seed_profile_skills` is called for all profiles

## The bug

In `hermes_cli/main.py`, the per-profile skill sync loop explicitly excluded the active profile:

```python
active = get_active_profile_name()
other_profiles = [p for p in list_profiles() if p.name != active]
```

`seed_profile_skills()` uses a subprocess with an explicit `HERMES_HOME` override, which means it is not affected by `sync_skills()`'s module-level HERMES_HOME cache and can reliably target any profile directory. The exclusion filter was the only barrier — removing it is sufficient.

The earlier `sync_skills()` call (module-level HERMES_HOME) runs before this loop and covers the "current HERMES_HOME" path. After this fix the active profile is additionally covered by the subprocess-based loop, which is the authoritative path.

## The fix

Remove `get_active_profile_name` from the import and the `p.name != active` filter. Rename `other_profiles` → `all_profiles` and update the header from "other profiles" → "all profiles".

## Test plan
- [x] **Before** (regression guard): simulating old `[p for p in all_profiles if p.name != active]` confirms `active_p.path not in synced` — bug reproduced
- [x] **After**: `test_active_profile_included_in_skill_sync` asserts `active_p.path in synced` and all 3 profile paths appear in the result — **PASS**
- [x] `test_single_profile_default_is_synced` — single-profile (default only) edge case — **PASS**
- [x] All 7 `tests/hermes_cli/test_cmd_update.py` tests **PASS**
- [x] Adjacent suites (`tests/hermes_cli/`) — 72 failures are pre-existing baselines on `origin/main` (web-server host-header, gateway-service systemd) unrelated to touched code

## Related
- Fixes #16176

🤖 Generated with [Claude Code](https://claude.com/claude-code)