### PR TITLE
fix(file-tools): keep read dedup status out of file content

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -16,8 +16,10 @@ from unittest.mock import patch, MagicMock
 
 from tools.file_tools import (
     read_file_tool,
+    write_file_tool,
     reset_file_dedup,
     _is_blocked_device,
+    _READ_DEDUP_STATUS_MESSAGE,
     _get_max_read_chars,
     _DEFAULT_MAX_READ_CHARS,
     _read_tracker,
@@ -161,7 +163,7 @@ class TestFileDedup(unittest.TestCase):
 
     @patch("tools.file_tools._get_file_ops")
     def test_second_read_returns_dedup_stub(self, mock_ops):
-        """Second read of same file+range returns dedup stub."""
+        """Second read of same file+range returns non-content dedup status."""
         mock_ops.return_value = _make_fake_ops(
             content="line one\nline two\n", file_size=20,
         )
@@ -172,7 +174,27 @@ class TestFileDedup(unittest.TestCase):
         # Second read — should get dedup stub
         r2 = json.loads(read_file_tool(self._tmpfile, task_id="dup"))
         self.assertTrue(r2.get("dedup"), "Second read should return dedup stub")
-        self.assertIn("unchanged", r2.get("content", ""))
+        self.assertEqual(r2.get("status"), "unchanged")
+        self.assertIn("unchanged", r2.get("message", ""))
+        self.assertFalse(r2.get("content_returned"))
+        self.assertNotIn("content", r2)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_internal_read_status_text(self, mock_ops):
+        """write_file must not persist internal read_file status text."""
+        fake = MagicMock()
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            _READ_DEDUP_STATUS_MESSAGE,
+            task_id="guard",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("internal read_file status text", result["error"])
+        fake.write_file.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_modified_file_not_deduped(self, mock_ops):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -214,6 +214,11 @@ _read_tracker: dict = {}
 _READ_HISTORY_CAP = 500       # set; used only by get_read_files_summary
 _DEDUP_CAP = 1000             # dict; skip-identical-reread guard
 _READ_TIMESTAMPS_CAP = 1000   # dict; external-edit detection for write/patch
+_READ_DEDUP_STATUS_MESSAGE = (
+    "File unchanged since last read. The content from "
+    "the earlier read_file result in this conversation is "
+    "still current — refer to that instead of re-reading."
+)
 
 
 def _cap_read_tracker_data(task_data: dict) -> None:
@@ -256,6 +261,13 @@ def _cap_read_tracker_data(task_data: dict) -> None:
                 ts.pop(next(iter(ts)))
             except (StopIteration, KeyError):
                 break
+
+
+def _is_internal_file_status_text(content: str) -> bool:
+    """Return True when content is an internal file-tool status, not file bytes."""
+    if not isinstance(content, str):
+        return False
+    return content.strip() == _READ_DEDUP_STATUS_MESSAGE
 
 
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
@@ -451,13 +463,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
                     return json.dumps({
-                        "content": (
-                            "File unchanged since last read. The content from "
-                            "the earlier read_file result in this conversation is "
-                            "still current — refer to that instead of re-reading."
-                        ),
+                        "status": "unchanged",
+                        "message": _READ_DEDUP_STATUS_MESSAGE,
                         "path": path,
                         "dedup": True,
+                        "content_returned": False,
                     }, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
@@ -667,6 +677,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    if _is_internal_file_status_text(content):
+        return tool_error(
+            "Refusing to write internal read_file status text as file content. "
+            "Re-read the file or reconstruct the intended file contents before writing."
+        )
     try:
         # Resolve once for the registry lock + stale check.  Failures here
         # fall back to the legacy path — write proceeds, per-task staleness


### PR DESCRIPTION
## What does this PR do?

Keeps the internal `read_file` dedup status from being represented as file contents.

Previously, a repeated unchanged `read_file` returned the dedup message in the normal `content` field. That made the status text look like real file bytes to the model, which can lead to a later `write_file` overwriting user content with Hermes bookkeeping text.

This changes dedup reads to return `status`, `message`, `dedup: true`, and `content_returned: false` instead of `content`. It also adds a defensive `write_file` guard that refuses to write that exact internal status text as file content.

This is supplemental to <https://github.com/NousResearch/hermes-agent/pull/13207>. That PR fixes stale dedup cache after writes; this PR prevents the dedup status itself from becoming writable content.

## Related Issue

Fixes #

Related support report: llm-wiki entity consolidation wrote `read_file` dedup text into a wiki markdown file.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_tools.py`: move the repeated-read dedup text into a shared internal status constant.
- `tools/file_tools.py`: return dedup status under `message` instead of `content`, with `content_returned: false`.
- `tools/file_tools.py`: reject `write_file` calls whose full content is the internal dedup status text.
- `tests/tools/test_file_read_guards.py`: cover the no-`content` dedup shape and the write guard.

## How to Test

1. Read the same unchanged file region twice with `read_file`.
2. Confirm the second result has `dedup: true`, `status: unchanged`, `content_returned: false`, and no `content` field.
3. Try to pass the internal dedup message as the complete `write_file` content and confirm it is rejected before the backend write runs.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: behavior is pure JSON/tool result handling, no platform-specific file APIs added
- [x] Tool description/schema update N/A

## Screenshots / Logs

Targeted tests pass:

`python -m pytest tests/tools/test_file_read_guards.py tests/tools/test_file_tools.py tests/tools/test_accretion_caps.py -n 4`

Result: `52 passed in 11.02s`

Full suite was run with:

`python -m pytest -n 4`

Result: `112 failed, 16066 passed, 41 skipped`.

The failures appear unrelated to this two-file file-tools change. Examples include API server default config reading port `8643` instead of expected `8642`, gateway approval/Tirith setup failures, Dingtalk mocked SDK failures, and broad Discord gateway config failures.