### PR TITLE
docs(api-server): describe bounded model discovery

### DIFF
--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -198,7 +198,10 @@ Delete a stored response.
 
 ### GET /v1/models
 
-Lists the agent as an available model. The advertised model name defaults to the [profile](/user-guide/profiles) name (or `hermes-agent` for the default profile). Required by most frontends for model discovery.
+Returns an OpenAI-style model list containing the backward-compatible alias
+model (`hermes-agent`, or the active [profile](/user-guide/profiles) name) plus
+any aliases explicitly configured in `gateway.platforms.api_server.model_routes`.
+Most OpenAI-compatible frontends call this endpoint for model discovery.
 
 `/v1/models` is intentionally the cheap OpenAI-compat surface. It does **not**
 enumerate every authenticated provider/model combination Hermes can route to,
@@ -659,9 +662,10 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
 - **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
-- **Simple OpenAI clients still see an alias** — `/v1/models` advertises the
-  stable Hermes alias (`hermes-agent` or the active profile name). Richer
-  clients can send explicit `provider` / `model_options` overrides on requests.
+- **Simple OpenAI clients see bounded aliases** — `/v1/models` advertises the
+  stable Hermes alias (`hermes-agent` or the active profile name) and any
+  explicitly configured `model_routes` aliases. Richer clients can use
+  `/api/model/options` and send explicit `provider` / `model_options` overrides.
 
 ## Proxy Mode
 


### PR DESCRIPTION
## What does this PR do?

Documents the API server's bounded OpenAI-compatible model discovery contract on current `main`.

`GET /v1/models` exposes:

- the stable Hermes alias (`hermes-agent`, or the active profile name); and
- aliases explicitly configured in `gateway.platforms.api_server.model_routes`.

It does not enumerate the full authenticated provider catalog. Hermes-aware clients that need the richer provider/model inventory use `GET /api/model/options`.

## Review feedback addressed

This branch was rebased onto current `main`, whose newer API routing implementation supersedes the original code in this PR:

- Active fallback runtimes preserve their own model instead of pairing fallback credentials with the primary model.
- Configured `model_routes` aliases use their explicit route, while unmatched bare model names on OpenAI-compatible endpoints retain the established global-model compatibility behavior unless `direct_model_requests` is enabled.
- `POST /v1/runs` uses the same route/model/provider selection path when creating its agent.

The superseded implementation commit was dropped during the rebase, so the old inline code threads are now outdated. The remaining change is the documentation clarification.

## Verification

- `scripts/run_tests.sh tests/gateway/test_api_server.py`: **99 passed, 0 failed**
- `git diff --check upstream/main..HEAD`: passed
- Repository-wide run under the available Windows Python runtime reached 100%: **26,099 passed, 564 failed**. Failures were dominated by Linux/POSIX assumptions under Windows (pipes, permissions, paths, symlinks, subprocesses). The final verification subprocess hung after its harness timeout and was terminated so the runner could emit its aggregate. These failures are outside this documentation-only diff.
