### PR TITLE
feat(cli): show session title in response header

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2915,6 +2915,44 @@ class HermesCLI:
                 self._stream_prefilt = self._stream_prefilt[-max_tag_len:]
             return
 
+    def _current_session_title_for_display(self) -> str:
+        """Return the current session title, if one is available for display."""
+        pending_title = (getattr(self, "_pending_title", None) or "").strip()
+        if pending_title:
+            return pending_title
+
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "session_id", None)
+        if not session_db or not session_id:
+            return ""
+
+        try:
+            session = session_db.get_session(session_id) or {}
+        except Exception:
+            return ""
+        return (session.get("title") or "").strip()
+
+    def _response_panel_label(self) -> str:
+        """Return the response-box title, including the chat title when set."""
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+            label = get_active_skin().get_branding("response_label", "⚕ Hermes")
+        except Exception:
+            label = "⚕ Hermes"
+
+        title = self._current_session_title_for_display()
+        if not title:
+            return label
+
+        max_title_len = 60
+        if len(title) > max_title_len:
+            title = f"{title[:max_title_len - 1]}…"
+
+        leading = label[:len(label) - len(label.lstrip())]
+        trailing = label[len(label.rstrip()):]
+        base_label = label.strip() or "⚕ Hermes"
+        return f"{leading}{base_label} · {title}{trailing}"
+
     def _emit_stream_text(self, text: str) -> None:
         """Emit filtered text to the streaming display."""
         if not text:
@@ -2940,10 +2978,10 @@ class HermesCLI:
             try:
                 from hermes_cli.skin_engine import get_active_skin
                 _skin = get_active_skin()
-                label = _skin.get_branding("response_label", "⚕ Hermes")
+                label = self._response_panel_label()
                 _text_hex = _skin.get_color("banner_text", "#FFF8DC")
             except Exception:
-                label = "⚕ Hermes"
+                label = self._response_panel_label()
                 _text_hex = "#FFF8DC"
             # Build a true-color ANSI escape for the response text color
             # so streamed content matches the Rich Panel appearance.
@@ -6376,18 +6414,18 @@ class HermesCLI:
                     try:
                         from hermes_cli.skin_engine import get_active_skin
                         _skin = get_active_skin()
-                        label = _skin.get_branding("response_label", "⚕ Hermes")
+                        label = self._response_panel_label()
                         _resp_color = _skin.get_color("response_border", "#CD7F32")
                         _resp_text = _skin.get_color("banner_text", "#FFF8DC")
                     except Exception:
-                        label = "⚕ Hermes"
+                        label = self._response_panel_label()
                         _resp_color = "#CD7F32"
                         _resp_text = "#FFF8DC"
 
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
                         _render_final_assistant_content(response, mode=self.final_response_markdown),
-                        title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
+                        title=f"[{_resp_color} bold]{_escape(label)} (background #{task_num})[/]",
                         title_align="left",
                         border_style=_resp_color,
                         style=_resp_text,
@@ -8630,11 +8668,11 @@ class HermesCLI:
                 try:
                     from hermes_cli.skin_engine import get_active_skin
                     _skin = get_active_skin()
-                    label = _skin.get_branding("response_label", "⚕ Hermes")
+                    label = self._response_panel_label()
                     _resp_color = _skin.get_color("response_border", "#CD7F32")
                     _resp_text = _skin.get_color("banner_text", "#FFF8DC")
                 except Exception:
-                    label = "⚕ Hermes"
+                    label = self._response_panel_label()
                     _resp_color = "#CD7F32"
                     _resp_text = "#FFF8DC"
 
@@ -8652,7 +8690,7 @@ class HermesCLI:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
                         _render_final_assistant_content(response, mode=self.final_response_markdown),
-                        title=f"[{_resp_color} bold]{label}[/]",
+                        title=f"[{_resp_color} bold]{_escape(label)}[/]",
                         title_align="left",
                         border_style=_resp_color,
                         style=_resp_text,

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -91,6 +91,28 @@ class TestCliSkinPromptIntegration:
         assert cli._app.style is not None
 
 
+class TestResponsePanelLabel:
+    def test_includes_current_session_title(self):
+        set_active_skin("default")
+        cli = _make_cli_stub()
+        cli.session_id = "session-123"
+        cli._pending_title = None
+        cli._session_db = SimpleNamespace(
+            get_session=lambda session_id: {"title": "A3 certificate setup"}
+        )
+
+        assert cli._response_panel_label() == " ⚕ Hermes · A3 certificate setup "
+
+    def test_uses_pending_title_before_session_is_persisted(self):
+        set_active_skin("default")
+        cli = _make_cli_stub()
+        cli.session_id = "session-123"
+        cli._pending_title = "Billing monitor"
+        cli._session_db = None
+
+        assert cli._response_panel_label() == " ⚕ Hermes · Billing monitor "
+
+
 class TestCompactBannerSkinIntegration:
     def test_default_compact_banner_keeps_legacy_nous_hermes_branding(self):
         set_active_skin("default")


### PR DESCRIPTION
## Summary
- Include the current session title in CLI response panel headers when available.
- Covers streamed, standard, and background-task response panels.
- Add tests for persisted and pending session titles.

## Test plan
- [x] `python3 -m pytest tests/test_cli_skin_integration.py -q -c /dev/null -o cache_dir=/tmp/hermes-pytest-cache-pr`
- [x] `python3 -m py_compile cli.py tests/test_cli_skin_integration.py`
- [x] Manual smoke: named session renders `⚕ Hermes · Header Smoke Test`

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent)
