### PR TITLE
feat(memory): add AgentMemory CLI integration

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -26,7 +26,10 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from agent.memory_provider import MemoryProvider
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +54,7 @@ def _is_memory_provider_dir(path: Path) -> bool:
     """Heuristic: does *path* look like a memory provider plugin?
 
     Checks for ``register_memory_provider`` or ``MemoryProvider`` in the
-    ``__init__.py`` source.  Cheap text scan — no import needed.
+    ``__init__.py`` source.  Cheap text scan, no import needed.
     """
     init_file = path / "__init__.py"
     if not init_file.exists():
@@ -140,7 +143,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
             except Exception:
                 pass
 
-        # Quick availability check — try loading and calling is_available()
+        # Quick availability check, try loading and calling is_available()
         available = True
         try:
             provider = _load_provider_from_dir(child)
@@ -185,8 +188,8 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
     """Import a provider module and extract the MemoryProvider instance.
 
     The module must have either:
-    - A register(ctx) function (plugin-style) — we simulate a ctx
-    - A top-level class that extends MemoryProvider — we instantiate it
+    - A register(ctx) function (plugin-style), we simulate a ctx
+    - A top-level class that extends MemoryProvider, we instantiate it
     """
     name = provider_dir.name
     # Use a separate namespace for user-installed plugins so they don't
@@ -308,7 +311,7 @@ def _get_active_memory_provider() -> Optional[str]:
     """Read the active memory provider name from config.yaml.
 
     Returns the provider name (e.g. ``"honcho"``) or None if no
-    external provider is configured.  Lightweight — only reads config,
+    external provider is configured.  Lightweight, only reads config,
     no plugin loading.
     """
     try:
@@ -320,87 +323,87 @@ def _get_active_memory_provider() -> Optional[str]:
 
 
 def discover_plugin_cli_commands() -> List[dict]:
-    """Return CLI commands for the **active** memory plugin only.
+    """Return CLI commands exposed by memory plugins.
 
-    Only one memory provider can be active at a time (set via
-    ``memory.provider`` in config.yaml).  This function reads that
-    value and only loads CLI registration for the matching plugin.
-    If no provider is active, no commands are registered.
+    The active memory provider may expose a CLI command. A plugin can also set
+    ``cli_always: true`` in ``plugin.yaml`` when its command is needed before it
+    becomes the active provider, for example setup/status helpers.
 
-    Looks for a ``register_cli(subparser)`` function in the active
-    plugin's ``cli.py``.  Returns a list of at most one dict with
-    keys: ``name``, ``help``, ``description``, ``setup_fn``,
-    ``handler_fn``.
-
-    This is a lightweight scan — it only imports ``cli.py``, not the
-    full plugin module.  Safe to call during argparse setup before
-    any provider is loaded.
+    This is a lightweight scan: it imports only ``cli.py``, not the full provider
+    module. Safe to call during argparse setup before any provider is loaded.
     """
     results: List[dict] = []
     if not _MEMORY_PLUGINS_DIR.is_dir():
         return results
 
     active_provider = _get_active_memory_provider()
-    if not active_provider:
-        return results
+    candidates: list[tuple[str, Path]] = []
+    seen: set[str] = set()
 
-    # Only look at the active provider's directory
-    plugin_dir = find_provider_dir(active_provider)
-    if not plugin_dir:
-        return results
-
-    cli_file = plugin_dir / "cli.py"
-    if not cli_file.exists():
-        return results
-
-    _is_bundled = _MEMORY_PLUGINS_DIR in plugin_dir.parents or plugin_dir.parent == _MEMORY_PLUGINS_DIR
-    module_name = f"plugins.memory.{active_provider}.cli" if _is_bundled else f"_hermes_user_memory.{active_provider}.cli"
-    try:
-        # Import the CLI module (lightweight — no SDK needed)
-        if module_name in sys.modules:
-            cli_mod = sys.modules[module_name]
-        else:
-            spec = importlib.util.spec_from_file_location(
-                module_name, str(cli_file)
-            )
-            if not spec or not spec.loader:
-                return results
-            cli_mod = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = cli_mod
-            spec.loader.exec_module(cli_mod)
-
-        register_cli = getattr(cli_mod, "register_cli", None)
-        if not callable(register_cli):
-            return results
-
-        # Read metadata from plugin.yaml if available
-        help_text = f"Manage {active_provider} memory plugin"
-        description = ""
+    for name, plugin_dir in _iter_provider_dirs():
+        include = name == active_provider
         yaml_file = plugin_dir / "plugin.yaml"
         if yaml_file.exists():
             try:
                 import yaml
                 with open(yaml_file) as f:
                     meta = yaml.safe_load(f) or {}
-                desc = meta.get("description", "")
-                if desc:
-                    help_text = desc
-                    description = desc
+                include = include or bool(meta.get("cli_always"))
             except Exception:
                 pass
+        if include and name not in seen:
+            candidates.append((name, plugin_dir))
+            seen.add(name)
 
-        handler_fn = getattr(cli_mod, f"{active_provider}_command", None) or \
-                     getattr(cli_mod, "honcho_command", None)
+    for provider_name, plugin_dir in candidates:
+        cli_file = plugin_dir / "cli.py"
+        if not cli_file.exists():
+            continue
 
-        results.append({
-            "name": active_provider,
-            "help": help_text,
-            "description": description,
-            "setup_fn": register_cli,
-            "handler_fn": handler_fn,
-            "plugin": active_provider,
-        })
-    except Exception as e:
-        logger.debug("Failed to scan CLI for memory plugin '%s': %s", active_provider, e)
+        _is_bundled = _MEMORY_PLUGINS_DIR in plugin_dir.parents or plugin_dir.parent == _MEMORY_PLUGINS_DIR
+        module_name = f"plugins.memory.{provider_name}.cli" if _is_bundled else f"_hermes_user_memory.{provider_name}.cli"
+        try:
+            if module_name in sys.modules:
+                cli_mod = sys.modules[module_name]
+            else:
+                spec = importlib.util.spec_from_file_location(module_name, str(cli_file))
+                if not spec or not spec.loader:
+                    continue
+                cli_mod = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = cli_mod
+                spec.loader.exec_module(cli_mod)
+
+            register_cli = getattr(cli_mod, "register_cli", None)
+            if not callable(register_cli):
+                continue
+
+            help_text = f"Manage {provider_name} memory plugin"
+            description = ""
+            yaml_file = plugin_dir / "plugin.yaml"
+            if yaml_file.exists():
+                try:
+                    import yaml
+                    with open(yaml_file) as f:
+                        meta = yaml.safe_load(f) or {}
+                    desc = meta.get("description", "")
+                    if desc:
+                        help_text = desc
+                        description = desc
+                except Exception:
+                    pass
+
+            handler_fn = getattr(cli_mod, f"{provider_name}_command", None) or \
+                         getattr(cli_mod, "honcho_command", None)
+
+            results.append({
+                "name": provider_name,
+                "help": help_text,
+                "description": description,
+                "setup_fn": register_cli,
+                "handler_fn": handler_fn,
+                "plugin": provider_name,
+            })
+        except Exception as e:
+            logger.debug("Failed to scan CLI for memory plugin '%s': %s", provider_name, e)
 
     return results

--- a/plugins/memory/agentmemory/__init__.py
+++ b/plugins/memory/agentmemory/__init__.py
@@ -1,0 +1,293 @@
+"""
+agentmemory memory provider for Hermes Agent.
+
+Drop this folder into ~/.hermes/plugins/memory/agentmemory/
+or install via: hermes plugin install agentmemory
+
+Requires agentmemory server running: npx @agentmemory/agentmemory
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+try:
+    from agent.memory_provider import MemoryProvider
+except ImportError:
+    from abc import ABC, abstractmethod
+
+    class MemoryProvider(ABC):
+        @property
+        @abstractmethod
+        def name(self) -> str: ...
+        @abstractmethod
+        def is_available(self) -> bool: ...
+        @abstractmethod
+        def initialize(self, session_id: str, **kwargs: Any) -> None: ...
+        @abstractmethod
+        def get_tool_schemas(self) -> list[dict]: ...
+        @abstractmethod
+        def handle_tool_call(self, name: str, args: dict) -> Any: ...
+        def get_config_schema(self) -> list[dict]: return []
+        def save_config(self, values: dict, hermes_home: str) -> None: pass
+        def system_prompt_block(self) -> str: return ""
+        def prefetch(self, query: str) -> str: return ""
+        def queue_prefetch(self, query: str) -> None: pass
+        def sync_turn(self, user: str, assistant: str) -> None: pass
+        def on_session_end(self, messages: list) -> None: pass
+        def on_pre_compress(self, messages: list) -> None: pass
+        def on_memory_write(self, action: str, target: str, content: str) -> None: pass
+        def shutdown(self) -> None: pass
+
+
+DEFAULT_BASE_URL = "http://localhost:3111"
+TIMEOUT = 5
+
+
+def _validate_url(base: str) -> bool:
+    from urllib.parse import urlparse
+    parsed = urlparse(base)
+    return parsed.scheme in ("http", "https")
+
+
+def _api(base: str, path: str, body: dict | None = None, method: str = "POST", secret: str = "") -> dict | None:
+    if not _validate_url(base):
+        return None
+    url = f"{base}/agentmemory/{path}"
+    headers = {"Content-Type": "application/json"}
+    auth = secret or os.environ.get("AGENTMEMORY_SECRET", "")
+    if auth:
+        headers["Authorization"] = f"Bearer {auth}"
+
+    data = json.dumps(body).encode() if body else None
+    req = Request(url, data=data, headers=headers, method=method)
+    try:
+        with urlopen(req, timeout=TIMEOUT) as resp:
+            return json.loads(resp.read().decode())
+    except (URLError, TimeoutError, json.JSONDecodeError):
+        return None
+
+
+def _api_bg(base: str, path: str, body: dict | None = None) -> None:
+    t = threading.Thread(target=_api, args=(base, path, body), daemon=True)
+    t.start()
+
+
+class AgentMemoryProvider(MemoryProvider):
+
+    @property
+    def name(self) -> str:
+        return "agentmemory"
+
+    def is_available(self) -> bool:
+        base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
+        if not _validate_url(base):
+            return False
+        try:
+            req = Request(f"{base}/", method="GET")
+            with urlopen(req, timeout=2):
+                return True
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
+        self._session_id = session_id
+        self._project = kwargs.get("cwd", os.getcwd())
+
+        _api(self._base, "session/start", {
+            "sessionId": session_id,
+            "project": self._project,
+            "cwd": self._project,
+        })
+
+    def get_config_schema(self) -> list[dict]:
+        return [
+            {
+                "key": "url",
+                "description": "agentmemory server URL",
+                "default": DEFAULT_BASE_URL,
+                "env_var": "AGENTMEMORY_URL",
+            },
+            {
+                "key": "secret",
+                "description": "agentmemory auth secret (optional)",
+                "secret": True,
+                "required": False,
+                "env_var": "AGENTMEMORY_SECRET",
+            },
+        ]
+
+    def save_config(self, values: dict, hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "agentmemory.json"
+        config_path.write_text(json.dumps(values, indent=2))
+
+    def system_prompt_block(self) -> str:
+        result = _api(self._base, "context", {
+            "sessionId": self._session_id,
+            "project": self._project,
+        })
+        if result and result.get("context"):
+            return result["context"]
+        return ""
+
+    def prefetch(self, query: str) -> str:
+        result = _api(self._base, "smart-search", {
+            "query": query,
+            "limit": 5,
+        })
+        if not result or not result.get("results"):
+            return ""
+
+        lines = []
+        for r in result["results"][:5]:
+            obs = r.get("observation", r)
+            title = obs.get("title", "")
+            narrative = obs.get("narrative", "")
+            if title:
+                lines.append(f"- {title}: {narrative[:200]}")
+        return "\n".join(lines) if lines else ""
+
+    def queue_prefetch(self, query: str) -> None:
+        _api_bg(self._base, "smart-search", {"query": query, "limit": 3})
+
+    def get_tool_schemas(self) -> list[dict]:
+        return [
+            {
+                "name": "memory_recall",
+                "description": "Search agentmemory for past observations by keyword",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "limit": {"type": "integer", "description": "Max results", "default": 10},
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "memory_save",
+                "description": "Save an insight, decision, or pattern to long-term memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string", "description": "What to remember"},
+                        "type": {
+                            "type": "string",
+                            "enum": ["pattern", "preference", "architecture", "bug", "workflow", "fact"],
+                            "description": "Memory type",
+                        },
+                    },
+                    "required": ["content"],
+                },
+            },
+            {
+                "name": "memory_search",
+                "description": "Hybrid semantic + keyword search across all memories",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer", "default": 5},
+                    },
+                    "required": ["query"],
+                },
+            },
+        ]
+
+    def handle_tool_call(self, name: str, args: dict) -> Any:
+        if name == "memory_recall":
+            result = _api(self._base, "search", {
+                "query": args["query"],
+                "limit": args.get("limit", 10),
+            })
+            if not result:
+                return {"results": []}
+            items = []
+            for r in result.get("results", []):
+                obs = r.get("observation", r)
+                items.append({
+                    "title": obs.get("title", ""),
+                    "type": obs.get("type", ""),
+                    "narrative": obs.get("narrative", ""),
+                    "importance": obs.get("importance", 0),
+                    "timestamp": obs.get("timestamp", ""),
+                })
+            return {"results": items}
+
+        if name == "memory_save":
+            result = _api(self._base, "remember", {
+                "content": args["content"],
+                "type": args.get("type", "fact"),
+            })
+            return result or {"success": False}
+
+        if name == "memory_search":
+            result = _api(self._base, "smart-search", {
+                "query": args["query"],
+                "limit": args.get("limit", 5),
+            })
+            if not result:
+                return {"results": []}
+            items = []
+            for r in result.get("results", []):
+                obs = r.get("observation", r)
+                items.append({
+                    "title": obs.get("title", ""),
+                    "narrative": obs.get("narrative", "")[:300],
+                    "score": r.get("combinedScore", r.get("score", 0)),
+                })
+            return {"results": items}
+
+        return {"error": f"Unknown tool: {name}"}
+
+    def sync_turn(self, user: str, assistant: str) -> None:
+        _api_bg(self._base, "observe", {
+            "hookType": "post_tool_use",
+            "sessionId": self._session_id,
+            "project": self._project,
+            "cwd": self._project,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "data": {
+                "tool_name": "conversation",
+                "input": user[:500],
+                "output": assistant[:2000],
+            },
+        })
+
+    def on_session_end(self, messages: list) -> None:
+        _api(self._base, "session/end", {
+            "sessionId": self._session_id,
+        })
+
+    def on_pre_compress(self, messages: list) -> None:
+        result = _api(self._base, "context", {
+            "sessionId": self._session_id,
+            "project": self._project,
+        })
+        if result and result.get("context"):
+            messages.insert(0, {
+                "role": "user",
+                "content": f"[agentmemory context before compaction]\n{result['context']}",
+            })
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if action in ("add", "update") and content:
+            _api_bg(self._base, "remember", {
+                "content": content,
+                "type": "fact",
+            })
+
+    def shutdown(self) -> None:
+        pass
+
+
+def register(ctx: Any) -> None:
+    ctx.register_memory_provider(AgentMemoryProvider())

--- a/plugins/memory/agentmemory/cli.py
+++ b/plugins/memory/agentmemory/cli.py
@@ -1,0 +1,259 @@
+"""CLI commands for AgentMemory integration management."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import webbrowser
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_URL = "http://localhost:3111"
+VIEWER_PORT = "3113"
+MCP_SERVER_NAME = "agentmemory"
+
+
+def _base_url(value: str | None = None) -> str:
+    return (value or os.environ.get("AGENTMEMORY_URL") or DEFAULT_URL).rstrip("/")
+
+
+def _viewer_url(base_url: str | None = None) -> str:
+    explicit = os.environ.get("AGENTMEMORY_VIEWER_URL")
+    if explicit:
+        return explicit
+    base = _base_url(base_url)
+    parsed = urlparse(base)
+    if parsed.hostname:
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        netloc = f"{host}:{VIEWER_PORT}"
+        return urlunparse((parsed.scheme or "http", netloc, "", "", "", ""))
+    return "http://localhost:3113"
+
+
+def _config_path() -> Path:
+    return get_hermes_home() / "config.yaml"
+
+
+def _read_config() -> dict[str, Any]:
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text()) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_config(config: dict[str, Any]) -> None:
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(config, sort_keys=False))
+
+
+def _get_json(path: str, base_url: str | None = None) -> dict[str, Any] | None:
+    url = f"{_base_url(base_url)}/agentmemory/{path.lstrip('/')}"
+    headers = {"Accept": "application/json"}
+    secret = os.environ.get("AGENTMEMORY_SECRET", "")
+    if secret:
+        headers["Authorization"] = f"Bearer {secret}"
+    req = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(req, timeout=2) as resp:
+            payload = resp.read().decode()
+        data = json.loads(payload or "{}")
+        return data if isinstance(data, dict) else None
+    except (OSError, URLError, TimeoutError, json.JSONDecodeError):
+        return None
+
+
+def _viewer_reachable(base_url: str | None = None) -> bool:
+    req = Request(_viewer_url(base_url), method="GET")
+    try:
+        with urlopen(req, timeout=2):
+            return True
+    except Exception:
+        return False
+
+
+def _mcp_configured(config: dict[str, Any]) -> bool:
+    server = (config.get("mcp_servers") or {}).get(MCP_SERVER_NAME) or {}
+    return server.get("command") == "npx" and "@agentmemory/mcp" in server.get("args", [])
+
+
+def _provider_enabled(config: dict[str, Any]) -> bool:
+    return (config.get("memory") or {}).get("provider") == "agentmemory"
+
+
+def _configure_mcp() -> None:
+    config = _read_config()
+    config.setdefault("mcp_servers", {})[MCP_SERVER_NAME] = {
+        "command": "npx",
+        "args": ["-y", "@agentmemory/mcp"],
+    }
+    _write_config(config)
+
+
+def _configure_provider() -> None:
+    config = _read_config()
+    config.setdefault("memory", {})["provider"] = "agentmemory"
+    _write_config(config)
+
+
+def _disable_provider() -> bool:
+    config = _read_config()
+    memory = config.setdefault("memory", {})
+    if memory.get("provider") != "agentmemory":
+        return False
+    memory["provider"] = ""
+    _write_config(config)
+    return True
+
+
+def cmd_mcp(args) -> None:
+    _configure_mcp()
+    print("\n  ✓ AgentMemory MCP configured")
+    print("  Saved to config.yaml")
+    print("  Restart Hermes or start a new session to load MCP tools.\n")
+
+
+def cmd_provider(args) -> None:
+    _configure_provider()
+    print("\n  ✓ Memory provider: agentmemory")
+    print("  Saved to config.yaml")
+    print("  Start the server with: npx @agentmemory/agentmemory\n")
+
+
+def cmd_enable(args) -> None:
+    cmd_provider(args)
+
+
+def cmd_disable(args) -> None:
+    if _disable_provider():
+        print("\n  ✓ AgentMemory provider disabled")
+        print("  Built-in memory remains active.\n")
+    else:
+        print("\n  AgentMemory provider was not active.\n")
+
+
+def cmd_setup(args) -> None:
+    _configure_mcp()
+    if getattr(args, "provider", False):
+        _configure_provider()
+    print("\n  ✓ AgentMemory setup saved")
+    print("  MCP server: agentmemory -> npx -y @agentmemory/mcp")
+    if getattr(args, "provider", False):
+        print("  Memory provider: agentmemory")
+    else:
+        print("  Memory provider: unchanged (use --provider for lifecycle hooks)")
+    print("\n  Next:")
+    print("    npx @agentmemory/agentmemory")
+    print("    hermes agentmemory status")
+    print("    Open viewer: http://localhost:3113\n")
+
+
+def cmd_status(args) -> None:
+    base = _base_url(getattr(args, "url", None))
+    config = _read_config()
+    health = _get_json("health", base)
+    flags = _get_json("config/flags", base) or {}
+    server_ok = bool(health and health.get("status") in ("healthy", "ok"))
+    viewer_ok = _viewer_reachable(base)
+    npx_ok = bool(shutil.which("npx"))
+    mcp_ok = _mcp_configured(config)
+    provider_ok = _provider_enabled(config)
+
+    print("\nAgentMemory")
+    print(f"  URL: {base}")
+    print(f"  Server... {'OK' if server_ok else 'FAILED'}")
+    print(f"  Viewer... {'OK' if viewer_ok else 'FAILED'} ({_viewer_url(base)})")
+    print(f"  npx... {'OK' if npx_ok else 'MISSING'}")
+    print(f"  MCP config... {'OK' if mcp_ok else 'MISSING'}")
+    print(f"  Provider... {'OK' if provider_ok else 'disabled'}")
+
+    flag_items = flags.get("flags") if isinstance(flags, dict) else None
+    if flag_items:
+        disabled = [f for f in flag_items if isinstance(f, dict) and not f.get("enabled")]
+        print(f"  Feature flags... {len(flag_items) - len(disabled)}/{len(flag_items)} enabled")
+        for flag in disabled[:5]:
+            print(f"    - {flag.get('key')}: off")
+    print()
+
+
+def cmd_doctor(args) -> None:
+    cmd_status(args)
+    print("Checks and fixes:")
+    if not shutil.which("npx"):
+        print("  - Install Node.js/npm so npx is available.")
+    if not _mcp_configured(_read_config()):
+        print("  - Run: hermes agentmemory mcp")
+    if not _get_json("health", _base_url(getattr(args, "url", None))):
+        print("  - Start server: npx @agentmemory/agentmemory")
+    print("  - Run AgentMemory diagnostics: npx @agentmemory/agentmemory doctor\n")
+
+
+def cmd_viewer(args) -> None:
+    url = _viewer_url(getattr(args, "url", None))
+    print(url)
+    if not getattr(args, "print_only", False):
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+
+def agentmemory_command(args) -> None:
+    sub = getattr(args, "agentmemory_command", None) or "status"
+    if sub == "setup":
+        cmd_setup(args)
+    elif sub == "status":
+        cmd_status(args)
+    elif sub == "doctor":
+        cmd_doctor(args)
+    elif sub == "viewer":
+        cmd_viewer(args)
+    elif sub == "mcp":
+        cmd_mcp(args)
+    elif sub == "provider":
+        cmd_provider(args)
+    elif sub == "enable":
+        cmd_enable(args)
+    elif sub == "disable":
+        cmd_disable(args)
+    else:
+        print(f"  Unknown agentmemory command: {sub}")
+
+
+def register_cli(subparser) -> None:
+    subparser.description = "Manage AgentMemory persistent cross-agent memory."
+    subs = subparser.add_subparsers(dest="agentmemory_command")
+
+    setup = subs.add_parser("setup", help="Configure AgentMemory MCP, optionally as memory provider")
+    setup.add_argument("--provider", action="store_true", help="Also enable AgentMemory as the active memory provider")
+
+    status = subs.add_parser("status", help="Show AgentMemory server, MCP, and provider status")
+    status.add_argument("--url", help="AgentMemory server URL")
+
+    doctor = subs.add_parser("doctor", help="Diagnose AgentMemory setup")
+    doctor.add_argument("--url", help="AgentMemory server URL")
+
+    viewer = subs.add_parser("viewer", help="Open or print the AgentMemory viewer URL")
+    viewer.add_argument("--url", help="AgentMemory server URL")
+    viewer.add_argument("--print", dest="print_only", action="store_true", help="Print only, do not open browser")
+
+    subs.add_parser("mcp", help="Configure AgentMemory as an MCP server")
+    subs.add_parser("provider", help="Enable AgentMemory memory-provider hooks")
+    subs.add_parser("enable", help="Alias for provider")
+    subs.add_parser("disable", help="Disable AgentMemory as active memory provider")
+
+    subparser.set_defaults(func=agentmemory_command)

--- a/plugins/memory/agentmemory/plugin.yaml
+++ b/plugins/memory/agentmemory/plugin.yaml
@@ -1,0 +1,10 @@
+name: agentmemory
+version: 0.8.0
+description: "Persistent cross-session project memory for Hermes Agent via AgentMemory."
+author: "Rohit Ghumare"
+homepage: "https://github.com/rohitg00/agentmemory"
+cli_always: true
+hooks:
+  - on_session_end
+  - on_pre_compress
+  - on_memory_write

--- a/tests/agentmemory_plugin/test_cli.py
+++ b/tests/agentmemory_plugin/test_cli.py
@@ -1,0 +1,81 @@
+"""Tests for plugins/memory/agentmemory/cli.py."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_mcp_command_writes_agentmemory_mcp_config(monkeypatch, tmp_path, capsys):
+    import plugins.memory.agentmemory.cli as agentmemory_cli
+
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(agentmemory_cli, "_config_path", lambda: config_path)
+
+    agentmemory_cli.agentmemory_command(SimpleNamespace(agentmemory_command="mcp"))
+
+    out = capsys.readouterr().out
+    assert "AgentMemory MCP configured" in out
+    saved = config_path.read_text()
+    assert "agentmemory:" in saved
+    assert "@agentmemory/mcp" in saved
+
+
+def test_provider_command_sets_memory_provider(monkeypatch, tmp_path, capsys):
+    import plugins.memory.agentmemory.cli as agentmemory_cli
+
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(agentmemory_cli, "_config_path", lambda: config_path)
+
+    agentmemory_cli.agentmemory_command(SimpleNamespace(agentmemory_command="provider"))
+
+    out = capsys.readouterr().out
+    assert "Memory provider: agentmemory" in out
+    assert "provider: agentmemory" in config_path.read_text()
+
+
+def test_viewer_url_uses_agentmemory_host(monkeypatch):
+    import plugins.memory.agentmemory.cli as agentmemory_cli
+
+    monkeypatch.delenv("AGENTMEMORY_VIEWER_URL", raising=False)
+
+    assert agentmemory_cli._viewer_url("http://127.0.0.1:65530") == "http://127.0.0.1:3113"
+
+
+def test_status_reports_server_and_viewer(monkeypatch, tmp_path, capsys):
+    import plugins.memory.agentmemory.cli as agentmemory_cli
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "mcp_servers:\n"
+        "  agentmemory:\n"
+        "    command: npx\n"
+        "    args: ['-y', '@agentmemory/mcp']\n"
+        "memory:\n"
+        "  provider: agentmemory\n"
+    )
+    monkeypatch.setattr(agentmemory_cli, "_config_path", lambda: config_path)
+    monkeypatch.setattr(agentmemory_cli.shutil, "which", lambda name: "/usr/bin/npx" if name == "npx" else None)
+    monkeypatch.setattr(agentmemory_cli, "_get_json", lambda path, base_url=None: {"status": "healthy"} if path == "health" else {"flags": []})
+    monkeypatch.setattr(agentmemory_cli, "_viewer_reachable", lambda base_url=None: True)
+
+    agentmemory_cli.agentmemory_command(SimpleNamespace(agentmemory_command="status", url=None))
+
+    out = capsys.readouterr().out
+    assert "Server... OK" in out
+    assert "Viewer... OK" in out
+    assert "MCP config... OK" in out
+    assert "Provider... OK" in out
+
+
+def test_disable_only_clears_agentmemory_provider(monkeypatch, tmp_path, capsys):
+    import plugins.memory.agentmemory.cli as agentmemory_cli
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("memory:\n  provider: agentmemory\n")
+    monkeypatch.setattr(agentmemory_cli, "_config_path", lambda: config_path)
+
+    agentmemory_cli.agentmemory_command(SimpleNamespace(agentmemory_command="disable"))
+
+    out = capsys.readouterr().out
+    assert "AgentMemory provider disabled" in out
+    assert "provider: ''" in config_path.read_text()

--- a/tests/agentmemory_plugin/test_discovery.py
+++ b/tests/agentmemory_plugin/test_discovery.py
@@ -1,0 +1,30 @@
+"""Tests for memory plugin CLI command discovery."""
+
+from __future__ import annotations
+
+
+def test_discovers_cli_always_memory_plugin_without_active_provider(monkeypatch, tmp_path):
+    import plugins.memory as memory_plugins
+
+    provider_dir = tmp_path / "agentmemory"
+    provider_dir.mkdir()
+    (provider_dir / "__init__.py").write_text("from agent.memory_provider import MemoryProvider\n")
+    (provider_dir / "plugin.yaml").write_text(
+        "name: agentmemory\n"
+        "description: AgentMemory commands\n"
+        "cli_always: true\n"
+    )
+    (provider_dir / "cli.py").write_text(
+        "def register_cli(subparser):\n"
+        "    subparser.set_defaults(func=agentmemory_command)\n"
+        "def agentmemory_command(args):\n"
+        "    return None\n"
+    )
+
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path)
+    monkeypatch.setattr(memory_plugins, "_get_active_memory_provider", lambda: None)
+
+    commands = memory_plugins.discover_plugin_cli_commands()
+
+    assert [cmd["name"] for cmd in commands] == ["agentmemory"]
+    assert commands[0]["help"] == "AgentMemory commands"

--- a/website/docs/user-guide/features/agentmemory.md
+++ b/website/docs/user-guide/features/agentmemory.md
@@ -1,0 +1,387 @@
+---
+sidebar_position: 100
+title: "AgentMemory"
+description: "Persistent cross-agent memory for Hermes via agentmemory, MCP, and the optional memory provider plugin"
+---
+
+# AgentMemory
+
+[agentmemory](https://github.com/rohitg00/agentmemory) is a persistent memory engine for AI coding agents. It captures what agents do across sessions, compresses that activity into searchable memory, and retrieves the right context when a future session starts.
+
+For Hermes users, the most important difference is that agentmemory is not only a place to store notes. It is a local memory service that can be shared by multiple coding agents:
+
+- Hermes
+- Claude Code
+- Cursor
+- Gemini CLI
+- OpenCode
+- Codex CLI
+- Cline
+- Aider
+- Any MCP or REST-capable agent
+
+:::info External integration
+AgentMemory is an external project that integrates with Hermes through MCP today. A deeper Hermes memory-provider plugin is available from the agentmemory repository and is being discussed for upstream integration.
+:::
+
+## When to Use AgentMemory
+
+Use AgentMemory when you want Hermes to remember project work across many sessions or share coding memory with other agents.
+
+Good use cases:
+
+- You switch between Hermes, Claude Code, Cursor, OpenCode, and other tools on the same repository.
+- You keep re-explaining project architecture, test commands, framework choices, and past bug fixes.
+- Your `MEMORY.md`, `USER.md`, `CLAUDE.md`, `.cursorrules`, or memory-bank files are becoming too large.
+- You want semantic recall, not only keyword search.
+- You want a local, self-hosted memory server with a viewer.
+- You want memory lifecycle features such as versioning, decay, contradiction handling, and auto-forget.
+
+AgentMemory is especially useful for long-running software projects where the useful context is not only who the user is, but what happened inside the codebase:
+
+```text
+Session 1: "Add auth to the API"
+  Hermes creates JWT middleware, chooses jose, adds tests, fixes failures.
+  AgentMemory captures the files touched, commands run, errors seen, and decisions made.
+
+Session 2: "Now add rate limiting"
+  Hermes can retrieve:
+    - Auth uses jose middleware in src/middleware/auth.ts
+    - Token validation tests live in test/auth.test.ts
+    - jose was chosen over jsonwebtoken for Edge compatibility
+    - The API already has an auth middleware pattern to reuse
+
+Result:
+  No re-explaining. No copy-pasting old logs. Hermes starts from project memory.
+```
+
+## How It Complements Hermes Memory
+
+Hermes already has several memory and context systems:
+
+| Hermes feature | What it is good for |
+|---|---|
+| `USER.md` | Durable facts about the human: preferences, writing style, expectations |
+| `MEMORY.md` | Compact environment facts, project conventions, and lessons |
+| Session search | Finding older conversation transcripts |
+| Skills | Reusable procedures that improve over time |
+| Context files | Explicit project instructions such as `AGENTS.md` |
+| Memory providers | External memory backends such as Honcho |
+
+AgentMemory adds a separate layer focused on searchable, cross-agent, project-level memory:
+
+| Hermes built-in | AgentMemory adds |
+|---|---|
+| Flat memory files | Structured observations with files, commands, facts, concepts, and outcomes |
+| Keyword-oriented session search | BM25 + vector + knowledge graph retrieval |
+| One Hermes profile/session at a time | Shared memory across Hermes and other agents |
+| Manual memory curation | Automatic capture through hooks, MCP tools, and REST calls |
+| Context loaded into prompt | Token-budgeted retrieval of only relevant memories |
+
+Think of the built-in Hermes memory as curated notes and preferences. Think of AgentMemory as the searchable project memory database behind those notes.
+
+## AgentMemory vs Honcho
+
+Honcho and AgentMemory solve different memory problems.
+
+| Capability | Honcho | AgentMemory |
+|---|---|---|
+| Primary focus | Deep user modeling and personalization | Project and coding-agent memory |
+| Best for | Understanding the human across conversations | Remembering codebase work across sessions and tools |
+| Context type | User representations, peer cards, conclusions, session summaries | Observations, files, commands, decisions, bugs, fixes, lessons |
+| Multi-agent model | Separate peers in a shared workspace | Shared memory service across MCP/REST-capable agents |
+| Retrieval style | Semantic search over conclusions and context | BM25 + vector + graph search over observations |
+| Setup style | Hermes memory provider | MCP server today, optional memory-provider plugin |
+| Storage | Honcho Cloud or self-hosted Honcho | Local/self-hosted AgentMemory server by default |
+
+Use Honcho when you want Hermes to understand the user better.
+
+Use AgentMemory when you want Hermes and other coding agents to remember what happened in a repository.
+
+You can also use them for different layers of memory: Honcho for user modeling, AgentMemory for project recall.
+
+## Reported Benchmarks
+
+AgentMemory reports the following results in its public benchmark docs:
+
+| Metric | Reported value |
+|---|---:|
+| LongMemEval-S retrieval R@5 | 95.2% |
+| LongMemEval-S retrieval R@10 | 98.6% |
+| MRR | 88.2% |
+| Token reduction vs loading large built-in memory | Up to 92% |
+| External database required | 0 |
+| Default REST API | `http://localhost:3111` |
+| Real-time viewer | `http://localhost:3113` |
+
+:::note Benchmark caveat
+These numbers come from AgentMemory's benchmark reports. Compare memory benchmarks carefully because projects often use different datasets, embedding models, corpus sizes, and evaluation methods.
+:::
+
+## Quick Setup
+
+Hermes includes dedicated AgentMemory commands so you do not need to edit `~/.hermes/config.yaml` by hand.
+
+### 1. Start the AgentMemory server
+
+```bash
+npx @agentmemory/agentmemory
+```
+
+By default, the REST API listens on:
+
+```text
+http://localhost:3111
+```
+
+The viewer runs on:
+
+```text
+http://localhost:3113
+```
+
+### 2. Configure Hermes
+
+For MCP tools only:
+
+```bash
+hermes agentmemory setup
+```
+
+For MCP plus the deeper memory-provider lifecycle hooks:
+
+```bash
+hermes agentmemory setup --provider
+```
+
+The command writes this MCP server config for you:
+
+```yaml
+mcp_servers:
+  agentmemory:
+    command: npx
+    args: ["-y", "@agentmemory/mcp"]
+```
+
+With `--provider`, it also enables:
+
+```yaml
+memory:
+  provider: agentmemory
+```
+
+Restart Hermes or start a new Hermes session so MCP servers reload.
+
+### 3. Verify the setup
+
+```bash
+hermes agentmemory status
+hermes agentmemory doctor
+```
+
+You can also verify the server directly:
+
+```bash
+curl http://localhost:3111/agentmemory/health
+```
+
+Expected response:
+
+```json
+{"status":"healthy"}
+```
+
+### 4. Open the viewer
+
+```bash
+hermes agentmemory viewer
+```
+
+Or open:
+
+```text
+http://localhost:3113
+```
+
+Use the viewer to inspect sessions, memories, lessons, feature flags, and captured activity.
+
+## CLI Commands
+
+```bash
+hermes agentmemory setup          # Configure MCP integration
+hermes agentmemory setup --provider  # Configure MCP and enable provider hooks
+hermes agentmemory status         # Show server, viewer, MCP, and provider status
+hermes agentmemory doctor         # Diagnose setup and print fixes
+hermes agentmemory viewer         # Open the real-time viewer
+hermes agentmemory mcp            # Configure only MCP
+hermes agentmemory provider       # Enable provider lifecycle hooks
+hermes agentmemory disable        # Disable AgentMemory as the active provider
+```
+
+## Optional: Memory Provider Plugin
+
+AgentMemory also includes a Hermes memory-provider plugin in its repository:
+
+```text
+integrations/hermes
+```
+
+This gives deeper integration than MCP alone. The plugin maps Hermes memory lifecycle hooks to the AgentMemory REST API.
+
+| Hermes lifecycle hook | AgentMemory behavior |
+|---|---|
+| `prefetch(query)` | Retrieves relevant memories before response generation |
+| `sync_turn(user, assistant)` | Captures each conversation turn asynchronously |
+| `on_session_end()` | Marks the session complete for summarization |
+| `on_pre_compress()` | Re-injects relevant context before compaction |
+| `on_memory_write()` | Mirrors `MEMORY.md` writes to AgentMemory |
+| `system_prompt_block()` | Injects a project profile at session start |
+
+To test the plugin manually from a checkout of the AgentMemory repository:
+
+```bash
+cp -r integrations/hermes ~/.hermes/plugins/memory/agentmemory
+npx @agentmemory/agentmemory
+```
+
+Then set Hermes to use the provider if the plugin is available in your installation:
+
+```yaml
+memory:
+  provider: agentmemory
+```
+
+:::warning Plugin availability
+The MCP integration works without copying plugin files. The memory-provider plugin is an external integration unless it has been bundled with your Hermes installation.
+:::
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENTMEMORY_URL` | `http://localhost:3111` | AgentMemory REST server URL |
+| `AGENTMEMORY_SECRET` | none | Optional auth token for protected instances |
+
+## Example Workflow
+
+Here is a realistic use case for a developer working on the same repository with multiple agents.
+
+### Day 1: Hermes fixes auth
+
+You ask Hermes:
+
+```text
+Add JWT auth to this FastAPI service and write tests.
+```
+
+Hermes edits files, runs tests, fixes failures, and explains the final design. AgentMemory captures observations like:
+
+```text
+Project uses FastAPI with routers under app/api.
+Auth middleware lives in app/middleware/auth.py.
+JWT validation uses python-jose.
+Tests are run with uv run pytest.
+A previous failure came from missing Authorization header normalization.
+```
+
+### Day 2: Claude Code debugs database performance
+
+You use Claude Code instead of Hermes. Since Claude Code can connect to the same AgentMemory server, it can save new observations:
+
+```text
+N+1 query fixed in app/repositories/users.py.
+SQLAlchemy selectinload is the preferred pattern for user dashboard queries.
+Regression test added in tests/test_user_dashboard.py.
+```
+
+### Day 3: Hermes adds rate limiting
+
+You return to Hermes and ask:
+
+```text
+Add per-user rate limiting to authenticated API routes.
+```
+
+Hermes can now retrieve both sets of memories:
+
+- The auth middleware pattern from Day 1
+- The test command and test layout
+- The database performance fix from Day 2
+- The preferred SQLAlchemy loading pattern
+
+That lets Hermes avoid re-discovery and make a smaller, safer change.
+
+## Best Practices
+
+- Keep `USER.md` for stable facts about the human.
+- Keep `MEMORY.md` for compact facts the agent should always know.
+- Use AgentMemory for large project histories, tool traces, code decisions, bug fixes, and cross-agent recall.
+- Use Skills for repeatable procedures, not raw memory.
+- Keep AgentMemory local unless you intentionally expose it.
+- Set `AGENTMEMORY_SECRET` if the server is reachable beyond localhost.
+- Use the viewer to audit what is being stored.
+- Prefer retrieved context over dumping huge logs or full memory files into prompts.
+
+## Troubleshooting
+
+### Hermes cannot see AgentMemory tools
+
+Check that MCP is configured and Hermes has been restarted:
+
+```bash
+hermes mcp list
+hermes mcp test agentmemory
+```
+
+Also confirm the server is running:
+
+```bash
+curl http://localhost:3111/agentmemory/health
+```
+
+### The viewer is empty
+
+Run the demo to seed sample sessions:
+
+```bash
+npx @agentmemory/agentmemory demo
+```
+
+Then refresh:
+
+```text
+http://localhost:3113
+```
+
+### Retrieval works only by exact words
+
+Check whether embeddings are enabled in AgentMemory. Without embeddings, AgentMemory can still use BM25 keyword retrieval, but semantic recall is weaker.
+
+Run:
+
+```bash
+npx @agentmemory/agentmemory doctor
+```
+
+### Remote server does not connect
+
+Set the server URL explicitly:
+
+```bash
+export AGENTMEMORY_URL=http://127.0.0.1:3111
+```
+
+If the server is protected, also set:
+
+```bash
+export AGENTMEMORY_SECRET=your-token
+```
+
+## Related Links
+
+- [AgentMemory repository](https://github.com/rohitg00/agentmemory)
+- [AgentMemory Hermes integration](https://github.com/rohitg00/agentmemory/tree/main/integrations/hermes)
+- [Hermes MCP](./mcp.md)
+- [Hermes Memory](./memory.md)
+- [Memory Providers](./memory-providers.md)
+- [Honcho Memory](./honcho.md)

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins: AgentMemory, Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time. The built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: agentmemory  # or honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory
 ```
 
 ## How It Works
@@ -39,6 +39,29 @@ When a memory provider is active, Hermes automatically:
 The built-in memory (MEMORY.md / USER.md) continues to work exactly as before. The external provider is additive.
 
 ## Available Providers
+
+### AgentMemory
+
+Persistent cross-agent project memory for coding agents. AgentMemory captures repository work across sessions, compresses observations into searchable memories, and makes those memories available to Hermes and other MCP or REST-capable agents.
+
+| | |
+|---|---|
+| **Best for** | Codebase memory shared across Hermes, Claude Code, Cursor, OpenCode, Gemini CLI, and other agents |
+| **Requires** | Node.js / `npx`, running AgentMemory server, optional provider hooks |
+| **Data storage** | Local/self-hosted AgentMemory server by default |
+| **Cost** | Free/self-hosted unless you configure external LLM or embedding providers |
+
+**Quick setup:**
+```bash
+npx @agentmemory/agentmemory
+hermes agentmemory setup
+# or, for lifecycle hooks too:
+hermes agentmemory setup --provider
+```
+
+**Tools and integration:** MCP exposes AgentMemory tools via `@agentmemory/mcp`. The memory-provider plugin adds lifecycle hooks for prefetch, turn sync, session end, pre-compression context injection, and mirroring built-in memory writes.
+
+See [AgentMemory](./agentmemory.md) for the detailed guide.
 
 ### Honcho
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -46,6 +46,8 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/skills',
             'user-guide/features/memory',
             'user-guide/features/memory-providers',
+            'user-guide/features/honcho',
+            'user-guide/features/agentmemory',
             'user-guide/features/context-files',
             'user-guide/features/context-references',
             'user-guide/features/personality',


### PR DESCRIPTION
## Summary

Adds a first-class AgentMemory integration for Hermes.

- Bundles the AgentMemory memory-provider plugin under `plugins/memory/agentmemory`.
- Adds dedicated `hermes agentmemory ...` commands for setup, diagnostics, viewer access, MCP config, provider enablement, and disablement.
- Lets memory plugins expose CLI commands before they become the active provider using `cli_always: true` in `plugin.yaml`.
- Adds docs for AgentMemory and links it from the memory providers page/sidebar.
- Adds targeted tests for AgentMemory CLI behavior and memory-plugin CLI discovery.

## Related issues

Closes #16218.

Builds on the AgentMemory provider proposal from #6715.

## Why

AgentMemory is project and codebase memory for coding agents. It helps Hermes recall repo-specific decisions, bug fixes, commands, files, lessons, and multi-agent work across sessions.

This complements Honcho:

- Honcho: user modeling, personalization, peer cards, conversation context.
- AgentMemory: project memory, codebase recall, tool traces, file-level context, decisions, and bug-fix history.

## Test plan

Passed:

```bash
./venv/bin/ruff check plugins/memory/__init__.py plugins/memory/agentmemory/__init__.py plugins/memory/agentmemory/cli.py tests/agentmemory_plugin --no-force-exclude
./venv/bin/python -m pytest tests/agentmemory_plugin tests/hermes_cli/test_plugins_cmd.py -q -o 'addopts='
./venv/bin/python -m py_compile plugins/memory/__init__.py plugins/memory/agentmemory/__init__.py plugins/memory/agentmemory/cli.py tests/agentmemory_plugin/test_cli.py tests/agentmemory_plugin/test_discovery.py
```

Manual CLI smoke test passed:

```bash
HERMES_HOME=$(mktemp -d) ./venv/bin/python -m hermes_cli.main agentmemory --help
HERMES_HOME=$(mktemp -d) ./venv/bin/python -m hermes_cli.main agentmemory setup --provider
HERMES_HOME=$(mktemp -d) ./venv/bin/python -m hermes_cli.main agentmemory status --url http://127.0.0.1:65530
```

Full test suite note:

```bash
./venv/bin/python -m pytest -q
```

This currently fails in this local checkout with unrelated existing failures in gateway/Discord/Matrix, OAuth credential lookup, WSL/systemd, and file-state tests. The new AgentMemory targeted tests pass.
