### PR TITLE
fix(gateway): let plain stop commands override resume notes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -308,6 +308,23 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _is_plain_stop_override_message(message: str) -> bool:
+    """Return true for short human stop commands that must override resume notes.
+
+    Telegram users often type plain `stop!` rather than `/stop` when an agent
+    is already looping. If the previous transcript ended on tool output, the
+    auto-continue system note would otherwise tell the model to process that
+    stale work first, defeating the user's stop instruction.
+    """
+    normalized = re.sub(r"[^a-z0-9']+", " ", (message or "").lower()).strip()
+    if not normalized:
+        return False
+    if normalized in {"stop", "stop now", "please stop", "stop please"}:
+        return True
+    words = normalized.split()
+    return len(words) <= 12 and "stop" in words and "loop" in words
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -9981,7 +9998,9 @@ class GatewayRunner:
                 _resume_entry is not None and getattr(_resume_entry, "resume_pending", False)
             )
 
-            if _is_resume_pending:
+            _suppress_resume_note = _is_plain_stop_override_message(message)
+
+            if _is_resume_pending and not _suppress_resume_note:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 _reason_phrase = (
                     "a gateway restart"
@@ -9998,7 +10017,7 @@ class GatewayRunner:
                     f"message below.]\n\n"
                     + message
                 )
-            elif agent_history and agent_history[-1].get("role") == "tool":
+            elif agent_history and agent_history[-1].get("role") == "tool" and not _suppress_resume_note:
                 message = (
                     "[System note: Your previous turn was interrupted before you could "
                     "process the last tool result(s). The conversation history contains "

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -9,6 +9,18 @@ finishes the interrupted work before addressing the new input.
 import pytest
 
 
+def _is_plain_stop_override_message(message: str) -> bool:
+    import re
+
+    normalized = re.sub(r"[^a-z0-9']+", " ", (message or "").lower()).strip()
+    if not normalized:
+        return False
+    if normalized in {"stop", "stop now", "please stop", "stop please"}:
+        return True
+    words = normalized.split()
+    return len(words) <= 12 and "stop" in words and "loop" in words
+
+
 def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
     """Reproduce the auto-continue injection logic from _run_agent().
 
@@ -17,7 +29,8 @@ def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
     gateway runner.
     """
     message = user_message
-    if agent_history and agent_history[-1].get("role") == "tool":
+    suppress_resume_note = _is_plain_stop_override_message(message)
+    if agent_history and agent_history[-1].get("role") == "tool" and not suppress_resume_note:
         message = (
             "[System note: Your previous turn was interrupted before you could "
             "process the last tool result(s). The conversation history contains "
@@ -79,6 +92,29 @@ class TestAutoDetection:
         ]
         result = _simulate_auto_continue(history, "continue")
         assert "[System note:" in result
+
+    def test_stop_override_does_not_get_tool_tail_note(self):
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "still running"},
+        ]
+        result = _simulate_auto_continue(history, "stop!")
+        assert result == "stop!"
+        assert "[System note:" not in result
+
+    def test_loop_stop_override_does_not_get_tool_tail_note(self):
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "still running"},
+        ]
+        message = "pk stop. you're in a loop STOP"
+        result = _simulate_auto_continue(history, message)
+        assert result == message
+        assert "[System note:" not in result
 
     def test_original_message_preserved_after_note(self):
         """The user's actual message must appear after the system note."""

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -31,6 +31,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from gateway import run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.session import SessionEntry, SessionSource, SessionStore
 from tests.gateway.restart_test_helpers import (
@@ -67,7 +68,9 @@ def _simulate_note_injection(
         resume_entry is not None and getattr(resume_entry, "resume_pending", False)
     )
 
-    if is_resume_pending:
+    suppress_resume_note = gateway_run._is_plain_stop_override_message(message)
+
+    if is_resume_pending and not suppress_resume_note:
         reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
         reason_phrase = (
             "a gateway restart"
@@ -84,7 +87,7 @@ def _simulate_note_injection(
             f"message below.]\n\n"
             + message
         )
-    elif agent_history and agent_history[-1].get("role") == "tool":
+    elif agent_history and agent_history[-1].get("role") == "tool" and not suppress_resume_note:
         message = (
             "[System note: Your previous turn was interrupted before you could "
             "process the last tool result(s). The conversation history contains "
@@ -411,6 +414,27 @@ class TestResumePendingSystemNote:
         result = _simulate_note_injection(history, "ping", resume_entry=None)
         assert "[System note:" in result
         assert "tool result" in result
+
+    def test_resume_pending_stop_override_suppresses_restart_note(self):
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            agent_history=[{"role": "assistant", "content": "in progress"}],
+            user_message="stop!",
+            resume_entry=entry,
+        )
+        assert result == "stop!"
+        assert "[System note:" not in result
+
+    def test_resume_pending_loop_stop_suppresses_restart_note(self):
+        entry = self._pending_entry(reason="restart_timeout")
+        message = "pk stop. you're in a loop STOP"
+        result = _simulate_note_injection(
+            agent_history=[{"role": "assistant", "content": "in progress"}],
+            user_message=message,
+            resume_entry=entry,
+        )
+        assert result == message
+        assert "[System note:" not in result
 
     def test_no_note_when_nothing_to_resume(self):
         history = [


### PR DESCRIPTION
## Summary
- Suppress gateway resume/auto-continue system notes for short human stop commands.
- Prevent plain messages like `stop!` from being buried under stale interrupted-work guidance.
- Add regression coverage for tool-tail auto-continue and resume_pending sessions.

## Test plan
- `python -m py_compile gateway/run.py`
- `python -m pytest tests/gateway/test_auto_continue.py tests/gateway/test_restart_resume_pending.py::TestResumePendingSystemNote -q`
